### PR TITLE
feat(graph): social graph — connections, close friends, blocks

### DIFF
--- a/.changeset/social-graph-data-model.md
+++ b/.changeset/social-graph-data-model.md
@@ -1,0 +1,10 @@
+---
+"@osn/db": minor
+"@osn/core": minor
+---
+
+Add social graph data model: connections, close friends, blocks.
+
+`@osn/db` — three new Drizzle tables: `connections` (pending/accepted requests), `close_friends` (unidirectional inner circle), `blocks` (unidirectional mutes/blocks). Exported inferred types for each.
+
+`@osn/core` — new `createGraphService` (Effect.ts, all graph operations) and `createGraphRoutes` (JWT-authenticated Elysia routes). Endpoints under `/graph/connections`, `/graph/close-friends`, `/graph/blocks`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,18 +47,42 @@ apps/
   messaging/           # Pending: bunx create-tauri-app
 packages/
   api/                 # ✓ Elysia + Eden
-  osn-db/              # ✓ @osn/db — Drizzle + SQLite (OSN Core: users, passkeys)
+  osn-db/              # ✓ @osn/db — Drizzle + SQLite (OSN Core: users, passkeys, social graph)
   pulse-db/            # ✓ @pulse/db — Drizzle + SQLite (Pulse: events, RSVPs)
   utils-db/            # ✓ @utils/db — shared DB utilities (createDrizzleClient, makeDbLive)
   ui/                  # ✓ Placeholder (shared components)
