### PR TITLE
feat(core): Redis migration plan + RateLimiterBackend abstraction

### DIFF
--- a/.changeset/redis-migration-todo.md
+++ b/.changeset/redis-migration-todo.md
@@ -1,5 +1,11 @@
 ---
-"@osn/core": patch
+"@osn/core": minor
 ---
 
-Add Redis migration plan to TODO.md for shared rate limiting across multiple processes (S-M2). Documents phased approach: abstraction layer, @shared/redis package, wire-up, and auth state migration. Cross-references S-M8, P-W1, P-W4, S-L18, S-L23.
+Add RateLimiterBackend abstraction and dependency injection for rate limiters (Redis migration Phase 1).
+
+- Extract backend-agnostic `RateLimiterBackend` interface (`check(key): boolean | Promise<boolean>`) so routes can be wired to a future Redis backend without call-site changes
+- Refactor graph route inline rate limiter to use shared `createRateLimiter` (fixes P-W1, S-L18: unbounded in-memory store with no eviction)
+- Add `rateLimiters` parameter to `createAuthRoutes` and `rateLimiter` parameter to `createGraphRoutes` for DI
+- Export `AuthRateLimiters`, `createDefaultAuthRateLimiters`, `createDefaultGraphRateLimiter`, `RateLimiterBackend` from `@osn/core`
+- Add TODO.md Redis migration plan (S-M2 umbrella) with phased approach across 4 phases

--- a/.changeset/redis-migration-todo.md
+++ b/.changeset/redis-migration-todo.md
@@ -1,0 +1,5 @@
+---
+"@osn/core": patch
+---
+
+Add Redis migration plan to TODO.md for shared rate limiting across multiple processes (S-M2). Documents phased approach: abstraction layer, @shared/redis package, wire-up, and auth state migration. Cross-references S-M8, P-W1, P-W4, S-L18, S-L23.

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] S-H4 — PKCE now mandatory at `/token`: `state` and `code_verifier` required for `authorization_code` grants; unknown/expired state returns 400; redirect_uri must match the value stored at `/authorize` (S-M9 RFC 6749 §4.1.3)
 - [x] S-H5 — Legacy unauth'd passkey path removed: `resolvePasskeyEnrollPrincipal` now returns 401 when `Authorization` header is absent. Hosted `/authorize` HTML passkey-enrollment prompt removed (passkey enrollment requires auth; users enrol through first-party apps). `console.warn` deprecation log removed. `SimpleWebAuthn` script tag removed from hosted HTML.
 - [ ] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
+- [ ] Redis migration — `@shared/redis` package + migrate rate limiters to shared counter (S-M2, S-M8, P-W1, P-W4, S-L18, S-L23)
 
 ---
 
@@ -228,6 +229,43 @@ Signal Protocol lives in `@osn/crypto`, not `zap/`.
 - [x] UserPromptSubmit hook for tone enforcement
 - [x] Changeset Check workflow runs `bunx changeset status` so a `.changeset/*.md` referencing a non-existent workspace name fails the PR — previously such typos blew up the Release workflow on main and blocked all subsequent versioning (e.g. `"pulse"` instead of `"@pulse/app"` in `fix-handle-regex-error-message.md`).
 
+### Redis Migration (S-M2 umbrella)
+
+Migrate in-memory rate limiters and auth state stores to Redis for horizontal scaling.
+Subsumes: S-M2, S-M8, P-W1, P-W4, S-L18, S-L23.
+
+**Phase 1 — Abstraction layer (no Redis dependency)**
+- [ ] Extract `RateLimiterBackend` interface from `osn/core/src/lib/rate-limit.ts` — backend-agnostic `check(key): boolean | Promise<boolean>`
+- [ ] Refactor graph route inline `rateLimitStore` + `checkRateLimit` (`osn/core/src/routes/graph.ts:10-30`) to use shared `createRateLimiter` from `rate-limit.ts` (fixes P-W1, S-L18)
+- [ ] Update `createAuthRoutes` and graph route factories to accept injected rate limiter instances (DI for testability)
+
+**Phase 2 — `@shared/redis` package**
+- [ ] Create `shared/redis` workspace (`@shared/redis`) — mirrors `@shared/db-utils` pattern
+- [ ] Effect-based `Redis` service tag (`Context.Tag`) + `RedisLive` layer (connection from `REDIS_URL` env); `Layer.scoped` finalizer calls `redis.quit()`
+- [ ] `RedisError` tagged error (`Data.TaggedError`, `_tag: "RedisError"`)
+- [ ] `createRedisRateLimiter(config)` — Lua script for atomic INCR + PEXPIRE (single round-trip fixed-window); key format `rl:{namespace}:{key}`
+- [ ] Redis health probe for `/ready` endpoint (simple `PING` with timeout)
+- [ ] Dev-mode: in-memory fallback when `REDIS_URL` is unset (local dev without Redis)
+- [ ] Tests: Lua script atomicity, window expiry, key independence, connection failure fallback
+
+**Phase 3 — Wire up**
+- [ ] Add `@shared/redis` dependency to `osn/core/package.json`
+- [ ] Construct `RedisLive` layer in `osn/app/src/index.ts`; env-driven backend selection (Redis when `REDIS_URL` set, in-memory otherwise)
+- [ ] Migrate all 11 auth rate limiter instances (`osn/core/src/routes/auth.ts`) to Redis backend
+- [ ] Migrate graph rate limiter (`osn/core/src/routes/graph.ts`) to Redis backend
+- [ ] Update CLAUDE.md Rate Limiting section to document the two-backend model
+
+**Phase 4 — Auth state migration (S-M8, follow-up)**
+- [ ] `otpStore` → Redis with TTL (resolves S-M8 partial, P-W4 partial)
+- [ ] `magicStore` → Redis with TTL (resolves S-M8 partial, P-W4 partial)
+- [ ] `pkceStore` → Redis with TTL + size bound (resolves S-M8 partial, S-L23)
+- [ ] `pendingRegistrations` → Redis with TTL
+
+**Observability (applied across all phases)**
+- [ ] Logs: `Effect.logError` on Redis connection failures + command errors; `Effect.logWarning` on fallback-to-in-memory transitions; add `redisPassword` / `redis_password` to redaction deny-list in `shared/observability/src/logger/redact.ts`
+- [ ] Traces: `Effect.withSpan("redis.rate_limit.check")`, `Effect.withSpan("redis.connection.health")`, `Effect.withSpan("redis.auth_state.get|set")` (Phase 4)
+- [ ] Metrics in `shared/redis/src/metrics.ts`: `redis.command.duration` histogram (`{ command: RedisCommand, result: RedisResult }`), `redis.command.errors` counter (`{ command: RedisCommand, error_type: RedisErrorType }`), `redis.connection.state` up/down gauge; bounded attrs: `RedisCommand = "evalsha" | "ping" | "get" | "set" | "del" | "incr" | "other"`, `RedisResult = "ok" | "error" | "timeout"`
+
 ---
 
 ## Security Backlog
