### PR TITLE
fix(core): sign-in field fix, registration flow, Email/Handle toggle

### DIFF
--- a/.changeset/arc-tokens-signin-fix.md
+++ b/.changeset/arc-tokens-signin-fix.md
@@ -1,0 +1,9 @@
+---
+"@osn/core": patch
+---
+
+Fix broken sign-in flow and add registration UI with handle claiming.
+
+- **Bug fix:** Sign-in page was sending `{ email }` to all auth endpoints but the API expects `{ identifier }` — all three sign-in methods (passkey, OTP, magic link) returned 400 errors. Renamed field throughout the JS.
+- **Improvement:** Login inputs now accept email or @handle (was email-only inputs, blocking handle-based sign-in).
+- **Feature:** Added "Create account" tab to the hosted sign-in page with real-time handle availability checking (debounced against `GET /handle/:handle`), registration form (email, handle, optional display name), and automatic OTP verification flow after `POST /register` succeeds.

--- a/.changeset/claude-md-arc-docs.md
+++ b/.changeset/claude-md-arc-docs.md
@@ -1,0 +1,5 @@
+---
+"osn": patch
+---
+
+Update CLAUDE.md with complete ARC token usage guidance: when to use ARC vs. direct package import, calling/receiving service patterns with code examples, and service registration steps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ packages/
   utils-db/            # ✓ @utils/db — shared DB utilities (createDrizzleClient, makeDbLive)
   ui/                  # ✓ Placeholder (shared components)
   core/                # ✓ @osn/core — auth services + Elysia routes (passkey, OTP, magic link, PKCE, JWT) + social graph service + routes
-  crypto/              # Pending: @osn/crypto — Signal protocol + ARC tokens (S2S auth)
+  crypto/              # ✓ @osn/crypto — ARC tokens (S2S auth); Signal protocol pending
   typescript-config/   # ✓ base, node, solid configs
 ```
 
@@ -72,17 +72,83 @@ ARC is OSN's service-to-service authentication token — an ASAP-style self-issu
 - Audience-scoped: `aud` claim names the target service (e.g. `"osn-core"`)
 - Public key discovery: first-party services registered in `service_accounts` DB table (`service_id`, `public_key_jwk`, `allowed_scopes`); third-party apps use JWKS URL derived from `iss`
 
-**Lives in:** `packages/crypto` (`@osn/crypto`) alongside Signal Protocol utilities.
+**Lives in:** `packages/crypto` (`@osn/crypto`). Import from `@osn/crypto/arc`.
 
-**Exports (planned):**
+**Exports:**
 ```typescript