-  core/                # ✓ @osn/core — auth services + Elysia routes (passkey, OTP, magic link, PKCE, JWT)
-  crypto/              # ✓ Placeholder (Signal protocol)
+  core/                # ✓ @osn/core — auth services + Elysia routes (passkey, OTP, magic link, PKCE, JWT) + social graph service + routes
+  crypto/              # Pending: @osn/crypto — Signal protocol + ARC tokens (S2S auth)
   typescript-config/   # ✓ base, node, solid configs
 ```
 
 ## Tech (one-liner)
 
 Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+REST, WebSockets, Signal Protocol, SolidJS, Astro, Tauri, Turborepo, oxlint, oxfmt, Vitest + @effect/vitest
+
+## ARC Tokens (S2S Auth)
+
+ARC is OSN's service-to-service authentication token — an ASAP-style self-issued JWT for backend-to-backend calls (e.g. Pulse API querying OSN Core's social graph).
+
+**Key properties:**
+- ES256 (ECDSA P-256) — compact, fast, no shared secret
+- Self-issued: each service signs its own token with its private key
+- Short-lived (5 min TTL); cached in-memory, re-issued 30s before expiry
+- Scope-gated: `scope` claim limits what the token can do (e.g. `graph:read`)
+- Audience-scoped: `aud` claim names the target service (e.g. `"osn-core"`)
+- Public key discovery: first-party services registered in `service_accounts` DB table (`service_id`, `public_key_jwk`, `allowed_scopes`); third-party apps use JWKS URL derived from `iss`
+
+**Lives in:** `packages/crypto` (`@osn/crypto`) alongside Signal Protocol utilities.
+
+**Exports (planned):**
+```typescript
+generateArcKeyPair()                          // → { privateKey, publicKey } CryptoKeyPair
+createArcToken(privateKey, { iss, aud, scope, ttl? })  // → signed JWT string
+verifyArcToken(token, publicKey)              // → { iss, aud, scope } or throws
+resolvePublicKey(iss, db)                     // → CryptoKey (from service_accounts or JWKS)
+```
+
+**Current S2S strategy:** Pulse API imports `createGraphService()` from `@osn/core` directly (Option 1 — zero network overhead, read-only access to `osn.db`). ARC tokens will be used when migrating to HTTP-based S2S (Option 2) at scaling time, and immediately for any third-party app needing graph access.
 
 ## Conventions
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 ## Current Status
 
-`@osn/core` — full OIDC-style auth server: passkey (WebAuthn), OTP, magic-link, PKCE, JWT, OIDC discovery. `@osn/db` — users + passkeys + social graph schema (connections, close friends, blocks). `apps/osn` — auth server entry point on port 4000. `@osn/client` — session expiry check, `handleCallback`. `apps/pulse` — auth callback handler, event CRUD UI, location autocomplete (with coordinate capture), Maps button on EventCard, toast notifications (solid-toast), double-click guard on delete; 59 component tests. `@pulse/db` — lat/lng columns + dynamic seed data. `@osn/api` — events domain fully tested with coordinate range validation. 124 tests passing across 11 files.
+`@osn/core` — full OIDC-style auth server (passkey, OTP, magic-link, PKCE, JWT, OIDC discovery) + complete social graph service + HTTP routes (connections, close friends, blocks) with rate limiting, input validation, pagination, N+1-free list queries, and safe error responses. `@osn/db` — users + passkeys + social graph schema. `apps/osn` — auth + graph server on port 4000. `apps/pulse` — full event CRUD UI (59 component tests), location autocomplete, Maps button, toast, double-click guard. `@pulse/db` — lat/lng + dynamic seed. `@osn/api` — events domain with coordinate range validation. 127 tests passing across 12 files.
 
 ---
 
@@ -187,6 +187,14 @@ Address **High** items before any non-local deployment.
 - [ ] No reserved-handle blocklist in DB — currently enforced in app layer only (`RESERVED_HANDLES` set in `@osn/core`); consider a DB-level check constraint or migration-managed table — L11
 - [x] `EventList` `console.error` logs raw server error objects — guarded with `import.meta.env.DEV` — L9
 - ~~`@vitest/coverage-istanbul` uses caret version range — L10~~ dismissed: caret ranges are the project standard
+- [x] Graph GET endpoints unguarded — all GET handlers now wrapped in try/catch; generic "Request failed" on unexpected errors — H2-graph (fixed in feat/social-graph-data-model)
+- [x] `is-blocked` route used `eitherBlocked`, leaking whether target had blocked caller — route now uses `isBlocked(caller, target)` only — M1-graph (fixed in feat/social-graph-data-model)
+- [x] No rate limiting on graph write endpoints — module-level fixed-window limiter added (60/user/min) — M2-graph (fixed in feat/social-graph-data-model)
+- [x] Raw DB/Effect errors surfaced in graph responses — `safeError()` helper added; only `GraphError`/`NotFoundError` messages exposed — M3-graph (fixed in feat/social-graph-data-model)
+- [x] No input validation on `:handle` route param in graph routes — TypeBox `HandleParam` with regex `^[a-z0-9_]+$` + length bounds added — M4-graph (fixed in feat/social-graph-data-model)
+- [ ] Graph rate-limit store (`rateLimitStore`) never evicts expired windows — same eviction gap as auth stores; add periodic sweep — L12-graph
+- [x] `displayName` returned as `undefined` in graph list responses when absent — normalised to `null` via `userProjection()` — L3-graph (fixed in feat/social-graph-data-model)
+- [ ] `jwtSecret` falls back to `"dev-secret"` in graph auth (pre-existing from auth service) — throw at startup in production — already tracked as M9
 
 ---
 
@@ -202,6 +210,11 @@ Address **High** items before any non-local deployment.
 - [x] Eliminate extra `getEvent` round-trips in `updateEvent` — P8 (returns in-memory merged result; applyTransition called locally)
 - [ ] Eliminate extra `getEvent` round-trip in `createEvent` via `RETURNING *` — P9
 - [ ] Add index on `created_by_user_id` in pulse-db events — done in feat/event-ownership; move to done once merged
+- [x] N+1 queries in graph list functions — replaced with `inArray` batch fetches — P1-graph (fixed in feat/social-graph-data-model)
+- [x] `eitherBlocked` made two sequential `isBlocked` calls — collapsed to single OR query — P2-graph (fixed in feat/social-graph-data-model)
+- [x] `blockUser` used SELECT-then-DELETE pattern — replaced with direct `DELETE WHERE OR` — P3-graph (fixed in feat/social-graph-data-model)
+- [ ] `resolveHandle` re-fetches user from DB even when the handler already has the User row — minor; consolidate once graph routes grow — P10-graph
+- [ ] Graph list endpoints load entire result set before slicing — add DB-level `LIMIT`/`OFFSET` once pagination is a user-facing concern — P11-graph (low priority; clamped to 100 rows today)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 ## Current Status
 
-`@osn/core` — full OIDC-style auth server: passkey (WebAuthn), OTP, magic-link, PKCE, JWT, OIDC discovery. `@osn/db` — users + passkeys schema. `apps/osn` — auth server entry point on port 4000. `@osn/client` — session expiry check, `handleCallback`. `apps/pulse` — auth callback handler, event CRUD UI, location autocomplete (with coordinate capture), Maps button on EventCard, toast notifications (solid-toast), double-click guard on delete; 59 component tests. `@pulse/db` — lat/lng columns + dynamic seed data. `@osn/api` — events domain fully tested with coordinate range validation. 119 tests passing across 10 files.
+`@osn/core` — full OIDC-style auth server: passkey (WebAuthn), OTP, magic-link, PKCE, JWT, OIDC discovery. `@osn/db` — users + passkeys + social graph schema (connections, close friends, blocks). `apps/osn` — auth server entry point on port 4000. `@osn/client` — session expiry check, `handleCallback`. `apps/pulse` — auth callback handler, event CRUD UI, location autocomplete (with coordinate capture), Maps button on EventCard, toast notifications (solid-toast), double-click guard on delete; 59 component tests. `@pulse/db` — lat/lng columns + dynamic seed data. `@osn/api` — events domain fully tested with coordinate range validation. 124 tests passing across 11 files.
 
 ---
 
@@ -12,8 +12,9 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 Highest-priority items across all areas.
 
-- [ ] OSN Core: social graph data model (connections, close friends, blocks)
+- [x] OSN Core: social graph data model (connections, close friends, blocks)
 - [x] Pulse: toast notification system (solid-toast)
+- [ ] Platform: ARC tokens — implement `@osn/crypto` arc module + `service_accounts` table (first consumer: Pulse API → OSN Core)
 - [ ] Pulse: "What's on today" default view
 - [ ] Landing page: design and content
 - [ ] Security: fix open redirect in `/magic/verify` before any deployment — H3
@@ -54,8 +55,9 @@ Highest-priority items across all areas.
 - [x] User registration/login flows
 - [x] `apps/osn` auth server entry point (port 4000)
 - [x] 50 tests: services, routes, lib/crypto, lib/html
-- [ ] Social graph data model (connections, close friends, blocks)
-- [ ] Per-app vs global blocking logic
+- [x] Social graph data model (connections, close friends, blocks) — 124 tests
+- [ ] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
+- [ ] Per-app vs global blocking logic (deferred — global blocking across all OSN apps for now)
 - [ ] Interest profile selection (onboarding)
 - [ ] Third-party app authorization flow
 
@@ -91,6 +93,7 @@ Highest-priority items across all areas.
 - [x] Events domain (list, today, get, create, update, delete) — 47 tests
 - [ ] Batch status-transition `UPDATE`s in `listEvents`/`listTodayEvents` (currently N individual writes)
 - [ ] Eliminate extra `getEvent` round-trips in `createEvent`/`updateEvent` via `RETURNING *`
+- [ ] S2S graph access: add `@osn/core` + `@osn/db` deps; use `createGraphService()` read-only for event filtering (`hideBlocked`, `onlyConnections`) — first ARC token consumer
 - [ ] OSN/messaging domain modules
 - [ ] WebSocket setup for real-time
 - [ ] REST endpoints for third-party consumers
@@ -100,7 +103,8 @@ Highest-priority items across all areas.
 - [x] Per-app DB packages (osn-db, pulse-db)
 - [x] Pulse: events schema, migrations, smoke tests
 - [x] OSN Core: users + passkeys schema, migration, smoke tests
-- [ ] OSN Core: social graph schema (connections, blocks)
+- [x] OSN Core: social graph schema (connections, close_friends, blocks)
+- [ ] OSN Core: `service_accounts` table — `service_id`, `public_key_jwk`, `allowed_scopes` (for ARC token verification)
 - [ ] OSN Core: session schema (JWT-based for now; DB storage deferred)
 - [ ] Pulse: event series schema
 - [ ] Pulse: chat/message schema (via messaging backend)
@@ -112,6 +116,16 @@ Highest-priority items across all areas.
 - [x] `getSession()` with expiry check
 - [x] `AuthProvider` + `handleCallback` for SolidJS
 - [x] 10 tests
+
+### Crypto (`packages/crypto`)
+
+ARC = OSN's ASAP-style service-to-service (S2S) auth token. ES256 (ECDSA), short-lived (5 min), cached in-memory until 30s before expiry. Self-issued by the calling service, verified by the receiver using the caller's public key (looked up from `service_accounts` table or a JWKS URL for third-party apps). Scope-gated (`graph:read`, `graph:write`, etc.).
+
+- [ ] `generateArcKeyPair()` — ES256 keypair generation
+- [ ] `createArcToken(privateKey, { iss, aud, scope, ttl? })` — signs and returns a short-lived JWT
+- [ ] `verifyArcToken(token, publicKey)` — verifies signature, expiry, audience
+- [ ] `resolvePublicKey(iss)` — looks up public key from `service_accounts` table or JWKS URL (for third-party apps)
+- [ ] In-memory token cache with 30s-before-expiry eviction
 
 ### UI Components (`packages/ui`)
 
@@ -205,6 +219,8 @@ Address **High** items before any non-local deployment.
 | Two-way calendar sync | Currently one-way (Pulse → external) | Phase 2 |
 | Community event-ended reporting | 15–20 attendees auto-finish; host notified | When attendee/messaging features land |
 | Max event duration | Prompt user when creating events without endTime | When Pulse event creation UI is built |
+| S2S scaling: HTTP graph API | Current approach is direct package import (`createGraphService()`) — zero network overhead, Pulse API reads `osn.db` read-only. When horizontal scaling is needed, migrate to HTTP `/graph/internal/*` endpoints verified via ARC tokens. | When multi-process or multi-machine deployment needed |
+| Per-app blocking | Currently blocks are global across all OSN apps. Per-app scope deferred. | When Messaging or a third-party app needs independent block lists |
 
 ---
 

--- a/apps/osn/src/index.ts
+++ b/apps/osn/src/index.ts
@@ -1,6 +1,6 @@
 import { Elysia } from "elysia";
 import { cors } from "@elysiajs/cors";
-import { createAuthRoutes } from "@osn/core";
+import { createAuthRoutes, createGraphRoutes } from "@osn/core";
 import { DbLive } from "@osn/db/service";
 
 const port = Number(process.env.PORT) || 4000;
@@ -19,7 +19,8 @@ const app = new Elysia()
   .use(cors())
   .get("/", () => ({ status: "ok", service: "osn-auth" }))
   .get("/health", () => ({ status: "healthy" }))
-  .use(createAuthRoutes(authConfig, DbLive));
+  .use(createAuthRoutes(authConfig, DbLive))
+  .use(createGraphRoutes(authConfig, DbLive));
 
 if (process.env.NODE_ENV !== "test") {
   app.listen(port);

--- a/bun.lock
+++ b/bun.lock
@@ -191,9 +191,6 @@
       },
     },
   },
-  "overrides": {
-    "vite": "^6.3.5",
-  },
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.7", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-dA7U5/OFg8/xaMUb2vUOOJuuJXnMpHy6F0BM8ZhL7WT5OkTBwJ0GoW38n4fC4CXt+lT9mLWL0y8Pa74tFByBpQ=="],
 
@@ -1705,6 +1702,8 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
+    "@astrojs/solid-js/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1747,6 +1746,8 @@
 
     "astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "astro/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1771,6 +1772,8 @@
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1782,6 +1785,8 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@astrojs/solid-js/vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1932,5 +1937,99 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "apps/osn": {
       "name": "@osn/osn",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -44,7 +44,7 @@
     },
     "apps/pulse": {
       "name": "@osn/pulse",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "dependencies": {
         "@osn/api": "workspace:*",
         "@osn/client": "workspace:*",
@@ -71,7 +71,7 @@
     },
     "packages/api": {
       "name": "@osn/api",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -106,7 +106,7 @@
     },
     "packages/core": {
       "name": "@osn/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/db": "workspace:*",
@@ -131,7 +131,7 @@
     },
     "packages/osn-db": {
       "name": "@osn/db",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@utils/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -148,7 +148,7 @@
     },
     "packages/pulse-db": {
       "name": "@pulse/db",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@utils/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -190,6 +190,9 @@
         "better-sqlite3": "^12.5.0",
       },
     },
+  },
+  "overrides": {
+    "vite": "^6.3.5",
   },
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.7", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-dA7U5/OFg8/xaMUb2vUOOJuuJXnMpHy6F0BM8ZhL7WT5OkTBwJ0GoW38n4fC4CXt+lT9mLWL0y8Pa74tFByBpQ=="],
@@ -1702,8 +1705,6 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/solid-js/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1746,8 +1747,6 @@
 
     "astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
-    "astro/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1772,8 +1771,6 @@
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1785,8 +1782,6 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "@astrojs/solid-js/vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1937,99 +1932,5 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "vitest/vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
-
-    "@astrojs/solid-js/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
-
-    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
-
-    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
-
-    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
-
-    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
-
-    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
-
-    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
-
-    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
-
-    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
-
-    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
-
-    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
-
-    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "release": "changeset publish",
     "prepare": "lefthook install"
   },
+  "overrides": {
+    "vite": "^6.3.5"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "bun-types": "latest",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "release": "changeset publish",
     "prepare": "lefthook install"
   },
-  "overrides": {
-    "vite": "^6.3.5"
-  },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "bun-types": "latest",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,6 @@ export { createAuthRoutes } from "./routes/auth";
 export { buildAuthorizeHtml } from "./lib/html";
 export { createAuthService } from "./services/auth";
 export type { AuthConfig, AuthService } from "./services/auth";
+export { createGraphRoutes } from "./routes/graph";
+export { createGraphService } from "./services/graph";
+export type { GraphService } from "./services/graph";

--- a/packages/core/src/routes/graph.ts
+++ b/packages/core/src/routes/graph.ts
@@ -1,13 +1,83 @@
 import { Elysia, t } from "elysia";
 import { Effect, type Layer } from "effect";
 import { DbLive, type Db } from "@osn/db/service";
+import type { User } from "@osn/db/schema";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createGraphService } from "../services/graph";
+
+// ---------------------------------------------------------------------------
+// Rate limiter — per-user fixed window (write operations only)
+// ---------------------------------------------------------------------------
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>();
+const RATE_LIMIT_MAX = 60; // requests per window
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+
+function checkRateLimit(userId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitStore.get(userId);
+  if (!entry || now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
+    rateLimitStore.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+  if (entry.count >= RATE_LIMIT_MAX) return false;
+  entry.count++;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function extractToken(authorization: string | undefined): string | null {
   if (!authorization) return null;
   const match = authorization.match(/^Bearer\s+(.+)$/i);
   return match ? match[1] : null;
+}
+
+/** Extracts a safe, non-leaking message from a caught error. */
+function safeError(e: unknown): string {
+  if (e instanceof Error) {
+    // Expose only tagged GraphError / NotFoundError messages; swallow DB internals
+    if ("_tag" in e && (e._tag === "GraphError" || e._tag === "NotFoundError")) {
+      return (e as { message: string }).message;
+    }
+  }
+  return "Request failed";
+}
+
+// TypeBox schema for validated handle params (M4)
+const HandleParam = t.Object({
+  handle: t.String({ minLength: 1, maxLength: 30, pattern: "^[a-z0-9_]+$" }),
+});
+
+// TypeBox schema for paginated list queries
+const PaginationQuery = t.Object({
+  limit: t.Optional(t.String()),
+  offset: t.Optional(t.String()),
+});
+
+// Shared projection for user fields in list responses (L3: displayName typed as nullable)
+function userProjection(u: User) {
+  return {
+    handle: u.handle,
+    displayName: u.displayName ?? null,
+  };
+}
+
+// Parse pagination query params
+function parsePagination(query: { limit?: string; offset?: string }) {
+  const limit = query.limit !== undefined ? parseInt(query.limit, 10) : undefined;
+  const offset = query.offset !== undefined ? parseInt(query.offset, 10) : undefined;
+  return {
+    limit: Number.isFinite(limit) ? limit : undefined,
+    offset: Number.isFinite(offset) ? offset : undefined,
+  };
 }
 
 export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db> = DbLive) {
@@ -17,7 +87,7 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
   const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
     Effect.runPromise(eff.pipe(Effect.provide(dbLayer)) as Effect.Effect<A, never, never>);
 
-  // Verify token and return userId, or throw with 401 set
+  // Verify token and return caller claims, or set 401
   async function requireAuth(
     authorization: string | undefined,
     set: { status?: number | string },
@@ -28,26 +98,34 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
       return null;
     }
     try {
-      const claims = await Effect.runPromise(Effect.orDie(auth.verifyAccessToken(token)));
-      return claims;
+      return await Effect.runPromise(Effect.orDie(auth.verifyAccessToken(token)));
     } catch {
       set.status = 401;
       return null;
     }
   }
 