@@ -267,13 +305,13 @@ Address **High** items before any non-local deployment.
 ### Medium
 
 - [ ] S-M1 — `verifyAccessToken` rejects tokens missing `handle` claim — old tokens 401 silently; treat missing `handle` as `null` during transition period
-- [ ] S-M2 — In-memory rate limiter resets on restart/deploy — document as known; migrate to shared counter when scaling horizontally
+- [ ] S-M2 — In-memory rate limiter resets on restart/deploy — migrate to Redis shared counter. See **Platform > Infrastructure > Redis Migration** for the full plan (phases 1–3). Cross-refs: S-M8, P-W1, P-W4, S-L18, S-L23
 - [ ] S-M3 — No "resend code" button after registration OTP; if SMTP fails, handle/email are claimed with no recovery path. Partly mitigated by the new flow's "refuse to overwrite a non-expired pending entry" policy (the user retries via the existing pending entry, no new email is sent), but a true resend button is still needed.
 - [ ] S-M4 — Legacy `POST /register` (unverified email) returns raw `String(catch)` error — can expose Drizzle constraint internals. The new `/register/{begin,complete}` routes already use the `publicError()` mapper from `routes/auth.ts`; extend the same mapper to the legacy endpoint and to all other routes that still use `String(e)`.
 - [ ] S-M5 — `displayName` embedded in JWT (1h TTL) — stale after profile update; `createdByName` on events reflects old value until token expires
 - [ ] S-M6 — Wildcard CORS on auth server — restrict to known client origins before deployment
 - [x] S-M7 — Login OTP attempt limit added: `verifyOtpCode` now increments `entry.attempts` on wrong-code and wipes the entry after `MAX_OTP_ATTEMPTS` (5) wrong guesses, mirroring the registration flow.
-- [ ] S-M8 — All auth state in process memory (`otpStore`, `magicStore`, `pkceStore`) — lost on restart, unsafe for multi-process
+- [ ] S-M8 — All auth state in process memory (`otpStore`, `magicStore`, `pkceStore`) — lost on restart, unsafe for multi-process. Resolved by Redis Migration Phase 4
 - [x] S-M9 — `redirect_uri` at `/token` now matched against value stored in `pkceStore` (RFC 6749 §4.1.3); fixed as part of S-H4.
 - [x] S-M10 — `/passkey/register/begin` arbitrary `userId` fixed: Authorization header now required (fixed as part of S-H5).
 - [ ] S-M11 — Magic-link tokens use `crypto.randomUUID` without additional entropy hardening
@@ -396,6 +434,7 @@ Address **High** items before any non-local deployment.
 | Two-way calendar sync | Currently one-way (Pulse → external) | Phase 2 |
 | Community event-ended reporting | 15–20 attendees auto-finish; host notified | When attendee/messaging features land |
 | Max event duration | Prompt user when creating events without endTime | When Pulse event creation UI is built |
