### PR TITLE
feat(redis): wire up Redis-backed rate limiters (Phase 3)

### DIFF
--- a/.changeset/redis-migration-phase-3.md
+++ b/.changeset/redis-migration-phase-3.md
@@ -1,0 +1,17 @@
+---
+"@osn/core": minor
+"@osn/app": minor
+"@shared/redis": patch
+---
+
+feat(redis): wire up Redis-backed rate limiters (Phase 3)
+
+- Add `createRedisAuthRateLimiters()` and `createRedisGraphRateLimiter()` factories
+  in `@osn/core` that build Redis-backed rate limiters from a `RedisClient`
+- Add `createClientFromUrl()` to `@shared/redis` so consumers don't need ioredis
+  as a direct dependency
+- Wire env-driven backend selection in `@osn/app`: `REDIS_URL` set → Redis with
+  startup health check; unset → in-memory fallback; graceful degradation on
+  connection failure
+- All 12 rate limiters (11 auth + 1 graph) now use Redis when available
+- Resolves S-M2 (rate limiter resets on restart) for production deployments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+RES
 
 **Observability** — OpenTelemetry end-to-end, shipped to Grafana Cloud. Three golden rules: no `console.*`, no raw OTel constructors, no unbounded metric attributes. See `[[wiki/observability/overview]]`.
 
-**Rate Limiting** — Per-IP fixed-window on all auth endpoints. In-memory, migrating to Redis. See `[[wiki/systems/rate-limiting]]`.
+**Rate Limiting** — Per-IP fixed-window on all auth endpoints; per-user on graph writes. Two backends: Redis-backed when `REDIS_URL` is set (cross-process, survives restarts), in-memory fallback when unset (local dev). See `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]`.
 
 **Testing** — `it.effect` + `createTestLayer()` for service tests; `createXxxRoutes(createTestLayer())` for route tests. All in-memory SQLite. See `[[wiki/conventions/testing-patterns]]`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@osn/core": "workspace:*",
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
+        "@shared/redis": "workspace:*",
         "effect": "^3.19.19",
         "elysia": "^1.2.0",
       },
@@ -54,6 +55,7 @@
         "@elysiajs/cors": "^1.4.0",
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
+        "@shared/redis": "workspace:*",
         "@simplewebauthn/server": "^13.1.1",
         "drizzle-orm": "^0.38.0",
         "effect": "^3.19.19",
@@ -242,7 +244,7 @@
     },
     "shared/redis": {
       "name": "@shared/redis",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "effect": "^3.19.19",
         "ioredis": "^5.6.0",

--- a/osn/app/package.json
+++ b/osn/app/package.json
@@ -16,6 +16,7 @@
     "@osn/core": "workspace:*",
     "@osn/db": "workspace:*",
     "@shared/observability": "workspace:*",
+    "@shared/redis": "workspace:*",
     "effect": "^3.19.19",
     "elysia": "^1.2.0"
   },

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -1,8 +1,19 @@
 import { Elysia } from "elysia";
 import { cors } from "@elysiajs/cors";
-import { createAuthRoutes, createGraphRoutes } from "@osn/core";
+import {
+  createAuthRoutes,
+  createGraphRoutes,
+  createRedisAuthRateLimiters,
+  createRedisGraphRateLimiter,
+} from "@osn/core";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
+import {
+  createMemoryClient,
+  createClientFromUrl,
+  checkRedisHealth,
+  type RedisClient,
+} from "@shared/redis";
 import { Effect, Logger } from "effect";
 
 const SERVICE_NAME = "osn-app";
@@ -21,13 +32,71 @@ const authConfig = {
   refreshTokenTtl: Number(process.env.OSN_REFRESH_TOKEN_TTL) || 2592000,
 };
 
+// ---------------------------------------------------------------------------
+// Redis client — env-driven backend selection (S-M2)
+//
+// When REDIS_URL is set, connect to Redis for cross-process rate limiting.
+// When unset (local dev), use an in-memory client with identical semantics.
+// If Redis is configured but unreachable at startup, fall back to in-memory
+// with a warning — fail-open on infrastructure, fail-closed on individual
+// rate limit checks (the rate limiter itself denies on backend errors per
+// S-M36).
+// ---------------------------------------------------------------------------
+
+async function initRedisClient(): Promise<RedisClient> {
+  const url = process.env.REDIS_URL;
+
+  if (!url) {
+    void Effect.runPromise(
+      Effect.logInfo("REDIS_URL not set — using in-memory rate limiters").pipe(
+        Effect.provide(observabilityLayer),
+      ),
+    );
+    return createMemoryClient();
+  }
+
+  try {
+    const client = createClientFromUrl(url);
+    const healthy = await checkRedisHealth(client);
+
+    if (!healthy) {
+      await client.quit().catch(() => {});
+      throw new Error("Redis startup health check failed");
+    }
+
+    void Effect.runPromise(
+      Effect.logInfo("Redis connected — using Redis-backed rate limiters").pipe(
+        Effect.provide(observabilityLayer),
+      ),
+    );
+    return client;
+  } catch (cause) {
+    void Effect.runPromise(
+      Effect.logWarning(
+        "Redis connection failed at startup — falling back to in-memory rate limiters",
+      ).pipe(
+        Effect.annotateLogs({
+          error: cause instanceof Error ? cause.message : String(cause),
+        }),
+        Effect.provide(observabilityLayer),
+      ),
+    );
+    return createMemoryClient();
+  }
+}
+
+const redisClient = await initRedisClient();
+
+const authRateLimiters = createRedisAuthRateLimiters(redisClient);
+const graphRateLimiter = createRedisGraphRateLimiter(redisClient);
+
 const app = new Elysia()
   .use(cors())
   .use(observabilityPlugin({ serviceName: SERVICE_NAME }))
   .use(healthRoutes({ serviceName: SERVICE_NAME }))
   .get("/", () => ({ status: "ok", service: "osn-auth" }))