-  // Resolve a handle to a userId
+  // Enforce rate limit; set 429 on breach
+  function requireRateLimit(userId: string, set: { status?: number | string }): boolean {
+    if (!checkRateLimit(userId)) {
+      set.status = 429;
+      return false;
+    }
+    return true;
+  }
+
+  // Resolve a handle to a full User row, or set 404
   async function resolveHandle(
     handle: string,
     set: { status?: number | string },
-  ): Promise<string | null> {
+  ): Promise<User | null> {
     try {
       const user = await run(auth.findUserByHandle(handle));
       if (!user) {
         set.status = 404;
         return null;
       }
-      return user.id;
+      return user;
     } catch {
       set.status = 500;
       return null;
@@ -64,44 +142,46 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const targetId = await resolveHandle(params.handle, set);
-          if (!targetId) return { error: "User not found" };
+          const target = await resolveHandle(params.handle, set);
+          if (!target) return { error: "User not found" };
 
           try {
-            await run(graph.sendConnectionRequest(caller.userId, targetId));
+            await run(graph.sendConnectionRequest(caller.userId, target.id));
             set.status = 201;
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
       .patch(
         "/connections/:handle",
         async ({ params, body, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const requesterId = await resolveHandle(params.handle, set);
-          if (!requesterId) return { error: "User not found" };
+          const requester = await resolveHandle(params.handle, set);
+          if (!requester) return { error: "User not found" };
 
           try {
             if (body.action === "accept") {
-              await run(graph.acceptConnection(caller.userId, requesterId));
+              await run(graph.acceptConnection(caller.userId, requester.id));
             } else {
-              await run(graph.rejectConnection(caller.userId, requesterId));
+              await run(graph.rejectConnection(caller.userId, requester.id));
             }
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
         {
-          params: t.Object({ handle: t.String() }),
+          params: HandleParam,
           body: t.Object({ action: t.Union([t.Literal("accept"), t.Literal("reject")]) }),
         },
       )
@@ -110,59 +190,79 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const otherId = await resolveHandle(params.handle, set);
-          if (!otherId) return { error: "User not found" };
+          const other = await resolveHandle(params.handle, set);
+          if (!other) return { error: "User not found" };
 
           try {
-            await run(graph.removeConnection(caller.userId, otherId));
+            await run(graph.removeConnection(caller.userId, other.id));
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
-      .get("/connections", async ({ headers, set }) => {
-        const caller = await requireAuth(headers.authorization, set);
-        if (!caller) return { error: "Unauthorized" };
-
-        const list = await run(graph.listConnections(caller.userId));
-        return {
-          connections: list.map((c) => ({
-            handle: c.user.handle,
-            displayName: c.user.displayName,
-            connectedAt: c.connectedAt.toISOString(),
-          })),
-        };
-      })
-      .get("/connections/pending", async ({ headers, set }) => {
-        const caller = await requireAuth(headers.authorization, set);
-        if (!caller) return { error: "Unauthorized" };
-
-        const list = await run(graph.listPendingRequests(caller.userId));
-        return {
-          pending: list.map((r) => ({
-            handle: r.user.handle,
-            displayName: r.user.displayName,
-            requestedAt: r.requestedAt.toISOString(),
-          })),
-        };
-      })
+      .get(
+        "/connections",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          try {
+            const list = await run(graph.listConnections(caller.userId, parsePagination(query)));
+            return {
+              connections: list.map((c) => ({
+                ...userProjection(c.user),
+                connectedAt: c.connectedAt.toISOString(),
+              })),
+            };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
+      .get(
+        "/connections/pending",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          try {
+            const list = await run(
+              graph.listPendingRequests(caller.userId, parsePagination(query)),
+            );
+            return {
+              pending: list.map((r) => ({
+                ...userProjection(r.user),
+                requestedAt: r.requestedAt.toISOString(),
+              })),
+            };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
       .get(
         "/connections/:handle",
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-
-          const targetId = await resolveHandle(params.handle, set);
-          if (!targetId) return { error: "User not found" };
-
-          const status = await run(graph.getConnectionStatus(caller.userId, targetId));
-          return { status };
+          try {
+            const target = await resolveHandle(params.handle, set);
+            if (!target) return { error: "User not found" };
+            const status = await run(graph.getConnectionStatus(caller.userId, target.id));
+            return { status };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
       // -------------------------------------------------------------------------
       // Close friends
@@ -172,52 +272,57 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const friendId = await resolveHandle(params.handle, set);
-          if (!friendId) return { error: "User not found" };
+          const friend = await resolveHandle(params.handle, set);
+          if (!friend) return { error: "User not found" };
 
           try {
-            await run(graph.addCloseFriend(caller.userId, friendId));
+            await run(graph.addCloseFriend(caller.userId, friend.id));
             set.status = 201;
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
       .delete(
         "/close-friends/:handle",
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const friendId = await resolveHandle(params.handle, set);
-          if (!friendId) return { error: "User not found" };
+          const friend = await resolveHandle(params.handle, set);
+          if (!friend) return { error: "User not found" };
 
           try {
-            await run(graph.removeCloseFriend(caller.userId, friendId));
+            await run(graph.removeCloseFriend(caller.userId, friend.id));
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
-      .get("/close-friends", async ({ headers, set }) => {
-        const caller = await requireAuth(headers.authorization, set);
-        if (!caller) return { error: "Unauthorized" };
-
-        const list = await run(graph.listCloseFriends(caller.userId));
-        return {
-          closeFriends: list.map((u) => ({
-            handle: u.handle,
-            displayName: u.displayName,
-          })),
-        };
-      })
+      .get(
+        "/close-friends",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          try {
+            const list = await run(graph.listCloseFriends(caller.userId, parsePagination(query)));
+            return { closeFriends: list.map(userProjection) };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
       // -------------------------------------------------------------------------
       // Blocks
       // -------------------------------------------------------------------------
@@ -226,69 +331,78 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const blockedId = await resolveHandle(params.handle, set);
-          if (!blockedId) return { error: "User not found" };
+          const blocked = await resolveHandle(params.handle, set);
+          if (!blocked) return { error: "User not found" };
 
           try {
-            await run(graph.blockUser(caller.userId, blockedId));
+            await run(graph.blockUser(caller.userId, blocked.id));
             set.status = 201;
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
       .delete(
         "/blocks/:handle",
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
+          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
 
-          const blockedId = await resolveHandle(params.handle, set);
-          if (!blockedId) return { error: "User not found" };
+          const blocked = await resolveHandle(params.handle, set);
+          if (!blocked) return { error: "User not found" };
 
           try {
-            await run(graph.unblockUser(caller.userId, blockedId));
+            await run(graph.unblockUser(caller.userId, blocked.id));
             return { ok: true };
           } catch (e) {
             set.status = 400;
-            return { error: String(e) };
+            return { error: safeError(e) };
           }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
-      .get("/blocks", async ({ headers, set }) => {
-        const caller = await requireAuth(headers.authorization, set);
-        if (!caller) return { error: "Unauthorized" };
-
-        const list = await run(graph.listBlocks(caller.userId));
-        return {
-          blocks: list.map((u) => ({
-            handle: u.handle,
-            displayName: u.displayName,
-          })),
-        };
-      })
-      // -----------------------------------------------------------------------
-      // Block status check (used by Messaging and other services)
-      // -----------------------------------------------------------------------
+      .get(
+        "/blocks",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          try {
+            const list = await run(graph.listBlocks(caller.userId, parsePagination(query)));
+            return { blocks: list.map(userProjection) };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
+      // -------------------------------------------------------------------------
+      // Block status check
+      // M1: user-facing endpoint reports only whether *caller* has blocked *target*.
+      // The symmetric eitherBlocked check is reserved for ARC token (service-to-service) calls.
+      // -------------------------------------------------------------------------
       .get(
         "/is-blocked/:handle",
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-
-          const targetId = await resolveHandle(params.handle, set);
-          if (!targetId) return { error: "User not found" };
-
-          // Returns true if caller blocked target OR target blocked caller
-          const blocked = await run(graph.eitherBlocked(caller.userId, targetId));
-          return { blocked };
+          try {
+            const target = await resolveHandle(params.handle, set);
+            if (!target) return { error: "User not found" };
+            const blocked = await run(graph.isBlocked(caller.userId, target.id));
+            return { blocked };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
         },
-        { params: t.Object({ handle: t.String() }) },
+        { params: HandleParam },
       )
   );
 }

--- a/packages/core/src/routes/graph.ts
+++ b/packages/core/src/routes/graph.ts
@@ -272,5 +272,23 @@ export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<D
           })),
         };
       })
+      // -----------------------------------------------------------------------
+      // Block status check (used by Messaging and other services)
+      // -----------------------------------------------------------------------
+      .get(
+        "/is-blocked/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const targetId = await resolveHandle(params.handle, set);
+          if (!targetId) return { error: "User not found" };
+
+          // Returns true if caller blocked target OR target blocked caller
+          const blocked = await run(graph.eitherBlocked(caller.userId, targetId));
+          return { blocked };
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
   );
 }

--- a/packages/core/src/routes/graph.ts
+++ b/packages/core/src/routes/graph.ts
@@ -1,0 +1,276 @@
+import { Elysia, t } from "elysia";
+import { Effect, type Layer } from "effect";
+import { DbLive, type Db } from "@osn/db/service";
+import { createAuthService, type AuthConfig } from "../services/auth";
+import { createGraphService } from "../services/graph";
+
+function extractToken(authorization: string | undefined): string | null {
+  if (!authorization) return null;
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export function createGraphRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db> = DbLive) {
+  const auth = createAuthService(authConfig);
+  const graph = createGraphService();
+
+  const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(dbLayer)) as Effect.Effect<A, never, never>);
+
+  // Verify token and return userId, or throw with 401 set
+  async function requireAuth(
+    authorization: string | undefined,
+    set: { status?: number | string },
+  ): Promise<{ userId: string; handle: string } | null> {
+    const token = extractToken(authorization);
+    if (!token) {
+      set.status = 401;
+      return null;
+    }
+    try {
+      const claims = await Effect.runPromise(Effect.orDie(auth.verifyAccessToken(token)));
+      return claims;
+    } catch {
+      set.status = 401;
+      return null;
+    }
+  }
+
+  // Resolve a handle to a userId
+  async function resolveHandle(
+    handle: string,
+    set: { status?: number | string },
+  ): Promise<string | null> {
+    try {
+      const user = await run(auth.findUserByHandle(handle));
+      if (!user) {
+        set.status = 404;
+        return null;
+      }
+      return user.id;
+    } catch {
+      set.status = 500;
+      return null;
+    }
+  }
+
+  return (
+    new Elysia({ prefix: "/graph" })
+      // -------------------------------------------------------------------------
+      // Connections
+      // -------------------------------------------------------------------------
+      .post(
+        "/connections/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const targetId = await resolveHandle(params.handle, set);
+          if (!targetId) return { error: "User not found" };
+
+          try {
+            await run(graph.sendConnectionRequest(caller.userId, targetId));
+            set.status = 201;
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .patch(
+        "/connections/:handle",
+        async ({ params, body, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const requesterId = await resolveHandle(params.handle, set);
+          if (!requesterId) return { error: "User not found" };
+
+          try {
+            if (body.action === "accept") {
+              await run(graph.acceptConnection(caller.userId, requesterId));
+            } else {
+              await run(graph.rejectConnection(caller.userId, requesterId));
+            }
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        {
+          params: t.Object({ handle: t.String() }),
+          body: t.Object({ action: t.Union([t.Literal("accept"), t.Literal("reject")]) }),
+        },
+      )
+      .delete(
+        "/connections/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const otherId = await resolveHandle(params.handle, set);
+          if (!otherId) return { error: "User not found" };
+
+          try {
+            await run(graph.removeConnection(caller.userId, otherId));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .get("/connections", async ({ headers, set }) => {
+        const caller = await requireAuth(headers.authorization, set);
+        if (!caller) return { error: "Unauthorized" };
+
+        const list = await run(graph.listConnections(caller.userId));
+        return {
+          connections: list.map((c) => ({
+            handle: c.user.handle,
+            displayName: c.user.displayName,
+            connectedAt: c.connectedAt.toISOString(),
+          })),
+        };
+      })
+      .get("/connections/pending", async ({ headers, set }) => {
+        const caller = await requireAuth(headers.authorization, set);
+        if (!caller) return { error: "Unauthorized" };
+
+        const list = await run(graph.listPendingRequests(caller.userId));
+        return {
+          pending: list.map((r) => ({
+            handle: r.user.handle,
+            displayName: r.user.displayName,
+            requestedAt: r.requestedAt.toISOString(),
+          })),
+        };
+      })
+      .get(
+        "/connections/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const targetId = await resolveHandle(params.handle, set);
+          if (!targetId) return { error: "User not found" };
+
+          const status = await run(graph.getConnectionStatus(caller.userId, targetId));
+          return { status };
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      // -------------------------------------------------------------------------
+      // Close friends
+      // -------------------------------------------------------------------------
+      .post(
+        "/close-friends/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const friendId = await resolveHandle(params.handle, set);
+          if (!friendId) return { error: "User not found" };
+
+          try {
+            await run(graph.addCloseFriend(caller.userId, friendId));
+            set.status = 201;
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .delete(
+        "/close-friends/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const friendId = await resolveHandle(params.handle, set);
+          if (!friendId) return { error: "User not found" };
+
+          try {
+            await run(graph.removeCloseFriend(caller.userId, friendId));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .get("/close-friends", async ({ headers, set }) => {
+        const caller = await requireAuth(headers.authorization, set);
+        if (!caller) return { error: "Unauthorized" };
+
+        const list = await run(graph.listCloseFriends(caller.userId));
+        return {
+          closeFriends: list.map((u) => ({
+            handle: u.handle,
+            displayName: u.displayName,
+          })),
+        };
+      })
+      // -------------------------------------------------------------------------
+      // Blocks
+      // -------------------------------------------------------------------------
+      .post(
+        "/blocks/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const blockedId = await resolveHandle(params.handle, set);
+          if (!blockedId) return { error: "User not found" };
+
+          try {
+            await run(graph.blockUser(caller.userId, blockedId));
+            set.status = 201;
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .delete(
+        "/blocks/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const blockedId = await resolveHandle(params.handle, set);
+          if (!blockedId) return { error: "User not found" };
+
+          try {
+            await run(graph.unblockUser(caller.userId, blockedId));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        { params: t.Object({ handle: t.String() }) },
+      )
+      .get("/blocks", async ({ headers, set }) => {
+        const caller = await requireAuth(headers.authorization, set);
+        if (!caller) return { error: "Unauthorized" };
+
+        const list = await run(graph.listBlocks(caller.userId));
+        return {
+          blocks: list.map((u) => ({
+            handle: u.handle,
+            displayName: u.displayName,
+          })),
+        };
+      })
+  );
+}

--- a/packages/core/src/services/graph.ts
+++ b/packages/core/src/services/graph.ts
@@ -1,0 +1,553 @@
+import { Data, Effect } from "effect";
+import { and, eq, or } from "drizzle-orm";
+import { users, connections, closeFriends, blocks } from "@osn/db/schema";
+import { Db } from "@osn/db/service";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class GraphError extends Data.TaggedError("GraphError")<{
+  readonly message: string;
+}> {}
+
+export class NotFoundError extends Data.TaggedError("NotFoundError")<{
+  readonly message: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function genId(prefix: string): string {
+  return prefix + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function now(): Date {
+  return new Date();
+}
+
+// ---------------------------------------------------------------------------
+// Graph service factory
+// ---------------------------------------------------------------------------
+
+export function createGraphService() {
+  // -------------------------------------------------------------------------
+  // Block checks
+  // -------------------------------------------------------------------------
+
+  const isBlocked = (
+    blockerId: string,
+    blockedId: string,
+  ): Effect.Effect<boolean, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const result = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(blocks)
+            .where(and(eq(blocks.blockerId, blockerId), eq(blocks.blockedId, blockedId)))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      return result.length > 0;
+    });
+
+  /** Returns true if either party has blocked the other. */
+  const eitherBlocked = (userA: string, userB: string): Effect.Effect<boolean, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const [aBlocksB, bBlocksA] = yield* Effect.all(
+        [isBlocked(userA, userB), isBlocked(userB, userA)],
+        {
+          concurrency: "unbounded",
+        },
+      );
+      return aBlocksB || bBlocksA;
+    });
+
+  // -------------------------------------------------------------------------
+  // Connections
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns the connection status from the perspective of `viewerId` toward `targetId`.
+   * "pending_sent"     — viewer sent a request that is still pending
+   * "pending_received" — target sent a request to viewer that is still pending
+   * "connected"        — accepted connection exists in either direction
+   * "none"             — no relationship
+   */
+  const getConnectionStatus = (
+    viewerId: string,
+    targetId: string,
+  ): Effect.Effect<"none" | "pending_sent" | "pending_received" | "connected", DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      // Check both directions in one query
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              or(
+                and(eq(connections.requesterId, viewerId), eq(connections.addresseeId, targetId)),
+                and(eq(connections.requesterId, targetId), eq(connections.addresseeId, viewerId)),
+              ),
+            ),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return "none";
+
+      for (const row of rows) {
+        if (row.status === "accepted") return "connected";
+        if (row.requesterId === viewerId) return "pending_sent";
+        return "pending_received";
+      }
+      return "none";
+    });
+
+  const sendConnectionRequest = (
+    requesterId: string,
+    addresseeId: string,
+  ): Effect.Effect<void, GraphError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      if (requesterId === addresseeId) {
+        return yield* Effect.fail(new GraphError({ message: "Cannot connect to yourself" }));
+      }
+
+      const blocked = yield* eitherBlocked(requesterId, addresseeId);
+      if (blocked) {
+        return yield* Effect.fail(new GraphError({ message: "Cannot send connection request" }));
+      }
+
+      const status = yield* getConnectionStatus(requesterId, addresseeId);
+      if (status !== "none") {
+        return yield* Effect.fail(new GraphError({ message: "Connection already exists" }));
+      }
+
+      const { db } = yield* Db;
+      const ts = now();
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(connections).values({
+            id: genId("conn_"),
+            requesterId,
+            addresseeId,
+            status: "pending",
+            createdAt: ts,
+            updatedAt: ts,
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const acceptConnection = (
+    addresseeId: string,
+    requesterId: string,
+  ): Effect.Effect<void, GraphError | NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              and(
+                eq(connections.requesterId, requesterId),
+                eq(connections.addresseeId, addresseeId),
+                eq(connections.status, "pending"),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Pending request not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .update(connections)
+            .set({ status: "accepted", updatedAt: now() })
+            .where(eq(connections.id, rows[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  /**
+   * Rejects a pending request by deleting the row (keeps schema clean).
+   */
+  const rejectConnection = (
+    addresseeId: string,
+    requesterId: string,
+  ): Effect.Effect<void, NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              and(
+                eq(connections.requesterId, requesterId),
+                eq(connections.addresseeId, addresseeId),
+                eq(connections.status, "pending"),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Pending request not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () => db.delete(connections).where(eq(connections.id, rows[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  /**
+   * Removes an accepted connection or cancels a pending request in either direction.
+   */
+  const removeConnection = (
+    userId: string,
+    otherId: string,
+  ): Effect.Effect<void, NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              or(
+                and(eq(connections.requesterId, userId), eq(connections.addresseeId, otherId)),
+                and(eq(connections.requesterId, otherId), eq(connections.addresseeId, userId)),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Connection not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () => db.delete(connections).where(eq(connections.id, rows[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const listConnections = (
+    userId: string,
+  ): Effect.Effect<{ user: typeof users.$inferSelect; connectedAt: Date }[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Fetch accepted rows where user is either party
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              and(
+                or(eq(connections.requesterId, userId), eq(connections.addresseeId, userId)),
+                eq(connections.status, "accepted"),
+              ),
+            ),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return [];
+
+      // Collect peer IDs
+      const peerIds = rows.map((r) => (r.requesterId === userId ? r.addresseeId : r.requesterId));
+      const updatedAtMap = new Map(
+        rows.map((r) => [r.requesterId === userId ? r.addresseeId : r.requesterId, r.updatedAt]),
+      );
+
+      // Fetch all peers concurrently
+      const peers = yield* Effect.all(
+        peerIds.map((peerId) =>
+          Effect.tryPromise({
+            try: () => db.select().from(users).where(eq(users.id, peerId)).limit(1),
+            catch: (cause) => new DatabaseError({ cause }),
+          }).pipe(Effect.map((r) => r[0] ?? null)),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      return peers
+        .filter((u): u is typeof users.$inferSelect => u !== null)
+        .map((u) => ({ user: u, connectedAt: updatedAtMap.get(u.id) ?? new Date() }));
+    });
+
+  const listPendingRequests = (
+    userId: string,
+  ): Effect.Effect<{ user: typeof users.$inferSelect; requestedAt: Date }[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(and(eq(connections.addresseeId, userId), eq(connections.status, "pending"))),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return [];
+
+      const requesters = yield* Effect.all(
+        rows.map((row) =>
+          Effect.tryPromise({
+            try: () => db.select().from(users).where(eq(users.id, row.requesterId)).limit(1),
+            catch: (cause) => new DatabaseError({ cause }),
+          }).pipe(Effect.map((r) => ({ user: r[0] ?? null, requestedAt: row.createdAt }))),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      return requesters.filter(
+        (r): r is { user: typeof users.$inferSelect; requestedAt: Date } => r.user !== null,
+      );
+    });
+
+  // -------------------------------------------------------------------------
+  // Close friends
+  // -------------------------------------------------------------------------
+
+  const addCloseFriend = (
+    userId: string,
+    friendId: string,
+  ): Effect.Effect<void, GraphError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      if (userId === friendId) {
+        return yield* Effect.fail(
+          new GraphError({ message: "Cannot add yourself as a close friend" }),
+        );
+      }
+
+      // Must be connected first
+      const status = yield* getConnectionStatus(userId, friendId);
+      if (status !== "connected") {
+        return yield* Effect.fail(
+          new GraphError({ message: "Must be connected before adding as a close friend" }),
+        );
+      }
+
+      const { db } = yield* Db;
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .insert(closeFriends)
+            .values({ id: genId("clf_"), userId, friendId, createdAt: now() })
+            .onConflictDoNothing(),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const removeCloseFriend = (
+    userId: string,
+    friendId: string,
+  ): Effect.Effect<void, NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(closeFriends)
+            .where(and(eq(closeFriends.userId, userId), eq(closeFriends.friendId, friendId)))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Close friend not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () => db.delete(closeFriends).where(eq(closeFriends.id, rows[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const listCloseFriends = (
+    userId: string,
+  ): Effect.Effect<(typeof users.$inferSelect)[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () => db.select().from(closeFriends).where(eq(closeFriends.userId, userId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return [];
+
+      const friends = yield* Effect.all(
+        rows.map((row) =>
+          Effect.tryPromise({
+            try: () => db.select().from(users).where(eq(users.id, row.friendId)).limit(1),
+            catch: (cause) => new DatabaseError({ cause }),
+          }).pipe(Effect.map((r) => r[0] ?? null)),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      return friends.filter((u): u is typeof users.$inferSelect => u !== null);
+    });
+
+  // -------------------------------------------------------------------------
+  // Blocks
+  // -------------------------------------------------------------------------
+
+  const blockUser = (
+    blockerId: string,
+    blockedId: string,
+  ): Effect.Effect<void, GraphError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      if (blockerId === blockedId) {
+        return yield* Effect.fail(new GraphError({ message: "Cannot block yourself" }));
+      }
+
+      const { db } = yield* Db;
+
+      // Remove any existing connection silently
+      const connRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              or(
+                and(eq(connections.requesterId, blockerId), eq(connections.addresseeId, blockedId)),
+                and(eq(connections.requesterId, blockedId), eq(connections.addresseeId, blockerId)),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (connRows.length > 0) {
+        yield* Effect.tryPromise({
+          try: () => db.delete(connections).where(eq(connections.id, connRows[0].id)),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+      }
+
+      // Also remove from close friends in both directions
+      yield* Effect.all(
+        [
+          Effect.tryPromise({
+            try: () =>
+              db
+                .delete(closeFriends)
+                .where(
+                  or(
+                    and(eq(closeFriends.userId, blockerId), eq(closeFriends.friendId, blockedId)),
+                    and(eq(closeFriends.userId, blockedId), eq(closeFriends.friendId, blockerId)),
+                  ),
+                ),
+            catch: (cause) => new DatabaseError({ cause }),
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .insert(blocks)
+            .values({ id: genId("blk_"), blockerId, blockedId, createdAt: now() })
+            .onConflictDoNothing(),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const unblockUser = (
+    blockerId: string,
+    blockedId: string,
+  ): Effect.Effect<void, NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(blocks)
+            .where(and(eq(blocks.blockerId, blockerId), eq(blocks.blockedId, blockedId)))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Block not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () => db.delete(blocks).where(eq(blocks.id, rows[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  const listBlocks = (
+    userId: string,
+  ): Effect.Effect<(typeof users.$inferSelect)[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () => db.select().from(blocks).where(eq(blocks.blockerId, userId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return [];
+
+      const blocked = yield* Effect.all(
+        rows.map((row) =>
+          Effect.tryPromise({
+            try: () => db.select().from(users).where(eq(users.id, row.blockedId)).limit(1),
+            catch: (cause) => new DatabaseError({ cause }),
+          }).pipe(Effect.map((r) => r[0] ?? null)),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      return blocked.filter((u): u is typeof users.$inferSelect => u !== null);
+    });
+
+  return {
+    isBlocked,
+    eitherBlocked,
+    getConnectionStatus,
+    sendConnectionRequest,
+    acceptConnection,
+    rejectConnection,
+    removeConnection,
+    listConnections,
+    listPendingRequests,
+    addCloseFriend,
+    removeCloseFriend,
+    listCloseFriends,
+    blockUser,
+    unblockUser,
+    listBlocks,
+  };
+}
+
+export type GraphService = ReturnType<typeof createGraphService>;

--- a/packages/core/src/services/graph.ts
+++ b/packages/core/src/services/graph.ts
@@ -1,5 +1,5 @@
 import { Data, Effect } from "effect";
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import { users, connections, closeFriends, blocks } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 
@@ -20,6 +20,17 @@ export class DatabaseError extends Data.TaggedError("DatabaseError")<{
 }> {}
 
 // ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ListOptions {
+  /** Maximum rows to return. Clamped to 1–100. Default: 50. */
+  limit?: number;
+  /** Zero-based row offset for pagination. Default: 0. */
+  offset?: number;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -29,6 +40,10 @@ function genId(prefix: string): string {
 
 function now(): Date {
   return new Date();
+}
+
+function clampLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? 50, 1), 100);
 }
 
 // ---------------------------------------------------------------------------
@@ -58,16 +73,28 @@ export function createGraphService() {
       return result.length > 0;
     });
 
-  /** Returns true if either party has blocked the other. */
+  /**
+   * Returns true if either party has blocked the other.
+   * Single query via OR — O(1) round-trips regardless of direction.
+   */
   const eitherBlocked = (userA: string, userB: string): Effect.Effect<boolean, DatabaseError, Db> =>
     Effect.gen(function* () {
-      const [aBlocksB, bBlocksA] = yield* Effect.all(
-        [isBlocked(userA, userB), isBlocked(userB, userA)],
-        {
-          concurrency: "unbounded",
-        },
-      );
-      return aBlocksB || bBlocksA;
+      const { db } = yield* Db;
+      const result = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(blocks)
+            .where(
+              or(
+                and(eq(blocks.blockerId, userA), eq(blocks.blockedId, userB)),
+                and(eq(blocks.blockerId, userB), eq(blocks.blockedId, userA)),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      return result.length > 0;
     });
 
   // -------------------------------------------------------------------------
@@ -87,7 +114,6 @@ export function createGraphService() {
   ): Effect.Effect<"none" | "pending_sent" | "pending_received" | "connected", DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
-      // Check both directions in one query
       const rows = yield* Effect.tryPromise({
         try: () =>
           db
@@ -254,11 +280,13 @@ export function createGraphService() {
 
   const listConnections = (
     userId: string,
+    options: ListOptions = {},
   ): Effect.Effect<{ user: typeof users.$inferSelect; connectedAt: Date }[], DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
 
-      // Fetch accepted rows where user is either party
       const rows = yield* Effect.tryPromise({
         try: () =>
           db
@@ -269,63 +297,61 @@ export function createGraphService() {
                 or(eq(connections.requesterId, userId), eq(connections.addresseeId, userId)),
                 eq(connections.status, "accepted"),
               ),
-            ),
+            )
+            .limit(limit)
+            .offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
       if (rows.length === 0) return [];
 
-      // Collect peer IDs
       const peerIds = rows.map((r) => (r.requesterId === userId ? r.addresseeId : r.requesterId));
       const updatedAtMap = new Map(
         rows.map((r) => [r.requesterId === userId ? r.addresseeId : r.requesterId, r.updatedAt]),
       );
 
-      // Fetch all peers concurrently
-      const peers = yield* Effect.all(
-        peerIds.map((peerId) =>
-          Effect.tryPromise({
-            try: () => db.select().from(users).where(eq(users.id, peerId)).limit(1),
-            catch: (cause) => new DatabaseError({ cause }),
-          }).pipe(Effect.map((r) => r[0] ?? null)),
-        ),
-        { concurrency: "unbounded" },
-      );
+      const peers = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, peerIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
 
-      return peers
-        .filter((u): u is typeof users.$inferSelect => u !== null)
-        .map((u) => ({ user: u, connectedAt: updatedAtMap.get(u.id) ?? new Date() }));
+      return peers.map((u) => ({ user: u, connectedAt: updatedAtMap.get(u.id) ?? new Date() }));
     });
 
   const listPendingRequests = (
     userId: string,
+    options: ListOptions = {},
   ): Effect.Effect<{ user: typeof users.$inferSelect; requestedAt: Date }[], DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
       const rows = yield* Effect.tryPromise({
         try: () =>
           db
             .select()
             .from(connections)
-            .where(and(eq(connections.addresseeId, userId), eq(connections.status, "pending"))),
+            .where(and(eq(connections.addresseeId, userId), eq(connections.status, "pending")))
+            .limit(limit)
+            .offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
       if (rows.length === 0) return [];
 
-      const requesters = yield* Effect.all(
-        rows.map((row) =>
-          Effect.tryPromise({
-            try: () => db.select().from(users).where(eq(users.id, row.requesterId)).limit(1),
-            catch: (cause) => new DatabaseError({ cause }),
-          }).pipe(Effect.map((r) => ({ user: r[0] ?? null, requestedAt: row.createdAt }))),
-        ),
-        { concurrency: "unbounded" },
-      );
+      const requesterIds = rows.map((r) => r.requesterId);
+      const requestedAtMap = new Map(rows.map((r) => [r.requesterId, r.createdAt]));
 
-      return requesters.filter(
-        (r): r is { user: typeof users.$inferSelect; requestedAt: Date } => r.user !== null,
-      );
+      const requesters = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, requesterIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return requesters.map((u) => ({
+        user: u,
+        requestedAt: requestedAtMap.get(u.id) ?? new Date(),
+      }));
     });
 
   // -------------------------------------------------------------------------
@@ -343,7 +369,6 @@ export function createGraphService() {
         );
       }
 
-      // Must be connected first
       const status = yield* getConnectionStatus(userId, friendId);
       if (status !== "connected") {
         return yield* Effect.fail(
@@ -390,27 +415,34 @@ export function createGraphService() {
 
   const listCloseFriends = (
     userId: string,
+    options: ListOptions = {},
   ): Effect.Effect<(typeof users.$inferSelect)[], DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
       const rows = yield* Effect.tryPromise({
-        try: () => db.select().from(closeFriends).where(eq(closeFriends.userId, userId)),
+        try: () =>
+          db
+            .select()
+            .from(closeFriends)
+            .where(eq(closeFriends.userId, userId))
+            .limit(limit)
+            .offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
       if (rows.length === 0) return [];
 
-      const friends = yield* Effect.all(
-        rows.map((row) =>
-          Effect.tryPromise({
-            try: () => db.select().from(users).where(eq(users.id, row.friendId)).limit(1),
-            catch: (cause) => new DatabaseError({ cause }),
-          }).pipe(Effect.map((r) => r[0] ?? null)),
-        ),
-        { concurrency: "unbounded" },
-      );
+      const friendIds = rows.map((r) => r.friendId);
 
-      return friends.filter((u): u is typeof users.$inferSelect => u !== null);
+      const friends = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, friendIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return friends;
     });
 
   // -------------------------------------------------------------------------
@@ -428,47 +460,33 @@ export function createGraphService() {
 
       const { db } = yield* Db;
 
-      // Remove any existing connection silently
-      const connRows = yield* Effect.tryPromise({
+      // Remove any existing connection directly — no SELECT needed
+      yield* Effect.tryPromise({
         try: () =>
           db
-            .select()
-            .from(connections)
+            .delete(connections)
             .where(
               or(
                 and(eq(connections.requesterId, blockerId), eq(connections.addresseeId, blockedId)),
                 and(eq(connections.requesterId, blockedId), eq(connections.addresseeId, blockerId)),
               ),
-            )
-            .limit(1),
+            ),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      if (connRows.length > 0) {
-        yield* Effect.tryPromise({
-          try: () => db.delete(connections).where(eq(connections.id, connRows[0].id)),
-          catch: (cause) => new DatabaseError({ cause }),
-        });
-      }
-
-      // Also remove from close friends in both directions
-      yield* Effect.all(
-        [
-          Effect.tryPromise({
-            try: () =>
-              db
-                .delete(closeFriends)
-                .where(
-                  or(
-                    and(eq(closeFriends.userId, blockerId), eq(closeFriends.friendId, blockedId)),
-                    and(eq(closeFriends.userId, blockedId), eq(closeFriends.friendId, blockerId)),
-                  ),
-                ),
-            catch: (cause) => new DatabaseError({ cause }),
-          }),
-        ],
-        { concurrency: "unbounded" },
-      );
+      // Remove close-friend entries in both directions
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .delete(closeFriends)
+            .where(
+              or(
+                and(eq(closeFriends.userId, blockerId), eq(closeFriends.friendId, blockedId)),
+                and(eq(closeFriends.userId, blockedId), eq(closeFriends.friendId, blockerId)),
+              ),
+            ),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
 
       yield* Effect.tryPromise({
         try: () =>
@@ -508,27 +526,29 @@ export function createGraphService() {
 
   const listBlocks = (
     userId: string,
+    options: ListOptions = {},
   ): Effect.Effect<(typeof users.$inferSelect)[], DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
       const rows = yield* Effect.tryPromise({
-        try: () => db.select().from(blocks).where(eq(blocks.blockerId, userId)),
+        try: () =>
+          db.select().from(blocks).where(eq(blocks.blockerId, userId)).limit(limit).offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
       if (rows.length === 0) return [];
 
-      const blocked = yield* Effect.all(
-        rows.map((row) =>
-          Effect.tryPromise({
-            try: () => db.select().from(users).where(eq(users.id, row.blockedId)).limit(1),
-            catch: (cause) => new DatabaseError({ cause }),
-          }).pipe(Effect.map((r) => r[0] ?? null)),
-        ),
-        { concurrency: "unbounded" },
-      );
+      const blockedIds = rows.map((r) => r.blockedId);
 
-      return blocked.filter((u): u is typeof users.$inferSelect => u !== null);
+      const blocked = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, blockedIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return blocked;
     });
 
   return {

--- a/packages/core/tests/helpers/db.ts
+++ b/packages/core/tests/helpers/db.ts
@@ -28,6 +28,38 @@ export function createTestLayer() {
       created_at INTEGER NOT NULL
     )
   `);
+  sqlite.run(`
+    CREATE TABLE connections (
+      id TEXT PRIMARY KEY,
+      requester_id TEXT NOT NULL REFERENCES users(id),
+      addressee_id TEXT NOT NULL REFERENCES users(id),
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (requester_id, addressee_id)
+    )
+  `);
+  sqlite.run(`CREATE INDEX connections_addressee_idx ON connections (addressee_id)`);
+  sqlite.run(`
+    CREATE TABLE close_friends (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES users(id),
+      friend_id TEXT NOT NULL REFERENCES users(id),
+      created_at INTEGER NOT NULL,
+      UNIQUE (user_id, friend_id)
+    )
+  `);
+  sqlite.run(`CREATE INDEX close_friends_user_idx ON close_friends (user_id)`);
+  sqlite.run(`
+    CREATE TABLE blocks (
+      id TEXT PRIMARY KEY,
+      blocker_id TEXT NOT NULL REFERENCES users(id),
+      blocked_id TEXT NOT NULL REFERENCES users(id),
+      created_at INTEGER NOT NULL,
+      UNIQUE (blocker_id, blocked_id)
+    )
+  `);
+  sqlite.run(`CREATE INDEX blocks_blocked_idx ON blocks (blocked_id)`);
   const db = drizzle(sqlite, { schema });
   return Layer.succeed(Db, { db });
 }

--- a/packages/core/tests/helpers/db.ts
+++ b/packages/core/tests/helpers/db.ts
@@ -39,6 +39,7 @@ export function createTestLayer() {
       UNIQUE (requester_id, addressee_id)
     )
   `);
+  sqlite.run(`CREATE INDEX connections_requester_idx ON connections (requester_id)`);
   sqlite.run(`CREATE INDEX connections_addressee_idx ON connections (addressee_id)`);
   sqlite.run(`
     CREATE TABLE close_friends (
@@ -59,6 +60,7 @@ export function createTestLayer() {
       UNIQUE (blocker_id, blocked_id)
     )
   `);
+  sqlite.run(`CREATE INDEX blocks_blocker_idx ON blocks (blocker_id)`);
   sqlite.run(`CREATE INDEX blocks_blocked_idx ON blocks (blocked_id)`);
   const db = drizzle(sqlite, { schema });
   return Layer.succeed(Db, { db });

--- a/packages/core/tests/routes/graph.test.ts
+++ b/packages/core/tests/routes/graph.test.ts
@@ -540,11 +540,11 @@ describe("graph routes", () => {
     expect(json.blocked).toBe(true);
   });
 
-  it("GET /graph/is-blocked/:handle returns true when target blocked caller", async () => {
+  it("GET /graph/is-blocked/:handle returns false when only target has blocked caller (M1: one-directional)", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
     const bob = await registerAndGetToken("bob@example.com", "bob");
 
-    // Bob blocks alice
+    // Bob blocks alice — but alice has NOT blocked bob
     await graphApp.handle(
       new Request("http://localhost/graph/blocks/alice", {
         method: "POST",
@@ -552,14 +552,14 @@ describe("graph routes", () => {
       }),
     );
 
-    // Alice queries — should still see blocked=true (eitherBlocked)
+    // Alice queries is-blocked/bob → false: she has not blocked him
     const res = await graphApp.handle(
       new Request("http://localhost/graph/is-blocked/bob", {
         headers: { Authorization: `Bearer ${alice.token}` },
       }),
     );
     const json = (await res.json()) as { blocked: boolean };
-    expect(json.blocked).toBe(true);
+    expect(json.blocked).toBe(false);
   });
 
   it("block removes existing connection", async () => {

--- a/packages/core/tests/routes/graph.test.ts
+++ b/packages/core/tests/routes/graph.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Effect } from "effect";
+import { createTestLayer } from "../helpers/db";
+import { createAuthRoutes } from "../../src/routes/auth";
+import { createGraphRoutes } from "../../src/routes/graph";
+import { createAuthService } from "../../src/services/auth";
+import type { Db } from "@osn/db/service";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("graph routes", () => {
+  let layer: ReturnType<typeof createTestLayer>;
+  let authApp: ReturnType<typeof createAuthRoutes>;
+  let graphApp: ReturnType<typeof createGraphRoutes>;
+  let auth: ReturnType<typeof createAuthService>;
+
+  beforeEach(() => {
+    layer = createTestLayer();
+    authApp = createAuthRoutes(config, layer);
+    graphApp = createGraphRoutes(config, layer);
+    auth = createAuthService(config);
+  });
+
+  const runWithLayer = <A>(eff: Effect.Effect<A, unknown, Db>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+  /** Register a user and return a valid access token for them. */
+  async function registerAndGetToken(
+    email: string,
+    handle: string,
+  ): Promise<{ userId: string; token: string }> {
+    const user = await runWithLayer(auth.registerUser(email, handle));
+    const tokens = await runWithLayer(
+      auth.issueTokens(user.id, user.email, user.handle, user.displayName),
+    );
+    return { userId: user.id, token: tokens.accessToken };
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth guard
+  // -------------------------------------------------------------------------
+
+  it("returns 401 without token on POST /graph/connections/:handle", async () => {
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", { method: "POST" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: "Bearer not-a-valid-token" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection flow
+  // -------------------------------------------------------------------------
+
+  it("POST /graph/connections/:handle → 201 sends a request", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+
+  it("GET /graph/connections/:handle returns pending_sent after request", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { status: string };
+    expect(json.status).toBe("pending_sent");
+  });
+
+  it("PATCH /graph/connections/:handle accept → connected", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const statusRes = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await statusRes.json()) as { status: string };
+    expect(json.status).toBe("connected");
+  });
+
+  it("GET /graph/connections lists connected peers", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { connections: { handle: string }[] };
+    expect(json.connections).toHaveLength(1);
+    expect(json.connections[0].handle).toBe("bob");
+  });
+
+  it("GET /graph/connections/pending lists incoming requests", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/pending", {
+        headers: { Authorization: `Bearer ${bob.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { pending: { handle: string }[] };
+    expect(json.pending).toHaveLength(1);
+    expect(json.pending[0].handle).toBe("alice");
+  });
+
+  it("DELETE /graph/connections/:handle removes connection", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const statusRes = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await statusRes.json()) as { status: string };
+    expect(json.status).toBe("none");
+  });
+
+  it("POST /graph/connections/:handle → 404 for unknown handle", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/nobody", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(404);
+    void authApp;
+  });
+
+  // -------------------------------------------------------------------------
+  // Close friends
+  // -------------------------------------------------------------------------
+
+  it("POST /graph/close-friends/:handle → 201 after connecting", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    // Connect first
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("POST /graph/close-friends/:handle → 400 if not connected", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /graph/close-friends lists close friends", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await res.json()) as { closeFriends: { handle: string }[] };
+    expect(json.closeFriends).toHaveLength(1);
+    expect(json.closeFriends[0].handle).toBe("bob");
+  });
+
+  // -------------------------------------------------------------------------
+  // Blocks
+  // -------------------------------------------------------------------------
+
+  it("POST /graph/blocks/:handle → 201 blocks a user", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("DELETE /graph/blocks/:handle unblocks", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /graph/blocks lists blocked users", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/blocks", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await res.json()) as { blocks: { handle: string }[] };
+    expect(json.blocks).toHaveLength(1);
+    expect(json.blocks[0].handle).toBe("bob");
+  });
+
+  it("block removes existing connection", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    // Connect first
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+
+    // Block
+    await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    // Connection should be gone
+    const statusRes = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await statusRes.json()) as { status: string };
+    expect(json.status).toBe("none");
+  });
+});

--- a/packages/core/tests/routes/graph.test.ts
+++ b/packages/core/tests/routes/graph.test.ts
@@ -381,6 +381,97 @@ describe("graph routes", () => {
     expect(json.blocks[0].handle).toBe("bob");
   });
 
+  // -------------------------------------------------------------------------
+  // Routing: static "pending" segment must not be swallowed by /:handle
+  // -------------------------------------------------------------------------
+
+  it("GET /graph/connections/pending is not confused with handle 'pending'", async () => {
+    // Register a user whose handle is literally "pending"
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const pending = await registerAndGetToken("pending@example.com", "pending");
+
+    // Alice sends a request to the user called "pending"
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/pending", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    // GET /graph/connections/pending from pending's perspective should return
+    // the incoming request list (alice), not a status check for handle "pending"
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/pending", {
+        headers: { Authorization: `Bearer ${pending.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { pending: { handle: string }[] };
+    // This should be the pending-requests list, not a status object
+    expect(Array.isArray(json.pending)).toBe(true);
+    expect(json.pending[0].handle).toBe("alice");
+  });
+
+  // -------------------------------------------------------------------------
+  // isBlocked
+  // -------------------------------------------------------------------------
+
+  it("GET /graph/is-blocked/:handle returns false when no block", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/is-blocked/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { blocked: boolean };
+    expect(json.blocked).toBe(false);
+  });
+
+  it("GET /graph/is-blocked/:handle returns true when caller blocked target", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/blocks/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/is-blocked/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await res.json()) as { blocked: boolean };
+    expect(json.blocked).toBe(true);
+  });
+
+  it("GET /graph/is-blocked/:handle returns true when target blocked caller", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    // Bob blocks alice
+    await graphApp.handle(
+      new Request("http://localhost/graph/blocks/alice", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${bob.token}` },
+      }),
+    );
+
+    // Alice queries — should still see blocked=true (eitherBlocked)
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/is-blocked/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await res.json()) as { blocked: boolean };
+    expect(json.blocked).toBe(true);
+  });
+
   it("block removes existing connection", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
     const bob = await registerAndGetToken("bob@example.com", "bob");

--- a/packages/core/tests/routes/graph.test.ts
+++ b/packages/core/tests/routes/graph.test.ts
@@ -243,6 +243,38 @@ describe("graph routes", () => {
   // Close friends
   // -------------------------------------------------------------------------
 
+  it("PATCH /graph/connections/:handle reject → none", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "reject" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const statusRes = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await statusRes.json()) as { status: string };
+    expect(json.status).toBe("none");
+  });
+
   it("POST /graph/close-friends/:handle → 201 after connecting", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
     const bob = await registerAndGetToken("bob@example.com", "bob");
@@ -327,6 +359,64 @@ describe("graph routes", () => {
   // -------------------------------------------------------------------------
   // Blocks
   // -------------------------------------------------------------------------
+
+  it("DELETE /graph/close-friends/:handle removes from list", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    // Connect and add as close friend
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/alice", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+    await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const listRes = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const json = (await listRes.json()) as { closeFriends: unknown[] };
+    expect(json.closeFriends).toHaveLength(0);
+  });
+
+  it("DELETE /graph/close-friends/:handle → 400 if not in list", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/close-friends/bob", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
 
   it("POST /graph/blocks/:handle → 201 blocks a user", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");

--- a/packages/core/tests/services/graph.test.ts
+++ b/packages/core/tests/services/graph.test.ts
@@ -1,0 +1,341 @@
+import { it, expect, describe } from "@effect/vitest";
+import { Effect } from "effect";
+import { createTestLayer } from "../helpers/db";
+import { createAuthService } from "../../src/services/auth";
+import { createGraphService } from "../../src/services/graph";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+const auth = createAuthService(config);
+const graph = createGraphService();
+
+/** Register two users and return their IDs. */
+const setupTwoUsers = Effect.gen(function* () {
+  const alice = yield* auth.registerUser("alice@example.com", "alice", "Alice");
+  const bob = yield* auth.registerUser("bob@example.com", "bob", "Bob");
+  return { alice, bob };
+});
+
+/** Register two users and connect them. */
+const setupConnected = Effect.gen(function* () {
+  const { alice, bob } = yield* setupTwoUsers;
+  yield* graph.sendConnectionRequest(alice.id, bob.id);
+  yield* graph.acceptConnection(bob.id, alice.id);
+  return { alice, bob };
+});
+
+// ---------------------------------------------------------------------------
+// Connection requests
+// ---------------------------------------------------------------------------
+
+describe("sendConnectionRequest", () => {
+  it.effect("creates a pending request", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("pending_sent");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("from bob's perspective is pending_received", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const status = yield* graph.getConnectionStatus(bob.id, alice.id);
+      expect(status).toBe("pending_received");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when connecting to yourself", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(graph.sendConnectionRequest(alice.id, alice.id));
+      expect(error._tag).toBe("GraphError");
+      expect(error.message).toContain("yourself");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when already pending", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const error = yield* Effect.flip(graph.sendConnectionRequest(alice.id, bob.id));
+      expect(error._tag).toBe("GraphError");
+      expect(error.message).toContain("already exists");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when blocked by target", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(bob.id, alice.id);
+      const error = yield* Effect.flip(graph.sendConnectionRequest(alice.id, bob.id));
+      expect(error._tag).toBe("GraphError");
+      expect(error.message).toContain("Cannot send");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when requester has blocked target", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(alice.id, bob.id);
+      const error = yield* Effect.flip(graph.sendConnectionRequest(alice.id, bob.id));
+      expect(error._tag).toBe("GraphError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("acceptConnection", () => {
+  it.effect("changes status to connected", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      yield* graph.acceptConnection(bob.id, alice.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("connected");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if no pending request exists", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const error = yield* Effect.flip(graph.acceptConnection(bob.id, alice.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("rejectConnection", () => {
+  it.effect("removes the request (status back to none)", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      yield* graph.rejectConnection(bob.id, alice.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("none");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if no pending request exists", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const error = yield* Effect.flip(graph.rejectConnection(bob.id, alice.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("removeConnection", () => {
+  it.effect("removes an accepted connection", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.removeConnection(alice.id, bob.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("none");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("can be called by either party", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.removeConnection(bob.id, alice.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("none");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if no connection exists", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const error = yield* Effect.flip(graph.removeConnection(alice.id, bob.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("listConnections", () => {
+  it.effect("returns all connected peers", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      const carol = yield* auth.registerUser("carol@example.com", "carol");
+      yield* graph.sendConnectionRequest(alice.id, carol.id);
+      yield* graph.acceptConnection(carol.id, alice.id);
+
+      const list = yield* graph.listConnections(alice.id);
+      const handles = list.map((c) => c.user.handle).sort();
+      expect(handles).toEqual(["bob", "carol"]);
+      void bob;
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("returns empty when no connections", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerUser("alice@example.com", "alice");
+      const list = yield* graph.listConnections(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("listPendingRequests", () => {
+  it.effect("returns incoming pending requests", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const list = yield* graph.listPendingRequests(bob.id);
+      expect(list).toHaveLength(1);
+      expect(list[0].user.handle).toBe("alice");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("does not include outgoing requests", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const list = yield* graph.listPendingRequests(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Close friends
+// ---------------------------------------------------------------------------
+
+describe("addCloseFriend", () => {
+  it.effect("adds a connected user as close friend", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.addCloseFriend(alice.id, bob.id);
+      const list = yield* graph.listCloseFriends(alice.id);
+      expect(list).toHaveLength(1);
+      expect(list[0].handle).toBe("bob");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if not connected", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const error = yield* Effect.flip(graph.addCloseFriend(alice.id, bob.id));
+      expect(error._tag).toBe("GraphError");
+      expect(error.message).toContain("Must be connected");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when adding yourself", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(graph.addCloseFriend(alice.id, alice.id));
+      expect(error._tag).toBe("GraphError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("is unidirectional — bob does not see alice as close friend", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.addCloseFriend(alice.id, bob.id);
+      const bobList = yield* graph.listCloseFriends(bob.id);
+      expect(bobList).toHaveLength(0);
+      void alice;
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("removeCloseFriend", () => {
+  it.effect("removes from close friends list", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.addCloseFriend(alice.id, bob.id);
+      yield* graph.removeCloseFriend(alice.id, bob.id);
+      const list = yield* graph.listCloseFriends(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if not in close friends", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      const error = yield* Effect.flip(graph.removeCloseFriend(alice.id, bob.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Blocks
+// ---------------------------------------------------------------------------
+
+describe("blockUser", () => {
+  it.effect("adds a block", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(alice.id, bob.id);
+      const list = yield* graph.listBlocks(alice.id);
+      expect(list).toHaveLength(1);
+      expect(list[0].handle).toBe("bob");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removes existing connection when blocking", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.blockUser(alice.id, bob.id);
+      const status = yield* graph.getConnectionStatus(alice.id, bob.id);
+      expect(status).toBe("none");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removes close friend entries when blocking", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      yield* graph.addCloseFriend(alice.id, bob.id);
+      yield* graph.blockUser(alice.id, bob.id);
+      const list = yield* graph.listCloseFriends(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when blocking yourself", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(graph.blockUser(alice.id, alice.id));
+      expect(error._tag).toBe("GraphError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("isBlocked returns true after blocking", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(alice.id, bob.id);
+      const blocked = yield* graph.isBlocked(alice.id, bob.id);
+      expect(blocked).toBe(true);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("unblockUser", () => {
+  it.effect("removes the block", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(alice.id, bob.id);
+      yield* graph.unblockUser(alice.id, bob.id);
+      const blocked = yield* graph.isBlocked(alice.id, bob.id);
+      expect(blocked).toBe(false);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails if not blocked", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const error = yield* Effect.flip(graph.unblockUser(alice.id, bob.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/packages/core/tests/services/graph.test.ts
+++ b/packages/core/tests/services/graph.test.ts
@@ -292,13 +292,34 @@ describe("blockUser", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("removes close friend entries when blocking", () =>
+  it.effect("removes close friend entries when blocking (blocker's list)", () =>
     Effect.gen(function* () {
       const { alice, bob } = yield* setupConnected;
       yield* graph.addCloseFriend(alice.id, bob.id);
       yield* graph.blockUser(alice.id, bob.id);
       const list = yield* graph.listCloseFriends(alice.id);
       expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removes close friend entries when blocking (blockee's list)", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupConnected;
+      // Bob has alice as a close friend
+      yield* graph.addCloseFriend(bob.id, alice.id);
+      // Alice blocks bob — should clear bob's list too
+      yield* graph.blockUser(alice.id, bob.id);
+      const list = yield* graph.listCloseFriends(bob.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("eitherBlocked is true when either party blocks", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.blockUser(bob.id, alice.id); // bob blocks alice
+      const either = yield* graph.eitherBlocked(alice.id, bob.id);
+      expect(either).toBe(true);
     }).pipe(Effect.provide(createTestLayer())),
   );
 

--- a/packages/osn-db/src/schema/index.ts
+++ b/packages/osn-db/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, unique } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable(
   "users",
@@ -36,3 +36,73 @@ export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Passkey = typeof passkeys.$inferSelect;
 export type NewPasskey = typeof passkeys.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Social graph
+// ---------------------------------------------------------------------------
+
+export const connections = sqliteTable(
+  "connections",
+  {
+    id: text("id").primaryKey(), // "conn_" prefix
+    requesterId: text("requester_id")
+      .notNull()
+      .references(() => users.id),
+    addresseeId: text("addressee_id")
+      .notNull()
+      .references(() => users.id),
+    /** pending → accepted | pending → rejected (rejected rows are deleted) */
+    status: text("status", { enum: ["pending", "accepted"] })
+      .notNull()
+      .default("pending"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    unique("connections_pair_idx").on(t.requesterId, t.addresseeId),
+    index("connections_addressee_idx").on(t.addresseeId),
+  ],
+);
+
+export const closeFriends = sqliteTable(
+  "close_friends",
+  {
+    id: text("id").primaryKey(), // "clf_" prefix
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    friendId: text("friend_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    unique("close_friends_pair_idx").on(t.userId, t.friendId),
+    index("close_friends_user_idx").on(t.userId),
+  ],
+);
+
+export const blocks = sqliteTable(
+  "blocks",
+  {
+    id: text("id").primaryKey(), // "blk_" prefix
+    blockerId: text("blocker_id")
+      .notNull()
+      .references(() => users.id),
+    blockedId: text("blocked_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    unique("blocks_pair_idx").on(t.blockerId, t.blockedId),
+    index("blocks_blocked_idx").on(t.blockedId),
+  ],
+);
+
+export type Connection = typeof connections.$inferSelect;
+export type NewConnection = typeof connections.$inferInsert;
+export type CloseFriend = typeof closeFriends.$inferSelect;
+export type NewCloseFriend = typeof closeFriends.$inferInsert;
+export type Block = typeof blocks.$inferSelect;
+export type NewBlock = typeof blocks.$inferInsert;

--- a/packages/osn-db/src/schema/index.ts
+++ b/packages/osn-db/src/schema/index.ts
@@ -60,6 +60,7 @@ export const connections = sqliteTable(
   },
   (t) => [
     unique("connections_pair_idx").on(t.requesterId, t.addresseeId),
+    index("connections_requester_idx").on(t.requesterId),
     index("connections_addressee_idx").on(t.addresseeId),
   ],
 );
@@ -96,6 +97,7 @@ export const blocks = sqliteTable(
   },
   (t) => [
     unique("blocks_pair_idx").on(t.blockerId, t.blockedId),
+    index("blocks_blocker_idx").on(t.blockerId),
     index("blocks_blocked_idx").on(t.blockedId),
   ],
 );


### PR DESCRIPTION
## Summary

- Adds complete social graph to `@osn/core`: directed connections (pending → accepted), unidirectional close friends (connection-gated), and blocks (auto-removes connections + close friends on both sides)
- Exposes 12 HTTP routes under `/graph` wired into `apps/osn`
- Addresses all security (H2, M1–M4, L3) and performance (P1–P3) review findings before merge
- Documents ARC token design decision in CLAUDE.md + TODO.md for future `@osn/crypto` implementation

## Changes

- `@osn/db`: `connections`, `close_friends`, `blocks` tables + indexes
- `@osn/core`: `createGraphService()` + `createGraphRoutes()` — rate limiting (60 writes/user/min), TypeBox handle validation, `inArray` batch fetches (no N+1), `safeError()` sanitisation, pagination on all list endpoints
- `GET /graph/is-blocked/:handle` — reports only whether *caller* blocked target (not symmetric); `eitherBlocked` reserved for S2S/ARC use
- `apps/osn`: graph routes mounted
- Tests: 127 passing (12 files)
- Changeset included (`@osn/db` minor, `@osn/core` minor)

## Security findings fixed

| ID | Finding | Fix |
|----|---------|-----|
| H2 | GET handlers unguarded — raw DB errors leaked | try/catch on all GETs; `safeError()` helper |
| M1 | `is-blocked` used `eitherBlocked`, leaking reverse block status | Route uses `isBlocked(caller, target)` only |
| M2 | No rate limiting on write endpoints | Module-level fixed-window limiter, 60/user/min |
| M3 | Raw Effect/DB errors in responses | `safeError()` — only `GraphError`/`NotFoundError` exposed |
| M4 | No handle param validation | TypeBox regex `^[a-z0-9_]+$` + length bounds |
| L3 | `displayName` undefined in list responses | `userProjection()` normalises to `null` |

## Performance findings fixed

| ID | Finding | Fix |
|----|---------|-----|
| P1 | N+1 queries in all 4 list functions | `inArray` batch fetch + Map lookup |
| P2 | `eitherBlocked` — two sequential queries | Single `SELECT … WHERE (A OR B) LIMIT 1` |
| P3 | `blockUser` SELECT-then-DELETE | Direct `DELETE WHERE OR` — one round-trip |

## Deferred

- L1: `jwtSecret` dev fallback (pre-existing, tracked as M9)
- L2: `removeConnection` cancels pending requests — intentional design
- L12-graph: rate-limit store eviction (same pattern as auth stores; tracked in backlog)
- Per-app blocking deferred to phase 2
- ARC token implementation tracked in TODO under `@osn/crypto`