+| Redis provider (self-hosted vs managed) | Upstash (serverless, free tier) vs Redis Cloud vs self-hosted. Upstash aligns with serverless deploy model; Cloudflare Durable Objects reconsidered if deploying to Workers. | When deploying beyond localhost |
 | S2S scaling: HTTP graph API | Current: direct package import (`createGraphService()`). Migrate to HTTP `/graph/internal/*` + ARC tokens when scaling horizontally. | When multi-process or multi-machine deployment needed |
 | Per-app blocking | Blocks are global across all OSN apps. Per-app scope deferred. | When Messaging or a third-party app needs independent block lists |
 | Tauri passkey support on iOS | Tauri webview does not expose WebAuthn natively — `pulse/app` registration flow (rendered by `@osn/ui/auth/Register`) feature-detects via `browserSupportsWebAuthn()` and auto-skips the passkey step on unsupported environments. Options when we ship mobile: (a) adopt [`tauri-plugin-webauthn`](https://github.com/Profiidev/tauri-plugin-webauthn) (third-party, audit first), (b) write our own thin Tauri plugin wrapping `ASAuthorizationPlatformPublicKeyCredentialProvider`, (c) wait for upstream — track [tauri#7926](https://github.com/tauri-apps/tauri/issues/7926). | When iOS build of Pulse is ready for sign-in |

--- a/TODO.md
+++ b/TODO.md
@@ -265,6 +265,7 @@ Subsumes: S-M2, S-M8, P-W1, P-W4, S-L18, S-L23.
 - [ ] Logs: `Effect.logError` on Redis connection failures + command errors; `Effect.logWarning` on fallback-to-in-memory transitions; add `redisPassword` / `redis_password` to redaction deny-list in `shared/observability/src/logger/redact.ts`
 - [ ] Traces: `Effect.withSpan("redis.rate_limit.check")`, `Effect.withSpan("redis.connection.health")`, `Effect.withSpan("redis.auth_state.get|set")` (Phase 4)
 - [ ] Metrics in `shared/redis/src/metrics.ts`: `redis.command.duration` histogram (`{ command: RedisCommand, result: RedisResult }`), `redis.command.errors` counter (`{ command: RedisCommand, error_type: RedisErrorType }`), `redis.connection.state` up/down gauge; bounded attrs: `RedisCommand = "evalsha" | "ping" | "get" | "set" | "del" | "incr" | "other"`, `RedisResult = "ok" | "error" | "timeout"`
+- [ ] Capacity metrics: `redis.memory.bytes` gauge (from periodic `INFO memory` → `used_memory`; alert at 80% of `maxmemory`), `redis.store.keys` gauge per namespace (`{ namespace: RedisNamespace }` where `RedisNamespace = "rate_limit" | "otp" | "magic" | "pkce" | "pending_registration"`; sampled via `SCAN` count or key-prefix `DBSIZE` equivalent). These are the at-a-glance indicators for whether we're approaching Redis capacity limits.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -339,6 +339,8 @@ Address **High** items before any non-local deployment.
 - [x] S-M33 — `enrollmentToken` (and snake-case `enrollment_token`) was missing from the trimmed redaction deny-list. It is a real single-use bearer credential returned by `/register/complete` (`osn/core/src/routes/auth.ts:225`) and sent back as `Authorization: Bearer <token>` for passkey enrollment (`osn/client/src/register.ts:131,142`) — same secrecy profile as `accessToken`. Defence-in-depth (no current log path emits the completeRegistration result), but the file header criterion in `redact.ts` explicitly requires real-bearer-credential fields to be on the list. Fixed by adding both spellings to `REDACT_KEYS` under the OAuth token block, updating the lock-step assertion + positive test, and pointing at the two call sites in the comment.
 - [ ] S-M34 — Rate limiter trusts `X-Forwarded-For` without reverse-proxy guarantee — any client can spoof the header to bypass IP-based rate limits. Add `trustProxy` config flag or fall back to socket IP when no proxy is configured.
 - [ ] S-M35 — Redirect URI allowlist matches origin only, not exact URI per OAuth 2.0 Security BCP (RFC 9700 §4.1.3). Upgrade to exact string comparison for stricter validation.
+- [x] S-M36 — Async `RateLimiterBackend.check()` rejection was fail-open: unhandled rejection propagated as 500 instead of 429, bypassing rate limit counter. Fixed: `rateLimit()` and `requireRateLimit()` wrap `await check()` in try/catch, defaulting to `false` (deny) on backend errors. Fail-closed posture established before Redis backend lands.
+- [x] S-M37 — `AuthRateLimiters` type was mutable, allowing post-construction limiter replacement via held reference. Fixed: type declared as `Readonly<{...}>`. Tests construct override objects via spread instead of mutation.
 
 ### Low
 
@@ -367,6 +369,8 @@ Address **High** items before any non-local deployment.
 - [ ] S-L24 — `/token` and legacy `POST /register` have no rate limiting — add per-IP limiters for consistency
 - [ ] S-L19 — `jwtSecret` falls back to `"dev-secret"` in graph auth — already tracked as S-L7
 - [x] S-L20 — `loadConfig` silently classified production deploys as `dev` if operators forgot to set `OSN_ENV=production` (Bun leaves `NODE_ENV` empty by default), enabling pretty-printing, 100% trace sampling, and any future dev-only code paths in prod. Fixed: `loadConfig` now throws when `OSN_ENV=production` in the environment but the resolved env differs, refusing to boot with a mismatched environment. Operators must be explicit about production classification.
+- [x] S-L25 — `createRateLimiter` was exported from the `@osn/core` barrel, letting downstream consumers construct limiters with arbitrary config (e.g. `maxRequests: Infinity`) and inject them to disable rate limiting. Fixed: removed from barrel; only `RateLimiterBackend` type + default factories are public.
+- [x] S-L26 — No runtime validation on injected `RateLimiterBackend` shape — a misconfigured DI object would cause `TypeError: check is not a function` at request time. Fixed: `createAuthRoutes` and `createGraphRoutes` validate every limiter slot at construction time, failing fast at boot.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -235,9 +235,9 @@ Migrate in-memory rate limiters and auth state stores to Redis for horizontal sc
 Subsumes: S-M2, S-M8, P-W1, P-W4, S-L18, S-L23.
 
 **Phase 1 — Abstraction layer (no Redis dependency)**
-- [ ] Extract `RateLimiterBackend` interface from `osn/core/src/lib/rate-limit.ts` — backend-agnostic `check(key): boolean | Promise<boolean>`
-- [ ] Refactor graph route inline `rateLimitStore` + `checkRateLimit` (`osn/core/src/routes/graph.ts:10-30`) to use shared `createRateLimiter` from `rate-limit.ts` (fixes P-W1, S-L18)
-- [ ] Update `createAuthRoutes` and graph route factories to accept injected rate limiter instances (DI for testability)
+- [x] Extract `RateLimiterBackend` interface from `osn/core/src/lib/rate-limit.ts` — backend-agnostic `check(key): boolean | Promise<boolean>`
+- [x] Refactor graph route inline `rateLimitStore` + `checkRateLimit` (`osn/core/src/routes/graph.ts:10-30`) to use shared `createRateLimiter` from `rate-limit.ts` (fixes P-W1, S-L18)
+- [x] Update `createAuthRoutes` and graph route factories to accept injected rate limiter instances (DI for testability)
 
 **Phase 2 — `@shared/redis` package**
 - [ ] Create `shared/redis` workspace (`@shared/redis`) — mirrors `@shared/db-utils` pattern
@@ -362,7 +362,7 @@ Address **High** items before any non-local deployment.
 - [ ] S-L15 — No reserved-handle blocklist in DB — enforced in app layer only; consider DB-level check constraint
 - [x] S-L16 — `EventList` `console.error` logs raw server error objects — guarded with `import.meta.env.DEV`
 - [x] S-L17 — `displayName` returned as `undefined` in graph list responses — normalised to `null` via `userProjection()`
-- [ ] S-L18 — Graph rate-limit store (`rateLimitStore`) never evicts expired windows — add periodic sweep
+- [x] S-L18 — Graph rate-limit store (`rateLimitStore`) never evicts expired windows — fixed: graph route now uses shared `createRateLimiter` with proactive sweep (Redis migration Phase 1)
 - [ ] S-L23 — `pkceStore` has no size bound or eviction sweep — unauthenticated `/authorize` can fill memory. Add maxEntries cap + sweepExpired.
 - [ ] S-L24 — `/token` and legacy `POST /register` have no rate limiting — add per-IP limiters for consistency
 - [ ] S-L19 — `jwtSecret` falls back to `"dev-secret"` in graph auth — already tracked as S-L7
@@ -378,7 +378,7 @@ Address **High** items before any non-local deployment.
 
 ### Warning
 
-- [ ] P-W1 — `rateLimitStore` in graph routes grows without bound — expired entries never evicted; add `setInterval` sweep
+- [x] P-W1 — `rateLimitStore` in graph routes grows without bound — fixed: graph route refactored to use shared `createRateLimiter` from `osn/core/src/lib/rate-limit.ts` which handles proactive sweeping + maxEntries cap
 - [x] P-W16 — Auth rate limiter Maps swept proactively: sweep now runs on every `check()` when at least one window has elapsed since the last sweep, not just when `maxEntries` is exceeded. Deterministic memory profile in long-running processes.
 - [x] P-W17 — Redirect URI allowlist pre-computed: `allowedOrigins` Set built once at boot in both `createAuthRoutes` and `createAuthService`. Per-request check is a single `Set.has()` call.
 - [ ] P-W2 — `resolvePublicKey` hits DB on every scoped call despite warm cache — cache `CryptoKey` + `allowedScopes` together

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -6,5 +6,4 @@ export type { AuthConfig, AuthService } from "./services/auth";
 export { createGraphRoutes, createDefaultGraphRateLimiter } from "./routes/graph";
 export { createGraphService } from "./services/graph";
 export type { GraphService } from "./services/graph";
-export { createRateLimiter } from "./lib/rate-limit";
-export type { RateLimiterBackend, RateLimiterConfig, RateLimiter } from "./lib/rate-limit";
+export type { RateLimiterBackend } from "./lib/rate-limit";

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -1,7 +1,10 @@
-export { createAuthRoutes } from "./routes/auth";
+export { createAuthRoutes, createDefaultAuthRateLimiters } from "./routes/auth";
+export type { AuthRateLimiters } from "./routes/auth";
 export { buildAuthorizeHtml } from "./lib/html";
 export { createAuthService } from "./services/auth";
 export type { AuthConfig, AuthService } from "./services/auth";
-export { createGraphRoutes } from "./routes/graph";
+export { createGraphRoutes, createDefaultGraphRateLimiter } from "./routes/graph";
 export { createGraphService } from "./services/graph";
 export type { GraphService } from "./services/graph";
+export { createRateLimiter } from "./lib/rate-limit";
+export type { RateLimiterBackend, RateLimiterConfig, RateLimiter } from "./lib/rate-limit";

--- a/osn/core/src/lib/rate-limit.ts
+++ b/osn/core/src/lib/rate-limit.ts
@@ -2,9 +2,26 @@
  * Generic per-key fixed-window rate limiter for unauthenticated endpoints.
  *
  * Designed for auth routes where keying is by IP address (callers aren't
- * authenticated). The store is in-process memory — resets on restart.
- * See S-M2 for the migration-to-shared-counter note.
+ * authenticated). The default in-memory backend stores state in-process —
+ * resets on restart. See S-M2 for the migration-to-shared-counter note.
+ *
+ * The `RateLimiterBackend` interface is backend-agnostic so routes can be
+ * wired to a future Redis backend without any call-site changes (Phase 2 of
+ * the Redis migration plan in TODO.md). `check()` returns `boolean | Promise<boolean>`
+ * so consumers `await` the result — sync backends resolve immediately, async
+ * backends (Redis INCR+EXPIRE via Lua) return a real promise.
  */
