### PR TITLE
feat: email-verified registration flow with passkey enrolment

### DIFF
--- a/.changeset/registration-flow-frontend.md
+++ b/.changeset/registration-flow-frontend.md
@@ -1,0 +1,11 @@
+---
+"@osn/core": minor
+"@osn/client": minor
+"@osn/pulse": minor
+---
+
+Add an email-verified registration flow end-to-end.
+
+- **`@osn/core`:** New `POST /register/begin` and `POST /register/complete` endpoints. `/register/begin` validates the email + handle, checks they are both free, and sends a 6-digit OTP without creating any DB rows. `/register/complete` verifies the OTP, then creates the user and returns a short-lived authorization code that can be exchanged at `/token` for a session. The legacy `POST /register` endpoint (which created users without verifying email ownership) is left in place for now.
+- **`@osn/client`:** New `createRegistrationClient` plain-fetch helper exposing `checkHandle`, `beginRegistration`, `completeRegistration`, `passkeyRegisterBegin`, `passkeyRegisterComplete`, and `exchangeAuthCode`. The Solid `AuthProvider` gains an `adoptSession` method for persisting a session obtained out-of-band by the registration flow.
+- **`@osn/pulse`:** New `Register` component implementing the multi-step UI: email + handle + display name (with debounced live availability check against `/handle/:handle`) → 6-digit OTP entry → passkey enrolment via `@simplewebauthn/browser` → automatic sign-in. Wired into `EventList` as a "Create account" button next to "Sign in with OSN".

--- a/.changeset/registration-flow-frontend.md
+++ b/.changeset/registration-flow-frontend.md
@@ -4,8 +4,30 @@
 "@osn/pulse": minor
 ---
 
-Add an email-verified registration flow end-to-end.
+Add an email-verified registration flow end-to-end with passkey enrolment, plus a security redesign that addresses the critical findings raised during review.
 
-- **`@osn/core`:** New `POST /register/begin` and `POST /register/complete` endpoints. `/register/begin` validates the email + handle, checks they are both free, and sends a 6-digit OTP without creating any DB rows. `/register/complete` verifies the OTP, then creates the user and returns a short-lived authorization code that can be exchanged at `/token` for a session. The legacy `POST /register` endpoint (which created users without verifying email ownership) is left in place for now.
-- **`@osn/client`:** New `createRegistrationClient` plain-fetch helper exposing `checkHandle`, `beginRegistration`, `completeRegistration`, `passkeyRegisterBegin`, `passkeyRegisterComplete`, and `exchangeAuthCode`. The Solid `AuthProvider` gains an `adoptSession` method for persisting a session obtained out-of-band by the registration flow.
-- **`@osn/pulse`:** New `Register` component implementing the multi-step UI: email + handle + display name (with debounced live availability check against `/handle/:handle`) → 6-digit OTP entry → passkey enrolment via `@simplewebauthn/browser` → automatic sign-in. Wired into `EventList` as a "Create account" button next to "Sign in with OSN".
+**`@osn/core` — new endpoints + service work**
+- `POST /register/begin` — validates email + handle, normalises email to lowercase, generates an unbiased 6-digit OTP via rejection sampling, stores a pending registration in a bounded (10k cap), swept-on-insert in-memory map, and emails the OTP. Always returns `{ sent: true }` regardless of conflict to remove the user-enumeration oracle (S-M1/S-M26). Refuses to overwrite a non-expired pending entry to prevent griefing of in-progress registrations (S-M2/S-M23).
+- `POST /register/complete` — verifies the OTP using a constant-time comparison (S-M4/S-M25), enforces a 5-attempts-then-wipe brute-force cap (S-H1 partial), inserts the user using the DB unique constraint as the source of truth (no TOCTOU; the pending entry is only deleted after a successful insert — S-H4/S-H10), and returns access + refresh tokens **directly** alongside a single-use enrollment token. The registration code path no longer touches `/token` so it does not depend on the pre-existing PKCE bypass at `/token` (tracked separately as S-H4/S-H9).
+- New `issueEnrollmentToken` / `verifyEnrollmentToken` service helpers — short-lived (5 min) JWTs of `type: "passkey-enroll"`, single-use via an in-memory consumed-jti set with opportunistic sweep.
+- `POST /passkey/register/{begin,complete}` now accept an `Authorization: Bearer <token>` header where the token is either an enrollment token or a normal access token; the token's `sub` is compared against the body `userId` and a mismatch returns `401` (S-C1/S-H5 partial). The legacy unauth'd path is preserved with a deprecation warning so the hosted `/authorize` HTML page still works; removing it is tracked in the security backlog.
+- New `publicError()` route helper maps Effect-tagged errors to opaque public payloads (`invalid_request`, `internal_error`) and logs the underlying cause server-side (S-H5/S-M6/S-M4).
+- Dev-only `console.log` of OTP codes is now gated on `NODE_ENV !== "production"` (S-M3/S-M22).
+
+**`@osn/client` — RegistrationClient redesign**
+- `createRegistrationClient` exposes `checkHandle`, `beginRegistration`, `completeRegistration`, `passkeyRegisterBegin`, `passkeyRegisterComplete`. **`exchangeAuthCode` is gone** — `completeRegistration` now returns a parsed `Session` ready for `AuthProvider.adoptSession` plus an `enrollmentToken`. Both passkey calls accept the enrollment token and send it as `Authorization: Bearer <token>`.
+- New `OsnAuth.setSession` + Solid `AuthProvider.adoptSession` for installing a session obtained out-of-band by the registration flow.
+
+**`@osn/pulse` — Register component**
+- Multi-step UI: details (email + handle + display name with debounced live availability check) → 6-digit OTP → optional passkey enrolment → done.
+- `adoptSession` is called immediately after OTP verification, **before** any passkey work — the user is signed in regardless of whether they go on to set up a passkey, so a flaky WebAuthn ceremony or an unsupported environment can no longer leave them stranded.
+- WebAuthn feature-detection via `browserSupportsWebAuthn()`; the passkey step is skipped entirely (and the UI jumps straight to "done") on environments without WebAuthn — currently Tauri's iOS webview, until we ship the native plugin.
+- Imperative skip path replacing the previous `createEffect` (P-I10), inlined `detailsValid` accessor (P-I11), module-scope `RegistrationClient` (P-I12).
+- Wired into `EventList` as a "Create account" button next to "Sign in with OSN".
+
+**Test coverage** (277 tests total, +58 from the previous PR baseline)
+- Service-level: happy path, lowercase normalisation, no-row-before-verify, ValidationError on bad inputs, enumeration-resistant begin, refuse-to-overwrite pending entry, wrong OTP, no-pending error, single-use replay, brute-force attempt cap, TOCTOU loss against legacy `/register`, enrollment token issue/verify/consume, replay rejection, type-claim discrimination.
+- Route-level: complete shape assertions, enumeration-resistant 200 responses, complete-without-begin, replay attack, reserved handle availability, Authorization gating with valid enrollment token / valid access token / mismatched sub / invalid bearer / legacy unauth'd path, enrollment-token consumption on `/complete`.
+- Client unit tests: URL composition, body shapes, Authorization header propagation, RegistrationError on non-OK, trailing-slash issuerUrl normalisation.
+- Solid `AuthProvider.adoptSession` round-trip test (real provider, harness component, asserts both `useAuth().session()` reactivity and `localStorage` persistence).
+- Pulse Register component test: input sanitisation, debounced availability with stale-result guard, `detailsValid` gating during `checking`, OTP digit-only clamp, immediate `adoptSession` after OTP, happy passkey enrolment with enrollment token propagation, "Skip for now" → done, WebAuthn-unsupported jump-to-done, Cancel.

--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,10 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 - [ ] Pulse: "What's on today" default view
 - [ ] Landing page: design and content
+- [ ] S-H1 — Rate limit registration + login auth endpoints (per-IP / per-email throttle)
 - [ ] S-H3 — Open redirect in `/magic/verify` — fix before any deployment
-- [ ] S-H4 — Make PKCE mandatory at `/token`
-- [ ] S-H1 — Rate limit `POST /register`
+- [ ] S-H4 — Make PKCE mandatory at `/token` (drop the `if (state)` conditional; affects every code-issuing flow)
+- [ ] S-H5 — Migrate the hosted `/authorize` HTML page to send `Authorization: Bearer <token>` to `/passkey/register/*`, then remove the legacy unauth'd path
 - [ ] S-M1 — `verifyAccessToken` rejects tokens missing `handle` claim — grace period needed
 - [ ] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
 
@@ -148,24 +149,27 @@ Address **High** items before any non-local deployment.
 
 ### High
 
-- [ ] S-H1 — `POST /register` no rate limit — handles squattable in bulk; add per-IP rate limit (urgency increased: now user-facing via "Create account" tab)
+- [ ] S-H1 — Rate limit `/register/begin`, `/register/complete`, `/handle/:handle`, and the OTP/magic-link login endpoints. New registration flow has a per-entry attempt cap (max 5 wrong OTPs → wipe) but still no per-IP / per-email throttle, so an attacker can email-bomb arbitrary addresses or spray begin-then-complete cycles. Needs middleware infra; the existing graph rate-limiter is per-user, which doesn't apply to unauthenticated routes.
 - [ ] S-H2 — `GET /handle/:handle` no rate limit — handle namespace fully enumerable at HTTP speeds; add 10 req/IP/min limit
-- [ ] S-H3 — Open redirect in `/magic/verify`: `redirect_uri` not validated against allowlist — attacker can steal auth codes (three call sites: magic verify + registration OTP verify path)
-- [ ] S-H4 — PKCE check optional at `/token`: silently skipped when `state` absent — make mandatory per RFC 7636
-- [ ] S-H5 — `/passkey/register/begin` accepts arbitrary `userId` with no auth check — combined with fresh `userId` returned pre-email-verification, enables account pre-hijacking; require verified session/code before accepting passkey registration
+- [ ] S-H3 — Open redirect in `/magic/verify`: `redirect_uri` not validated against allowlist — attacker can steal auth codes
+- [ ] S-H4 — PKCE check optional at `/token`: silently skipped when `state` absent — make mandatory per RFC 7636. The new registration flow no longer depends on this bypass (it returns tokens directly from `register/complete`), but every other flow that mints an authorization code (`/passkey/login/complete`, `/otp/complete`, `/magic/verify`) is still vulnerable: any leaked code can be redeemed without proof of possession by simply omitting `state`. Drop the `if (state) { … }` conditional in `routes/auth.ts:150-180` so PKCE verification is unconditional on `authorization_code` grants.
+- [ ] S-H5 — `/passkey/register/{begin,complete}` legacy unauth'd path: when no `Authorization` header is present, the routes still trust `body.userId` as proof of identity. The new registration flow no longer hits this path (it carries an enrollment token), but the hosted `/authorize` HTML page (`buildAuthorizeHtml`) still does, which means the cross-user passkey enrolment vector is reachable for any user that authenticates through the hosted UI. Migrate the hosted UI to also use enrollment tokens (or just access tokens for already-logged-in flows) and then make the `Authorization` header required on both routes.
 - [x] S-H6 — No auth/authorisation middleware on API routes (OWASP A01) — POST/PATCH/DELETE require auth; unauthenticated → 401
 - [x] S-H7 — No ownership check on mutating event operations — createdByUserId NOT NULL; 403 on non-owner
 - [x] S-H8 — Graph GET endpoints unguarded — all GET handlers wrapped in try/catch; generic "Request failed" on unexpected errors
+- [x] S-H9 — `/register/complete` exploited a pre-existing PKCE bypass at `/token` to mint a session — fixed in the registration flow redesign: `register/complete` now issues access + refresh tokens directly and the registration code path never calls `/token`. Underlying `/token` bypass is tracked separately as S-H4.
+- [x] S-H10 — TOCTOU between OTP verify and user insert in `completeRegistration` — fixed: insert is attempted directly, the unique constraint is the source of truth, and a losing race no longer burns the pending OTP entry.
+- [x] S-H11 — `email.toLowerCase()` was used as the pending-registrations map key but the original-cased value was persisted, allowing two near-duplicate accounts — fixed: the lowercased value is now the canonical form throughout the registration pipeline (the legacy `/register` path is unchanged; tracked as S-M19 below).
 
 ### Medium
 
 - [ ] S-M1 — `verifyAccessToken` rejects tokens missing `handle` claim — old tokens 401 silently; treat missing `handle` as `null` during transition period
 - [ ] S-M2 — In-memory rate limiter resets on restart/deploy — document as known; migrate to shared counter when scaling horizontally
-- [ ] S-M3 — No "resend code" button after registration OTP; if SMTP fails, handle/email are claimed with no recovery path
-- [ ] S-M4 — `POST /register` returns raw `String(catch)` error — can expose Drizzle constraint internals; normalise to user-safe strings
+- [ ] S-M3 — No "resend code" button after registration OTP; if SMTP fails, handle/email are claimed with no recovery path. Partly mitigated by the new flow's "refuse to overwrite a non-expired pending entry" policy (the user retries via the existing pending entry, no new email is sent), but a true resend button is still needed.
+- [ ] S-M4 — Legacy `POST /register` (unverified email) returns raw `String(catch)` error — can expose Drizzle constraint internals. The new `/register/{begin,complete}` routes already use the `publicError()` mapper from `routes/auth.ts`; extend the same mapper to the legacy endpoint and to all other routes that still use `String(e)`.
 - [ ] S-M5 — `displayName` embedded in JWT (1h TTL) — stale after profile update; `createdByName` on events reflects old value until token expires
 - [ ] S-M6 — Wildcard CORS on auth server — restrict to known client origins before deployment
-- [ ] S-M7 — No OTP attempt limit — 6-digit codes brute-forceable at HTTP speeds
+- [ ] S-M7 — Login OTP (`/otp/begin` → `/otp/complete`) has no per-entry attempt limit. The new registration `completeRegistration` enforces 5 wrong guesses → wipe; mirror that into `completeOtp`.
 - [ ] S-M8 — All auth state in process memory (`otpStore`, `magicStore`, `pkceStore`) — lost on restart, unsafe for multi-process
 - [ ] S-M9 — `redirect_uri` at `/token` not matched against value stored in `pkceStore` during `/authorize` (RFC 6749 §4.1.3)
 - [ ] S-M10 — `/passkey/register/begin` accepts arbitrary `userId` with no auth check (elevated to S-H5; see High section)
@@ -177,6 +181,14 @@ Address **High** items before any non-local deployment.
 - [x] S-M16 — No rate limiting on graph write endpoints — module-level fixed-window limiter added (60/user/min)
 - [x] S-M17 — Raw DB/Effect errors surfaced in graph responses — `safeError()` helper; only `GraphError`/`NotFoundError` messages exposed
 - [x] S-M18 — No input validation on `:handle` route param in graph routes — TypeBox `HandleParam` with regex + length bounds added
+- [ ] S-M19 — Legacy `/register` does not lowercase emails — two users can register `Alice@example.com` and `alice@example.com` as distinct accounts. New email-verified path normalises; lift the same normalisation into `registerUser`, `findUserByEmail`, OTP login, and magic-link login. Add a DB-level unique index on `lower(email)` to enforce.
+- [ ] S-M20 — Refresh tokens stored in `localStorage` via `OsnAuth.setSession` (default `Storage` adapter is `localStorage`). XSS in the Pulse webview = permanent account takeover. For Tauri, swap in a keychain-backed adapter (`tauri-plugin-stronghold` or an OS-encrypted store); for web targets, prefer HttpOnly cookies issued by the auth server.
+- [ ] S-M21 — `/register/begin` differential timing oracle on the silent no-op branch — when an email is already taken, the route skips the `sendEmail` call, so the response is consistently faster than the legitimate path. Add a synthetic delay or perform a dummy hash to flatten timing if/when this becomes exploitable.
+- [x] S-M22 — `console.log` of OTP in dev fallback unconditionally exposed credentials in any environment without `sendEmail` set — fixed in the new registration flow: gated on `NODE_ENV !== "production"`. Same fix should be applied to the login OTP path (`beginOtp`).
+- [x] S-M23 — `pendingRegistrations` Map grew unboundedly with no eviction (P-W1 / S-M2 of the security review) — fixed: capped at 10 000 entries, swept on every insert, and refuses to overwrite a non-expired entry to prevent griefing.
+- [x] S-M24 — Biased modulo OTP generation (`buf[0] % 900_000` over a 32-bit draw) — fixed in the new registration flow via rejection sampling in `genOtpCode()`. Login OTP path still uses the biased version; lift the helper.
+- [x] S-M25 — Non-constant-time OTP comparison via `===` — fixed in the new registration flow via `timingSafeEqualString()`. Login OTP path still uses `!==`; lift the helper.
+- [x] S-M26 — Differential error responses on `/register/begin` (`Email already registered` vs `Handle already taken` vs `sent: true`) leaked which accounts exist — fixed: the route now always returns `{ sent: true }` regardless of conflict status. The handle availability check via `/handle/:handle` remains the appropriate channel for that question and can be rate-limited independently.
 
 ### Low
 
@@ -209,7 +221,9 @@ Address **High** items before any non-local deployment.
 - [ ] P-W1 — `rateLimitStore` in graph routes grows without bound — expired entries never evicted; add `setInterval` sweep
 - [ ] P-W2 — `resolvePublicKey` hits DB on every scoped call despite warm cache — cache `CryptoKey` + `allowedScopes` together
 - [ ] P-W3 — `sendConnectionRequest` makes two sequential independent DB reads — use `Effect.all` with `concurrency: "unbounded"`
-- [ ] P-W4 — Auth Maps (`otpStore`, `magicStore`, `pkceStore`) never evict expired entries — add periodic sweep
+- [ ] P-W4 — Auth Maps (`otpStore`, `magicStore`, `pkceStore`) never evict expired entries — add periodic sweep. The new `pendingRegistrations` map already uses `sweepExpired()` on insert; lift the helper into the other stores.
+- [ ] P-W10 — `RegistrationClient.checkHandle` has no `AbortController` — debounced bursts of typing can leave multiple in-flight `GET /handle/:handle` requests racing each other; results are guarded against display races but the network requests still hit the DB. Plumb an `AbortSignal` through and abort the previous request when a new one is scheduled.
+- [ ] P-W11 — `beginRegistration` and the legacy `registerUser` issue two parallel `findUserByEmail` + `findUserByHandle` queries instead of a single `WHERE email = ? OR handle = ?` — doubles the DB latency component on a hot signup path. Add a `findUserByEmailOrHandle` helper.
 - [ ] P-W5 — Batch status-transition `UPDATE`s in `listEvents`/`listTodayEvents` (N individual writes today)
 - [x] P-W6 — N+1 queries in graph list functions — replaced with `inArray` batch fetches
 - [x] P-W7 — `eitherBlocked` made two sequential `isBlocked` calls — collapsed to single OR query
@@ -227,6 +241,9 @@ Address **High** items before any non-local deployment.
 - [ ] P-I7 — Eliminate extra `getEvent` round-trip in `createEvent` via `RETURNING *`
 - [ ] P-I8 — `resolveHandle` re-fetches user from DB when handler already has the User row
 - [ ] P-I9 — Graph list endpoints load entire result set before slicing — add DB-level `LIMIT`/`OFFSET` when pagination is user-facing
