### PR TITLE
feat(pulse-db): dynamic seed with relative timestamps and full status distribution

### DIFF
--- a/.changeset/pulse-db-seed.md
+++ b/.changeset/pulse-db-seed.md
@@ -1,0 +1,5 @@
+---
+"@pulse/db": patch
+---
+
+Add realistic relative-timestamp seed data with full status distribution (1 finished, 3 ongoing, 5 upcoming) across varied categories; idempotent via onConflictDoNothing

--- a/packages/pulse-db/src/seed.ts
+++ b/packages/pulse-db/src/seed.ts
@@ -1,144 +1,155 @@
-import { Effect } from "effect";
+import { Effect, Data } from "effect";
 import { DbLive, Db } from "./service";
 import { events } from "./schema";
+import type { NewEvent } from "./schema";
+
+class SeedError extends Data.TaggedError("SeedError")<{ cause: unknown }> {}
+
+/**
+ * Builds the seed event rows relative to the given `now`.
+ * Exported so tests can assert on the data without hitting a real DB.
+ */
+export function buildSeedEvents(now: Date): NewEvent[] {
+  const ms = now.getTime();
+  const hMs = (n: number) => ms + n * 3_600_000;
+  const dMs = (n: number) => ms + n * 86_400_000;
+  const h = (n: number) => new Date(hMs(n));
+  const d = (n: number) => new Date(dMs(n));
+
+  return [
+    // ── Finished ────────────────────────────────────────────────────────────
+    {
+      id: "evt_seed_finished1",
+      title: "Jazz Night at the Cellar",
+      description: "An intimate evening of live jazz across three sets.",
+      location: "Lower East Side, New York",
+      venue: "The Cellar Bar",
+      category: "music",
+      startTime: d(-3),
+      endTime: new Date(dMs(-3) + 3 * 3_600_000),
+      status: "finished",
+      createdAt: now,
+      updatedAt: now,
+    },
+
+    // ── Ongoing ─────────────────────────────────────────────────────────────
+    {
+      id: "evt_seed_ongoing1",
+      title: "Farmers Market – Spring Edition",
+      description: "Local produce, street food, and live acoustic sets.",
+      location: "Brooklyn, New York",
+      venue: "Grand Army Plaza",
+      category: "food",
+      startTime: h(-2),
+      endTime: h(4),
+      status: "ongoing",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_ongoing2",
+      title: "Open Source Hack Day",
+      description: "All-day hacking session. Bring a laptop and a project idea.",
+      location: "SOMA, San Francisco",
+      venue: "Cloudflare HQ",
+      category: "tech",
+      startTime: h(-5),
+      endTime: h(7),
+      status: "ongoing",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_ongoing3",
+      title: "Sunset Rooftop Yoga",
+      description: "Vinyasa flow with panoramic city views as the sun goes down.",
+      location: "Midtown, New York",
+      venue: "The High Line Hotel",
+      category: "wellness",
+      startTime: new Date(ms - 45 * 60_000),
+      endTime: new Date(ms + 75 * 60_000),
+      status: "ongoing",
+      createdAt: now,
+      updatedAt: now,
+    },
+
+    // ── Upcoming ────────────────────────────────────────────────────────────
+    {
+      id: "evt_seed_upcoming1",
+      title: "Bun + Effect.ts Workshop",
+      description: "Hands-on workshop covering Bun internals and Effect service patterns.",
+      location: "Tech District, San Francisco",
+      venue: "Innovation Hub",
+      category: "tech",
+      startTime: d(2),
+      endTime: new Date(dMs(2) + 3 * 3_600_000),
+      status: "upcoming",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_upcoming2",
+      title: "Community 5K Run",
+      description: "A flat, friendly 5K through the park. All paces welcome.",
+      location: "Golden Gate Park, San Francisco",
+      venue: "Main Meadow",
+      category: "fitness",
+      startTime: d(5),
+      endTime: new Date(dMs(5) + 2 * 3_600_000),
+      status: "upcoming",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_upcoming3",
+      title: "Rooftop Cocktail Mixer",
+      description: "Meet founders, designers, and engineers over craft cocktails.",
+      location: "Downtown, Los Angeles",
+      venue: "Sky Lounge",
+      category: "social",
+      startTime: d(8),
+      endTime: new Date(dMs(8) + 4 * 3_600_000),
+      status: "upcoming",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_upcoming4",
+      title: "Photography Walk – Street Portraits",
+      description: "Guided street photography session with portfolio critique at the end.",
+      location: "Williamsburg, Brooklyn",
+      venue: "Starts at Bedford Ave L",
+      category: "art",
+      startTime: d(12),
+      endTime: new Date(dMs(12) + 3 * 3_600_000),
+      status: "upcoming",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "evt_seed_upcoming5",
+      title: "Indie Film Screening: Short Cuts",
+      description: "Curated selection of short films from emerging directors, followed by a Q&A.",
+      location: "SoHo, New York",
+      venue: "IFC Center",
+      category: "film",
+      startTime: d(18),
+      endTime: new Date(dMs(18) + 2.5 * 3_600_000),
+      status: "upcoming",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+}
 
 const seed = Effect.gen(function* () {
   const { db } = yield* Db;
   const now = new Date();
 
-  const h = (n: number) => new Date(now.getTime() + n * 3_600_000);
-  const d = (n: number) => new Date(now.getTime() + n * 86_400_000);
-
-  yield* Effect.tryPromise(() =>
-    db
-      .insert(events)
-      .values([
-        // ── Finished ──────────────────────────────────────────────────────────
-        {
-          id: "evt_seed_finished1",
-          title: "Jazz Night at the Cellar",
-          description: "An intimate evening of live jazz across three sets.",
-          location: "Lower East Side, New York",
-          venue: "The Cellar Bar",
-          category: "music",
-          startTime: d(-3),
-          endTime: new Date(d(-3).getTime() + 3 * 3_600_000),
-          status: "finished",
-          createdAt: now,
-          updatedAt: now,
-        },
-
-        // ── Ongoing ───────────────────────────────────────────────────────────
-        {
-          id: "evt_seed_ongoing1",
-          title: "Farmers Market – Spring Edition",
-          description: "Local produce, street food, and live acoustic sets.",
-          location: "Brooklyn, New York",
-          venue: "Grand Army Plaza",
-          category: "food",
-          startTime: h(-2),
-          endTime: h(4),
-          status: "ongoing",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_ongoing2",
-          title: "Open Source Hack Day",
-          description: "All-day hacking session. Bring a laptop and a project idea.",
-          location: "SOMA, San Francisco",
-          venue: "Cloudflare HQ",
-          category: "tech",
-          startTime: h(-5),
-          endTime: h(7),
-          status: "ongoing",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_ongoing3",
-          title: "Sunset Rooftop Yoga",
-          description: "Vinyasa flow with panoramic city views as the sun goes down.",
-          location: "Midtown, New York",
-          venue: "The High Line Hotel",
-          category: "wellness",
-          startTime: new Date(now.getTime() - 45 * 60_000),
-          endTime: new Date(now.getTime() + 75 * 60_000),
-          status: "ongoing",
-          createdAt: now,
-          updatedAt: now,
-        },
-
-        // ── Upcoming ──────────────────────────────────────────────────────────
-        {
-          id: "evt_seed_upcoming1",
-          title: "Bun + Effect.ts Workshop",
-          description: "Hands-on workshop covering Bun internals and Effect service patterns.",
-          location: "Tech District, San Francisco",
-          venue: "Innovation Hub",
-          category: "tech",
-          startTime: d(2),
-          endTime: new Date(d(2).getTime() + 3 * 3_600_000),
-          status: "upcoming",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_upcoming2",
-          title: "Community 5K Run",
-          description: "A flat, friendly 5K through the park. All paces welcome.",
-          location: "Golden Gate Park, San Francisco",
-          venue: "Main Meadow",
-          category: "fitness",
-          startTime: d(5),
-          endTime: new Date(d(5).getTime() + 2 * 3_600_000),
-          status: "upcoming",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_upcoming3",
-          title: "Rooftop Cocktail Mixer",
-          description: "Meet founders, designers, and engineers over craft cocktails.",
-          location: "Downtown, Los Angeles",
-          venue: "Sky Lounge",
-          category: "social",
-          startTime: d(8),
-          endTime: new Date(d(8).getTime() + 4 * 3_600_000),
-          status: "upcoming",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_upcoming4",
-          title: "Photography Walk – Street Portraits",
-          description: "Guided street photography session with portfolio critique at the end.",
-          location: "Williamsburg, Brooklyn",
-          venue: "Starts at Bedford Ave L",
-          category: "art",
-          startTime: d(12),
-          endTime: new Date(d(12).getTime() + 3 * 3_600_000),
-          status: "upcoming",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: "evt_seed_upcoming5",
-          title: "Indie Film Screening: Short Cuts",
-          description:
-            "Curated selection of short films from emerging directors, followed by a Q&A.",
-          location: "SoHo, New York",
-          venue: "IFC Center",
-          category: "film",
-          startTime: d(18),
-          endTime: new Date(d(18).getTime() + 2.5 * 3_600_000),
-          status: "upcoming",
-          createdAt: now,
-          updatedAt: now,
-        },
-      ])
-      .onConflictDoNothing(),
-  );
+  yield* Effect.tryPromise({
+    try: () => db.insert(events).values(buildSeedEvents(now)).onConflictDoNothing(),
+    catch: (cause) => new SeedError({ cause }),
+  });
 
   console.log("Seed complete — 9 events inserted (existing seed rows skipped).");
 }).pipe(Effect.provide(DbLive));

--- a/packages/pulse-db/src/seed.ts
+++ b/packages/pulse-db/src/seed.ts
@@ -6,49 +6,141 @@ const seed = Effect.gen(function* () {
   const { db } = yield* Db;
   const now = new Date();
 
+  const h = (n: number) => new Date(now.getTime() + n * 3_600_000);
+  const d = (n: number) => new Date(now.getTime() + n * 86_400_000);
+
   yield* Effect.tryPromise(() =>
-    db.insert(events).values([
-      {
-        id: "evt_rooftop001",
-        title: "Rooftop Sunset Party",
-        description: "Join us for an evening of music and views.",
-        location: "Downtown",
-        venue: "Sky Lounge",
-        category: "social",
-        startTime: new Date("2030-07-15T18:00:00.000Z"),
-        endTime: new Date("2030-07-15T23:00:00.000Z"),
-        status: "upcoming",
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: "evt_techmeet02",
-        title: "Tech Meetup: Bun & Effect",
-        description: "Deep dive into the Bun runtime and Effect.ts.",
-        location: "Tech District",
-        venue: "Innovation Hub",
-        category: "tech",
-        startTime: new Date("2030-08-01T19:00:00.000Z"),
-        status: "upcoming",
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: "evt_yoga00003",
-        title: "Morning Yoga in the Park",
-        description: "Start your day with an outdoor yoga session.",
-        location: "Central Park",
-        category: "wellness",
-        startTime: new Date("2030-06-20T07:00:00.000Z"),
-        endTime: new Date("2030-06-20T08:30:00.000Z"),
-        status: "upcoming",
-        createdAt: now,
-        updatedAt: now,
-      },
-    ]),
+    db
+      .insert(events)
+      .values([
+        // ── Finished ──────────────────────────────────────────────────────────
+        {
+          id: "evt_seed_finished1",
+          title: "Jazz Night at the Cellar",
+          description: "An intimate evening of live jazz across three sets.",
+          location: "Lower East Side, New York",
+          venue: "The Cellar Bar",
+          category: "music",
+          startTime: d(-3),
+          endTime: new Date(d(-3).getTime() + 3 * 3_600_000),
+          status: "finished",
+          createdAt: now,
+          updatedAt: now,
+        },
+
+        // ── Ongoing ───────────────────────────────────────────────────────────
+        {
+          id: "evt_seed_ongoing1",
+          title: "Farmers Market – Spring Edition",
+          description: "Local produce, street food, and live acoustic sets.",
+          location: "Brooklyn, New York",
+          venue: "Grand Army Plaza",
+          category: "food",
+          startTime: h(-2),
+          endTime: h(4),
+          status: "ongoing",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_ongoing2",
+          title: "Open Source Hack Day",
+          description: "All-day hacking session. Bring a laptop and a project idea.",
+          location: "SOMA, San Francisco",
+          venue: "Cloudflare HQ",
+          category: "tech",
+          startTime: h(-5),
+          endTime: h(7),
+          status: "ongoing",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_ongoing3",
+          title: "Sunset Rooftop Yoga",
+          description: "Vinyasa flow with panoramic city views as the sun goes down.",
+          location: "Midtown, New York",
+          venue: "The High Line Hotel",
+          category: "wellness",
+          startTime: new Date(now.getTime() - 45 * 60_000),
+          endTime: new Date(now.getTime() + 75 * 60_000),
+          status: "ongoing",
+          createdAt: now,
+          updatedAt: now,
+        },
+
+        // ── Upcoming ──────────────────────────────────────────────────────────
+        {
+          id: "evt_seed_upcoming1",
+          title: "Bun + Effect.ts Workshop",
+          description: "Hands-on workshop covering Bun internals and Effect service patterns.",
+          location: "Tech District, San Francisco",
+          venue: "Innovation Hub",
+          category: "tech",
+          startTime: d(2),
+          endTime: new Date(d(2).getTime() + 3 * 3_600_000),
+          status: "upcoming",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_upcoming2",
+          title: "Community 5K Run",
+          description: "A flat, friendly 5K through the park. All paces welcome.",
+          location: "Golden Gate Park, San Francisco",
+          venue: "Main Meadow",
+          category: "fitness",
+          startTime: d(5),
+          endTime: new Date(d(5).getTime() + 2 * 3_600_000),
+          status: "upcoming",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_upcoming3",
+          title: "Rooftop Cocktail Mixer",
+          description: "Meet founders, designers, and engineers over craft cocktails.",
+          location: "Downtown, Los Angeles",
+          venue: "Sky Lounge",
+          category: "social",
+          startTime: d(8),
+          endTime: new Date(d(8).getTime() + 4 * 3_600_000),
+          status: "upcoming",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_upcoming4",
+          title: "Photography Walk – Street Portraits",
+          description: "Guided street photography session with portfolio critique at the end.",
+          location: "Williamsburg, Brooklyn",
+          venue: "Starts at Bedford Ave L",
+          category: "art",
+          startTime: d(12),
+          endTime: new Date(d(12).getTime() + 3 * 3_600_000),
+          status: "upcoming",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "evt_seed_upcoming5",
+          title: "Indie Film Screening: Short Cuts",
+          description:
+            "Curated selection of short films from emerging directors, followed by a Q&A.",
+          location: "SoHo, New York",
+          venue: "IFC Center",
+          category: "film",
+          startTime: d(18),
+          endTime: new Date(d(18).getTime() + 2.5 * 3_600_000),
+          status: "upcoming",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+      .onConflictDoNothing(),
   );
 
-  console.log("Seeded 3 events.");
+  console.log("Seed complete — 9 events inserted (existing seed rows skipped).");
 }).pipe(Effect.provide(DbLive));
 
 Effect.runPromise(seed).catch(console.error);

--- a/packages/pulse-db/tests/seed.test.ts
+++ b/packages/pulse-db/tests/seed.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../src/schema";
+import { buildSeedEvents } from "../src/seed";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.run(`
+    CREATE TABLE events (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      description TEXT,
+      location TEXT,
+      venue TEXT,
+      category TEXT,
+      start_time INTEGER NOT NULL,
+      end_time INTEGER,
+      status TEXT NOT NULL DEFAULT 'upcoming',
+      image_url TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  return drizzle(sqlite, { schema });
+}
+
+describe("buildSeedEvents", () => {
+  it("returns 9 events", () => {
+    const rows = buildSeedEvents(new Date());
+    expect(rows).toHaveLength(9);
+  });
+
+  it("status distribution: 1 finished, 3 ongoing, 5 upcoming", () => {
+    const rows = buildSeedEvents(new Date());
+    const counts = { finished: 0, ongoing: 0, upcoming: 0, cancelled: 0 };
+    for (const r of rows) counts[r.status as keyof typeof counts]++;
+    expect(counts.finished).toBe(1);
+    expect(counts.ongoing).toBe(3);
+    expect(counts.upcoming).toBe(5);
+  });
+
+  it("finished events: startTime and endTime are both in the past", () => {
+    const now = new Date();
+    const finished = buildSeedEvents(now).filter((r) => r.status === "finished");
+    for (const r of finished) {
+      expect(r.startTime.getTime()).toBeLessThan(now.getTime());
+      expect(r.endTime!.getTime()).toBeLessThan(now.getTime());
+    }
+  });
+
+  it("ongoing events: startTime is in the past, endTime is in the future", () => {
+    const now = new Date();
+    const ongoing = buildSeedEvents(now).filter((r) => r.status === "ongoing");
+    for (const r of ongoing) {
+      expect(r.startTime.getTime()).toBeLessThan(now.getTime());
+      expect(r.endTime!.getTime()).toBeGreaterThan(now.getTime());
+    }
+  });
+
+  it("upcoming events: startTime is in the future", () => {
+    const now = new Date();
+    const upcoming = buildSeedEvents(now).filter((r) => r.status === "upcoming");
+    for (const r of upcoming) {
+      expect(r.startTime.getTime()).toBeGreaterThan(now.getTime());
+    }
+  });
+
+  it("all events have stable evt_seed_* IDs", () => {
+    const rows = buildSeedEvents(new Date());
+    for (const r of rows) {
+      expect(r.id).toMatch(/^evt_seed_/);
+    }
+  });
+
+  it("all events have a category", () => {
+    const rows = buildSeedEvents(new Date());
+    const categories = rows.map((r) => r.category);
+    expect(categories.every(Boolean)).toBe(true);
+    // Covers the full spread of categories used for preference/discovery testing
+    expect(new Set(categories).size).toBeGreaterThanOrEqual(7);
+  });
+});
+
+describe("seed idempotency", () => {
+  it("inserting twice does not duplicate rows", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    const seedData = buildSeedEvents(now);
+
+    await db.insert(schema.events).values(seedData).onConflictDoNothing();
+    await db.insert(schema.events).values(seedData).onConflictDoNothing();
+
+    const rows = await db.select().from(schema.events);
+    expect(rows).toHaveLength(9);
+  });
+
+  it("second insert does not throw", async () => {
+    const db = createTestDb();
+    const seedData = buildSeedEvents(new Date());
+
+    await db.insert(schema.events).values(seedData).onConflictDoNothing();
+    await expect(
+      db.insert(schema.events).values(seedData).onConflictDoNothing(),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the 3 hardcoded 2030-date events in `seed.ts` with 9 realistic events whose timestamps are relative to `new Date()` at run time
- Distribution: 1 finished, 3 ongoing, 5 upcoming across 8 categories (music, food, tech, wellness, fitness, social, art, film)
- Idempotent via `.onConflictDoNothing()` on stable `evt_seed_*` IDs — safe to run repeatedly and against a DB with existing developer data
- Foundation for future preference/discovery testing as more event attributes are added

## Workspaces affected
- `packages/pulse-db` (`@pulse/db`) — patch bump

## Decisions & issues

**Exported `buildSeedEvents(now)` for testability**
The original script ran everything on import (`Effect.runPromise(seed)` at top level), making it impossible to test without hitting a real DB. Refactored to export `buildSeedEvents(now: Date)` as a pure function that returns the insert data. The Effect entry point calls it; tests import it directly with a test DB.

**Added typed `SeedError` and `Effect.tryPromise` error mapper**
The original used the single-argument form of `Effect.tryPromise`, which types the error channel as `unknown` and was inconsistent with the rest of the codebase. Fixed to `Effect.tryPromise({ try, catch: (cause) => new SeedError({ cause }) })`.

**Fixed redundant `Date` construction in `endTime` expressions**
The original `endTime: new Date(d(2).getTime() + 3 * 3_600_000)` called `d(2)` (which allocates a `Date`), then `.getTime()` (discards it), then built another `Date`. Fixed by introducing `dMs`/`hMs` numeric helpers so `startTime` and `endTime` each allocate exactly one `Date` object.

**Format fix on first commit attempt**
oxfmt flagged formatting on `seed.ts`. Applied `bunx --bun oxfmt` before the second commit attempt.

**Performance findings: Info only, no action needed**
Both perf findings were seed-script-specific with no production footprint. The Date construction issue was fixed as part of the refactor; the error mapper was also fixed.

**Security review: no findings**
All DB writes go through Drizzle's parameterised API. No new dependencies. No sensitive data.

## Test plan
- [ ] `bun run --cwd packages/pulse-db test:run` → 12/12 pass
- [ ] `bun run --cwd packages/pulse-db db:seed` → "Seed complete" log, no errors
- [ ] Run seed twice → row count stays at 9, no errors
- [ ] Check that ongoing events have `startTime` in the past and `endTime` in the future relative to now
- [ ] Check that the finished event has both `startTime` and `endTime` in the past

🤖 Generated with [Claude Code](https://claude.com/claude-code)