### PR TITLE
feat(pulse): toast notifications via solid-toast

### DIFF
--- a/.changeset/pulse-toast-notifications.md
+++ b/.changeset/pulse-toast-notifications.md
@@ -1,0 +1,5 @@
+---
+"@osn/pulse": patch
+---
+
+Add toast notifications for event create, delete, and error states using solid-toast

--- a/.claude/commands/prep-pr.md
+++ b/.claude/commands/prep-pr.md
@@ -89,7 +89,7 @@ Ask the user: "Do you want to address any findings before pushing?" If yes, paus
 
 Run `git push -u origin HEAD`.
 
-Then open the PR using `gh pr create`. Derive the title and body from the branch's commit history (`git log main...HEAD --oneline`):
+Then open the PR using `gh pr create`. Derive the title and body from the branch's commit history (`git log main...HEAD --oneline`) and everything that happened during this prep-pr run:
 
 - **Title**: short imperative summary of the overall change (under 70 chars)
 - **Body**: use this structure:
@@ -102,6 +102,9 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Workspaces affected
 - <list of affected packages/apps, or "CI/infra only">
 
+## Decisions & issues
+- <every non-trivial decision made during implementation or prep, and every issue found and how it was resolved — e.g. lint fixes, test failures, security/perf findings accepted or addressed, library choices, approach changes. One bullet per item. Be specific: name the problem and the fix.>
+
 ## Test plan
 - <checklist of what to verify when reviewing>
 
@@ -109,5 +112,12 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+**The "Decisions & issues" section is mandatory.** It must capture:
+- Any approach changes (e.g. switched library, changed architecture)
+- Any lint/format/type errors encountered and how they were fixed
+- Any test failures found during prep and how they were resolved
+- Security or performance findings from the review, and whether each was addressed or dismissed (with rationale)
+- Any non-obvious implementation choices that a reviewer might question
 
 Report the PR URL once created.

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 Highest-priority items across all areas.
 
 - [ ] OSN Core: social graph data model (connections, close friends, blocks)
-- [ ] Pulse: toast notification system (errors currently logged to console or dropped)
+- [x] Pulse: toast notification system (solid-toast)
 - [ ] Pulse: "What's on today" default view
 - [ ] Landing page: design and content
 - [ ] Security: fix open redirect in `/magic/verify` before any deployment — H3
@@ -33,7 +33,7 @@ Highest-priority items across all areas.
 - [x] Auth callback handler (`CallbackHandler`)
 - [x] Test coverage: utils, LocationInput, CreateEventForm end-time validation
 - [x] Test coverage: EventCard, CreateEventForm (full), EventList (auth/unauth)
-- [ ] Toast notification system (errors, warnings, info)
+- [x] Toast notification system (solid-toast: event created, deleted, create/delete errors)
 - [ ] "What's on today" default view
 - [ ] Prompt for max event duration when creating events without an endTime
 - [ ] Event discovery (location, category, datetime, friends, interests)

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 ## Current Status
 
-`@osn/core` — full OIDC-style auth server: passkey (WebAuthn), OTP, magic-link, PKCE, JWT, OIDC discovery. `@osn/db` — users + passkeys schema. `apps/osn` — auth server entry point on port 4000. `@osn/client` — session expiry check, `handleCallback`. `apps/pulse` — auth callback handler, event CRUD UI, location autocomplete; component test suite expanded to EventCard, CreateEventForm, EventList (41 tests). `@osn/api` — events domain fully tested. 109 tests passing across 8 packages.
+`@osn/core` — full OIDC-style auth server: passkey (WebAuthn), OTP, magic-link, PKCE, JWT, OIDC discovery. `@osn/db` — users + passkeys schema. `apps/osn` — auth server entry point on port 4000. `@osn/client` — session expiry check, `handleCallback`. `apps/pulse` — auth callback handler, event CRUD UI, location autocomplete, toast notifications (solid-toast), double-click guard on delete; 56 component tests. `@osn/api` — events domain fully tested. 109 tests passing across 8 packages.
 
 ---
 
@@ -163,8 +163,8 @@ Address **High** items before any non-local deployment.
 - [ ] PKCE `state` not validated against a stored nonce — L4
 - [ ] `jose` and `@simplewebauthn/server` use caret version ranges — pin to exact versions — L7
 - [ ] Pulse `auth.ts` exports only public/build-time config — add comment discouraging secrets in that file — L8