-  .use(createAuthRoutes(authConfig, DbLive, observabilityLayer))
-  .use(createGraphRoutes(authConfig, DbLive, observabilityLayer));
+  .use(createAuthRoutes(authConfig, DbLive, observabilityLayer, authRateLimiters))
+  .use(createGraphRoutes(authConfig, DbLive, observabilityLayer, graphRateLimiter));
 
 if (process.env.NODE_ENV !== "test") {
   app.listen(port);

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -8,13 +8,8 @@ import {
 } from "@osn/core";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
-import {
-  createMemoryClient,
-  createClientFromUrl,
-  checkRedisHealth,
-  type RedisClient,
-} from "@shared/redis";
 import { Effect, Logger } from "effect";
+import { initRedisClient } from "./redis";
 
 const SERVICE_NAME = "osn-app";
 const port = Number(process.env.PORT) || 4000;
@@ -35,57 +30,16 @@ const authConfig = {
 // ---------------------------------------------------------------------------
 // Redis client — env-driven backend selection (S-M2)
 //
-// When REDIS_URL is set, connect to Redis for cross-process rate limiting.
-// When unset (local dev), use an in-memory client with identical semantics.
-// If Redis is configured but unreachable at startup, fall back to in-memory
-// with a warning — fail-open on infrastructure, fail-closed on individual
-// rate limit checks (the rate limiter itself denies on backend errors per
-// S-M36).
+// See `./redis.ts` for the full initialisation logic (TLS warning, credential
+// redaction, REDIS_REQUIRED fail-closed mode, lazyConnect lifecycle).
 // ---------------------------------------------------------------------------
 
-async function initRedisClient(): Promise<RedisClient> {
-  const url = process.env.REDIS_URL;
-
-  if (!url) {
-    void Effect.runPromise(
-      Effect.logInfo("REDIS_URL not set — using in-memory rate limiters").pipe(
-        Effect.provide(observabilityLayer),
-      ),
-    );
-    return createMemoryClient();
-  }
-
-  try {
-    const client = createClientFromUrl(url);
-    const healthy = await checkRedisHealth(client);
-
-    if (!healthy) {
-      await client.quit().catch(() => {});
-      throw new Error("Redis startup health check failed");
-    }
-
-    void Effect.runPromise(
-      Effect.logInfo("Redis connected — using Redis-backed rate limiters").pipe(
-        Effect.provide(observabilityLayer),
-      ),
-    );
-    return client;
-  } catch (cause) {
-    void Effect.runPromise(
-      Effect.logWarning(
-        "Redis connection failed at startup — falling back to in-memory rate limiters",
-      ).pipe(
-        Effect.annotateLogs({
-          error: cause instanceof Error ? cause.message : String(cause),
-        }),
-        Effect.provide(observabilityLayer),
-      ),
-    );
-    return createMemoryClient();
-  }
-}
-
-const redisClient = await initRedisClient();
+const redisClient = await initRedisClient({
+  redisUrl: process.env.REDIS_URL,
+  redisRequired: process.env.REDIS_REQUIRED === "true",
+  nodeEnv: process.env.NODE_ENV,
+  loggerLayer: observabilityLayer,
+});
 
 const authRateLimiters = createRedisAuthRateLimiters(redisClient);
 const graphRateLimiter = createRedisGraphRateLimiter(redisClient);

--- a/osn/app/src/redis.ts
+++ b/osn/app/src/redis.ts
@@ -1,0 +1,101 @@
+/**
+ * Redis client initialisation for the osn-app composition root.
+ *
+ * Extracted from `index.ts` so the three startup branches (no-URL, healthy,
+ * fallback) are independently testable.
+ *
+ * Security / performance considerations addressed here:
+ * - S-M1: TLS warning when production URL uses `redis://` instead of `rediss://`
+ * - S-M2: Credential redaction in error logs via `sanitizeCause`
+ * - S-L1: Optional `REDIS_REQUIRED` env var for fail-closed startup
+ * - S-L2 / P-W1: `lazyConnect` + explicit `connect()` / `disconnect()` lifecycle
+ * - P-I2: Warning-level logs are `await`-ed, not fire-and-forget
+ */
+
+import {
+  createMemoryClient,
+  createClientFromUrl,
+  checkRedisHealth,
+  sanitizeCause,
+  type RedisClient,
+} from "@shared/redis";
+import { Effect, type Layer } from "effect";
+
+export interface InitRedisOptions {
+  /** `REDIS_URL` env value (or undefined). */
+  redisUrl?: string;
+  /** When `true`, the process exits instead of falling back to in-memory (S-L1). */
+  redisRequired?: boolean;
+  /** `NODE_ENV` value — used for the TLS warning (S-M1). */
+  nodeEnv?: string;
+  /** Effect layer for structured logging. */
+  loggerLayer: Layer.Layer<never>;
+}
+
+/**
+ * Initialise the Redis client with env-driven backend selection.
+ *
+ * - `REDIS_URL` set → connect to Redis; verify with health check
+ * - `REDIS_URL` unset → in-memory client (local dev)
+ * - Health check fails → fall back to in-memory (or exit if `REDIS_REQUIRED`)
+ */
+export async function initRedisClient(opts: InitRedisOptions): Promise<RedisClient> {
+  const { redisUrl, redisRequired = false, nodeEnv, loggerLayer } = opts;
+
+  if (!redisUrl) {
+    void Effect.runPromise(
+      Effect.logInfo("REDIS_URL not set — using in-memory rate limiters").pipe(
+        Effect.provide(loggerLayer),
+      ),
+    );
+    return createMemoryClient();
+  }
+
+  // S-M1: warn when production connection is unencrypted
+  if (nodeEnv === "production" && !redisUrl.startsWith("rediss://")) {
+    await Effect.runPromise(
+      Effect.logWarning("REDIS_URL does not use TLS (rediss://) — connection is unencrypted").pipe(
+        Effect.provide(loggerLayer),
+      ),
+    );
+  }
+
+  try {
+    const client = createClientFromUrl(redisUrl);
+    await client.connect();
+
+    const healthy = await checkRedisHealth(client);
+    if (!healthy) {
+      await client.disconnect();
+      throw new Error("Redis startup health check failed");
+    }
+
+    void Effect.runPromise(
+      Effect.logInfo("Redis connected — using Redis-backed rate limiters").pipe(
+        Effect.provide(loggerLayer),
+      ),
+    );
+    return client;
+  } catch (cause) {
+    // S-M2: redact credentials from error messages before logging
+    const safeMessage = sanitizeCause(cause);
+
+    // S-L1: fail-closed when REDIS_REQUIRED is set
+    if (redisRequired) {
+      await Effect.runPromise(
+        Effect.logError(
+          "Redis connection failed and REDIS_REQUIRED is set — aborting startup",
+        ).pipe(Effect.annotateLogs({ error: safeMessage }), Effect.provide(loggerLayer)),
+      );
+      process.exit(1);
+    }
+
+    // P-I2: await the warning log so observability bootstrap failures surface
+    await Effect.runPromise(
+      Effect.logWarning(
+        "Redis connection failed at startup — falling back to in-memory rate limiters",
+      ).pipe(Effect.annotateLogs({ error: safeMessage }), Effect.provide(loggerLayer)),
+    );
+    return createMemoryClient();
+  }
+}

--- a/osn/app/tests/redis.test.ts
+++ b/osn/app/tests/redis.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Layer } from "effect";
+import { initRedisClient } from "../src/redis";
+
+// Mock @shared/redis to avoid real ioredis connections
+vi.mock("@shared/redis", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // Override createClientFromUrl to return a controllable mock
+    createClientFromUrl: vi.fn(),
+  };
+});
+
+import {
+  createClientFromUrl,
+  createMemoryClient,
+  type ConnectableRedisClient,
+} from "@shared/redis";
+
+const mockedCreateClientFromUrl = vi.mocked(createClientFromUrl);
+
+function createMockConnectableClient(
+  overrides: Partial<ConnectableRedisClient> = {},
+): ConnectableRedisClient {
+  const base = createMemoryClient();
+  return {
+    ...base,
+    connect: vi.fn<any>().mockResolvedValue(undefined),
+    disconnect: vi.fn<any>().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const silentLogger = Layer.empty;
+
+describe("initRedisClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Branch 1: REDIS_URL not set
+  // -------------------------------------------------------------------------
+
+  it("returns an in-memory client when redisUrl is undefined", async () => {
+    const client = await initRedisClient({
+      redisUrl: undefined,
+      loggerLayer: silentLogger,
+    });
+
+    // Should work as a rate limiter backend (in-memory)
+    expect(await client.ping()).toBe("PONG");
+    expect(mockedCreateClientFromUrl).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Branch 2: REDIS_URL set + healthy
+  // -------------------------------------------------------------------------
+
+  it("returns the Redis client when health check passes", async () => {
+    const mockClient = createMockConnectableClient();
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    const client = await initRedisClient({
+      redisUrl: "redis://localhost:6379",
+      loggerLayer: silentLogger,
+    });
+
+    expect(mockedCreateClientFromUrl).toHaveBeenCalledWith("redis://localhost:6379");
+    expect(mockClient.connect).toHaveBeenCalledOnce();
+    expect(client).toBe(mockClient);
+  });
+
+  // -------------------------------------------------------------------------
+  // Branch 3: REDIS_URL set + connection fails → fallback
+  // -------------------------------------------------------------------------
+
+  it("falls back to in-memory when connect() throws", async () => {
+    const mockClient = createMockConnectableClient({
+      connect: vi.fn<any>().mockRejectedValue(new Error("ECONNREFUSED")),
+    });
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    const client = await initRedisClient({
+      redisUrl: "redis://localhost:6379",
+      loggerLayer: silentLogger,
+    });
+
+    // Should return a working in-memory client, not the failed one
+    expect(client).not.toBe(mockClient);
+    expect(await client.ping()).toBe("PONG");
+  });
+
+  it("falls back to in-memory when health check returns false", async () => {
+    const mockClient = createMockConnectableClient({
+      ping: vi.fn<any>().mockResolvedValue("NOT_PONG"), // health check fails
+    });
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    const client = await initRedisClient({
+      redisUrl: "redis://localhost:6379",
+      loggerLayer: silentLogger,
+    });
+
+    expect(client).not.toBe(mockClient);
+    expect(await client.ping()).toBe("PONG");
+  });
+
+  it("calls disconnect() on health check failure (P-W1)", async () => {
+    const disconnectFn = vi.fn<any>().mockResolvedValue(undefined);
+    const mockClient = createMockConnectableClient({
+      ping: vi.fn<any>().mockResolvedValue("NOT_PONG"),
+      disconnect: disconnectFn,
+    });
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    await initRedisClient({
+      redisUrl: "redis://localhost:6379",
+      loggerLayer: silentLogger,
+    });
+
+    expect(disconnectFn).toHaveBeenCalledOnce();
+  });
+
+  // -------------------------------------------------------------------------
+  // S-L1: REDIS_REQUIRED
+  // -------------------------------------------------------------------------
+
+  it("exits process when REDIS_REQUIRED is true and Redis fails", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    const mockClient = createMockConnectableClient({
+      connect: vi.fn<any>().mockRejectedValue(new Error("ECONNREFUSED")),
+    });
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    await expect(
+      initRedisClient({
+        redisUrl: "redis://localhost:6379",
+        redisRequired: true,
+        loggerLayer: silentLogger,
+      }),
+    ).rejects.toThrow("process.exit called");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it("does not exit when REDIS_REQUIRED is false and Redis fails", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    const mockClient = createMockConnectableClient({
+      connect: vi.fn<any>().mockRejectedValue(new Error("ECONNREFUSED")),
+    });
+    mockedCreateClientFromUrl.mockReturnValue(mockClient);
+
+    // Should NOT throw — falls back gracefully
+    const client = await initRedisClient({
+      redisUrl: "redis://localhost:6379",
+      redisRequired: false,
+      loggerLayer: silentLogger,
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(await client.ping()).toBe("PONG");
+    exitSpy.mockRestore();
+  });
+});

--- a/osn/core/package.json
+++ b/osn/core/package.json
@@ -17,6 +17,7 @@
     "@elysiajs/cors": "^1.4.0",
     "@osn/db": "workspace:*",
     "@shared/observability": "workspace:*",
+    "@shared/redis": "workspace:*",
     "@simplewebauthn/server": "^13.1.1",
     "drizzle-orm": "^0.38.0",
     "effect": "^3.19.19",

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -7,3 +7,7 @@ export { createGraphRoutes, createDefaultGraphRateLimiter } from "./routes/graph
 export { createGraphService } from "./services/graph";
 export type { GraphService } from "./services/graph";
 export type { RateLimiterBackend } from "./lib/rate-limit";
+export {
+  createRedisAuthRateLimiters,
+  createRedisGraphRateLimiter,
+} from "./lib/redis-rate-limiters";

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -1,0 +1,55 @@
+/**
+ * Redis-backed rate limiter factories for auth and graph routes.
+ *
+ * These mirror the in-memory defaults in `createDefaultAuthRateLimiters()` and
+ * `createDefaultGraphRateLimiter()` but delegate to `createRedisRateLimiter`
+ * from `@shared/redis`, which uses an atomic Lua script (INCR + PEXPIRE) for
+ * correct fixed-window counting across processes.
+ *
+ * The returned objects satisfy `RateLimiterBackend` from `./rate-limit.ts` —
+ * `check(key)` returns `Promise<boolean>`, which the existing `await`-based
+ * call sites in auth.ts / graph.ts handle transparently.
+ */
+
+import { createRedisRateLimiter } from "@shared/redis";
+import type { RedisClient } from "@shared/redis";
+import type { AuthRateLimiters } from "../routes/auth";
+import type { RateLimiterBackend } from "./rate-limit";
+
+const ONE_MINUTE_MS = 60_000;
+
+/**
+ * Build all 11 auth rate limiters backed by a shared Redis client.
+ * Namespace convention: `auth:{endpoint_name}` — produces Redis keys like
+ * `rl:auth:register_begin:192.168.1.1`.
+ */
+export function createRedisAuthRateLimiters(client: RedisClient): AuthRateLimiters {
+  const rl = (namespace: string, maxRequests: number): RateLimiterBackend =>
+    createRedisRateLimiter(client, { namespace, maxRequests, windowMs: ONE_MINUTE_MS });
+
+  return {
+    registerBegin: rl("auth:register_begin", 5),
+    registerComplete: rl("auth:register_complete", 10),
+    handleCheck: rl("auth:handle_check", 10),
+    otpBegin: rl("auth:otp_begin", 5),
+    otpComplete: rl("auth:otp_complete", 10),
+    magicBegin: rl("auth:magic_begin", 5),
+    magicVerify: rl("auth:magic_verify", 10),
+    passkeyLoginBegin: rl("auth:passkey_login_begin", 10),
+    passkeyLoginComplete: rl("auth:passkey_login_complete", 10),
+    passkeyRegisterBegin: rl("auth:passkey_register_begin", 10),
+    passkeyRegisterComplete: rl("auth:passkey_register_complete", 10),
+  };
+}
+
+/**
+ * Build the graph write rate limiter backed by Redis.
+ * Namespace: `graph:write` — key is the authenticated user ID.
+ */
+export function createRedisGraphRateLimiter(client: RedisClient): RateLimiterBackend {
+  return createRedisRateLimiter(client, {
+    namespace: "graph:write",
+    maxRequests: 60,
+    windowMs: ONE_MINUTE_MS,
+  });
+}

--- a/osn/core/tests/lib/redis-rate-limiters.test.ts
+++ b/osn/core/tests/lib/redis-rate-limiters.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { createMemoryClient } from "@shared/redis";
+import {
+  createRedisAuthRateLimiters,
+  createRedisGraphRateLimiter,
+} from "../../src/lib/redis-rate-limiters";
+
+describe("createRedisAuthRateLimiters", () => {
+  it("returns all 11 rate limiter slots", () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+
+    const expectedKeys = [
+      "registerBegin",
+      "registerComplete",
+      "handleCheck",
+      "otpBegin",
+      "otpComplete",
+      "magicBegin",
+      "magicVerify",
+      "passkeyLoginBegin",
+      "passkeyLoginComplete",
+      "passkeyRegisterBegin",
+      "passkeyRegisterComplete",
+    ] as const;
+
+    for (const key of expectedKeys) {
+      expect(limiters[key]).toBeDefined();
+      expect(typeof limiters[key].check).toBe("function");
+    }
+  });
+
+  it("enforces begin-endpoint limits (5 req/min)", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+
+    for (let i = 0; i < 5; i++) {
+      expect(await limiters.registerBegin.check("ip1")).toBe(true);
+    }
+    expect(await limiters.registerBegin.check("ip1")).toBe(false);
+  });
+
+  it("enforces complete-endpoint limits (10 req/min)", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+
+    for (let i = 0; i < 10; i++) {
+      expect(await limiters.registerComplete.check("ip1")).toBe(true);
+    }
+    expect(await limiters.registerComplete.check("ip1")).toBe(false);
+  });
+
+  it("isolates namespaces between endpoints", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+
+    // Exhaust registerBegin (5 req)
+    for (let i = 0; i < 5; i++) {
+      await limiters.registerBegin.check("ip1");
+    }
+    expect(await limiters.registerBegin.check("ip1")).toBe(false);
+
+    // otpBegin should still have its own quota
+    expect(await limiters.otpBegin.check("ip1")).toBe(true);
+  });
+
+  it("check() returns a Promise (async-compatible)", () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+    const result = limiters.registerBegin.check("ip1");
+    expect(result).toBeInstanceOf(Promise);
+  });
+});
+
+describe("createRedisGraphRateLimiter", () => {
+  it("returns a valid rate limiter backend", () => {
+    const client = createMemoryClient();
+    const limiter = createRedisGraphRateLimiter(client);
+    expect(typeof limiter.check).toBe("function");
+  });
+
+  it("enforces 60 req/min limit", async () => {
+    const client = createMemoryClient();
+    const limiter = createRedisGraphRateLimiter(client);
+
+    for (let i = 0; i < 60; i++) {
+      expect(await limiter.check("user1")).toBe(true);
+    }
+    expect(await limiter.check("user1")).toBe(false);
+  });
+
+  it("tracks users independently", async () => {
+    const client = createMemoryClient();
+    const limiter = createRedisGraphRateLimiter(client);
+
+    expect(await limiter.check("user1")).toBe(true);
+    expect(await limiter.check("user2")).toBe(true);
+  });
+
+  it("uses a separate namespace from auth rate limiters", async () => {
+    const client = createMemoryClient();
+    const authLimiters = createRedisAuthRateLimiters(client);
+    const graphLimiter = createRedisGraphRateLimiter(client);
+
+    // Exhaust graph limiter for a key
+    for (let i = 0; i < 60; i++) {
+      await graphLimiter.check("shared_key");
+    }
+    expect(await graphLimiter.check("shared_key")).toBe(false);
+
+    // Auth limiter with the same key should be unaffected
+    expect(await authLimiters.handleCheck.check("shared_key")).toBe(true);
+  });
+});

