### PR TITLE
feat: add @handle system for user identity

### DIFF
--- a/.changeset/feat-user-handle-system.md
+++ b/.changeset/feat-user-handle-system.md
@@ -1,0 +1,15 @@
+---
+"@osn/db": minor
+"@osn/core": minor
+"@osn/api": patch
+"@osn/pulse": patch
+---
+
+Add user handle system
+
+Each OSN user now has a unique `@handle` (immutable, required at registration) alongside a mutable `displayName`. Key changes:
+
+- **`@osn/db`**: New `handle` column (`NOT NULL UNIQUE`) on the `users` table with migration `0002_add_user_handle.sql`
+- **`@osn/core`**: Registration is now an explicit step (`POST /register { email, handle, displayName? }`); OTP, magic link, and passkey login all accept an `identifier` that can be either an email or a handle; JWT access tokens now include `handle` and `displayName` claims; new `GET /handle/:handle` endpoint for availability checks; `verifyAccessToken` returns `handle` and `displayName`
+- **`@osn/api`**: `createdByName` on events now uses `displayName` → `@handle` → email local-part (in that priority order)
+- **`@osn/pulse`**: `getDisplayNameFromToken` updated to prefer `displayName` then `@handle`; new `getHandleFromToken` utility

--- a/TODO.md
+++ b/TODO.md
@@ -143,6 +143,8 @@ Address **High** items before any non-local deployment.
 - [x] No ownership check on mutating event operations (create/update/delete) — H2 (createdByUserId NOT NULL; 403 on non-owner)
 
 ### Medium
+- [ ] `POST /register` has no rate limiting or email verification — handles can be squatted in bulk; add per-IP rate limit and email confirmation before first login — M13
+- [ ] `displayName` is embedded in JWT access tokens (1 h TTL) — stale after a profile update; `createdByName` on events reflects the old value until token expires — M14
 - [ ] Wildcard CORS on auth server — restrict to known client origins before deployment — M3
 - [ ] No OTP attempt limit — 6-digit codes brute-forceable at HTTP speeds — M8
 - [ ] All auth state in process memory (`otpStore`, `magicStore`, `pkceStore`, etc.) — lost on restart, unsafe for multi-process — M6
@@ -167,6 +169,8 @@ Address **High** items before any non-local deployment.
 - [ ] PKCE `state` not validated against a stored nonce — L4
 - [ ] `jose` and `@simplewebauthn/server` use caret version ranges — pin to exact versions — L7
 - [ ] Pulse `auth.ts` exports only public/build-time config — add comment discouraging secrets in that file — L8
+- [ ] `assertion: t.Any()` on passkey register/login routes — add lightweight TypeBox shape validation for top-level WebAuthn fields (`id`, `rawId`, `response`, `type`) — L10
+- [ ] No reserved-handle blocklist in DB — currently enforced in app layer only (`RESERVED_HANDLES` set in `@osn/core`); consider a DB-level check constraint or migration-managed table — L11
 - [x] `EventList` `console.error` logs raw server error objects — guarded with `import.meta.env.DEV` — L9
 - ~~`@vitest/coverage-istanbul` uses caret version range — L10~~ dismissed: caret ranges are the project standard
 
@@ -179,7 +183,7 @@ Address **High** items before any non-local deployment.
 - [ ] `new TextEncoder()` allocated per `verifyPkceChallenge` call — move to module scope — P3
 - [ ] `AuthProvider` reconstructs Effect `Layer` on every render — wrap with `createMemo` — P4
 - [ ] `completePasskeyLogin` calls `findUserByEmail` redundantly — `pk.userId` already on passkey row — P5
-- [ ] Duplicate index on `users.email` — `unique()` already creates one implicitly — P6
+- [ ] Duplicate index on `users.email` — `unique()` already creates one implicitly in SQLite; explicit `users_email_idx` is redundant (pre-existing; handle_idx removed in feat/user-handle-system) — P6
 - [ ] Batch status-transition `UPDATE`s in `listEvents`/`listTodayEvents` (N individual writes today) — P7
 - [x] Eliminate extra `getEvent` round-trips in `updateEvent` — P8 (returns in-memory merged result; applyTransition called locally)
 - [ ] Eliminate extra `getEvent` round-trip in `createEvent` via `RETURNING *` — P9

--- a/apps/pulse/src/lib/utils.ts
+++ b/apps/pulse/src/lib/utils.ts
@@ -51,9 +51,25 @@ function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
 
 /** Extracts the `sub` (user ID) claim from an access token. */
 export function getUserIdFromToken(accessToken: string | null): string | null {
-  if (!accessToken) return null;
-  const payload = decodeJwtPayload(accessToken);
-  return typeof payload?.sub === "string" ? payload.sub : null;
+  return getTokenClaims(accessToken).userId;
+}
+
+export interface TokenClaims {
+  userId: string | null;
+  email: string | null;
+  handle: string | null;
+  displayName: string | null;
+}
+
+/** Decodes all OSN claims from an access token in one pass. */
+export function getTokenClaims(accessToken: string | null): TokenClaims {
+  const payload = decodeJwtPayload(accessToken ?? "");
+  return {
+    userId: typeof payload?.sub === "string" ? payload.sub : null,
+    email: typeof payload?.email === "string" ? payload.email : null,
+    handle: typeof payload?.handle === "string" ? payload.handle : null,
+    displayName: typeof payload?.displayName === "string" ? payload.displayName : null,
+  };
 }
 
 /**
@@ -62,16 +78,14 @@ export function getUserIdFromToken(accessToken: string | null): string | null {
  */
 export function getDisplayNameFromToken(accessToken: string | null): string | null {
   if (!accessToken) return null;
-  const payload = decodeJwtPayload(accessToken);
-  if (typeof payload?.displayName === "string") return payload.displayName;
-  if (typeof payload?.handle === "string") return `@${payload.handle}`;
-  if (typeof payload?.email === "string") return payload.email.split("@")[0] ?? null;
+  const { displayName, handle, email } = getTokenClaims(accessToken);
+  if (displayName) return displayName;
+  if (handle) return `@${handle}`;
+  if (email) return email.split("@")[0] ?? null;
   return null;
 }
 
 /** Extracts the `handle` claim from an access token, without the @ sigil. */
 export function getHandleFromToken(accessToken: string | null): string | null {
-  if (!accessToken) return null;
-  const payload = decodeJwtPayload(accessToken);
-  return typeof payload?.handle === "string" ? payload.handle : null;
+  return getTokenClaims(accessToken).handle;
 }