+- [x] P-I10 — `Register.tsx` used `createEffect` to auto-skip the passkey step when WebAuthn was unsupported — fixed: skip is now imperative, called directly from `submitOtp` after the step transition. Removes the re-fire surface area and the `!busy()` infinite-loop guard.
+- [x] P-I11 — `Register.tsx` wrapped `detailsValid` in `createMemo` for a 3-line boolean expression — fixed: inlined as a plain accessor function. Solid's reactivity already re-runs JSX accessors fine-grainedly; the memo node was pure overhead.
+- [x] P-I12 — `Register.tsx` reallocated the `RegistrationClient` (and its closures) on every component mount — fixed: hoisted to module scope.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] Test coverage: utils, LocationInput, CreateEventForm end-time validation
 - [x] Test coverage: EventCard, CreateEventForm (full), EventList (auth/unauth)
 - [x] Toast notification system (solid-toast: event created, deleted, create/delete errors)
+- [x] Registration UI: multi-step flow (email + handle + display name → OTP → passkey enrolment), live handle availability check, auto-login on completion via `adoptSession`
 - [x] Coordinate storage (lat/lng from Photon autocomplete) + Maps button on EventCard
 - [ ] Map preview in expanded event view (Leaflet + OpenStreetMap, no API key)
 - [ ] "What's on today" default view

--- a/TODO.md
+++ b/TODO.md
@@ -246,6 +246,7 @@ Address **High** items before any non-local deployment.
 | Max event duration | Prompt user when creating events without endTime | When Pulse event creation UI is built |
 | S2S scaling: HTTP graph API | Current: direct package import (`createGraphService()`). Migrate to HTTP `/graph/internal/*` + ARC tokens when scaling horizontally. | When multi-process or multi-machine deployment needed |
 | Per-app blocking | Blocks are global across all OSN apps. Per-app scope deferred. | When Messaging or a third-party app needs independent block lists |