--- a/osn/core/tests/routes/redis-rate-limit-integration.test.ts
+++ b/osn/core/tests/routes/redis-rate-limit-integration.test.ts
@@ -8,14 +8,17 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
+import { Effect } from "effect";
 import { createTestLayer } from "../helpers/db";
 import { createAuthRoutes } from "../../src/routes/auth";
 import { createGraphRoutes } from "../../src/routes/graph";
+import { createAuthService } from "../../src/services/auth";
+import { type Db } from "@osn/db/service";
 import {
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
 } from "../../src/lib/redis-rate-limiters";
-import { createMemoryClient } from "@shared/redis";
+import { createMemoryClient, createRedisRateLimiter } from "@shared/redis";
 
 const config = {
   rpId: "localhost",
@@ -134,5 +137,48 @@ describe("graph routes with Redis-backed rate limiter", () => {
     const limiter = createRedisGraphRateLimiter(client);
     const layer = createTestLayer();
     expect(() => createGraphRoutes(config, layer, undefined, limiter)).not.toThrow();
+  });
+
+  it("rate limits graph write at 3 req/user via Redis backend", async () => {
+    const client = createMemoryClient();
+    // Use a very low limit (3) so the test is fast
+    const limiter = createRedisRateLimiter(client, {
+      namespace: "graph:write",
+      maxRequests: 3,
+      windowMs: 60_000,
+    });
+
+    const layer = createTestLayer();
+    const graphApp = createGraphRoutes(config, layer, undefined, limiter);
+
+    // Register two users so we can attempt a connection
+    const auth = createAuthService(config);
+    const run = <A, E>(eff: Effect.Effect<A, E, Db>) =>
+      Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+    const alice = await run(auth.registerUser("alice@test.com", "alice"));
+    await run(auth.registerUser("bob@test.com", "bob"));
+    const tokens = await run(
+      auth.issueTokens(alice.id, alice.email, alice.handle, alice.displayName),
+    );
+
+    const makeRequest = () =>
+      graphApp.handle(
+        new Request("http://localhost/graph/connections/bob", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+        }),
+      );
+
+    // First 3 requests should not be rate-limited (may be 201 or 400 for
+    // duplicate connection, but never 429)
+    for (let i = 0; i < 3; i++) {
+      const res = await makeRequest();
+      expect(res.status).not.toBe(429);
+    }
+
+    // 4th request should be rate-limited
+    const blocked = await makeRequest();
+    expect(blocked.status).toBe(429);
   });
 });