--- a/apps/pulse/src/lib/utils.ts
+++ b/apps/pulse/src/lib/utils.ts
@@ -57,15 +57,21 @@ export function getUserIdFromToken(accessToken: string | null): string | null {
 }
 
 /**
- * Derives a display name from the `email` claim in an access token.
- * Uses the local-part of the email (before @) as a fallback until a
- * proper user profile endpoint is available.
+ * Derives a display name from an access token.
+ * Prefers the `displayName` claim, falls back to `@handle`, then to the email local-part.
  */
 export function getDisplayNameFromToken(accessToken: string | null): string | null {
   if (!accessToken) return null;
   const payload = decodeJwtPayload(accessToken);
-  if (typeof payload?.email === "string") {
-    return payload.email.split("@")[0] ?? null;
-  }
+  if (typeof payload?.displayName === "string") return payload.displayName;
+  if (typeof payload?.handle === "string") return `@${payload.handle}`;
+  if (typeof payload?.email === "string") return payload.email.split("@")[0] ?? null;
   return null;
+}
+
+/** Extracts the `handle` claim from an access token, without the @ sigil. */
+export function getHandleFromToken(accessToken: string | null): string | null {
+  if (!accessToken) return null;
+  const payload = decodeJwtPayload(accessToken);
+  return typeof payload?.handle === "string" ? payload.handle : null;
 }

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -24,14 +24,21 @@ const statusEnum = t.Optional(
 async function extractClaims(
   authHeader: string | undefined,
   secret: Uint8Array,
-): Promise<{ userId: string; email: string | null } | null> {
+): Promise<{
+  userId: string;
+  email: string | null;
+  handle: string | null;
+  displayName: string | null;
+} | null> {
   if (!authHeader?.startsWith("Bearer ")) return null;
   try {
     const { payload } = await jwtVerify(authHeader.slice(7), secret);
     const userId = typeof payload.sub === "string" ? payload.sub : null;
     if (!userId) return null;
     const email = typeof payload.email === "string" ? payload.email : null;
-    return { userId, email };
+    const handle = typeof payload.handle === "string" ? payload.handle : null;
+    const displayName = typeof payload.displayName === "string" ? payload.displayName : null;
+    return { userId, email, handle, displayName };
   } catch {
     return null;
   }
@@ -95,7 +102,10 @@ export const createEventsRoutes = (
         }
         const creator = {
           createdByUserId: claims.userId,
-          createdByName: claims.email ? (claims.email.split("@")[0] ?? null) : null,
+          createdByName:
+            claims.displayName ??
+            (claims.handle ? `@${claims.handle}` : null) ??
+            (claims.email ? (claims.email.split("@")[0] ?? null) : null),
           createdByAvatar: null,
         };
         const result = await Effect.runPromise(

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -25,6 +25,47 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
   return (
     new Elysia({ prefix: "" })
       // -------------------------------------------------------------------------
+      // Handle availability check
+      // -------------------------------------------------------------------------
+      .get(
+        "/handle/:handle",
+        async ({ params, set }) => {
+          try {
+            const result = await run(auth.checkHandle(params.handle));
+            return result;
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        {
+          params: t.Object({ handle: t.String() }),
+        },
+      )
+      // -------------------------------------------------------------------------
+      // Registration
+      // -------------------------------------------------------------------------
+      .post(
+        "/register",
+        async ({ body, set }) => {
+          try {
+            const user = await run(auth.registerUser(body.email, body.handle, body.displayName));
+            set.status = 201;
+            return { userId: user.id, handle: user.handle, email: user.email };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        {
+          body: t.Object({
+            email: t.String(),
+            handle: t.String(),
+            displayName: t.Optional(t.String()),
+          }),
+        },
+      )
+      // -------------------------------------------------------------------------
       // Authorization endpoint — renders the sign-in page
       // -------------------------------------------------------------------------
       .get(
@@ -105,10 +146,6 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
               return { error: "invalid_request" };
             }
 
-            // Verify PKCE if we have a stored entry
-            // For simplicity, we look up the pkce entry by trying all unexpired entries
-            // In production you'd associate code with the pkce entry directly
-            // Here we do a best-effort: if state provided, use it
             if (state) {
               const pkce = pkceStore.get(state);
               if (pkce) {
@@ -219,13 +256,13 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
         },
       )
       // -------------------------------------------------------------------------
-      // Passkey: begin login
+      // Passkey: begin login (identifier = email or handle)
       // -------------------------------------------------------------------------
       .post(
         "/passkey/login/begin",
         async ({ body, set }) => {
           try {
-            const result = await run(auth.beginPasskeyLogin(body.email));
+            const result = await run(auth.beginPasskeyLogin(body.identifier));
             return result;
           } catch (e) {
             set.status = 400;
@@ -233,17 +270,17 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
           }
         },
         {
-          body: t.Object({ email: t.String() }),
+          body: t.Object({ identifier: t.String() }),
         },
       )
       // -------------------------------------------------------------------------
-      // Passkey: complete login
+      // Passkey: complete login (identifier = email or handle)
       // -------------------------------------------------------------------------
       .post(
         "/passkey/login/complete",
         async ({ body, set }) => {
           try {
-            const result = await run(auth.completePasskeyLogin(body.email, body.assertion));
+            const result = await run(auth.completePasskeyLogin(body.identifier, body.assertion));
             return result;
           } catch (e) {
             set.status = 400;
@@ -252,19 +289,19 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
         },
         {
           body: t.Object({
-            email: t.String(),
+            identifier: t.String(),
             assertion: t.Any(),
           }),
         },
       )
       // -------------------------------------------------------------------------
-      // OTP: begin
+      // OTP: begin (identifier = email or handle)
       // -------------------------------------------------------------------------
       .post(
         "/otp/begin",
         async ({ body, set }) => {
           try {
-            const result = await run(auth.beginOtp(body.email));
+            const result = await run(auth.beginOtp(body.identifier));
             return result;
           } catch (e) {
             set.status = 400;
@@ -272,17 +309,17 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
           }
         },
         {
-          body: t.Object({ email: t.String() }),
+          body: t.Object({ identifier: t.String() }),
         },
       )
       // -------------------------------------------------------------------------
-      // OTP: complete
+      // OTP: complete (identifier = email or handle)
       // -------------------------------------------------------------------------
       .post(
         "/otp/complete",
         async ({ body, set }) => {
           try {
-            const result = await run(auth.completeOtp(body.email, body.code));
+            const result = await run(auth.completeOtp(body.identifier, body.code));
             return result;
           } catch (e) {
             set.status = 400;
@@ -290,17 +327,17 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
           }
         },
         {
-          body: t.Object({ email: t.String(), code: t.String() }),
+          body: t.Object({ identifier: t.String(), code: t.String() }),
         },
       )
       // -------------------------------------------------------------------------
-      // Magic link: begin
+      // Magic link: begin (identifier = email or handle)
       // -------------------------------------------------------------------------
       .post(
         "/magic/begin",
         async ({ body, set }) => {
           try {
-            const result = await run(auth.beginMagic(body.email));
+            const result = await run(auth.beginMagic(body.identifier));
             return result;
           } catch (e) {
             set.status = 400;
@@ -308,7 +345,7 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
           }
         },
         {
-          body: t.Object({ email: t.String() }),
+          body: t.Object({ identifier: t.String() }),
         },
       )
       // -------------------------------------------------------------------------

--- a/packages/core/src/services/auth.ts
+++ b/packages/core/src/services/auth.ts
@@ -131,10 +131,41 @@ const HandleSchema = Schema.String.pipe(
   }),
 );
 
-/** Returns true if the identifier looks like an email address. */
+/**
+ * Normalises an identifier by stripping a leading @ sigil.
+ * Users may type "@alice" meaning handle "alice"; this strips it before dispatch.
+ */
+function normaliseIdentifier(identifier: string): string {
+  return identifier.startsWith("@") ? identifier.slice(1) : identifier;
+}
+
+/** Returns true if the (already-normalised) identifier looks like an email address. */
 function looksLikeEmail(identifier: string): boolean {
   return identifier.includes("@");
 }
+
+const RESERVED_HANDLES = new Set([
+  "me",
+  "admin",
+  "api",
+  "support",
+  "help",
+  "osn",
+  "pulse",
+  "messaging",
+  "auth",
+  "login",
+  "logout",
+  "register",
+  "signup",
+  "signin",
+  "about",
+  "terms",
+  "privacy",
+  "status",
+  "null",
+  "undefined",
+]);
 
 // ---------------------------------------------------------------------------
 // Auth service factory
@@ -171,7 +202,7 @@ export function createAuthService(config: AuthConfig) {
     });
 
   /**
-   * Resolves an identifier (email or @handle) to a user.
+   * Resolves a (normalised) identifier to a user.
    * Identifiers containing "@" are treated as email addresses; all others as handles.
    */
   const resolveIdentifier = (identifier: string): Effect.Effect<User | null, DatabaseError, Db> =>
@@ -194,12 +225,17 @@ export function createAuthService(config: AuthConfig) {
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
 
-      const existingEmail = yield* findUserByEmail(email);
+      if (RESERVED_HANDLES.has(handle)) {
+        return yield* Effect.fail(new AuthError({ message: "Handle is reserved" }));
+      }
+
+      const [existingEmail, existingHandle] = yield* Effect.all(
+        [findUserByEmail(email), findUserByHandle(handle)],
+        { concurrency: "unbounded" },
+      );
       if (existingEmail) {
         return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
       }
-
-      const existingHandle = yield* findUserByHandle(handle);
       if (existingHandle) {
         return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
       }
@@ -230,6 +266,7 @@ export function createAuthService(config: AuthConfig) {
       yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
+      if (RESERVED_HANDLES.has(handle)) return { available: false };
       const existing = yield* findUserByHandle(handle);
       return { available: existing === null };
     });
@@ -486,9 +523,10 @@ export function createAuthService(config: AuthConfig) {
     Db
   > =>
     Effect.gen(function* () {
-      const user = yield* resolveIdentifier(identifier);
+      const normalised = normaliseIdentifier(identifier);
+      const user = yield* resolveIdentifier(normalised);
       if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
       }
 
       const { db } = yield* Db;
@@ -518,7 +556,9 @@ export function createAuthService(config: AuthConfig) {
         catch: (cause) => new AuthError({ message: String(cause) }),
       });
 
-      loginChallenges.set(user.email, {
+      // Key challenge by normalised identifier so completePasskeyLogin can
+      // check the in-memory guard before touching the DB.
+      loginChallenges.set(normalised, {
         challenge: options.challenge,
         expiresAt: Date.now() + 120_000,
       });
@@ -535,16 +575,18 @@ export function createAuthService(config: AuthConfig) {
     assertion: AuthenticationResponseJSON,
   ): Effect.Effect<{ code: string; userId: string }, AuthError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      const user = yield* resolveIdentifier(identifier);
-      if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "User not found" }));
-      }
-
-      const entry = loginChallenges.get(user.email);
+      // Check in-memory challenge guard before any DB lookup.
+      const normalised = normaliseIdentifier(identifier);
+      const entry = loginChallenges.get(normalised);
       if (!entry || Date.now() > entry.expiresAt) {
         return yield* Effect.fail(new AuthError({ message: "Challenge expired or not found" }));
       }
-      loginChallenges.delete(user.email);
+      loginChallenges.delete(normalised);
+
+      const user = yield* resolveIdentifier(normalised);
+      if (!user) {
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
+      }
 
       const { db } = yield* Db;
       const pkResult = yield* Effect.tryPromise({
@@ -601,26 +643,28 @@ export function createAuthService(config: AuthConfig) {
     identifier: string,
   ): Effect.Effect<{ sent: boolean }, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      if (looksLikeEmail(identifier)) {
-        yield* Schema.decodeUnknown(EmailSchema)(identifier).pipe(
+      const normalised = normaliseIdentifier(identifier);
+      if (looksLikeEmail(normalised)) {
+        yield* Schema.decodeUnknown(EmailSchema)(normalised).pipe(
           Effect.mapError((cause) => new ValidationError({ cause })),
         );
       } else {
-        yield* Schema.decodeUnknown(HandleSchema)(identifier).pipe(
+        yield* Schema.decodeUnknown(HandleSchema)(normalised).pipe(
           Effect.mapError((cause) => new ValidationError({ cause })),
         );
       }
 
-      const user = yield* resolveIdentifier(identifier);
+      const user = yield* resolveIdentifier(normalised);
       if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
       }
 
       const buf = new Uint32Array(1);
       crypto.getRandomValues(buf);
       const code = (100_000 + (buf[0] % 900_000)).toString();
 
-      otpStore.set(user.email, {
+      // Key by normalised identifier so completeOtp can check in-memory first.
+      otpStore.set(normalised, {
         code,
         userId: user.id,
         expiresAt: Date.now() + otpTtl * 1000,
@@ -650,21 +694,18 @@ export function createAuthService(config: AuthConfig) {
   const completeOtp = (
     identifier: string,
     code: string,
-  ): Effect.Effect<{ code: string; userId: string }, AuthError | DatabaseError, Db> =>
+  ): Effect.Effect<{ code: string; userId: string }, AuthError, Db> =>
     Effect.gen(function* () {
-      const user = yield* resolveIdentifier(identifier);
-      if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "No account found" }));
-      }
-
-      const entry = otpStore.get(user.email);
+      // Check in-memory store first — no DB hit on expired/invalid attempts.
+      const normalised = normaliseIdentifier(identifier);
+      const entry = otpStore.get(normalised);
       if (!entry || Date.now() > entry.expiresAt) {
-        return yield* Effect.fail(new AuthError({ message: "Code expired or not found" }));
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
       }
       if (entry.code !== code) {
-        return yield* Effect.fail(new AuthError({ message: "Invalid code" }));
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
       }
-      otpStore.delete(user.email);
+      otpStore.delete(normalised);
 
       const authCode = yield* issueCode(entry.userId);
       return { code: authCode, userId: entry.userId };
@@ -678,19 +719,20 @@ export function createAuthService(config: AuthConfig) {
     identifier: string,
   ): Effect.Effect<{ sent: boolean }, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      if (looksLikeEmail(identifier)) {
-        yield* Schema.decodeUnknown(EmailSchema)(identifier).pipe(
+      const normalised = normaliseIdentifier(identifier);
+      if (looksLikeEmail(normalised)) {
+        yield* Schema.decodeUnknown(EmailSchema)(normalised).pipe(
           Effect.mapError((cause) => new ValidationError({ cause })),
         );
       } else {
-        yield* Schema.decodeUnknown(HandleSchema)(identifier).pipe(
+        yield* Schema.decodeUnknown(HandleSchema)(normalised).pipe(
           Effect.mapError((cause) => new ValidationError({ cause })),
         );
       }
 
-      const user = yield* resolveIdentifier(identifier);
+      const user = yield* resolveIdentifier(normalised);
       if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+        return yield* Effect.fail(new AuthError({ message: "Invalid request" }));
       }
 
       const token = genId("mlnk_") + crypto.randomUUID().replace(/-/g, "");

--- a/packages/core/src/services/auth.ts
+++ b/packages/core/src/services/auth.ts
@@ -125,6 +125,17 @@ const EmailSchema = Schema.String.pipe(
   }),
 );
 
+const HandleSchema = Schema.String.pipe(
+  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
+    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
+  }),
+);
+
+/** Returns true if the identifier looks like an email address. */
+function looksLikeEmail(identifier: string): boolean {
+  return identifier.includes("@");
+}
+
 // ---------------------------------------------------------------------------
 // Auth service factory
 // ---------------------------------------------------------------------------
@@ -149,33 +160,97 @@ export function createAuthService(config: AuthConfig) {
       return result[0] ?? null;
     });
 
-  const upsertUser = (email: string): Effect.Effect<User, DatabaseError, Db> =>
+  const findUserByHandle = (handle: string): Effect.Effect<User | null, DatabaseError, Db> =>
     Effect.gen(function* () {
-      const existing = yield* findUserByEmail(email);
-      if (existing) return existing;
+      const { db } = yield* Db;
+      const result = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(eq(users.handle, handle)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      return result[0] ?? null;
+    });
+
+  /**
+   * Resolves an identifier (email or @handle) to a user.
+   * Identifiers containing "@" are treated as email addresses; all others as handles.
+   */
+  const resolveIdentifier = (identifier: string): Effect.Effect<User | null, DatabaseError, Db> =>
+    looksLikeEmail(identifier) ? findUserByEmail(identifier) : findUserByHandle(identifier);
+
+  /**
+   * Registers a new user. Fails if the email or handle is already taken.
+   * This is the only way to create a user — OTP/magic/passkey flows are login-only.
+   */
+  const registerUser = (
+    email: string,
+    handle: string,
+    displayName?: string,
+  ): Effect.Effect<User, AuthError | ValidationError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+
+      const existingEmail = yield* findUserByEmail(email);
+      if (existingEmail) {
+        return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
+      }
+
+      const existingHandle = yield* findUserByHandle(handle);
+      if (existingHandle) {
+        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+      }
+
       const { db } = yield* Db;
       const id = genId("usr_");
       const ts = now();
+      const dn = displayName ?? null;
+
       yield* Effect.tryPromise({
-        try: () => db.insert(users).values({ id, email, createdAt: ts, updatedAt: ts }),
+        try: () =>
+          db
+            .insert(users)
+            .values({ id, handle, email, displayName: dn, createdAt: ts, updatedAt: ts }),
         catch: (cause) => new DatabaseError({ cause }),
       });
-      return { id, email, displayName: null, avatarUrl: null, createdAt: ts, updatedAt: ts };
+
+      return { id, handle, email, displayName: dn, avatarUrl: null, createdAt: ts, updatedAt: ts };
+    });
+
+  /**
+   * Checks whether a handle is valid format and not yet taken.
+   */
+  const checkHandle = (
+    handle: string,
+  ): Effect.Effect<{ available: boolean }, ValidationError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+      const existing = yield* findUserByHandle(handle);
+      return { available: existing === null };
     });
 
   // -------------------------------------------------------------------------
   // Token issuance
   // -------------------------------------------------------------------------
 
-  const issueTokens = (userId: string, email: string) =>
+  const issueTokens = (userId: string, email: string, handle: string, displayName: string | null) =>
     Effect.tryPromise({
       try: async () => {
+        const payload: Record<string, unknown> = {
+          sub: userId,
+          email,
+          handle,
+          scope: "openid profile",
+        };
+        if (displayName !== null) payload["displayName"] = displayName;
+
         const [accessToken, refreshToken] = await Promise.all([
-          signJwt(
-            { sub: userId, email, scope: "openid profile" },
-            config.jwtSecret,
-            accessTokenTtl,
-          ),
+          signJwt(payload, config.jwtSecret, accessTokenTtl),
           signJwt({ sub: userId, type: "refresh" }, config.jwtSecret, refreshTokenTtl),
         ]);
         return { accessToken, refreshToken, expiresIn: accessTokenTtl };
@@ -222,7 +297,7 @@ export function createAuthService(config: AuthConfig) {
       if (!user) {
         return yield* Effect.fail(new AuthError({ message: "User not found" }));
       }
-      return yield* issueTokens(userId, user.email);
+      return yield* issueTokens(userId, user.email, user.handle, user.displayName);
     });
 
   // -------------------------------------------------------------------------
@@ -254,7 +329,7 @@ export function createAuthService(config: AuthConfig) {
       if (!user) {
         return yield* Effect.fail(new AuthError({ message: "User not found" }));
       }
-      return yield* issueTokens(userId, user.email);
+      return yield* issueTokens(userId, user.email, user.handle, user.displayName);
     });
 
   // -------------------------------------------------------------------------
@@ -263,16 +338,28 @@ export function createAuthService(config: AuthConfig) {
 
   const verifyAccessToken = (
     token: string,
-  ): Effect.Effect<{ userId: string; email: string }, AuthError> =>
+  ): Effect.Effect<
+    { userId: string; email: string; handle: string; displayName: string | null },
+    AuthError
+  > =>
     Effect.gen(function* () {
       const payload = yield* Effect.tryPromise({
         try: () => verifyJwt(token, config.jwtSecret),
         catch: () => new AuthError({ message: "Invalid or expired access token" }),
       });
-      if (typeof payload["sub"] !== "string" || typeof payload["email"] !== "string") {
+      if (
+        typeof payload["sub"] !== "string" ||
+        typeof payload["email"] !== "string" ||
+        typeof payload["handle"] !== "string"
+      ) {
         return yield* Effect.fail(new AuthError({ message: "Invalid token claims" }));
       }
-      return { userId: payload["sub"], email: payload["email"] };
+      return {
+        userId: payload["sub"],
+        email: payload["email"],
+        handle: payload["handle"],
+        displayName: typeof payload["displayName"] === "string" ? payload["displayName"] : null,
+      };
     });
 
   // -------------------------------------------------------------------------
@@ -308,8 +395,8 @@ export function createAuthService(config: AuthConfig) {
             rpName: config.rpName,
             rpID: config.rpId,
             userID: new TextEncoder().encode(userId),
-            userName: user.email,
-            userDisplayName: user.email,
+            userName: `@${user.handle}`,
+            userDisplayName: user.displayName ?? `@${user.handle}`,
             attestationType: "none",
             excludeCredentials: existingPasskeys.map((pk) => ({
               id: pk.credentialId,
@@ -392,16 +479,16 @@ export function createAuthService(config: AuthConfig) {
   // -------------------------------------------------------------------------
 
   const beginPasskeyLogin = (
-    email: string,
+    identifier: string,
   ): Effect.Effect<
     { options: PublicKeyCredentialRequestOptionsJSON },
     AuthError | DatabaseError,
     Db
   > =>
     Effect.gen(function* () {
-      const user = yield* findUserByEmail(email);
+      const user = yield* resolveIdentifier(identifier);
       if (!user) {
-        return yield* Effect.fail(new AuthError({ message: "No account found for this email" }));
+        return yield* Effect.fail(new AuthError({ message: "No account found" }));
       }
 
       const { db } = yield* Db;
@@ -431,7 +518,7 @@ export function createAuthService(config: AuthConfig) {
         catch: (cause) => new AuthError({ message: String(cause) }),
       });
 
-      loginChallenges.set(email, {
+      loginChallenges.set(user.email, {
         challenge: options.challenge,
         expiresAt: Date.now() + 120_000,
       });
@@ -444,20 +531,20 @@ export function createAuthService(config: AuthConfig) {
   // -------------------------------------------------------------------------
 
   const completePasskeyLogin = (
-    email: string,
+    identifier: string,
     assertion: AuthenticationResponseJSON,
   ): Effect.Effect<{ code: string; userId: string }, AuthError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      const entry = loginChallenges.get(email);
-      if (!entry || Date.now() > entry.expiresAt) {
-        return yield* Effect.fail(new AuthError({ message: "Challenge expired or not found" }));
-      }
-      loginChallenges.delete(email);
-
-      const user = yield* findUserByEmail(email);
+      const user = yield* resolveIdentifier(identifier);
       if (!user) {
         return yield* Effect.fail(new AuthError({ message: "User not found" }));
       }
+
+      const entry = loginChallenges.get(user.email);
+      if (!entry || Date.now() > entry.expiresAt) {
+        return yield* Effect.fail(new AuthError({ message: "Challenge expired or not found" }));
+      }
+      loginChallenges.delete(user.email);
 
       const { db } = yield* Db;
       const pkResult = yield* Effect.tryPromise({
@@ -493,7 +580,6 @@ export function createAuthService(config: AuthConfig) {
         return yield* Effect.fail(new AuthError({ message: "Passkey verification failed" }));
       }
 
-      // Update counter
       yield* Effect.tryPromise({
         try: () =>
           db
@@ -508,23 +594,33 @@ export function createAuthService(config: AuthConfig) {
     });
 
   // -------------------------------------------------------------------------
-  // OTP: begin
+  // OTP: begin (login only — user must already be registered)
   // -------------------------------------------------------------------------
 
   const beginOtp = (
-    email: string,
+    identifier: string,
   ): Effect.Effect<{ sent: boolean }, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
-        Effect.mapError((cause) => new ValidationError({ cause })),
-      );
+      if (looksLikeEmail(identifier)) {
+        yield* Schema.decodeUnknown(EmailSchema)(identifier).pipe(
+          Effect.mapError((cause) => new ValidationError({ cause })),
+        );
+      } else {
+        yield* Schema.decodeUnknown(HandleSchema)(identifier).pipe(
+          Effect.mapError((cause) => new ValidationError({ cause })),
+        );
+      }
 
-      const user = yield* upsertUser(email);
+      const user = yield* resolveIdentifier(identifier);
+      if (!user) {
+        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+      }
+
       const buf = new Uint32Array(1);
       crypto.getRandomValues(buf);
       const code = (100_000 + (buf[0] % 900_000)).toString();
 
-      otpStore.set(email, {
+      otpStore.set(user.email, {
         code,
         userId: user.id,
         expiresAt: Date.now() + otpTtl * 1000,
@@ -534,14 +630,14 @@ export function createAuthService(config: AuthConfig) {
         yield* Effect.tryPromise({
           try: () =>
             config.sendEmail!(
-              email,
+              user.email,
               "Your OSN sign-in code",
               `Your one-time sign-in code is: ${code}\n\nThis code expires in ${otpTtl / 60} minutes.`,
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
       } else {
-        console.log(`[OSN dev] OTP for ${email}: ${code}`);
+        console.log(`[OSN dev] OTP for ${user.email}: ${code}`);
       }
 
       return { sent: true };
@@ -552,36 +648,51 @@ export function createAuthService(config: AuthConfig) {
   // -------------------------------------------------------------------------
 
   const completeOtp = (
-    email: string,
+    identifier: string,
     code: string,
-  ): Effect.Effect<{ code: string; userId: string }, AuthError, Db> =>
+  ): Effect.Effect<{ code: string; userId: string }, AuthError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      const entry = otpStore.get(email);
+      const user = yield* resolveIdentifier(identifier);
+      if (!user) {
+        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+      }
+
+      const entry = otpStore.get(user.email);
       if (!entry || Date.now() > entry.expiresAt) {
         return yield* Effect.fail(new AuthError({ message: "Code expired or not found" }));
       }
       if (entry.code !== code) {
         return yield* Effect.fail(new AuthError({ message: "Invalid code" }));
       }
-      otpStore.delete(email);
+      otpStore.delete(user.email);
 
       const authCode = yield* issueCode(entry.userId);
       return { code: authCode, userId: entry.userId };
     });
 
   // -------------------------------------------------------------------------
-  // Magic link: begin
+  // Magic link: begin (login only — user must already be registered)
   // -------------------------------------------------------------------------
 
   const beginMagic = (
-    email: string,
+    identifier: string,
   ): Effect.Effect<{ sent: boolean }, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
-        Effect.mapError((cause) => new ValidationError({ cause })),
-      );
+      if (looksLikeEmail(identifier)) {
+        yield* Schema.decodeUnknown(EmailSchema)(identifier).pipe(
+          Effect.mapError((cause) => new ValidationError({ cause })),
+        );
+      } else {
+        yield* Schema.decodeUnknown(HandleSchema)(identifier).pipe(
+          Effect.mapError((cause) => new ValidationError({ cause })),
+        );
+      }
 
-      const user = yield* upsertUser(email);
+      const user = yield* resolveIdentifier(identifier);
+      if (!user) {
+        return yield* Effect.fail(new AuthError({ message: "No account found" }));
+      }
+
       const token = genId("mlnk_") + crypto.randomUUID().replace(/-/g, "");
 
       magicStore.set(token, {
@@ -596,14 +707,14 @@ export function createAuthService(config: AuthConfig) {
         yield* Effect.tryPromise({
           try: () =>
             config.sendEmail!(
-              email,
+              user.email,
               "Your OSN magic sign-in link",
               `Click this link to sign in: ${magicUrl}\n\nThis link expires in ${magicTtl / 60} minutes.`,
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
       } else {
-        console.log(`[OSN dev] Magic link for ${email}: ${magicUrl}`);
+        console.log(`[OSN dev] Magic link for ${user.email}: ${magicUrl}`);
       }
 
       return { sent: true };
@@ -634,7 +745,10 @@ export function createAuthService(config: AuthConfig) {
 
   return {
     findUserByEmail,
-    upsertUser,
+    findUserByHandle,
+    resolveIdentifier,
+    registerUser,
+    checkHandle,
     issueTokens,
     exchangeCode,
     refreshTokens,

--- a/packages/core/tests/helpers/db.ts
+++ b/packages/core/tests/helpers/db.ts
@@ -9,6 +9,7 @@ export function createTestLayer() {
   sqlite.run(`
     CREATE TABLE users (
       id TEXT PRIMARY KEY,
+      handle TEXT NOT NULL UNIQUE,
       email TEXT NOT NULL UNIQUE,
       display_name TEXT,
       avatar_url TEXT,

--- a/packages/core/tests/routes/auth.test.ts
+++ b/packages/core/tests/routes/auth.test.ts
@@ -21,6 +21,111 @@ describe("auth routes", () => {
     app = createAuthRoutes(config, layer);
   });
 
+  // -------------------------------------------------------------------------
+  // Registration
+  // -------------------------------------------------------------------------
+  describe("POST /register", () => {
+    it("creates a user and returns 201", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "alice@example.com",
+            handle: "alice",
+            displayName: "Alice",
+          }),
+        }),
+      );
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as { userId: string; handle: string; email: string };
+      expect(json.handle).toBe("alice");
+      expect(json.email).toBe("alice@example.com");
+      expect(json.userId).toMatch(/^usr_/);
+    });
+
+    it("returns 400 for duplicate email", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "bob@example.com", handle: "bob" }),
+        }),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "bob@example.com", handle: "bob2" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for duplicate handle", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "carol@example.com", handle: "carol" }),
+        }),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "carol2@example.com", handle: "carol" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid handle format", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "dan@example.com", handle: "Dan!" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Handle availability
+  // -------------------------------------------------------------------------
+  describe("GET /handle/:handle", () => {
+    it("returns available:true for a free handle", async () => {
+      const res = await app.handle(new Request("http://localhost/handle/freehandle"));
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { available: boolean };
+      expect(json.available).toBe(true);
+    });
+
+    it("returns available:false for a taken handle", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "eve@example.com", handle: "eve" }),
+        }),
+      );
+      const res = await app.handle(new Request("http://localhost/handle/eve"));
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { available: boolean };
+      expect(json.available).toBe(false);
+    });
+
+    it("returns 400 for invalid handle format", async () => {
+      const res = await app.handle(new Request("http://localhost/handle/INVALID%21"));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
   describe("GET /authorize", () => {
     it("returns 400 for unsupported response_type", async () => {
       const res = await app.handle(
@@ -43,6 +148,9 @@ describe("auth routes", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Token endpoint
+  // -------------------------------------------------------------------------
   describe("POST /token", () => {
     it("returns 400 for unsupported grant_type", async () => {
       const res = await app.handle(
@@ -57,19 +165,8 @@ describe("auth routes", () => {
       expect(json.error).toBe("unsupported_grant_type");
     });
 
-    it("returns 400 for invalid authorization_code grant (missing params)", async () => {
-      const res = await app.handle(
-        new Request("http://localhost/token", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ grant_type: "authorization_code" }),
-        }),
-      );
-      expect(res.status).toBe(400);
-    });
-
     it("returns tokens for a valid authorization_code grant", async () => {
-      // Use OTP flow to obtain a real auth code, then exchange it via the route
+      // Register then obtain a real auth code via OTP flow
       let capturedOtp: string | undefined;
       const authHelper = createAuthService({
         ...config,
@@ -78,6 +175,9 @@ describe("auth routes", () => {
           if (m) capturedOtp = m[1];
         },
       });
+      await Effect.runPromise(
+        authHelper.registerUser("judy@example.com", "judy").pipe(Effect.provide(layer)),
+      );
       await Effect.runPromise(authHelper.beginOtp("judy@example.com").pipe(Effect.provide(layer)));
       const { code } = await Effect.runPromise(
         authHelper.completeOtp("judy@example.com", capturedOtp!).pipe(Effect.provide(layer)),
@@ -110,13 +210,23 @@ describe("auth routes", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // OTP
+  // -------------------------------------------------------------------------
   describe("POST /otp/begin", () => {
-    it("returns sent:true for valid email", async () => {
+    it("returns sent:true when user exists (email identifier)", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "kate@example.com", handle: "kate" }),
+        }),
+      );
       const res = await app.handle(
         new Request("http://localhost/otp/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "kate@example.com" }),
+          body: JSON.stringify({ identifier: "kate@example.com" }),
         }),
       );
       expect(res.status).toBe(200);
@@ -124,12 +234,32 @@ describe("auth routes", () => {
       expect(json.sent).toBe(true);
     });
 
-    it("returns 400 for invalid email", async () => {
+    it("returns sent:true when user exists (handle identifier)", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "lars@example.com", handle: "lars" }),
+        }),
+      );
       const res = await app.handle(
         new Request("http://localhost/otp/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "not-an-email" }),
+          body: JSON.stringify({ identifier: "lars" }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { sent: boolean };
+      expect(json.sent).toBe(true);
+    });
+
+    it("returns 400 when user does not exist", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/otp/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identifier: "ghost@example.com" }),
         }),
       );
       expect(res.status).toBe(400);
@@ -138,38 +268,64 @@ describe("auth routes", () => {
 
   describe("POST /otp/complete", () => {
     it("returns 400 for wrong OTP code", async () => {
-      // Start an OTP
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "liam@example.com", handle: "liam" }),
+        }),
+      );
       await app.handle(
         new Request("http://localhost/otp/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "liam@example.com" }),
+          body: JSON.stringify({ identifier: "liam@example.com" }),
         }),
       );
-
       const res = await app.handle(
         new Request("http://localhost/otp/complete", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "liam@example.com", code: "000000" }),
+          body: JSON.stringify({ identifier: "liam@example.com", code: "000000" }),
         }),
       );
       expect(res.status).toBe(400);
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Magic link
+  // -------------------------------------------------------------------------
   describe("POST /magic/begin", () => {
-    it("returns sent:true for valid email", async () => {
+    it("returns sent:true for existing user", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "mia@example.com", handle: "mia" }),
+        }),
+      );
       const res = await app.handle(
         new Request("http://localhost/magic/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "mia@example.com" }),
+          body: JSON.stringify({ identifier: "mia@example.com" }),
         }),
       );
       expect(res.status).toBe(200);
       const json = (await res.json()) as { sent: boolean };
       expect(json.sent).toBe(true);
+    });
+
+    it("returns 400 for non-existent user", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/magic/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identifier: "ghost@example.com" }),
+        }),
+      );
+      expect(res.status).toBe(400);
     });
   });
 
@@ -184,6 +340,11 @@ describe("auth routes", () => {
         },
       });
       await Effect.runPromise(
+        authHelper
+          .registerUser("magic-route@example.com", "magicroute")
+          .pipe(Effect.provide(layer)),
+      );
+      await Effect.runPromise(
         authHelper.beginMagic("magic-route@example.com").pipe(Effect.provide(layer)),
       );
 
@@ -193,8 +354,6 @@ describe("auth routes", () => {
           `http://localhost/magic/verify?token=${capturedToken}&redirect_uri=${encodedRedirect}&state=abc123`,
         ),
       );
-      // Elysia sets status 302; Location header may not be readable via app.handle()
-      // so we confirm the redirect is issued and the route succeeded
       expect(res.status).toBe(302);
     });
 
@@ -209,11 +368,13 @@ describe("auth routes", () => {
 
     it("returns 422 when required query params are missing", async () => {
       const res = await app.handle(new Request("http://localhost/magic/verify?token=something"));
-      // Elysia TypeBox validation returns 422 for missing required params
       expect(res.status).toBe(422);
     });
   });
 
+  // -------------------------------------------------------------------------
+  // OIDC discovery
+  // -------------------------------------------------------------------------
   describe("GET /.well-known/openid-configuration", () => {
     it("returns OIDC discovery document", async () => {
       const res = await app.handle(
@@ -231,17 +392,37 @@ describe("auth routes", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Passkey login
+  // -------------------------------------------------------------------------
   describe("POST /passkey/login/begin", () => {
-    it("returns 400 when user has no passkeys", async () => {
-      // Create a user but don't register a passkey
+    it("returns 400 when user has no passkeys (by email)", async () => {
       const auth = createAuthService(config);
-      await Effect.runPromise(auth.upsertUser("noah@example.com").pipe(Effect.provide(layer)));
+      await Effect.runPromise(
+        auth.registerUser("noah@example.com", "noah").pipe(Effect.provide(layer)),
+      );
 
       const res = await app.handle(
         new Request("http://localhost/passkey/login/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "noah@example.com" }),
+          body: JSON.stringify({ identifier: "noah@example.com" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when user has no passkeys (by handle)", async () => {
+      const auth = createAuthService(config);
+      await Effect.runPromise(
+        auth.registerUser("olivia@example.com", "olivia").pipe(Effect.provide(layer)),
+      );
+
+      const res = await app.handle(
+        new Request("http://localhost/passkey/login/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identifier: "olivia" }),
         }),
       );
       expect(res.status).toBe(400);
@@ -252,7 +433,7 @@ describe("auth routes", () => {
         new Request("http://localhost/passkey/login/begin", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "nobody@example.com" }),
+          body: JSON.stringify({ identifier: "nobody@example.com" }),
         }),
       );
       expect(res.status).toBe(400);

--- a/packages/core/tests/services/auth.test.ts
+++ b/packages/core/tests/services/auth.test.ts
@@ -209,7 +209,6 @@ describe("OTP flow", () => {
     Effect.gen(function* () {
       const error = yield* Effect.flip(auth.beginOtp("ghost@example.com"));
       expect(error._tag).toBe("AuthError");
-      expect(error.message).toContain("No account found");
     }).pipe(Effect.provide(createTestLayer())),
   );
 

--- a/packages/core/tests/services/auth.test.ts
+++ b/packages/core/tests/services/auth.test.ts
@@ -13,57 +13,130 @@ const config = {
 
 const auth = createAuthService(config);
 
-describe("upsertUser", () => {
-  it.effect("creates a new user with usr_ prefix", () =>
+describe("registerUser", () => {
+  it.effect("creates a new user with usr_ prefix and correct fields", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("alice@example.com");
+      const user = yield* auth.registerUser("alice@example.com", "alice", "Alice");
       expect(user.id).toMatch(/^usr_/);
       expect(user.email).toBe("alice@example.com");
+      expect(user.handle).toBe("alice");
+      expect(user.displayName).toBe("Alice");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("returns the existing user on subsequent calls", () =>
+  it.effect("creates user without displayName", () =>
     Effect.gen(function* () {
-      const first = yield* auth.upsertUser("bob@example.com");
-      const second = yield* auth.upsertUser("bob@example.com");
-      expect(first.id).toBe(second.id);
+      const user = yield* auth.registerUser("bob@example.com", "bob");
+      expect(user.handle).toBe("bob");
+      expect(user.displayName).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if email already registered", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("carol@example.com", "carol");
+      const error = yield* Effect.flip(auth.registerUser("carol@example.com", "carol2"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Email already registered");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if handle already taken", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("dan@example.com", "dan");
+      const error = yield* Effect.flip(auth.registerUser("dan2@example.com", "dan"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid email format", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.registerUser("not-an-email", "myhandle"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid handle format (uppercase)", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.registerUser("eve@example.com", "Eve"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid handle format (too long)", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.registerUser("frank@example.com", "a".repeat(31)));
+      expect(error._tag).toBe("ValidationError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });
 
-describe("findUserByEmail", () => {
-  it.effect("returns null when user does not exist", () =>
+describe("checkHandle", () => {
+  it.effect("returns available:true for a free handle", () =>
     Effect.gen(function* () {
-      const result = yield* auth.findUserByEmail("nobody@example.com");
-      expect(result).toBeNull();
+      const result = yield* auth.checkHandle("freehandle");
+      expect(result.available).toBe(true);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("returns the user after insertion", () =>
+  it.effect("returns available:false for a taken handle", () =>
     Effect.gen(function* () {
-      yield* auth.upsertUser("carol@example.com");
-      const result = yield* auth.findUserByEmail("carol@example.com");
-      expect(result).not.toBeNull();
-      expect(result!.email).toBe("carol@example.com");
+      yield* auth.registerUser("grace@example.com", "grace");
+      const result = yield* auth.checkHandle("grace");
+      expect(result.available).toBe(false);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with ValidationError for invalid format", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.checkHandle("INVALID!"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("findUserByEmail + findUserByHandle", () => {
+  it.effect("returns null when user does not exist", () =>
+    Effect.gen(function* () {
+      const byEmail = yield* auth.findUserByEmail("nobody@example.com");
+      const byHandle = yield* auth.findUserByHandle("nobody");
+      expect(byEmail).toBeNull();
+      expect(byHandle).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("finds user by email and by handle", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("heidi@example.com", "heidi");
+      const byEmail = yield* auth.findUserByEmail("heidi@example.com");
+      const byHandle = yield* auth.findUserByHandle("heidi");
+      expect(byEmail).not.toBeNull();
+      expect(byHandle).not.toBeNull();
+      expect(byEmail!.id).toBe(byHandle!.id);
     }).pipe(Effect.provide(createTestLayer())),
   );
 });
 
 describe("issueTokens + exchangeCode", () => {
-  it.effect("issueTokens returns access + refresh tokens with correct shape", () =>
+  it.effect("issueTokens returns access + refresh tokens with handle in payload", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("dan@example.com");
-      const tokens = yield* auth.issueTokens(user.id, user.email);
+      const user = yield* auth.registerUser("ivan@example.com", "ivan", "Ivan");
+      const tokens = yield* auth.issueTokens(user.id, user.email, user.handle, user.displayName);
       expect(tokens.accessToken).toBeTruthy();
       expect(tokens.refreshToken).toBeTruthy();
       expect(tokens.expiresIn).toBe(3600);
+
+      // Verify claims include handle and displayName
+      const claims = yield* auth.verifyAccessToken(tokens.accessToken);
+      expect(claims.handle).toBe("ivan");
+      expect(claims.displayName).toBe("Ivan");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
   it.effect("exchangeCode returns tokens for a valid auth code", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("dan-exchange@example.com");
-      // Get a real code via completeOtp
+      const user = yield* auth.registerUser("judy@example.com", "judy");
       let capturedCode: string | undefined;
       const authSpy = createAuthService({
         ...config,
@@ -72,15 +145,13 @@ describe("issueTokens + exchangeCode", () => {
           if (m) capturedCode = m[1];
         },
       });
-      yield* authSpy.beginOtp("dan-exchange@example.com");
-      const { code } = yield* authSpy.completeOtp("dan-exchange@example.com", capturedCode!);
+      yield* authSpy.beginOtp("judy@example.com");
+      const { code } = yield* authSpy.completeOtp("judy@example.com", capturedCode!);
       const tokens = yield* auth.exchangeCode(code);
       expect(tokens.accessToken).toBeTruthy();
-      expect(tokens.refreshToken).toBeTruthy();
-      expect(tokens.expiresIn).toBe(3600);
-      // Access token should be verifiable
       const claims = yield* auth.verifyAccessToken(tokens.accessToken);
       expect(claims.userId).toBe(user.id);
+      expect(claims.handle).toBe("judy");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -93,8 +164,9 @@ describe("issueTokens + exchangeCode", () => {
 });
 
 describe("OTP flow", () => {
-  it.effect("beginOtp + completeOtp issues a code", () =>
+  it.effect("beginOtp + completeOtp via email identifier issues a code", () =>
     Effect.gen(function* () {
+      yield* auth.registerUser("kate@example.com", "kate");
       let capturedCode: string | undefined;
       const authWithSpy = createAuthService({
         ...config,
@@ -104,32 +176,69 @@ describe("OTP flow", () => {
         },
       });
 
-      yield* authWithSpy.beginOtp("eve@example.com");
+      yield* authWithSpy.beginOtp("kate@example.com");
       expect(capturedCode).toMatch(/^\d{6}$/);
 
-      const result = yield* authWithSpy.completeOtp("eve@example.com", capturedCode!);
+      const result = yield* authWithSpy.completeOtp("kate@example.com", capturedCode!);
       expect(result.code).toBeTruthy();
       expect(result.userId).toMatch(/^usr_/);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("beginOtp + completeOtp via handle identifier issues a code", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("liam@example.com", "liam");
+      let capturedCode: string | undefined;
+      const authWithSpy = createAuthService({
+        ...config,
+        sendEmail: async (_to, _subject, body) => {
+          const match = body.match(/code is: (\d{6})/);
+          if (match) capturedCode = match[1];
+        },
+      });
+
+      yield* authWithSpy.beginOtp("liam"); // handle, not email
+      expect(capturedCode).toMatch(/^\d{6}$/);
+
+      const result = yield* authWithSpy.completeOtp("liam", capturedCode!);
+      expect(result.code).toBeTruthy();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("beginOtp fails when user does not exist", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.beginOtp("ghost@example.com"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("No account found");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("completeOtp fails with wrong code", () =>
     Effect.gen(function* () {
-      yield* auth.beginOtp("frank@example.com");
-      const error = yield* Effect.flip(auth.completeOtp("frank@example.com", "000000"));
+      yield* auth.registerUser("mia@example.com", "mia");
+      yield* auth.beginOtp("mia@example.com");
+      const error = yield* Effect.flip(auth.completeOtp("mia@example.com", "000000"));
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("beginOtp fails with invalid email", () =>
+  it.effect("beginOtp fails with invalid email format", () =>
     Effect.gen(function* () {
-      const error = yield* Effect.flip(auth.beginOtp("not-an-email"));
+      const error = yield* Effect.flip(auth.beginOtp("not-an-email@"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("beginOtp fails with invalid handle format", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.beginOtp("INVALID!"));
       expect(error._tag).toBe("ValidationError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
   it.effect("second beginOtp overwrites the first code", () =>
     Effect.gen(function* () {
+      yield* auth.registerUser("noah@example.com", "noah");
       let firstCode: string | undefined;
       let callCount = 0;
       const authSpy = createAuthService({
@@ -142,23 +251,22 @@ describe("OTP flow", () => {
           }
         },
       });
-      yield* authSpy.beginOtp("overwrite@example.com");
-      yield* authSpy.beginOtp("overwrite@example.com");
-      // The first code is no longer valid — the store was overwritten
-      const error = yield* Effect.flip(authSpy.completeOtp("overwrite@example.com", firstCode!));
+      yield* authSpy.beginOtp("noah@example.com");
+      yield* authSpy.beginOtp("noah@example.com");
+      const error = yield* Effect.flip(authSpy.completeOtp("noah@example.com", firstCode!));
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });
 
 describe("passkey registration", () => {
-  it.effect("beginPasskeyRegistration returns options for an existing user", () =>
+  it.effect("beginPasskeyRegistration returns options with @handle as userName", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("passkey-reg@example.com");
+      const user = yield* auth.registerUser("passkey@example.com", "passkeyuser");
       const result = yield* auth.beginPasskeyRegistration(user.id);
       expect(result.options).toBeTruthy();
       expect(result.options.challenge).toBeTruthy();
-      expect(result.options.user.name).toBe("passkey-reg@example.com");
+      expect(result.options.user.name).toBe("@passkeyuser");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -171,8 +279,9 @@ describe("passkey registration", () => {
 });
 
 describe("magic link flow", () => {
-  it.effect("beginMagic + verifyMagic redirects correctly", () =>
+  it.effect("beginMagic + verifyMagic via email redirects correctly", () =>
     Effect.gen(function* () {
+      yield* auth.registerUser("oliver@example.com", "oliver");
       let capturedToken: string | undefined;
       const authWithSpy = createAuthService({
         ...config,
@@ -182,7 +291,7 @@ describe("magic link flow", () => {
         },
       });
 
-      yield* authWithSpy.beginMagic("grace@example.com");
+      yield* authWithSpy.beginMagic("oliver@example.com");
       expect(capturedToken).toBeTruthy();
 
       const result = yield* authWithSpy.verifyMagic(
@@ -195,6 +304,29 @@ describe("magic link flow", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("beginMagic via handle finds and emails the user", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("petra@example.com", "petra");
+      let emailedTo: string | undefined;
+      const authWithSpy = createAuthService({
+        ...config,
+        sendEmail: async (to) => {
+          emailedTo = to;
+        },
+      });
+
+      yield* authWithSpy.beginMagic("petra"); // handle
+      expect(emailedTo).toBe("petra@example.com");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("beginMagic fails when user does not exist", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.beginMagic("ghost@example.com"));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("verifyMagic fails with unknown token", () =>
     Effect.gen(function* () {
       const error = yield* Effect.flip(
@@ -203,20 +335,13 @@ describe("magic link flow", () => {
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );
-
-  it.effect("beginMagic fails with invalid email", () =>
-    Effect.gen(function* () {
-      const error = yield* Effect.flip(auth.beginMagic("not-an-email"));
-      expect(error._tag).toBe("ValidationError");
-    }).pipe(Effect.provide(createTestLayer())),
-  );
 });
 
 describe("token refresh", () => {
   it.effect("refreshTokens issues new tokens from a valid refresh token", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("heidi@example.com");
-      const tokens = yield* auth.issueTokens(user.id, user.email);
+      const user = yield* auth.registerUser("quinn@example.com", "quinn");
+      const tokens = yield* auth.issueTokens(user.id, user.email, user.handle, user.displayName);
       const refreshed = yield* auth.refreshTokens(tokens.refreshToken);
       expect(refreshed.accessToken).toBeTruthy();
       expect(refreshed.expiresIn).toBe(3600);
@@ -232,13 +357,24 @@ describe("token refresh", () => {
 });
 
 describe("verifyAccessToken", () => {
-  it.effect("verifies a valid access token", () =>
+  it.effect("verifies a valid access token and returns all claims", () =>
     Effect.gen(function* () {
-      const user = yield* auth.upsertUser("ivan@example.com");
-      const tokens = yield* auth.issueTokens(user.id, user.email);
+      const user = yield* auth.registerUser("rose@example.com", "rose", "Rose");
+      const tokens = yield* auth.issueTokens(user.id, user.email, user.handle, user.displayName);
       const claims = yield* auth.verifyAccessToken(tokens.accessToken);
       expect(claims.userId).toBe(user.id);
-      expect(claims.email).toBe("ivan@example.com");
+      expect(claims.email).toBe("rose@example.com");
+      expect(claims.handle).toBe("rose");
+      expect(claims.displayName).toBe("Rose");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("displayName is null when not set", () =>
+    Effect.gen(function* () {
+      const user = yield* auth.registerUser("sam@example.com", "sam");
+      const tokens = yield* auth.issueTokens(user.id, user.email, user.handle, user.displayName);
+      const claims = yield* auth.verifyAccessToken(tokens.accessToken);
+      expect(claims.displayName).toBeNull();
     }).pipe(Effect.provide(createTestLayer())),
   );
 

--- a/packages/osn-db/drizzle/0002_add_user_handle.sql
+++ b/packages/osn-db/drizzle/0002_add_user_handle.sql
@@ -18,5 +18,4 @@ ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE UNIQUE INDEX `users_handle_unique` ON `users` (`handle`);--> statement-breakpoint
 CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);--> statement-breakpoint
-CREATE INDEX `users_email_idx` ON `users` (`email`);--> statement-breakpoint
-CREATE INDEX `users_handle_idx` ON `users` (`handle`);
+CREATE INDEX `users_email_idx` ON `users` (`email`);

--- a/packages/osn-db/drizzle/0002_add_user_handle.sql
+++ b/packages/osn-db/drizzle/0002_add_user_handle.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`handle` text NOT NULL,
+	`email` text NOT NULL,
+	`display_name` text,
+	`avatar_url` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_users`(`id`, `handle`, `email`, `display_name`, `avatar_url`, `created_at`, `updated_at`)
+	SELECT `id`, COALESCE(`handle`, 'usr_' || substr(`id`, 5)), `email`, `display_name`, `avatar_url`, `created_at`, `updated_at`
+	FROM `users`;
+--> statement-breakpoint
+DROP TABLE `users`;--> statement-breakpoint
+ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_handle_unique` ON `users` (`handle`);--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);--> statement-breakpoint
+CREATE INDEX `users_email_idx` ON `users` (`email`);--> statement-breakpoint
+CREATE INDEX `users_handle_idx` ON `users` (`handle`);

--- a/packages/osn-db/drizzle/meta/_journal.json
+++ b/packages/osn-db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775050483600,
       "tag": "0001_pink_invisible_woman",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1743724800000,
+      "tag": "0002_add_user_handle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/osn-db/src/schema/index.ts
+++ b/packages/osn-db/src/schema/index.ts
@@ -4,13 +4,14 @@ export const users = sqliteTable(
   "users",
   {
     id: text("id").primaryKey(), // "usr_" prefix
+    handle: text("handle").notNull().unique(), // @handle — immutable social identity
     email: text("email").notNull().unique(),
     displayName: text("display_name"),
     avatarUrl: text("avatar_url"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },
-  (t) => [index("users_email_idx").on(t.email)],
+  (t) => [index("users_email_idx").on(t.email), index("users_handle_idx").on(t.handle)],
 );
 
 export const passkeys = sqliteTable(

--- a/packages/osn-db/src/schema/index.ts
+++ b/packages/osn-db/src/schema/index.ts
@@ -11,7 +11,9 @@ export const users = sqliteTable(
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },
-  (t) => [index("users_email_idx").on(t.email), index("users_handle_idx").on(t.handle)],
+  // users_email_idx kept for explicit query planning; handle UNIQUE constraint
+  // already provides an implicit index so no separate handle index is needed.
+  (t) => [index("users_email_idx").on(t.email)],
 );
 
 export const passkeys = sqliteTable(

--- a/packages/osn-db/src/seed.ts
+++ b/packages/osn-db/src/seed.ts
@@ -19,6 +19,7 @@ export function buildSeedUsers(now: Date): NewUser[] {
   return [
     {
       id: "usr_seed_alice",
+      handle: "alice",
       email: "alice@seed.osn.dev",
       displayName: "Alice Chen",
       avatarUrl: null,
@@ -27,6 +28,7 @@ export function buildSeedUsers(now: Date): NewUser[] {
     },
     {
       id: "usr_seed_bob",
+      handle: "bob",
       email: "bob@seed.osn.dev",
       displayName: "Bob Martinez",
       avatarUrl: null,
@@ -35,6 +37,7 @@ export function buildSeedUsers(now: Date): NewUser[] {
     },
     {
       id: "usr_seed_me",
+      handle: "me",
       email: "me@seed.osn.dev",
       displayName: "You (seed)",
       avatarUrl: null,

--- a/packages/osn-db/tests/schema.test.ts
+++ b/packages/osn-db/tests/schema.test.ts
@@ -9,6 +9,7 @@ function createTestDb() {
   sqlite.run(`
     CREATE TABLE users (
       id TEXT PRIMARY KEY,
+      handle TEXT NOT NULL UNIQUE,
       email TEXT NOT NULL UNIQUE,
       display_name TEXT,
       avatar_url TEXT,
@@ -36,6 +37,7 @@ describe("users schema", () => {
     const now = new Date("2030-06-01T10:00:00.000Z");
     await db.insert(schema.users).values({
       id: "usr_test",
+      handle: "testuser",
       email: "test@example.com",
       createdAt: now,
       updatedAt: now,
@@ -45,6 +47,7 @@ describe("users schema", () => {
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBe("usr_test");
+    expect(row.handle).toBe("testuser");
     expect(row.email).toBe("test@example.com");
     expect(row.createdAt).toBeInstanceOf(Date);
   });
@@ -52,13 +55,42 @@ describe("users schema", () => {
   it("enforces unique email constraint", async () => {
     const db = createTestDb();
     const now = new Date();
-    await db
-      .insert(schema.users)
-      .values({ id: "usr_a", email: "dup@example.com", createdAt: now, updatedAt: now });
+    await db.insert(schema.users).values({
+      id: "usr_a",
+      handle: "usera",
+      email: "dup@example.com",
+      createdAt: now,
+      updatedAt: now,
+    });
     await expect(
-      db
-        .insert(schema.users)
-        .values({ id: "usr_b", email: "dup@example.com", createdAt: now, updatedAt: now }),
+      db.insert(schema.users).values({
+        id: "usr_b",
+        handle: "userb",
+        email: "dup@example.com",
+        createdAt: now,
+        updatedAt: now,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("enforces unique handle constraint", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.users).values({
+      id: "usr_h1",
+      handle: "duphandle",
+      email: "h1@example.com",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await expect(
+      db.insert(schema.users).values({
+        id: "usr_h2",
+        handle: "duphandle",
+        email: "h2@example.com",
+        createdAt: now,
+        updatedAt: now,
+      }),
     ).rejects.toThrow();
   });
 
@@ -67,6 +99,7 @@ describe("users schema", () => {
     const now = new Date();
     await db.insert(schema.users).values({
       id: "usr_display",
+      handle: "alice",
       email: "display@example.com",
       displayName: "Alice Chen",
       avatarUrl: "https://example.com/avatar.jpg",
@@ -83,6 +116,7 @@ describe("users schema", () => {
     const now = new Date();
     await db.insert(schema.users).values({
       id: "usr_nodisplay",
+      handle: "nodisplay",
       email: "nodisplay@example.com",
       createdAt: now,
       updatedAt: now,
@@ -95,9 +129,13 @@ describe("users schema", () => {
   it("createdAt round-trips as Date via timestamp mode", async () => {
     const db = createTestDb();
     const ts = new Date("2030-01-15T08:00:00.000Z");
-    await db
-      .insert(schema.users)
-      .values({ id: "usr_ts", email: "ts@example.com", createdAt: ts, updatedAt: ts });
+    await db.insert(schema.users).values({
+      id: "usr_ts",
+      handle: "tsuser",
+      email: "ts@example.com",
+      createdAt: ts,
+      updatedAt: ts,
+    });
     const [row] = await db.select().from(schema.users).where(eq(schema.users.id, "usr_ts"));
     expect(row!.createdAt).toBeInstanceOf(Date);
     expect(row!.createdAt.getTime()).toBe(ts.getTime());
@@ -108,9 +146,13 @@ describe("passkeys schema", () => {
   it("inserts and retrieves a passkey linked to a user", async () => {
     const db = createTestDb();
     const now = new Date("2030-06-01T10:00:00.000Z");
-    await db
-      .insert(schema.users)
-      .values({ id: "usr_pk", email: "pk@example.com", createdAt: now, updatedAt: now });
+    await db.insert(schema.users).values({
+      id: "usr_pk",
+      handle: "pkuser",
+      email: "pk@example.com",
+      createdAt: now,
+      updatedAt: now,
+    });
     await db.insert(schema.passkeys).values({
       id: "pk_test",
       userId: "usr_pk",
@@ -135,6 +177,7 @@ describe("passkeys schema", () => {
     const now = new Date();
     await db.insert(schema.users).values({
       id: "usr_notransport",
+      handle: "notransport",
       email: "notransport@example.com",
       createdAt: now,
       updatedAt: now,
@@ -157,9 +200,13 @@ describe("passkeys schema", () => {
   it("enforces unique credentialId constraint", async () => {
     const db = createTestDb();
     const now = new Date();
-    await db
-      .insert(schema.users)
-      .values({ id: "usr_cred", email: "cred@example.com", createdAt: now, updatedAt: now });
+    await db.insert(schema.users).values({
+      id: "usr_cred",
+      handle: "creduser",
+      email: "cred@example.com",
+      createdAt: now,
+      updatedAt: now,
+    });
     await db.insert(schema.passkeys).values({
       id: "pk_c1",
       userId: "usr_cred",


### PR DESCRIPTION
## Summary
- Each OSN user now has a unique, immutable `@handle` (e.g. `@alice`) chosen at sign-up, stored without the sigil
- Registration is an explicit step (`POST /register { email, handle, displayName? }`) — OTP, magic link, and passkey flows are login-only
- Login accepts an `identifier` that can be either an email address or a handle; a leading `@` is stripped automatically
- JWT access tokens now carry `handle` and `displayName` claims
- New `GET /handle/:handle` endpoint returns `{ available: boolean }` for real-time availability checks during sign-up
- `createdByName` on Pulse events now uses `displayName` → `@handle` → email local-part (priority order)

## Workspaces affected
- `@osn/db` — minor (new `handle TEXT NOT NULL UNIQUE` column, migration `0002_add_user_handle.sql`, seed handles)
- `@osn/core` — minor (registerUser, checkHandle, findUserByHandle, identifier-based auth flows, enriched JWT, new routes)
- `@osn/api` — patch (updated `createdByName` derivation from JWT claims)
- `@osn/pulse` — patch (getDisplayNameFromToken, getHandleFromToken, getTokenClaims helper, getUserIdFromToken refactor)

## Decisions & issues

**Architecture**
- Handle is required at registration, not a post-login onboarding step — eliminates the upsertUser pattern; OTP/magic/passkey flows now fail with `"Invalid request"` if the user doesn't exist
- OTP and passkey challenge stores are keyed by the normalised identifier (not `user.email`) so `completeOtp`/`completePasskeyLogin` can check the in-memory guard before touching the DB — avoids a DB hit on every expired/invalid attempt
- `registerUser` uses `Effect.all` with `concurrency: "unbounded"` to parallelise the email + handle uniqueness checks (was two sequential DB round-trips)
- `verifyAccessToken` return type widened to include `handle` and `displayName`; backward-compatible since new fields are always present post-migration

**Security fixes applied during prep-pr review**
- Leading `@` sigil stripped from identifiers before dispatch (`@alice` → handle `alice`, not a confusing "invalid email" error)
- Reserved handle blocklist added to `registerUser` and `checkHandle`: `me`, `admin`, `api`, `auth`, `login`, `register`, `signup`, `signin`, `about`, `terms`, `privacy`, `status`, `support`, `help`, `osn`, `pulse`, `messaging`, `null`, `undefined`
- Auth flow user-not-found errors unified to `"Invalid request"` to prevent username enumeration; `GET /handle/:handle` intentionally returns accurate availability (UX requirement for sign-up)
- Redundant `users_handle_idx` removed from schema and migration — SQLite `UNIQUE` constraint already creates an implicit index

**Deferred to TODO.md (M13, M14, L10, L11)**
- `POST /register` rate limiting and email verification (M13)
- `displayName` staleness in JWT after profile updates (M14)
- `assertion: t.Any()` passkey shape validation (L10, pre-existing pattern)
- Reserved handle enforcement at DB level (L11, currently app-layer only)

**Build/tooling issues resolved**
- `drizzle-kit` not installed locally — migration SQL written manually; `_journal.json` updated manually
- Two lefthook format-then-re-stage cycles needed (formatter rewrites code before hook re-reads staged content)
- `packages/osn-db/tests/schema.test.ts` missed in initial commit — all user inserts needed `handle` added; caught by pre-push typecheck

## Test plan
- [ ] `GET /handle/alice` returns `{ available: true }` before registration and `{ available: false }` after
- [ ] `GET /handle/me` returns `{ available: false }` (reserved)
- [ ] `GET /handle/INVALID!` returns 400
- [ ] `POST /register` with valid email + handle returns 201 with `userId`, `handle`, `email`
- [ ] `POST /register` with duplicate email or handle returns 400
- [ ] `POST /otp/begin` with email identifier sends OTP and returns `{ sent: true }`
- [ ] `POST /otp/begin` with handle identifier sends OTP to the user's email
- [ ] `POST /otp/begin` with `@alice` (sigil) resolves correctly
- [ ] `POST /otp/begin` for unregistered user returns 400
- [ ] Complete OTP flow → `POST /token` → verify JWT contains `handle` and `displayName` claims
- [ ] `POST /magic/begin` with handle identifier sends magic link to correct email
- [ ] Creating a Pulse event with a logged-in user sets `createdByName` to `displayName` (if set) or `@handle`
- [ ] `getDisplayNameFromToken` prefers `displayName`, falls back to `@handle`, then email local-part
- [ ] `getTokenClaims()` returns all four claims in one call without double-decoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)