-generateArcKeyPair()                          // → { privateKey, publicKey } CryptoKeyPair
-createArcToken(privateKey, { iss, aud, scope, ttl? })  // → signed JWT string
-verifyArcToken(token, publicKey)              // → { iss, aud, scope } or throws
-resolvePublicKey(iss, db)                     // → CryptoKey (from service_accounts or JWKS)
+generateArcKeyPair()                                      // → CryptoKeyPair (ES256)
+exportKeyToJwk(key)                                       // → JSON string (for DB storage)
+importKeyFromJwk(jwk)                                     // → CryptoKey
+createArcToken(privateKey, { iss, aud, scope }, ttl?)     // → signed JWT string
+verifyArcToken(token, publicKey, expectedAud, scope?)     // → ArcTokenPayload or throws
+resolvePublicKey(issuer, tokenScopes?)                    // → Effect<CryptoKey, ArcTokenError, Db>
+getOrCreateArcToken(privateKey, { iss, aud, scope }, ttl?) // → cached JWT (re-issues 30s before expiry)
+clearTokenCache() / clearPublicKeyCache()                 // → for testing / key rotation
 ```
 
-**Current S2S strategy:** Pulse API imports `createGraphService()` from `@osn/core` directly (Option 1 — zero network overhead, read-only access to `osn.db`). ARC tokens will be used when migrating to HTTP-based S2S (Option 2) at scaling time, and immediately for any third-party app needing graph access.
+### When to use ARC tokens
+
+| Scenario | Use ARC? | Why |
+|----------|----------|-----|
+| Pulse API → OSN Core graph (current) | No | Direct package import (`createGraphService()`); zero overhead |
+| Pulse API → OSN Core graph (multi-process) | **Yes** | HTTP call to `/graph/internal/*` must prove caller identity |
+| Third-party app → any OSN endpoint | **Yes** | Caller has no shared secret; presents its public key via JWKS |
+| User-facing API call | No | Use user JWT (Bearer token); ARC is machine-to-machine only |
+| Background job → OSN Core | **Yes** | Job acts as a service, not a user |
+
+### Calling service (token issuer) — typical pattern
+
+```typescript
+import { getOrCreateArcToken, importKeyFromJwk } from "@osn/crypto/arc";
+
+// Boot-time: load private key from env/secret store
+const privateKey = await importKeyFromJwk(process.env.ARC_PRIVATE_KEY_JWK!);
+
+// Per-request: get a cached or fresh token
+const token = await getOrCreateArcToken(privateKey, {
+  iss: "pulse-api",      // this service's service_id
+  aud: "osn-core",       // target service
+  scope: "graph:read",   // minimal required scope
+});
+
+// Attach to outgoing HTTP request
+fetch("http://localhost:4000/graph/internal/connections", {
+  headers: { Authorization: `ARC ${token}` },
+});
+```
+
+### Receiving service (token verifier) — typical pattern
+
+```typescript
+import { verifyArcToken } from "@osn/crypto/arc";
+import { resolvePublicKey } from "@osn/crypto/arc";
+import { Effect } from "effect";
+
+// In an Elysia route guard or middleware:
+const arcMiddleware = (requiredScope: string) => async (ctx) => {
+  const auth = ctx.headers.authorization;
+  if (!auth?.startsWith("ARC ")) return ctx.set.status = 401;
+
+  const token = auth.slice(4);
+  // resolvePublicKey looks up the issuer in service_accounts table + validates allowed_scopes
+  const publicKey = await Effect.runPromise(
+    resolvePublicKey(/* iss from token */, [requiredScope]).pipe(Effect.provide(DbLive))
+  );
+  const claims = await verifyArcToken(token, publicKey, "osn-core", requiredScope);
+  // claims.iss, claims.aud, claims.scope are now verified
+};
+```
+
+### Service registration
+
+Each first-party service must have a row in `service_accounts`:
+```sql
+INSERT INTO service_accounts (service_id, public_key_jwk, allowed_scopes)
+VALUES ('pulse-api', '<exported-public-key-jwk>', 'graph:read');
+```
+Generate a key pair once at service setup with `generateArcKeyPair()`, store the **private key** in an env/secret store, and insert the **public key** (via `exportKeyToJwk`) into the DB.
+
+**Current S2S strategy:** Pulse API imports `createGraphService()` from `@osn/core` directly (zero network overhead). ARC tokens guard HTTP-based S2S (`/graph/internal/*`) — needed when scaling to multi-process, and immediately for any third-party app. See the "S2S scaling" deferred decision in TODO.md.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 AI coding assistant reference. For full spec see README.md. For progress/decisions see TODO.md.
 
+## Communication Style
+
+- Short, 3–6 word sentences.
+- No filler, preamble, or pleasantries.
+- Run tools first, show result, then stop. Do not narrate.
+- Drop articles ("Fix bug" not "I will fix the bug").
+
 ## Quick Context
 
 OSN: Modular social platform. Users own identity + social graph. Apps opt-in/out independently.

--- a/TODO.md
+++ b/TODO.md
@@ -153,19 +153,23 @@ ARC = OSN's ASAP-style service-to-service (S2S) auth token. ES256 (ECDSA), short
 Address **High** items before any non-local deployment.
 
 ### High
-- [ ] Open redirect in `/magic/verify`: `redirect_uri` not validated against an allowlist — attacker can steal auth codes — H3
+- [ ] Open redirect in `/magic/verify`: `redirect_uri` not validated against an allowlist — attacker can steal auth codes — H3 (now also reachable via registration OTP verify path — three call sites total)
 - [ ] PKCE check optional at `/token`: silently skipped when `state` absent — make mandatory per RFC 7636 — H4
+- [ ] `/passkey/register/begin` accepts arbitrary `userId` with no auth check (M11) — worsened by registration flow: fresh `userId` returned pre-email-verification; combined with M11 enables account pre-hijacking. Fix: require verified session/code before accepting passkey registration — H5
 - [x] No auth/authorisation middleware on API routes (OWASP A01) — H1 (POST/PATCH/DELETE require auth; unauthenticated → 401)
 - [x] No ownership check on mutating event operations (create/update/delete) — H2 (createdByUserId NOT NULL; 403 on non-owner)
 
 ### Medium
-- [ ] `POST /register` has no rate limiting or email verification — handles can be squatted in bulk; add per-IP rate limit and email confirmation before first login — M13
+- [ ] `POST /register` has no rate limiting or email verification — handles can be squatted in bulk; add per-IP rate limit and email confirmation before first login — M13 (now user-facing via "Create account" tab — urgency increased)
+- [ ] No "resend code" button after registration OTP send; if SMTP fails the handle/email are claimed but user is stuck with no recovery path — M15
+- [ ] `GET /handle/:handle` has no auth and no rate limit — handle namespace fully enumerable at HTTP speeds — M16
+- [ ] `POST /register` returns raw `String(catch)` error — can expose Drizzle constraint internals; normalise to user-safe strings — M17
 - [ ] `displayName` is embedded in JWT access tokens (1 h TTL) — stale after a profile update; `createdByName` on events reflects the old value until token expires — M14
 - [ ] Wildcard CORS on auth server — restrict to known client origins before deployment — M3
 - [ ] No OTP attempt limit — 6-digit codes brute-forceable at HTTP speeds — M8
 - [ ] All auth state in process memory (`otpStore`, `magicStore`, `pkceStore`, etc.) — lost on restart, unsafe for multi-process — M6
 - [ ] `redirect_uri` at `/token` not matched against value stored in `pkceStore` during `/authorize` (RFC 6749 §4.1.3) — M10
-- [ ] `/passkey/register/begin` accepts arbitrary `userId` with no auth check — M11
+- [ ] `/passkey/register/begin` accepts arbitrary `userId` with no auth check — M11 (elevated to H5 above; see High section)
 - [ ] Magic-link tokens use `crypto.randomUUID` without additional entropy hardening — M7
 - [x] `limit` query param in `listEvents` uncapped — guard `NaN` and clamp to 1–100 — M2 (clamped in service layer)
 - [ ] Photon (Komoot) geocoding: keystrokes sent to third-party with no user notice — add consent UI or proxy — M1

--- a/packages/core/src/lib/html.ts
+++ b/packages/core/src/lib/html.ts
@@ -67,6 +67,31 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     input:focus { border-color: #111; }
     input.valid { border-color: #16a34a; }
     input.invalid { border-color: #c00; }
+    .id-toggle {
+      display: flex;
+      background: #f0f0f0;
+      border-radius: 6px;
+      padding: 2px;
+      gap: 2px;
+      margin-bottom: 0.5rem;
+    }
+    .id-opt {
+      flex: 1;
+      padding: 0.375rem 0.5rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      background: none;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      color: #666;
+      transition: background 0.12s, color 0.12s;
+    }
+    .id-opt.active {
+      background: #fff;
+      color: #111;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
     button.primary {
       width: 100%;
       padding: 0.625rem;
@@ -117,8 +142,15 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   <!-- Passkey tab -->
   <div class="panel active" id="panel-passkey">
     <div class="field">
-      <label for="passkey-identifier">Email or @handle</label>
-      <input type="text" id="passkey-identifier" autocomplete="username webauthn" placeholder="you@example.com or @handle" />
+      <div class="id-toggle" data-group="passkey">
+        <button class="id-opt active" data-mode="email">Email</button>
+        <button class="id-opt" data-mode="handle">Handle</button>
+      </div>
+      <input type="email" id="passkey-email" autocomplete="email webauthn" placeholder="you@example.com" />
+      <div class="handle-wrap hidden" id="passkey-handle-wrap">
+        <span class="at">@</span>
+        <input type="text" id="passkey-handle" autocomplete="username" placeholder="yourhandle" maxlength="30" />
+      </div>
     </div>
     <button class="primary" id="passkey-btn">Sign in with passkey</button>
     <p class="err hidden" id="passkey-err"></p>
@@ -127,8 +159,15 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   <!-- OTP tab -->
   <div class="panel" id="panel-otp">
     <div class="field">
-      <label for="otp-identifier">Email or @handle</label>
-      <input type="text" id="otp-identifier" autocomplete="username" placeholder="you@example.com or @handle" />
+      <div class="id-toggle" data-group="otp">
+        <button class="id-opt active" data-mode="email">Email</button>
+        <button class="id-opt" data-mode="handle">Handle</button>
+      </div>
+      <input type="email" id="otp-email" autocomplete="email" placeholder="you@example.com" />
+      <div class="handle-wrap hidden" id="otp-handle-wrap">
+        <span class="at">@</span>
+        <input type="text" id="otp-handle" autocomplete="username" placeholder="yourhandle" maxlength="30" />
+      </div>
     </div>
     <button class="primary" id="otp-send-btn">Send code</button>
     <div id="otp-verify-section" class="hidden" style="display:flex;flex-direction:column;gap:0.75rem;">
@@ -144,8 +183,15 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   <!-- Magic link tab -->
   <div class="panel" id="panel-magic">
     <div class="field">
-      <label for="magic-identifier">Email or @handle</label>
-      <input type="text" id="magic-identifier" autocomplete="username" placeholder="you@example.com or @handle" />
+      <div class="id-toggle" data-group="magic">
+        <button class="id-opt active" data-mode="email">Email</button>
+        <button class="id-opt" data-mode="handle">Handle</button>
+      </div>
+      <input type="email" id="magic-email" autocomplete="email" placeholder="you@example.com" />
+      <div class="handle-wrap hidden" id="magic-handle-wrap">
+        <span class="at">@</span>
+        <input type="text" id="magic-handle" autocomplete="username" placeholder="yourhandle" maxlength="30" />
+      </div>
     </div>
     <button class="primary" id="magic-btn">Send magic link</button>
     <p class="msg hidden" id="magic-msg">Check your email for the sign-in link.</p>
@@ -214,6 +260,41 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // Email / Handle toggle (shared across passkey, otp, magic panels)
+  // ---------------------------------------------------------------------------
+  document.querySelectorAll('.id-toggle').forEach(function(toggle) {
+    var group = toggle.dataset.group;
+    toggle.querySelectorAll('.id-opt').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        toggle.querySelectorAll('.id-opt').forEach(function(b) { b.classList.remove('active'); });
+        btn.classList.add('active');
+        var mode = btn.dataset.mode;
+        var emailInput = document.getElementById(group + '-email');
+        var handleWrap = document.getElementById(group + '-handle-wrap');
+        if (mode === 'email') {
+          emailInput.classList.remove('hidden');
+          handleWrap.classList.add('hidden');
+          emailInput.focus();
+        } else {
+          emailInput.classList.add('hidden');
+          handleWrap.classList.remove('hidden');
+          document.getElementById(group + '-handle').focus();
+        }
+      });
+    });
+  });
+
+  /** Returns the current identifier value for a given panel group. */
+  function getIdentifier(group) {
+    var toggle = document.querySelector('.id-toggle[data-group="' + group + '"]');
+    var activeMode = toggle.querySelector('.id-opt.active').dataset.mode;
+    if (activeMode === 'handle') {
+      return document.getElementById(group + '-handle').value.trim();
+    }
+    return document.getElementById(group + '-email').value.trim();
+  }
+
   function showErr(id, msg) {
     var el = document.getElementById(id);
     el.textContent = msg;
@@ -271,7 +352,7 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   // ---------------------------------------------------------------------------
   document.getElementById('passkey-btn').addEventListener('click', async function() {
     hideErr('passkey-err');
-    var identifier = document.getElementById('passkey-identifier').value.trim();
+    var identifier = getIdentifier('passkey');
     if (!identifier) { showErr('passkey-err', 'Please enter your email or handle.'); return; }
     try {
       var beginRes = await fetch(issuer + '/passkey/login/begin', {
@@ -281,13 +362,19 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
       }).then(function(r) { return r.json(); });
 
       if (beginRes.error) {
-        // No account or no passkeys — offer OTP instead
-        document.getElementById('otp-identifier').value = identifier;
+        // No account or no passkeys — pre-fill OTP panel and switch to it
+        var otpToggle = document.querySelector('.id-toggle[data-group="otp"]');
+        var activeMode = otpToggle.querySelector('.id-opt.active').dataset.mode;
+        if (activeMode === 'handle' && !identifier.includes('@')) {
+          document.getElementById('otp-handle').value = identifier;
+        } else {
+          document.getElementById('otp-email').value = identifier;
+        }
         document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
         document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
         document.querySelector('.tab[data-tab="otp"]').classList.add('active');
         document.getElementById('panel-otp').classList.add('active');
-        showErr('otp-err', 'No passkey found — enter your email or handle to receive a one-time code instead.');
+        showErr('otp-err', 'No passkey found — receive a one-time code instead.');
         return;
       }
 
@@ -312,7 +399,7 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
 
   document.getElementById('otp-send-btn').addEventListener('click', async function() {
     hideErr('otp-err');
-    otpIdentifier = document.getElementById('otp-identifier').value.trim();
+    otpIdentifier = getIdentifier('otp');
     if (!otpIdentifier) { showErr('otp-err', 'Please enter your email or handle.'); return; }
     try {
       var res = await fetch(issuer + '/otp/begin', {
@@ -351,7 +438,7 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   // ---------------------------------------------------------------------------
   document.getElementById('magic-btn').addEventListener('click', async function() {
     hideErr('magic-err');
-    var identifier = document.getElementById('magic-identifier').value.trim();
+    var identifier = getIdentifier('magic');
     if (!identifier) { showErr('magic-err', 'Please enter your email or handle.'); return; }
     try {
       var res = await fetch(issuer + '/magic/begin', {

--- a/packages/core/src/lib/html.ts
+++ b/packages/core/src/lib/html.ts
@@ -16,7 +16,6 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sign in — OSN</title>
-  <script src="https://unpkg.com/@simplewebauthn/browser@13/dist/bundle/index.es5.umd.min.js"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body {
@@ -241,18 +240,31 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   </div>
 </div>
 
+<script src="https://unpkg.com/@simplewebauthn/browser@13/dist/bundle/index.es5.umd.min.js"></script>
 <script>
 (function () {
   var P = ${escaped};
   var issuer = P.issuerUrl;
 
   // ---------------------------------------------------------------------------
+  // Cached DOM references (queried once at init)
+  // ---------------------------------------------------------------------------
+  var tabs = document.querySelectorAll('.tab');
+  var panels = document.querySelectorAll('.panel');
+  // Tracks which input mode is active per sign-in panel group
+  var activeMode = { passkey: 'email', otp: 'email', magic: 'email' };
+  // Closure state for multi-step flows
+  var otpIdentifier = '';
+  var _regEmail = '';
+  var _regUserId = '';
+
+  // ---------------------------------------------------------------------------
   // Tab switching
   // ---------------------------------------------------------------------------
-  document.querySelectorAll('.tab').forEach(function(btn) {
+  tabs.forEach(function(btn) {
     btn.addEventListener('click', function() {
-      document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
-      document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
+      tabs.forEach(function(b) { b.classList.remove('active'); });
+      panels.forEach(function(p) { p.classList.remove('active'); });
       btn.classList.add('active');
       document.getElementById('panel-' + btn.dataset.tab).classList.add('active');
       document.getElementById('page-title').textContent =
@@ -265,21 +277,22 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   // ---------------------------------------------------------------------------
   document.querySelectorAll('.id-toggle').forEach(function(toggle) {
     var group = toggle.dataset.group;
+    var emailInput = document.getElementById(group + '-email');
+    var handleWrap = document.getElementById(group + '-handle-wrap');
+    var handleInput = document.getElementById(group + '-handle');
     toggle.querySelectorAll('.id-opt').forEach(function(btn) {
       btn.addEventListener('click', function() {
         toggle.querySelectorAll('.id-opt').forEach(function(b) { b.classList.remove('active'); });
         btn.classList.add('active');
-        var mode = btn.dataset.mode;
-        var emailInput = document.getElementById(group + '-email');
-        var handleWrap = document.getElementById(group + '-handle-wrap');
-        if (mode === 'email') {
+        activeMode[group] = btn.dataset.mode;
+        if (btn.dataset.mode === 'email') {
           emailInput.classList.remove('hidden');
           handleWrap.classList.add('hidden');
           emailInput.focus();
         } else {
           emailInput.classList.add('hidden');
           handleWrap.classList.remove('hidden');
-          document.getElementById(group + '-handle').focus();
+          handleInput.focus();
         }
       });
     });
@@ -287,12 +300,9 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
 
   /** Returns the current identifier value for a given panel group. */
   function getIdentifier(group) {
-    var toggle = document.querySelector('.id-toggle[data-group="' + group + '"]');
-    var activeMode = toggle.querySelector('.id-opt.active').dataset.mode;
-    if (activeMode === 'handle') {
-      return document.getElementById(group + '-handle').value.trim();
-    }
-    return document.getElementById(group + '-email').value.trim();
+    return activeMode[group] === 'handle'
+      ? document.getElementById(group + '-handle').value.trim()
+      : document.getElementById(group + '-email').value.trim();
   }
 
   function showErr(id, msg) {
@@ -363,15 +373,13 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
 
       if (beginRes.error) {
         // No account or no passkeys — pre-fill OTP panel and switch to it
-        var otpToggle = document.querySelector('.id-toggle[data-group="otp"]');
-        var activeMode = otpToggle.querySelector('.id-opt.active').dataset.mode;
-        if (activeMode === 'handle' && !identifier.includes('@')) {
+        if (activeMode.otp === 'handle' && !identifier.includes('@')) {
           document.getElementById('otp-handle').value = identifier;
         } else {
           document.getElementById('otp-email').value = identifier;
         }
-        document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
-        document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
+        tabs.forEach(function(b) { b.classList.remove('active'); });
+        panels.forEach(function(p) { p.classList.remove('active'); });
         document.querySelector('.tab[data-tab="otp"]').classList.add('active');
         document.getElementById('panel-otp').classList.add('active');
         showErr('otp-err', 'No passkey found — receive a one-time code instead.');
@@ -395,7 +403,6 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   // ---------------------------------------------------------------------------
   // OTP sign-in
   // ---------------------------------------------------------------------------
-  var otpIdentifier = '';
 
   document.getElementById('otp-send-btn').addEventListener('click', async function() {
     hideErr('otp-err');
@@ -467,7 +474,6 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     var input = this;
 
     input.classList.remove('valid', 'invalid');
-    hint.classList.add('hidden');
     hint.className = 'hint hidden';
     handleAvailable = false;
 
@@ -477,14 +483,12 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     if (!/^[a-z0-9_]{1,30}$/.test(handle)) {
       hint.textContent = 'Handles can only contain lowercase letters, numbers, and underscores (max 30 chars).';
       hint.className = 'hint bad';
-      hint.classList.remove('hidden');
       input.classList.add('invalid');
       return;
     }
 
     hint.textContent = 'Checking\u2026';
     hint.className = 'hint';
-    hint.classList.remove('hidden');
 
     handleCheckTimer = setTimeout(async function() {
       try {
@@ -502,11 +506,9 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
           input.classList.add('invalid');
           handleAvailable = false;
         }
-        hint.classList.remove('hidden');
       } catch(e) {
         hint.textContent = 'Could not check handle availability.';
         hint.className = 'hint bad';
-        hint.classList.remove('hidden');
       }
     }, 350);
   });
@@ -559,9 +561,9 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
         showErr('reg-otp-err', 'Account created but could not send code: ' + otpSent.error);
       }
 
-      // Store email for the verify step
-      window._regEmail = email;
-      window._regUserId = res.userId;
+      // Store for the OTP verify step (closure vars, not window globals)
+      _regEmail = email;
+      _regUserId = res.userId;
     } catch(e) {
       showErr('reg-err', e.message || 'Registration failed.');
       document.getElementById('reg-btn').disabled = false;
@@ -576,10 +578,10 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
       var res = await fetch(issuer + '/otp/complete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ identifier: window._regEmail, code: code })
+        body: JSON.stringify({ identifier: _regEmail, code: code })
       }).then(function(r) { return r.json(); });
       if (res.error) { showErr('reg-otp-err', res.error); return; }
-      showPasskeyPrompt(window._regUserId, function() { completeAuth(res.code); });
+      showPasskeyPrompt(_regUserId, function() { completeAuth(res.code); });
     } catch(e) {
       showErr('reg-otp-err', e.message || 'Verification failed.');
     }

--- a/packages/core/src/lib/html.ts
+++ b/packages/core/src/lib/html.ts
@@ -55,7 +55,7 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     .panel { display: none; }
     .panel.active { display: flex; flex-direction: column; gap: 0.75rem; }
     label { font-size: 0.75rem; font-weight: 600; color: #555; display: block; margin-bottom: 0.25rem; }
-    input[type="email"], input[type="text"] {
+    input[type="email"], input[type="text"], input[type="password"] {
       width: 100%;
       padding: 0.5rem 0.75rem;
       border: 1px solid #ddd;
@@ -65,6 +65,8 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
       transition: border-color 0.15s;
     }
     input:focus { border-color: #111; }
+    input.valid { border-color: #16a34a; }
+    input.invalid { border-color: #c00; }
     button.primary {
       width: 100%;
       padding: 0.625rem;
@@ -81,6 +83,9 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     button.primary:disabled { opacity: 0.4; cursor: not-allowed; }
     .msg { font-size: 0.8125rem; color: #555; padding: 0.5rem; background: #f5f5f5; border-radius: 6px; }
     .err { color: #c00; font-size: 0.8125rem; }
+    .hint { font-size: 0.75rem; color: #777; margin: 0; }
+    .hint.ok { color: #16a34a; }
+    .hint.bad { color: #c00; }
     .hidden { display: none !important; }
     .passkey-prompt {
       border-top: 1px solid #e5e5e5;
@@ -93,22 +98,27 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     .passkey-prompt .actions { display: flex; gap: 0.5rem; }
     .passkey-prompt .actions button { flex: 1; padding: 0.5rem; font-size: 0.8125rem; border-radius: 6px; border: 1px solid #ddd; background: #fff; cursor: pointer; }
     .passkey-prompt .actions button.yes { background: #111; color: #fff; border-color: #111; }
+    .field { display: flex; flex-direction: column; gap: 0.25rem; }
+    .handle-wrap { position: relative; }
+    .handle-wrap .at { position: absolute; left: 0.75rem; top: 50%; transform: translateY(-50%); color: #999; font-size: 0.875rem; pointer-events: none; }
+    .handle-wrap input { padding-left: 1.5rem; }
   </style>
 </head>
 <body>
 <div class="card">
-  <h1>Sign in to OSN</h1>
+  <h1 id="page-title">Sign in to OSN</h1>
   <div class="tabs">
     <button class="tab active" data-tab="passkey">Passkey</button>
-    <button class="tab" data-tab="otp">OTP</button>
-    <button class="tab" data-tab="email">Email link</button>
+    <button class="tab" data-tab="otp">One-time code</button>
+    <button class="tab" data-tab="magic">Email link</button>
+    <button class="tab" data-tab="register">Create account</button>
   </div>
 
   <!-- Passkey tab -->
   <div class="panel active" id="panel-passkey">
-    <div>
-      <label for="passkey-email">Email</label>
-      <input type="email" id="passkey-email" autocomplete="email webauthn" placeholder="you@example.com" />
+    <div class="field">
+      <label for="passkey-identifier">Email or @handle</label>
+      <input type="text" id="passkey-identifier" autocomplete="username webauthn" placeholder="you@example.com or @handle" />
     </div>
     <button class="primary" id="passkey-btn">Sign in with passkey</button>
     <p class="err hidden" id="passkey-err"></p>
@@ -116,28 +126,63 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
 
   <!-- OTP tab -->
   <div class="panel" id="panel-otp">
-    <div>
-      <label for="otp-email">Email</label>
-      <input type="email" id="otp-email" autocomplete="email" placeholder="you@example.com" />
+    <div class="field">
+      <label for="otp-identifier">Email or @handle</label>
+      <input type="text" id="otp-identifier" autocomplete="username" placeholder="you@example.com or @handle" />
     </div>
     <button class="primary" id="otp-send-btn">Send code</button>
-    <div id="otp-verify-section" class="hidden">
-      <label for="otp-code">Enter code</label>
-      <input type="text" id="otp-code" placeholder="6-digit code" autocomplete="one-time-code" maxlength="6" />
-      <button class="primary" id="otp-verify-btn" style="margin-top:0.5rem">Verify</button>
+    <div id="otp-verify-section" class="hidden" style="display:flex;flex-direction:column;gap:0.75rem;">
+      <div class="field">
+        <label for="otp-code">Enter code</label>
+        <input type="text" id="otp-code" placeholder="6-digit code" autocomplete="one-time-code" maxlength="6" inputmode="numeric" />
+      </div>
+      <button class="primary" id="otp-verify-btn">Verify</button>
     </div>
     <p class="err hidden" id="otp-err"></p>
   </div>
 
-  <!-- Email / magic link tab -->
-  <div class="panel" id="panel-email">
-    <div>
-      <label for="magic-email">Email</label>
-      <input type="email" id="magic-email" autocomplete="email" placeholder="you@example.com" />
+  <!-- Magic link tab -->
+  <div class="panel" id="panel-magic">
+    <div class="field">
+      <label for="magic-identifier">Email or @handle</label>
+      <input type="text" id="magic-identifier" autocomplete="username" placeholder="you@example.com or @handle" />
     </div>
     <button class="primary" id="magic-btn">Send magic link</button>
     <p class="msg hidden" id="magic-msg">Check your email for the sign-in link.</p>
     <p class="err hidden" id="magic-err"></p>
+  </div>
+
+  <!-- Register tab -->
+  <div class="panel" id="panel-register">
+    <div class="field">
+      <label for="reg-email">Email</label>
+      <input type="email" id="reg-email" autocomplete="email" placeholder="you@example.com" />
+    </div>
+    <div class="field">
+      <label for="reg-handle">Handle</label>
+      <div class="handle-wrap">
+        <span class="at">@</span>
+        <input type="text" id="reg-handle" autocomplete="username" placeholder="yourhandle" maxlength="30" />
+      </div>
+      <p class="hint hidden" id="reg-handle-hint"></p>
+    </div>
+    <div class="field">
+      <label for="reg-display-name">Display name <span style="font-weight:400;color:#999;">(optional)</span></label>
+      <input type="text" id="reg-display-name" autocomplete="name" placeholder="Your Name" />
+    </div>
+    <button class="primary" id="reg-btn">Create account</button>
+    <p class="err hidden" id="reg-err"></p>
+
+    <!-- Post-registration: verify via OTP -->
+    <div id="reg-otp-section" class="hidden" style="display:flex;flex-direction:column;gap:0.75rem;">
+      <p class="msg">Account created! Enter the code sent to your email to sign in.</p>
+      <div class="field">
+        <label for="reg-otp-code">One-time code</label>
+        <input type="text" id="reg-otp-code" placeholder="6-digit code" autocomplete="one-time-code" maxlength="6" inputmode="numeric" />
+      </div>
+      <button class="primary" id="reg-otp-verify-btn">Verify and sign in</button>
+      <p class="err hidden" id="reg-otp-err"></p>
+    </div>
   </div>
 
   <!-- Post-auth passkey prompt -->
@@ -155,13 +200,17 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
   var P = ${escaped};
   var issuer = P.issuerUrl;
 
+  // ---------------------------------------------------------------------------
   // Tab switching
+  // ---------------------------------------------------------------------------
   document.querySelectorAll('.tab').forEach(function(btn) {
     btn.addEventListener('click', function() {
       document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
       document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
       btn.classList.add('active');
       document.getElementById('panel-' + btn.dataset.tab).classList.add('active');
+      document.getElementById('page-title').textContent =
+        btn.dataset.tab === 'register' ? 'Create an OSN account' : 'Sign in to OSN';
     });
   });
 
@@ -169,8 +218,12 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     var el = document.getElementById(id);
     el.textContent = msg;
     el.classList.remove('hidden');
+    el.style.display = '';
   }
-  function hideErr(id) { document.getElementById(id).classList.add('hidden'); }
+  function hideErr(id) {
+    var el = document.getElementById(id);
+    el.classList.add('hidden');
+  }
 
   function completeAuth(code) {
     var url = new URL(P.redirectUri);
@@ -179,12 +232,21 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
     window.location.href = url.toString();
   }
 
-  function showPasskeyPrompt(userId) {
-    document.getElementById('passkey-prompt').classList.remove('hidden');
-    document.getElementById('passkey-prompt-no').addEventListener('click', function() {
-      document.getElementById('passkey-prompt').classList.add('hidden');
-    });
-    document.getElementById('passkey-prompt-yes').addEventListener('click', async function() {
+  // ---------------------------------------------------------------------------
+  // Post-auth passkey prompt
+  // ---------------------------------------------------------------------------
+  function showPasskeyPrompt(userId, onDone) {
+    var prompt = document.getElementById('passkey-prompt');
+    prompt.classList.remove('hidden');
+
+    function dismiss() {
+      prompt.classList.add('hidden');
+      onDone();
+    }
+
+    document.getElementById('passkey-prompt-no').onclick = dismiss;
+
+    document.getElementById('passkey-prompt-yes').onclick = async function() {
       try {
         var opts = await fetch(issuer + '/passkey/register/begin', {
           method: 'POST',
@@ -197,68 +259,76 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ userId: userId, attestation: attestation })
         });
-        document.getElementById('passkey-prompt').classList.add('hidden');
       } catch(e) {
         console.error('Passkey registration failed:', e);
-        document.getElementById('passkey-prompt').classList.add('hidden');
       }
-    });
+      dismiss();
+    };
   }
 
+  // ---------------------------------------------------------------------------
   // Passkey sign-in
+  // ---------------------------------------------------------------------------
   document.getElementById('passkey-btn').addEventListener('click', async function() {
     hideErr('passkey-err');
-    var email = document.getElementById('passkey-email').value.trim();
-    if (!email) { showErr('passkey-err', 'Please enter your email.'); return; }
+    var identifier = document.getElementById('passkey-identifier').value.trim();
+    if (!identifier) { showErr('passkey-err', 'Please enter your email or handle.'); return; }
     try {
-      var opts = await fetch(issuer + '/passkey/login/begin', {
+      var beginRes = await fetch(issuer + '/passkey/login/begin', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email })
+        body: JSON.stringify({ identifier: identifier })
       }).then(function(r) { return r.json(); });
-      if (opts.error) {
-        // No account or no passkeys registered — switch to OTP to get started
-        document.getElementById('otp-email').value = email;
+
+      if (beginRes.error) {
+        // No account or no passkeys — offer OTP instead
+        document.getElementById('otp-identifier').value = identifier;
         document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
         document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
         document.querySelector('.tab[data-tab="otp"]').classList.add('active');
         document.getElementById('panel-otp').classList.add('active');
-        showErr('otp-err', 'No passkey found for this account — enter your email to receive a one-time code instead.');
+        showErr('otp-err', 'No passkey found — enter your email or handle to receive a one-time code instead.');
         return;
       }
-      var assertion = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: opts.options });
-      var res = await fetch(issuer + '/passkey/login/complete', {
+
+      var assertion = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: beginRes.options });
+      var completeRes = await fetch(issuer + '/passkey/login/complete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email, assertion: assertion })
+        body: JSON.stringify({ identifier: identifier, assertion: assertion })
       }).then(function(r) { return r.json(); });
-      if (res.error) { showErr('passkey-err', res.error); return; }
-      completeAuth(res.code);
+
+      if (completeRes.error) { showErr('passkey-err', completeRes.error); return; }
+      completeAuth(completeRes.code);
     } catch(e) {
       showErr('passkey-err', e.message || 'Sign-in failed.');
     }
   });
 
-  // OTP send
-  var otpEmail = '';
+  // ---------------------------------------------------------------------------
+  // OTP sign-in
+  // ---------------------------------------------------------------------------
+  var otpIdentifier = '';
+
   document.getElementById('otp-send-btn').addEventListener('click', async function() {
     hideErr('otp-err');
-    otpEmail = document.getElementById('otp-email').value.trim();
-    if (!otpEmail) { showErr('otp-err', 'Please enter your email.'); return; }
+    otpIdentifier = document.getElementById('otp-identifier').value.trim();
+    if (!otpIdentifier) { showErr('otp-err', 'Please enter your email or handle.'); return; }
     try {
       var res = await fetch(issuer + '/otp/begin', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: otpEmail })
+        body: JSON.stringify({ identifier: otpIdentifier })
       }).then(function(r) { return r.json(); });
       if (res.error) { showErr('otp-err', res.error); return; }
-      document.getElementById('otp-verify-section').classList.remove('hidden');
+      var section = document.getElementById('otp-verify-section');
+      section.classList.remove('hidden');
+      section.style.display = 'flex';
     } catch(e) {
       showErr('otp-err', e.message || 'Failed to send code.');
     }
   });
 
-  // OTP verify
   document.getElementById('otp-verify-btn').addEventListener('click', async function() {
     hideErr('otp-err');
     var code = document.getElementById('otp-code').value.trim();
@@ -267,43 +337,164 @@ export function buildAuthorizeHtml(params: AuthorizeHtmlParams): string {
       var res = await fetch(issuer + '/otp/complete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: otpEmail, code: code })
+        body: JSON.stringify({ identifier: otpIdentifier, code: code })
       }).then(function(r) { return r.json(); });
       if (res.error) { showErr('otp-err', res.error); return; }
-      showPasskeyPrompt(res.userId);
-      setTimeout(function() {
-        if (document.getElementById('passkey-prompt').classList.contains('hidden')) {
-          completeAuth(res.code);
-        } else {
-          document.getElementById('passkey-prompt-no').addEventListener('click', function() {
-            completeAuth(res.code);
-          }, { once: true });
-          document.getElementById('passkey-prompt-yes').addEventListener('click', function() {
-            completeAuth(res.code);
-          }, { once: true });
-        }
-      }, 100);
+      showPasskeyPrompt(res.userId, function() { completeAuth(res.code); });
     } catch(e) {
       showErr('otp-err', e.message || 'Verification failed.');
     }
   });
 
-  // Magic link
+  // ---------------------------------------------------------------------------
+  // Magic link sign-in
+  // ---------------------------------------------------------------------------
   document.getElementById('magic-btn').addEventListener('click', async function() {
     hideErr('magic-err');
-    var email = document.getElementById('magic-email').value.trim();
-    if (!email) { showErr('magic-err', 'Please enter your email.'); return; }
+    var identifier = document.getElementById('magic-identifier').value.trim();
+    if (!identifier) { showErr('magic-err', 'Please enter your email or handle.'); return; }
     try {
       var res = await fetch(issuer + '/magic/begin', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email })
+        body: JSON.stringify({ identifier: identifier })
       }).then(function(r) { return r.json(); });
       if (res.error) { showErr('magic-err', res.error); return; }
       document.getElementById('magic-msg').classList.remove('hidden');
       document.getElementById('magic-btn').disabled = true;
     } catch(e) {
       showErr('magic-err', e.message || 'Failed to send link.');
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Registration with handle claiming
+  // ---------------------------------------------------------------------------
+  var handleCheckTimer = null;
+  var handleAvailable = false;
+
+  document.getElementById('reg-handle').addEventListener('input', function() {
+    clearTimeout(handleCheckTimer);
+    var handle = this.value.trim().toLowerCase();
+    var hint = document.getElementById('reg-handle-hint');
+    var input = this;
+
+    input.classList.remove('valid', 'invalid');
+    hint.classList.add('hidden');
+    hint.className = 'hint hidden';
+    handleAvailable = false;
+
+    if (!handle) return;
+
+    // Basic format check client-side before hitting the server
+    if (!/^[a-z0-9_]{1,30}$/.test(handle)) {
+      hint.textContent = 'Handles can only contain lowercase letters, numbers, and underscores (max 30 chars).';
+      hint.className = 'hint bad';
+      hint.classList.remove('hidden');
+      input.classList.add('invalid');
+      return;
+    }
+
+    hint.textContent = 'Checking\u2026';
+    hint.className = 'hint';
+    hint.classList.remove('hidden');
+
+    handleCheckTimer = setTimeout(async function() {
+      try {
+        var res = await fetch(issuer + '/handle/' + encodeURIComponent(handle)).then(function(r) { return r.json(); });
+        if (res.available) {
+          hint.textContent = '@' + handle + ' is available';
+          hint.className = 'hint ok';
+          input.classList.remove('invalid');
+          input.classList.add('valid');
+          handleAvailable = true;
+        } else {
+          hint.textContent = '@' + handle + ' is already taken';
+          hint.className = 'hint bad';
+          input.classList.remove('valid');
+          input.classList.add('invalid');
+          handleAvailable = false;
+        }
+        hint.classList.remove('hidden');
+      } catch(e) {
+        hint.textContent = 'Could not check handle availability.';
+        hint.className = 'hint bad';
+        hint.classList.remove('hidden');
+      }
+    }, 350);
+  });
+
+  document.getElementById('reg-btn').addEventListener('click', async function() {
+    hideErr('reg-err');
+    var email = document.getElementById('reg-email').value.trim();
+    var handle = document.getElementById('reg-handle').value.trim().toLowerCase();
+    var displayName = document.getElementById('reg-display-name').value.trim();
+
+    if (!email) { showErr('reg-err', 'Please enter your email.'); return; }
+    if (!handle) { showErr('reg-err', 'Please enter a handle.'); return; }
+    if (!handleAvailable) { showErr('reg-err', 'Please choose an available handle.'); return; }
+
+    this.disabled = true;
+    try {
+      var body = { email: email, handle: handle };
+      if (displayName) body.displayName = displayName;
+
+      var res = await fetch(issuer + '/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }).then(function(r) { return r.json(); });
+
+      if (res.error) {
+        showErr('reg-err', res.error);
+        this.disabled = false;
+        return;
+      }
+
+      // Registration succeeded — hide the form, show OTP verification
+      document.getElementById('reg-btn').classList.add('hidden');
+      document.getElementById('reg-email').disabled = true;
+      document.getElementById('reg-handle').disabled = true;
+      document.getElementById('reg-display-name').disabled = true;
+
+      // Trigger OTP send automatically so user can sign in immediately
+      var otpSent = await fetch(issuer + '/otp/begin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: email })
+      }).then(function(r) { return r.json(); });
+
+      var regOtpSection = document.getElementById('reg-otp-section');
+      regOtpSection.classList.remove('hidden');
+      regOtpSection.style.display = 'flex';
+
+      if (otpSent.error) {
+        showErr('reg-otp-err', 'Account created but could not send code: ' + otpSent.error);
+      }
+
+      // Store email for the verify step
+      window._regEmail = email;
+      window._regUserId = res.userId;
+    } catch(e) {
+      showErr('reg-err', e.message || 'Registration failed.');
+      document.getElementById('reg-btn').disabled = false;
+    }
+  });
+
+  document.getElementById('reg-otp-verify-btn').addEventListener('click', async function() {
+    hideErr('reg-otp-err');
+    var code = document.getElementById('reg-otp-code').value.trim();
+    if (!code) { showErr('reg-otp-err', 'Please enter the code.'); return; }
+    try {
+      var res = await fetch(issuer + '/otp/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: window._regEmail, code: code })
+      }).then(function(r) { return r.json(); });
+      if (res.error) { showErr('reg-otp-err', res.error); return; }
+      showPasskeyPrompt(window._regUserId, function() { completeAuth(res.code); });
+    } catch(e) {
+      showErr('reg-otp-err', e.message || 'Verification failed.');
     }
   });
 })();

--- a/packages/core/tests/lib/html.test.ts
+++ b/packages/core/tests/lib/html.test.ts
@@ -45,11 +45,28 @@ describe("buildAuthorizeHtml", () => {
     expect(html).toContain('"issuerUrl"');
   });
 
-  it("includes three sign-in tabs", () => {
+  it("includes four sign-in tabs", () => {
     const html = buildAuthorizeHtml(baseParams);
     expect(html).toContain('data-tab="passkey"');
     expect(html).toContain('data-tab="otp"');
-    expect(html).toContain('data-tab="email"');
+    expect(html).toContain('data-tab="magic"');
+    expect(html).toContain('data-tab="register"');
+  });
+
+  it("includes registration panel with handle field and OTP section", () => {
+    const html = buildAuthorizeHtml(baseParams);
+    expect(html).toContain('id="panel-register"');
+    expect(html).toContain('id="reg-email"');
+    expect(html).toContain('id="reg-handle"');
+    expect(html).toContain('id="reg-btn"');
+    expect(html).toContain('id="reg-otp-section"');
+  });
+
+  it("includes email/handle toggle for each sign-in panel", () => {
+    const html = buildAuthorizeHtml(baseParams);
+    expect(html).toContain('data-group="passkey"');
+    expect(html).toContain('data-group="otp"');
+    expect(html).toContain('data-group="magic"');
   });
 
   it("references the issuerUrl in the script body", () => {


### PR DESCRIPTION
## Summary
- **Bug fix:** Sign-in page sent `{ email }` to all auth endpoints but API expects `{ identifier }` — every sign-in method (passkey, OTP, magic link) returned 400 errors. Field renamed throughout the inline JS.
- **Feature:** Added "Create account" tab to the hosted sign-in page: email + handle form, real-time handle availability check (debounced 350ms against `GET /handle/:handle`), `POST /register` on submit, automatic `POST /otp/begin` trigger after registration, OTP verification inline.
- **UX:** Replaced single "Email or @handle" text inputs on all three sign-in panels with a segmented **Email / Handle** toggle — conditionally shows `type="email"` or `@`-prefixed `type="text"` input.
- **Docs:** Updated CLAUDE.md with complete ARC token usage guidance (when to use, calling/receiving patterns, service registration) and communication style guidelines.

## Workspaces affected
- `packages/core` (`@osn/core`) — `src/lib/html.ts`, `tests/lib/html.test.ts`
- Root — `CLAUDE.md`, `TODO.md`, `.changeset/`

## Decisions & issues

- **Root cause of broken sign-in:** `buildAuthorizeHtml` JS sent `{ email }` but Elysia TypeBox schemas on all auth routes declare `{ identifier: t.String() }`. Elysia returns 422 on unknown fields — all three sign-in methods silently failed.
- **Toggle approach:** Chose a CSS segmented-control pill over a single `type="text"` input to give browsers correct autocomplete hints (`email` vs `username`) and make the intent explicit.
- **Passkey fallback pre-fill:** When passkey login fails (no account / no passkeys), the panel switches to OTP and pre-fills the correct input based on the currently active toggle mode in the OTP panel.
- **Registration OTP flow:** After `POST /register` the page automatically calls `POST /otp/begin` so the user doesn't have to switch tabs — then shows the OTP verify section inline. Passkey prompt appears only after OTP verification, not immediately after registration.
- **Stale test:** `tests/lib/html.test.ts` asserted `data-tab="email"` (old tab name) — updated to `data-tab="magic"` and added assertions for the new register tab and toggle markup.
- **Perf fixes (from review):** Moved `@simplewebauthn/browser` CDN script from blocking `<head>` to bottom of `<body>`; cached tab/panel NodeLists and toggle input refs at init; replaced all inline `querySelectorAll` calls; `getIdentifier()` now reads from a closure `activeMode` map instead of querying the DOM.
- **Security fix (from review):** `_regEmail`/`_regUserId` were stored as `window.*` globals — moved to IIFE closure vars, consistent with `otpIdentifier`.
- **H5 (new, deferred):** `POST /register` returns `userId` before email is verified; combined with pre-existing M11 (no auth on `/passkey/register/begin`) this enables account pre-hijacking. Tracked as H5 in TODO.md security backlog — needs its own PR.
- **H3 (pre-existing, wider surface):** Open redirect in `completeAuth()` now has three call sites (passkey, OTP, registration OTP). Fix requires allowlist validation in `/authorize` — tracked, not in scope here.
- **M13 urgency raised:** `POST /register` rate limit gap is now user-facing via the new tab — noted in TODO.md.
- **M15–M17 (new, deferred):** No resend-code on registration OTP failure; handle endpoint enumerable; raw DB error strings from `/register` — all tracked in TODO.md.

## Test plan
- [ ] Sign in with OTP using email — should send code and verify
- [ ] Sign in with OTP using handle — toggle to Handle, enter handle, send code
- [ ] Sign in with magic link using email
- [ ] Sign in with magic link using handle
- [ ] Passkey sign-in — if no passkey registered, should fall back to OTP panel with value pre-filled
- [ ] Create account tab — handle availability hint shows green/red as you type
- [ ] Create account tab — reserved handle (e.g. "admin") shows unavailable
- [ ] Create account tab — submit registers user and shows OTP section automatically
- [ ] Create account OTP verify — completes auth and redirects back to app
- [ ] Create account OTP verify — passkey prompt appears before redirect
- [ ] All 129 core tests pass (`bun run --cwd packages/core test:run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)