--- a/osn/core/tests/routes/redis-rate-limit-integration.test.ts
+++ b/osn/core/tests/routes/redis-rate-limit-integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration test: auth + graph routes with Redis-backed rate limiters.
+ *
+ * Verifies that the Redis rate limiter factory from `redis-rate-limiters.ts`
+ * produces backends that are accepted by `createAuthRoutes` / `createGraphRoutes`
+ * and correctly enforce limits via the in-memory Redis client (same code path
+ * as a real Redis backend, minus the network).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestLayer } from "../helpers/db";
+import { createAuthRoutes } from "../../src/routes/auth";
+import { createGraphRoutes } from "../../src/routes/graph";
+import {
+  createRedisAuthRateLimiters,
+  createRedisGraphRateLimiter,
+} from "../../src/lib/redis-rate-limiters";
+import { createMemoryClient } from "@shared/redis";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("auth routes with Redis-backed rate limiters", () => {
+  let layer: ReturnType<typeof createTestLayer>;
+
+  beforeEach(() => {
+    layer = createTestLayer();
+  });
+
+  it("createAuthRoutes accepts Redis-backed rate limiters without error", () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+    // Should not throw — validates every slot at construction time (S-L2)
+    expect(() => createAuthRoutes(config, layer, undefined, limiters)).not.toThrow();
+  });
+
+  it("rate limits /register/begin at 5 req/IP/min via Redis backend", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+    const app = createAuthRoutes(config, layer, undefined, limiters);
+
+    const makeRequest = () =>
+      app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": "203.0.113.1",
+          },
+          body: JSON.stringify({
+            email: "test@example.com",
+            handle: "testuser",
+          }),
+        }),
+      );
+
+    // First 5 requests should succeed (or return 400 due to validation,
+    // but NOT 429)
+    for (let i = 0; i < 5; i++) {
+      const res = await makeRequest();
+      expect(res.status).not.toBe(429);
+    }
+
+    // 6th request should be rate-limited
+    const blocked = await makeRequest();
+    expect(blocked.status).toBe(429);
+    const body = (await blocked.json()) as { error: string };
+    expect(body.error).toBe("rate_limited");
+  });
+
+  it("rate limits /handle/:handle at 10 req/IP/min via Redis backend", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+    const app = createAuthRoutes(config, layer, undefined, limiters);
+
+    const makeRequest = () =>
+      app.handle(
+        new Request("http://localhost/handle/testuser", {
+          headers: { "X-Forwarded-For": "203.0.113.2" },
+        }),
+      );
+
+    for (let i = 0; i < 10; i++) {
+      const res = await makeRequest();
+      expect(res.status).not.toBe(429);
+    }
+
+    const blocked = await makeRequest();
+    expect(blocked.status).toBe(429);
+  });
+
+  it("different IPs get independent rate limit buckets", async () => {
+    const client = createMemoryClient();
+    const limiters = createRedisAuthRateLimiters(client);
+    const app = createAuthRoutes(config, layer, undefined, limiters);
+
+    // Exhaust IP1's register/begin quota
+    for (let i = 0; i < 5; i++) {
+      await app.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": "10.0.0.1",
+          },
+          body: JSON.stringify({ email: "a@b.com", handle: "a" }),
+        }),
+      );
+    }
+
+    // IP2 should still be allowed
+    const res = await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Forwarded-For": "10.0.0.2",
+        },
+        body: JSON.stringify({ email: "b@b.com", handle: "b" }),
+      }),
+    );
+    expect(res.status).not.toBe(429);
+  });
+});
+
+describe("graph routes with Redis-backed rate limiter", () => {
+  it("createGraphRoutes accepts Redis-backed rate limiter without error", () => {
+    const client = createMemoryClient();
+    const limiter = createRedisGraphRateLimiter(client);
+    const layer = createTestLayer();
+    expect(() => createGraphRoutes(config, layer, undefined, limiter)).not.toThrow();
+  });
+});

--- a/shared/redis/src/client.ts
+++ b/shared/redis/src/client.ts
@@ -7,7 +7,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type IORedis from "ioredis";
+import IORedis from "ioredis";
 
 /**
  * Backend-agnostic Redis client contract. Production uses ioredis via
@@ -87,6 +87,19 @@ export function wrapIoRedis(client: IORedis): RedisClient {
       await client.quit();
     },
   };
+}
+
+/**
+ * Create a `RedisClient` connected to the given URL.
+ *
+ * Encapsulates the ioredis constructor so consumers (e.g. `osn/app`) don't
+ * need ioredis as a direct dependency — they go through this factory instead.
+ * Does NOT perform a health check; callers should use `checkRedisHealth()`
+ * from `./health.ts` after creation if startup verification is desired.
+ */
+export function createClientFromUrl(url: string): RedisClient {
+  const raw = new IORedis(url);
+  return wrapIoRedis(raw);
 }
 
 const DEFAULT_MAX_ENTRIES = 10_000;

