### PR TITLE
feat(zap): add messaging backend for event chat integration

### DIFF
--- a/.changeset/zap-backend-setup.md
+++ b/.changeset/zap-backend-setup.md
@@ -1,0 +1,13 @@
+---
+"@zap/db": minor
+"@zap/api": minor
+"@pulse/db": minor
+"@pulse/api": minor
+---
+
+Add Zap messaging backend with chat and message services for event chat integration
+
+- Create `@zap/db` package with chats, chat_members, and messages schema (Drizzle + SQLite)
+- Create `@zap/api` package with Elysia server (port 3002), chat/message REST routes, Effect services, and observability metrics
+- Add `chatId` column to Pulse events schema for event-chat linking
+- Add `zapBridge` service in Pulse for provisioning event chats and managing membership

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Monorepo organised by domain. Four directories, four prefixes — see `[[wiki/ar
 |-----|--------|-----------------|
 | `osn/` | `@osn/*` | Identity stack (auth, graph, SDK, crypto, landing) |
 | `pulse/` | `@pulse/*` | Events stack (app, API, DB) |
-| `zap/` | `@zap/*` | Messaging stack (placeholder) |
+| `zap/` | `@zap/*` | Messaging stack (API on port 3002, DB) |
 | `shared/` | `@shared/*` | Cross-cutting utilities |
 
 ## Tech (one-liner)
@@ -128,6 +128,8 @@ bun run --cwd osn/client test:run         # run OSN client SDK tests once
 bun run --cwd osn/ui test:run             # run shared auth component tests once
 bun run --cwd pulse/db test:run           # run Pulse DB schema tests once
 bun run --cwd pulse/api test              # watch mode
+bun run --cwd zap/db test:run             # run Zap DB schema tests once
+bun run --cwd zap/api test:run            # run Zap API service tests once
 
 # Code quality
 bun run lint             # oxlint

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "osn/app": {
       "name": "@osn/app",
-      "version": "0.2.4",
+      "version": "0.3.1",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -50,7 +50,7 @@
     },
     "osn/core": {
       "name": "@osn/core",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/crypto": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.7.4",
+      "version": "0.7.6",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -162,7 +162,7 @@
     },
     "pulse/app": {
       "name": "@pulse/app",
-      "version": "0.6.4",
+      "version": "0.6.6",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -246,7 +246,7 @@
     },
     "shared/redis": {
       "name": "@shared/redis",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "effect": "^3.19.19",
         "ioredis": "^5.6.0",
@@ -267,6 +267,7 @@
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
+        "@osn/core": "workspace:*",
         "@shared/observability": "workspace:*",
         "@zap/db": "workspace:*",
         "drizzle-orm": "^0.38.0",

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
         "@osn/db": "workspace:*",
         "@pulse/db": "workspace:*",
         "@shared/observability": "workspace:*",
+        "@zap/db": "workspace:*",
         "drizzle-orm": "^0.38.0",
         "effect": "^3.19.19",
         "elysia": "^1.2.0",
@@ -259,6 +260,42 @@
     "shared/typescript-config": {
       "name": "@shared/typescript-config",
       "version": "0.0.2",
+    },
+    "zap/api": {
+      "name": "@zap/api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@elysiajs/cors": "^1.4.0",
+        "@elysiajs/eden": "^1.2.0",
+        "@shared/observability": "workspace:*",
+        "@zap/db": "workspace:*",
+        "drizzle-orm": "^0.38.0",
+        "effect": "^3.19.19",
+        "elysia": "^1.2.0",
+        "jose": "^6.2.2",
+      },
+      "devDependencies": {
+        "@effect/vitest": "^0.27.0",
+        "@shared/typescript-config": "workspace:*",
+        "vitest": "^4.0.18",
+      },
+    },
+    "zap/db": {
+      "name": "@zap/db",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/db-utils": "workspace:*",
+        "drizzle-orm": "^0.38.0",
+        "effect": "^3.19.19",
+      },
+      "devDependencies": {
+        "@effect/vitest": "^0.27.0",
+        "@shared/typescript-config": "workspace:*",
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^12.5.0",
+        "drizzle-kit": "^0.30.0",
+        "vitest": "^4.0.18",
+      },
     },
   },
   "packages": {
@@ -903,6 +940,10 @@
     "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "@zap/api": ["@zap/api@workspace:zap/api"],
+
+    "@zap/db": ["@zap/db@workspace:zap/db"],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -7,7 +7,7 @@ export { createGraphRoutes, createDefaultGraphRateLimiter } from "./routes/graph
 export { createInternalGraphRoutes } from "./routes/graph-internal";
 export { createGraphService } from "./services/graph";
 export type { GraphService } from "./services/graph";
-export type { RateLimiterBackend } from "./lib/rate-limit";
+export { createRateLimiter, getClientIp, type RateLimiterBackend } from "./lib/rate-limit";
 export {
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,

--- a/pulse/api/src/services/zapBridge.ts
+++ b/pulse/api/src/services/zapBridge.ts
@@ -1,0 +1,143 @@
+/**
+ * Bridge to @zap/api for event-chat provisioning.
+ *
+ * Currently a direct in-process import of Zap service functions.
+ * When Zap moves to its own process, this file becomes an ARC-token
+ * HTTP client — single-file change, no callers affected.
+ */
+
+import { Data, Effect } from "effect";
+import { and, eq } from "drizzle-orm";
+import { events } from "@pulse/db/schema";
+import { Db } from "@pulse/db/service";
+import { Db as ZapDb } from "@zap/db/service";
+import { chats, chatMembers } from "@zap/db/schema";
+import type { Chat, ChatMember } from "@zap/db/schema";
+
+// ---------------------------------------------------------------------------
+// Tagged errors
+// ---------------------------------------------------------------------------
+
+export class ZapBridgeError extends Data.TaggedError("ZapBridgeError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Service functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Provision an event chat in Zap and link it to the Pulse event.
+ *
+ * Idempotent: if the event already has a chatId, returns the existing chat.
+ */
+export const provisionEventChat = (
+  eventId: string,
+  creatorUserId: string,
+  title: string,
+): Effect.Effect<Chat, ZapBridgeError, Db | ZapDb> =>
+  Effect.gen(function* () {
+    const pulseDb = (yield* Db).db;
+    const zapDb = (yield* ZapDb).db;
+
+    // Check if event already has a chat.
+    const eventRows = yield* Effect.tryPromise({
+      try: () =>
+        pulseDb
+          .select({ chatId: events.chatId })
+          .from(events)
+          .where(eq(events.id, eventId))
+          .limit(1) as Promise<{ chatId: string | null }[]>,
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+    if (eventRows[0]?.chatId) {
+      const existingChats = yield* Effect.tryPromise({
+        try: () =>
+          zapDb.select().from(chats).where(eq(chats.id, eventRows[0]!.chatId!)).limit(1) as Promise<
+            Chat[]
+          >,
+        catch: (cause) => new ZapBridgeError({ cause }),
+      });
+      if (existingChats[0]) return existingChats[0];
+    }
+
+    // Create the event chat in Zap DB.
+    const chatId = "chat_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+    yield* Effect.tryPromise({
+      try: () =>
+        zapDb.insert(chats).values({
+          id: chatId,
+          type: "event",
+          title,
+          eventId,
+          createdByUserId: creatorUserId,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+
+    // Add creator as admin member.
+    const memberId = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    yield* Effect.tryPromise({
+      try: () =>
+        zapDb.insert(chatMembers).values({
+          id: memberId,
+          chatId,
+          userId: creatorUserId,
+          role: "admin",
+          joinedAt: now,
+        }),
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+
+    // Link the chat to the Pulse event.
+    yield* Effect.tryPromise({
+      try: () => pulseDb.update(events).set({ chatId }).where(eq(events.id, eventId)),
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+
+    const chatRows = yield* Effect.tryPromise({
+      try: () => zapDb.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+    return chatRows[0]!;
+  }).pipe(Effect.withSpan("pulse.zap_bridge.provision_event_chat"));
+
+/**
+ * Add a user to an event chat (e.g. when they RSVP).
+ */
+export const addEventChatMember = (
+  chatId: string,
+  userId: string,
+): Effect.Effect<void, ZapBridgeError, ZapDb> =>
+  Effect.gen(function* () {
+    const zapDb = (yield* ZapDb).db;
+
+    // Check if already a member (idempotent).
+    const existing = yield* Effect.tryPromise({
+      try: () =>
+        zapDb
+          .select()
+          .from(chatMembers)
+          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.userId, userId))) as Promise<
+          ChatMember[]
+        >,
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+    if (existing.length > 0) return;
+
+    const memberId = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    yield* Effect.tryPromise({
+      try: () =>
+        zapDb.insert(chatMembers).values({
+          id: memberId,
+          chatId,
+          userId,
+          role: "member",
+          joinedAt: new Date(),
+        }),
+      catch: (cause) => new ZapBridgeError({ cause }),
+    });
+  }).pipe(Effect.withSpan("pulse.zap_bridge.add_event_chat_member"));

--- a/pulse/api/tests/helpers/db.ts
+++ b/pulse/api/tests/helpers/db.ts
@@ -26,6 +26,7 @@ export function createTestLayer() {
       join_policy TEXT NOT NULL DEFAULT 'open',
       allow_interested INTEGER NOT NULL DEFAULT 1,
       comms_channels TEXT NOT NULL DEFAULT '["email"]',
+      chat_id TEXT,
       created_by_user_id TEXT NOT NULL,
       created_by_name TEXT,
       created_by_avatar TEXT,
@@ -89,6 +90,7 @@ export interface SeedEventInput {
   joinPolicy?: "open" | "guest_list";
   allowInterested?: boolean;
   commsChannels?: ("sms" | "email")[];
+  chatId?: string;
 }
 
 export const seedEvent = (input: SeedEventInput): Effect.Effect<Event, never, Db> =>
@@ -114,6 +116,7 @@ export const seedEvent = (input: SeedEventInput): Effect.Effect<Event, never, Db
       joinPolicy: input.joinPolicy ?? "open",
       allowInterested: input.allowInterested ?? true,
       commsChannels: JSON.stringify(input.commsChannels ?? ["email"]),
+      chatId: input.chatId ?? null,
       createdByUserId: input.createdByUserId ?? "usr_alice",
       createdByName: input.createdByName ?? "Alice",
       createdByAvatar: input.createdByAvatar ?? null,

--- a/pulse/api/tests/services/calendar.test.ts
+++ b/pulse/api/tests/services/calendar.test.ts
@@ -21,6 +21,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     joinPolicy: "open",
     allowInterested: true,
     commsChannels: '["email"]',
+    chatId: null,
     createdByUserId: "usr_alice",
     createdByName: "Alice",
     createdByAvatar: null,

--- a/pulse/api/tests/services/zapBridge.test.ts
+++ b/pulse/api/tests/services/zapBridge.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as pulseSchema from "@pulse/db/schema";
+import { events } from "@pulse/db/schema";
+import { Db as PulseDb } from "@pulse/db/service";
+import * as zapSchema from "@zap/db/schema";
+import { chatMembers } from "@zap/db/schema";
+import { Db as ZapDb } from "@zap/db/service";
+import { eq } from "drizzle-orm";
+import { provisionEventChat, addEventChatMember } from "../../src/services/zapBridge";
+
+function createDualTestLayer() {
+  const pulseSqlite = new Database(":memory:");
+  pulseSqlite.run(`
+    CREATE TABLE events (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      description TEXT,
+      location TEXT,
+      venue TEXT,
+      category TEXT,
+      start_time INTEGER NOT NULL,
+      end_time INTEGER,
+      status TEXT NOT NULL DEFAULT 'upcoming',
+      image_url TEXT,
+      latitude REAL,
+      longitude REAL,
+      visibility TEXT NOT NULL DEFAULT 'public',
+      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
+      join_policy TEXT NOT NULL DEFAULT 'open',
+      allow_interested INTEGER NOT NULL DEFAULT 1,
+      comms_channels TEXT NOT NULL DEFAULT '["email"]',
+      chat_id TEXT,
+      created_by_user_id TEXT NOT NULL,
+      created_by_name TEXT,
+      created_by_avatar TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  const pulseDb = drizzle(pulseSqlite, { schema: pulseSchema });
+
+  const zapSqlite = new Database(":memory:");
+  zapSqlite.run(`
+    CREATE TABLE chats (
+      id TEXT PRIMARY KEY, type TEXT NOT NULL, title TEXT, event_id TEXT,
+      created_by_user_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    )
+  `);
+  zapSqlite.run(`
+    CREATE TABLE chat_members (
+      id TEXT PRIMARY KEY, chat_id TEXT NOT NULL REFERENCES chats(id),
+      user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+      joined_at INTEGER NOT NULL, UNIQUE (chat_id, user_id)
+    )
+  `);
+  zapSqlite.run(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY, chat_id TEXT NOT NULL REFERENCES chats(id),
+      sender_user_id TEXT NOT NULL, ciphertext TEXT NOT NULL, nonce TEXT NOT NULL,
+      created_at INTEGER NOT NULL, expires_at INTEGER
+    )
+  `);
+  const zapDb = drizzle(zapSqlite, { schema: zapSchema });
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(PulseDb, { db: pulseDb }),
+    Layer.succeed(ZapDb, { db: zapDb }),
+  );
+  return { layer, pulseDb, zapDb };
+}
+
+const seedEvent = (
+  pulseDb: ReturnType<typeof createDualTestLayer>["pulseDb"],
+  id: string,
+  createdByUserId: string,
+): Effect.Effect<void> => {
+  const now = new Date();
+  return Effect.promise(() =>
+    pulseDb.insert(events).values({
+      id,
+      title: "Test Event",
+      startTime: new Date("2030-06-01T10:00:00.000Z"),
+      createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  ).pipe(Effect.asVoid);
+};
+
+describe("zapBridge", () => {
+  describe("provisionEventChat", () => {
+    it.effect("provisions a new event chat and links it to the event", () => {
+      const { layer, pulseDb, zapDb } = createDualTestLayer();
+      return Effect.gen(function* () {
+        yield* seedEvent(pulseDb, "evt_test1", "usr_alice");
+
+        const chat = yield* provisionEventChat("evt_test1", "usr_alice", "Event Chat");
+        expect(chat.id).toMatch(/^chat_/);
+        expect(chat.type).toBe("event");
+        expect(chat.title).toBe("Event Chat");
+        expect(chat.eventId).toBe("evt_test1");
+
+        // Verify the event now has a chatId.
+        const eventRows = yield* Effect.promise(() =>
+          pulseDb.select({ chatId: events.chatId }).from(events).where(eq(events.id, "evt_test1")),
+        );
+        expect(eventRows[0]!.chatId).toBe(chat.id);
+
+        // Verify creator was added as admin.
+        const members = yield* Effect.promise(() =>
+          zapDb.select().from(chatMembers).where(eq(chatMembers.chatId, chat.id)),
+        );
+        expect(members).toHaveLength(1);
+        expect(members[0]!.userId).toBe("usr_alice");
+        expect(members[0]!.role).toBe("admin");
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("returns existing chat on idempotent re-provision", () => {
+      const { layer, pulseDb } = createDualTestLayer();
+      return Effect.gen(function* () {
+        yield* seedEvent(pulseDb, "evt_idem", "usr_alice");
+
+        const chat1 = yield* provisionEventChat("evt_idem", "usr_alice", "Event Chat");
+        const chat2 = yield* provisionEventChat("evt_idem", "usr_alice", "Event Chat");
+        expect(chat2.id).toBe(chat1.id);
+      }).pipe(Effect.provide(layer));
+    });
+  });
+
+  describe("addEventChatMember", () => {
+    it.effect("adds a new member to the event chat", () => {
+      const { layer, pulseDb, zapDb } = createDualTestLayer();
+      return Effect.gen(function* () {
+        yield* seedEvent(pulseDb, "evt_mem", "usr_alice");
+        const chat = yield* provisionEventChat("evt_mem", "usr_alice", "Event Chat");
+        yield* addEventChatMember(chat.id, "usr_bob");
+
+        const members = yield* Effect.promise(() =>
+          zapDb.select().from(chatMembers).where(eq(chatMembers.chatId, chat.id)),
+        );
+        expect(members).toHaveLength(2);
+        const userIds = members.map((m) => m.userId).sort();
+        expect(userIds).toEqual(["usr_alice", "usr_bob"]);
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("is idempotent for existing members", () => {
+      const { layer, pulseDb, zapDb } = createDualTestLayer();
+      return Effect.gen(function* () {
+        yield* seedEvent(pulseDb, "evt_idem2", "usr_alice");
+        const chat = yield* provisionEventChat("evt_idem2", "usr_alice", "Event Chat");
+        yield* addEventChatMember(chat.id, "usr_bob");
+        yield* addEventChatMember(chat.id, "usr_bob");
+
+        const members = yield* Effect.promise(() =>
+          zapDb.select().from(chatMembers).where(eq(chatMembers.chatId, chat.id)),
+        );
+        expect(members).toHaveLength(2);
+      }).pipe(Effect.provide(layer));
+    });
+  });
+});

--- a/pulse/db/src/schema/events.ts
+++ b/pulse/db/src/schema/events.ts
@@ -50,6 +50,11 @@ export const events = sqliteTable(
     // blasts. Must be at least one of "sms" | "email". Actual blast history
     // lives in the `event_comms` table (see rsvps/index.ts siblings).
     commsChannels: text("comms_channels").notNull().default('["email"]'),
+    // ── Chat ──────────────────────────────────────────────────────────────
+    // Opaque reference to a @zap/db chat. Populated when the organiser
+    // enables event chat (provisioned via zapBridge). NOT a foreign key —
+    // the chat lives in a different SQLite file.
+    chatId: text("chat_id"),
     createdByUserId: text("created_by_user_id").notNull(),
     createdByName: text("created_by_name"),
     createdByAvatar: text("created_by_avatar"),

--- a/pulse/db/tests/schema.test.ts
+++ b/pulse/db/tests/schema.test.ts
@@ -25,6 +25,7 @@ function createTestDb() {
       join_policy TEXT NOT NULL DEFAULT 'open',
       allow_interested INTEGER NOT NULL DEFAULT 1,
       comms_channels TEXT NOT NULL DEFAULT '["email"]',
+      chat_id TEXT,
       created_by_user_id TEXT NOT NULL,
       created_by_name TEXT,
       created_by_avatar TEXT,

--- a/pulse/db/tests/seed.test.ts
+++ b/pulse/db/tests/seed.test.ts
@@ -25,6 +25,7 @@ function createTestDb() {
       join_policy TEXT NOT NULL DEFAULT 'open',
       allow_interested INTEGER NOT NULL DEFAULT 1,
       comms_channels TEXT NOT NULL DEFAULT '["email"]',
+      chat_id TEXT,
       created_by_user_id TEXT,
       created_by_name TEXT,
       created_by_avatar TEXT,

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -7,8 +7,9 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] S-H21 — Migrated the three dev-mode `console.log` calls in `osn/core/src/services/auth.ts` (registration OTP, login OTP, magic link) to `Effect.logDebug`. Values stay interpolated into the message string so the redacting logger doesn't scrub them — that's the whole point of the dev branch. The registration path keeps its `NODE_ENV !== "production"` gate; the login OTP / magic-link branches still rely on `config.sendEmail` being unset, which is the existing behaviour (S-M22 follow-up tracks tightening that to a `NODE_ENV` gate as well). Also threaded an optional `loggerLayer` parameter through `createAuthRoutes` / `createGraphRoutes` so `@osn/app` can provide its `observabilityLayer` to per-request Effect pipelines (S-L1 — without this the new `Effect.logDebug` calls would be silently dropped at Effect's default `Info` minimum level). Coverage locked with three `it.effect` tests (T-U1) using a `Logger.replace` capture sink that asserts the literal OTP/URL appears in the message and `[REDACTED]` never does.
 - [ ] Provision Grafana Cloud free tier + wire `OTEL_EXPORTER_OTLP_ENDPOINT` + headers into deploy env — see [[observability-setup]]
 - [ ] Build first observability dashboards (HTTP RED, auth funnel, ARC verification, events CRUD) — see [[observability/overview]]
-- [ ] Zap M0 scaffold — `@zap/app` (Tauri+Solid), `@zap/api` (Elysia), `@zap/db` (Drizzle) — see [[zap]]
-- [ ] Wire Pulse event chat to Zap once M2 lands (replace `EventChatPlaceholder`)
+- [x] Zap M0 scaffold (partial) — `@zap/api` (Elysia, port 3002), `@zap/db` (Drizzle) with chat/message schema, Effect services, 33 tests. `@zap/app` (Tauri+Solid) deferred. Pulse event-chat integration via `zapBridge` + `chatId` column on events.
+- [ ] Zap route-level tests + zapBridge tests (T-R1, T-M1 from review)
+- [ ] Zap rate limiting on write endpoints (S-M1) — see [[rate-limiting]]
 - [ ] Pulse: "What's on today" default view
 - [ ] Landing page: design and content
 - [x] S-H1 — Rate limit all auth endpoints (per-IP fixed-window via `osn/core/src/lib/rate-limit.ts`; 5 req/min on begin/send endpoints, 10 req/min on verify/complete; new `osn.auth.rate_limited` metric with bounded `AuthRateLimitedEndpoint` union)
@@ -90,18 +91,18 @@ Signal Protocol lives in `@osn/crypto`, not `zap/`.
 ### M0 — Scaffold (no behaviour, just the skeleton)
 
 - [ ] `bunx create-tauri-app` for `@zap/app` (iOS target enabled, Solid template)
-- [ ] `@zap/api` workspace (Elysia + Eden, mirror `@pulse/api` layout, port TBD)
-- [ ] `@zap/db` workspace (Drizzle + SQLite, mirror `@pulse/db` layout)
+- [x] `@zap/api` workspace (Elysia + Eden, port 3002, mirror `@pulse/api` layout)
+- [x] `@zap/db` workspace (Drizzle + SQLite, mirror `@pulse/db` layout)
 - [ ] `@zap/app` consumes `@osn/client` + `@osn/ui/auth` for sign-in (re-uses the same `<SignIn>` / `<Register>` from Pulse)
-- [ ] Initial test infra (`tests/helpers/db.ts`, `createTestLayer()`) for `@zap/api` and `@zap/db`
-- [ ] Add `@zap/app`, `@zap/api`, `@zap/db` to the turbo pipeline (build / check / test)
+- [x] Initial test infra (`tests/helpers/db.ts`, `createTestLayer()`) for `@zap/api` and `@zap/db`
+- [x] Add `@zap/api`, `@zap/db` to the turbo pipeline (build / check / test)
 - [ ] Register `zap-app` and `zap-api` in `service_accounts` (ARC token issuer rows)
 
 ### M1 — 1:1 DMs (E2E)
 
 - [ ] Signal Protocol primitives in `@osn/crypto/signal` (X3DH handshake, double ratchet)
-- [ ] `@zap/db` schema: `chats`, `chat_members`, `messages`, `device_keys`, `prekey_bundles`
-- [ ] `@zap/api` routes: `POST /chats` (create DM), `POST /chats/:id/messages`, `GET /chats/:id/messages`
+- [x] `@zap/db` schema: `chats`, `chat_members`, `messages` (device_keys, prekey_bundles deferred to E2E crypto work)
+- [x] `@zap/api` routes: chat CRUD, member management, message send/list with cursor pagination
 - [ ] WebSocket transport for live message delivery (`@zap/api`)
 - [ ] Push receipt + read receipt model (defer push notifications themselves to M4)
 - [ ] `@zap/app` Socials view: chat list + message thread UI
@@ -115,7 +116,7 @@ Signal Protocol lives in `@osn/crypto`, not `zap/`.
 - [ ] `@zap/db` schema: `chat_role` (admin/member), `chat_invites`
 - [ ] Add/remove members, role transitions, invite links
 - [ ] Group-level disappearing-message defaults
-- [ ] Event chat linking: when a `@pulse/api` event is created, optionally provision a Zap group chat and stash the chat ID on the event row
+- [x] Event chat linking: `chatId` column on events, `zapBridge` provisions Zap event chat and links it to the Pulse event
 - [ ] Show linked event overview inside the chat settings sheet (read from `@pulse/api` via Eden or ARC-gated S2S)
 - [ ] Test coverage: group rekeying on member removal, race conditions on simultaneous joins
 
@@ -189,7 +190,7 @@ Signal Protocol lives in `@osn/crypto`, not `zap/`.
 - [x] OSN Core: `service_accounts` table — `service_id`, `public_key_jwk`, `allowed_scopes` (for ARC token verification)
 - [ ] OSN Core: session schema (JWT-based for now; DB storage deferred)
 - [ ] Pulse: event series schema
-- [ ] Pulse: chat/message schema (via messaging backend)
+- [x] Pulse: `chatId` column on events (links to `@zap/db` chats); full chat/message schema in `@zap/db`
 - [ ] Add indexes on `status` and `category` columns in pulse-db events schema
 
 ### Auth Client (`osn/client`)
@@ -340,6 +341,18 @@ Address **High** items before any non-local deployment.
 - [x] S-M31 — Redaction deny-list was missing user-chosen name fields — `displayName` (the only such field that exists in the schema today) was added so it gets scrubbed alongside `email` / `handle`. Originally also added speculative entries for `firstName`, `lastName`, `fullName`, `legalName`, `dob`, `address`, `streetAddress`, `postalCode`, `ssn`, `taxId`; these were removed in the S-H21 follow-up because none of them exist as real object keys in the codebase. The deny-list is now grown only when a sensitive field actually lands in the schema/types — see the file header in `shared/observability/src/logger/redact.ts` for the criteria and the lock-step assertion in `redact.test.ts` that pins the exact set.
 - [x] S-M32 — `span.recordException(error)` in the Elysia plugin wrote the error's enumerable own properties as span event attributes outside the log redactor's reach. Effect tagged errors embedding `email`, `handle`, `cause` etc. would leak to trace storage. Fixed: plugin wraps `recordException` to first scrub the error via `redact()` and only passes `name` + redacted `message` to OTel; `span.setStatus.message` is also routed through `redact()`.
 - [x] S-M33 — `enrollmentToken` (and snake-case `enrollment_token`) was missing from the trimmed redaction deny-list. It is a real single-use bearer credential returned by `/register/complete` (`osn/core/src/routes/auth.ts:225`) and sent back as `Authorization: Bearer <token>` for passkey enrollment (`osn/client/src/register.ts:131,142`) — same secrecy profile as `accessToken`. Defence-in-depth (no current log path emits the completeRegistration result), but the file header criterion in `redact.ts` explicitly requires real-bearer-credential fields to be on the list. Fixed by adding both spellings to `REDACT_KEYS` under the OAuth token block, updating the lock-step assertion + positive test, and pointing at the two call sites in the comment.
+- [x] S-H2 (zap) — Missing membership check on `GET /chats/:id` allowed any authenticated user to read chat metadata. Fixed: `assertMember` gate added.
+- [x] S-H3 (zap) — Missing membership check on `GET /chats/:id/members` leaked member rosters. Fixed: `assertMember` gate added.
+- [x] S-H4 (zap) — `PATCH /chats/:id` differentiated 403/404 for non-members, leaking chat existence. Fixed: 404 for non-members.
+- [ ] S-M1 (zap) — No rate limiting on any Zap API endpoint. Add per-IP rate limiting on write endpoints (POST `/chats`, POST `/:id/messages`, POST `/:id/members`). — see [[rate-limiting]]
+- [ ] S-M2 (zap) — CORS wildcard (`cors()` with no config) on `@zap/api` allows any origin. Restrict to known client origins. — see S-M6 (same pattern on Pulse)
+- [ ] S-M3 (zap) — `zapBridge.provisionEventChat` does not verify caller owns the event. Add ownership check.
+- [ ] S-M4 (zap) — Non-atomic cross-DB writes in `zapBridge.provisionEventChat`. Wrap Zap-side ops in transaction + add compensating logic.
+- [ ] S-M5 (zap) — `addEventChatMember` does not verify chat is type "event". Add type guard.
+- [ ] S-M6 (zap) — Truncated UUIDs (12 hex chars = 48 bits) reduce ID entropy. Consider using 24+ hex chars.
+- [ ] S-L1 (zap) — `jwtVerify` does not restrict algorithms. Pass `{ algorithms: ['HS256'] }`. — see S-L7
+- [ ] S-L2 (zap) — DM chats have no member count enforcement. Validate exactly 2 participants.
+- [ ] S-L3 (zap) — Admin can remove themselves leaving chat with no admin. Check last-admin before self-removal.
 - [ ] S-M43 — No rate limiting on `/graph/internal/*` S2S endpoints. ARC tokens are the primary gate, but a compromised service account could hammer graph queries without throttling. Add per-issuer rate limiter (keyed on `caller.iss`) via the existing `RateLimiterBackend` abstraction. — see [[arc-tokens]]
 - [ ] S-M34 — Rate limiter trusts `X-Forwarded-For` without reverse-proxy guarantee — any client can spoof the header to bypass IP-based rate limits. Add `trustProxy` config flag or fall back to socket IP when no proxy is configured. — see [[rate-limiting]]
 - [ ] S-M35 — Redirect URI allowlist matches origin only, not exact URI per OAuth 2.0 Security BCP (RFC 9700 §4.1.3). Upgrade to exact string comparison for stricter validation.
@@ -394,9 +407,15 @@ Address **High** items before any non-local deployment.
 ### Critical
 
 - [x] P-C1 — `filterByAttendeePrivacy` in `pulse/api/src/services/rsvps.ts` had an N+1 lookup against `pulse_users` (the comment claimed "batch-fetch" but the implementation did `for (id of attendeeIds) yield* getAttendanceVisibility(id)`), firing up to 200 extra queries per `listRsvps` call on busy events. Fixed in the full-event-view PR by adding `getAttendanceVisibilityBatch(userIds[])` to `pulseUsers.ts` (single `WHERE userId IN (...)` query, defaults missing keys to `connections`) and replacing the for-loop with a single call.
+- [x] P-C1 (zap) — N+1 query in `listChats` fetched each chat individually in a loop. Fixed: replaced with `inArray` single query.
+- [x] P-C2 (zap) — `createChat` inserted initial members one-by-one. Fixed: batch `db.insert(chatMembers).values(memberRows)`.
 
 ### Warning
 
+- [ ] P-W1 (zap) — `listChats` returns unbounded results (no pagination). Add cursor-based pagination consistent with `listMessages`.
+- [ ] P-W2 (zap) — `addMember` fetches all members to check count/duplicates. Use `COUNT(*)` + existence check or catch unique constraint violation.
+- [ ] P-W3 (zap) — `provisionEventChat` non-atomic cross-DB writes — wrap Zap-side in transaction, add secondary idempotency check on `eventId`.
+- [ ] P-W4 (zap) — `getChatMembers` returns all members without pagination. Add optional `limit`/`offset`.
 - [x] P-W1 — `rateLimitStore` in graph routes grows without bound — fixed: graph route refactored to use shared `createRateLimiter` from `osn/core/src/lib/rate-limit.ts` which handles proactive sweeping + maxEntries cap
 - [x] P-W16 — Auth rate limiter Maps swept proactively: sweep now runs on every `check()` when at least one window has elapsed since the last sweep, not just when `maxEntries` is exceeded. Deterministic memory profile in long-running processes.
 - [x] P-W17 — Redirect URI allowlist pre-computed: `allowedOrigins` Set built once at boot in both `createAuthRoutes` and `createAuthService`. Per-request check is a single `Set.has()` call.

--- a/zap/README.md
+++ b/zap/README.md
@@ -17,7 +17,7 @@ directory + workspace prefix:
 
 - `@zap/app` — Tauri + SolidJS frontend
 - `@zap/api` — Elysia + Eden messaging backend (port TBD)
-- `@zap/db`  — Drizzle + SQLite schema (chats, messages, group state)
+- `@zap/db` — Drizzle + SQLite schema (chats, messages, group state)
 
 The Signal Protocol implementation lives in `@osn/crypto` (next to ARC
 tokens), not in `zap/` — every OSN app that needs E2E messaging consumes
@@ -26,6 +26,7 @@ it from there.
 ## Planned features
 
 ### Core
+
 - DMs and group chats
 - Disappearing messages (optional)
 - Themes
@@ -36,6 +37,7 @@ it from there.
 - E2E security (Signal Protocol via `@osn/crypto`)
 
 ### Differentiator — Organisation chats
+
 Verified organisations (Twitter-blue-tick style) operating support and
 broadcast channels through a Zap handle instead of an email address.
 
@@ -68,19 +70,19 @@ broadcast channels through a Zap handle instead of an email address.
 
 Same as Pulse unless a real reason emerges:
 
-| Layer            | Tool |
-|------------------|------|
-| Runtime          | Bun |
-| Frontend         | Tauri + SolidJS (iOS first) |
-| Backend          | Elysia + Eden |
-| ORM / DB         | Drizzle + SQLite (→ Supabase later) |
-| Functional core  | Effect.ts |
-| Real-time        | WebSockets |
-| E2E              | Signal Protocol (`@osn/crypto`) |
-| S2S auth         | ARC tokens (`@osn/crypto/arc`) |
-| Identity         | OSN Core (`@osn/client`) |
-| Shared UI        | `@osn/ui` |
-| Validation       | TypeBox at HTTP boundary, Effect Schema in services |
+| Layer           | Tool                                                |
+| --------------- | --------------------------------------------------- |
+| Runtime         | Bun                                                 |
+| Frontend        | Tauri + SolidJS (iOS first)                         |
+| Backend         | Elysia + Eden                                       |
+| ORM / DB        | Drizzle + SQLite (→ Supabase later)                 |
+| Functional core | Effect.ts                                           |
+| Real-time       | WebSockets                                          |
+| E2E             | Signal Protocol (`@osn/crypto`)                     |
+| S2S auth        | ARC tokens (`@osn/crypto/arc`)                      |
+| Identity        | OSN Core (`@osn/client`)                            |
+| Shared UI       | `@osn/ui`                                           |
+| Validation      | TypeBox at HTTP boundary, Effect Schema in services |
 
 The DB layer may diverge later (messages have very different access
 patterns to events and users), but we'll cross that bridge when message

--- a/zap/api/package.json
+++ b/zap/api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.0",
     "@elysiajs/eden": "^1.2.0",
+    "@osn/core": "workspace:*",
     "@shared/observability": "workspace:*",
     "@zap/db": "workspace:*",
     "drizzle-orm": "^0.38.0",

--- a/zap/api/package.json
+++ b/zap/api/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@pulse/api",
-  "version": "0.7.6",
+  "name": "@zap/api",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -18,9 +18,6 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.0",
     "@elysiajs/eden": "^1.2.0",
-    "@osn/core": "workspace:*",
-    "@osn/db": "workspace:*",
-    "@pulse/db": "workspace:*",
     "@shared/observability": "workspace:*",
     "@zap/db": "workspace:*",
     "drizzle-orm": "^0.38.0",

--- a/zap/api/src/client.ts
+++ b/zap/api/src/client.ts
@@ -1,0 +1,4 @@
+import { treaty, type Treaty } from "@elysiajs/eden";
+import type { App } from "./index";
+
+export const createClient = (baseUrl: string): Treaty.Create<App> => treaty<App>(baseUrl);

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -1,0 +1,31 @@
+import { Elysia } from "elysia";
+import { cors } from "@elysiajs/cors";
+import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
+import { Effect, Logger } from "effect";
+import { chatsRoutes } from "./routes/chats";
+
+const SERVICE_NAME = "zap-api";
+const { layer: observabilityLayer } = initObservability({ serviceName: SERVICE_NAME });
+
+const app = new Elysia()
+  .use(cors())
+  .use(observabilityPlugin({ serviceName: SERVICE_NAME }))
+  .use(healthRoutes({ serviceName: SERVICE_NAME }))
+  .get("/", () => ({ status: "ok", service: "zap-api" }))
+  .use(chatsRoutes);
+
+const port = process.env.PORT || 3002;
+
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port);
+  void Effect.runPromise(
+    Effect.logInfo("zap-api listening").pipe(
+      Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),
+      Effect.provide(Logger.pretty),
+      Effect.provide(observabilityLayer),
+    ),
+  );
+}
+
+export { app };
+export type App = typeof app;

--- a/zap/api/src/lib/limits.ts
+++ b/zap/api/src/lib/limits.ts
@@ -1,0 +1,24 @@
+/**
+ * Platform-wide limits for Zap messaging.
+ *
+ * Single source of truth for cap constants. Changing a limit here is an
+ * auditable edit — never inline these into a schema.
+ */
+
+/** Maximum members in a group or event chat. */
+export const MAX_CHAT_MEMBERS = 500;
+
+/** Maximum ciphertext length in bytes (base64-encoded). ~256 KB. */
+export const MAX_CIPHERTEXT_LENGTH = 262_144;
+
+/** Maximum nonce length in bytes (base64-encoded). */
+export const MAX_NONCE_LENGTH = 128;
+
+/** Maximum title length for group/event chats. */
+export const MAX_CHAT_TITLE_LENGTH = 200;
+
+/** Default page size for message pagination. */
+export const DEFAULT_MESSAGE_LIMIT = 50;
+
+/** Maximum page size for message pagination. */
+export const MAX_MESSAGE_LIMIT = 100;

--- a/zap/api/src/metrics.ts
+++ b/zap/api/src/metrics.ts
@@ -1,0 +1,166 @@
+/**
+ * Zap API domain metrics.
+ *
+ * Single source of truth — every counter/histogram for Zap lives here.
+ * Services import the recording helpers (`metric*`) and call them at the
+ * relevant points. Raw OTel instruments are never used.
+ *
+ * See `CLAUDE.md` "Observability" section for the full rules.
+ */
+
+import {
+  BYTE_BUCKETS,
+  createCounter,
+  createHistogram,
+  createUpDownCounter,
+} from "@shared/observability/metrics";
+import type { Result } from "@shared/observability/metrics";
+
+/** Canonical metric name consts — grep-able, refactor-safe. */
+export const ZAP_METRICS = {
+  chatsCreated: "zap.chats.created",
+  chatsMembersAdded: "zap.chats.members.added",
+  chatsMembersRemoved: "zap.chats.members.removed",
+  messagesSent: "zap.messages.sent",
+  messagesSentSize: "zap.messages.sent.size",
+  messagesListed: "zap.messages.listed",
+  wsConnections: "zap.ws.connections",
+  wsMessagesDelivered: "zap.ws.messages.delivered",
+  accessDenied: "zap.access.denied",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Attribute shapes — bounded string-literal unions ONLY.
+// ---------------------------------------------------------------------------
+
+type ChatType = "dm" | "group" | "event";
+
+type ChatsCreatedAttrs = {
+  type: ChatType;
+  result: Result;
+};
+
+type MemberAttrs = {
+  result: Result;
+};
+
+type MessagesSentAttrs = {
+  chat_type: ChatType;
+  result: Result;
+};
+
+type MessagesSentSizeAttrs = {
+  chat_type: ChatType;
+};
+
+type MessagesListedAttrs = {
+  result_empty: "true" | "false";
+};
+
+type WsConnectionAttrs = {
+  event: "open" | "close";
+};
+
+type WsDeliveredAttrs = {
+  result: Result;
+};
+
+type AccessDeniedSurface = "chat" | "messages" | "members";
+type AccessDeniedReason = "not_member" | "blocked" | "not_found";
+
+type AccessDeniedAttrs = {
+  surface: AccessDeniedSurface;
+  reason: AccessDeniedReason;
+};
+
+// ---------------------------------------------------------------------------
+// Counters / histograms
+// ---------------------------------------------------------------------------
+
+const chatsCreated = createCounter<ChatsCreatedAttrs>({
+  name: ZAP_METRICS.chatsCreated,
+  description: "Chats created by type and outcome",
+  unit: "{chat}",
+});
+
+const chatsMembersAdded = createCounter<MemberAttrs>({
+  name: ZAP_METRICS.chatsMembersAdded,
+  description: "Members added to chats",
+  unit: "{member}",
+});
+
+const chatsMembersRemoved = createCounter<MemberAttrs>({
+  name: ZAP_METRICS.chatsMembersRemoved,
+  description: "Members removed from chats",
+  unit: "{member}",
+});
+
+const messagesSent = createCounter<MessagesSentAttrs>({
+  name: ZAP_METRICS.messagesSent,
+  description: "Messages sent by chat type and outcome",
+  unit: "{message}",
+});
+
+const messagesSentSize = createHistogram<MessagesSentSizeAttrs>({
+  name: ZAP_METRICS.messagesSentSize,
+  description: "Ciphertext size distribution in bytes",
+  unit: "By",
+  boundaries: BYTE_BUCKETS,
+});
+
+const messagesListed = createCounter<MessagesListedAttrs>({
+  name: ZAP_METRICS.messagesListed,
+  description: "Message list queries",
+  unit: "{query}",
+});
+
+const wsConnections = createUpDownCounter<WsConnectionAttrs>({
+  name: ZAP_METRICS.wsConnections,
+  description: "Active WebSocket connections gauge",
+  unit: "{connection}",
+});
+
+const wsMessagesDelivered = createCounter<WsDeliveredAttrs>({
+  name: ZAP_METRICS.wsMessagesDelivered,
+  description: "WebSocket push deliveries",
+  unit: "{delivery}",
+});
+
+const accessDenied = createCounter<AccessDeniedAttrs>({
+  name: ZAP_METRICS.accessDenied,
+  description: "Chat access denials — a spike signals probing",
+  unit: "{denial}",
+});
+
+// ---------------------------------------------------------------------------
+// Public recording helpers — the ONLY way Zap code should emit metrics.
+// ---------------------------------------------------------------------------
+
+export const metricChatCreated = (type: ChatType, result: Result): void =>
+  chatsCreated.inc({ type, result });
+
+export const metricMemberAdded = (result: Result): void => chatsMembersAdded.inc({ result });
+
+export const metricMemberRemoved = (result: Result): void => chatsMembersRemoved.inc({ result });
+
+export const metricMessageSent = (
+  chatType: ChatType,
+  ciphertextBytes: number,
+  result: Result,
+): void => {
+  messagesSent.inc({ chat_type: chatType, result });
+  if (result === "ok") messagesSentSize.record(ciphertextBytes, { chat_type: chatType });
+};
+
+export const metricMessagesListed = (resultCount: number): void =>
+  messagesListed.inc({ result_empty: resultCount === 0 ? "true" : "false" });
+
+export const metricWsConnection = (event: "open" | "close"): void => wsConnections.inc({ event });
+
+export const metricWsMessageDelivered = (result: Result): void =>
+  wsMessagesDelivered.inc({ result });
+
+export const metricAccessDenied = (
+  surface: AccessDeniedSurface,
+  reason: AccessDeniedReason,
+): void => accessDenied.inc({ surface, reason });

--- a/zap/api/src/routes/chats.ts
+++ b/zap/api/src/routes/chats.ts
@@ -15,6 +15,7 @@ import {
 import { sendMessage, listMessages } from "../services/messages";
 import { metricAccessDenied } from "../metrics";
 import { MAX_CHAT_MEMBERS, MAX_CIPHERTEXT_LENGTH, MAX_NONCE_LENGTH } from "../lib/limits";
+import { createRateLimiter, getClientIp, type RateLimiterBackend } from "@osn/core";
 
 const chatTypeEnum = t.Union([t.Literal("dm"), t.Literal("group"), t.Literal("event")]);
 
@@ -36,9 +37,28 @@ async function extractClaims(
 
 const DEFAULT_JWT_SECRET = process.env.OSN_JWT_SECRET ?? "dev-secret-change-in-prod";
 
+/** Rate limiter configuration for Zap write endpoints. */
+export interface ZapRateLimiters {
+  /** POST /chats — 20 req/IP/min */
+  readonly createChat: RateLimiterBackend;
+  /** POST /chats/:id/messages — 60 req/IP/min */
+  readonly sendMessage: RateLimiterBackend;
+  /** POST /chats/:id/members — 30 req/IP/min */
+  readonly addMember: RateLimiterBackend;
+}
+
+export function createDefaultZapRateLimiters(): ZapRateLimiters {
+  return {
+    createChat: createRateLimiter({ maxRequests: 20, windowMs: 60_000 }),
+    sendMessage: createRateLimiter({ maxRequests: 60, windowMs: 60_000 }),
+    addMember: createRateLimiter({ maxRequests: 30, windowMs: 60_000 }),
+  };
+}
+
 export const createChatsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
   jwtSecret: string = DEFAULT_JWT_SECRET,
+  rateLimiters: ZapRateLimiters = createDefaultZapRateLimiters(),
 ) => {
   const secretBytes = new TextEncoder().encode(jwtSecret);
 
@@ -89,6 +109,11 @@ export const createChatsRoutes = (
       .post(
         "/",
         async ({ body, headers, set }) => {
+          const ip = getClientIp(headers);
+          if (!(await rateLimiters.createChat.check(ip))) {
+            set.status = 429;
+            return { message: "Too many requests" } as const;
+          }
           const claims = await extractClaims(headers["authorization"], secretBytes);
           if (!claims) {
             set.status = 401;
@@ -192,6 +217,11 @@ export const createChatsRoutes = (
       .post(
         "/:id/members",
         async ({ params, body, headers, set }) => {
+          const ip = getClientIp(headers);
+          if (!(await rateLimiters.addMember.check(ip))) {
+            set.status = 429;
+            return { message: "Too many requests" } as const;
+          }
           const claims = await extractClaims(headers["authorization"], secretBytes);
           if (!claims) {
             set.status = 401;
@@ -276,6 +306,11 @@ export const createChatsRoutes = (
       .post(
         "/:id/messages",
         async ({ params, body, headers, set }) => {
+          const ip = getClientIp(headers);
+          if (!(await rateLimiters.sendMessage.check(ip))) {
+            set.status = 429;
+            return { message: "Too many requests" } as const;
+          }
           const claims = await extractClaims(headers["authorization"], secretBytes);
           if (!claims) {
             set.status = 401;

--- a/zap/api/src/routes/chats.ts
+++ b/zap/api/src/routes/chats.ts
@@ -1,0 +1,348 @@
+import { Elysia, t } from "elysia";
+import { Effect, Layer } from "effect";
+import { jwtVerify } from "jose";
+import { DbLive, type Db } from "@zap/db/service";
+import {
+  createChat,
+  getChat,
+  listChats,
+  updateChat,
+  addMember,
+  removeMember,
+  getChatMembers,
+} from "../services/chats";
+import { sendMessage, listMessages } from "../services/messages";
+import { metricAccessDenied } from "../metrics";
+import { MAX_CHAT_MEMBERS, MAX_CIPHERTEXT_LENGTH, MAX_NONCE_LENGTH } from "../lib/limits";
+
+const chatTypeEnum = t.Union([t.Literal("dm"), t.Literal("group"), t.Literal("event")]);
+
+/** Extracts verified claims from a Bearer token. Returns null on any failure. */
+async function extractClaims(
+  authHeader: string | undefined,
+  secret: Uint8Array,
+): Promise<{ userId: string } | null> {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  try {
+    const { payload } = await jwtVerify(authHeader.slice(7), secret);
+    const userId = typeof payload.sub === "string" ? payload.sub : null;
+    if (!userId) return null;
+    return { userId };
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_JWT_SECRET = process.env.OSN_JWT_SECRET ?? "dev-secret-change-in-prod";
+
+export const createChatsRoutes = (
+  dbLayer: Layer.Layer<Db> = DbLive,
+  jwtSecret: string = DEFAULT_JWT_SECRET,
+) => {
+  const secretBytes = new TextEncoder().encode(jwtSecret);
+
+  return (
+    new Elysia({ prefix: "/chats" })
+      // ── List user's chats ─────────────────────────────────────────────
+      .get("/", async ({ headers, set }) => {
+        const claims = await extractClaims(headers["authorization"], secretBytes);
+        if (!claims) {
+          set.status = 401;
+          return { message: "Unauthorized" } as const;
+        }
+        const result = await Effect.runPromise(
+          listChats(claims.userId).pipe(Effect.provide(dbLayer)),
+        );
+        return { chats: result };
+      })
+      // ── Get chat by ID ────────────────────────────────────────────────
+      .get(
+        "/:id",
+        async ({ params, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            getChat(params.id).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            metricAccessDenied("chat", "not_found");
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          return { chat: result };
+        },
+        { params: t.Object({ id: t.String() }) },
+      )
+      // ── Create chat ───────────────────────────────────────────────────
+      .post(
+        "/",
+        async ({ body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            createChat(body, claims.userId).pipe(
+              Effect.catchTag("ValidationError", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: String(e.cause) } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if ("error" in result) return result;
+          set.status = 201;
+          return { chat: result };
+        },
+        {
+          body: t.Object({
+            type: chatTypeEnum,
+            title: t.Optional(t.String()),
+            eventId: t.Optional(t.String()),
+            memberUserIds: t.Optional(t.Array(t.String(), { maxItems: MAX_CHAT_MEMBERS })),
+          }),
+        },
+      )
+      // ── Update chat ───────────────────────────────────────────────────
+      .patch(
+        "/:id",
+        async ({ params, body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            updateChat(params.id, body, claims.userId).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatAdmin", () =>
+                Effect.sync(() => {
+                  set.status = 403;
+                  return { message: "Forbidden" } as const;
+                }),
+              ),
+              Effect.catchTag("ValidationError", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: String(e.cause) } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          if ("error" in result || "message" in result) return result;
+          return { chat: result };
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          body: t.Object({ title: t.Optional(t.String()) }),
+        },
+      )
+      // ── Get members ───────────────────────────────────────────────────
+      .get(
+        "/:id/members",
+        async ({ params, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            getChatMembers(params.id).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          return { members: result };
+        },
+        { params: t.Object({ id: t.String() }) },
+      )
+      // ── Add member ────────────────────────────────────────────────────
+      .post(
+        "/:id/members",
+        async ({ params, body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            addMember(params.id, body.userId, claims.userId).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatAdmin", () =>
+                Effect.sync(() => {
+                  set.status = 403;
+                  return { message: "Forbidden" } as const;
+                }),
+              ),
+              Effect.catchTag("MemberLimitReached", () =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: "Member limit reached" } as const;
+                }),
+              ),
+              Effect.catchTag("AlreadyMember", () =>
+                Effect.sync(() => {
+                  set.status = 409;
+                  return { error: "Already a member" } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          if ("error" in result || "message" in result) return result;
+          set.status = 201;
+          return { member: result };
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          body: t.Object({ userId: t.String() }),
+        },
+      )
+      // ── Remove member ─────────────────────────────────────────────────
+      .delete(
+        "/:id/members/:userId",
+        async ({ params, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            removeMember(params.id, params.userId, claims.userId).pipe(
+              Effect.map(() => ({ ok: true }) as const),
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatAdmin", () =>
+                Effect.sync(() => {
+                  set.status = 403;
+                  return { message: "Forbidden" } as const;
+                }),
+              ),
+              Effect.catchTag("NotChatMember", () =>
+                Effect.sync(() => {
+                  set.status = 404;
+                  return { message: "Not a member" } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          if ("message" in result) return result;
+          set.status = 204;
+          return null;
+        },
+        { params: t.Object({ id: t.String(), userId: t.String() }) },
+      )
+      // ── Send message ──────────────────────────────────────────────────
+      .post(
+        "/:id/messages",
+        async ({ params, body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            sendMessage(params.id, claims.userId, body).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatMember", () =>
+                Effect.sync(() => {
+                  metricAccessDenied("messages", "not_member");
+                  set.status = 403;
+                  return { message: "Not a member" } as const;
+                }),
+              ),
+              Effect.catchTag("ValidationError", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: String(e.cause) } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          if ("error" in result || "message" in result) return result;
+          set.status = 201;
+          return { message: result };
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          body: t.Object({
+            ciphertext: t.String({ maxLength: MAX_CIPHERTEXT_LENGTH }),
+            nonce: t.String({ maxLength: MAX_NONCE_LENGTH }),
+          }),
+        },
+      )
+      // ── List messages ─────────────────────────────────────────────────
+      .get(
+        "/:id/messages",
+        async ({ params, query, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], secretBytes);
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await Effect.runPromise(
+            listMessages(params.id, claims.userId, {
+              limit: query.limit ? Number(query.limit) : undefined,
+              cursor: query.cursor,
+            }).pipe(
+              Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatMember", () =>
+                Effect.sync(() => {
+                  metricAccessDenied("messages", "not_member");
+                  set.status = 403;
+                  return { message: "Not a member" } as const;
+                }),
+              ),
+              Effect.provide(dbLayer),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Chat not found" };
+          }
+          if ("message" in result && !Array.isArray(result)) return result;
+          return { messages: result };
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          query: t.Object({
+            limit: t.Optional(t.String()),
+            cursor: t.Optional(t.String()),
+          }),
+        },
+      )
+  );
+};
+
+export const chatsRoutes = createChatsRoutes();

--- a/zap/api/src/routes/chats.ts
+++ b/zap/api/src/routes/chats.ts
@@ -10,6 +10,7 @@ import {
   addMember,
   removeMember,
   getChatMembers,
+  assertMember,
 } from "../services/chats";
 import { sendMessage, listMessages } from "../services/messages";
 import { metricAccessDenied } from "../metrics";
@@ -65,8 +66,13 @@ export const createChatsRoutes = (
             return { message: "Unauthorized" } as const;
           }
           const result = await Effect.runPromise(
-            getChat(params.id).pipe(
+            Effect.gen(function* () {
+              const chat = yield* getChat(params.id);
+              yield* assertMember(params.id, claims.userId);
+              return chat;
+            }).pipe(
               Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatMember", () => Effect.succeed(null)),
               Effect.provide(dbLayer),
             ),
           );
@@ -122,8 +128,12 @@ export const createChatsRoutes = (
             return { message: "Unauthorized" } as const;
           }
           const result = await Effect.runPromise(
-            updateChat(params.id, body, claims.userId).pipe(
+            Effect.gen(function* () {
+              yield* assertMember(params.id, claims.userId);
+              return yield* updateChat(params.id, body, claims.userId);
+            }).pipe(
               Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatMember", () => Effect.succeed(null)),
               Effect.catchTag("NotChatAdmin", () =>
                 Effect.sync(() => {
                   set.status = 403;
@@ -161,8 +171,12 @@ export const createChatsRoutes = (
             return { message: "Unauthorized" } as const;
           }
           const result = await Effect.runPromise(
-            getChatMembers(params.id).pipe(
+            Effect.gen(function* () {
+              yield* assertMember(params.id, claims.userId);
+              return yield* getChatMembers(params.id);
+            }).pipe(
               Effect.catchTag("ChatNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotChatMember", () => Effect.succeed(null)),
               Effect.provide(dbLayer),
             ),
           );

--- a/zap/api/src/services/chats.ts
+++ b/zap/api/src/services/chats.ts
@@ -1,0 +1,337 @@
+import { Data, Effect, Schema } from "effect";
+import { and, eq } from "drizzle-orm";
+import { chats, chatMembers } from "@zap/db/schema";
+import type { Chat, ChatMember } from "@zap/db/schema";
+import { Db } from "@zap/db/service";
+import { metricChatCreated, metricMemberAdded, metricMemberRemoved } from "../metrics";
+import { MAX_CHAT_MEMBERS, MAX_CHAT_TITLE_LENGTH } from "../lib/limits";
+
+// ---------------------------------------------------------------------------
+// Tagged errors
+// ---------------------------------------------------------------------------
+
+export class ChatNotFound extends Data.TaggedError("ChatNotFound")<{
+  readonly id: string;
+}> {}
+
+export class NotChatMember extends Data.TaggedError("NotChatMember")<{
+  readonly chatId: string;
+}> {}
+
+export class NotChatAdmin extends Data.TaggedError("NotChatAdmin")<{
+  readonly chatId: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+export class ValidationError extends Data.TaggedError("ValidationError")<{
+  readonly cause: unknown;
+}> {}
+
+export class MemberLimitReached extends Data.TaggedError("MemberLimitReached")<{
+  readonly chatId: string;
+}> {}
+
+export class AlreadyMember extends Data.TaggedError("AlreadyMember")<{
+  readonly chatId: string;
+  readonly userId: string;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Effect schemas (service-layer validation)
+// ---------------------------------------------------------------------------
+
+const ChatTypeEnum = Schema.Literal("dm", "group", "event");
+const TitleString = Schema.String.pipe(Schema.maxLength(MAX_CHAT_TITLE_LENGTH));
+
+const CreateChatSchema = Schema.Struct({
+  type: ChatTypeEnum,
+  title: Schema.optional(TitleString),
+  eventId: Schema.optional(Schema.String),
+  memberUserIds: Schema.optional(Schema.Array(Schema.String)),
+});
+
+const UpdateChatSchema = Schema.Struct({
+  title: Schema.optional(TitleString),
+});
+
+// ---------------------------------------------------------------------------
+// Service functions
+// ---------------------------------------------------------------------------
+
+export const getChat = (id: string): Effect.Effect<Chat, ChatNotFound | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const result = yield* Effect.tryPromise({
+      try: (): Promise<Chat[]> =>
+        db.select().from(chats).where(eq(chats.id, id)).limit(1) as Promise<Chat[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (result.length === 0) {
+      return yield* Effect.fail(new ChatNotFound({ id }));
+    }
+    return result[0]!;
+  }).pipe(Effect.withSpan("zap.chats.get"));
+
+export const listChats = (userId: string): Effect.Effect<Chat[], DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    // Find all chats the user is a member of.
+    const memberRows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db.select().from(chatMembers).where(eq(chatMembers.userId, userId)) as Promise<
+          ChatMember[]
+        >,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (memberRows.length === 0) return [];
+    const chatIds = memberRows.map((m) => m.chatId);
+    const results = yield* Effect.tryPromise({
+      try: async (): Promise<Chat[]> => {
+        // SQLite doesn't have an IN operator in drizzle-orm's builder that
+        // takes an array directly, so we use a loop with bounded concurrency.
+        const rows: Chat[] = [];
+        for (const cid of chatIds) {
+          const r = (await db.select().from(chats).where(eq(chats.id, cid))) as Chat[];
+          rows.push(...r);
+        }
+        return rows;
+      },
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    return results;
+  }).pipe(Effect.withSpan("zap.chats.list"));
+
+export const createChat = (
+  data: unknown,
+  creatorUserId: string,
+): Effect.Effect<Chat, ValidationError | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+
+    const validated = yield* Schema.decodeUnknown(CreateChatSchema)(data).pipe(
+      Effect.mapError((cause) => new ValidationError({ cause })),
+    );
+
+    const id = "chat_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+
+    yield* Effect.tryPromise({
+      try: () =>
+        db.insert(chats).values({
+          id,
+          type: validated.type,
+          title: validated.title ?? null,
+          eventId: validated.eventId ?? null,
+          createdByUserId: creatorUserId,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+
+    // Add creator as admin member.
+    const memberId = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    yield* Effect.tryPromise({
+      try: () =>
+        db.insert(chatMembers).values({
+          id: memberId,
+          chatId: id,
+          userId: creatorUserId,
+          role: "admin",
+          joinedAt: now,
+        }),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+
+    // Add initial members if provided.
+    if (validated.memberUserIds && validated.memberUserIds.length > 0) {
+      for (const userId of validated.memberUserIds) {
+        if (userId === creatorUserId) continue; // already added as admin
+        const mid = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+        yield* Effect.tryPromise({
+          try: () =>
+            db.insert(chatMembers).values({
+              id: mid,
+              chatId: id,
+              userId,
+              role: "member",
+              joinedAt: now,
+            }),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+      }
+    }
+
+    metricChatCreated(validated.type, "ok");
+    return yield* getChat(id).pipe(
+      Effect.mapError((e) => (e instanceof ChatNotFound ? new DatabaseError({ cause: e }) : e)),
+    );
+  }).pipe(Effect.withSpan("zap.chats.create"));
+
+export const updateChat = (
+  id: string,
+  data: unknown,
+  requestingUserId: string,
+): Effect.Effect<Chat, ChatNotFound | NotChatAdmin | ValidationError | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* getChat(id);
+
+    // Check that the requesting user is an admin.
+    yield* assertAdmin(id, requestingUserId);
+
+    const validated = yield* Schema.decodeUnknown(UpdateChatSchema)(data).pipe(
+      Effect.mapError((cause) => new ValidationError({ cause })),
+    );
+
+    const now = new Date();
+    yield* Effect.tryPromise({
+      try: () =>
+        db.update(chats).set({ title: validated.title, updatedAt: now }).where(eq(chats.id, id)),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+
+    return yield* getChat(id);
+  }).pipe(Effect.withSpan("zap.chats.update"));
+
+export const addMember = (
+  chatId: string,
+  userId: string,
+  requestingUserId: string,
+): Effect.Effect<
+  ChatMember,
+  ChatNotFound | NotChatAdmin | MemberLimitReached | AlreadyMember | DatabaseError,
+  Db
+> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* getChat(chatId);
+    yield* assertAdmin(chatId, requestingUserId);
+
+    // Check member count.
+    const existing = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db.select().from(chatMembers).where(eq(chatMembers.chatId, chatId)) as Promise<
+          ChatMember[]
+        >,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (existing.length >= MAX_CHAT_MEMBERS) {
+      return yield* Effect.fail(new MemberLimitReached({ chatId }));
+    }
+
+    // Check if already a member.
+    const alreadyExists = existing.some((m) => m.userId === userId);
+    if (alreadyExists) {
+      return yield* Effect.fail(new AlreadyMember({ chatId, userId }));
+    }
+
+    const id = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+    yield* Effect.tryPromise({
+      try: () =>
+        db.insert(chatMembers).values({
+          id,
+          chatId,
+          userId,
+          role: "member",
+          joinedAt: now,
+        }),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    metricMemberAdded("ok");
+
+    const [member] = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db.select().from(chatMembers).where(eq(chatMembers.id, id)) as Promise<ChatMember[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    return member!;
+  }).pipe(Effect.withSpan("zap.chats.add_member"));
+
+export const removeMember = (
+  chatId: string,
+  userId: string,
+  requestingUserId: string,
+): Effect.Effect<void, ChatNotFound | NotChatAdmin | NotChatMember | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* getChat(chatId);
+
+    // Allow self-removal (leaving) or admin removal of others.
+    if (userId !== requestingUserId) {
+      yield* assertAdmin(chatId, requestingUserId);
+    }
+
+    // Verify the target is a member.
+    const memberRows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db
+          .select()
+          .from(chatMembers)
+          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.userId, userId))) as Promise<
+          ChatMember[]
+        >,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (memberRows.length === 0) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
+
+    yield* Effect.tryPromise({
+      try: () =>
+        db
+          .delete(chatMembers)
+          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.userId, userId))),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    metricMemberRemoved("ok");
+  }).pipe(Effect.withSpan("zap.chats.remove_member"));
+
+export const getChatMembers = (
+  chatId: string,
+): Effect.Effect<ChatMember[], ChatNotFound | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* getChat(chatId);
+    const members = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db.select().from(chatMembers).where(eq(chatMembers.chatId, chatId)) as Promise<
+          ChatMember[]
+        >,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    return members;
+  }).pipe(Effect.withSpan("zap.chats.get_members"));
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const assertAdmin = (
+  chatId: string,
+  userId: string,
+): Effect.Effect<void, NotChatAdmin | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db
+          .select()
+          .from(chatMembers)
+          .where(
+            and(
+              eq(chatMembers.chatId, chatId),
+              eq(chatMembers.userId, userId),
+              eq(chatMembers.role, "admin"),
+            ),
+          ) as Promise<ChatMember[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (rows.length === 0) {
+      return yield* Effect.fail(new NotChatAdmin({ chatId }));
+    }
+  });

--- a/zap/api/src/services/chats.ts
+++ b/zap/api/src/services/chats.ts
@@ -1,5 +1,5 @@
 import { Data, Effect, Schema } from "effect";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { chats, chatMembers } from "@zap/db/schema";
 import type { Chat, ChatMember } from "@zap/db/schema";
 import { Db } from "@zap/db/service";
@@ -89,16 +89,8 @@ export const listChats = (userId: string): Effect.Effect<Chat[], DatabaseError, 
     if (memberRows.length === 0) return [];
     const chatIds = memberRows.map((m) => m.chatId);
     const results = yield* Effect.tryPromise({
-      try: async (): Promise<Chat[]> => {
-        // SQLite doesn't have an IN operator in drizzle-orm's builder that
-        // takes an array directly, so we use a loop with bounded concurrency.
-        const rows: Chat[] = [];
-        for (const cid of chatIds) {
-          const r = (await db.select().from(chats).where(eq(chats.id, cid))) as Chat[];
-          rows.push(...r);
-        }
-        return rows;
-      },
+      try: (): Promise<Chat[]> =>
+        db.select().from(chats).where(inArray(chats.id, chatIds)) as Promise<Chat[]>,
       catch: (cause) => new DatabaseError({ cause }),
     });
     return results;
@@ -146,20 +138,20 @@ export const createChat = (
       catch: (cause) => new DatabaseError({ cause }),
     });
 
-    // Add initial members if provided.
+    // Batch-insert initial members if provided.
     if (validated.memberUserIds && validated.memberUserIds.length > 0) {
-      for (const userId of validated.memberUserIds) {
-        if (userId === creatorUserId) continue; // already added as admin
-        const mid = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+      const memberRows = validated.memberUserIds
+        .filter((uid) => uid !== creatorUserId) // already added as admin
+        .map((uid) => ({
+          id: "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+          chatId: id,
+          userId: uid,
+          role: "member" as const,
+          joinedAt: now,
+        }));
+      if (memberRows.length > 0) {
         yield* Effect.tryPromise({
-          try: () =>
-            db.insert(chatMembers).values({
-              id: mid,
-              chatId: id,
-              userId,
-              role: "member",
-              joinedAt: now,
-            }),
+          try: () => db.insert(chatMembers).values(memberRows),
           catch: (cause) => new DatabaseError({ cause }),
         });
       }
@@ -306,6 +298,30 @@ export const getChatMembers = (
     });
     return members;
   }).pipe(Effect.withSpan("zap.chats.get_members"));
+
+// ---------------------------------------------------------------------------
+// Helpers (public — used by routes for membership gating)
+// ---------------------------------------------------------------------------
+
+export const assertMember = (
+  chatId: string,
+  userId: string,
+): Effect.Effect<void, NotChatMember | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db
+          .select()
+          .from(chatMembers)
+          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.userId, userId)))
+          .limit(1) as Promise<ChatMember[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (rows.length === 0) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
+  });
 
 // ---------------------------------------------------------------------------
 // Internal helpers

--- a/zap/api/src/services/messages.ts
+++ b/zap/api/src/services/messages.ts
@@ -1,0 +1,178 @@
+import { Data, Effect, Schema } from "effect";
+import { and, desc, eq, lt } from "drizzle-orm";
+import { chats, chatMembers, messages } from "@zap/db/schema";
+import type { Chat, ChatMember, Message } from "@zap/db/schema";
+import { Db } from "@zap/db/service";
+import { metricMessageSent, metricMessagesListed } from "../metrics";
+import {
+  MAX_CIPHERTEXT_LENGTH,
+  MAX_NONCE_LENGTH,
+  DEFAULT_MESSAGE_LIMIT,
+  MAX_MESSAGE_LIMIT,
+} from "../lib/limits";
+
+// ---------------------------------------------------------------------------
+// Tagged errors
+// ---------------------------------------------------------------------------
+
+export class ChatNotFound extends Data.TaggedError("ChatNotFound")<{
+  readonly id: string;
+}> {}
+
+export class NotChatMember extends Data.TaggedError("NotChatMember")<{
+  readonly chatId: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+export class ValidationError extends Data.TaggedError("ValidationError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Effect schemas
+// ---------------------------------------------------------------------------
+
+const CiphertextString = Schema.String.pipe(Schema.maxLength(MAX_CIPHERTEXT_LENGTH));
+const NonceString = Schema.String.pipe(Schema.maxLength(MAX_NONCE_LENGTH));
+
+const SendMessageSchema = Schema.Struct({
+  ciphertext: CiphertextString,
+  nonce: NonceString,
+});
+
+// ---------------------------------------------------------------------------
+// Service functions
+// ---------------------------------------------------------------------------
+
+export const sendMessage = (
+  chatId: string,
+  senderUserId: string,
+  data: unknown,
+): Effect.Effect<Message, ChatNotFound | NotChatMember | ValidationError | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+
+    // Verify chat exists.
+    const chatRows = yield* Effect.tryPromise({
+      try: (): Promise<Chat[]> =>
+        db.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (chatRows.length === 0) {
+      return yield* Effect.fail(new ChatNotFound({ id: chatId }));
+    }
+    const chat = chatRows[0]!;
+
+    // Verify sender is a member.
+    yield* assertMember(chatId, senderUserId);
+
+    const validated = yield* Schema.decodeUnknown(SendMessageSchema)(data).pipe(
+      Effect.mapError((cause) => new ValidationError({ cause })),
+    );
+
+    const id = "msg_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+
+    yield* Effect.tryPromise({
+      try: () =>
+        db.insert(messages).values({
+          id,
+          chatId,
+          senderUserId,
+          ciphertext: validated.ciphertext,
+          nonce: validated.nonce,
+          createdAt: now,
+        }),
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+
+    metricMessageSent(chat.type as "dm" | "group" | "event", validated.ciphertext.length, "ok");
+
+    const [msg] = yield* Effect.tryPromise({
+      try: (): Promise<Message[]> =>
+        db.select().from(messages).where(eq(messages.id, id)) as Promise<Message[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    return msg!;
+  }).pipe(Effect.withSpan("zap.messages.send"));
+
+export const listMessages = (
+  chatId: string,
+  userId: string,
+  opts: { limit?: number; cursor?: string } = {},
+): Effect.Effect<Message[], ChatNotFound | NotChatMember | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+
+    // Verify chat exists.
+    const chatRows = yield* Effect.tryPromise({
+      try: (): Promise<Chat[]> =>
+        db.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (chatRows.length === 0) {
+      return yield* Effect.fail(new ChatNotFound({ id: chatId }));
+    }
+
+    // Verify user is a member.
+    yield* assertMember(chatId, userId);
+
+    const limit = Math.min(Math.max(1, opts.limit ?? DEFAULT_MESSAGE_LIMIT), MAX_MESSAGE_LIMIT);
+
+    // Cursor-based pagination: fetch messages older than the cursor.
+    const conditions = [eq(messages.chatId, chatId)];
+    if (opts.cursor) {
+      // The cursor is a message ID. Look up its createdAt to paginate.
+      const cursorRows = yield* Effect.tryPromise({
+        try: (): Promise<Message[]> =>
+          db.select().from(messages).where(eq(messages.id, opts.cursor!)).limit(1) as Promise<
+            Message[]
+          >,
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      if (cursorRows.length > 0) {
+        conditions.push(lt(messages.createdAt, cursorRows[0]!.createdAt));
+      }
+    }
+
+    const results = yield* Effect.tryPromise({
+      try: (): Promise<Message[]> =>
+        db
+          .select()
+          .from(messages)
+          .where(and(...conditions))
+          .orderBy(desc(messages.createdAt))
+          .limit(limit) as Promise<Message[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+
+    metricMessagesListed(results.length);
+    return results;
+  }).pipe(Effect.withSpan("zap.messages.list"));
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const assertMember = (
+  chatId: string,
+  userId: string,
+): Effect.Effect<void, NotChatMember | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db
+          .select()
+          .from(chatMembers)
+          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.userId, userId)))
+          .limit(1) as Promise<ChatMember[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (rows.length === 0) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
+  });

--- a/zap/api/tests/helpers/db.ts
+++ b/zap/api/tests/helpers/db.ts
@@ -2,7 +2,14 @@ import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Effect, Layer } from "effect";
 import * as schema from "@zap/db/schema";
-import { chats, chatMembers, type Chat, type ChatMember } from "@zap/db/schema";
+import {
+  chats,
+  chatMembers,
+  messages,
+  type Chat,
+  type ChatMember,
+  type Message,
+} from "@zap/db/schema";
 import { Db } from "@zap/db/service";
 
 export function createTestLayer() {
@@ -93,5 +100,30 @@ export const seedMember = (
     const now = new Date();
     const row: ChatMember = { id, chatId, userId, role, joinedAt: now };
     yield* Effect.promise(() => db.insert(chatMembers).values(row));
+    return row;
+  });
+
+/**
+ * Seed a message directly into the DB with a controllable timestamp.
+ */
+export const seedMessage = (
+  chatId: string,
+  senderUserId: string,
+  ciphertext: string,
+  createdAt: Date,
+): Effect.Effect<Message, never, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const id = "msg_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const row: Message = {
+      id,
+      chatId,
+      senderUserId,
+      ciphertext,
+      nonce: "test_nonce",
+      createdAt,
+      expiresAt: null,
+    };
+    yield* Effect.promise(() => db.insert(messages).values(row));
     return row;
   });

--- a/zap/api/tests/helpers/db.ts
+++ b/zap/api/tests/helpers/db.ts
@@ -1,0 +1,97 @@
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect, Layer } from "effect";
+import * as schema from "@zap/db/schema";
+import { chats, chatMembers, type Chat, type ChatMember } from "@zap/db/schema";
+import { Db } from "@zap/db/service";
+
+export function createTestLayer() {
+  const sqlite = new Database(":memory:");
+  sqlite.run(`
+    CREATE TABLE chats (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      title TEXT,
+      event_id TEXT,
+      created_by_user_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  sqlite.run(`CREATE INDEX chats_type_idx ON chats (type)`);
+  sqlite.run(`CREATE INDEX chats_event_id_idx ON chats (event_id)`);
+  sqlite.run(`CREATE INDEX chats_created_by_user_id_idx ON chats (created_by_user_id)`);
+  sqlite.run(`
+    CREATE TABLE chat_members (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id),
+      user_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'member',
+      joined_at INTEGER NOT NULL,
+      UNIQUE (chat_id, user_id)
+    )
+  `);
+  sqlite.run(`CREATE INDEX chat_members_chat_idx ON chat_members (chat_id)`);
+  sqlite.run(`CREATE INDEX chat_members_user_idx ON chat_members (user_id)`);
+  sqlite.run(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id),
+      sender_user_id TEXT NOT NULL,
+      ciphertext TEXT NOT NULL,
+      nonce TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER
+    )
+  `);
+  sqlite.run(`CREATE INDEX messages_chat_idx ON messages (chat_id)`);
+  sqlite.run(`CREATE INDEX messages_chat_created_idx ON messages (chat_id, created_at)`);
+  sqlite.run(`CREATE INDEX messages_sender_idx ON messages (sender_user_id)`);
+  const db = drizzle(sqlite, { schema });
+  return Layer.succeed(Db, { db });
+}
+
+/**
+ * Seed a chat directly into the DB, bypassing service-layer validation.
+ */
+export interface SeedChatInput {
+  type: "dm" | "group" | "event";
+  title?: string;
+  eventId?: string;
+  createdByUserId?: string;
+}
+
+export const seedChat = (input: SeedChatInput): Effect.Effect<Chat, never, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const id = "chat_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+    const row: Chat = {
+      id,
+      type: input.type,
+      title: input.title ?? null,
+      eventId: input.eventId ?? null,
+      createdByUserId: input.createdByUserId ?? "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    };
+    yield* Effect.promise(() => db.insert(chats).values(row));
+    return row;
+  });
+
+/**
+ * Seed a chat member directly into the DB.
+ */
+export const seedMember = (
+  chatId: string,
+  userId: string,
+  role: "admin" | "member" = "member",
+): Effect.Effect<ChatMember, never, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const id = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    const now = new Date();
+    const row: ChatMember = { id, chatId, userId, role, joinedAt: now };
+    yield* Effect.promise(() => db.insert(chatMembers).values(row));
+    return row;
+  });

--- a/zap/api/tests/routes/chats.test.ts
+++ b/zap/api/tests/routes/chats.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SignJWT } from "jose";
+import { createChatsRoutes } from "../../src/routes/chats";
+import { createTestLayer } from "../helpers/db";
+
+const TEST_JWT_SECRET = "test-secret";
+
+async function makeToken(userId: string): Promise<string> {
+  return new SignJWT({ sub: userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+}
+
+const json = (body: unknown) => JSON.stringify(body);
+
+function req(
+  app: ReturnType<typeof createChatsRoutes>,
+  method: string,
+  path: string,
+  opts: { body?: unknown; token?: string } = {},
+) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+      },
+      ...(opts.body ? { body: json(opts.body) } : {}),
+    }),
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const body = (res: Response): Promise<any> => res.json();
+
+describe("chats routes", () => {
+  let app: ReturnType<typeof createChatsRoutes>;
+  let layer: ReturnType<typeof createTestLayer>;
+  let aliceToken: string;
+  let bobToken: string;
+
+  beforeEach(async () => {
+    layer = createTestLayer();
+    app = createChatsRoutes(layer, TEST_JWT_SECRET);
+    aliceToken = await makeToken("usr_alice");
+    bobToken = await makeToken("usr_bob");
+  });
+
+  // ── Auth ────────────────────────────────────────────────────────────────
+
+  it("GET /chats returns 401 without token", async () => {
+    const res = await req(app, "GET", "/chats");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /chats returns 401 without token", async () => {
+    const res = await req(app, "POST", "/chats", { body: { type: "group" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /chats/:id returns 401 without token", async () => {
+    const res = await req(app, "GET", "/chats/chat_123");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /chats/:id/messages returns 401 without token", async () => {
+    const res = await req(app, "POST", "/chats/chat_123/messages", {
+      body: { ciphertext: "x", nonce: "y" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // ── Create chat ─────────────────────────────────────────────────────────
+
+  it("POST /chats creates a group chat and returns 201", async () => {
+    const res = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Test Group" },
+    });
+    expect(res.status).toBe(201);
+    const data = await body(res);
+    expect(data.chat.type).toBe("group");
+    expect(data.chat.title).toBe("Test Group");
+    expect(data.chat.id).toMatch(/^chat_/);
+  });
+
+  it("POST /chats returns 422 for invalid type", async () => {
+    const res = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "invalid" },
+    });
+    expect(res.status).toBe(422);
+  });
+
+  // ── Get chat (membership gated) ─────────────────────────────────────────
+
+  it("GET /chats/:id returns chat for member", async () => {
+    // Create a chat as alice.
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Members Only" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "GET", `/chats/${chatId}`, { token: aliceToken });
+    expect(res.status).toBe(200);
+    const data = await body(res);
+    expect(data.chat.id).toBe(chatId);
+  });
+
+  it("GET /chats/:id returns 404 for non-member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Private" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "GET", `/chats/${chatId}`, { token: bobToken });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /chats/:id returns 404 for nonexistent chat", async () => {
+    const res = await req(app, "GET", "/chats/chat_nonexistent", { token: aliceToken });
+    expect(res.status).toBe(404);
+  });
+
+  // ── List chats ──────────────────────────────────────────────────────────
+
+  it("GET /chats returns only user's chats", async () => {
+    // Create two chats as alice.
+    await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Chat A" },
+    });
+    await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "dm" },
+    });
+
+    const res = await req(app, "GET", "/chats", { token: aliceToken });
+    expect(res.status).toBe(200);
+    const data = await body(res);
+    expect(data.chats).toHaveLength(2);
+
+    // Bob should see no chats.
+    const bobRes = await req(app, "GET", "/chats", { token: bobToken });
+    const bobData = await body(bobRes);
+    expect(bobData.chats).toHaveLength(0);
+  });
+
+  // ── Update chat ─────────────────────────────────────────────────────────
+
+  it("PATCH /chats/:id updates title for admin", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Old" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "PATCH", `/chats/${chatId}`, {
+      token: aliceToken,
+      body: { title: "New Title" },
+    });
+    expect(res.status).toBe(200);
+    const data = await body(res);
+    expect(data.chat.title).toBe("New Title");
+  });
+
+  it("PATCH /chats/:id returns 404 for non-member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", title: "Hidden" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "PATCH", `/chats/${chatId}`, {
+      token: bobToken,
+      body: { title: "Nope" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // ── Members ─────────────────────────────────────────────────────────────
+
+  it("GET /chats/:id/members returns 404 for non-member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "GET", `/chats/${chatId}/members`, { token: bobToken });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /chats/:id/members returns members for member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "GET", `/chats/${chatId}/members`, { token: aliceToken });
+    expect(res.status).toBe(200);
+    const data = await body(res);
+    expect(data.members).toHaveLength(1);
+  });
+
+  it("POST /chats/:id/members adds member and returns 201", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "POST", `/chats/${chatId}/members`, {
+      token: aliceToken,
+      body: { userId: "usr_bob" },
+    });
+    expect(res.status).toBe(201);
+    const data = await body(res);
+    expect(data.member.userId).toBe("usr_bob");
+  });
+
+  it("POST /chats/:id/members returns 403 for non-admin", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", memberUserIds: ["usr_bob"] },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "POST", `/chats/${chatId}/members`, {
+      token: bobToken,
+      body: { userId: "usr_charlie" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /chats/:id/members returns 409 for duplicate", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", memberUserIds: ["usr_bob"] },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "POST", `/chats/${chatId}/members`, {
+      token: aliceToken,
+      body: { userId: "usr_bob" },
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("DELETE /chats/:id/members/:userId removes member and returns 204", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group", memberUserIds: ["usr_bob"] },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "DELETE", `/chats/${chatId}/members/usr_bob`, {
+      token: aliceToken,
+    });
+    expect(res.status).toBe(204);
+  });
+
+  // ── Messages ────────────────────────────────────────────────────────────
+
+  it("POST /chats/:id/messages sends a message and returns 201", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "POST", `/chats/${chatId}/messages`, {
+      token: aliceToken,
+      body: { ciphertext: "dGVzdA==", nonce: "bm9uY2U=" },
+    });
+    expect(res.status).toBe(201);
+    const data = await body(res);
+    expect(data.message.ciphertext).toBe("dGVzdA==");
+  });
+
+  it("POST /chats/:id/messages returns 403 for non-member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "POST", `/chats/${chatId}/messages`, {
+      token: bobToken,
+      body: { ciphertext: "x", nonce: "y" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /chats/:id/messages returns messages for member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    // Send a message first.
+    await req(app, "POST", `/chats/${chatId}/messages`, {
+      token: aliceToken,
+      body: { ciphertext: "dGVzdA==", nonce: "bm9uY2U=" },
+    });
+
+    const res = await req(app, "GET", `/chats/${chatId}/messages`, { token: aliceToken });
+    expect(res.status).toBe(200);
+    const data = await body(res);
+    expect(data.messages).toHaveLength(1);
+  });
+
+  it("GET /chats/:id/messages returns 403 for non-member", async () => {
+    const createRes = await req(app, "POST", "/chats", {
+      token: aliceToken,
+      body: { type: "group" },
+    });
+    const chatId = (await body(createRes)).chat.id;
+
+    const res = await req(app, "GET", `/chats/${chatId}/messages`, { token: bobToken });
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /chats/:id/messages returns 404 for nonexistent chat", async () => {
+    const res = await req(app, "GET", "/chats/chat_nope/messages", { token: aliceToken });
+    expect(res.status).toBe(404);
+  });
+});

--- a/zap/api/tests/services/chats.test.ts
+++ b/zap/api/tests/services/chats.test.ts
@@ -185,4 +185,73 @@ describe("chats service", () => {
       }
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  // ── Validation error paths (T-E1) ────────────────────────────────────
+
+  it.effect("createChat fails with ValidationError for oversized title", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.either(
+        createChat({ type: "group", title: "X".repeat(201) }, "usr_alice"),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ValidationError");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── Authorization edge cases (T-S2) ─────────────────────────────────
+
+  it.effect("removeMember fails with NotChatAdmin when non-admin removes another member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      yield* seedMember(chat.id, "usr_bob");
+      yield* seedMember(chat.id, "usr_charlie");
+      // Bob (non-admin) tries to remove Charlie.
+      const result = yield* Effect.either(removeMember(chat.id, "usr_charlie", "usr_bob"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("NotChatAdmin");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── Membership filtering (T-S3) ─────────────────────────────────────
+
+  it.effect("listChats returns empty when chats exist but user is not a member", () =>
+    Effect.gen(function* () {
+      // Seed chats with other users as members.
+      const chat1 = yield* seedChat({ type: "group", title: "Not Mine" });
+      const chat2 = yield* seedChat({ type: "dm" });
+      yield* seedMember(chat1.id, "usr_bob", "admin");
+      yield* seedMember(chat2.id, "usr_charlie", "admin");
+
+      const result = yield* listChats("usr_nobody");
+      expect(result).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── getChatMembers standalone (T-U2) ────────────────────────────────
+
+  it.effect("getChatMembers returns all members", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      yield* seedMember(chat.id, "usr_bob");
+      yield* seedMember(chat.id, "usr_charlie");
+      const members = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(3);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("getChatMembers fails with ChatNotFound for missing chat", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.either(getChatMembers("chat_nonexistent"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ChatNotFound");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });

--- a/zap/api/tests/services/chats.test.ts
+++ b/zap/api/tests/services/chats.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { createTestLayer, seedChat, seedMember } from "../helpers/db";
+import {
+  createChat,
+  getChat,
+  listChats,
+  updateChat,
+  addMember,
+  removeMember,
+  getChatMembers,
+} from "../../src/services/chats";
+
+describe("chats service", () => {
+  it.effect("createChat creates a group chat with creator as admin", () =>
+    Effect.gen(function* () {
+      const chat = yield* createChat({ type: "group", title: "Test Group" }, "usr_alice");
+      expect(chat.id).toMatch(/^chat_/);
+      expect(chat.type).toBe("group");
+      expect(chat.title).toBe("Test Group");
+      expect(chat.createdByUserId).toBe("usr_alice");
+
+      // Creator should be an admin member.
+      const members = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(1);
+      expect(members[0]!.userId).toBe("usr_alice");
+      expect(members[0]!.role).toBe("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("createChat creates a DM", () =>
+    Effect.gen(function* () {
+      const chat = yield* createChat({ type: "dm" }, "usr_alice");
+      expect(chat.type).toBe("dm");
+      expect(chat.title).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("createChat creates an event chat with eventId", () =>
+    Effect.gen(function* () {
+      const chat = yield* createChat(
+        { type: "event", title: "Event Chat", eventId: "evt_abc123" },
+        "usr_alice",
+      );
+      expect(chat.type).toBe("event");
+      expect(chat.eventId).toBe("evt_abc123");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("createChat adds initial members", () =>
+    Effect.gen(function* () {
+      const chat = yield* createChat(
+        { type: "group", title: "With Members", memberUserIds: ["usr_bob", "usr_charlie"] },
+        "usr_alice",
+      );
+      const members = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(3); // alice (admin) + bob + charlie
+      const userIds = members.map((m) => m.userId).sort();
+      expect(userIds).toEqual(["usr_alice", "usr_bob", "usr_charlie"]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("getChat returns existing chat", () =>
+    Effect.gen(function* () {
+      const created = yield* seedChat({ type: "group", title: "Fetch Me" });
+      const fetched = yield* getChat(created.id);
+      expect(fetched.id).toBe(created.id);
+      expect(fetched.title).toBe("Fetch Me");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("getChat fails with ChatNotFound for missing id", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.either(getChat("chat_nonexistent"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ChatNotFound");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listChats returns only chats the user is a member of", () =>
+    Effect.gen(function* () {
+      const chat1 = yield* seedChat({ type: "group", title: "Chat 1" });
+      const chat2 = yield* seedChat({ type: "group", title: "Chat 2" });
+      yield* seedChat({ type: "group", title: "Chat 3" });
+
+      yield* seedMember(chat1.id, "usr_alice", "admin");
+      yield* seedMember(chat2.id, "usr_alice");
+
+      const result = yield* listChats("usr_alice");
+      expect(result).toHaveLength(2);
+      const ids = result.map((c) => c.id).sort();
+      expect(ids).toEqual([chat1.id, chat2.id].sort());
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listChats returns empty for user with no chats", () =>
+    Effect.gen(function* () {
+      const result = yield* listChats("usr_nobody");
+      expect(result).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("updateChat updates title", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({
+        type: "group",
+        title: "Old Title",
+        createdByUserId: "usr_alice",
+      });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      const updated = yield* updateChat(chat.id, { title: "New Title" }, "usr_alice");
+      expect(updated.title).toBe("New Title");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("updateChat fails for non-admin", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group", title: "Admin Only" });
+      yield* seedMember(chat.id, "usr_bob");
+      const result = yield* Effect.either(updateChat(chat.id, { title: "Nope" }, "usr_bob"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("NotChatAdmin");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("addMember adds a new member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      const member = yield* addMember(chat.id, "usr_bob", "usr_alice");
+      expect(member.userId).toBe("usr_bob");
+      expect(member.role).toBe("member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("addMember fails with AlreadyMember for duplicate", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      yield* seedMember(chat.id, "usr_bob");
+      const result = yield* Effect.either(addMember(chat.id, "usr_bob", "usr_alice"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("AlreadyMember");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removeMember removes a member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      yield* seedMember(chat.id, "usr_bob");
+      yield* removeMember(chat.id, "usr_bob", "usr_alice");
+      const members = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(1);
+      expect(members[0]!.userId).toBe("usr_alice");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removeMember allows self-removal (leaving)", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      yield* seedMember(chat.id, "usr_bob");
+      yield* removeMember(chat.id, "usr_bob", "usr_bob");
+      const members = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(1);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("removeMember fails with NotChatMember for non-member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+      const result = yield* Effect.either(removeMember(chat.id, "usr_nobody", "usr_alice"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("NotChatMember");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/zap/api/tests/services/messages.test.ts
+++ b/zap/api/tests/services/messages.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect, Either } from "effect";
-import { createTestLayer, seedChat, seedMember } from "../helpers/db";
+import { createTestLayer, seedChat, seedMember, seedMessage } from "../helpers/db";
 import { sendMessage, listMessages } from "../../src/services/messages";
 
 describe("messages service", () => {
@@ -111,6 +111,67 @@ describe("messages service", () => {
 
       const msgs = yield* listMessages(chat.id, "usr_alice");
       expect(msgs).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── Validation error paths (T-E2) ────────────────────────────────────
+
+  it.effect("sendMessage fails with ValidationError for oversized ciphertext", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      const result = yield* Effect.either(
+        sendMessage(chat.id, "usr_alice", {
+          ciphertext: "X".repeat(262_145), // exceeds MAX_CIPHERTEXT_LENGTH
+          nonce: "bm9uY2U=",
+        }),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ValidationError");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── Cursor pagination (T-U1) ─────────────────────────────────────────
+
+  it.effect("listMessages supports cursor-based pagination", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      // Seed 5 messages with distinct second-granularity timestamps
+      // (SQLite stores timestamps as integer seconds).
+      const baseTime = new Date("2030-01-01T00:00:00.000Z").getTime();
+      for (let i = 0; i < 5; i++) {
+        yield* seedMessage(
+          chat.id,
+          "usr_alice",
+          `msg${i}`,
+          new Date(baseTime + i * 1000), // 1 second apart
+        );
+      }
+
+      // First page: get 2 newest messages.
+      const page1 = yield* listMessages(chat.id, "usr_alice", { limit: 2 });
+      expect(page1).toHaveLength(2);
+      // Newest first — should be msg4, msg3.
+      expect(page1[0]!.ciphertext).toBe("msg4");
+      expect(page1[1]!.ciphertext).toBe("msg3");
+
+      // Second page: use last message ID as cursor.
+      const cursor = page1[1]!.id;
+      const page2 = yield* listMessages(chat.id, "usr_alice", { limit: 2, cursor });
+      expect(page2).toHaveLength(2);
+      expect(page2[0]!.ciphertext).toBe("msg2");
+      expect(page2[1]!.ciphertext).toBe("msg1");
+
+      // Third page: should get only 1 remaining message.
+      const cursor2 = page2[1]!.id;
+      const page3 = yield* listMessages(chat.id, "usr_alice", { limit: 2, cursor: cursor2 });
+      expect(page3).toHaveLength(1);
+      expect(page3[0]!.ciphertext).toBe("msg0");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });

--- a/zap/api/tests/services/messages.test.ts
+++ b/zap/api/tests/services/messages.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { createTestLayer, seedChat, seedMember } from "../helpers/db";
+import { sendMessage, listMessages } from "../../src/services/messages";
+
+describe("messages service", () => {
+  it.effect("sendMessage stores an encrypted message", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      const msg = yield* sendMessage(chat.id, "usr_alice", {
+        ciphertext: "dGVzdCBtZXNzYWdl",
+        nonce: "YWJjZGVmMTIzNDU2",
+      });
+      expect(msg.id).toMatch(/^msg_/);
+      expect(msg.chatId).toBe(chat.id);
+      expect(msg.senderUserId).toBe("usr_alice");
+      expect(msg.ciphertext).toBe("dGVzdCBtZXNzYWdl");
+      expect(msg.nonce).toBe("YWJjZGVmMTIzNDU2");
+      expect(msg.createdAt).toBeInstanceOf(Date);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("sendMessage fails for non-member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      const result = yield* Effect.either(
+        sendMessage(chat.id, "usr_bob", { ciphertext: "dGVzdA==", nonce: "bm9uY2U=" }),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("NotChatMember");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("sendMessage fails for nonexistent chat", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.either(
+        sendMessage("chat_nope", "usr_alice", { ciphertext: "dGVzdA==", nonce: "bm9uY2U=" }),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ChatNotFound");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listMessages returns messages in reverse chronological order", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      yield* sendMessage(chat.id, "usr_alice", {
+        ciphertext: "bXNnMQ==",
+        nonce: "bm9uY2Ux",
+      });
+      // Small delay to ensure ordering by createdAt.
+      yield* Effect.promise(() => new Promise((r) => setTimeout(r, 10)));
+      yield* sendMessage(chat.id, "usr_alice", {
+        ciphertext: "bXNnMg==",
+        nonce: "bm9uY2Uy",
+      });
+
+      const msgs = yield* listMessages(chat.id, "usr_alice");
+      expect(msgs).toHaveLength(2);
+      // Newest first.
+      expect(msgs[0]!.ciphertext).toBe("bXNnMg==");
+      expect(msgs[1]!.ciphertext).toBe("bXNnMQ==");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listMessages respects limit", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      for (let i = 0; i < 5; i++) {
+        yield* sendMessage(chat.id, "usr_alice", {
+          ciphertext: `bXNn${i}`,
+          nonce: `bm9uY2U${i}`,
+        });
+      }
+
+      const msgs = yield* listMessages(chat.id, "usr_alice", { limit: 2 });
+      expect(msgs).toHaveLength(2);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listMessages fails for non-member", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      const result = yield* Effect.either(listMessages(chat.id, "usr_bob"));
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("NotChatMember");
+      }
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("listMessages returns empty for chat with no messages", () =>
+    Effect.gen(function* () {
+      const chat = yield* seedChat({ type: "group" });
+      yield* seedMember(chat.id, "usr_alice", "admin");
+
+      const msgs = yield* listMessages(chat.id, "usr_alice");
+      expect(msgs).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/zap/api/tsconfig.json
+++ b/zap/api/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/node.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/zap/api/vitest.config.ts
+++ b/zap/api/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { environment: "node", include: ["tests/**/*.test.ts"] } });

--- a/zap/db/drizzle.config.ts
+++ b/zap/db/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/schema/index.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: process.env.ZAP_DATABASE_URL || "../../data/zap.db",
+  },
+});

--- a/zap/db/package.json
+++ b/zap/db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@zap/db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema/index.ts",
+    "./service": "./src/service.ts"
+  },
+  "scripts": {
+    "db:migrate": "bunx drizzle-kit generate",
+    "db:push": "bunx drizzle-kit push",
+    "db:studio": "bunx drizzle-kit studio",
+    "db:seed": "bun run src/seed.ts",
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
+  },
+  "dependencies": {
+    "@shared/db-utils": "workspace:*",
+    "drizzle-orm": "^0.38.0",
+    "effect": "^3.19.19"
+  },
+  "devDependencies": {
+    "@effect/vitest": "^0.27.0",
+    "@shared/typescript-config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.5.0",
+    "drizzle-kit": "^0.30.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/zap/db/src/index.ts
+++ b/zap/db/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/zap/db/src/schema/chatMembers.ts
+++ b/zap/db/src/schema/chatMembers.ts
@@ -1,0 +1,27 @@
+import { sqliteTable, text, integer, index, unique } from "drizzle-orm/sqlite-core";
+import { chats } from "./chats";
+
+export const chatMembers = sqliteTable(
+  "chat_members",
+  {
+    id: text("id").primaryKey(), // "cmem_" prefix
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id),
+    userId: text("user_id").notNull(), // references osn-db users (cross-DB, no FK)
+    role: text("role", { enum: ["admin", "member"] })
+      .notNull()
+      .default("member"),
+    joinedAt: integer("joined_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (t) => [
+    unique("chat_members_pair_idx").on(t.chatId, t.userId),
+    index("chat_members_chat_idx").on(t.chatId),
+    index("chat_members_user_idx").on(t.userId),
+  ],
+);
+
+export type ChatMember = typeof chatMembers.$inferSelect;
+export type NewChatMember = typeof chatMembers.$inferInsert;

--- a/zap/db/src/schema/chats.ts
+++ b/zap/db/src/schema/chats.ts
@@ -1,0 +1,31 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+export const chats = sqliteTable(
+  "chats",
+  {
+    id: text("id").primaryKey(), // "chat_" prefix
+    // "dm"    → 1:1 direct message
+    // "group" → user-created group chat
+    // "event" → Pulse event chat (provisioned via zapBridge)
+    type: text("type", { enum: ["dm", "group", "event"] }).notNull(),
+    title: text("title"),
+    // Opaque reference to a Pulse event. Only populated for type = "event".
+    // NOT a foreign key (cross-DB boundary — different SQLite files).
+    eventId: text("event_id"),
+    createdByUserId: text("created_by_user_id").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (t) => [
+    index("chats_type_idx").on(t.type),
+    index("chats_event_id_idx").on(t.eventId),
+    index("chats_created_by_user_id_idx").on(t.createdByUserId),
+  ],
+);
+
+export type Chat = typeof chats.$inferSelect;
+export type NewChat = typeof chats.$inferInsert;

--- a/zap/db/src/schema/index.ts
+++ b/zap/db/src/schema/index.ts
@@ -1,0 +1,3 @@
+export * from "./chats";
+export * from "./chatMembers";
+export * from "./messages";

--- a/zap/db/src/schema/messages.ts
+++ b/zap/db/src/schema/messages.ts
@@ -1,0 +1,36 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { chats } from "./chats";
+
+/**
+ * Messages store E2E-encrypted payloads. The server never sees plaintext.
+ *
+ * `ciphertext` holds the encrypted message body as base64 text.
+ * `nonce` holds the IV/nonce used for encryption.
+ *
+ * The encryption protocol (Signal sender-keys vs MLS) is a deferred
+ * decision — this schema accepts opaque blobs regardless of protocol.
+ */
+export const messages = sqliteTable(
+  "messages",
+  {
+    id: text("id").primaryKey(), // "msg_" prefix
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id),
+    senderUserId: text("sender_user_id").notNull(), // references osn-db users (cross-DB, no FK)
+    ciphertext: text("ciphertext").notNull(),
+    nonce: text("nonce").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    expiresAt: integer("expires_at", { mode: "timestamp" }),
+  },
+  (t) => [
+    index("messages_chat_idx").on(t.chatId),
+    index("messages_chat_created_idx").on(t.chatId, t.createdAt),
+    index("messages_sender_idx").on(t.senderUserId),
+  ],
+);
+
+export type Message = typeof messages.$inferSelect;
+export type NewMessage = typeof messages.$inferInsert;

--- a/zap/db/src/service.ts
+++ b/zap/db/src/service.ts
@@ -1,0 +1,20 @@
+import { Context } from "effect";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeDbLive } from "@shared/db-utils";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import * as schema from "./schema";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface DbService {
+  readonly db: BunSQLiteDatabase<typeof schema>;
+}
+
+export class Db extends Context.Tag("@zap/db/Db")<Db, DbService>() {}
+
+export const DbLive = makeDbLive(
+  Db,
+  process.env.ZAP_DATABASE_URL || resolve(__dirname, "../../../data/zap.db"),
+  schema,
+);

--- a/zap/db/tests/schema.test.ts
+++ b/zap/db/tests/schema.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from "vitest";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { eq } from "drizzle-orm";
+import * as schema from "../src/schema";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.run(`
+    CREATE TABLE chats (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      title TEXT,
+      event_id TEXT,
+      created_by_user_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  sqlite.run(`
+    CREATE TABLE chat_members (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id),
+      user_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'member',
+      joined_at INTEGER NOT NULL,
+      UNIQUE (chat_id, user_id)
+    )
+  `);
+  sqlite.run(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id),
+      sender_user_id TEXT NOT NULL,
+      ciphertext TEXT NOT NULL,
+      nonce TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER
+    )
+  `);
+  return drizzle(sqlite, { schema });
+}
+
+// ---------------------------------------------------------------------------
+// chats schema
+// ---------------------------------------------------------------------------
+
+describe("chats schema", () => {
+  it("inserts and retrieves a chat", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.chats).values({
+      id: "chat_test1",
+      type: "group",
+      title: "Test Group",
+      createdByUserId: "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const rows = await db.select().from(schema.chats).where(eq(schema.chats.id, "chat_test1"));
+    expect(rows).toHaveLength(1);
+
+    const row = rows[0]!;
+    expect(row.id).toBe("chat_test1");
+    expect(row.type).toBe("group");
+    expect(row.title).toBe("Test Group");
+    expect(row.eventId).toBeNull();
+    expect(row.createdByUserId).toBe("usr_alice");
+    expect(row.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("stores event chat with eventId", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.chats).values({
+      id: "chat_evt1",
+      type: "event",
+      title: "Event Chat",
+      eventId: "evt_abc123",
+      createdByUserId: "usr_bob",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [row] = await db.select().from(schema.chats).where(eq(schema.chats.id, "chat_evt1"));
+    expect(row!.type).toBe("event");
+    expect(row!.eventId).toBe("evt_abc123");
+  });
+
+  it("DM chats have null title and eventId", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.chats).values({
+      id: "chat_dm1",
+      type: "dm",
+      createdByUserId: "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [row] = await db.select().from(schema.chats).where(eq(schema.chats.id, "chat_dm1"));
+    expect(row!.type).toBe("dm");
+    expect(row!.title).toBeNull();
+    expect(row!.eventId).toBeNull();
+  });
+
+  it("createdAt round-trips as Date via timestamp mode", async () => {
+    const db = createTestDb();
+    const ts = new Date("2030-01-15T08:00:00.000Z");
+    await db.insert(schema.chats).values({
+      id: "chat_ts",
+      type: "group",
+      createdByUserId: "usr_alice",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    const [row] = await db.select().from(schema.chats).where(eq(schema.chats.id, "chat_ts"));
+    expect(row!.createdAt).toBeInstanceOf(Date);
+    expect(row!.createdAt.getTime()).toBe(ts.getTime());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chat_members schema
+// ---------------------------------------------------------------------------
+
+describe("chat_members schema", () => {
+  async function seedChat(db: ReturnType<typeof createTestDb>) {
+    const now = new Date();
+    await db.insert(schema.chats).values({
+      id: "chat_mem_test",
+      type: "group",
+      title: "Members Test",
+      createdByUserId: "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  it("inserts and retrieves a member", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    const now = new Date();
+    await db.insert(schema.chatMembers).values({
+      id: "cmem_1",
+      chatId: "chat_mem_test",
+      userId: "usr_alice",
+      role: "admin",
+      joinedAt: now,
+    });
+
+    const rows = await db
+      .select()
+      .from(schema.chatMembers)
+      .where(eq(schema.chatMembers.id, "cmem_1"));
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.chatId).toBe("chat_mem_test");
+    expect(row.userId).toBe("usr_alice");
+    expect(row.role).toBe("admin");
+    expect(row.joinedAt).toBeInstanceOf(Date);
+  });
+
+  it("defaults role to member", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    await db.insert(schema.chatMembers).values({
+      id: "cmem_default",
+      chatId: "chat_mem_test",
+      userId: "usr_bob",
+      joinedAt: new Date(),
+    });
+    const [row] = await db
+      .select()
+      .from(schema.chatMembers)
+      .where(eq(schema.chatMembers.id, "cmem_default"));
+    expect(row!.role).toBe("member");
+  });
+
+  it("enforces unique (chatId, userId) constraint", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    const now = new Date();
+    await db.insert(schema.chatMembers).values({
+      id: "cmem_dup1",
+      chatId: "chat_mem_test",
+      userId: "usr_alice",
+      joinedAt: now,
+    });
+    await expect(
+      db.insert(schema.chatMembers).values({
+        id: "cmem_dup2",
+        chatId: "chat_mem_test",
+        userId: "usr_alice",
+        joinedAt: now,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("allows same user in different chats", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.chats).values([
+      {
+        id: "chat_a",
+        type: "group",
+        createdByUserId: "usr_x",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "chat_b",
+        type: "group",
+        createdByUserId: "usr_x",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await db.insert(schema.chatMembers).values([
+      { id: "cmem_a", chatId: "chat_a", userId: "usr_alice", joinedAt: now },
+      { id: "cmem_b", chatId: "chat_b", userId: "usr_alice", joinedAt: now },
+    ]);
+    const rows = await db.select().from(schema.chatMembers);
+    expect(rows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messages schema
+// ---------------------------------------------------------------------------
+
+describe("messages schema", () => {
+  async function seedChat(db: ReturnType<typeof createTestDb>) {
+    const now = new Date();
+    await db.insert(schema.chats).values({
+      id: "chat_msg_test",
+      type: "group",
+      title: "Message Test",
+      createdByUserId: "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  it("inserts and retrieves a message", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    const now = new Date();
+    await db.insert(schema.messages).values({
+      id: "msg_1",
+      chatId: "chat_msg_test",
+      senderUserId: "usr_alice",
+      ciphertext: "dGVzdCBtZXNzYWdl",
+      nonce: "YWJjZGVmMTIzNDU2",
+      createdAt: now,
+    });
+
+    const rows = await db.select().from(schema.messages).where(eq(schema.messages.id, "msg_1"));
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.chatId).toBe("chat_msg_test");
+    expect(row.senderUserId).toBe("usr_alice");
+    expect(row.ciphertext).toBe("dGVzdCBtZXNzYWdl");
+    expect(row.nonce).toBe("YWJjZGVmMTIzNDU2");
+    expect(row.expiresAt).toBeNull();
+    expect(row.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("stores optional expiresAt", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    const now = new Date("2030-06-01T12:00:00.000Z");
+    const expires = new Date("2030-06-02T12:00:00.000Z");
+    await db.insert(schema.messages).values({
+      id: "msg_exp",
+      chatId: "chat_msg_test",
+      senderUserId: "usr_alice",
+      ciphertext: "ZXhwaXJpbmc=",
+      nonce: "bm9uY2UxMjM=",
+      createdAt: now,
+      expiresAt: expires,
+    });
+    const [row] = await db.select().from(schema.messages).where(eq(schema.messages.id, "msg_exp"));
+    expect(row!.expiresAt).toBeInstanceOf(Date);
+    expect(row!.expiresAt!.getTime()).toBe(expires.getTime());
+  });
+
+  it("createdAt round-trips as Date via timestamp mode", async () => {
+    const db = createTestDb();
+    await seedChat(db);
+    const ts = new Date("2030-06-01T12:00:00.000Z");
+    await db.insert(schema.messages).values({
+      id: "msg_ts",
+      chatId: "chat_msg_test",
+      senderUserId: "usr_alice",
+      ciphertext: "dGVzdA==",
+      nonce: "bm9uY2U=",
+      createdAt: ts,
+    });
+    const [row] = await db.select().from(schema.messages).where(eq(schema.messages.id, "msg_ts"));
+    expect(row!.createdAt).toBeInstanceOf(Date);
+    expect(row!.createdAt.getTime()).toBe(ts.getTime());
+  });
+});

--- a/zap/db/tsconfig.json
+++ b/zap/db/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/node.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/zap/db/vitest.config.ts
+++ b/zap/db/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { environment: "node", include: ["tests/**/*.test.ts"] } });


### PR DESCRIPTION
## Summary
- Create `@zap/db` package with `chats`, `chat_members`, and `messages` schema (Drizzle + SQLite) — the server stores opaque E2E-encrypted ciphertext blobs
- Create `@zap/api` package with Elysia server (port 3002), 9 REST endpoints for chat CRUD, member management, and message send/list with cursor pagination
- Effect services with tagged errors (`ChatNotFound`, `NotChatMember`, `NotChatAdmin`, etc.) and `Effect.withSpan` tracing on every function
- Observability metrics (`zap.chats.created`, `zap.messages.sent`, `zap.access.denied`, etc.) with bounded string-literal union attributes
- Per-IP rate limiting on write endpoints via `@osn/core` `createRateLimiter` (POST /chats 20/min, POST /messages 60/min, POST /members 30/min)
- Membership-gated reads on all chat endpoints (GET /chats/:id, GET /chats/:id/members, PATCH /chats/:id return 404 for non-members)
- Add `chatId` column to Pulse events schema for event-chat linking
- Add `zapBridge` service in Pulse for provisioning event chats and managing membership
- 63 new tests (11 schema + 26 service + 26 route), 297 total tests passing across affected packages

## Workspaces affected
- `@zap/db` (new)
- `@zap/api` (new)
- `@pulse/db` (schema change: `chatId` column)
- `@pulse/api` (new `zapBridge` service, test updates)
- `@osn/core` (barrel export: `createRateLimiter`, `getClientIp`)

## Decisions & issues

**[P-C1] — N+1 query in `listChats`**
- **Issue:** `listChats` fetched each chat individually in a sequential loop, issuing N+1 DB queries.
- **Why:** A user in 50 chats would trigger 51 queries; scales linearly and degrades with power users.
- **Solution:** Replaced with `inArray(chats.id, chatIds)` — single query.
- **Rationale:** `inArray` is already used elsewhere in the codebase (graph, rsvps) and is fully supported by Drizzle's SQLite dialect.

**[P-C2] — N+1 writes in `createChat`**
- **Issue:** Initial members were inserted one-by-one in a `for` loop (up to 500 individual INSERTs).
- **Why:** Creating a group chat with many members would be very slow due to serial inserts.
- **Solution:** Batch insert via `db.insert(chatMembers).values(memberRows)`.
- **Rationale:** Drizzle supports multi-row inserts natively; reduces N writes to 1.

**[S-H2] — Missing membership check on GET `/chats/:id`**
- **Issue:** Any authenticated user who knew a chat ID could read its metadata (title, type, eventId).
- **Why:** OWASP A01 (Broken Access Control) — horizontal privilege escalation.
- **Solution:** Added `assertMember` gate before returning chat data; non-members get 404.
- **Rationale:** Membership-gated reads are standard for private messaging. 404 avoids leaking chat existence.

**[S-H3] — Missing membership check on GET `/chats/:id/members`**
- **Issue:** Member roster of any chat was visible to any authenticated user.
- **Why:** Exposes who is in private chats/DMs/event chats.
- **Solution:** Added `assertMember` gate; non-members get 404.
- **Rationale:** Same pattern as S-H2.

**[S-H4] — Information leakage via error differentiation on PATCH `/chats/:id`**
- **Issue:** Non-members got 403 (Forbidden) while unknown chats got 404, letting attackers enumerate valid chat IDs.
- **Why:** Differentiated error responses leak existence information.
- **Solution:** Added membership gate; non-members now get 404 uniformly. Only confirmed members see 403 for non-admin actions.
- **Rationale:** Prevents chat-ID enumeration attacks.

**[S-M1] — No rate limiting on Zap endpoints — fixed**
- **Issue:** Zero rate limiting on chat creation, message sending, member addition.
- **Why:** Enables flood attacks and brute-force ID enumeration.
- **Solution:** Per-IP fixed-window rate limiting via `@osn/core` `createRateLimiter` + `getClientIp` (newly exported from barrel). POST /chats 20/min, POST /messages 60/min, POST /members 30/min. `ZapRateLimiters` interface + `createDefaultZapRateLimiters()` factory for DI/testing.
- **Rationale:** Reuses proven rate limiting infrastructure from OSN Core.

**[S-H1] — Hardcoded JWT fallback secret — deferred**
- **Issue:** `OSN_JWT_SECRET ?? "dev-secret-change-in-prod"` means a predictable key if env var is unset.
- **Why:** Same pattern as Pulse API; higher impact for messaging.
- **Solution:** Deferred — tracked as S-L7 in the Security Backlog. Production guard will be added in a follow-up.
- **Rationale:** Existing pattern across all services; needs a coordinated fix.

**[S-M6] — Truncated UUIDs (48-bit entropy) — deferred**
- **Issue:** IDs use `crypto.randomUUID().slice(0, 12)` = 48 bits, below 128-bit recommendation.
- **Why:** Same pattern as all existing OSN/Pulse ID generation.
- **Solution:** Tracked in Security Backlog. Needs a coordinated change across all packages.
- **Rationale:** Changing ID length is a schema migration; not appropriate for this PR.

**[P-W1/P-W2/P-W3/P-W4] — Pagination and efficiency gaps — deferred**
- **Issue:** `listChats` and `getChatMembers` have no pagination; `addMember` fetches all members for count check; `zapBridge` has non-atomic cross-DB writes.
- **Why:** Scale concerns for high-volume chats.
- **Solution:** All tracked in Performance Backlog with specific fix descriptions.
- **Rationale:** Acceptable for M0 scaffold; will be addressed as message volume grows.

**[T-M1] — zapBridge tests — fixed**
- **Issue:** `provisionEventChat` and `addEventChatMember` had no dedicated tests.
- **Why:** Cross-DB integration seam; idempotency logic needs coverage.
- **Solution:** 4 tests in `pulse/api/tests/services/zapBridge.test.ts` covering create, idempotent re-provision, add member, and idempotent duplicate.
- **Rationale:** Validates the four core code paths including the idempotency guarantees.

**[T-R1] — Route-level tests — fixed**
- **Issue:** 9 HTTP endpoints lacked route-level integration tests (auth, status codes, body validation).
- **Why:** Service tests don't exercise JWT auth extraction or HTTP error mapping.
- **Solution:** 26 route tests in `zap/api/tests/routes/chats.test.ts` following the `createChatsRoutes(createTestLayer())` pattern from Pulse.
- **Rationale:** Covers the entire auth + status-code + membership-gating surface.

**[P-I2] — Cursor pagination skips same-second messages — noted**
- **Issue:** `listMessages` cursor uses `lt(createdAt)` which skips messages with identical integer-second timestamps.
- **Why:** SQLite stores timestamps as integer seconds; rapid message sends can produce duplicates.
- **Solution:** Deferred — tracked in Performance Backlog. Fix: composite cursor `(createdAt, id)`.
- **Rationale:** Low frequency in practice; proper fix requires query refactoring.

## Test plan
- [x] `bun run --cwd zap/db test:run` — 11 schema tests pass
- [x] `bun run --cwd zap/api test:run` — 52 tests pass (22 service + 4 route auth + 26 route integration)
- [x] `bun run --cwd pulse/db test:run` — 35 tests pass (includes chatId column)
- [x] `bun run --cwd pulse/api test:run` — 199 tests pass (includes 4 zapBridge tests + calendar fixture)
- [x] `bun run check` — all 16 packages type-check clean
- [ ] Verify new `@zap/api` starts on port 3002 (`bun run --cwd zap/api dev`)
- [ ] Verify rate limiting returns 429 after exceeding thresholds
- [ ] Verify non-members get 404 on all gated endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)