### PR TITLE
Reject event creation with past startTime

### DIFF
--- a/.changeset/prevent-past-event-creation.md
+++ b/.changeset/prevent-past-event-creation.md
@@ -1,0 +1,5 @@
+---
+"@osn/api": patch
+---
+
+Reject event creation when `startTime` is not strictly in the future. The events service now returns a `ValidationError` (HTTP 422) if the supplied `startTime` is at or before the current moment, preventing past-dated events from being created.

--- a/packages/api/src/services/events.ts
+++ b/packages/api/src/services/events.ts
@@ -187,6 +187,10 @@ export const createEvent = (
     const id = "evt_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
     const now = new Date();
 
+    if (validated.startTime.getTime() <= now.getTime()) {
+      return yield* Effect.fail(new ValidationError({ cause: "startTime must be in the future" }));
+    }
+
     yield* Effect.tryPromise({
       try: () =>
         db.insert(events).values({ ...validated, ...creator, id, createdAt: now, updatedAt: now }),

--- a/packages/api/tests/helpers/db.ts
+++ b/packages/api/tests/helpers/db.ts
@@ -1,7 +1,8 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import * as schema from "@pulse/db/schema";
+import { events, type Event } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
 
 export function createTestLayer() {
@@ -42,3 +43,46 @@ export function createTestLayer() {
   const db = drizzle(sqlite, { schema });
   return Layer.succeed(Db, { db });
 }
+
+/**
+ * Insert an event directly into the DB, bypassing service-layer validation.
+ * Used by tests that need events with past startTime (e.g. transition tests).
+ */
+export interface SeedEventInput {
+  title: string;
+  startTime: string | Date;
+  endTime?: string | Date;
+  status?: "upcoming" | "ongoing" | "finished" | "cancelled";
+  category?: string;
+  createdByUserId?: string;
+  createdByName?: string | null;
+  createdByAvatar?: string | null;
+}
+
+export const seedEvent = (input: SeedEventInput): Effect.Effect<Event, never, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const id = "evt_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+    const row: Event = {
+      id,
+      title: input.title,
+      description: null,
+      location: null,
+      venue: null,
+      latitude: null,
+      longitude: null,
+      category: input.category ?? null,
+      startTime: new Date(input.startTime),
+      endTime: input.endTime ? new Date(input.endTime) : null,
+      status: input.status ?? "upcoming",
+      imageUrl: null,
+      createdByUserId: input.createdByUserId ?? "usr_alice",
+      createdByName: input.createdByName ?? "Alice",
+      createdByAvatar: input.createdByAvatar ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    yield* Effect.promise(() => db.insert(events).values(row));
+    return row;
+  });

--- a/packages/api/tests/routes/events.test.ts
+++ b/packages/api/tests/routes/events.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { Effect } from "effect";
 import { SignJWT } from "jose";
 import { createEventsRoutes } from "../../src/routes/events";
-import { createTestLayer } from "../helpers/db";
+import { createTestLayer, seedEvent } from "../helpers/db";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
 const TEST_JWT_SECRET = "test-secret";
@@ -57,10 +58,12 @@ const del = (app: ReturnType<typeof createEventsRoutes>, path: string, token?: s
 
 describe("events routes", () => {
   let app: ReturnType<typeof createEventsRoutes>;
+  let layer: ReturnType<typeof createTestLayer>;
   let aliceToken: string;
 
   beforeEach(async () => {
-    app = createEventsRoutes(createTestLayer(), TEST_JWT_SECRET);
+    layer = createTestLayer();
+    app = createEventsRoutes(layer, TEST_JWT_SECRET);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -197,14 +200,24 @@ describe("events routes", () => {
   });
 
   it("GET /events?status=upcoming filters results", async () => {
-    const STARTED = new Date(Date.now() - 60_000).toISOString();
+    const STARTED = new Date(Date.now() - 60_000);
     await post(app, "/events", { title: "Upcoming Event", startTime: FUTURE }, aliceToken);
-    await post(app, "/events", { title: "Ongoing Event", startTime: STARTED }, aliceToken);
+    await Effect.runPromise(
+      seedEvent({ title: "Ongoing Event", startTime: STARTED, status: "ongoing" }).pipe(
+        Effect.provide(layer),
+      ),
+    );
     const res = await app.handle(new Request("http://localhost/events?status=upcoming"));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { events: { title: string }[] };
     expect(body.events.every((e) => e.title === "Upcoming Event")).toBe(true);
     expect(body.events.length).toBe(1);
+  });
+
+  it("POST /events returns 422 when startTime is in the past", async () => {
+    const PAST = "2020-01-01T10:00:00.000Z";
+    const res = await post(app, "/events", { title: "Past", startTime: PAST }, aliceToken);
+    expect(res.status).toBe(422);
   });
 
   it("GET /events?limit=1 returns at most 1 event", async () => {

--- a/packages/api/tests/services/events.test.ts
+++ b/packages/api/tests/services/events.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { createTestLayer } from "../helpers/db";
+import { createTestLayer, seedEvent } from "../helpers/db";
 import {
   createEvent,
   deleteEvent,
@@ -53,7 +53,7 @@ it.effect("listEvents returns all events regardless of time", () =>
   provide(
     Effect.gen(function* () {
       yield* createEvent({ title: "Future", startTime: FUTURE }, ALICE);
-      yield* createEvent({ title: "Past", startTime: PAST }, ALICE);
+      yield* seedEvent({ title: "Past", startTime: PAST });
       const events = yield* listEvents({});
       expect(events.length).toBe(2);
     }),
@@ -64,7 +64,7 @@ it.effect("listEvents filters by status", () =>
   provide(
     Effect.gen(function* () {
       yield* createEvent({ title: "Upcoming Event", startTime: FUTURE }, ALICE);
-      yield* createEvent({ title: "Ongoing Event", startTime: STARTED }, ALICE);
+      yield* seedEvent({ title: "Ongoing Event", startTime: STARTED, status: "ongoing" });
       const events = yield* listEvents({ status: "ongoing" });
       expect(events.length).toBe(1);
       expect(events[0]!.title).toBe("Ongoing Event");
@@ -87,8 +87,7 @@ it.effect("listEvents filters by category", () =>
 it.effect("listTodayEvents returns only today's events", () =>
   provide(
     Effect.gen(function* () {
-      const now = new Date().toISOString();
-      yield* createEvent({ title: "Today Event", startTime: now }, ALICE);
+      yield* seedEvent({ title: "Today Event", startTime: new Date() });
       yield* createEvent({ title: "Future Event", startTime: FUTURE }, ALICE);
       const events = yield* listTodayEvents;
       expect(events.length).toBe(1);
@@ -121,6 +120,25 @@ it.effect("createEvent fails with ValidationError for empty title", () =>
   provide(
     Effect.gen(function* () {
       const error = yield* Effect.flip(createEvent({ title: "", startTime: FUTURE }, ALICE));
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("createEvent fails with ValidationError for past startTime", () =>
+  provide(
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(createEvent({ title: "Test", startTime: PAST }, ALICE));
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("createEvent fails with ValidationError for startTime equal to now", () =>
+  provide(
+    Effect.gen(function* () {
+      const now = new Date().toISOString();
+      const error = yield* Effect.flip(createEvent({ title: "Test", startTime: now }, ALICE));
       expect(error._tag).toBe("ValidationError");
     }),
   ),
@@ -308,9 +326,8 @@ it.effect("updateEvent succeeds when requestingUserId matches createdByUserId", 
 it.effect("getEvent auto-transitions upcoming → ongoing when startTime passed", () =>
   provide(
     Effect.gen(function* () {
-      const created = yield* createEvent({ title: "Started", startTime: STARTED }, ALICE);
-      expect(created.status).toBe("ongoing");
-      const fetched = yield* getEvent(created.id);
+      const seeded = yield* seedEvent({ title: "Started", startTime: STARTED });
+      const fetched = yield* getEvent(seeded.id);
       expect(fetched.status).toBe("ongoing");
     }),
   ),
@@ -319,12 +336,12 @@ it.effect("getEvent auto-transitions upcoming → ongoing when startTime passed"
 it.effect("getEvent auto-transitions to finished when endTime passed", () =>
   provide(
     Effect.gen(function* () {
-      const created = yield* createEvent(
-        { title: "Ended", startTime: STARTED, endTime: ENDED },
-        ALICE,
-      );
-      expect(created.status).toBe("finished");
-      const fetched = yield* getEvent(created.id);
+      const seeded = yield* seedEvent({
+        title: "Ended",
+        startTime: STARTED,
+        endTime: ENDED,
+      });
+      const fetched = yield* getEvent(seeded.id);
       expect(fetched.status).toBe("finished");
     }),
   ),
@@ -333,15 +350,12 @@ it.effect("getEvent auto-transitions to finished when endTime passed", () =>
 it.effect("getEvent does not transition cancelled events", () =>
   provide(
     Effect.gen(function* () {
-      const created = yield* createEvent(
-        {
-          title: "Cancelled",
-          startTime: STARTED,
-          status: "cancelled",
-        },
-        ALICE,
-      );
-      const fetched = yield* getEvent(created.id);
+      const seeded = yield* seedEvent({
+        title: "Cancelled",
+        startTime: STARTED,
+        status: "cancelled",
+      });
+      const fetched = yield* getEvent(seeded.id);
       expect(fetched.status).toBe("cancelled");
     }),
   ),
@@ -350,15 +364,12 @@ it.effect("getEvent does not transition cancelled events", () =>
 it.effect("getEvent does not transition finished events", () =>
   provide(
     Effect.gen(function* () {
-      const created = yield* createEvent(
-        {
-          title: "Finished",
-          startTime: STARTED,
-          status: "finished",
-        },
-        ALICE,
-      );
-      const fetched = yield* getEvent(created.id);
+      const seeded = yield* seedEvent({
+        title: "Finished",
+        startTime: STARTED,
+        status: "finished",
+      });
+      const fetched = yield* getEvent(seeded.id);
       expect(fetched.status).toBe("finished");
     }),
   ),
@@ -367,7 +378,7 @@ it.effect("getEvent does not transition finished events", () =>
 it.effect("listEvents returns transitioned statuses", () =>
   provide(
     Effect.gen(function* () {
-      yield* createEvent({ title: "Started", startTime: STARTED }, ALICE);
+      yield* seedEvent({ title: "Started", startTime: STARTED });
       const results = yield* listEvents({});
       const started = results.find((e) => e.title === "Started");
       expect(started?.status).toBe("ongoing");
@@ -378,7 +389,7 @@ it.effect("listEvents returns transitioned statuses", () =>
 it.effect("listTodayEvents returns transitioned statuses", () =>
   provide(
     Effect.gen(function* () {
-      yield* createEvent({ title: "Today Started", startTime: STARTED }, ALICE);
+      yield* seedEvent({ title: "Today Started", startTime: STARTED });
       const results = yield* listTodayEvents;
       const started = results.find((e) => e.title === "Today Started");
       expect(started?.status).toBe("ongoing");


### PR DESCRIPTION
## Summary
- `createEvent` now fails with `ValidationError` (HTTP 422) when `startTime` is at or before the current moment, so events can only be scheduled strictly in the future.
- Added a `seedEvent` test helper that inserts events directly into the DB, bypassing service validation, so transition/filter tests can still set up past-dated events.
- Refactored existing service + route tests that previously relied on `createEvent` accepting past times to use `seedEvent`.

## Workspaces affected
- `@osn/api` (patch)

## Decisions & issues
- **Validation placement:** Added the past-time guard inside `createEvent` after `Schema.decodeUnknown` rather than as a `Schema.filter` on `startTime`. The schema layer is meant to be pure/transform-only; checking against `new Date()` is a runtime policy that belongs in the service. Reuses the existing `ValidationError` tag so the route's existing `catchTag` already maps it to 422 — no route changes needed.
- **Strict future (`<=`) vs `<`:** Chose `<=` so even "now exactly" is rejected, matching the user's "strictly in the future" wording. Added a boundary test (`startTime equal to now`) to lock this in.
- **Test fallout:** Many existing transition/filter tests created events with past `startTime` (e.g. `STARTED = Date.now() - 60_000`) to exercise `applyTransition`. Rather than weakening the new validation with a flag or fake timers, added a `seedEvent` helper in `tests/helpers/db.ts` that inserts via Drizzle directly. This keeps the production path strict and tests honest. The helper is test-only and not reachable from any route.
- **Status filter quirk:** First seed-helper pass inserted with default `status: "upcoming"`, but `listEvents({ status: "ongoing" })` filters at the SQL layer (before `applyTransition`), so the test failed. Fix: tests that need the SQL filter to match a transitioned status now seed with the explicit pre-transitioned `status` value.
- **Lint:** Pre-existing `eslint(no-new)` warning on `new URL(s)` in `events.ts:36` is unchanged and out of scope.
- **Reviews:** Performance review found 0 issues (O(1) in-memory check, no new DB calls). Security review found 0 issues (no new routes, no new deps, parameterized queries via Drizzle, no PII in error message).
- **Coverage notes from review-tests (not addressed, minor):** No assertion on the error `cause` string and no positive "now + 1s" boundary test. Both are nice-to-haves; the existing negative + equality tests already lock the contract.

## Test plan
- [ ] `bun run --cwd packages/api test:run` — all 64 tests pass
- [ ] `POST /events` with a past `startTime` returns 422
- [ ] `POST /events` with `startTime` equal to "now" returns 422
- [ ] `POST /events` with a future `startTime` still creates successfully (201)
- [ ] Existing event transition behaviour (upcoming → ongoing → finished) still works for events that were already in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)