--- a/shared/redis/src/client.ts
+++ b/shared/redis/src/client.ts
@@ -37,34 +37,38 @@ export interface RedisClient {
  *
  * Transparently caches Lua script SHAs and uses EVALSHA on subsequent calls
  * to avoid re-transmitting the full script body on every request (P-W1).
+ * SHAs are computed eagerly on first sight of each script (P-W2) so the
+ * crypto cost is paid once, not on every EVAL fallback.
  * Falls back to EVAL on NOSCRIPT errors (e.g. after a Redis restart).
  */
 export function wrapIoRedis(client: IORedis): RedisClient {
   const scriptShas = new Map<string, string>();
 
+  /** Compute + cache SHA-1 on first sight of a script (P-W2). */
+  function ensureSha(script: string): string {
+    let sha = scriptShas.get(script);
+    if (!sha) {
+      sha = createHash("sha1").update(script).digest("hex");
+      scriptShas.set(script, sha);
+    }
+    return sha;
+  }
+
   return {
     async eval(script, keys, args) {
       const allArgs: (string | number)[] = [...keys, ...args];
-      const cachedSha = scriptShas.get(script);
+      const sha = ensureSha(script);
 
-      if (cachedSha) {
-        try {
-          return await client.evalsha(cachedSha, keys.length, ...allArgs);
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : "";
-          if (msg.includes("NOSCRIPT")) {
-            scriptShas.delete(script);
-          } else {
-            throw err;
-          }
-        }
+      // Always try EVALSHA first — avoids sending full script body (P-W2)
+      try {
+        return await client.evalsha(sha, keys.length, ...allArgs);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "";
+        if (!msg.includes("NOSCRIPT")) throw err;
       }
 
-      // Full EVAL — cache SHA after success for next call
-      const sha = createHash("sha1").update(script).digest("hex");
-      const result = await client.eval(script, keys.length, ...allArgs);
-      scriptShas.set(script, sha);
-      return result;
+      // NOSCRIPT fallback: full EVAL (first call or after Redis restart)
+      return await client.eval(script, keys.length, ...allArgs);
     },
     async ping() {
       return client.ping();
@@ -90,16 +94,50 @@ export function wrapIoRedis(client: IORedis): RedisClient {
 }
 
 /**
- * Create a `RedisClient` connected to the given URL.
- *
- * Encapsulates the ioredis constructor so consumers (e.g. `osn/app`) don't
- * need ioredis as a direct dependency — they go through this factory instead.
- * Does NOT perform a health check; callers should use `checkRedisHealth()`
- * from `./health.ts` after creation if startup verification is desired.
+ * Extended client returned by `createClientFromUrl` with explicit lifecycle
+ * methods for startup and teardown (S-L2 / P-W1).
  */
-export function createClientFromUrl(url: string): RedisClient {
-  const raw = new IORedis(url);
-  return wrapIoRedis(raw);
+export interface ConnectableRedisClient extends RedisClient {
+  /** Explicitly open the TCP connection. Required because `lazyConnect` is used. */
+  connect(): Promise<void>;
+  /**
+   * Forcibly tear down the connection and stop the ioredis retry loop.
+   * Use this instead of `quit()` when the connection was never fully
+   * established (e.g. health check failure at startup).
+   */
+  disconnect(): Promise<void>;
+}
+
+/**
+ * Create a `RedisClient` from a URL with safe connection defaults (S-L2 / P-W1):
+ *
+ * - `lazyConnect: true` — prevents background connection before the caller is
+ *   ready. Call `.connect()` explicitly before use.
+ * - `connectTimeout: 5_000` — bounds the TCP handshake so a firewalled port
+ *   doesn't hang indefinitely.
+ * - `maxRetriesPerRequest: 1` — prevents a single command from retrying
+ *   internally for an unbounded period.
+ *
+ * The returned `ConnectableRedisClient` extends `RedisClient` with `connect()`
+ * and `disconnect()` for explicit lifecycle management.
+ */
+export function createClientFromUrl(url: string): ConnectableRedisClient {
+  const raw = new IORedis(url, {
+    lazyConnect: true,
+    connectTimeout: 5_000,
+    maxRetriesPerRequest: 1,
+  });
+  const client = wrapIoRedis(raw);
+
+  return {
+    ...client,
+    async connect() {
+      await raw.connect();
+    },
+    async disconnect() {
+      raw.disconnect(false);
+    },
+  };
 }
 
 const DEFAULT_MAX_ENTRIES = 10_000;

--- a/shared/redis/src/index.ts
+++ b/shared/redis/src/index.ts
@@ -1,5 +1,5 @@
 export { RedisError } from "./errors";
-export { type RedisClient, wrapIoRedis, createMemoryClient } from "./client";
+export { type RedisClient, wrapIoRedis, createMemoryClient, createClientFromUrl } from "./client";
 export { Redis, type RedisService, RedisLive, RedisMemoryLive } from "./service";
 export { createRedisRateLimiter, type RedisRateLimiterConfig } from "./rate-limiter";
 export { checkRedisHealth } from "./health";

--- a/shared/redis/src/index.ts
+++ b/shared/redis/src/index.ts
@@ -1,5 +1,11 @@
 export { RedisError } from "./errors";
-export { type RedisClient, wrapIoRedis, createMemoryClient, createClientFromUrl } from "./client";
-export { Redis, type RedisService, RedisLive, RedisMemoryLive } from "./service";
+export {
+  type RedisClient,
+  type ConnectableRedisClient,
+  wrapIoRedis,
+  createMemoryClient,
+  createClientFromUrl,
+} from "./client";
+export { Redis, type RedisService, RedisLive, RedisMemoryLive, sanitizeCause } from "./service";
 export { createRedisRateLimiter, type RedisRateLimiterConfig } from "./rate-limiter";
 export { checkRedisHealth } from "./health";

--- a/shared/redis/src/service.ts
+++ b/shared/redis/src/service.ts
@@ -90,4 +90,4 @@ export const RedisMemoryLive: Layer.Layer<Redis> = Layer.scoped(
   }),
 );
 
-export { sanitizeCause as _sanitizeCause };
+export { sanitizeCause };

--- a/shared/redis/tests/client.test.ts
+++ b/shared/redis/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type IORedis from "ioredis";
-import { wrapIoRedis, createMemoryClient } from "../src/client";
+import { wrapIoRedis, createMemoryClient, createClientFromUrl } from "../src/client";
 
 function createMockIoRedis() {
   return {
@@ -23,67 +23,74 @@ describe("wrapIoRedis", () => {
     client = wrapIoRedis(mock as unknown as IORedis);
   });
 
-  describe("eval — EVALSHA caching (P-W1)", () => {
-    it("uses EVAL on first call and EVALSHA on subsequent calls", async () => {
-      await client.eval("script", ["key1"], [1, 2]);
-      expect(mock.eval).toHaveBeenCalledOnce();
-      expect(mock.evalsha).not.toHaveBeenCalled();
+  describe("eval — EVALSHA-first with eager SHA caching (P-W2)", () => {
+    it("tries EVALSHA first, falls back to EVAL on NOSCRIPT (first call)", async () => {
+      // First call: EVALSHA fails with NOSCRIPT, falls back to EVAL
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
 
-      await client.eval("script", ["key2"], [3, 4]);
-      expect(mock.eval).toHaveBeenCalledOnce(); // still only one EVAL
+      await client.eval("script", ["key1"], [1, 2]);
       expect(mock.evalsha).toHaveBeenCalledOnce();
+      expect(mock.eval).toHaveBeenCalledOnce();
     });
 
-    it("spreads keys and args correctly for EVAL", async () => {
+    it("uses EVALSHA successfully on subsequent calls (SHA cached by server)", async () => {
+      // First call: NOSCRIPT → EVAL loads the script
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      await client.eval("script", ["key1"], [1, 2]);
+
+      // Second call: EVALSHA succeeds (script now loaded on server)
+      await client.eval("script", ["key2"], [3, 4]);
+      expect(mock.evalsha).toHaveBeenCalledTimes(2);
+      expect(mock.eval).toHaveBeenCalledOnce(); // no new EVAL
+    });
+
+    it("spreads keys and args correctly for EVALSHA", async () => {
+      await client.eval("script", ["k1", "k2"], [10, 20]);
+      // SHA is computed eagerly from "script"
+      expect(mock.evalsha).toHaveBeenCalledWith(expect.any(String), 2, "k1", "k2", 10, 20);
+    });
+
+    it("spreads keys and args correctly for EVAL fallback", async () => {
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
       await client.eval("script", ["k1", "k2"], [10, 20]);
       expect(mock.eval).toHaveBeenCalledWith("script", 2, "k1", "k2", 10, 20);
     });
 
-    it("spreads keys and args correctly for EVALSHA", async () => {
-      await client.eval("script", ["k1"], [1]); // prime the cache
-      mock.evalsha.mockResolvedValue(42);
-
-      const result = await client.eval("script", ["k2", "k3"], [5, 6]);
-      expect(result).toBe(42);
-      // SHA is the sha1 of "script", numkeys=2, then keys, then args
-      expect(mock.evalsha).toHaveBeenCalledWith(expect.any(String), 2, "k2", "k3", 5, 6);
-    });
-
-    it("falls back to EVAL on NOSCRIPT error", async () => {
-      await client.eval("script", ["k1"], [1]); // prime cache
-      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
-
-      await client.eval("script", ["k2"], [2]); // EVALSHA fails, falls back to EVAL
-      expect(mock.eval).toHaveBeenCalledTimes(2);
-    });
-
-    it("re-caches SHA after NOSCRIPT fallback", async () => {
-      await client.eval("script", ["k1"], [1]); // prime cache
-      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
-
-      await client.eval("script", ["k2"], [2]); // fallback to EVAL, re-caches
-      expect(mock.eval).toHaveBeenCalledTimes(2);
-
-      await client.eval("script", ["k3"], [3]); // should use EVALSHA again
-      expect(mock.evalsha).toHaveBeenCalledTimes(2); // first failed + this one
-      expect(mock.eval).toHaveBeenCalledTimes(2); // no new EVAL
-    });
-
     it("rethrows non-NOSCRIPT errors from EVALSHA", async () => {
-      await client.eval("script", ["k1"], [1]); // prime cache
       mock.evalsha.mockRejectedValueOnce(new Error("OOM command not allowed"));
 
       await expect(client.eval("script", ["k2"], [2])).rejects.toThrow("OOM command not allowed");
     });
 
-    it("caches different scripts independently", async () => {
+    it("caches different scripts independently (P-W2)", async () => {
+      // Both scripts succeed on first EVALSHA (already loaded on server)
       await client.eval("script_a", ["k1"], [1]);
       await client.eval("script_b", ["k2"], [2]);
-      expect(mock.eval).toHaveBeenCalledTimes(2);
+      expect(mock.evalsha).toHaveBeenCalledTimes(2);
 
+      // Subsequent calls reuse cached SHAs
       await client.eval("script_a", ["k3"], [3]);
       await client.eval("script_b", ["k4"], [4]);
-      expect(mock.evalsha).toHaveBeenCalledTimes(2);
+      expect(mock.evalsha).toHaveBeenCalledTimes(4);
+      // No EVAL calls at all — EVALSHA succeeded every time
+      expect(mock.eval).not.toHaveBeenCalled();
+    });
+
+    it("computes SHA eagerly — no createHash per EVAL fallback (P-W2)", async () => {
+      // Two NOSCRIPT errors for the same script — SHA should only be computed once
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      await client.eval("script", ["k1"], [1]);
+      expect(mock.eval).toHaveBeenCalledOnce();
+
+      // Simulate Redis restart: NOSCRIPT again on next call
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      await client.eval("script", ["k2"], [2]);
+      expect(mock.eval).toHaveBeenCalledTimes(2);
+
+      // The same SHA should be used for both EVALSHA attempts
+      const sha1 = mock.evalsha.mock.calls[0][0];
+      const sha2 = mock.evalsha.mock.calls[1][0];
+      expect(sha1).toBe(sha2);
     });
   });
 
@@ -130,6 +137,24 @@ describe("wrapIoRedis", () => {
       await client.quit();
       expect(mock.quit).toHaveBeenCalledOnce();
     });
+  });
+});
+
+describe("createClientFromUrl", () => {
+  it("returns an object satisfying RedisClient", () => {
+    // We can't connect to a real server, but we can verify the shape
+    const client = createClientFromUrl("redis://localhost:6379");
+    expect(typeof client.eval).toBe("function");
+    expect(typeof client.ping).toBe("function");
+    expect(typeof client.get).toBe("function");
+    expect(typeof client.set).toBe("function");
+    expect(typeof client.del).toBe("function");
+    expect(typeof client.quit).toBe("function");
+    // ConnectableRedisClient extras
+    expect(typeof client.connect).toBe("function");
+    expect(typeof client.disconnect).toBe("function");
+    // Clean up the lazy connection (never opened)
+    client.disconnect();
   });
 });
 

--- a/shared/redis/tests/health.test.ts
+++ b/shared/redis/tests/health.test.ts
@@ -23,4 +23,12 @@ describe("checkRedisHealth", () => {
     };
     expect(await checkRedisHealth(client, 50)).toBe(false);
   });
+
+  it("returns false when ping returns a non-PONG response", async () => {
+    const client: RedisClient = {
+      ...createMemoryClient(),
+      ping: () => Promise.resolve("NOT_PONG"),
+    };
+    expect(await checkRedisHealth(client)).toBe(false);
+  });
 });

--- a/shared/redis/tests/service.test.ts
+++ b/shared/redis/tests/service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "@effect/vitest";
 import { it as vitestIt } from "vitest";
 import { Effect } from "effect";
-import { Redis, RedisMemoryLive, _sanitizeCause } from "../src/service";
+import { Redis, RedisMemoryLive, sanitizeCause } from "../src/service";
 
 describe("RedisMemoryLive", () => {
   it.effect("provides the Redis service with a working client", () =>
@@ -48,21 +48,21 @@ describe("RedisMemoryLive", () => {
 describe("sanitizeCause (S-M3)", () => {
   vitestIt("redacts credentials from redis:// URLs", () => {
     const err = new Error("connect ECONNREFUSED redis://admin:s3cret@redis.example.com:6379");
-    expect(_sanitizeCause(err)).toBe(
+    expect(sanitizeCause(err)).toBe(
       "connect ECONNREFUSED redis://[REDACTED]@redis.example.com:6379",
     );
   });
 
   vitestIt("redacts credentials from rediss:// URLs", () => {
     const err = new Error("failed: rediss://user:pass@host:6380/0");
-    expect(_sanitizeCause(err)).toBe("failed: rediss://[REDACTED]@host:6380/0");
+    expect(sanitizeCause(err)).toBe("failed: rediss://[REDACTED]@host:6380/0");
   });
 
   vitestIt("passes through messages without URLs", () => {
-    expect(_sanitizeCause(new Error("timeout"))).toBe("timeout");
+    expect(sanitizeCause(new Error("timeout"))).toBe("timeout");
   });
 
   vitestIt("handles non-Error causes", () => {
-    expect(_sanitizeCause("raw string error")).toBe("raw string error");
+    expect(sanitizeCause("raw string error")).toBe("raw string error");
   });
 });

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -16,7 +16,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] S-H4 — PKCE now mandatory at `/token`: `state` and `code_verifier` required for `authorization_code` grants; unknown/expired state returns 400; redirect_uri must match the value stored at `/authorize` (S-M9 RFC 6749 §4.1.3)
 - [x] S-H5 — Legacy unauth'd passkey path removed: `resolvePasskeyEnrollPrincipal` now returns 401 when `Authorization` header is absent. Hosted `/authorize` HTML passkey-enrollment prompt removed (passkey enrollment requires auth; users enrol through first-party apps). `console.warn` deprecation log removed. `SimpleWebAuthn` script tag removed from hosted HTML.
 - [ ] ARC token verification middleware on internal graph routes (`/graph/internal/*`) — see [[arc-tokens]], [[arc-token-debugging]]
-- [ ] Redis migration — Phase 2 (`@shared/redis` package) done; Phase 3 (wire up rate limiters) is next — see [[redis]]
+- [x] Redis migration — Phase 3 (wire up rate limiters) done: `createRedisAuthRateLimiters()` + `createRedisGraphRateLimiter()` factories in `osn/core`, env-driven backend selection in `osn/app` (`REDIS_URL` → Redis, unset → in-memory), 10 integration tests. Resolves S-M2 for production. Phase 4 (auth state migration) is next — see [[redis]]
 
 ---
 
@@ -249,11 +249,13 @@ Subsumes: S-M2, S-M8, P-W1, P-W4, S-L18, S-L23. See [[rate-limiting]] for curren
 - [x] Tests: Lua script atomicity, window expiry, key independence, connection failure fallback — 13 tests across 3 files
 
 **Phase 3 — Wire up**
-- [ ] Add `@shared/redis` dependency to `osn/core/package.json`
-- [ ] Construct `RedisLive` layer in `osn/app/src/index.ts`; env-driven backend selection (Redis when `REDIS_URL` set, in-memory otherwise)
-- [ ] Migrate all 11 auth rate limiter instances (`osn/core/src/routes/auth.ts`) to Redis backend
-- [ ] Migrate graph rate limiter (`osn/core/src/routes/graph.ts`) to Redis backend
-- [ ] Update CLAUDE.md Rate Limiting section to document the two-backend model
+- [x] Add `@shared/redis` dependency to `osn/core/package.json` and `osn/app/package.json`
+- [x] `createClientFromUrl()` factory in `@shared/redis/client` — encapsulates ioredis constructor
+- [x] `createRedisAuthRateLimiters(client)` + `createRedisGraphRateLimiter(client)` factories in `osn/core/src/lib/redis-rate-limiters.ts`
+- [x] Env-driven backend selection in `osn/app/src/index.ts`: `REDIS_URL` → Redis with startup health check; unset → in-memory fallback; graceful fallback on connection failure
+- [x] All 12 rate limiters (11 auth + 1 graph) now use Redis backends when available
+- [x] 10 new integration tests verifying Redis-backed limiters integrate with route factories
+- [x] Updated CLAUDE.md Rate Limiting section + [[rate-limiting]] wiki page to document the two-backend model
 
 **Phase 4 — Auth state migration (S-M8, follow-up)**
 - [ ] `otpStore` → Redis with TTL (resolves S-M8 partial, P-W4 partial)
@@ -306,7 +308,7 @@ Address **High** items before any non-local deployment.
 ### Medium
 
 - [ ] S-M1 — `verifyAccessToken` rejects tokens missing `handle` claim — old tokens 401 silently; treat missing `handle` as `null` during transition period
-- [ ] S-M2 — In-memory rate limiter resets on restart/deploy — migrate to Redis shared counter. See **Platform > Infrastructure > Redis Migration** for the full plan (phases 1–3). Cross-refs: S-M8, P-W1, P-W4, S-L18, S-L23 — see [[rate-limiting]], [[redis]]
+- [x] S-M2 — In-memory rate limiter resets on restart/deploy — migrated to Redis shared counter (Phase 3). All 12 rate limiters now use Redis when `REDIS_URL` is set, with in-memory fallback. Cross-refs: S-M8 (Phase 4), P-W1 (Phase 1), P-W4 (Phase 4), S-L18 (Phase 1), S-L23 (Phase 4) — see [[rate-limiting]], [[redis]]
 - [ ] S-M3 — No "resend code" button after registration OTP; if SMTP fails, handle/email are claimed with no recovery path. Partly mitigated by the new flow's "refuse to overwrite a non-expired pending entry" policy (the user retries via the existing pending entry, no new email is sent), but a true resend button is still needed.
 - [ ] S-M4 — Legacy `POST /register` (unverified email) returns raw `String(catch)` error — can expose Drizzle constraint internals. The new `/register/{begin,complete}` routes already use the `publicError()` mapper from `routes/auth.ts`; extend the same mapper to the legacy endpoint and to all other routes that still use `String(e)`.
 - [ ] S-M5 — `displayName` embedded in JWT (1h TTL) — stale after profile update; `createdByName` on events reflects old value until token expires

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -347,6 +347,8 @@ Address **High** items before any non-local deployment.
 - [x] S-M38 — `@shared/redis` `RedisLive` logs raw connection error cause which may contain credentials from `REDIS_URL`. Fixed: `sanitizeCause()` redacts `redis://user:pass@` patterns before logging. — see [[redis]]
 - [x] S-M39 — `@shared/redis` rate limiter key built from unsanitised input — namespace validated at construction (`/^[a-zA-Z0-9_:.-]+$/`), keys >256 bytes denied. — see [[redis]]
 - [x] S-M40 — `@shared/redis` `RedisLive` does not enforce TLS. Fixed: logs warning when `REDIS_URL` lacks `rediss://` and `NODE_ENV=production`. — see [[redis]]
+- [x] S-M41 — `createClientFromUrl()` bypassed the TLS warning established in `RedisLive` (S-M40). Fixed: `initRedisClient()` in `osn/app/src/redis.ts` checks `NODE_ENV=production` + `rediss://` and logs a warning, matching the `RedisLive` posture. — see [[redis]], [[rate-limiting]]
+- [x] S-M42 — `initRedisClient()` logged raw `cause.message` on Redis connection failure, potentially leaking `REDIS_URL` credentials. Fixed: error messages are passed through `sanitizeCause()` before logging, matching the redaction in `RedisLive`. — see [[redis]]
 
 ### Low
 
@@ -379,6 +381,8 @@ Address **High** items before any non-local deployment.
 - [x] S-L20 — `loadConfig` silently classified production deploys as `dev` if operators forgot to set `OSN_ENV=production` (Bun leaves `NODE_ENV` empty by default), enabling pretty-printing, 100% trace sampling, and any future dev-only code paths in prod. Fixed: `loadConfig` now throws when `OSN_ENV=production` in the environment but the resolved env differs, refusing to boot with a mismatched environment. Operators must be explicit about production classification.
 - [x] S-L25 — `createRateLimiter` was exported from the `@osn/core` barrel, letting downstream consumers construct limiters with arbitrary config (e.g. `maxRequests: Infinity`) and inject them to disable rate limiting. Fixed: removed from barrel; only `RateLimiterBackend` type + default factories are public.
 - [x] S-L26 — No runtime validation on injected `RateLimiterBackend` shape — a misconfigured DI object would cause `TypeError: check is not a function` at request time. Fixed: `createAuthRoutes` and `createGraphRoutes` validate every limiter slot at construction time, failing fast at boot.
+- [x] S-L27 — `initRedisClient()` fail-open startup fallback weakens rate limiting in multi-replica production (each process gets independent in-memory counters). Fixed: `REDIS_REQUIRED=true` env var added — when set, process exits on Redis failure instead of falling back. Operators can choose availability vs rate-limit integrity. — see [[redis]]
+- [x] S-L28 — `createClientFromUrl()` used eager ioredis connection, allowing zombie connections on health-check failure. Fixed: `lazyConnect: true` + explicit `connect()` / `disconnect()` lifecycle via `ConnectableRedisClient` interface. — see [[redis]]
 
 ---
 
@@ -400,7 +404,7 @@ Address **High** items before any non-local deployment.
 - [ ] P-W11 — `beginRegistration` and the legacy `registerUser` issue two parallel `findUserByEmail` + `findUserByHandle` queries instead of a single `WHERE email = ? OR handle = ?` — doubles the DB latency component on a hot signup path. Add a `findUserByEmailOrHandle` helper.
 - [x] P-W16 — Missing index on `close_friends.friend_id` caused table scan in `getCloseFriendsOfBatch` and `removeConnection` cleanup — fixed: added `close_friends_friend_idx`
 - [x] P-W17 — `removeConnection` and `blockUser` multi-step mutations not wrapped in a transaction — fixed: both now use `db.transaction()`
-- [x] P-W18 — `@shared/redis` `wrapIoRedis` sent full Lua script body on every EVAL call. Fixed: transparent EVALSHA caching with NOSCRIPT fallback — see [[redis]]
+- [x] P-W18 — `@shared/redis` `wrapIoRedis` sent full Lua script body on every EVAL call. Fixed: transparent EVALSHA caching with NOSCRIPT fallback — see [[redis]]. Further improved: SHA now computed eagerly on first sight of each script (P-W2 follow-up) and EVALSHA tried first on every call.
 - [x] P-W19 — `@shared/redis` `createMemoryClient` had no expiry sweep (unbounded Map growth). Fixed: proactive sweep when store exceeds `maxEntries` cap, mirroring `osn/core` rate limiter pattern — see [[redis]]
 - [ ] P-W5 — Batch status-transition `UPDATE`s in `listEvents`/`listTodayEvents` (N individual writes today)
 - [x] P-W6 — N+1 queries in graph list functions — replaced with `inArray` batch fetches
@@ -420,6 +424,7 @@ Address **High** items before any non-local deployment.
 - [x] P-I4 — `getCloseFriendsOfBatch` had no upper bound on `userIds` array size — fixed: clamped to `MAX_BATCH_SIZE` (1000)
 - [x] P-I14 — `@shared/redis` `checkRedisHealth` timeout timer leaked on success path. Fixed: `clearTimeout` in `.finally()` — see [[redis]]
 - [x] P-I15 — `@shared/redis` `RedisLive` startup ping had no timeout (indefinite hang on unresponsive Redis). Fixed: 5s timeout with `Promise.race` — see [[redis]]
+- [x] P-I16 — `void Effect.runPromise(...)` fire-and-forget log statements in `initRedisClient()` could swallow observability bootstrap errors. Fixed: warning-level logs are now `await`-ed; info-level remain fire-and-forget. — see [[redis]]
 - [ ] P-I3 — `new TextEncoder()` allocated per `verifyPkceChallenge` call — move to module scope
 - [ ] P-I4 — `AuthProvider` reconstructs Effect `Layer` on every render — wrap with `createMemo`
 - [ ] P-I5 — `completePasskeyLogin` calls `findUserByEmail` redundantly — `pk.userId` already on passkey row

--- a/wiki/systems/rate-limiting.md
+++ b/wiki/systems/rate-limiting.md
@@ -25,22 +25,39 @@ finding-ids:
   - P-W16
 packages:
   - "@osn/core"
+  - "@shared/redis"
+  - "@osn/app"
 last-reviewed: 2026-04-12
 ---
 
 # Rate Limiting
 
-OSN uses **per-IP fixed-window rate limiting** on all auth endpoints. The implementation lives in [rate-limit.ts](../osn/core/src/lib/rate-limit.ts) and is consumed by `createAuthRoutes` in [auth.ts](../osn/core/src/routes/auth.ts).
+OSN uses **per-IP fixed-window rate limiting** on all auth endpoints and **per-user** limiting on graph write endpoints. Two backends are supported: **Redis** (production, cross-process) and **in-memory** (local dev fallback).
 
 ## Architecture
 
 ```
-osn/core/src/lib/rate-limit.ts     # Generic createRateLimiter + getClientIp
-osn/core/src/routes/auth.ts        # 11 limiter instances, one per endpoint group
-osn/core/src/metrics.ts            # osn.auth.rate_limited counter
+osn/core/src/lib/rate-limit.ts         # RateLimiterBackend interface + in-memory createRateLimiter + getClientIp
+osn/core/src/lib/redis-rate-limiters.ts # createRedisAuthRateLimiters() + createRedisGraphRateLimiter()
+osn/core/src/routes/auth.ts            # 11 limiter instances, one per endpoint group
+osn/core/src/routes/graph.ts           # graph write rate limiter (60 req/user/min)
+osn/core/src/metrics.ts                # osn.auth.rate_limited counter
+osn/app/src/index.ts                   # Composition root: env-driven Redis/memory backend selection
+shared/redis/src/rate-limiter.ts       # createRedisRateLimiter() — Lua INCR+PEXPIRE
 shared/observability/src/metrics/
-  attrs.ts                          # AuthRateLimitedEndpoint bounded union
+  attrs.ts                              # AuthRateLimitedEndpoint bounded union
 ```
+
+## Backend Selection
+
+At startup, `osn/app/src/index.ts` selects the rate limiter backend:
+
+| `REDIS_URL` env var | Backend | Behaviour |
+|---------------------|---------|-----------|
+| Set | Redis via ioredis | Atomic Lua script (INCR+PEXPIRE), shared across processes, survives restarts |
+| Unset | In-memory `createMemoryClient()` | Same semantics, process-local, resets on restart |
+
+If `REDIS_URL` is set but Redis is unreachable at startup, the app falls back to in-memory with a warning log. Individual rate limit checks are always **fail-closed** (S-M36) — a Redis error during `check()` denies the request.
 
 ## When to Add Rate Limiting
 
@@ -127,10 +144,9 @@ Expired entries are evicted on every `check()` call when at least one window has
 
 ## Known Limitations
 
-- **In-memory only** -- resets on restart; not safe for multi-process. S-M2 tracks migration to a shared counter ([[redis|Redis]] / Cloudflare Durable Objects) for horizontal scaling.
 - **Trusts `X-Forwarded-For`** -- clients can spoof the header without a trusted reverse proxy. S-M34 tracks adding a `trustProxy` config flag.
 - **Fixed window** -- a burst at the window boundary can allow 2x the limit. Acceptable for auth endpoints; sliding window is overkill for current traffic.
-- **Proactive sweep** -- expired entries are evicted on every `check()` call when at least one window has elapsed since the last sweep. The `maxEntries` cap is a hard backstop; periodic sweeping keeps memory deterministic under normal load.
+- **In-memory fallback** -- when `REDIS_URL` is unset (or Redis unreachable at startup), rate limits are process-local and reset on restart. S-M2 is resolved for production (Redis-backed) but the dev fallback retains the limitation by design.
 
 ## Security Finding History
 
@@ -138,7 +154,7 @@ Expired entries are evicted on every `check()` call when at least one window has
 |----|--------|-------------|
 | S-H1 | Fixed | Rate limit all auth endpoints (per-IP fixed-window) |
 | S-H2 | Fixed | `/handle/:handle` rate limited at 10 req/IP/min |
-| S-M2 | Open | In-memory rate limiter resets on restart -- migrate to Redis |
+| S-M2 | Fixed | In-memory rate limiter resets on restart -- migrated to Redis (Phase 3) |
 | S-M34 | Open | Trusts `X-Forwarded-For` without reverse-proxy guarantee |
 | S-M36 | Fixed | Async backend rejection was fail-open (now fail-closed) |
 | P-W1 | Fixed | Graph rate-limit store grew without bound (now uses shared limiter) |
@@ -146,9 +162,12 @@ Expired entries are evicted on every `check()` call when at least one window has
 
 ## Source Files
 
-- [osn/core/src/lib/rate-limit.ts](../osn/core/src/lib/rate-limit.ts) -- rate limiter implementation
+- [osn/core/src/lib/rate-limit.ts](../osn/core/src/lib/rate-limit.ts) -- `RateLimiterBackend` interface + in-memory implementation
+- [osn/core/src/lib/redis-rate-limiters.ts](../osn/core/src/lib/redis-rate-limiters.ts) -- Redis-backed rate limiter factories
 - [osn/core/src/routes/auth.ts](../osn/core/src/routes/auth.ts) -- auth route limiter instances
 - [osn/core/src/routes/graph.ts](../osn/core/src/routes/graph.ts) -- graph route rate limiting
 - [osn/core/src/metrics.ts](../osn/core/src/metrics.ts) -- `osn.auth.rate_limited` metric
+- [osn/app/src/index.ts](../osn/app/src/index.ts) -- composition root with env-driven Redis/memory selection
+- [shared/redis/src/rate-limiter.ts](../shared/redis/src/rate-limiter.ts) -- `createRedisRateLimiter()` Lua script backend
 - [shared/observability/src/metrics/attrs.ts](../shared/observability/src/metrics/attrs.ts) -- `AuthRateLimitedEndpoint` type
 - [CLAUDE.md](../CLAUDE.md) -- "Rate Limiting" section

--- a/wiki/systems/redis.md
+++ b/wiki/systems/redis.md
@@ -59,15 +59,18 @@ Created the `@shared/redis` package following the `@shared/db-utils` pattern.
 - [x] Dev-mode: in-memory fallback when `REDIS_URL` is unset -- `createMemoryClient()` + `RedisMemoryLive` layer
 - [x] Tests: 13 tests across 3 files (rate limiter, health probe, Effect service layer)
 
-## Phase 3: Wire Up
+## Phase 3: Wire Up (DONE)
 
-Connect the Redis package to the existing rate limiting infrastructure.
+Connected the Redis package to the existing rate limiting infrastructure.
 
-- [ ] Add `@shared/redis` dependency to `osn/core/package.json`
-- [ ] Construct `RedisLive` layer in `osn/app/src/index.ts`; env-driven backend selection (Redis when `REDIS_URL` set, in-memory otherwise)
-- [ ] Migrate all 11 auth rate limiter instances (`osn/core/src/routes/auth.ts`) to Redis backend
-- [ ] Migrate graph rate limiter (`osn/core/src/routes/graph.ts`) to Redis backend
-- [ ] Update CLAUDE.md Rate Limiting section to document the two-backend model
+- [x] Add `@shared/redis` dependency to `osn/core/package.json` and `osn/app/package.json`
+- [x] `createClientFromUrl()` factory in `@shared/redis/client` — encapsulates ioredis constructor so consumers don't need ioredis as a direct dep
+- [x] `createRedisAuthRateLimiters(client)` in `osn/core/src/lib/redis-rate-limiters.ts` — builds all 11 auth rate limiters with `auth:{endpoint}` namespaces
+- [x] `createRedisGraphRateLimiter(client)` in same file — builds graph write limiter with `graph:write` namespace
+- [x] Env-driven backend selection in `osn/app/src/index.ts`: `REDIS_URL` set → Redis-backed limiters; unset → in-memory fallback; startup health check with graceful fallback + logging
+- [x] All 12 rate limiters (11 auth + 1 graph) now use Redis backends when available — fail-closed on individual check errors (S-M36), fail-open on infrastructure (startup fallback to in-memory)
+- [x] Integration tests: 10 new tests verifying Redis-backed limiters integrate with route factories
+- [x] Updated CLAUDE.md Rate Limiting section to document the two-backend model
 
 ## Phase 4: Auth State Migration (S-M8, follow-up)
 
@@ -124,7 +127,7 @@ Decision deferred until deploying beyond localhost.
 
 | ID | Phase | Description |
 |----|-------|-------------|
-| S-M2 | 3 | In-memory rate limiter resets on restart -- umbrella finding |
+| S-M2 | 3 (done) | In-memory rate limiter resets on restart -- umbrella finding (Redis-backed when REDIS_URL set) |
 | S-M8 | 4 | Auth state in process memory -- lost on restart |
 | P-W1 | 1 (done) | Graph rate-limit store grew without bound |
 | P-W4 | 4 | Auth Maps never evict expired entries |
@@ -134,12 +137,14 @@ Decision deferred until deploying beyond localhost.
 ## Source Files
 
 - [shared/redis/src/index.ts](../shared/redis/src/index.ts) -- `@shared/redis` public API (Phase 2)
-- [shared/redis/src/client.ts](../shared/redis/src/client.ts) -- `RedisClient` interface, `wrapIoRedis()`, `createMemoryClient()` (Phase 2)
+- [shared/redis/src/client.ts](../shared/redis/src/client.ts) -- `RedisClient` interface, `wrapIoRedis()`, `createMemoryClient()`, `createClientFromUrl()` (Phase 2+3)
 - [shared/redis/src/service.ts](../shared/redis/src/service.ts) -- `Redis` Context.Tag, `RedisLive`, `RedisMemoryLive` layers (Phase 2)
 - [shared/redis/src/rate-limiter.ts](../shared/redis/src/rate-limiter.ts) -- `createRedisRateLimiter()` with Lua script (Phase 2)
 - [shared/redis/src/health.ts](../shared/redis/src/health.ts) -- `checkRedisHealth()` probe (Phase 2)
 - [shared/redis/src/errors.ts](../shared/redis/src/errors.ts) -- `RedisError` tagged error (Phase 2)
 - [osn/core/src/lib/rate-limit.ts](../osn/core/src/lib/rate-limit.ts) -- `RateLimiterBackend` interface (Phase 1)
-- [osn/core/src/routes/auth.ts](../osn/core/src/routes/auth.ts) -- 11 auth rate limiter instances to migrate
-- [osn/core/src/routes/graph.ts](../osn/core/src/routes/graph.ts) -- graph rate limiter to migrate
+- [osn/core/src/lib/redis-rate-limiters.ts](../osn/core/src/lib/redis-rate-limiters.ts) -- `createRedisAuthRateLimiters()`, `createRedisGraphRateLimiter()` factories (Phase 3)
+- [osn/core/src/routes/auth.ts](../osn/core/src/routes/auth.ts) -- 11 auth rate limiter instances (wired to Redis in Phase 3)
+- [osn/core/src/routes/graph.ts](../osn/core/src/routes/graph.ts) -- graph rate limiter (wired to Redis in Phase 3)
+- [osn/app/src/index.ts](../osn/app/src/index.ts) -- composition root: env-driven Redis client + rate limiter wiring (Phase 3)
 - [TODO.md](../TODO.md) -- "Redis Migration" section


### PR DESCRIPTION
## Summary

- **Wire all 12 rate limiters (11 auth + 1 graph) to Redis** when `REDIS_URL` is set, with in-memory fallback when unset — completing Phase 3 of the Redis migration (S-M2)
- **Add `createRedisAuthRateLimiters()` and `createRedisGraphRateLimiter()`** factories in `@osn/core` with proper namespace isolation (`auth:register_begin`, `graph:write`, etc.)
- **Add `createClientFromUrl()`** to `@shared/redis` with safe connection defaults (`lazyConnect`, `connectTimeout`, `maxRetriesPerRequest`) via `ConnectableRedisClient` interface
- **Env-driven backend selection** in `@osn/app`: TLS warning in production (S-M41), credential redaction in logs (S-M42), `REDIS_REQUIRED=true` for fail-closed startup (S-L27), startup health check with graceful fallback
- **EVALSHA-first optimization** in `wrapIoRedis` with eager SHA caching (P-W2)

## Workspaces affected

- `@osn/core` — rate limiter factories + exports
- `@osn/app` — composition root wiring + extracted `redis.ts` init module
- `@shared/redis` — `createClientFromUrl()`, `ConnectableRedisClient`, `sanitizeCause` export, EVALSHA-first eval

## Decisions & issues

**[S-M41] — TLS warning parity with RedisLive**
- **Issue:** `createClientFromUrl()` bypassed the TLS check established in `RedisLive` (S-M40). Production `redis://` URLs proceeded silently.
- **Why:** Unencrypted Redis connections carrying rate-limit state are exposed to network eavesdropping (OWASP A02/A04).
- **Solution:** `initRedisClient()` checks `NODE_ENV === "production"` + `rediss://` scheme and logs a structured warning, matching `RedisLive` posture.
- **Rationale:** Maintains parity — operators get a clear signal regardless of which init path is used.

**[S-M42] — Credential redaction in error logs**
- **Issue:** The catch block in `initRedisClient()` logged raw `cause.message`, which could contain embedded `REDIS_URL` credentials when ioredis surfaces the URL in connection errors.
- **Why:** Credentials in structured logs violate OWASP A04 and propagate to Grafana Cloud.
- **Solution:** Error messages are passed through `sanitizeCause()` (now exported from `@shared/redis`) before logging.
- **Rationale:** Ensures credentials never reach the log pipeline regardless of init path.

**[S-L27] — REDIS_REQUIRED env var for fail-closed startup**
- **Issue:** Silent fallback to in-memory on Redis failure multiplies effective rate limits by replica count in production.
- **Why:** An attacker causing Redis unavailability forces degraded per-process rate limiting.
- **Solution:** `REDIS_REQUIRED=true` causes `process.exit(1)` on Redis failure instead of fallback. Operators choose availability vs rate-limit integrity.
- **Rationale:** Design trade-off made explicit — security-sensitive deployments opt into fail-closed startup.

**[S-L28 / P-W1] — lazyConnect + explicit lifecycle**
- **Issue:** `new IORedis(url)` eagerly connected in background. On health-check failure, `quit()` raced against reconnect attempts, potentially leaving zombie connections.
- **Why:** Leaked connections waste file descriptors, generate error logs, and can trip server connection limits.
- **Solution:** `createClientFromUrl()` now uses `lazyConnect: true`, `connectTimeout: 5000`, `maxRetriesPerRequest: 1`. Returns `ConnectableRedisClient` with explicit `connect()` / `disconnect()`. The failure path calls `disconnect()` to fully tear down the connection state machine.
- **Rationale:** Deterministic connection management avoids zombie connections and unhandled-rejection edge cases.

**[P-W2] — Eager SHA caching in wrapIoRedis**
- **Issue:** SHA-1 was computed after each full EVAL. On NOSCRIPT retry, the hash was recomputed. First call always sent full script body.
- **Why:** Minor per-cold-start cost (12 SHA computations) and potential correctness risk if SHA mismatches occurred.
- **Solution:** SHA computed eagerly on first sight of each script via `ensureSha()`. EVALSHA is now tried first on every call, with EVAL as NOSCRIPT fallback only.
- **Rationale:** Eliminates per-request crypto overhead and avoids permanent EVAL-only hot path on SHA mismatch.

**[P-I1] — Single connection for 12 rate limiters**
- **Issue:** All rate limiters share one Redis connection. Under high concurrency, requests serialize on the command queue.
- **Why:** ioredis internally pipelines queued commands, so this is adequate for 13 limiters.
- **Solution:** No action taken — documented for future consideration when Redis usage expands.
- **Rationale:** Premature optimization. Connection pool warranted only when adding sessions/caching.

**[P-I2] — Fire-and-forget startup logs**
- **Issue:** `void Effect.runPromise(...)` on warning-level logs silently swallowed observability bootstrap errors.
- **Why:** If the logger fails, the fallback path becomes invisible to operators.
- **Solution:** Warning and error logs are now `await`-ed. Info-level logs remain fire-and-forget.
- **Rationale:** Ensures the critical fallback path is fully observable without adding meaningful startup latency.

## Test plan

- [x] 268 `@osn/core` tests pass (including 11 new Redis rate limiter + integration tests)
- [x] 37 `@shared/redis` tests pass (including updated EVALSHA-first tests + non-PONG health check)
- [x] 10 `@osn/app` tests pass (including 7 new `initRedisClient` branch tests)
- [x] All 14 packages type-check clean (`bun run check`)
- [x] Lint clean (`bun run lint`)
- [x] Format clean (`bun run fmt:check`)
- [ ] Verify with `REDIS_URL` set against a real Redis instance (manual)
- [ ] Verify `REDIS_REQUIRED=true` exits on connection failure (manual)
- [ ] Verify without `REDIS_URL` — should behave identically to before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVPrwMQLK3N93m7kvr5gDo