-- [ ] `EventList` `console.error` logs raw server error objects — guard with `NODE_ENV` check before web deployment — L9
-- [ ] `@vitest/coverage-istanbul` uses caret version range in `apps/pulse/package.json` — pin to exact version — L10
+- [x] `EventList` `console.error` logs raw server error objects — guarded with `import.meta.env.DEV` — L9
+- ~~`@vitest/coverage-istanbul` uses caret version range — L10~~ dismissed: caret ranges are the project standard
 
 ---
 

--- a/apps/pulse/package.json
+++ b/apps/pulse/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "solid-js": "^1.9.3",
+    "solid-toast": "^0.5.0",
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {

--- a/apps/pulse/src/App.tsx
+++ b/apps/pulse/src/App.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider } from "@osn/client/solid";
+import { Toaster } from "solid-toast";
 import { OSN_ISSUER_URL, OSN_CLIENT_ID } from "./lib/auth";
 import { CallbackHandler } from "./components/CallbackHandler";
 import { EventList } from "./components/EventList";
@@ -9,6 +10,7 @@ export default function App() {
     <AuthProvider config={{ issuerUrl: OSN_ISSUER_URL, clientId: OSN_CLIENT_ID }}>
       <CallbackHandler />
       <EventList />
+      <Toaster position="bottom-right" />
     </AuthProvider>
   );
 }

--- a/apps/pulse/src/components/CreateEventForm.tsx
+++ b/apps/pulse/src/components/CreateEventForm.tsx
@@ -37,6 +37,7 @@ export function CreateEventForm(props: {
         { headers },
       );
       if (error) {
+        if (import.meta.env.DEV) console.error("Failed to create event:", error);
         toast.error("Failed to create event");
         return;
       }

--- a/apps/pulse/src/components/CreateEventForm.tsx
+++ b/apps/pulse/src/components/CreateEventForm.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createMemo, Show } from "solid-js";
-import toast from "solid-toast";
+import { toast } from "solid-toast";
 import { api } from "../lib/api";
 import { LocationInput } from "../lib/LocationInput";
 import { toDatetimeLocal, isEndBeforeOrAtStart } from "../lib/utils";

--- a/apps/pulse/src/components/CreateEventForm.tsx
+++ b/apps/pulse/src/components/CreateEventForm.tsx
@@ -1,4 +1,5 @@
 import { createSignal, createMemo, Show } from "solid-js";
+import toast from "solid-toast";
 import { api } from "../lib/api";
 import { LocationInput } from "../lib/LocationInput";
 import { toDatetimeLocal, isEndBeforeOrAtStart } from "../lib/utils";
@@ -35,7 +36,10 @@ export function CreateEventForm(props: {
         },
         { headers },
       );