+| Tauri passkey support on iOS | Tauri webview does not expose WebAuthn natively — `apps/pulse` registration flow feature-detects via `browserSupportsWebAuthn()` and auto-skips the passkey step on unsupported environments. Options when we ship mobile: (a) adopt [`tauri-plugin-webauthn`](https://github.com/Profiidev/tauri-plugin-webauthn) (third-party, audit first), (b) write our own thin Tauri plugin wrapping `ASAuthorizationPlatformPublicKeyCredentialProvider`, (c) wait for upstream — track [tauri#7926](https://github.com/tauri-apps/tauri/issues/7926). | When iOS build of Pulse is ready for sign-in |
 
 ---
 

--- a/apps/pulse/package.json
+++ b/apps/pulse/package.json
@@ -21,6 +21,7 @@
     "@osn/client": "workspace:*",
     "@osn/core": "workspace:*",
     "@osn/ui": "workspace:*",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",

--- a/apps/pulse/src/components/EventList.tsx
+++ b/apps/pulse/src/components/EventList.tsx
@@ -7,6 +7,7 @@ import { REDIRECT_URI } from "../lib/auth";
 import { getUserIdFromToken, getDisplayNameFromToken } from "../lib/utils";
 import { EventCard } from "./EventCard";
 import { CreateEventForm } from "./CreateEventForm";
+import { Register } from "./Register";
 
 async function fetchEvents(accessToken: string | null): Promise<EventItem[]> {
   const headers: Record<string, string> = {};
@@ -27,6 +28,7 @@ export function EventList() {
   const tokenSource = createMemo(() => ({ token: accessToken() }));
   const [events, { refetch }] = createResource(tokenSource, ({ token }) => fetchEvents(token));
   const [showForm, setShowForm] = createSignal(false);
+  const [showRegister, setShowRegister] = createSignal(false);
   const [deletingIds, setDeletingIds] = createSignal(new Set<string>());
 
   function handleDelete(id: string) {
@@ -68,6 +70,12 @@ export function EventList() {
         <div class="flex gap-2">
           <Show when={!session()}>
             <button
+              onClick={() => setShowRegister(true)}
+              class="rounded-md px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              Create account
+            </button>
+            <button
               onClick={() => login(REDIRECT_URI())}
               class="rounded-md px-3 py-1.5 text-sm font-medium bg-secondary text-secondary-foreground hover:bg-secondary/80"
             >
@@ -90,6 +98,9 @@ export function EventList() {
           </Show>
         </div>
       </div>
+      <Show when={showRegister() && !session()}>
+        <Register onCancel={() => setShowRegister(false)} />
+      </Show>
       <Show when={showForm()}>
         <CreateEventForm
           accessToken={accessToken()}

--- a/apps/pulse/src/components/Register.tsx
+++ b/apps/pulse/src/components/Register.tsx
@@ -1,0 +1,286 @@
+import { createSignal, createMemo, Show, onCleanup } from "solid-js";
+import { startRegistration } from "@simplewebauthn/browser";
+import { useAuth } from "@osn/client/solid";
+import { createRegistrationClient, type RegistrationClient } from "@osn/client";
+import { toast } from "solid-toast";
+import { OSN_ISSUER_URL, OSN_CLIENT_ID } from "../lib/auth";
+
+type Step = "details" | "verify" | "passkey" | "done";
+
+const HANDLE_RE = /^[a-z0-9_]{1,30}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface RegisterProps {
+  onCancel: () => void;
+}
+
+export function Register(props: RegisterProps) {
+  const { adoptSession } = useAuth();
+  const client: RegistrationClient = createRegistrationClient({
+    issuerUrl: OSN_ISSUER_URL,
+    clientId: OSN_CLIENT_ID,
+  });
+
+  const [step, setStep] = createSignal<Step>("details");
+  const [email, setEmail] = createSignal("");
+  const [handle, setHandle] = createSignal("");
+  const [displayName, setDisplayName] = createSignal("");
+  const [otp, setOtp] = createSignal("");
+  const [busy, setBusy] = createSignal(false);
+  const [userId, setUserId] = createSignal<string | null>(null);
+  const [authCode, setAuthCode] = createSignal<string | null>(null);
+
+  // Live handle availability check (debounced).
+  const [handleStatus, setHandleStatus] = createSignal<
+    "idle" | "checking" | "available" | "taken" | "invalid"
+  >("idle");
+  let handleTimer: ReturnType<typeof setTimeout> | null = null;
+  onCleanup(() => {
+    if (handleTimer) clearTimeout(handleTimer);
+  });
+
+  function onHandleInput(value: string) {
+    const next = value.toLowerCase().replace(/[^a-z0-9_]/g, "");
+    setHandle(next);
+    if (handleTimer) clearTimeout(handleTimer);
+    if (!next) {
+      setHandleStatus("idle");
+      return;
+    }
+    if (!HANDLE_RE.test(next)) {
+      setHandleStatus("invalid");
+      return;
+    }
+    setHandleStatus("checking");
+    handleTimer = setTimeout(async () => {
+      try {
+        const { available } = await client.checkHandle(next);
+        // Guard against stale results if the user kept typing.
+        if (handle() !== next) return;
+        setHandleStatus(available ? "available" : "taken");
+      } catch {
+        if (handle() !== next) return;
+        setHandleStatus("invalid");
+      }
+    }, 300);
+  }
+
+  const detailsValid = createMemo(() => EMAIL_RE.test(email()) && handleStatus() === "available");
+
+  async function submitDetails(e: Event) {
+    e.preventDefault();
+    if (!detailsValid() || busy()) return;
+    setBusy(true);
+    try {
+      await client.beginRegistration({
+        email: email(),
+        handle: handle(),
+        displayName: displayName().trim() || undefined,
+      });
+      toast.success("Verification code sent");
+      setStep("verify");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not send code");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function submitOtp(e: Event) {
+    e.preventDefault();
+    if (busy() || otp().length !== 6) return;
+    setBusy(true);
+    try {
+      const result = await client.completeRegistration({ email: email(), code: otp() });
+      setUserId(result.userId);
+      setAuthCode(result.code);
+      toast.success("Email verified");
+      setStep("passkey");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Invalid code");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function enrollPasskey() {
+    const id = userId();
+    const code = authCode();
+    if (!id || !code || busy()) return;
+    setBusy(true);
+    try {
+      const options = (await client.passkeyRegisterBegin(id)) as Parameters<
+        typeof startRegistration
+      >[0]["optionsJSON"];
+      const attestation = await startRegistration({ optionsJSON: options });
+      await client.passkeyRegisterComplete({ userId: id, attestation });
+      const session = await client.exchangeAuthCode(code);
+      await adoptSession(session);
+      toast.success(`Welcome, @${handle()}`);
+      setStep("done");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Passkey setup failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function skipPasskeyForNow() {
+    const code = authCode();
+    if (!code || busy()) return;
+    setBusy(true);
+    try {
+      const session = await client.exchangeAuthCode(code);
+      await adoptSession(session);
+      toast.success(`Welcome, @${handle()}`);
+      setStep("done");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Sign in failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div class="max-w-sm mx-auto px-4 py-8">
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-foreground">Create your OSN account</h2>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          class="text-sm text-muted-foreground hover:text-foreground"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <Show when={step() === "details"}>
+        <form onSubmit={submitDetails} class="flex flex-col gap-4">
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Email</span>
+            <input
+              type="email"
+              required
+              autocomplete="email"
+              value={email()}
+              onInput={(e) => setEmail(e.currentTarget.value)}
+              class="rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Handle</span>
+            <div class="flex items-center gap-2">
+              <span class="text-muted-foreground">@</span>
+              <input
+                type="text"
+                required
+                autocomplete="username"
+                value={handle()}
+                onInput={(e) => onHandleInput(e.currentTarget.value)}
+                placeholder="lowercase, numbers, _"
+                class="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+              />
+            </div>
+            <Show when={handleStatus() === "checking"}>
+              <span class="text-xs text-muted-foreground">Checking…</span>
+            </Show>
+            <Show when={handleStatus() === "available"}>
+              <span class="text-xs text-green-600">@{handle()} is available</span>
+            </Show>
+            <Show when={handleStatus() === "taken"}>
+              <span class="text-xs text-destructive">@{handle()} is taken</span>
+            </Show>
+            <Show when={handleStatus() === "invalid"}>
+              <span class="text-xs text-destructive">
+                1–30 chars: lowercase letters, numbers, underscores
+              </span>
+            </Show>
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Display name (optional)</span>
+            <input
+              type="text"
+              value={displayName()}
+              onInput={(e) => setDisplayName(e.currentTarget.value)}
+              class="rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={!detailsValid() || busy()}
+            class="rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy() ? "Sending…" : "Send verification code"}
+          </button>
+        </form>
+      </Show>
+
+      <Show when={step() === "verify"}>
+        <form onSubmit={submitOtp} class="flex flex-col gap-4">
+          <p class="text-sm text-muted-foreground">
+            We sent a 6-digit code to <strong>{email()}</strong>. Enter it below to verify.
+          </p>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Verification code</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              maxLength={6}
+              required
+              value={otp()}
+              onInput={(e) => setOtp(e.currentTarget.value.replace(/\D/g, "").slice(0, 6))}
+              class="rounded-md border border-input bg-background px-3 py-2 text-sm tracking-[0.5em] text-center"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={otp().length !== 6 || busy()}
+            class="rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy() ? "Verifying…" : "Verify email"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setStep("details")}
+            class="text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← Use a different email
+          </button>
+        </form>
+      </Show>
+
+      <Show when={step() === "passkey"}>
+        <div class="flex flex-col gap-4">
+          <p class="text-sm text-muted-foreground">
+            Set up a passkey so you can sign back in with Face ID, Touch ID, or your device PIN — no
+            password required.
+          </p>
+          <button
+            type="button"
+            onClick={enrollPasskey}
+            disabled={busy()}
+            class="rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy() ? "Setting up…" : "Create passkey"}
+          </button>
+          <button
+            type="button"
+            onClick={skipPasskeyForNow}
+            disabled={busy()}
+            class="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Skip for now (you can add one later)
+          </button>
+        </div>
+      </Show>
+
+      <Show when={step() === "done"}>
+        <p class="text-sm text-muted-foreground">You&apos;re all set. Loading Pulse…</p>
+      </Show>
+    </div>
+  );
+}

--- a/apps/pulse/src/components/Register.tsx
+++ b/apps/pulse/src/components/Register.tsx
@@ -1,5 +1,5 @@
-import { createSignal, createMemo, Show, onCleanup } from "solid-js";
-import { startRegistration } from "@simplewebauthn/browser";
+import { createSignal, createMemo, Show, onCleanup, createEffect } from "solid-js";
+import { browserSupportsWebAuthn, startRegistration } from "@simplewebauthn/browser";
 import { useAuth } from "@osn/client/solid";
 import { createRegistrationClient, type RegistrationClient } from "@osn/client";
 import { toast } from "solid-toast";
@@ -29,6 +29,12 @@ export function Register(props: RegisterProps) {
   const [busy, setBusy] = createSignal(false);
   const [userId, setUserId] = createSignal<string | null>(null);
   const [authCode, setAuthCode] = createSignal<string | null>(null);
+
+  // WebAuthn feature detection. On native Tauri the system webview may not
+  // expose a platform authenticator, in which case we skip step 3 entirely and
+  // finish sign-in with just the verified email. Users can add a passkey later
+  // from account settings once we ship that screen.
+  const passkeySupported = browserSupportsWebAuthn();
 
   // Live handle availability check (debounced).
   const [handleStatus, setHandleStatus] = createSignal<
@@ -102,6 +108,14 @@ export function Register(props: RegisterProps) {
       setBusy(false);
     }
   }
+
+  // If the environment can't do WebAuthn, don't stall the user on a step they
+  // can't complete — finish sign-in as soon as we reach the passkey step.
+  createEffect(() => {
+    if (step() === "passkey" && !passkeySupported && !busy() && authCode()) {
+      void skipPasskeyForNow();
+    }
+  });
 
   async function enrollPasskey() {
     const id = userId();
@@ -254,28 +268,38 @@ export function Register(props: RegisterProps) {
       </Show>
 
       <Show when={step() === "passkey"}>
-        <div class="flex flex-col gap-4">
-          <p class="text-sm text-muted-foreground">
-            Set up a passkey so you can sign back in with Face ID, Touch ID, or your device PIN — no
-            password required.
-          </p>
-          <button
-            type="button"
-            onClick={enrollPasskey}
-            disabled={busy()}
-            class="rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
-          >
-            {busy() ? "Setting up…" : "Create passkey"}
-          </button>
-          <button
-            type="button"
-            onClick={skipPasskeyForNow}
-            disabled={busy()}
-            class="text-xs text-muted-foreground hover:text-foreground"
-          >
-            Skip for now (you can add one later)
-          </button>
-        </div>
+        <Show
+          when={passkeySupported}
+          fallback={
+            <p class="text-sm text-muted-foreground">
+              Signing you in… (passkeys aren&apos;t supported in this environment — you can add one
+              later once we ship the mobile app).
+            </p>
+          }
+        >
+          <div class="flex flex-col gap-4">
+            <p class="text-sm text-muted-foreground">
+              Set up a passkey so you can sign back in with Face ID, Touch ID, or your device PIN —
+              no password required.
+            </p>
+            <button
+              type="button"
+              onClick={enrollPasskey}
+              disabled={busy()}
+              class="rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+            >
+              {busy() ? "Setting up…" : "Create passkey"}
+            </button>
+            <button
+              type="button"
+              onClick={skipPasskeyForNow}
+              disabled={busy()}
+              class="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Skip for now (you can add one later)
+            </button>
+          </div>
+        </Show>
       </Show>
 
       <Show when={step() === "done"}>

--- a/apps/pulse/src/components/Register.tsx
+++ b/apps/pulse/src/components/Register.tsx
@@ -1,14 +1,20 @@
-import { createSignal, createMemo, Show, onCleanup, createEffect } from "solid-js";
+import { createSignal, Show, onCleanup } from "solid-js";
 import { browserSupportsWebAuthn, startRegistration } from "@simplewebauthn/browser";
 import { useAuth } from "@osn/client/solid";
 import { createRegistrationClient, type RegistrationClient } from "@osn/client";
 import { toast } from "solid-toast";
-import { OSN_ISSUER_URL, OSN_CLIENT_ID } from "../lib/auth";
+import { OSN_ISSUER_URL } from "../lib/auth";
 
 type Step = "details" | "verify" | "passkey" | "done";
 
 const HANDLE_RE = /^[a-z0-9_]{1,30}$/;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Hoisted to module scope so we don't reallocate the client (and its closures)
+// every time the Register component mounts (P-W2).
+const registrationClient: RegistrationClient = createRegistrationClient({
+  issuerUrl: OSN_ISSUER_URL,
+});
 
 interface RegisterProps {
   onCancel: () => void;
@@ -16,10 +22,10 @@ interface RegisterProps {
 
 export function Register(props: RegisterProps) {
   const { adoptSession } = useAuth();
-  const client: RegistrationClient = createRegistrationClient({
-    issuerUrl: OSN_ISSUER_URL,
-    clientId: OSN_CLIENT_ID,
-  });
+  const client = registrationClient;
+  // Feature-detect on each mount so test code can toggle the underlying
+  // mock between renders. Calling once per mount is negligible cost.
+  const passkeySupported = browserSupportsWebAuthn();
 
   const [step, setStep] = createSignal<Step>("details");
   const [email, setEmail] = createSignal("");
@@ -28,13 +34,7 @@ export function Register(props: RegisterProps) {
   const [otp, setOtp] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [userId, setUserId] = createSignal<string | null>(null);
-  const [authCode, setAuthCode] = createSignal<string | null>(null);
-
-  // WebAuthn feature detection. On native Tauri the system webview may not
-  // expose a platform authenticator, in which case we skip step 3 entirely and
-  // finish sign-in with just the verified email. Users can add a passkey later
-  // from account settings once we ship that screen.
-  const passkeySupported = browserSupportsWebAuthn();
+  const [enrollmentToken, setEnrollmentToken] = createSignal<string | null>(null);
 
   // Live handle availability check (debounced).
   const [handleStatus, setHandleStatus] = createSignal<
@@ -71,7 +71,10 @@ export function Register(props: RegisterProps) {
     }, 300);
   }
 
-  const detailsValid = createMemo(() => EMAIL_RE.test(email()) && handleStatus() === "available");
+  // P-I2: inlined as a plain function. Solid's fine-grained reactivity
+  // re-evaluates this on every read; the computation is cheap enough that
+  // wrapping it in createMemo costs more than it saves.
+  const detailsValid = () => EMAIL_RE.test(email()) && handleStatus() === "available";
 
   async function submitDetails(e: Event) {
     e.preventDefault();
@@ -92,6 +95,17 @@ export function Register(props: RegisterProps) {
     }
   }
 
+  /**
+   * Verifies the OTP, persists the new Session immediately, then either
+   * advances the user to the passkey step (if WebAuthn is supported) or
+   * jumps straight to "done" (P-I1: no createEffect; the branch is
+   * imperative right after the state transition).
+   *
+   * Crucially, `adoptSession` happens BEFORE any passkey work — once the
+   * user has verified their email, they're signed in. A flaky WebAuthn
+   * ceremony or an unsupported environment can no longer leave them
+   * stranded between "verified" and "logged in".
+   */
   async function submitOtp(e: Event) {
     e.preventDefault();
     if (busy() || otp().length !== 6) return;
@@ -99,9 +113,16 @@ export function Register(props: RegisterProps) {
     try {
       const result = await client.completeRegistration({ email: email(), code: otp() });
       setUserId(result.userId);
-      setAuthCode(result.code);
+      setEnrollmentToken(result.enrollmentToken);
+      // Sign them in *now* — passkey enrolment is an upsell, not a gate.
+      await adoptSession(result.session);
       toast.success("Email verified");
-      setStep("passkey");
+      if (passkeySupported) {
+        setStep("passkey");
+      } else {
+        toast.success(`Welcome, @${handle()}`);
+        setStep("done");
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Invalid code");
     } finally {
@@ -109,27 +130,22 @@ export function Register(props: RegisterProps) {
     }
   }
 
-  // If the environment can't do WebAuthn, don't stall the user on a step they
-  // can't complete — finish sign-in as soon as we reach the passkey step.
-  createEffect(() => {
-    if (step() === "passkey" && !passkeySupported && !busy() && authCode()) {
-      void skipPasskeyForNow();
-    }
-  });
-
   async function enrollPasskey() {
     const id = userId();
-    const code = authCode();
-    if (!id || !code || busy()) return;
+    const token = enrollmentToken();
+    if (!id || !token || busy()) return;
     setBusy(true);
     try {
-      const options = (await client.passkeyRegisterBegin(id)) as Parameters<
-        typeof startRegistration
-      >[0]["optionsJSON"];
+      const options = (await client.passkeyRegisterBegin({
+        userId: id,
+        enrollmentToken: token,
+      })) as Parameters<typeof startRegistration>[0]["optionsJSON"];
       const attestation = await startRegistration({ optionsJSON: options });
-      await client.passkeyRegisterComplete({ userId: id, attestation });
-      const session = await client.exchangeAuthCode(code);
-      await adoptSession(session);
+      await client.passkeyRegisterComplete({
+        userId: id,
+        enrollmentToken: token,
+        attestation,
+      });
       toast.success(`Welcome, @${handle()}`);
       setStep("done");
     } catch (err) {
@@ -139,20 +155,11 @@ export function Register(props: RegisterProps) {
     }
   }
 
-  async function skipPasskeyForNow() {
-    const code = authCode();
-    if (!code || busy()) return;
-    setBusy(true);
-    try {
-      const session = await client.exchangeAuthCode(code);
-      await adoptSession(session);
-      toast.success(`Welcome, @${handle()}`);
-      setStep("done");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Sign in failed");
-    } finally {
-      setBusy(false);
-    }
+  function skipPasskeyForNow() {
+    // The user is already signed in (we adopted the session at submitOtp
+    // time). Skipping is purely a UI advance.
+    toast.success(`Welcome, @${handle()}`);
+    setStep("done");
   }
 
   return (

--- a/apps/pulse/tests/components/AuthProviderAdoptSession.test.tsx
+++ b/apps/pulse/tests/components/AuthProviderAdoptSession.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { render, cleanup, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, it, expect, beforeEach } from "vitest";
+import { AuthProvider, useAuth } from "@osn/client/solid";
+import type { Session } from "@osn/client";
+
+/**
+ * T-M2: assert that AuthProvider.adoptSession persists a session via the
+ * underlying OsnAuth.setSession call AND triggers a refetch so consumers of
+ * useAuth().session() see the new value. This is the only path the
+ * registration flow uses to install a session into the auth context, so a
+ * regression here (e.g. forgetting to refetch) would silently leave the user
+ * "logged in" at the storage layer but invisible to the UI.
+ */
+
+function AdoptHarness(props: { session: Session }) {
+  const { session, adoptSession } = useAuth();
+  return (
+    <div>
+      <p data-testid="status">{session() ? `signed-in:${session()!.accessToken}` : "anon"}</p>
+      <button data-testid="adopt" onClick={() => void adoptSession(props.session)}>
+        Adopt
+      </button>
+    </div>
+  );
+}
+
+describe("AuthProvider.adoptSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("persists the session and updates session() so consumers see it", async () => {
+    const fixture: Session = {
+      accessToken: "acc_adopt",
+      refreshToken: "ref_adopt",
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: ["openid", "profile"],
+    };
+
+    render(() => (
+      <AuthProvider config={{ issuerUrl: "https://osn.example.com", clientId: "test" }}>
+        <AdoptHarness session={fixture} />
+      </AuthProvider>
+    ));
+
+    // Initially anonymous (no session in storage).
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("anon");
+    });
+
+    screen.getByTestId("adopt").click();
+
+    // After adoptSession, the resource should refetch and the harness should
+    // reflect the new session.
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("signed-in:acc_adopt");
+    });
+
+    // And the session must have been written through to localStorage so a
+    // page reload would still see it.
+    const stored = localStorage.getItem("@osn/client:session");
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).accessToken).toBe("acc_adopt");
+  });
+
+  it("overwrites a previously adopted session", async () => {
+    const first: Session = {
+      accessToken: "first",
+      refreshToken: null,
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: [],
+    };
+    const second: Session = { ...first, accessToken: "second" };
+
+    function Harness() {
+      const { session, adoptSession } = useAuth();
+      return (
+        <div>
+          <p data-testid="status">{session()?.accessToken ?? "anon"}</p>
+          <button data-testid="first" onClick={() => void adoptSession(first)}>
+            First
+          </button>
+          <button data-testid="second" onClick={() => void adoptSession(second)}>
+            Second
+          </button>
+        </div>
+      );
+    }
+
+    render(() => (
+      <AuthProvider config={{ issuerUrl: "https://osn.example.com", clientId: "test" }}>
+        <Harness />
+      </AuthProvider>
+    ));
+
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+
+    screen.getByTestId("first").click();
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("first"));
+
+    screen.getByTestId("second").click();
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("second"));
+  });
+});

--- a/apps/pulse/tests/components/Register.test.tsx
+++ b/apps/pulse/tests/components/Register.test.tsx
@@ -1,0 +1,332 @@
+// @vitest-environment happy-dom
+import { render, cleanup, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+/**
+ * T-R1: Register.tsx is the consumer of the entire registration flow. It
+ * orchestrates input sanitisation, debounced handle availability, the
+ * details/verify/passkey/done step machine, the WebAuthn auto-skip branch,
+ * and the adoptSession hand-off. None of those is covered anywhere else.
+ *
+ * Strategy: mock @osn/client (createRegistrationClient), @osn/client/solid
+ * (useAuth → adoptSession spy), and @simplewebauthn/browser (toggleable
+ * support flag). The mocks are hoisted via vi.hoisted() so we can flip
+ * `webauthnSupported` between tests before importing the component.
+ */
+
+const hoisted = vi.hoisted(() => {
+  return {
+    webauthnSupported: true,
+    stub: {
+      checkHandle: vi.fn(),
+      beginRegistration: vi.fn(),
+      completeRegistration: vi.fn(),
+      passkeyRegisterBegin: vi.fn(),
+      passkeyRegisterComplete: vi.fn(),
+      exchangeAuthCode: vi.fn(),
+    },
+    adoptSession: vi.fn(),
+    startRegistration: vi.fn(),
+  };
+});
+
+vi.mock("@osn/client", () => ({
+  createRegistrationClient: () => hoisted.stub,
+  RegistrationError: class RegistrationError extends Error {},
+}));
+
+vi.mock("@osn/client/solid", () => ({
+  useAuth: () => ({
+    adoptSession: hoisted.adoptSession,
+  }),
+}));
+
+vi.mock("@simplewebauthn/browser", () => ({
+  browserSupportsWebAuthn: () => hoisted.webauthnSupported,
+  startRegistration: hoisted.startRegistration,
+}));
+
+vi.mock("solid-toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../src/lib/auth", () => ({
+  OSN_ISSUER_URL: "https://osn.test",
+  OSN_CLIENT_ID: "pulse",
+  REDIRECT_URI: () => "http://localhost/callback",
+}));
+
+// Import after mocks so the component picks them up.
+import { Register } from "../../src/components/Register";
+
+const sampleSession = {
+  accessToken: "acc_x",
+  refreshToken: null,
+  idToken: null,
+  expiresAt: Date.now() + 60_000,
+  scopes: [],
+};
+
+function fillEmail(value: string) {
+  const input = screen.getByLabelText(/Email/) as HTMLInputElement;
+  fireEvent.input(input, { target: { value } });
+}
+
+function fillHandle(value: string) {
+  const input = screen.getByLabelText(/Handle/) as HTMLInputElement;
+  fireEvent.input(input, { target: { value } });
+  return input;
+}
+
+describe("Register component", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    hoisted.webauthnSupported = true;
+    hoisted.stub.checkHandle.mockReset();
+    hoisted.stub.beginRegistration.mockReset();
+    hoisted.stub.completeRegistration.mockReset();
+    hoisted.stub.passkeyRegisterBegin.mockReset();
+    hoisted.stub.passkeyRegisterComplete.mockReset();
+    hoisted.stub.exchangeAuthCode.mockReset();
+    hoisted.adoptSession.mockReset();
+    hoisted.startRegistration.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  describe("details step", () => {
+    it("sanitises handle input: lowercases and strips invalid chars", () => {
+      render(() => <Register onCancel={() => {}} />);
+      const input = fillHandle("Alice WONDERLAND!");
+      expect(input.value).toBe("alicewonderland");
+    });
+
+    it("flags handle as invalid format synchronously, no fetch", () => {
+      render(() => <Register onCancel={() => {}} />);
+      // Empty after sanitisation? No — we want a string that survives
+      // sanitisation but fails HANDLE_RE. The sanitiser strips everything
+      // except [a-z0-9_], so any input that survives is by construction valid.
+      // Instead, drive the "invalid" branch via length: > 30 chars.
+      fillHandle("a".repeat(31));
+      expect(screen.getByText(/1.30 chars/)).toBeTruthy();
+      expect(hoisted.stub.checkHandle).not.toHaveBeenCalled();
+    });
+
+    it("debounces availability check and shows 'available'", async () => {
+      hoisted.stub.checkHandle.mockResolvedValue({ available: true });
+      render(() => <Register onCancel={() => {}} />);
+      fillHandle("alice");
+      // Synchronously transitions to "checking".
+      expect(screen.getByText(/Checking/)).toBeTruthy();
+      expect(hoisted.stub.checkHandle).not.toHaveBeenCalled();
+
+      // Advance past the 300ms debounce.
+      await vi.advanceTimersByTimeAsync(350);
+      await waitFor(() => {
+        expect(screen.getByText(/@alice is available/)).toBeTruthy();
+      });
+      expect(hoisted.stub.checkHandle).toHaveBeenCalledWith("alice");
+    });
+
+    it("shows 'taken' when the server reports unavailable", async () => {
+      hoisted.stub.checkHandle.mockResolvedValue({ available: false });
+      render(() => <Register onCancel={() => {}} />);
+      fillHandle("taken");
+      await vi.advanceTimersByTimeAsync(350);
+      await waitFor(() => {
+        expect(screen.getByText(/@taken is taken/)).toBeTruthy();
+      });
+    });
+
+    it("submit is disabled while handle status is 'checking'", () => {
+      hoisted.stub.checkHandle.mockImplementation(
+        () => new Promise(() => {}), // never resolves
+      );
+      render(() => <Register onCancel={() => {}} />);
+      fillEmail("alice@example.com");
+      fillHandle("alice");
+      // Still "checking" — debounce hasn't fired but the synchronous status
+      // change to "checking" is enough to keep detailsValid() false.
+      const submit = screen.getByRole("button", {
+        name: /Send verification code/i,
+      }) as HTMLButtonElement;
+      expect(submit.disabled).toBe(true);
+    });
+
+    it("submit becomes enabled once email + handle are both valid", async () => {
+      hoisted.stub.checkHandle.mockResolvedValue({ available: true });
+      render(() => <Register onCancel={() => {}} />);
+      fillEmail("alice@example.com");
+      fillHandle("alice");
+      await vi.advanceTimersByTimeAsync(350);
+      await waitFor(() => {
+        const submit = screen.getByRole("button", {
+          name: /Send verification code/i,
+        }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(false);
+      });
+    });
+  });
+
+  describe("verify step", () => {
+    async function advanceToVerify() {
+      hoisted.stub.checkHandle.mockResolvedValue({ available: true });
+      hoisted.stub.beginRegistration.mockResolvedValue({ sent: true });
+      render(() => <Register onCancel={() => {}} />);
+      fillEmail("alice@example.com");
+      fillHandle("alice");
+      await vi.advanceTimersByTimeAsync(350);
+      await waitFor(() => {
+        const submit = screen.getByRole("button", {
+          name: /Send verification code/i,
+        }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(false);
+      });
+      const submit = screen.getByRole("button", { name: /Send verification code/i });
+      fireEvent.click(submit);
+      await waitFor(() => {
+        expect(screen.getByText(/We sent a 6-digit code/)).toBeTruthy();
+      });
+    }
+
+    it("calls beginRegistration with the form values and advances to verify", async () => {
+      await advanceToVerify();
+      expect(hoisted.stub.beginRegistration).toHaveBeenCalledWith({
+        email: "alice@example.com",
+        handle: "alice",
+        displayName: undefined,
+      });
+    });
+
+    it("verify submit stays disabled until 6 digits are entered", async () => {
+      await advanceToVerify();
+      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
+      fireEvent.input(otp, { target: { value: "123" } });
+      const submit = screen.getByRole("button", {
+        name: /Verify email/i,
+      }) as HTMLButtonElement;
+      expect(submit.disabled).toBe(true);
+
+      fireEvent.input(otp, { target: { value: "123456" } });
+      expect(submit.disabled).toBe(false);
+    });
+
+    it("OTP input strips non-digits and clamps to 6", async () => {
+      await advanceToVerify();
+      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
+      fireEvent.input(otp, { target: { value: "12ab34cd5678" } });
+      expect(otp.value).toBe("123456");
+    });
+  });
+
+  describe("passkey step (supported)", () => {
+    async function reachPasskey() {
+      hoisted.stub.checkHandle.mockResolvedValue({ available: true });
+      hoisted.stub.beginRegistration.mockResolvedValue({ sent: true });
+      hoisted.stub.completeRegistration.mockResolvedValue({
+        userId: "usr_abc",
+        handle: "alice",
+        email: "alice@example.com",
+        code: "auth_code_xyz",
+      });
+      render(() => <Register onCancel={() => {}} />);
+      fillEmail("alice@example.com");
+      fillHandle("alice");
+      await vi.advanceTimersByTimeAsync(350);
+      fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
+      await waitFor(() => screen.getByLabelText(/Verification code/));
+      fireEvent.input(screen.getByLabelText(/Verification code/), {
+        target: { value: "123456" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Verify email/i }));
+      await waitFor(() => screen.getByRole("button", { name: /Create passkey/i }));
+    }
+
+    it("happy path: enrolls a passkey and adopts the resulting session", async () => {
+      await reachPasskey();
+      hoisted.stub.passkeyRegisterBegin.mockResolvedValue({ challenge: "ch" });
+      hoisted.startRegistration.mockResolvedValue({ id: "cred", rawId: "raw" });
+      hoisted.stub.passkeyRegisterComplete.mockResolvedValue({ passkeyId: "pk_1" });
+      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
+      hoisted.adoptSession.mockResolvedValue(undefined);
+
+      fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+
+      await waitFor(() => {
+        expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
+      });
+      expect(hoisted.stub.passkeyRegisterBegin).toHaveBeenCalledWith("usr_abc");
+      expect(hoisted.startRegistration).toHaveBeenCalledWith({ optionsJSON: { challenge: "ch" } });
+      expect(hoisted.stub.passkeyRegisterComplete).toHaveBeenCalledWith({
+        userId: "usr_abc",
+        attestation: { id: "cred", rawId: "raw" },
+      });
+      expect(hoisted.stub.exchangeAuthCode).toHaveBeenCalledWith("auth_code_xyz");
+    });
+
+    it("'Skip for now' bypasses the passkey ceremony and still adopts a session", async () => {
+      await reachPasskey();
+      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
+      hoisted.adoptSession.mockResolvedValue(undefined);
+
+      fireEvent.click(screen.getByRole("button", { name: /Skip for now/i }));
+
+      await waitFor(() => {
+        expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
+      });
+      expect(hoisted.stub.passkeyRegisterBegin).not.toHaveBeenCalled();
+      expect(hoisted.startRegistration).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("passkey step (unsupported environment)", () => {
+    it("auto-skips passkey enrolment and signs in directly", async () => {
+      hoisted.webauthnSupported = false;
+      hoisted.stub.checkHandle.mockResolvedValue({ available: true });
+      hoisted.stub.beginRegistration.mockResolvedValue({ sent: true });
+      hoisted.stub.completeRegistration.mockResolvedValue({
+        userId: "usr_abc",
+        handle: "alice",
+        email: "alice@example.com",
+        code: "auth_code_xyz",
+      });
+      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
+      hoisted.adoptSession.mockResolvedValue(undefined);
+
+      render(() => <Register onCancel={() => {}} />);
+      fillEmail("alice@example.com");
+      fillHandle("alice");
+      await vi.advanceTimersByTimeAsync(350);
+      fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
+      await waitFor(() => screen.getByLabelText(/Verification code/));
+      fireEvent.input(screen.getByLabelText(/Verification code/), {
+        target: { value: "123456" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Verify email/i }));
+
+      // The createEffect should fire as soon as step transitions to "passkey"
+      // and call skipPasskeyForNow → exchangeAuthCode → adoptSession.
+      await waitFor(() => {
+        expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
+      });
+
+      // Crucially, the passkey ceremony APIs were never touched.
+      expect(hoisted.stub.passkeyRegisterBegin).not.toHaveBeenCalled();
+      expect(hoisted.startRegistration).not.toHaveBeenCalled();
+
+      // And the "Create passkey" button is not in the DOM — only the
+      // fallback message.
+      expect(screen.queryByRole("button", { name: /Create passkey/i })).toBeNull();
+    });
+  });
+
+  it("Cancel button calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(() => <Register onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/apps/pulse/tests/components/Register.test.tsx
+++ b/apps/pulse/tests/components/Register.test.tsx
@@ -23,7 +23,6 @@ const hoisted = vi.hoisted(() => {
       completeRegistration: vi.fn(),
       passkeyRegisterBegin: vi.fn(),
       passkeyRegisterComplete: vi.fn(),
-      exchangeAuthCode: vi.fn(),
     },
     adoptSession: vi.fn(),
     startRegistration: vi.fn(),
@@ -52,7 +51,6 @@ vi.mock("solid-toast", () => ({
 
 vi.mock("../../src/lib/auth", () => ({
   OSN_ISSUER_URL: "https://osn.test",
-  OSN_CLIENT_ID: "pulse",
   REDIRECT_URI: () => "http://localhost/callback",
 }));
 
@@ -87,7 +85,6 @@ describe("Register component", () => {
     hoisted.stub.completeRegistration.mockReset();
     hoisted.stub.passkeyRegisterBegin.mockReset();
     hoisted.stub.passkeyRegisterComplete.mockReset();
-    hoisted.stub.exchangeAuthCode.mockReset();
     hoisted.adoptSession.mockReset();
     hoisted.startRegistration.mockReset();
   });
@@ -230,8 +227,10 @@ describe("Register component", () => {
         userId: "usr_abc",
         handle: "alice",
         email: "alice@example.com",
-        code: "auth_code_xyz",
+        session: sampleSession,
+        enrollmentToken: "enroll_xyz",
       });
+      hoisted.adoptSession.mockResolvedValue(undefined);
       render(() => <Register onCancel={() => {}} />);
       fillEmail("alice@example.com");
       fillHandle("alice");
@@ -245,45 +244,56 @@ describe("Register component", () => {
       await waitFor(() => screen.getByRole("button", { name: /Create passkey/i }));
     }
 
-    it("happy path: enrolls a passkey and adopts the resulting session", async () => {
+    it("adopts the session immediately after OTP verify, before any passkey work", async () => {
+      await reachPasskey();
+      // Crucial: adoptSession was called as soon as the OTP verified, NOT
+      // gated on the user clicking "Create passkey". This is the redesign
+      // that eliminates the "stranded between verified and logged in" UX
+      // dead-end.
+      expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
+      expect(hoisted.stub.passkeyRegisterBegin).not.toHaveBeenCalled();
+    });
+
+    it("happy path: enrolls a passkey using the enrollment token", async () => {
       await reachPasskey();
       hoisted.stub.passkeyRegisterBegin.mockResolvedValue({ challenge: "ch" });
       hoisted.startRegistration.mockResolvedValue({ id: "cred", rawId: "raw" });
       hoisted.stub.passkeyRegisterComplete.mockResolvedValue({ passkeyId: "pk_1" });
-      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
-      hoisted.adoptSession.mockResolvedValue(undefined);
 
       fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
 
       await waitFor(() => {
-        expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
+        expect(hoisted.stub.passkeyRegisterComplete).toHaveBeenCalled();
       });
-      expect(hoisted.stub.passkeyRegisterBegin).toHaveBeenCalledWith("usr_abc");
+      // Both passkey calls must carry the enrollment token.
+      expect(hoisted.stub.passkeyRegisterBegin).toHaveBeenCalledWith({
+        userId: "usr_abc",
+        enrollmentToken: "enroll_xyz",
+      });
       expect(hoisted.startRegistration).toHaveBeenCalledWith({ optionsJSON: { challenge: "ch" } });
       expect(hoisted.stub.passkeyRegisterComplete).toHaveBeenCalledWith({
         userId: "usr_abc",
+        enrollmentToken: "enroll_xyz",
         attestation: { id: "cred", rawId: "raw" },
       });
-      expect(hoisted.stub.exchangeAuthCode).toHaveBeenCalledWith("auth_code_xyz");
     });
 
-    it("'Skip for now' bypasses the passkey ceremony and still adopts a session", async () => {
+    it("'Skip for now' advances to done — user already signed in", async () => {
       await reachPasskey();
-      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
-      hoisted.adoptSession.mockResolvedValue(undefined);
+      // Reset the call count from reachPasskey() so we only see clicks here.
+      hoisted.adoptSession.mockClear();
 
       fireEvent.click(screen.getByRole("button", { name: /Skip for now/i }));
 
-      await waitFor(() => {
-        expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
-      });
+      // No passkey calls, no second adoptSession (already adopted at OTP step).
       expect(hoisted.stub.passkeyRegisterBegin).not.toHaveBeenCalled();
       expect(hoisted.startRegistration).not.toHaveBeenCalled();
+      expect(hoisted.adoptSession).not.toHaveBeenCalled();
     });
   });
 
   describe("passkey step (unsupported environment)", () => {
-    it("auto-skips passkey enrolment and signs in directly", async () => {
+    it("submitOtp jumps straight to done; passkey APIs untouched", async () => {
       hoisted.webauthnSupported = false;
       hoisted.stub.checkHandle.mockResolvedValue({ available: true });
       hoisted.stub.beginRegistration.mockResolvedValue({ sent: true });
@@ -291,9 +301,9 @@ describe("Register component", () => {
         userId: "usr_abc",
         handle: "alice",
         email: "alice@example.com",
-        code: "auth_code_xyz",
+        session: sampleSession,
+        enrollmentToken: "enroll_xyz",
       });
-      hoisted.stub.exchangeAuthCode.mockResolvedValue(sampleSession);
       hoisted.adoptSession.mockResolvedValue(undefined);
 
       render(() => <Register onCancel={() => {}} />);
@@ -307,18 +317,15 @@ describe("Register component", () => {
       });
       fireEvent.click(screen.getByRole("button", { name: /Verify email/i }));
 
-      // The createEffect should fire as soon as step transitions to "passkey"
-      // and call skipPasskeyForNow → exchangeAuthCode → adoptSession.
+      // adoptSession is called as part of submitOtp, then we jump to done.
       await waitFor(() => {
         expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession);
       });
 
-      // Crucially, the passkey ceremony APIs were never touched.
+      // Crucially, the passkey ceremony APIs were never touched and the
+      // "Create passkey" button never appeared in the DOM.
       expect(hoisted.stub.passkeyRegisterBegin).not.toHaveBeenCalled();
       expect(hoisted.startRegistration).not.toHaveBeenCalled();
-
-      // And the "Create passkey" button is not in the DOM — only the
-      // fallback message.
       expect(screen.queryByRole("button", { name: /Create passkey/i })).toBeNull();
     });
   });

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "apps/osn": {
       "name": "@osn/osn",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -44,12 +44,13 @@
     },
     "apps/pulse": {
       "name": "@osn/pulse",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@osn/api": "workspace:*",
         "@osn/client": "workspace:*",
         "@osn/core": "workspace:*",
         "@osn/ui": "workspace:*",
+        "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
@@ -71,7 +72,7 @@
     },
     "packages/api": {
       "name": "@osn/api",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -106,7 +107,7 @@
     },
     "packages/core": {
       "name": "@osn/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/db": "workspace:*",
@@ -124,7 +125,7 @@
     },
     "packages/crypto": {
       "name": "@osn/crypto",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@osn/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -139,7 +140,7 @@
     },
     "packages/osn-db": {
       "name": "@osn/db",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@utils/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -156,7 +157,7 @@
     },
     "packages/pulse-db": {
       "name": "@pulse/db",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@utils/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
@@ -605,6 +606,8 @@
     "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
     "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./errors";
 export * from "./pkce";
+export * from "./register";
 export * from "./service";
 export * from "./storage";
 export * from "./tokens";

--- a/packages/client/src/register.ts
+++ b/packages/client/src/register.ts
@@ -1,0 +1,129 @@
+import { parseTokenResponse, type Session } from "./tokens";
+
+/**
+ * Plain-fetch helpers for the email-verified registration flow + passkey
+ * enrolment. Kept separate from the Effect-based OsnAuth service so consumers
+ * can use these directly from UI components without dragging in the Storage
+ * layer.
+ *
+ * Flow:
+ *  1. checkHandle(handle)             — front-end "is this @ free?" check
+ *  2. beginRegistration(...)          — sends a 6-digit OTP to the email
+ *  3. completeRegistration(...)       — verifies the OTP, creates the user,
+ *                                       returns { userId, code }
+ *  4. passkeyRegisterBegin(userId)    — fetch WebAuthn creation options. The
+ *                                       caller is responsible for running the
+ *                                       browser ceremony with @simplewebauthn
+ *  5. passkeyRegisterComplete(...)    — submit the attestation
+ *  6. exchangeAuthCode(code)          — swap the auth code from step 3 for an
+ *                                       access/refresh token Session
+ *
+ * The WebAuthn browser ceremony is intentionally not performed inside this
+ * package — keeping it caller-side avoids adding @simplewebauthn/browser as a
+ * dependency of @osn/client.
+ */
+
+export interface RegistrationClientConfig {
+  /** OSN issuer base URL, e.g. http://localhost:4000 */
+  issuerUrl: string;
+  /** OAuth client id (used when exchanging the auth code for tokens) */
+  clientId: string;
+}
+
+export class RegistrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RegistrationError";
+  }
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new RegistrationError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+export interface RegistrationClient {
+  checkHandle(handle: string): Promise<{ available: boolean }>;
+  beginRegistration(input: {
+    email: string;
+    handle: string;
+    displayName?: string;
+  }): Promise<{ sent: boolean }>;
+  completeRegistration(input: {
+    email: string;
+    code: string;
+  }): Promise<{ userId: string; handle: string; email: string; code: string }>;
+  passkeyRegisterBegin(userId: string): Promise<unknown>;
+  passkeyRegisterComplete(input: {
+    userId: string;
+    attestation: unknown;
+  }): Promise<{ passkeyId: string }>;
+  exchangeAuthCode(code: string, redirectUri?: string): Promise<Session>;
+}
+
+export function createRegistrationClient(config: RegistrationClientConfig): RegistrationClient {
+  const base = config.issuerUrl.replace(/\/$/, "");
+
+  const checkHandle = async (handle: string) => {
+    const res = await fetch(`${base}/handle/${encodeURIComponent(handle)}`);
+    const json = (await res.json()) as { available?: boolean; error?: string };
+    if (!res.ok || typeof json.available !== "boolean") {
+      throw new RegistrationError(json.error ?? "Invalid handle");
+    }
+    return { available: json.available };
+  };
+
+  const beginRegistration = (input: { email: string; handle: string; displayName?: string }) =>
+    postJson<{ sent: boolean }>(`${base}/register/begin`, input);
+
+  const completeRegistration = (input: { email: string; code: string }) =>
+    postJson<{ userId: string; handle: string; email: string; code: string }>(
+      `${base}/register/complete`,
+      input,
+    );
+
+  const passkeyRegisterBegin = (userId: string) =>
+    postJson<unknown>(`${base}/passkey/register/begin`, { userId });
+
+  const passkeyRegisterComplete = (input: { userId: string; attestation: unknown }) =>
+    postJson<{ passkeyId: string }>(`${base}/passkey/register/complete`, input);
+
+  const exchangeAuthCode = async (code: string, redirectUri?: string): Promise<Session> => {
+    const res = await fetch(`${base}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        // The token endpoint accepts these without state — PKCE is bypassed
+        // when no `state` is supplied (used by the registration flow, which
+        // never went through /authorize).
+        redirect_uri: redirectUri ?? `${base}/callback`,
+        client_id: config.clientId,
+        code_verifier: "registration",
+      }).toString(),
+    });
+    const raw = (await res.json()) as { error?: string };
+    if (!res.ok) {
+      throw new RegistrationError(raw.error ?? "Token exchange failed");
+    }
+    return parseTokenResponse(raw);
+  };
+
+  return {
+    checkHandle,
+    beginRegistration,
+    completeRegistration,
+    passkeyRegisterBegin,
+    passkeyRegisterComplete,
+    exchangeAuthCode,
+  };
+}

--- a/packages/client/src/register.ts
+++ b/packages/client/src/register.ts
@@ -10,24 +10,30 @@ import { parseTokenResponse, type Session } from "./tokens";
  *  1. checkHandle(handle)             — front-end "is this @ free?" check
  *  2. beginRegistration(...)          — sends a 6-digit OTP to the email
  *  3. completeRegistration(...)       — verifies the OTP, creates the user,
- *                                       returns { userId, code }
- *  4. passkeyRegisterBegin(userId)    — fetch WebAuthn creation options. The
- *                                       caller is responsible for running the
- *                                       browser ceremony with @simplewebauthn
- *  5. passkeyRegisterComplete(...)    — submit the attestation
- *  6. exchangeAuthCode(code)          — swap the auth code from step 3 for an
- *                                       access/refresh token Session
+ *                                       and returns { userId, session,
+ *                                       enrollmentToken } in a single
+ *                                       response. The session is ready to
+ *                                       hand to AuthProvider.adoptSession.
+ *  4. passkeyRegisterBegin({userId,enrollmentToken})  — fetch WebAuthn options
+ *  5. passkeyRegisterComplete({userId,enrollmentToken,attestation}) — submit
  *
  * The WebAuthn browser ceremony is intentionally not performed inside this
  * package — keeping it caller-side avoids adding @simplewebauthn/browser as a
  * dependency of @osn/client.
+ *
+ * Notes:
+ *  - There is NO `exchangeAuthCode` step. The previous design routed through
+ *    /token with a literal `code_verifier: "registration"` and no `state`,
+ *    which exploited a pre-existing PKCE bypass at /token. The bypass is now
+ *    out of the registration code path entirely.
+ *  - Both passkey calls require an Authorization: Bearer header carrying the
+ *    enrollment token returned from completeRegistration. The server compares
+ *    the token's `sub` against the body `userId` and rejects mismatches.
  */
 
 export interface RegistrationClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
   issuerUrl: string;
-  /** OAuth client id (used when exchanging the auth code for tokens) */
-  clientId: string;
 }
 
 export class RegistrationError extends Error {
@@ -37,10 +43,16 @@ export class RegistrationError extends Error {
   }
 }
 
-async function postJson<T>(url: string, body: unknown): Promise<T> {
+async function postJson<T>(
+  url: string,
+  body: unknown,
+  options: { bearer?: string } = {},
+): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (options.bearer) headers["Authorization"] = `Bearer ${options.bearer}`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
   const json = (await res.json()) as T & { error?: string };
@@ -50,6 +62,16 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
   return json;
 }
 
+export interface CompleteRegistrationResult {
+  userId: string;
+  handle: string;
+  email: string;
+  /** Ready to pass to AuthProvider.adoptSession. */
+  session: Session;
+  /** Single-use bearer token for /passkey/register/{begin,complete}. */
+  enrollmentToken: string;
+}
+
 export interface RegistrationClient {
   checkHandle(handle: string): Promise<{ available: boolean }>;
   beginRegistration(input: {
@@ -57,16 +79,13 @@ export interface RegistrationClient {
     handle: string;
     displayName?: string;
   }): Promise<{ sent: boolean }>;
-  completeRegistration(input: {
-    email: string;
-    code: string;
-  }): Promise<{ userId: string; handle: string; email: string; code: string }>;
-  passkeyRegisterBegin(userId: string): Promise<unknown>;
+  completeRegistration(input: { email: string; code: string }): Promise<CompleteRegistrationResult>;
+  passkeyRegisterBegin(input: { userId: string; enrollmentToken: string }): Promise<unknown>;
   passkeyRegisterComplete(input: {
     userId: string;
+    enrollmentToken: string;
     attestation: unknown;
   }): Promise<{ passkeyId: string }>;
-  exchangeAuthCode(code: string, redirectUri?: string): Promise<Session>;
 }
 
 export function createRegistrationClient(config: RegistrationClientConfig): RegistrationClient {
@@ -84,39 +103,44 @@ export function createRegistrationClient(config: RegistrationClientConfig): Regi
   const beginRegistration = (input: { email: string; handle: string; displayName?: string }) =>
     postJson<{ sent: boolean }>(`${base}/register/begin`, input);
 
-  const completeRegistration = (input: { email: string; code: string }) =>
-    postJson<{ userId: string; handle: string; email: string; code: string }>(
-      `${base}/register/complete`,
-      input,
+  const completeRegistration = async (input: {
+    email: string;
+    code: string;
+  }): Promise<CompleteRegistrationResult> => {
+    const raw = await postJson<{
+      userId: string;
+      handle: string;
+      email: string;
+      session: unknown;
+      enrollment_token: string;
+    }>(`${base}/register/complete`, input);
+    const session = parseTokenResponse(raw.session);
+    return {
+      userId: raw.userId,
+      handle: raw.handle,
+      email: raw.email,
+      session,
+      enrollmentToken: raw.enrollment_token,
+    };
+  };
+
+  const passkeyRegisterBegin = (input: { userId: string; enrollmentToken: string }) =>
+    postJson<unknown>(
+      `${base}/passkey/register/begin`,
+      { userId: input.userId },
+      { bearer: input.enrollmentToken },
     );
 
-  const passkeyRegisterBegin = (userId: string) =>
-    postJson<unknown>(`${base}/passkey/register/begin`, { userId });
-
-  const passkeyRegisterComplete = (input: { userId: string; attestation: unknown }) =>
-    postJson<{ passkeyId: string }>(`${base}/passkey/register/complete`, input);
-
-  const exchangeAuthCode = async (code: string, redirectUri?: string): Promise<Session> => {
-    const res = await fetch(`${base}/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        grant_type: "authorization_code",
-        code,
-        // The token endpoint accepts these without state — PKCE is bypassed
-        // when no `state` is supplied (used by the registration flow, which
-        // never went through /authorize).
-        redirect_uri: redirectUri ?? `${base}/callback`,
-        client_id: config.clientId,
-        code_verifier: "registration",
-      }).toString(),
-    });
-    const raw = (await res.json()) as { error?: string };
-    if (!res.ok) {
-      throw new RegistrationError(raw.error ?? "Token exchange failed");
-    }
-    return parseTokenResponse(raw);
-  };
+  const passkeyRegisterComplete = (input: {
+    userId: string;
+    enrollmentToken: string;
+    attestation: unknown;
+  }) =>
+    postJson<{ passkeyId: string }>(
+      `${base}/passkey/register/complete`,
+      { userId: input.userId, attestation: input.attestation },
+      { bearer: input.enrollmentToken },
+    );
 
   return {
     checkHandle,
@@ -124,6 +148,5 @@ export function createRegistrationClient(config: RegistrationClientConfig): Regi
     completeRegistration,
     passkeyRegisterBegin,
     passkeyRegisterComplete,
-    exchangeAuthCode,
   };
 }

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -41,6 +41,13 @@ export interface OsnAuthService {
   readonly refreshSession: () => Effect.Effect<Session, TokenRefreshError | StorageError>;
 
   readonly logout: () => Effect.Effect<void, StorageError>;
+
+  /**
+   * Persists a Session that was obtained out-of-band (e.g. from the
+   * email-verified registration flow, which exchanges its auth code through
+   * the standalone registration client and bypasses the PKCE callback).
+   */
+  readonly setSession: (session: Session) => Effect.Effect<void, StorageError>;
 }
 
 export class OsnAuth extends Context.Tag("@osn/client/OsnAuth")<OsnAuth, OsnAuthService>() {}
@@ -164,7 +171,9 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
 
       const logout = () => storage.remove(SESSION_KEY);
 
-      return { startLogin, handleCallback, getSession, refreshSession, logout };
+      const setSession = (session: Session) => storage.set(SESSION_KEY, JSON.stringify(session));
+
+      return { startLogin, handleCallback, getSession, refreshSession, logout, setSession };
     }),
   );
 }

--- a/packages/client/src/solid/context.tsx
+++ b/packages/client/src/solid/context.tsx
@@ -15,6 +15,11 @@ interface AuthContextValue {
   login: (redirectUri: string, scopes?: string[]) => void;
   logout: () => Promise<void>;
   handleCallback: (params: { code: string; state: string; redirectUri: string }) => Promise<void>;
+  /**
+   * Persists a Session obtained from the registration flow (or any other
+   * out-of-band source) and refetches the session resource so the UI updates.
+   */
+  adoptSession: (session: Session) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextValue>();
@@ -57,8 +62,13 @@ export function AuthProvider(props: AuthProviderProps) {
     refetch();
   };
 
+  const adoptSession = async (next: Session) => {
+    await run(Effect.flatMap(OsnAuth, (auth) => auth.setSession(next)));
+    refetch();
+  };
+
   return (
-    <AuthContext.Provider value={{ session, login, logout, handleCallback }}>
+    <AuthContext.Provider value={{ session, login, logout, handleCallback, adoptSession }}>
       {props.children}
     </AuthContext.Provider>
   );

--- a/packages/client/tests/register.test.ts
+++ b/packages/client/tests/register.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createRegistrationClient, RegistrationError } from "../src/register";
 
-const config = { issuerUrl: "https://osn.example.com", clientId: "test-client" };
+const config = { issuerUrl: "https://osn.example.com" };
 
 interface FetchCall {
   url: string;
@@ -92,14 +92,21 @@ describe("createRegistrationClient", () => {
   });
 
   describe("completeRegistration", () => {
-    it("POSTs JSON to /register/complete and returns the new user + auth code", async () => {
+    it("POSTs JSON to /register/complete and parses session + enrollment token", async () => {
       const { calls } = stubFetch(() =>
         jsonResponse(
           {
             userId: "usr_abc",
             handle: "alice",
             email: "alice@example.com",
-            code: "auth_code_xyz",
+            session: {
+              access_token: "acc_999",
+              refresh_token: "ref_999",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "openid profile",
+            },
+            enrollment_token: "enroll_xyz",
           },
           { status: 201 },
         ),
@@ -109,7 +116,17 @@ describe("createRegistrationClient", () => {
         code: "123456",
       });
       expect(result.userId).toBe("usr_abc");
-      expect(result.code).toBe("auth_code_xyz");
+      expect(result.handle).toBe("alice");
+      expect(result.email).toBe("alice@example.com");
+      expect(result.enrollmentToken).toBe("enroll_xyz");
+
+      // The session is parsed via the same parseTokenResponse used for the
+      // OAuth callback flow.
+      expect(result.session.accessToken).toBe("acc_999");
+      expect(result.session.refreshToken).toBe("ref_999");
+      expect(result.session.scopes).toEqual(["openid", "profile"]);
+      expect(result.session.expiresAt).toBeGreaterThan(Date.now());
+
       expect(calls[0].url).toBe("https://osn.example.com/register/complete");
       expect(JSON.parse(calls[0].init?.body as string)).toEqual({
         email: "alice@example.com",
@@ -118,94 +135,57 @@ describe("createRegistrationClient", () => {
     });
 
     it("throws RegistrationError on wrong OTP", async () => {
-      stubFetch(() => jsonResponse({ error: "Invalid or expired code" }, { status: 400 }));
+      stubFetch(() => jsonResponse({ error: "invalid_request" }, { status: 400 }));
       await expect(
         client.completeRegistration({ email: "alice@example.com", code: "000000" }),
-      ).rejects.toThrow("Invalid or expired code");
+      ).rejects.toThrow("invalid_request");
     });
   });
 
-  describe("passkeyRegisterBegin / passkeyRegisterComplete", () => {
-    it("passkeyRegisterBegin POSTs userId and returns the options blob verbatim", async () => {
+  describe("passkeyRegisterBegin / passkeyRegisterComplete (Authorization-gated)", () => {
+    it("passkeyRegisterBegin sends Authorization: Bearer <enrollmentToken>", async () => {
       const options = { challenge: "ch_123", rp: { name: "OSN" } };
       const { calls } = stubFetch(() => jsonResponse(options));
-      const result = await client.passkeyRegisterBegin("usr_abc");
+      const result = await client.passkeyRegisterBegin({
+        userId: "usr_abc",
+        enrollmentToken: "enroll_xyz",
+      });
       expect(result).toEqual(options);
       expect(calls[0].url).toBe("https://osn.example.com/passkey/register/begin");
+      const headers = new Headers(calls[0].init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer enroll_xyz");
       expect(JSON.parse(calls[0].init?.body as string)).toEqual({ userId: "usr_abc" });
     });
 
-    it("passkeyRegisterComplete POSTs userId + attestation and returns the passkey id", async () => {
+    it("passkeyRegisterComplete sends Authorization header and userId+attestation body", async () => {
       const { calls } = stubFetch(() => jsonResponse({ passkeyId: "pk_xyz" }));
       const attestation = { id: "cred_id", rawId: "raw" };
       const result = await client.passkeyRegisterComplete({
         userId: "usr_abc",
+        enrollmentToken: "enroll_xyz",
         attestation,
       });
       expect(result).toEqual({ passkeyId: "pk_xyz" });
       expect(calls[0].url).toBe("https://osn.example.com/passkey/register/complete");
+      const headers = new Headers(calls[0].init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer enroll_xyz");
       expect(JSON.parse(calls[0].init?.body as string)).toEqual({
         userId: "usr_abc",
         attestation,
       });
     });
-  });
 
-  describe("exchangeAuthCode", () => {
-    it("POSTs form-urlencoded to /token with the registration verifier", async () => {
-      const { calls } = stubFetch(() =>
-        jsonResponse({
-          access_token: "acc_999",
-          refresh_token: "ref_999",
-          token_type: "Bearer",
-          expires_in: 3600,
-          scope: "openid profile",
-        }),
-      );
-
-      const session = await client.exchangeAuthCode("auth_code_xyz");
-      expect(session.accessToken).toBe("acc_999");
-      expect(session.refreshToken).toBe("ref_999");
-      expect(session.scopes).toEqual(["openid", "profile"]);
-      expect(session.expiresAt).toBeGreaterThan(Date.now());
-
-      expect(calls[0].url).toBe("https://osn.example.com/token");
-      const headers = new Headers(calls[0].init?.headers);
-      expect(headers.get("Content-Type")).toBe("application/x-www-form-urlencoded");
-
-      const params = new URLSearchParams(calls[0].init?.body as string);
-      expect(params.get("grant_type")).toBe("authorization_code");
-      expect(params.get("code")).toBe("auth_code_xyz");
-      expect(params.get("client_id")).toBe("test-client");
-      expect(params.get("code_verifier")).toBe("registration");
-      expect(params.get("redirect_uri")).toBe("https://osn.example.com/callback");
-      // No state — registration flow bypasses PKCE on the server side.
-      expect(params.has("state")).toBe(false);
-    });
-
-    it("uses a custom redirect_uri when provided", async () => {
-      const { calls } = stubFetch(() =>
-        jsonResponse({
-          access_token: "acc_x",
-          token_type: "Bearer",
-          expires_in: 60,
-        }),
-      );
-      await client.exchangeAuthCode("code", "http://app.local/cb");
-      const params = new URLSearchParams(calls[0].init?.body as string);
-      expect(params.get("redirect_uri")).toBe("http://app.local/cb");
-    });
-
-    it("throws RegistrationError on token exchange failure", async () => {
-      stubFetch(() => jsonResponse({ error: "invalid_grant" }, { status: 400 }));
-      await expect(client.exchangeAuthCode("bad_code")).rejects.toThrow("invalid_grant");
+    it("propagates 401 from the server as a RegistrationError", async () => {
+      stubFetch(() => jsonResponse({ error: "unauthorized" }, { status: 401 }));
+      await expect(
+        client.passkeyRegisterBegin({ userId: "usr_abc", enrollmentToken: "bad" }),
+      ).rejects.toThrow("unauthorized");
     });
   });
 
   it("strips a trailing slash from issuerUrl", async () => {
     const c = createRegistrationClient({
       issuerUrl: "https://osn.example.com/",
-      clientId: "test-client",
     });
     const { calls } = stubFetch(() => jsonResponse({ available: true }));
     await c.checkHandle("alice");

--- a/packages/client/tests/register.test.ts
+++ b/packages/client/tests/register.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRegistrationClient, RegistrationError } from "../src/register";
+
+const config = { issuerUrl: "https://osn.example.com", clientId: "test-client" };
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+function stubFetch(handler: (call: FetchCall) => Response | Promise<Response>) {
+  const calls: FetchCall[] = [];
+  const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const call: FetchCall = { url, init };
+    calls.push(call);
+    return handler(call);
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = { status: 200 }) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}
+
+describe("createRegistrationClient", () => {
+  let client: ReturnType<typeof createRegistrationClient>;
+
+  beforeEach(() => {
+    client = createRegistrationClient(config);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("checkHandle", () => {
+    it("GETs /handle/:handle and returns availability", async () => {
+      const { calls } = stubFetch(() => jsonResponse({ available: true }));
+      const result = await client.checkHandle("alice");
+      expect(result).toEqual({ available: true });
+      expect(calls[0].url).toBe("https://osn.example.com/handle/alice");
+      expect(calls[0].init).toBeUndefined();
+    });
+
+    it("URL-encodes the handle path segment", async () => {
+      const { calls } = stubFetch(() => jsonResponse({ available: false }));
+      await client.checkHandle("weird name");
+      expect(calls[0].url).toBe("https://osn.example.com/handle/weird%20name");
+    });
+
+    it("throws RegistrationError when the server replies with an error", async () => {
+      stubFetch(() => jsonResponse({ error: "Invalid handle" }, { status: 400 }));
+      await expect(client.checkHandle("Bad!")).rejects.toBeInstanceOf(RegistrationError);
+      await expect(client.checkHandle("Bad!")).rejects.toThrow("Invalid handle");
+    });
+
+    it("throws RegistrationError when the response shape is unexpected", async () => {
+      stubFetch(() => jsonResponse({ something: "else" }));
+      await expect(client.checkHandle("alice")).rejects.toBeInstanceOf(RegistrationError);
+    });
+  });
+
+  describe("beginRegistration", () => {
+    it("POSTs JSON to /register/begin with the right body", async () => {
+      const { calls } = stubFetch(() => jsonResponse({ sent: true }));
+      const result = await client.beginRegistration({
+        email: "alice@example.com",
+        handle: "alice",
+        displayName: "Alice",
+      });
+      expect(result).toEqual({ sent: true });
+      expect(calls[0].url).toBe("https://osn.example.com/register/begin");
+      expect(calls[0].init?.method).toBe("POST");
+      expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+        email: "alice@example.com",
+        handle: "alice",
+        displayName: "Alice",
+      });
+    });
+
+    it("propagates the server error message", async () => {
+      stubFetch(() => jsonResponse({ error: "Email already registered" }, { status: 400 }));
+      await expect(
+        client.beginRegistration({ email: "taken@example.com", handle: "taken" }),
+      ).rejects.toThrow("Email already registered");
+    });
+  });
+
+  describe("completeRegistration", () => {
+    it("POSTs JSON to /register/complete and returns the new user + auth code", async () => {
+      const { calls } = stubFetch(() =>
+        jsonResponse(
+          {
+            userId: "usr_abc",
+            handle: "alice",
+            email: "alice@example.com",
+            code: "auth_code_xyz",
+          },
+          { status: 201 },
+        ),
+      );
+      const result = await client.completeRegistration({
+        email: "alice@example.com",
+        code: "123456",
+      });
+      expect(result.userId).toBe("usr_abc");
+      expect(result.code).toBe("auth_code_xyz");
+      expect(calls[0].url).toBe("https://osn.example.com/register/complete");
+      expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+        email: "alice@example.com",
+        code: "123456",
+      });
+    });
+
+    it("throws RegistrationError on wrong OTP", async () => {
+      stubFetch(() => jsonResponse({ error: "Invalid or expired code" }, { status: 400 }));
+      await expect(
+        client.completeRegistration({ email: "alice@example.com", code: "000000" }),
+      ).rejects.toThrow("Invalid or expired code");
+    });
+  });
+
+  describe("passkeyRegisterBegin / passkeyRegisterComplete", () => {
+    it("passkeyRegisterBegin POSTs userId and returns the options blob verbatim", async () => {
+      const options = { challenge: "ch_123", rp: { name: "OSN" } };
+      const { calls } = stubFetch(() => jsonResponse(options));
+      const result = await client.passkeyRegisterBegin("usr_abc");
+      expect(result).toEqual(options);
+      expect(calls[0].url).toBe("https://osn.example.com/passkey/register/begin");
+      expect(JSON.parse(calls[0].init?.body as string)).toEqual({ userId: "usr_abc" });
+    });
+
+    it("passkeyRegisterComplete POSTs userId + attestation and returns the passkey id", async () => {
+      const { calls } = stubFetch(() => jsonResponse({ passkeyId: "pk_xyz" }));
+      const attestation = { id: "cred_id", rawId: "raw" };
+      const result = await client.passkeyRegisterComplete({
+        userId: "usr_abc",
+        attestation,
+      });
+      expect(result).toEqual({ passkeyId: "pk_xyz" });
+      expect(calls[0].url).toBe("https://osn.example.com/passkey/register/complete");
+      expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+        userId: "usr_abc",
+        attestation,
+      });
+    });
+  });
+
+  describe("exchangeAuthCode", () => {
+    it("POSTs form-urlencoded to /token with the registration verifier", async () => {
+      const { calls } = stubFetch(() =>
+        jsonResponse({
+          access_token: "acc_999",
+          refresh_token: "ref_999",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "openid profile",
+        }),
+      );
+
+      const session = await client.exchangeAuthCode("auth_code_xyz");
+      expect(session.accessToken).toBe("acc_999");
+      expect(session.refreshToken).toBe("ref_999");
+      expect(session.scopes).toEqual(["openid", "profile"]);
+      expect(session.expiresAt).toBeGreaterThan(Date.now());
+
+      expect(calls[0].url).toBe("https://osn.example.com/token");
+      const headers = new Headers(calls[0].init?.headers);
+      expect(headers.get("Content-Type")).toBe("application/x-www-form-urlencoded");
+
+      const params = new URLSearchParams(calls[0].init?.body as string);
+      expect(params.get("grant_type")).toBe("authorization_code");
+      expect(params.get("code")).toBe("auth_code_xyz");
+      expect(params.get("client_id")).toBe("test-client");
+      expect(params.get("code_verifier")).toBe("registration");
+      expect(params.get("redirect_uri")).toBe("https://osn.example.com/callback");
+      // No state — registration flow bypasses PKCE on the server side.
+      expect(params.has("state")).toBe(false);
+    });
+
+    it("uses a custom redirect_uri when provided", async () => {
+      const { calls } = stubFetch(() =>
+        jsonResponse({
+          access_token: "acc_x",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+      );
+      await client.exchangeAuthCode("code", "http://app.local/cb");
+      const params = new URLSearchParams(calls[0].init?.body as string);
+      expect(params.get("redirect_uri")).toBe("http://app.local/cb");
+    });
+
+    it("throws RegistrationError on token exchange failure", async () => {
+      stubFetch(() => jsonResponse({ error: "invalid_grant" }, { status: 400 }));
+      await expect(client.exchangeAuthCode("bad_code")).rejects.toThrow("invalid_grant");
+    });
+  });
+
+  it("strips a trailing slash from issuerUrl", async () => {
+    const c = createRegistrationClient({
+      issuerUrl: "https://osn.example.com/",
+      clientId: "test-client",
+    });
+    const { calls } = stubFetch(() => jsonResponse({ available: true }));
+    await c.checkHandle("alice");
+    expect(calls[0].url).toBe("https://osn.example.com/handle/alice");
+  });
+});

--- a/packages/client/tests/service.test.ts
+++ b/packages/client/tests/service.test.ts
@@ -145,3 +145,46 @@ it.effect("refreshSession fails when there is no refresh token", () =>
     vi.unstubAllGlobals();
   }).pipe(Effect.provide(createTestLayer())),
 );
+
+it.effect("setSession persists a session that getSession can read back", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    const fixture = {
+      accessToken: "acc_persisted",
+      refreshToken: "ref_persisted",
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: ["openid", "profile"],
+    };
+    yield* auth.setSession(fixture);
+
+    const stored = yield* auth.getSession();
+    expect(stored).not.toBeNull();
+    expect(stored?.accessToken).toBe("acc_persisted");
+    expect(stored?.refreshToken).toBe("ref_persisted");
+    expect(stored?.scopes).toEqual(["openid", "profile"]);
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("setSession overwrites a previously persisted session", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    yield* auth.setSession({
+      accessToken: "first",
+      refreshToken: null,
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: [],
+    });
+    yield* auth.setSession({
+      accessToken: "second",
+      refreshToken: null,
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: [],
+    });
+
+    const stored = yield* auth.getSession();
+    expect(stored?.accessToken).toBe("second");
+  }).pipe(Effect.provide(createTestLayer())),
+);

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -5,6 +5,45 @@ import { createAuthService, type AuthConfig } from "../services/auth";
 import { buildAuthorizeHtml } from "../lib/html";
 import { verifyPkceChallenge } from "../lib/crypto";
 
+/**
+ * Maps a thrown Effect-tagged error (or anything else) to a stable, public,
+ * non-leaky error payload. The full cause is logged server-side for diagnosis,
+ * but only opaque codes / sanitised messages cross the wire (S-H5 / S-M6).
+ *
+ * Tagged Effect errors come through `Effect.runPromise` wrapped in a
+ * `FiberFailure`; we walk the cause chain looking for the original tag.
+ */
+function publicError(e: unknown): { status: number; body: { error: string; message?: string } } {
+  // Walk the FiberFailure / Cause chain to find an Effect-tagged error.
+  const tag = (() => {
+    const seen = new Set<unknown>();
+    const queue: unknown[] = [e];
+    while (queue.length) {
+      const node = queue.shift();
+      if (!node || typeof node !== "object" || seen.has(node)) continue;
+      seen.add(node);
+      const t = (node as { _tag?: unknown })._tag;
+      if (typeof t === "string") return t;
+      for (const v of Object.values(node)) queue.push(v);
+    }
+    return null;
+  })();
+
+  // Always log the underlying cause for operators.
+  console.error("[auth route]", e);
+
+  switch (tag) {
+    case "ValidationError":
+      return { status: 400, body: { error: "invalid_request" } };
+    case "AuthError":
+      return { status: 400, body: { error: "invalid_request" } };
+    case "DatabaseError":
+      return { status: 500, body: { error: "internal_error" } };
+    default:
+      return { status: 400, body: { error: "invalid_request" } };
+  }
+}
+
 // In-memory PKCE challenge store (keyed by state)
 interface PkceEntry {
   codeChallenge: string;
@@ -21,6 +60,55 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
 
   const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
     Effect.runPromise(eff.pipe(Effect.provide(dbLayer)) as Effect.Effect<A, never, never>);
+
+  /**
+   * Resolves the authenticated principal for /passkey/register/* calls. The
+   * caller may present an Authorization header containing either a normal
+   * access token (existing user) or an enrollment token (new user from the
+   * registration flow). When the header is present and verifies, the
+   * resulting userId is compared against `bodyUserId` and a mismatch returns
+   * `{ unauthorized: true }`.
+   *
+   * When the header is absent, the route falls back to the legacy unauth'd
+   * path that simply trusts `bodyUserId`. This is preserved only for the
+   * hosted /authorize HTML page (`buildAuthorizeHtml`); see the security
+   * backlog for the removal plan.
+   */
+  type Principal = { unauthorized: true } | { unauthorized: false; userId: string };
+  async function resolvePasskeyEnrollPrincipal(
+    authHeader: string | undefined,
+    bodyUserId: string,
+    options: { consume: boolean } = { consume: false },
+  ): Promise<Principal> {
+    if (authHeader && /^Bearer\s+/i.test(authHeader)) {
+      const token = authHeader.replace(/^Bearer\s+/i, "");
+
+      // Try as a normal access token first.
+      const accessResult = await Effect.runPromise(Effect.either(auth.verifyAccessToken(token)));
+      if (accessResult._tag === "Right") {
+        if (accessResult.right.userId !== bodyUserId) return { unauthorized: true };
+        return { unauthorized: false, userId: accessResult.right.userId };
+      }
+
+      // Otherwise try as an enrollment token (and consume on /complete).
+      const enrollResult = await Effect.runPromise(
+        Effect.either(auth.verifyEnrollmentToken(token, options)),
+      );
+      if (enrollResult._tag === "Right") {
+        if (enrollResult.right.userId !== bodyUserId) return { unauthorized: true };
+        return { unauthorized: false, userId: enrollResult.right.userId };
+      }
+
+      return { unauthorized: true };
+    }
+
+    // Legacy unauth'd path — kept only for the hosted sign-in HTML page.
+    // Removal is tracked as S-C1-followup in the security backlog.
+    console.warn(
+      "[auth] DEPRECATED: /passkey/register/* called without Authorization header — body.userId is being trusted as principal. This path will be removed; see security backlog (S-C1-followup).",
+    );
+    return { unauthorized: false, userId: bodyUserId };
+  }
 
   return (
     new Elysia({ prefix: "" })
@@ -67,18 +155,20 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
       )
       // -------------------------------------------------------------------------
       // Email-verified registration: begin (sends OTP, does not create user)
+      //
+      // Always returns `{ sent: true }` (or a public error code on validation
+      // failure) regardless of whether the email/handle is already taken —
+      // this removes the user-enumeration oracle (S-M1).
       // -------------------------------------------------------------------------
       .post(
         "/register/begin",
         async ({ body, set }) => {
           try {
-            const result = await run(
-              auth.beginRegistration(body.email, body.handle, body.displayName),
-            );
-            return result;
+            return await run(auth.beginRegistration(body.email, body.handle, body.displayName));
           } catch (e) {
-            set.status = 400;
-            return { error: String(e) };
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
           }
         },
         {
@@ -91,6 +181,10 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
       )
       // -------------------------------------------------------------------------
       // Email-verified registration: complete (verifies OTP, creates user)
+      //
+      // Returns access + refresh tokens directly (no `/token` round-trip) plus
+      // a single-use enrollment_token the client uses to authenticate the
+      // subsequent passkey-enrolment calls.
       // -------------------------------------------------------------------------
       .post(
         "/register/complete",
@@ -98,10 +192,23 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
           try {
             const result = await run(auth.completeRegistration(body.email, body.code));
             set.status = 201;
-            return result;
+            return {
+              userId: result.userId,
+              handle: result.handle,
+              email: result.email,
+              session: {
+                access_token: result.accessToken,
+                refresh_token: result.refreshToken,
+                token_type: "Bearer",
+                expires_in: result.expiresIn,
+                scope: "openid profile",
+              },
+              enrollment_token: result.enrollmentToken,
+            };
           } catch (e) {
-            set.status = 400;
-            return { error: String(e) };
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
           }
         },
         {
@@ -262,16 +369,36 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
       )
       // -------------------------------------------------------------------------
       // Passkey: begin registration
+      //
+      // Authorization model:
+      //  - Preferred: client sends `Authorization: Bearer <token>`. Token is
+      //    either a normal access token (existing user adding a passkey from
+      //    a settings screen) or an enrollment token (new user from the
+      //    registration flow). The principal's userId is taken from the token
+      //    and the request body's `userId` MUST match.
+      //  - Legacy: no header. The route trusts `body.userId` as-is. This is
+      //    insecure and is tracked for removal in the security backlog (the
+      //    hosted /authorize HTML page is the last remaining caller). A
+      //    deprecation warning is logged on every legacy hit.
       // -------------------------------------------------------------------------
       .post(
         "/passkey/register/begin",
-        async ({ body, set }) => {
+        async ({ body, set, headers }) => {
           try {
-            const result = await run(auth.beginPasskeyRegistration(body.userId));
+            const principal = await resolvePasskeyEnrollPrincipal(
+              headers.authorization,
+              body.userId,
+            );
+            if (principal.unauthorized) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const result = await run(auth.beginPasskeyRegistration(principal.userId));
             return result.options;
           } catch (e) {
-            set.status = 400;
-            return { error: String(e) };
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
           }
         },
         {
@@ -283,15 +410,25 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
       // -------------------------------------------------------------------------
       .post(
         "/passkey/register/complete",
-        async ({ body, set }) => {
+        async ({ body, set, headers }) => {
           try {
+            const principal = await resolvePasskeyEnrollPrincipal(
+              headers.authorization,
+              body.userId,
+              { consume: true },
+            );
+            if (principal.unauthorized) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
             const result = await run(
-              auth.completePasskeyRegistration(body.userId, body.attestation),
+              auth.completePasskeyRegistration(principal.userId, body.attestation),
             );
             return result;
           } catch (e) {
-            set.status = 400;
-            return { error: String(e) };
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
           }
         },
         {

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -66,6 +66,52 @@ export function createAuthRoutes(authConfig: AuthConfig, dbLayer: Layer.Layer<Db
         },
       )
       // -------------------------------------------------------------------------
+      // Email-verified registration: begin (sends OTP, does not create user)
+      // -------------------------------------------------------------------------
+      .post(
+        "/register/begin",
+        async ({ body, set }) => {
+          try {
+            const result = await run(
+              auth.beginRegistration(body.email, body.handle, body.displayName),
+            );
+            return result;
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        {
+          body: t.Object({
+            email: t.String(),
+            handle: t.String(),
+            displayName: t.Optional(t.String()),
+          }),
+        },
+      )
+      // -------------------------------------------------------------------------
+      // Email-verified registration: complete (verifies OTP, creates user)
+      // -------------------------------------------------------------------------
+      .post(
+        "/register/complete",
+        async ({ body, set }) => {
+          try {
+            const result = await run(auth.completeRegistration(body.email, body.code));
+            set.status = 201;
+            return result;
+          } catch (e) {
+            set.status = 400;
+            return { error: String(e) };
+          }
+        },
+        {
+          body: t.Object({
+            email: t.String(),
+            code: t.String(),
+          }),
+        },
+      )
+      // -------------------------------------------------------------------------
       // Authorization endpoint — renders the sign-in page
       // -------------------------------------------------------------------------
       .get(

--- a/packages/core/src/services/auth.ts
+++ b/packages/core/src/services/auth.ts
@@ -82,11 +82,21 @@ interface MagicEntry {
   expiresAt: number;
 }
 
+interface PendingRegistration {
+  email: string;
+  handle: string;
+  displayName: string | null;
+  code: string;
+  expiresAt: number;
+}
+
 // keyed by userId for registration, by email for login
 const registrationChallenges = new Map<string, ChallengeEntry>();
 const loginChallenges = new Map<string, ChallengeEntry>();
 const otpStore = new Map<string, OtpEntry>();
 const magicStore = new Map<string, MagicEntry>();
+// Pending email-verification registrations, keyed by lowercased email.
+const pendingRegistrations = new Map<string, PendingRegistration>();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -254,6 +264,128 @@ export function createAuthService(config: AuthConfig) {
       });
 
       return { id, handle, email, displayName: dn, avatarUrl: null, createdAt: ts, updatedAt: ts };
+    });
+
+  /**
+   * Step 1 of email-verified registration. Validates the inputs, ensures the
+   * email and handle are free, generates a 6-digit OTP, stores a pending
+   * registration entry, and emails the code. The user row is NOT created yet —
+   * it is only created in completeRegistration once the code is verified.
+   */
+  const beginRegistration = (
+    email: string,
+    handle: string,
+    displayName?: string,
+  ): Effect.Effect<{ sent: boolean }, AuthError | ValidationError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+
+      if (RESERVED_HANDLES.has(handle)) {
+        return yield* Effect.fail(new AuthError({ message: "Handle is reserved" }));
+      }
+
+      const [existingEmail, existingHandle] = yield* Effect.all(
+        [findUserByEmail(email), findUserByHandle(handle)],
+        { concurrency: "unbounded" },
+      );
+      if (existingEmail) {
+        return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
+      }
+      if (existingHandle) {
+        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+      }
+
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      const code = (100_000 + (buf[0] % 900_000)).toString();
+
+      const key = email.toLowerCase();
+      pendingRegistrations.set(key, {
+        email,
+        handle,
+        displayName: displayName ?? null,
+        code,
+        expiresAt: Date.now() + otpTtl * 1000,
+      });
+
+      if (config.sendEmail) {
+        yield* Effect.tryPromise({
+          try: () =>
+            config.sendEmail!(
+              email,
+              "Verify your OSN email",
+              `Your OSN verification code is: ${code}\n\nThis code expires in ${otpTtl / 60} minutes.`,
+            ),
+          catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
+        });
+      } else {
+        console.log(`[OSN dev] Registration OTP for ${email}: ${code}`);
+      }
+
+      return { sent: true };
+    });
+
+  /**
+   * Step 2 of email-verified registration. Verifies the OTP against the
+   * pending registration and, if valid, creates the user row. Returns the new
+   * user plus a short-lived authorization code that the client can exchange
+   * for access/refresh tokens via /token.
+   */
+  const completeRegistration = (
+    email: string,
+    code: string,
+  ): Effect.Effect<
+    { userId: string; handle: string; email: string; code: string },
+    AuthError | DatabaseError,
+    Db
+  > =>
+    Effect.gen(function* () {
+      const key = email.toLowerCase();
+      const pending = pendingRegistrations.get(key);
+      if (!pending || Date.now() > pending.expiresAt) {
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
+      }
+      if (pending.code !== code) {
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
+      }
+      pendingRegistrations.delete(key);
+
+      // Re-check uniqueness in case someone raced us between begin and complete.
+      const [existingEmail, existingHandle] = yield* Effect.all(
+        [findUserByEmail(pending.email), findUserByHandle(pending.handle)],
+        { concurrency: "unbounded" },
+      );
+      if (existingEmail) {
+        return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
+      }
+      if (existingHandle) {
+        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+      }
+
+      const { db } = yield* Db;
+      const id = genId("usr_");
+      const ts = now();
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(users).values({
+            id,
+            handle: pending.handle,
+            email: pending.email,
+            displayName: pending.displayName,
+            createdAt: ts,
+            updatedAt: ts,
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const authCode = yield* issueCode(id);
+      return { userId: id, handle: pending.handle, email: pending.email, code: authCode };
     });
 
   /**
@@ -790,6 +922,8 @@ export function createAuthService(config: AuthConfig) {
     findUserByHandle,
     resolveIdentifier,
     registerUser,
+    beginRegistration,
+    completeRegistration,
     checkHandle,
     issueTokens,
     exchangeCode,

--- a/packages/core/src/services/auth.ts
+++ b/packages/core/src/services/auth.ts
@@ -1,5 +1,6 @@
 import { Data, Effect, Schema } from "effect";
 import { eq } from "drizzle-orm";
+import { timingSafeEqual } from "node:crypto";
 import {
   generateRegistrationOptions,
   verifyRegistrationResponse,
@@ -87,8 +88,14 @@ interface PendingRegistration {
   handle: string;
   displayName: string | null;
   code: string;
+  attempts: number;
   expiresAt: number;
 }
+
+// Bound on in-memory pending registrations to cap memory under abuse.
+const MAX_PENDING_REGISTRATIONS = 10_000;
+// Max OTP guesses against a single pending entry before it is wiped.
+const MAX_OTP_ATTEMPTS = 5;
 
 // keyed by userId for registration, by email for login
 const registrationChallenges = new Map<string, ChallengeEntry>();
@@ -97,6 +104,9 @@ const otpStore = new Map<string, OtpEntry>();
 const magicStore = new Map<string, MagicEntry>();
 // Pending email-verification registrations, keyed by lowercased email.
 const pendingRegistrations = new Map<string, PendingRegistration>();
+// Single-use enrollment tokens that have already been consumed by a passkey
+// register/complete call. Cleared opportunistically by sweepEnrollmentTokens.
+const consumedEnrollmentTokens = new Map<string, number>();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,6 +137,44 @@ async function verifyJwt(token: string, secret: string): Promise<Record<string, 
   const key = new TextEncoder().encode(secret);
   const { payload } = await jwtVerify(token, key);
   return payload as Record<string, unknown>;
+}
+
+/**
+ * Generates a uniformly distributed 6-digit OTP via rejection sampling.
+ * `crypto.getRandomValues` returns a 32-bit value; naive `% 900_000` is biased
+ * because 2^32 is not a multiple of 900_000. We discard draws that fall in the
+ * tail and resample.
+ */
+function genOtpCode(): string {
+  const buf = new Uint32Array(1);
+  // 2^32 = 4_294_967_296. Largest multiple of 900_000 not exceeding it.
+  const ceil = Math.floor(0x1_0000_0000 / 900_000) * 900_000;
+  do {
+    crypto.getRandomValues(buf);
+  } while (buf[0]! >= ceil);
+  return (100_000 + (buf[0]! % 900_000)).toString();
+}
+
+/**
+ * Constant-time string comparison. Falls back to `false` for length mismatch.
+ * Used for comparing user-supplied OTP codes against expected values to remove
+ * the (already small) timing side channel that JS string `===` exposes.
+ */
+function timingSafeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+/**
+ * Drops expired entries from a TTL-keyed map. Called opportunistically on
+ * insert paths to bound memory growth without needing a background sweeper.
+ * O(n) but n is capped (MAX_PENDING_REGISTRATIONS for that store).
+ */
+function sweepExpired<T extends { expiresAt: number }>(map: Map<string, T>): void {
+  const nowMs = Date.now();
+  for (const [key, entry] of map) {
+    if (entry.expiresAt <= nowMs) map.delete(key);
+  }
 }
 
 const EmailSchema = Schema.String.pipe(
@@ -267,10 +315,27 @@ export function createAuthService(config: AuthConfig) {
     });
 
   /**
-   * Step 1 of email-verified registration. Validates the inputs, ensures the
-   * email and handle are free, generates a 6-digit OTP, stores a pending
-   * registration entry, and emails the code. The user row is NOT created yet —
-   * it is only created in completeRegistration once the code is verified.
+   * Step 1 of email-verified registration. Validates input, normalises the
+   * email to lowercase, generates an unbiased 6-digit OTP, stores a pending
+   * registration entry, and emails the code. No DB row is created yet.
+   *
+   * Security properties:
+   *  - Always returns `{ sent: true }` regardless of whether the email or
+   *    handle is already taken (S-M1: removes the user-enumeration oracle).
+   *    The "is this handle free?" question is answered separately by the
+   *    public `/handle/:handle` endpoint, which is the appropriate channel
+   *    and can be rate-limited independently.
+   *  - The pending-registrations map is bounded (MAX_PENDING_REGISTRATIONS)
+   *    and swept of expired entries on every insert, so unauthenticated
+   *    abuse can't grow it without bound (S-M2 / P-W1).
+   *  - Refuses to overwrite a non-expired pending entry, preventing an
+   *    attacker from resetting a victim's in-progress OTP (S-M2).
+   *  - The dev-only `console.log` of the OTP is gated on
+   *    `NODE_ENV !== "production"` (S-M3).
+   *
+   * Validation errors (bad email format, bad handle format, reserved handle)
+   * are still surfaced as ValidationError / AuthError because they're not
+   * enumeration leaks — the same input would fail client-side too.
    */
   const beginRegistration = (
     email: string,
@@ -289,27 +354,46 @@ export function createAuthService(config: AuthConfig) {
         return yield* Effect.fail(new AuthError({ message: "Handle is reserved" }));
       }
 
+      // Normalise email to lowercase (S-H3) — the canonical form is what we
+      // persist and what we key the pending-registrations map by.
+      const normalisedEmail = email.toLowerCase();
+
+      // Sweep expired entries first so we don't refuse a legitimate retry
+      // simply because the user's previous OTP timed out.
+      sweepExpired(pendingRegistrations);
+
+      // Refuse to grow the map past its cap. Returning the same generic
+      // success keeps the response shape uniform under abuse.
+      if (pendingRegistrations.size >= MAX_PENDING_REGISTRATIONS) {
+        return { sent: true };
+      }
+
       const [existingEmail, existingHandle] = yield* Effect.all(
-        [findUserByEmail(email), findUserByHandle(handle)],
+        [findUserByEmail(normalisedEmail), findUserByHandle(handle)],
         { concurrency: "unbounded" },
       );
-      if (existingEmail) {
-        return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
-      }
-      if (existingHandle) {
-        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+
+      // S-M1: silently no-op when the email/handle already exists. The user
+      // can use the login flow if they already have an account; we don't
+      // confirm or deny their existence over an unauthenticated channel.
+      if (existingEmail || existingHandle) {
+        return { sent: true };
       }
 
-      const buf = new Uint32Array(1);
-      crypto.getRandomValues(buf);
-      const code = (100_000 + (buf[0] % 900_000)).toString();
+      // S-M2: don't let an attacker reset a victim's in-progress OTP by
+      // re-posting begin with the same email.
+      const existingPending = pendingRegistrations.get(normalisedEmail);
+      if (existingPending && existingPending.expiresAt > Date.now()) {
+        return { sent: true };
+      }
 
-      const key = email.toLowerCase();
-      pendingRegistrations.set(key, {
-        email,
+      const code = genOtpCode();
+      pendingRegistrations.set(normalisedEmail, {
+        email: normalisedEmail,
         handle,
         displayName: displayName ?? null,
         code,
+        attempts: 0,
         expiresAt: Date.now() + otpTtl * 1000,
       });
 
@@ -317,14 +401,15 @@ export function createAuthService(config: AuthConfig) {
         yield* Effect.tryPromise({
           try: () =>
             config.sendEmail!(
-              email,
+              normalisedEmail,
               "Verify your OSN email",
               `Your OSN verification code is: ${code}\n\nThis code expires in ${otpTtl / 60} minutes.`,
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else {
-        console.log(`[OSN dev] Registration OTP for ${email}: ${code}`);
+      } else if (process.env["NODE_ENV"] !== "production") {
+        // S-M3: only print the OTP to logs in non-production environments.
+        console.log(`[OSN dev] Registration OTP for ${normalisedEmail}: ${code}`);
       }
 
       return { sent: true };
@@ -332,15 +417,40 @@ export function createAuthService(config: AuthConfig) {
 
   /**
    * Step 2 of email-verified registration. Verifies the OTP against the
-   * pending registration and, if valid, creates the user row. Returns the new
-   * user plus a short-lived authorization code that the client can exchange
-   * for access/refresh tokens via /token.
+   * pending registration and, if valid, creates the user row, then returns a
+   * full Session (access + refresh tokens) AND a short-lived single-use
+   * enrollment token the client can use to add a passkey via the
+   * Authorization-gated `/passkey/register/*` routes.
+   *
+   * Security properties:
+   *  - Constant-time OTP comparison (S-M4 / `timingSafeEqualString`).
+   *  - Per-entry attempt counter; after MAX_OTP_ATTEMPTS the entry is wiped,
+   *    capping brute-force probability at ~5/1_000_000 per registration (S-H1
+   *    partial; full rate-limit fix is tracked in the security backlog).
+   *  - The pending entry is only deleted AFTER a successful insert. A losing
+   *    race against another insert (TOCTOU) leaves the pending entry intact
+   *    so the user can retry without burning their OTP (S-H4).
+   *  - Insert relies on the DB-level UNIQUE constraint on email/handle as
+   *    the source of truth, mapping constraint violations to a clean
+   *    AuthError instead of leaking driver text (S-H4 / S-H5).
+   *  - Returns access + refresh tokens directly. The legacy `/token` PKCE
+   *    bypass (tracked separately as a security-backlog item) is therefore
+   *    not on the registration code path at all.
    */
   const completeRegistration = (
     email: string,
     code: string,
   ): Effect.Effect<
-    { userId: string; handle: string; email: string; code: string },
+    {
+      userId: string;
+      handle: string;
+      email: string;
+      displayName: string | null;
+      accessToken: string;
+      refreshToken: string;
+      expiresIn: number;
+      enrollmentToken: string;
+    },
     AuthError | DatabaseError,
     Db
   > =>
@@ -350,42 +460,71 @@ export function createAuthService(config: AuthConfig) {
       if (!pending || Date.now() > pending.expiresAt) {
         return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
       }
-      if (pending.code !== code) {
-        return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
-      }
-      pendingRegistrations.delete(key);
 
-      // Re-check uniqueness in case someone raced us between begin and complete.
-      const [existingEmail, existingHandle] = yield* Effect.all(
-        [findUserByEmail(pending.email), findUserByHandle(pending.handle)],
-        { concurrency: "unbounded" },
-      );
-      if (existingEmail) {
-        return yield* Effect.fail(new AuthError({ message: "Email already registered" }));
-      }
-      if (existingHandle) {
-        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+      if (!timingSafeEqualString(pending.code, code)) {
+        // Increment the attempt counter; wipe after too many guesses.
+        pending.attempts += 1;
+        if (pending.attempts >= MAX_OTP_ATTEMPTS) {
+          pendingRegistrations.delete(key);
+        }
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
       }
 
       const { db } = yield* Db;
       const id = genId("usr_");
       const ts = now();
 
-      yield* Effect.tryPromise({
-        try: () =>
-          db.insert(users).values({
-            id,
-            handle: pending.handle,
-            email: pending.email,
-            displayName: pending.displayName,
-            createdAt: ts,
-            updatedAt: ts,
-          }),
+      // Insert directly. The DB-level UNIQUE constraints on `email` and
+      // `handle` are the source of truth for race-free uniqueness; a
+      // constraint violation here means another registration won the race
+      // (or the legacy `/register` endpoint was called concurrently). We
+      // surface that as a clean AuthError without leaking driver text.
+      const inserted = yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            await db.insert(users).values({
+              id,
+              handle: pending.handle,
+              email: pending.email,
+              displayName: pending.displayName,
+              createdAt: ts,
+              updatedAt: ts,
+            });
+            return { ok: true as const };
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (/UNIQUE|constraint/i.test(msg)) {
+              return { ok: false as const, reason: "conflict" };
+            }
+            throw e;
+          }
+        },
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      const authCode = yield* issueCode(id);
-      return { userId: id, handle: pending.handle, email: pending.email, code: authCode };
+      if (!inserted.ok) {
+        // Don't burn the pending entry — the user can still retry if the
+        // conflicting insert is rolled back. The collision is rare in
+        // practice (race window is microseconds).
+        return yield* Effect.fail(new AuthError({ message: "Email or handle already registered" }));
+      }
+
+      // Success: only NOW delete the pending entry.
+      pendingRegistrations.delete(key);
+
+      const tokens = yield* issueTokens(id, pending.email, pending.handle, pending.displayName);
+      const enrollmentToken = yield* issueEnrollmentToken(id);
+
+      return {
+        userId: id,
+        handle: pending.handle,
+        email: pending.email,
+        displayName: pending.displayName,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresIn: tokens.expiresIn,
+        enrollmentToken,
+      };
     });
 
   /**
@@ -435,6 +574,75 @@ export function createAuthService(config: AuthConfig) {
     Effect.tryPromise({
       try: () => signJwt({ sub: userId, type: "code" }, config.jwtSecret, 120),
       catch: (cause) => new AuthError({ message: String(cause) }),
+    });
+
+  // -------------------------------------------------------------------------
+  // Enrollment tokens
+  //
+  // Short-lived (5 min) single-use bearer tokens minted by completeRegistration
+  // (and only by completeRegistration) so that the new user can prove the
+  // server-side identity it just received over the same channel when it calls
+  // /passkey/register/{begin,complete}. The token's `sub` is the userId of the
+  // user being enrolled. Calls to /passkey/register/* compare the token's sub
+  // against the request body's userId; a mismatch is rejected.
+  //
+  // The "consumed" set tracks the JWT IDs (`jti`) of tokens that have already
+  // been used by /passkey/register/complete. /passkey/register/begin does NOT
+  // consume the token (the user may need to retry the WebAuthn ceremony).
+  // -------------------------------------------------------------------------
+
+  const enrollmentTokenTtl = 5 * 60; // seconds
+
+  const issueEnrollmentToken = (userId: string) =>
+    Effect.tryPromise({
+      try: () => {
+        const jti = crypto.randomUUID();
+        return signJwt(
+          { sub: userId, type: "passkey-enroll", jti },
+          config.jwtSecret,
+          enrollmentTokenTtl,
+        );
+      },
+      catch: (cause) => new AuthError({ message: String(cause) }),
+    });
+
+  /**
+   * Verifies an enrollment token. Returns the userId on success.
+   * If `consume` is true (used by /passkey/register/complete) the token's jti
+   * is recorded in `consumedEnrollmentTokens` and any subsequent verification
+   * with the same jti will fail.
+   */
+  const verifyEnrollmentToken = (
+    token: string,
+    options: { consume: boolean } = { consume: false },
+  ): Effect.Effect<{ userId: string }, AuthError> =>
+    Effect.gen(function* () {
+      const payload = yield* Effect.tryPromise({
+        try: () => verifyJwt(token, config.jwtSecret),
+        catch: () => new AuthError({ message: "Invalid or expired enrollment token" }),
+      });
+      if (
+        payload["type"] !== "passkey-enroll" ||
+        typeof payload["sub"] !== "string" ||
+        typeof payload["jti"] !== "string"
+      ) {
+        return yield* Effect.fail(new AuthError({ message: "Invalid enrollment token" }));
+      }
+
+      // Sweep consumed tokens whose original TTL has elapsed (Date.now() ms).
+      const cutoff = Date.now() - enrollmentTokenTtl * 1000;
+      for (const [jti, ts] of consumedEnrollmentTokens) {
+        if (ts < cutoff) consumedEnrollmentTokens.delete(jti);
+      }
+
+      const jti = payload["jti"] as string;
+      if (consumedEnrollmentTokens.has(jti)) {
+        return yield* Effect.fail(new AuthError({ message: "Enrollment token already used" }));
+      }
+      if (options.consume) {
+        consumedEnrollmentTokens.set(jti, Date.now());
+      }
+      return { userId: payload["sub"] as string };
     });
 
   // -------------------------------------------------------------------------
@@ -924,6 +1132,8 @@ export function createAuthService(config: AuthConfig) {
     registerUser,
     beginRegistration,
     completeRegistration,
+    issueEnrollmentToken,
+    verifyEnrollmentToken,
     checkHandle,
     issueTokens,
     exchangeCode,

--- a/packages/core/tests/routes/auth.test.ts
+++ b/packages/core/tests/routes/auth.test.ts
@@ -127,7 +127,8 @@ describe("auth routes", () => {
       const checkRes = await verifiedApp.handle(new Request("http://localhost/handle/verifyme"));
       expect(((await checkRes.json()) as { available: boolean }).available).toBe(true);
 
-      // Complete: with the right code, user is created and an auth code returned.
+      // Complete: with the right code, user is created and a Session +
+      // enrollment_token are returned directly (no /token round-trip).
       const completeRes = await verifiedApp.handle(
         new Request("http://localhost/register/complete", {
           method: "POST",
@@ -140,12 +141,22 @@ describe("auth routes", () => {
         userId: string;
         handle: string;
         email: string;
-        code: string;
+        session: {
+          access_token: string;
+          refresh_token: string;
+          token_type: string;
+          expires_in: number;
+        };
+        enrollment_token: string;
       };
       expect(json.userId).toMatch(/^usr_/);
       expect(json.handle).toBe("verifyme");
       expect(json.email).toBe("verify-me@example.com");
-      expect(json.code.length).toBeGreaterThan(0);
+      expect(json.session.access_token.length).toBeGreaterThan(0);
+      expect(json.session.refresh_token.length).toBeGreaterThan(0);
+      expect(json.session.token_type).toBe("Bearer");
+      expect(json.session.expires_in).toBeGreaterThan(0);
+      expect(json.enrollment_token.length).toBeGreaterThan(0);
 
       // Handle now taken.
       const checkRes2 = await verifiedApp.handle(new Request("http://localhost/handle/verifyme"));
@@ -175,7 +186,10 @@ describe("auth routes", () => {
       expect(((await checkRes.json()) as { available: boolean }).available).toBe(true);
     });
 
-    it("rejects begin when the email is already registered", async () => {
+    it("S-M1: returns sent:true silently when the email is already registered", async () => {
+      // Enumeration-resistant: never differentiate between "free" and "taken"
+      // accounts on /register/begin. The handle availability check is the
+      // appropriate channel for that question.
       await app.handle(
         new Request("http://localhost/register", {
           method: "POST",
@@ -190,10 +204,11 @@ describe("auth routes", () => {
           body: JSON.stringify({ email: "taken@example.com", handle: "newhandle" }),
         }),
       );
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { sent: boolean }).sent).toBe(true);
     });
 
-    it("rejects begin when the handle is already taken", async () => {
+    it("S-M1: returns sent:true silently when the handle is already taken", async () => {
       await app.handle(
         new Request("http://localhost/register", {
           method: "POST",
@@ -208,7 +223,8 @@ describe("auth routes", () => {
           body: JSON.stringify({ email: "second@example.com", handle: "duphandle" }),
         }),
       );
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { sent: boolean }).sent).toBe(true);
     });
 
     it("rejects begin for an invalid handle format", async () => {
@@ -629,6 +645,149 @@ describe("auth routes", () => {
         }),
       );
       expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization gating on /passkey/register/*
+  // -------------------------------------------------------------------------
+  describe("POST /passkey/register/begin (Authorization gating)", () => {
+    /**
+     * Helper: register a user via the legacy path, then mint an enrollment
+     * token directly via the service. Mirrors what completeRegistration does
+     * in the new flow.
+     */
+    async function setupUserAndEnrollmentToken(): Promise<{
+      userId: string;
+      enrollmentToken: string;
+    }> {
+      const svc = createAuthService(config);
+      const user = await Effect.runPromise(
+        svc.registerUser("paul@example.com", "paul").pipe(Effect.provide(layer)),
+      );
+      const enrollmentToken = await Effect.runPromise(svc.issueEnrollmentToken(user.id));
+      return { userId: user.id, enrollmentToken };
+    }
+
+    it("S-C1: rejects with 401 when Authorization header is present but invalid", async () => {
+      const { userId } = await setupUserAndEnrollmentToken();
+      const res = await app.handle(
+        new Request("http://localhost/passkey/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer not-a-real-token",
+          },
+          body: JSON.stringify({ userId }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("S-C1: rejects with 401 when enrollment token's sub mismatches body.userId", async () => {
+      const { enrollmentToken } = await setupUserAndEnrollmentToken();
+      const res = await app.handle(
+        new Request("http://localhost/passkey/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${enrollmentToken}`,
+          },
+          body: JSON.stringify({ userId: "usr_someoneelse" }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts a valid enrollment token whose sub matches body.userId", async () => {
+      const { userId, enrollmentToken } = await setupUserAndEnrollmentToken();
+      const res = await app.handle(
+        new Request("http://localhost/passkey/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${enrollmentToken}`,
+          },
+          body: JSON.stringify({ userId }),
+        }),
+      );
+      // 200 OK (WebAuthn options blob) — not 401, not 400.
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { challenge?: string };
+      expect(json.challenge).toBeTruthy();
+    });
+
+    it("accepts a normal access token (existing user adding a passkey)", async () => {
+      const svc = createAuthService(config);
+      const user = await Effect.runPromise(
+        svc.registerUser("quinn@example.com", "quinn").pipe(Effect.provide(layer)),
+      );
+      const tokens = await Effect.runPromise(
+        svc.issueTokens(user.id, user.email, user.handle, user.displayName),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/passkey/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${tokens.accessToken}`,
+          },
+          body: JSON.stringify({ userId: user.id }),
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("legacy unauth'd path is still permitted (deprecated; tracked for removal)", async () => {
+      const svc = createAuthService(config);
+      const user = await Effect.runPromise(
+        svc.registerUser("rita@example.com", "rita").pipe(Effect.provide(layer)),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/passkey/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId: user.id }),
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("POST /passkey/register/complete (enrollment token consumption)", () => {
+    it("rejects when the enrollment token has already been consumed", async () => {
+      const svc = createAuthService(config);
+      const user = await Effect.runPromise(
+        svc.registerUser("sam@example.com", "samuser").pipe(Effect.provide(layer)),
+      );
+      const enrollmentToken = await Effect.runPromise(svc.issueEnrollmentToken(user.id));
+
+      // First call: consumes the token. The attestation is bogus so the
+      // service will fail downstream — but the *consumption* happens in the
+      // route guard before that, so this still marks the token used.
+      await app.handle(
+        new Request("http://localhost/passkey/register/complete", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${enrollmentToken}`,
+          },
+          body: JSON.stringify({ userId: user.id, attestation: { id: "x" } }),
+        }),
+      );
+
+      // Second call with the same token must be rejected at the auth layer.
+      const second = await app.handle(
+        new Request("http://localhost/passkey/register/complete", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${enrollmentToken}`,
+          },
+          body: JSON.stringify({ userId: user.id, attestation: { id: "x" } }),
+        }),
+      );
+      expect(second.status).toBe(401);
     });
   });
 });

--- a/packages/core/tests/routes/auth.test.ts
+++ b/packages/core/tests/routes/auth.test.ts
@@ -93,6 +93,137 @@ describe("auth routes", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Email-verified registration (begin + complete)
+  // -------------------------------------------------------------------------
+  describe("POST /register/begin + /register/complete", () => {
+    it("does not create the user until the OTP is verified", async () => {
+      let captured: string | undefined;
+      const verifiedConfig = {
+        ...config,
+        sendEmail: async (_to: string, _subject: string, body: string) => {
+          const m = body.match(/code is: (\d{6})/);
+          if (m) captured = m[1];
+        },
+      };
+      const verifiedApp = createAuthRoutes(verifiedConfig, layer);
+
+      // Begin: should send a code but NOT create the user yet.
+      const beginRes = await verifiedApp.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "verify-me@example.com",
+            handle: "verifyme",
+            displayName: "Verify Me",
+          }),
+        }),
+      );
+      expect(beginRes.status).toBe(200);
+      expect(((await beginRes.json()) as { sent: boolean }).sent).toBe(true);
+      expect(captured).toMatch(/^\d{6}$/);
+
+      // Handle should still be free, since user wasn't created.
+      const checkRes = await verifiedApp.handle(new Request("http://localhost/handle/verifyme"));
+      expect(((await checkRes.json()) as { available: boolean }).available).toBe(true);
+
+      // Complete: with the right code, user is created and an auth code returned.
+      const completeRes = await verifiedApp.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "verify-me@example.com", code: captured! }),
+        }),
+      );
+      expect(completeRes.status).toBe(201);
+      const json = (await completeRes.json()) as {
+        userId: string;
+        handle: string;
+        email: string;
+        code: string;
+      };
+      expect(json.userId).toMatch(/^usr_/);
+      expect(json.handle).toBe("verifyme");
+      expect(json.email).toBe("verify-me@example.com");
+      expect(json.code.length).toBeGreaterThan(0);
+
+      // Handle now taken.
+      const checkRes2 = await verifiedApp.handle(new Request("http://localhost/handle/verifyme"));
+      expect(((await checkRes2.json()) as { available: boolean }).available).toBe(false);
+    });
+
+    it("rejects the wrong OTP and does not create the user", async () => {
+      const beginRes = await app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "wrong-otp@example.com", handle: "wrongotp" }),
+        }),
+      );
+      expect(beginRes.status).toBe(200);
+
+      const completeRes = await app.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "wrong-otp@example.com", code: "000000" }),
+        }),
+      );
+      expect(completeRes.status).toBe(400);
+
+      const checkRes = await app.handle(new Request("http://localhost/handle/wrongotp"));
+      expect(((await checkRes.json()) as { available: boolean }).available).toBe(true);
+    });
+
+    it("rejects begin when the email is already registered", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "taken@example.com", handle: "takenuser" }),
+        }),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "taken@example.com", handle: "newhandle" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects begin when the handle is already taken", async () => {
+      await app.handle(
+        new Request("http://localhost/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "first@example.com", handle: "duphandle" }),
+        }),
+      );
+      const res = await app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "second@example.com", handle: "duphandle" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects begin for an invalid handle format", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "ok@example.com", handle: "Bad Handle!" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Handle availability
   // -------------------------------------------------------------------------
   describe("GET /handle/:handle", () => {

--- a/packages/core/tests/routes/auth.test.ts
+++ b/packages/core/tests/routes/auth.test.ts
@@ -221,6 +221,67 @@ describe("auth routes", () => {
       );
       expect(res.status).toBe(400);
     });
+
+    it("rejects /register/complete with no preceding /register/begin", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "never-began@example.com", code: "123456" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects /register/complete on replay (single-use OTP)", async () => {
+      let captured: string | undefined;
+      const verifiedConfig = {
+        ...config,
+        sendEmail: async (_to: string, _subject: string, body: string) => {
+          const m = body.match(/code is: (\d{6})/);
+          if (m) captured = m[1];
+        },
+      };
+      const verifiedApp = createAuthRoutes(verifiedConfig, layer);
+
+      await verifiedApp.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "replay-route@example.com", handle: "replayroute" }),
+        }),
+      );
+
+      const first = await verifiedApp.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "replay-route@example.com", code: captured! }),
+        }),
+      );
+      expect(first.status).toBe(201);
+
+      const second = await verifiedApp.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "replay-route@example.com", code: captured! }),
+        }),
+      );
+      expect(second.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reserved handles via /handle/:handle
+  // -------------------------------------------------------------------------
+  describe("GET /handle/:handle (reserved)", () => {
+    it("returns available:false for a reserved handle", async () => {
+      const res = await app.handle(new Request("http://localhost/handle/admin"));
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { available: boolean };
+      expect(json.available).toBe(false);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/core/tests/services/auth.test.ts
+++ b/packages/core/tests/services/auth.test.ts
@@ -124,22 +124,43 @@ describe("beginRegistration + completeRegistration", () => {
     return { svc, captured };
   }
 
-  it.effect("happy path: begin → complete creates the user and returns an auth code", () =>
+  it.effect(
+    "happy path: begin → complete creates user and returns session + enrollment token",
+    () =>
+      Effect.gen(function* () {
+        const { svc, captured } = makeAuth();
+        yield* svc.beginRegistration("verify@example.com", "verifyme", "Verify Me");
+        expect(captured.code).toMatch(/^\d{6}$/);
+
+        const result = yield* svc.completeRegistration("verify@example.com", captured.code!);
+        expect(result.userId).toMatch(/^usr_/);
+        expect(result.handle).toBe("verifyme");
+        expect(result.email).toBe("verify@example.com");
+        expect(result.displayName).toBe("Verify Me");
+        expect(result.accessToken.length).toBeGreaterThan(0);
+        expect(result.refreshToken.length).toBeGreaterThan(0);
+        expect(result.expiresIn).toBeGreaterThan(0);
+        expect(result.enrollmentToken.length).toBeGreaterThan(0);
+
+        // The user row must now exist.
+        const found = yield* svc.findUserByEmail("verify@example.com");
+        expect(found?.handle).toBe("verifyme");
+        expect(found?.displayName).toBe("Verify Me");
+      }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("S-H3: email is normalised to lowercase across the pipeline", () =>
     Effect.gen(function* () {
       const { svc, captured } = makeAuth();
-      yield* svc.beginRegistration("verify@example.com", "verifyme", "Verify Me");
-      expect(captured.code).toMatch(/^\d{6}$/);
+      yield* svc.beginRegistration("MixedCase@Example.com", "mixedcase");
+      // The OTP is captured from the email body which is sent to the
+      // lowercased address; complete must also accept the lowercased form.
+      const result = yield* svc.completeRegistration("MixedCase@Example.com", captured.code!);
+      expect(result.email).toBe("mixedcase@example.com");
 
-      const result = yield* svc.completeRegistration("verify@example.com", captured.code!);
-      expect(result.userId).toMatch(/^usr_/);
-      expect(result.handle).toBe("verifyme");
-      expect(result.email).toBe("verify@example.com");
-      expect(result.code.length).toBeGreaterThan(0);
-
-      // The user row must now exist.
-      const found = yield* svc.findUserByEmail("verify@example.com");
-      expect(found?.handle).toBe("verifyme");
-      expect(found?.displayName).toBe("Verify Me");
+      // Lookups by either casing find the same row.
+      const a = yield* svc.findUserByEmail("mixedcase@example.com");
+      expect(a?.id).toBe(result.userId);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -182,23 +203,41 @@ describe("beginRegistration + completeRegistration", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("rejects begin when the email is already registered", () =>
+  it.effect("S-M1: begin returns sent:true silently when email is already taken", () =>
     Effect.gen(function* () {
-      const { svc } = makeAuth();
+      const { svc, captured } = makeAuth();
       yield* svc.registerUser("taken@example.com", "takenuser");
-      const error = yield* Effect.flip(svc.beginRegistration("taken@example.com", "newhandle"));
-      expect(error._tag).toBe("AuthError");
-      expect(error.message).toContain("Email already registered");
+      // No throw — and crucially, no email sent (otherwise enumeration is
+      // possible via timing or via observing outbound mail).
+      const result = yield* svc.beginRegistration("taken@example.com", "newhandle");
+      expect(result.sent).toBe(true);
+      expect(captured.code).toBeUndefined();
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("rejects begin when the handle is already taken", () =>
+  it.effect("S-M1: begin returns sent:true silently when handle is already taken", () =>
     Effect.gen(function* () {
-      const { svc } = makeAuth();
+      const { svc, captured } = makeAuth();
       yield* svc.registerUser("first@example.com", "duphandle");
-      const error = yield* Effect.flip(svc.beginRegistration("second@example.com", "duphandle"));
-      expect(error._tag).toBe("AuthError");
-      expect(error.message).toContain("Handle already taken");
+      const result = yield* svc.beginRegistration("second@example.com", "duphandle");
+      expect(result.sent).toBe(true);
+      expect(captured.code).toBeUndefined();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("S-M2: begin refuses to overwrite a non-expired pending entry", () =>
+    Effect.gen(function* () {
+      const { svc, captured } = makeAuth();
+      yield* svc.beginRegistration("dup@example.com", "dupuser");
+      const firstCode = captured.code;
+      captured.code = undefined;
+      // Second call within the TTL should not send another email and should
+      // not change the stored OTP.
+      yield* svc.beginRegistration("dup@example.com", "differenthandle");
+      expect(captured.code).toBeUndefined();
+      // The original code must still verify.
+      const result = yield* svc.completeRegistration("dup@example.com", firstCode!);
+      expect(result.userId).toMatch(/^usr_/);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -233,6 +272,80 @@ describe("beginRegistration + completeRegistration", () => {
       const error = yield* Effect.flip(
         svc.completeRegistration("replay@example.com", captured.code!),
       );
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("S-H1: brute-force is capped — pending entry is wiped after 5 wrong guesses", () =>
+    Effect.gen(function* () {
+      const { svc, captured } = makeAuth();
+      yield* svc.beginRegistration("brute@example.com", "bruteuser");
+      // 5 wrong guesses
+      for (let i = 0; i < 5; i++) {
+        const err = yield* Effect.flip(svc.completeRegistration("brute@example.com", "000000"));
+        expect(err._tag).toBe("AuthError");
+      }
+      // The correct code should now ALSO fail because the entry was wiped.
+      const err = yield* Effect.flip(svc.completeRegistration("brute@example.com", captured.code!));
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toContain("Invalid or expired code");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("S-H4: a TOCTOU loss against the legacy /register doesn't burn the OTP", () =>
+    Effect.gen(function* () {
+      const { svc, captured } = makeAuth();
+      yield* svc.beginRegistration("toctou@example.com", "toctouuser");
+      // Simulate someone winning the race via the legacy registerUser path.
+      yield* svc.registerUser("toctou@example.com", "toctouuser");
+      // Our complete fails (handle/email taken) but the pending entry must
+      // not have been deleted — though in practice the user would now be
+      // told to log in instead.
+      const err = yield* Effect.flip(
+        svc.completeRegistration("toctou@example.com", captured.code!),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toContain("already registered");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("issueEnrollmentToken + verifyEnrollmentToken", () => {
+  it.effect("issues a token whose sub matches the userId", () =>
+    Effect.gen(function* () {
+      const token = yield* auth.issueEnrollmentToken("usr_abc");
+      expect(token.length).toBeGreaterThan(0);
+      const result = yield* auth.verifyEnrollmentToken(token);
+      expect(result.userId).toBe("usr_abc");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("verify with consume:true marks the token as used; replay fails", () =>
+    Effect.gen(function* () {
+      const token = yield* auth.issueEnrollmentToken("usr_consume");
+      const first = yield* auth.verifyEnrollmentToken(token, { consume: true });
+      expect(first.userId).toBe("usr_consume");
+
+      const error = yield* Effect.flip(auth.verifyEnrollmentToken(token, { consume: true }));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("already used");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("verify with consume:false can be called repeatedly", () =>
+    Effect.gen(function* () {
+      const token = yield* auth.issueEnrollmentToken("usr_repeat");
+      const first = yield* auth.verifyEnrollmentToken(token);
+      const second = yield* auth.verifyEnrollmentToken(token);
+      expect(first.userId).toBe(second.userId);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects a normal access token (wrong type claim)", () =>
+    Effect.gen(function* () {
+      yield* auth.registerUser("typecheck@example.com", "typecheck");
+      const tokens = yield* auth.issueTokens("usr_x", "typecheck@example.com", "typecheck", null);
+      const error = yield* Effect.flip(auth.verifyEnrollmentToken(tokens.accessToken));
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );

--- a/packages/core/tests/services/auth.test.ts
+++ b/packages/core/tests/services/auth.test.ts
@@ -88,10 +88,152 @@ describe("checkHandle", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("returns available:false for a reserved handle", () =>
+    Effect.gen(function* () {
+      const result = yield* auth.checkHandle("admin");
+      expect(result.available).toBe(false);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("fails with ValidationError for invalid format", () =>
     Effect.gen(function* () {
       const error = yield* Effect.flip(auth.checkHandle("INVALID!"));
       expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Email-verified registration: beginRegistration + completeRegistration
+// ---------------------------------------------------------------------------
+
+describe("beginRegistration + completeRegistration", () => {
+  /**
+   * Each test gets its own auth service with a fresh in-memory `sendEmail`
+   * capture so the OTP sent in step 1 can be replayed in step 2.
+   */
+  function makeAuth() {
+    const captured: { code?: string } = {};
+    const svc = createAuthService({
+      ...config,
+      sendEmail: async (_to, _subject, body) => {
+        const m = body.match(/code is: (\d{6})/);
+        if (m) captured.code = m[1];
+      },
+    });
+    return { svc, captured };
+  }
+
+  it.effect("happy path: begin → complete creates the user and returns an auth code", () =>
+    Effect.gen(function* () {
+      const { svc, captured } = makeAuth();
+      yield* svc.beginRegistration("verify@example.com", "verifyme", "Verify Me");
+      expect(captured.code).toMatch(/^\d{6}$/);
+
+      const result = yield* svc.completeRegistration("verify@example.com", captured.code!);
+      expect(result.userId).toMatch(/^usr_/);
+      expect(result.handle).toBe("verifyme");
+      expect(result.email).toBe("verify@example.com");
+      expect(result.code.length).toBeGreaterThan(0);
+
+      // The user row must now exist.
+      const found = yield* svc.findUserByEmail("verify@example.com");
+      expect(found?.handle).toBe("verifyme");
+      expect(found?.displayName).toBe("Verify Me");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("does not create the user before the OTP is verified", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      yield* svc.beginRegistration("pending@example.com", "pendinguser");
+
+      // No DB row yet.
+      const found = yield* svc.findUserByEmail("pending@example.com");
+      expect(found).toBeNull();
+      // Handle still free.
+      const status = yield* svc.checkHandle("pendinguser");
+      expect(status.available).toBe(true);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects begin with ValidationError on bad email", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      const error = yield* Effect.flip(svc.beginRegistration("not-an-email", "okhandle"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects begin with ValidationError on bad handle format", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      const error = yield* Effect.flip(svc.beginRegistration("ok@example.com", "Bad Handle!"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects begin with AuthError on a reserved handle", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      const error = yield* Effect.flip(svc.beginRegistration("ok@example.com", "admin"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("reserved");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects begin when the email is already registered", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      yield* svc.registerUser("taken@example.com", "takenuser");
+      const error = yield* Effect.flip(svc.beginRegistration("taken@example.com", "newhandle"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Email already registered");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects begin when the handle is already taken", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      yield* svc.registerUser("first@example.com", "duphandle");
+      const error = yield* Effect.flip(svc.beginRegistration("second@example.com", "duphandle"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("complete fails with AuthError when the OTP is wrong", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      yield* svc.beginRegistration("wrong@example.com", "wronguser");
+      const error = yield* Effect.flip(svc.completeRegistration("wrong@example.com", "000000"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Invalid or expired code");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("complete fails with AuthError when there is no pending registration", () =>
+    Effect.gen(function* () {
+      const { svc } = makeAuth();
+      const error = yield* Effect.flip(
+        svc.completeRegistration("never-began@example.com", "123456"),
+      );
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Invalid or expired code");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("complete is single-use: a replayed code fails", () =>
+    Effect.gen(function* () {
+      const { svc, captured } = makeAuth();
+      yield* svc.beginRegistration("replay@example.com", "replayuser");
+      yield* svc.completeRegistration("replay@example.com", captured.code!);
+
+      // Second call with the same code must fail — pending entry was deleted.
+      const error = yield* Effect.flip(
+        svc.completeRegistration("replay@example.com", captured.code!),
+      );
+      expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });


### PR DESCRIPTION
## Summary

End-to-end user registration in Pulse: email + handle (with debounced live availability) → 6-digit OTP → optional passkey → signed in. Includes a security redesign that addresses the critical findings from the review pass.

- **`@osn/core`**: new `POST /register/begin` and `POST /register/complete` endpoints; new `issueEnrollmentToken` / `verifyEnrollmentToken` service helpers; `/passkey/register/{begin,complete}` now accept an `Authorization: Bearer <token>` header (enrollment token or normal access token); new `publicError()` route helper for opaque public payloads.
- **`@osn/client`**: new `createRegistrationClient` (plain-fetch, framework-free); `OsnAuth.setSession` + Solid `AuthProvider.adoptSession` for installing a session obtained out-of-band.
- **`@osn/pulse`**: new `Register` component implementing the multi-step UI, wired into `EventList` as a "Create account" button next to "Sign in with OSN". WebAuthn feature-detected via `browserSupportsWebAuthn()`; the passkey step is auto-skipped on environments without it (e.g. current Tauri iOS webview).

## Workspaces affected

- `@osn/core` (minor)
- `@osn/client` (minor)
- `@osn/pulse` (minor)

## Decisions & issues

This PR went through two review passes and was substantially redesigned in response to security findings. Capturing the lineage so reviewers don't have to reconstruct it from commits.

**Architecture / approach**

- **Initial design (commits 1–3)** routed registration through the standard OAuth dance: `register/complete` returned a short-lived authorization code, which the client then exchanged at `/token` for tokens. This required passing `code_verifier: "registration"` and omitting `state`, exploiting a pre-existing PKCE bypass at `/token` (skips verification when `state` is absent). The security review flagged this as **S-C2 Critical** — the bypass was pre-existing but my code was the first first-party caller to deliberately rely on it, normalising what should be a bug.
- **Initial design also relied on** the pre-existing unauth'd `/passkey/register/{begin,complete}` routes (which trust `body.userId` as identity). The security review flagged this as **S-C1 Critical** — by handing a freshly-minted `userId` to the client over plain JSON and then immediately using it to enrol a passkey, the flow created a documented account-takeover path for any user whose `userId` an attacker could observe.
- **Redesign (commit 5)** removes both dependencies: `register/complete` now issues access + refresh tokens directly (no `/token` round-trip); a single-use enrollment JWT (`type: "passkey-enroll"`, 5-min TTL, jti tracked in a consumed-set) is returned in the same response and presented as `Authorization: Bearer` on the passkey calls. The passkey routes verify the token's `sub` matches the body `userId` and reject mismatches with 401. Legacy unauth'd path is preserved with a deprecation warning so the hosted `/authorize` HTML page (the only other caller) keeps working — removing it is tracked as an S-H5 follow-up.
- **WebAuthn feature detection (commit 2)** added because Tauri's iOS webview doesn't expose WebAuthn natively. Investigated [`tauri-plugin-webauthn`](https://github.com/Profiidev/tauri-plugin-webauthn) as the eventual solution; logged it in TODO.md with the upstream tracking issue [tauri#7926](https://github.com/tauri-apps/tauri/issues/7926). For now the passkey step auto-skips on unsupported environments and the user is still signed in.
- **`adoptSession` happens at OTP-verify time, not after passkey enrolment.** This is a UX correctness fix — a flaky WebAuthn ceremony or an unsupported environment can no longer leave the user "verified but not signed in". Passkey enrolment is now an upsell on top of an already-active session.

**Security findings addressed in this PR**

- S-H2 unbiased OTP via rejection sampling in `genOtpCode()`
- S-H3 lowercase email normalisation through the new pipeline (legacy `/register` and login OTP unchanged; tracked as S-M19)
- S-H4 transactional insert via UNIQUE constraint catch; pending entry only deleted on successful insert (no TOCTOU)
- S-H5 / S-M6 `publicError()` mapper — opaque payloads, server-side cause logging
- S-M1 / S-M26 `register/begin` always returns `{sent: true}` regardless of conflict — enumeration-resistant
- S-M2 / S-M23 `pendingRegistrations` capped at 10 000 + swept on insert + refuses to overwrite a non-expired entry
- S-M3 dev OTP `console.log` gated on `NODE_ENV !== "production"`
- S-M4 / S-M25 timing-safe OTP comparison via `node:crypto.timingSafeEqual`
- 5-attempts brute-force cap on the new OTP (partial S-H1; full per-IP rate limiting still tracked as S-H1)
- New marker entries S-H9/H10/H11 in TODO.md so future readers can see what was done

**Performance findings addressed**

- P-W1 / S-M2 bounded + swept-on-insert pending-registrations Map (same fix)
- P-I10 dropped the `createEffect` auto-skip in `Register.tsx`; replaced with an imperative call from `submitOtp` after the step transition (cleaner control flow, no re-fire surface area)
- P-I11 inlined `detailsValid` — removed unnecessary `createMemo` for a 3-line boolean
- P-I12 hoisted `RegistrationClient` to module scope so it's not reallocated on every component mount

**Findings deferred to security/perf backlog (with rationale)**

- **S-H1** rate-limit infra — needs middleware that doesn't yet exist; the existing graph rate-limiter is per-user (won't apply to unauthenticated routes). 5-attempts-per-pending-entry cap mitigates the OTP brute-force vector for now.
- **S-H4** `/token` PKCE bypass — fix affects every flow that mints a code (passkey login, OTP, magic link), not just registration. Out of scope for this PR; the registration flow no longer depends on it, which removes the immediate exploit path.
- **S-H5 follow-up** — removing the legacy unauth'd `/passkey/register/*` path requires migrating the hosted `/authorize` HTML page first.
- **S-M5 / S-M20** Tauri secure-storage adapter for refresh tokens — separate piece of work, affects all flows.
- **S-L1/L2/L3** hygiene items.
- **P-W3** AbortController on debounced handle check, **P-W4** other auth Maps need the same sweep helper, **P-W11** single OR query for uniqueness — all minor.

**Process / friction during prep-pr**

- Local `main` was stale; rebased onto `origin/main` (which had advanced 4 commits via `feat(tooling): dependency review skill, finding IDs, prep-pr improvements (#17)` and `Reject event creation with past startTime (#18)`). Resolved two `TODO.md` conflicts by accepting the upstream restructure that removed the "Current Status" section.
- One lint error from the auto-formatter (`...init.headers ?? {}` flagged by `eslint(no-new)` rule) — replaced with `...init.headers` after narrowing the type.
- The first `Register.test.tsx` run failed because `getByLabelText("Email")` and `getByLabelText("Handle")` couldn't match labels that contained extra text inside (`<span>@</span>`); switched to regex matchers.
- The redesign introduced a test isolation problem: the WebAuthn `passkeySupported` flag had been hoisted to module scope, which prevented per-test toggling via `vi.hoisted()`. Moved feature detection back inside the component body (negligible cost per mount, restores test toggling).
- The original `completeRegistration` test referenced the now-removed `result.code` field; updated to assert the new `accessToken`/`refreshToken`/`enrollmentToken` shape.
- Two route tests (`rejects begin when the email is already registered` / `... handle is already taken`) were inverted by the redesign — the new enumeration-resistant behaviour returns 200 with `{sent: true}` instead of 400. Updated the assertions and renamed to the `S-M1` finding ID.

**Tests** — 277 total (was 219 baseline)
- 162 in `@osn/core` (+14 service tests for begin/complete + enrollment tokens; +9 route tests for Authorization gating, replay, and edge cases)
- 24 in `@osn/client` (12 unit tests for `createRegistrationClient`, including all 4 Authorization-bearing call shapes)
- 91 in `@osn/pulse` (+15: 2 for `AuthProvider.adoptSession` round-trip, 13 for the `Register` component covering input sanitisation, debounced availability, OTP gating, happy passkey enrolment with enrollment-token propagation, "Skip for now", and the WebAuthn-unsupported jump-to-done)

## Test plan

- [ ] `bun run test` — all 277 pass
- [ ] `bun run check` — clean
- [ ] `bun run lint` — clean (pre-existing `events.ts` warning unchanged)
- [ ] `bun run fmt:check` — clean
- [ ] Manual: open Pulse, click "Create account", verify form gates submit until handle availability returns "available"
- [ ] Manual: complete the OTP step, verify you're signed in *before* the passkey step renders (check the EventList header swap)
- [ ] Manual: verify "Skip for now" advances cleanly without re-running passkey enrolment
- [ ] Manual: in a non-WebAuthn environment, verify the passkey step is skipped entirely and the user lands on "done"
- [ ] Verify the existing hosted `/authorize` HTML page still works for OTP/passkey/magic-link sign-in (it relies on the legacy unauth'd `/passkey/register/*` path which is preserved with a deprecation warning)
- [ ] Verify the security backlog entries S-H9/H10/H11 and S-M22-26 reflect the actual state of the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)