+
+/**
+ * Backend-agnostic rate limiter contract. The in-memory implementation
+ * (`createRateLimiter`) satisfies this sync-only; a future Redis backend
+ * will satisfy it async. Route factories depend on this abstract type so
+ * swapping backends is a single-import change at composition time.
+ */
+export interface RateLimiterBackend {
+  /** Returns `true` if the request is allowed, `false` if rate-limited. */
+  check(key: string): boolean | Promise<boolean>;
+}
 
 export interface RateLimiterConfig {
   /** Maximum requests allowed per window. */
@@ -20,10 +37,9 @@ interface Entry {
   windowStart: number;
 }
 
-export interface RateLimiter {
-  /** Returns `true` if the request is allowed, `false` if rate-limited. */
+/** In-memory backend extension of `RateLimiterBackend`. `_store` is visible for testing. */
+export interface RateLimiter extends RateLimiterBackend {
   check(key: string): boolean;
-  /** Visible for testing only. */
   readonly _store: Map<string, Entry>;
 }
 

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -4,7 +4,7 @@ import { DbLive, type Db } from "@osn/db/service";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { buildAuthorizeHtml } from "../lib/html";
 import { verifyPkceChallenge } from "../lib/crypto";
-import { createRateLimiter, getClientIp } from "../lib/rate-limit";
+import { createRateLimiter, getClientIp, type RateLimiterBackend } from "../lib/rate-limit";
 import { metricAuthRateLimited } from "../metrics";
 import type { AuthRateLimitedEndpoint } from "@shared/observability/metrics";
 
@@ -19,6 +19,48 @@ interface PkceEntry {
 }
 const pkceStore = new Map<string, PkceEntry>();
 
+/**
+ * Typed map of every rate limiter the auth routes consume. Split out as a
+ * named type so the Redis migration (Phase 2) can supply a mixed bag of
+ * Redis-backed and in-memory backends per endpoint without touching
+ * `createAuthRoutes` call sites.
+ */
+export type AuthRateLimiters = {
+  registerBegin: RateLimiterBackend;
+  registerComplete: RateLimiterBackend;
+  handleCheck: RateLimiterBackend;
+  otpBegin: RateLimiterBackend;
+  otpComplete: RateLimiterBackend;
+  magicBegin: RateLimiterBackend;
+  magicVerify: RateLimiterBackend;
+  passkeyLoginBegin: RateLimiterBackend;
+  passkeyLoginComplete: RateLimiterBackend;
+  passkeyRegisterBegin: RateLimiterBackend;
+  passkeyRegisterComplete: RateLimiterBackend;
+};
+
+/**
+ * Default in-memory rate limiter bundle used when callers don't pass an
+ * explicit `rateLimiters` override. Limits match the values documented in
+ * CLAUDE.md > Rate Limiting (S-H1): 5 req/IP/min on send endpoints, 10
+ * req/IP/min on verify/complete endpoints.
+ */
+export function createDefaultAuthRateLimiters(): AuthRateLimiters {
+  return {
+    registerBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
+    registerComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    handleCheck: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    otpBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
+    otpComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    magicBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
+    magicVerify: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    passkeyLoginBegin: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    passkeyLoginComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    passkeyRegisterBegin: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    passkeyRegisterComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+  };
+}
+
 export function createAuthRoutes(
   authConfig: AuthConfig,
   dbLayer: Layer.Layer<Db> = DbLive,
@@ -32,6 +74,13 @@ export function createAuthRoutes(
    * `osn/app/src/index.ts` for the canonical wiring.
    */
   loggerLayer: Layer.Layer<never> = Layer.empty,
+  /**
+   * Rate limiter backends for every auth endpoint group. Defaults to a fresh
+   * in-memory bundle via `createDefaultAuthRateLimiters()`. Phase 2 of the
+   * Redis migration will construct Redis-backed bundles at the host
+   * application (`osn/app/src/index.ts`) and inject them here.
+   */
+  rateLimiters: AuthRateLimiters = createDefaultAuthRateLimiters(),
 ) {
   const auth = createAuthService(authConfig);
 
@@ -85,30 +134,21 @@ export function createAuthRoutes(
   }
 
   // ---------------------------------------------------------------------------
-  // IP-based rate limiters (S-H1)
+  // IP-based rate limiters (S-H1). Injected via the `rateLimiters` parameter
+  // so callers can swap in Redis-backed backends at composition time.
   // ---------------------------------------------------------------------------
 
-  const rl = {
-    registerBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
-    registerComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    handleCheck: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    otpBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
-    otpComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    magicBegin: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
-    magicVerify: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    passkeyLoginBegin: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    passkeyLoginComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    passkeyRegisterBegin: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-    passkeyRegisterComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
-  } as const;
+  const rl = rateLimiters;
 
-  function rateLimit(
+  // Async to accommodate future Redis backends where `check()` returns a Promise.
+  // In-memory backends resolve immediately; `await` on a non-Promise is a no-op.
+  async function rateLimit(
     headers: Record<string, string | undefined>,
     endpoint: AuthRateLimitedEndpoint,
-    limiter: ReturnType<typeof createRateLimiter>,
-  ): { error: string } | null {
+    limiter: RateLimiterBackend,
+  ): Promise<{ error: string } | null> {
     const ip = getClientIp(headers);
-    if (!limiter.check(ip)) {
+    if (!(await limiter.check(ip))) {
       metricAuthRateLimited(endpoint);
       return { error: "rate_limited" };
     }
@@ -177,7 +217,7 @@ export function createAuthRoutes(
       .get(
         "/handle/:handle",
         async ({ params, set, headers }) => {
-          const rlErr = rateLimit(headers, "handle_check", rl.handleCheck);
+          const rlErr = await rateLimit(headers, "handle_check", rl.handleCheck);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -227,7 +267,7 @@ export function createAuthRoutes(
       .post(
         "/register/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "register_begin", rl.registerBegin);
+          const rlErr = await rateLimit(headers, "register_begin", rl.registerBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -258,7 +298,7 @@ export function createAuthRoutes(
       .post(
         "/register/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "register_complete", rl.registerComplete);
+          const rlErr = await rateLimit(headers, "register_complete", rl.registerComplete);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -475,7 +515,7 @@ export function createAuthRoutes(
       .post(
         "/passkey/register/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_register_begin", rl.passkeyRegisterBegin);
+          const rlErr = await rateLimit(headers, "passkey_register_begin", rl.passkeyRegisterBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -507,7 +547,11 @@ export function createAuthRoutes(
       .post(
         "/passkey/register/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_register_complete", rl.passkeyRegisterComplete);
+          const rlErr = await rateLimit(
+            headers,
+            "passkey_register_complete",
+            rl.passkeyRegisterComplete,
+          );
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -545,7 +589,7 @@ export function createAuthRoutes(
       .post(
         "/passkey/login/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_login_begin", rl.passkeyLoginBegin);
+          const rlErr = await rateLimit(headers, "passkey_login_begin", rl.passkeyLoginBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -568,7 +612,7 @@ export function createAuthRoutes(
       .post(
         "/passkey/login/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_login_complete", rl.passkeyLoginComplete);
+          const rlErr = await rateLimit(headers, "passkey_login_complete", rl.passkeyLoginComplete);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -594,7 +638,7 @@ export function createAuthRoutes(
       .post(
         "/otp/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "otp_begin", rl.otpBegin);
+          const rlErr = await rateLimit(headers, "otp_begin", rl.otpBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -617,7 +661,7 @@ export function createAuthRoutes(
       .post(
         "/otp/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "otp_complete", rl.otpComplete);
+          const rlErr = await rateLimit(headers, "otp_complete", rl.otpComplete);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -640,7 +684,7 @@ export function createAuthRoutes(
       .post(
         "/magic/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "magic_begin", rl.magicBegin);
+          const rlErr = await rateLimit(headers, "magic_begin", rl.magicBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -663,7 +707,7 @@ export function createAuthRoutes(
       .get(
         "/magic/verify",
         async ({ query, set, headers }) => {
-          const rlErr = rateLimit(headers, "magic_verify", rl.magicVerify);
+          const rlErr = await rateLimit(headers, "magic_verify", rl.magicVerify);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -707,7 +751,7 @@ export function createAuthRoutes(
       .post(
         "/login/passkey/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_login_begin", rl.passkeyLoginBegin);
+          const rlErr = await rateLimit(headers, "passkey_login_begin", rl.passkeyLoginBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -727,7 +771,7 @@ export function createAuthRoutes(
       .post(
         "/login/passkey/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "passkey_login_complete", rl.passkeyLoginComplete);
+          const rlErr = await rateLimit(headers, "passkey_login_complete", rl.passkeyLoginComplete);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -752,7 +796,7 @@ export function createAuthRoutes(
       .post(
         "/login/otp/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "otp_begin", rl.otpBegin);
+          const rlErr = await rateLimit(headers, "otp_begin", rl.otpBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -774,7 +818,7 @@ export function createAuthRoutes(
       .post(
         "/login/otp/complete",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "otp_complete", rl.otpComplete);
+          const rlErr = await rateLimit(headers, "otp_complete", rl.otpComplete);
           if (rlErr) {
             set.status = 429;
             return rlErr;
@@ -794,7 +838,7 @@ export function createAuthRoutes(
       .post(
         "/login/magic/begin",
         async ({ body, set, headers }) => {
-          const rlErr = rateLimit(headers, "magic_begin", rl.magicBegin);
+          const rlErr = await rateLimit(headers, "magic_begin", rl.magicBegin);
           if (rlErr) {
             set.status = 429;
             return rlErr;

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -25,7 +25,7 @@ const pkceStore = new Map<string, PkceEntry>();
  * Redis-backed and in-memory backends per endpoint without touching
  * `createAuthRoutes` call sites.
  */
-export type AuthRateLimiters = {
+export type AuthRateLimiters = Readonly<{
   registerBegin: RateLimiterBackend;
   registerComplete: RateLimiterBackend;
   handleCheck: RateLimiterBackend;
@@ -37,7 +37,7 @@ export type AuthRateLimiters = {
   passkeyLoginComplete: RateLimiterBackend;
   passkeyRegisterBegin: RateLimiterBackend;
   passkeyRegisterComplete: RateLimiterBackend;
-};
+}>;
 
 /**
  * Default in-memory rate limiter bundle used when callers don't pass an
@@ -82,6 +82,15 @@ export function createAuthRoutes(
    */
   rateLimiters: AuthRateLimiters = createDefaultAuthRateLimiters(),
 ) {
+  // Fail-fast: validate every limiter slot at construction time (S-L2) so a
+  // partially-valid object surfaces immediately instead of on the first
+  // request to a rarely-hit endpoint.
+  for (const [key, backend] of Object.entries(rateLimiters)) {
+    if (typeof (backend as RateLimiterBackend)?.check !== "function") {
+      throw new Error(`AuthRateLimiters.${key} must have a check() method`);
+    }
+  }
+
   const auth = createAuthService(authConfig);
 
   const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
@@ -142,13 +151,21 @@ export function createAuthRoutes(
 
   // Async to accommodate future Redis backends where `check()` returns a Promise.
   // In-memory backends resolve immediately; `await` on a non-Promise is a no-op.
+  // Fail-closed (S-M1): if the backend rejects, treat it as rate-limited so a
+  // Redis outage blocks rather than bypasses the limiter.
   async function rateLimit(
     headers: Record<string, string | undefined>,
     endpoint: AuthRateLimitedEndpoint,
     limiter: RateLimiterBackend,
   ): Promise<{ error: string } | null> {
     const ip = getClientIp(headers);
-    if (!(await limiter.check(ip))) {
+    let allowed: boolean;
+    try {
+      allowed = await limiter.check(ip);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
       metricAuthRateLimited(endpoint);
       return { error: "rate_limited" };
     }

--- a/osn/core/src/routes/graph.ts
+++ b/osn/core/src/routes/graph.ts
@@ -4,30 +4,27 @@ import { DbLive, type Db } from "@osn/db/service";
 import type { User } from "@osn/db/schema";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createGraphService } from "../services/graph";
+import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
 
 // ---------------------------------------------------------------------------
 // Rate limiter — per-user fixed window (write operations only)
+//
+// Uses the shared `createRateLimiter` from lib/rate-limit so Phase 2 of the
+// Redis migration (TODO.md) swaps graph and auth rate limiters via the same
+// backend abstraction. Previous inline `rateLimitStore` + `checkRateLimit`
+// duplicated the logic AND never evicted expired entries (P-W1 / S-L18);
+// the shared limiter handles sweeping + maxEntries for us.
 // ---------------------------------------------------------------------------
 
-interface RateLimitEntry {
-  count: number;
-  windowStart: number;
-}
+const GRAPH_RATE_LIMIT_MAX = 60; // requests per window
+const GRAPH_RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
 
-const rateLimitStore = new Map<string, RateLimitEntry>();
-const RATE_LIMIT_MAX = 60; // requests per window
-const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
-
-function checkRateLimit(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitStore.get(userId);
-  if (!entry || now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
-    rateLimitStore.set(userId, { count: 1, windowStart: now });
-    return true;
-  }
-  if (entry.count >= RATE_LIMIT_MAX) return false;
-  entry.count++;
-  return true;
+/** Default in-memory graph rate limiter. Override via `createGraphRoutes` for Redis. */
+export function createDefaultGraphRateLimiter(): RateLimiterBackend {
+  return createRateLimiter({
+    maxRequests: GRAPH_RATE_LIMIT_MAX,
+    windowMs: GRAPH_RATE_LIMIT_WINDOW_MS,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +82,13 @@ export function createGraphRoutes(
   dbLayer: Layer.Layer<Db> = DbLive,
   /** See `createAuthRoutes` — same semantics. */
   loggerLayer: Layer.Layer<never> = Layer.empty,
+  /**
+   * Rate limiter backend for graph write operations (connections / close-friends /
+   * blocks mutations, keyed by user ID). Default is a fresh in-memory limiter;
+   * supply a Redis-backed `RateLimiterBackend` here to share state across
+   * processes (Phase 2 of the Redis migration plan).
+   */
+  rateLimiter: RateLimiterBackend = createDefaultGraphRateLimiter(),
 ) {
   const auth = createAuthService(authConfig);
   const graph = createGraphService();
@@ -116,9 +120,13 @@ export function createGraphRoutes(
     }
   }
 
-  // Enforce rate limit; set 429 on breach
-  function requireRateLimit(userId: string, set: { status?: number | string }): boolean {
-    if (!checkRateLimit(userId)) {
+  // Enforce rate limit; set 429 on breach. Async to accommodate future
+  // Redis backend where `check()` returns a Promise.
+  async function requireRateLimit(
+    userId: string,
+    set: { status?: number | string },
+  ): Promise<boolean> {
+    if (!(await rateLimiter.check(userId))) {
       set.status = 429;
       return false;
     }
@@ -153,7 +161,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const target = await resolveHandle(params.handle, set);
           if (!target) return { error: "User not found" };
@@ -174,7 +182,7 @@ export function createGraphRoutes(
         async ({ params, body, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const requester = await resolveHandle(params.handle, set);
           if (!requester) return { error: "User not found" };
@@ -201,7 +209,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const other = await resolveHandle(params.handle, set);
           if (!other) return { error: "User not found" };
@@ -283,7 +291,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const friend = await resolveHandle(params.handle, set);
           if (!friend) return { error: "User not found" };
@@ -304,7 +312,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const friend = await resolveHandle(params.handle, set);
           if (!friend) return { error: "User not found" };
@@ -342,7 +350,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const blocked = await resolveHandle(params.handle, set);
           if (!blocked) return { error: "User not found" };
@@ -363,7 +371,7 @@ export function createGraphRoutes(
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
-          if (!requireRateLimit(caller.userId, set)) return { error: "Too many requests" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
 
           const blocked = await resolveHandle(params.handle, set);
           if (!blocked) return { error: "User not found" };

--- a/osn/core/src/routes/graph.ts
+++ b/osn/core/src/routes/graph.ts
@@ -90,6 +90,11 @@ export function createGraphRoutes(
    */
   rateLimiter: RateLimiterBackend = createDefaultGraphRateLimiter(),
 ) {
+  // Fail-fast: validate the injected rate limiter at construction time (S-L2).
+  if (typeof rateLimiter?.check !== "function") {
+    throw new Error("Graph rateLimiter must have a check() method");
+  }
+
   const auth = createAuthService(authConfig);
   const graph = createGraphService();
 
@@ -122,11 +127,18 @@ export function createGraphRoutes(
 
   // Enforce rate limit; set 429 on breach. Async to accommodate future
   // Redis backend where `check()` returns a Promise.
+  // Fail-closed (S-M1): if the backend rejects, treat as rate-limited.
   async function requireRateLimit(
     userId: string,
     set: { status?: number | string },
   ): Promise<boolean> {
-    if (!(await rateLimiter.check(userId))) {
+    let allowed: boolean;
+    try {
+      allowed = await rateLimiter.check(userId);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
       set.status = 429;
       return false;
     }

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestLayer } from "../helpers/db";
-import { createAuthRoutes } from "../../src/routes/auth";
+import { createAuthRoutes, createDefaultAuthRateLimiters } from "../../src/routes/auth";
 import { createAuthService } from "../../src/services/auth";
-import { Effect } from "effect";
+import type { RateLimiterBackend } from "../../src/lib/rate-limit";
+import { Effect, Layer } from "effect";
 
 const config = {
   rpId: "localhost",
@@ -1282,6 +1283,70 @@ describe("auth routes", () => {
       expect(res.status).toBe(400);
       const json = (await res.json()) as { error: string; message: string };
       expect(json.message).toBe("redirect_uri not allowed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiter dependency injection (Phase 1 of Redis migration)
+  //
+  // Verifies the `RateLimiterBackend` abstraction: createAuthRoutes accepts
+  // an injected rate limiter bundle, sync and async backends both work, and
+  // the endpoint-to-limiter wiring inside the route factory is stable. This
+  // is the contract Phase 2 (Redis) relies on.
+  // -------------------------------------------------------------------------
+  describe("rate limiter dependency injection", () => {
+    it("uses the injected rate limiter bundle instead of the default", async () => {
+      // An "always reject" limiter — every check returns false.
+      const rejectAll: RateLimiterBackend = { check: () => false };
+      const limiters = createDefaultAuthRateLimiters();
+      limiters.handleCheck = rejectAll;
+
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      const res = await freshApp.handle(
+        new Request("http://localhost/handle/alice", {
+          headers: { "x-forwarded-for": "9.9.9.9" },
+        }),
+      );
+      expect(res.status).toBe(429);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toBe("rate_limited");
+    });
+
+    it("supports async rate limiter backends (Promise<boolean>)", async () => {
+      // Simulates the future Redis backend's async check().
+      const asyncBackend: RateLimiterBackend = {
+        check: () => Promise.resolve(false),
+      };
+      const limiters = createDefaultAuthRateLimiters();
+      limiters.registerBegin = asyncBackend;
+
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      const res = await freshApp.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "8.8.8.8" },
+          body: JSON.stringify({ email: "async@example.com", handle: "async" }),
+        }),
+      );
+      expect(res.status).toBe(429);
+    });
+
+    it("passes when the injected limiter returns true", async () => {
+      const allowAll: RateLimiterBackend = { check: () => true };
+      const limiters = createDefaultAuthRateLimiters();
+      limiters.handleCheck = allowAll;
+
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      // Fire a burst that would exceed the default 10/min cap; everything
+      // should pass because the injected limiter always says yes.
+      for (let i = 0; i < 20; i++) {
+        const res = await freshApp.handle(
+          new Request(`http://localhost/handle/user${i}`, {
+            headers: { "x-forwarded-for": "7.7.7.7" },
+          }),
+        );
+        expect(res.status).not.toBe(429);
+      }
     });
   });
 });

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -1298,8 +1298,7 @@ describe("auth routes", () => {
     it("uses the injected rate limiter bundle instead of the default", async () => {
       // An "always reject" limiter — every check returns false.
       const rejectAll: RateLimiterBackend = { check: () => false };
-      const limiters = createDefaultAuthRateLimiters();
-      limiters.handleCheck = rejectAll;
+      const limiters = { ...createDefaultAuthRateLimiters(), handleCheck: rejectAll };
 
       const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
       const res = await freshApp.handle(
@@ -1317,8 +1316,7 @@ describe("auth routes", () => {
       const asyncBackend: RateLimiterBackend = {
         check: () => Promise.resolve(false),
       };
-      const limiters = createDefaultAuthRateLimiters();
-      limiters.registerBegin = asyncBackend;
+      const limiters = { ...createDefaultAuthRateLimiters(), registerBegin: asyncBackend };
 
       const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
       const res = await freshApp.handle(
@@ -1331,10 +1329,26 @@ describe("auth routes", () => {
       expect(res.status).toBe(429);
     });
 
+    it("fails closed when the backend rejects (S-M1)", async () => {
+      // Simulates a Redis outage where check() throws.
+      const failing: RateLimiterBackend = {
+        check: () => Promise.reject(new Error("Redis connection refused")),
+      };
+      const limiters = { ...createDefaultAuthRateLimiters(), handleCheck: failing };
+
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      const res = await freshApp.handle(
+        new Request("http://localhost/handle/alice", {
+          headers: { "x-forwarded-for": "4.4.4.4" },
+        }),
+      );
+      // Must return 429 (fail-closed), not 500 (unhandled rejection).
+      expect(res.status).toBe(429);
+    });
+
     it("passes when the injected limiter returns true", async () => {
       const allowAll: RateLimiterBackend = { check: () => true };
-      const limiters = createDefaultAuthRateLimiters();
-      limiters.handleCheck = allowAll;
+      const limiters = { ...createDefaultAuthRateLimiters(), handleCheck: allowAll };
 
       const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
       // Fire a burst that would exceed the default 10/min cap; everything

--- a/osn/core/tests/routes/graph.test.ts
+++ b/osn/core/tests/routes/graph.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { createTestLayer } from "../helpers/db";
 import { createAuthRoutes } from "../../src/routes/auth";
 import { createGraphRoutes } from "../../src/routes/graph";
+import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createAuthService } from "../../src/services/auth";
 import type { Db } from "@osn/db/service";
 
@@ -600,5 +601,58 @@ describe("graph routes", () => {
     );
     const json = (await statusRes.json()) as { status: string };
     expect(json.status).toBe("none");
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiter dependency injection (Phase 1 of Redis migration)
+  // -------------------------------------------------------------------------
+  describe("rate limiter dependency injection", () => {
+    it("uses the injected rate limiter on write operations", async () => {
+      const rejectAll: RateLimiterBackend = { check: () => false };
+      const freshGraph = createGraphRoutes(config, layer, Layer.empty, rejectAll);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+      await registerAndGetToken("bob@example.com", "bob");
+
+      const res = await freshGraph.handle(
+        new Request("http://localhost/graph/connections/bob", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      expect(res.status).toBe(429);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Too many requests");
+    });
+
+    it("supports async rate limiter backends", async () => {
+      const asyncReject: RateLimiterBackend = {
+        check: () => Promise.resolve(false),
+      };
+      const freshGraph = createGraphRoutes(config, layer, Layer.empty, asyncReject);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+      await registerAndGetToken("bob@example.com", "bob");
+
+      const res = await freshGraph.handle(
+        new Request("http://localhost/graph/close-friends/bob", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      expect(res.status).toBe(429);
+    });
+
+    it("does not rate-limit read operations", async () => {
+      const rejectAll: RateLimiterBackend = { check: () => false };
+      const freshGraph = createGraphRoutes(config, layer, Layer.empty, rejectAll);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+
+      // GET /connections is a read — should not hit the rate limiter
+      const res = await freshGraph.handle(
+        new Request("http://localhost/graph/connections", {
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/osn/core/tests/routes/graph.test.ts
+++ b/osn/core/tests/routes/graph.test.ts
@@ -641,6 +641,24 @@ describe("graph routes", () => {
       expect(res.status).toBe(429);
     });
 
+    it("fails closed when the backend rejects (S-M1)", async () => {
+      const failing: RateLimiterBackend = {
+        check: () => Promise.reject(new Error("Redis connection refused")),
+      };
+      const freshGraph = createGraphRoutes(config, layer, Layer.empty, failing);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+      await registerAndGetToken("bob@example.com", "bob");
+
+      const res = await freshGraph.handle(
+        new Request("http://localhost/graph/connections/bob", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      // Must return 429 (fail-closed), not 500 (unhandled rejection).
+      expect(res.status).toBe(429);
+    });
+
     it("does not rate-limit read operations", async () => {
       const rejectAll: RateLimiterBackend = { check: () => false };
       const freshGraph = createGraphRoutes(config, layer, Layer.empty, rejectAll);


### PR DESCRIPTION
## Summary
- Add 4-phase Redis migration plan to TODO.md (S-M2 umbrella) covering rate limiter abstraction, `@shared/redis` package, wire-up, and auth state store migration
- Implement Phase 1: extract `RateLimiterBackend` interface (`check(key): boolean | Promise<boolean>`) for backend-agnostic rate limiting
- Refactor graph route inline rate limiter to use shared `createRateLimiter`, fixing P-W1 (unbounded store) and S-L18 (no expired entry eviction)
- Add DI parameters to `createAuthRoutes` (`AuthRateLimiters`) and `createGraphRoutes` (`RateLimiterBackend`) so a future Redis backend can be injected at composition time
- Address all security review findings: fail-closed rate limiting (S-M36), immutable type (S-M37), minimal barrel export (S-L25), boot-time validation (S-L26)

## Workspaces affected
- `@osn/core` (minor)

## Decisions & issues

**[P-W1 / S-L18] — Graph route inline rate limiter had no eviction**
- **Issue:** The graph route's `rateLimitStore` Map grew without bound — expired entries were never evicted.
- **Why:** Memory leak under sustained load; one of the oldest open performance findings.
- **Solution:** Replaced inline implementation with shared `createRateLimiter` from `osn/core/src/lib/rate-limit.ts` which has proactive sweep + maxEntries cap.
- **Rationale:** Reuses the battle-tested auth rate limiter implementation rather than fixing the inline version separately. Also unifies the codebase on a single rate limiter implementation ahead of Phase 2.

**[S-M36] — Async `check()` rejection was fail-open**
- **Issue:** `rateLimit()` and `requireRateLimit()` did not catch rejections from `await limiter.check()`. A future Redis backend throwing on connection failure would propagate as 500, bypassing the rate limit counter entirely.
- **Why:** Fail-open rate limiting lets attackers bypass limits by causing backend failures (e.g. exhausting Redis connection pool).
- **Solution:** Wrapped `await check()` in try/catch, defaulting to `false` (deny) on any error. Two new tests verify the fail-closed behavior.
- **Rationale:** Fail-closed is the standard posture for rate limiters. Establishing this before the Redis backend exists prevents a class of bugs in Phase 2.

**[S-M37] — `AuthRateLimiters` type was mutable**
- **Issue:** The type allowed post-construction mutation (`limiters.handleCheck = rejectAll`), meaning a held reference could disable rate limiting at runtime.
- **Why:** Defense-in-depth — prevents accidental or malicious runtime replacement of rate limiter backends.
- **Solution:** Declared as `Readonly<{...}>`. Tests construct override objects via spread (`{ ...createDefaultAuthRateLimiters(), handleCheck: rejectAll }`).
- **Rationale:** Immutability at the type level is zero-cost and prevents a class of subtle bugs.

**[S-L25] — `createRateLimiter` exposed in barrel export**
- **Issue:** Exporting the raw factory let downstream consumers construct limiters with arbitrary config (e.g. `maxRequests: Infinity`) to disable rate limiting.
- **Why:** Expanding the public API surface unnecessarily. Consumers should use the default factories or implement `RateLimiterBackend` directly.
- **Solution:** Removed `createRateLimiter` from the `@osn/core` barrel. Only the `RateLimiterBackend` type and default factory functions are public.
- **Rationale:** Principle of least privilege — expose the abstraction, not the implementation.

**[S-L26] — No runtime validation on injected backend shape**
- **Issue:** A misconfigured DI object (missing `check()` method) would cause an opaque `TypeError` at request time rather than at boot.
- **Why:** Different endpoints use different limiter keys, so a partially-valid object could work for most endpoints but fail on a rarely-hit one.
- **Solution:** Both route factories validate every limiter slot at construction time; missing or malformed `check()` throws immediately at boot.
- **Rationale:** Fail-fast at boot converts subtle runtime bugs into immediate, clear startup errors.

**[P-I1] — `await` on sync boolean adds microtask overhead (dismissed)**
- **Issue:** `await` on the in-memory limiter's sync `boolean` return wraps it in `Promise.resolve()`, adding ~0.1μs per check.
- **Why:** Sub-microsecond — invisible against DB/crypto costs that dominate every handler.
- **Solution:** No action. The `await` becomes load-bearing when the Redis backend lands in Phase 2.
- **Rationale:** Premature optimization that would require re-adding the `await` later. Current overhead is unmeasurable.

**[T-U1/T-U2] — Not all rate-limited endpoints have explicit 429 wiring tests (deferred)**
- **Issue:** 12 of 16 auth and 5 of 7 graph write `await rateLimit(...)` call sites lack endpoint-specific 429 assertions.
- **Why:** Low risk — the `rateLimit()` helper itself is well-tested; the gap is only in per-endpoint wiring.
- **Solution:** Deferred to a follow-up. The 8 new DI tests cover the contract (sync, async, fail-closed, allow-all, reads-unaffected).
- **Rationale:** The helper is the single point of enforcement. A wiring mistake on a specific endpoint would be caught by the existing integration test suite that exercises each endpoint's happy path.

## Test plan
- [x] `bun run --cwd osn/core test:run` — 239 tests pass (8 new: 4 DI + 2 fail-closed + 2 async)
- [x] `bun run check` — full monorepo type check clean (13/13 packages)
- [x] `bun run test` — all packages green
- [x] Pre-commit hooks pass (oxlint + oxfmt)
- [x] Pre-push hooks pass (turbo type check)
- [ ] Verify `createAuthRoutes(config, layer)` still works without explicit rate limiters (defaults)
- [ ] Verify `createGraphRoutes(config, layer)` still works without explicit rate limiter (default)
- [ ] Verify injecting a custom `RateLimiterBackend` correctly overrides default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)