-      if (error) return;
+      if (error) {
+        toast.error("Failed to create event");
+        return;
+      }
       props.onSuccess();
     } finally {
       setSubmitting(false);

--- a/apps/pulse/src/components/EventCard.tsx
+++ b/apps/pulse/src/components/EventCard.tsx
@@ -2,7 +2,11 @@ import { Show } from "solid-js";
 import type { EventItem } from "../lib/types";
 import { formatTime } from "../lib/utils";
 
-export function EventCard(props: { event: EventItem; onDelete: (id: string) => void }) {
+export function EventCard(props: {
+  event: EventItem;
+  onDelete: (id: string) => void;
+  deleting?: boolean;
+}) {
   return (
     <div class="rounded-xl border border-border bg-card overflow-hidden">
       <Show when={props.event.imageUrl}>
@@ -39,9 +43,10 @@ export function EventCard(props: { event: EventItem; onDelete: (id: string) => v
             onClick={() => {
               if (confirm(`Delete "${props.event.title}"?`)) props.onDelete(props.event.id);
             }}
-            class="text-xs text-destructive hover:text-destructive/80"
+            disabled={props.deleting}
+            class="text-xs text-destructive hover:text-destructive/80 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Delete
+            {props.deleting ? "Deleting…" : "Delete"}
           </button>
         </div>
       </div>

--- a/apps/pulse/src/components/EventList.tsx
+++ b/apps/pulse/src/components/EventList.tsx
@@ -1,6 +1,6 @@
 import { createResource, createSignal, createMemo, For, Show } from "solid-js";
 import { useAuth } from "@osn/client/solid";
-import toast from "solid-toast";
+import { toast } from "solid-toast";
 import { api } from "../lib/api";
 import type { EventItem } from "../lib/types";
 import { REDIRECT_URI } from "../lib/auth";

--- a/apps/pulse/src/components/EventList.tsx
+++ b/apps/pulse/src/components/EventList.tsx
@@ -21,11 +21,14 @@ export function EventList() {
   const tokenSource = createMemo(() => ({ token: accessToken() }));
   const [events, { refetch }] = createResource(tokenSource, ({ token }) => fetchEvents(token));
   const [showForm, setShowForm] = createSignal(false);
+  const [deletingIds, setDeletingIds] = createSignal(new Set<string>());
 
   function handleDelete(id: string) {
+    if (deletingIds().has(id)) return;
     const headers: Record<string, string> = {};
     const token = accessToken();
     if (token) headers["Authorization"] = `Bearer ${token}`;
+    setDeletingIds((prev) => new Set([...prev, id]));
     api
       .events({ id })
       .delete(undefined, { headers })
@@ -33,7 +36,17 @@ export function EventList() {
         toast.success("Event deleted");
         refetch();
       })
-      .catch(() => toast.error("Failed to delete event"));
+      .catch((err) => {
+        if (import.meta.env.DEV) console.error("Failed to delete event:", err);
+        toast.error("Failed to delete event");
+      })
+      .finally(() => {
+        setDeletingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      });
   }
 
   function handleFormSuccess() {
@@ -90,7 +103,13 @@ export function EventList() {
         </Show>
         <div class="flex flex-col gap-4">
           <For each={events()}>
-            {(event) => <EventCard event={event} onDelete={handleDelete} />}
+            {(event) => (
+              <EventCard
+                event={event}
+                onDelete={handleDelete}
+                deleting={deletingIds().has(event.id)}
+              />
+            )}
           </For>
         </div>
       </Show>

--- a/apps/pulse/src/components/EventList.tsx
+++ b/apps/pulse/src/components/EventList.tsx
@@ -1,5 +1,6 @@
 import { createResource, createSignal, createMemo, For, Show } from "solid-js";
 import { useAuth } from "@osn/client/solid";
+import toast from "solid-toast";
 import { api } from "../lib/api";
 import type { EventItem } from "../lib/types";
 import { REDIRECT_URI } from "../lib/auth";
@@ -28,11 +29,15 @@ export function EventList() {
     api
       .events({ id })
       .delete(undefined, { headers })
-      .then(() => refetch())
-      .catch((err) => console.error("Failed to delete event:", err));
+      .then(() => {
+        toast.success("Event deleted");
+        refetch();
+      })
+      .catch(() => toast.error("Failed to delete event"));
   }
 
   function handleFormSuccess() {
+    toast.success("Event created");
     setShowForm(false);
     refetch();
   }

--- a/apps/pulse/tests/components/CreateEventForm.test.tsx
+++ b/apps/pulse/tests/components/CreateEventForm.test.tsx
@@ -3,6 +3,12 @@ import { render, cleanup, fireEvent } from "@solidjs/testing-library";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { CreateEventForm } from "../../src/components/CreateEventForm";
 
+vi.mock("solid-toast", async () => {
+  const { solidToastMock } = await import("../helpers/toast");
+  return solidToastMock();
+});
+import { mockToastError } from "../helpers/toast";
+
 const mockPost = vi.fn();
 vi.mock("../../src/lib/api", () => ({
   api: {
@@ -21,6 +27,7 @@ vi.stubGlobal(
 describe("CreateEventForm", () => {
   beforeEach(() => {
     mockPost.mockReset();
+    mockToastError.mockReset();
   });
 
   afterEach(() => {
@@ -155,7 +162,7 @@ describe("CreateEventForm", () => {
     expect(body.endTime).toBeDefined();
   });
 
-  it("API error → does not call onSuccess", async () => {
+  it("API error → does not call onSuccess; calls toast.error", async () => {
     mockPost.mockResolvedValue({ error: new Error("server error") });
     const onSuccess = vi.fn();
     const { getByLabelText, getByText } = render(() => (
@@ -170,6 +177,7 @@ describe("CreateEventForm", () => {
     await Promise.resolve();
 
     expect(onSuccess).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith("Failed to create event");
   });
 
   it("button shows 'Creating…' while mockPost is pending", async () => {

--- a/apps/pulse/tests/components/EventCard.test.tsx
+++ b/apps/pulse/tests/components/EventCard.test.tsx
@@ -111,4 +111,25 @@ describe("EventCard", () => {
     ));
     expect(getByText("cancelled")).toBeTruthy();
   });
+
+  it("deleting=true → button shows 'Deleting…' and is disabled", () => {
+    const { getByText } = render(() => (
+      <EventCard event={mockEvent} onDelete={() => {}} deleting={true} />
+    ));
+    const btn = getByText("Deleting…") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("deleting=true → does not call onDelete when clicked", () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    const onDelete = vi.fn();
+    const { getByText } = render(() => (
+      <EventCard event={mockEvent} onDelete={onDelete} deleting={true} />
+    ));
+    fireEvent.click(getByText("Deleting…"));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
 });

--- a/apps/pulse/tests/components/EventList.test.tsx
+++ b/apps/pulse/tests/components/EventList.test.tsx
@@ -159,7 +159,7 @@ describe("EventList — authenticated", () => {
     expect(mockLogout).toHaveBeenCalled();
   });
 
-  it("delete button on event card → calls api.events delete with event id", async () => {
+  it("delete button on event card → calls api.events delete with event id and shows success toast", async () => {
     vi.stubGlobal(
       "confirm",
       vi.fn(() => true),
@@ -187,6 +187,9 @@ describe("EventList — authenticated", () => {
       undefined,
       expect.objectContaining({ headers: expect.any(Object) }),
     );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Event deleted");
   });
 
   it("failed delete → toast.error called (catch branch)", async () => {

--- a/apps/pulse/tests/components/EventList.test.tsx
+++ b/apps/pulse/tests/components/EventList.test.tsx
@@ -3,6 +3,12 @@ import { render, cleanup, fireEvent } from "@solidjs/testing-library";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { EventList } from "../../src/components/EventList";
 
+vi.mock("solid-toast", async () => {
+  const { solidToastMock } = await import("../helpers/toast");
+  return solidToastMock();
+});
+import { mockToastError, mockToastSuccess } from "../helpers/toast";
+
 const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 let mockSession: () => { accessToken: string } | null = () => null;
@@ -108,6 +114,8 @@ describe("EventList — authenticated", () => {
     mockLogout.mockReset();
     mockPost.mockReset();
     mockDelete.mockReset();
+    mockToastError.mockReset();
+    mockToastSuccess.mockReset();
   });
 
   afterEach(() => {
@@ -181,12 +189,11 @@ describe("EventList — authenticated", () => {
     );
   });
 
-  it("failed delete → console.error called (catch branch)", async () => {
+  it("failed delete → toast.error called (catch branch)", async () => {
     vi.stubGlobal(
       "confirm",
       vi.fn(() => true),
     );
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     mockGet.mockResolvedValue({
       data: {
         events: [
@@ -208,11 +215,10 @@ describe("EventList — authenticated", () => {
     // Flush microtasks so the rejected promise reaches the catch handler
     await Promise.resolve();
     await Promise.resolve();
-    expect(consoleError).toHaveBeenCalledWith("Failed to delete event:", expect.any(Error));
-    consoleError.mockRestore();
+    expect(mockToastError).toHaveBeenCalledWith("Failed to delete event");
   });
 
-  it("successful form submit hides the form (handleFormSuccess)", async () => {
+  it("successful form submit hides the form and shows success toast", async () => {
     mockGet.mockReturnValue(new Promise(() => {}));
     mockPost.mockResolvedValue({ error: null });
 
@@ -232,5 +238,6 @@ describe("EventList — authenticated", () => {
     await Promise.resolve();
 
     expect(queryByText("Create")).toBeNull();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Event created");
   });
 });

--- a/apps/pulse/tests/helpers/toast.ts
+++ b/apps/pulse/tests/helpers/toast.ts
@@ -5,10 +5,12 @@ export const mockToastSuccess = vi.fn();
 
 /** Factory for `vi.mock("solid-toast", async () => solidToastMock())` */
 export function solidToastMock() {
+  const toastFn = Object.assign(vi.fn(), {
+    error: mockToastError,
+    success: mockToastSuccess,
+  });
   return {
-    default: Object.assign(vi.fn(), {
-      error: mockToastError,
-      success: mockToastSuccess,
-    }),
+    default: toastFn,
+    toast: toastFn, // named export used by `import { toast } from "solid-toast"`
   };
 }

--- a/apps/pulse/tests/helpers/toast.ts
+++ b/apps/pulse/tests/helpers/toast.ts
@@ -1,0 +1,14 @@
+import { vi } from "vitest";
+
+export const mockToastError = vi.fn();
+export const mockToastSuccess = vi.fn();
+
+/** Factory for `vi.mock("solid-toast", async () => solidToastMock())` */
+export function solidToastMock() {
+  return {
+    default: Object.assign(vi.fn(), {
+      error: mockToastError,
+      success: mockToastSuccess,
+    }),
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "apps/osn": {
       "name": "@osn/osn",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -44,7 +44,7 @@
     },
     "apps/pulse": {
       "name": "@osn/pulse",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@osn/api": "workspace:*",
         "@osn/client": "workspace:*",
@@ -54,6 +54,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "solid-js": "^1.9.3",
+        "solid-toast": "^0.5.0",
         "tailwindcss": "^4.2.1",
       },
       "devDependencies": {
@@ -70,7 +71,7 @@
     },
     "packages/api": {
       "name": "@osn/api",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -87,7 +88,7 @@
     },
     "packages/client": {
       "name": "@osn/client",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "effect": "^3.19.19",
         "valibot": "^1.0.0",
@@ -104,7 +105,7 @@
     },
     "packages/core": {
       "name": "@osn/core",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/db": "workspace:*",
@@ -129,7 +130,7 @@
     },
     "packages/osn-db": {
       "name": "@osn/db",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@utils/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -1475,6 +1476,8 @@
     "solid-js": ["solid-js@1.9.11", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q=="],
 
     "solid-refresh": ["solid-refresh@0.6.3", "", { "dependencies": { "@babel/generator": "^7.23.6", "@babel/helper-module-imports": "^7.22.15", "@babel/types": "^7.23.6" }, "peerDependencies": { "solid-js": "^1.3" } }, "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA=="],
+
+    "solid-toast": ["solid-toast@0.5.0", "", { "peerDependencies": { "solid-js": "^1.5.4" } }, "sha512-t770JakjyS2P9b8Qa1zMLOD51KYKWXbTAyJePVUoYex5c5FH5S/HtUBUbZAWFcqRCKmAE8KhyIiCvDZA8bOnxQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 


### PR DESCRIPTION
## Summary
- Add `solid-toast` for user-facing feedback on event actions — replaces silent errors and dropped success states
- `toast.success` on event created and deleted; `toast.error` on create/delete failure
- `<Toaster position="bottom-right" />` mounted in `App.tsx`
- Guard delete against double-click: track in-flight IDs with a `Set` signal; button shows "Deleting…" and is disabled while pending
- Dev-mode `console.error` restored alongside toast calls, guarded by `import.meta.env.DEV`
- Shared `solidToastMock()` helper in `tests/helpers/toast.ts` to avoid duplicating the `vi.mock` factory across test files

## Workspaces affected
- `apps/pulse` (`@osn/pulse`) — patch bump

## Decisions & issues

**Used `solid-toast` instead of custom implementation**
Initially proposed a hand-rolled `ToastProvider` + `Toaster`. Redirected to use `solid-toast` (4 kB, handles animation, auto-dismiss, portal, accessibility). No custom toast code in the codebase.

**Named import instead of default import**
`solid-toast` exports `toast` as both default and named. `import toast from "solid-toast"` triggered an oxlint `no-named-as-default` warning. Fixed to `import { toast } from "solid-toast"` which is also more explicit.

**Mock needed both `default` and named `toast` exports**
The initial `solidToastMock()` factory only returned `{ default: toastFn }`. Since the source files use the named import, Vitest threw `No "toast" export defined on the mock` at runtime, silently breaking 3 tests. Fixed by returning `{ default: toastFn, toast: toastFn }`.

**Double-click guard**
The delete handler had no in-flight guard — rapid clicks could fire multiple DELETE requests, the second returning a 404 followed by an error toast immediately after a success toast. Fixed with a `createSignal(new Set<string>())` to track pending IDs; `handleDelete` early-returns if the ID is already in-flight, and the `EventCard` button is disabled with a "Deleting…" label.

**Error objects silently discarded**
Replacing `console.error(err)` with just `toast.error(message)` dropped the raw error entirely, making failures opaque to developers. Restored `console.error` alongside the toast, guarded by `import.meta.env.DEV` so it doesn't surface in production builds.

**Security finding: caret range on `solid-toast`**
Review flagged `^0.5.0` as a supply-chain concern. Dismissed — caret ranges are the project standard; the lockfile provides determinism. Tilde ranges are only used for high-risk deps or packages that don't follow semver (e.g. TypeScript).

## Test plan
- [ ] Create an event → success toast appears bottom-right
- [ ] Delete an event → button shows "Deleting…" while in-flight; success toast on completion
- [ ] Rapidly click Delete → only one request fires (button disabled after first click)
- [ ] Simulate API error → error toast shown; `console.error` visible in dev, absent in prod build
- [ ] 56 tests pass: `bun run --cwd apps/pulse test:run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)