### PR TITLE
feat(osn): add organisation support with membership and roles

### DIFF
--- a/.changeset/add-org-support.md
+++ b/.changeset/add-org-support.md
@@ -1,0 +1,8 @@
+---
+"@osn/db": minor
+"@osn/core": minor
+"@osn/app": patch
+"@shared/observability": patch
+---
+
+Add organisation support with membership and role management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Monorepo organised by domain. Four directories, four prefixes — see `[[wiki/ar
 
 | Dir | Prefix | What lives here |
 |-----|--------|-----------------|
-| `osn/` | `@osn/*` | Identity stack (auth, graph, SDK, crypto, landing) |
+| `osn/` | `@osn/*` | Identity stack (auth, graph, organisations, SDK, crypto, landing) |
 | `pulse/` | `@pulse/*` | Events stack (app, API, DB) |
 | `zap/` | `@zap/*` | Messaging stack (API on port 3002, DB) |
 | `shared/` | `@shared/*` | Cross-cutting utilities |

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -3,8 +3,11 @@ import {
   createAuthRoutes,
   createGraphRoutes,
   createInternalGraphRoutes,
+  createOrganisationRoutes,
+  createInternalOrganisationRoutes,
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
+  createRedisOrgRateLimiter,
 } from "@osn/core";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
@@ -45,6 +48,7 @@ const redisClient = await initRedisClient({
 
 const authRateLimiters = createRedisAuthRateLimiters(redisClient);
 const graphRateLimiter = createRedisGraphRateLimiter(redisClient);
+const orgRateLimiter = createRedisOrgRateLimiter(redisClient);
 
 const app = new Elysia()
   .use(cors())
@@ -53,7 +57,9 @@ const app = new Elysia()
   .get("/", () => ({ status: "ok", service: "osn-auth" }))
   .use(createAuthRoutes(authConfig, DbLive, observabilityLayer, authRateLimiters))
   .use(createGraphRoutes(authConfig, DbLive, observabilityLayer, graphRateLimiter))
-  .use(createInternalGraphRoutes(DbLive));
+  .use(createInternalGraphRoutes(DbLive))
+  .use(createOrganisationRoutes(authConfig, DbLive, observabilityLayer, orgRateLimiter))
+  .use(createInternalOrganisationRoutes(DbLive));
 
 if (process.env.NODE_ENV !== "test") {
   app.listen(port);

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -7,10 +7,15 @@ export { createGraphRoutes, createDefaultGraphRateLimiter } from "./routes/graph
 export { createInternalGraphRoutes } from "./routes/graph-internal";
 export { createGraphService } from "./services/graph";
 export type { GraphService } from "./services/graph";
+export { createOrganisationRoutes, createDefaultOrgRateLimiter } from "./routes/organisation";
+export { createInternalOrganisationRoutes } from "./routes/organisation-internal";
+export { createOrganisationService } from "./services/organisation";
+export type { OrganisationService } from "./services/organisation";
 export { createRateLimiter, getClientIp, type RateLimiterBackend } from "./lib/rate-limit";
 export {
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
+  createRedisOrgRateLimiter,
 } from "./lib/redis-rate-limiters";
 export { requireArc } from "./lib/arc-middleware";
 export type { ArcCaller } from "./lib/arc-middleware";

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -54,3 +54,15 @@ export function createRedisGraphRateLimiter(client: RedisClient): RateLimiterBac
     windowMs: ONE_MINUTE_MS,
   });
 }
+
+/**
+ * Build the organisation write rate limiter backed by Redis.
+ * Namespace: `org:write` — key is the authenticated user ID.
+ */
+export function createRedisOrgRateLimiter(client: RedisClient): RateLimiterBackend {
+  return createRedisRateLimiter(client, {
+    namespace: "org:write",
+    maxRequests: 60,
+    windowMs: ONE_MINUTE_MS,
+  });
+}

--- a/osn/core/src/metrics.ts
+++ b/osn/core/src/metrics.ts
@@ -19,6 +19,8 @@ import type {
   GraphBlockAction,
   GraphCloseFriendAction,
   GraphConnectionAction,
+  OrgAction,
+  OrgMemberAction,
   RegisterStep,
   Result,
 } from "@shared/observability/metrics";
@@ -38,6 +40,8 @@ export const OSN_METRICS = {
   graphConnectionOps: "osn.graph.connection.operations",
   graphBlockOps: "osn.graph.block.operations",
   graphCloseFriendOps: "osn.graph.close_friend.operations",
+  orgOps: "osn.org.operations",
+  orgMemberOps: "osn.org.member.operations",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -54,6 +58,8 @@ type AuthRateLimitAttrs = { endpoint: AuthRateLimitedEndpoint };
 type GraphConnectionAttrs = { action: GraphConnectionAction; result: Result };
 type GraphBlockAttrs = { action: GraphBlockAction; result: Result };
 type GraphCloseFriendAttrs = { action: GraphCloseFriendAction; result: Result };
+type OrgAttrs = { action: OrgAction; result: Result };
+type OrgMemberAttrs = { action: OrgMemberAction; result: Result };
 
 // ---------------------------------------------------------------------------
 // Counters / histograms
@@ -130,6 +136,18 @@ const graphBlockOps = createCounter<GraphBlockAttrs>({
 const graphCloseFriendOps = createCounter<GraphCloseFriendAttrs>({
   name: OSN_METRICS.graphCloseFriendOps,
   description: "Social graph close-friend add/remove operations",
+  unit: "{operation}",
+});
+
+const orgOps = createCounter<OrgAttrs>({
+  name: OSN_METRICS.orgOps,
+  description: "Organisation CRUD operations",
+  unit: "{operation}",
+});
+
+const orgMemberOps = createCounter<OrgMemberAttrs>({
+  name: OSN_METRICS.orgMemberOps,
+  description: "Organisation membership state changes",
   unit: "{operation}",
 });
 
@@ -313,6 +331,34 @@ export const metricAuthOtpSent = (purpose: "registration" | "login"): void =>
   authOtpSent.inc({ purpose });
 
 export const metricAuthMagicLinkSent = (result: Result): void => authMagicLinkSent.inc({ result });
+
+export const withOrgOp =
+  (action: OrgAction) =>
+  <A, E, Ctx>(effect: Effect.Effect<A, E, Ctx>): Effect.Effect<A, E, Ctx> =>
+    effect.pipe(
+      Effect.withSpan(`org.${action}`),
+      Effect.tap(() => Effect.sync(() => orgOps.inc({ action, result: "ok" }))),
+      Effect.tapError((e) =>
+        Effect.all([
+          Effect.sync(() => orgOps.inc({ action, result: classifyError(e) })),
+          Effect.logError("org operation failed", { action, ...safeErrorSummary(e) }),
+        ]),
+      ),
+    );
+
+export const withOrgMemberOp =
+  (action: OrgMemberAction) =>
+  <A, E, Ctx>(effect: Effect.Effect<A, E, Ctx>): Effect.Effect<A, E, Ctx> =>
+    effect.pipe(
+      Effect.withSpan(`org.member.${action}`),
+      Effect.tap(() => Effect.sync(() => orgMemberOps.inc({ action, result: "ok" }))),
+      Effect.tapError((e) =>
+        Effect.all([
+          Effect.sync(() => orgMemberOps.inc({ action, result: classifyError(e) })),
+          Effect.logError("org.member operation failed", { action, ...safeErrorSummary(e) }),
+        ]),
+      ),
+    );
 
 export const metricAuthRateLimited = (endpoint: AuthRateLimitedEndpoint): void =>
   authRateLimited.inc({ endpoint });

--- a/osn/core/src/routes/organisation-internal.ts
+++ b/osn/core/src/routes/organisation-internal.ts
@@ -1,0 +1,92 @@
+import { DbLive, type Db } from "@osn/db/service";
+import { Effect, Layer } from "effect";
+import { Elysia, t } from "elysia";
+
+import { requireArc } from "../lib/arc-middleware";
+import { createOrganisationService } from "../services/organisation";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AUDIENCE = "osn-core";
+const SCOPE_ORG_READ = "org:read";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeError(e: unknown): string {
+  if (e instanceof Error) {
+    if ("_tag" in e && (e._tag === "OrgError" || e._tag === "NotFoundError")) {
+      return (e as { message: string }).message;
+    }
+  }
+  return "Request failed";
+}
+
+// ---------------------------------------------------------------------------
+// Internal organisation routes — ARC token protected
+// ---------------------------------------------------------------------------
+
+export function createInternalOrganisationRoutes(dbLayer: Layer.Layer<Db> = DbLive) {
+  const org = createOrganisationService();
+
+  const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(dbLayer)) as Effect.Effect<A, never, never>);
+
+  return new Elysia({ prefix: "/organisations/internal" })
+    .get(
+      "/user-orgs",
+      async ({ query, headers, set }) => {
+        const caller = await requireArc(
+          headers.authorization,
+          set,
+          dbLayer,
+          AUDIENCE,
+          SCOPE_ORG_READ,
+        );
+        if (!caller) return { error: "Unauthorized" };
+
+        try {
+          const list = await run(org.listUserOrganisations(query.userId));
+          return { organisationIds: list.map((o) => o.id) };
+        } catch (e) {
+          set.status = 500;
+          return { error: safeError(e) };
+        }
+      },
+      {
+        query: t.Object({
+          userId: t.String({ minLength: 1 }),
+        }),
+      },
+    )
+    .get(
+      "/membership",
+      async ({ query, headers, set }) => {
+        const caller = await requireArc(
+          headers.authorization,
+          set,
+          dbLayer,
+          AUDIENCE,
+          SCOPE_ORG_READ,
+        );
+        if (!caller) return { error: "Unauthorized" };
+
+        try {
+          const role = await run(org.getMemberRole(query.orgId, query.userId));
+          return { role };
+        } catch (e) {
+          set.status = 500;
+          return { error: safeError(e) };
+        }
+      },
+      {
+        query: t.Object({
+          orgId: t.String({ minLength: 1 }),
+          userId: t.String({ minLength: 1 }),
+        }),
+      },
+    );
+}

--- a/osn/core/src/routes/organisation-internal.ts
+++ b/osn/core/src/routes/organisation-internal.ts
@@ -11,6 +11,9 @@ import { createOrganisationService } from "../services/organisation";
 
 const AUDIENCE = "osn-core";
 const SCOPE_ORG_READ = "org:read";
+/** S-M2: defined now so future mutation endpoints use the write scope, not read. */
+const _SCOPE_ORG_WRITE = "org:write";
+void _SCOPE_ORG_WRITE;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -58,7 +61,7 @@ export function createInternalOrganisationRoutes(dbLayer: Layer.Layer<Db> = DbLi
       },
       {
         query: t.Object({
-          userId: t.String({ minLength: 1 }),
+          userId: t.String({ minLength: 1, maxLength: 50 }),
         }),
       },
     )
@@ -84,8 +87,8 @@ export function createInternalOrganisationRoutes(dbLayer: Layer.Layer<Db> = DbLi
       },
       {
         query: t.Object({
-          orgId: t.String({ minLength: 1 }),
-          userId: t.String({ minLength: 1 }),
+          orgId: t.String({ minLength: 1, maxLength: 50 }),
+          userId: t.String({ minLength: 1, maxLength: 50 }),
         }),
       },
     );

--- a/osn/core/src/routes/organisation.ts
+++ b/osn/core/src/routes/organisation.ts
@@ -379,11 +379,12 @@ export function createOrganisationRoutes(
           try {
             const list = await run(org.listMembers(organisation.id, parsePagination(query)));
             return {
-              members: list.map((m) => ({
-                ...userProjection(m.user),
-                role: m.role,
-                joinedAt: m.joinedAt.toISOString(),
-              })),
+              members: list.map((m) =>
+                Object.assign({}, userProjection(m.user), {
+                  role: m.role,
+                  joinedAt: m.joinedAt.toISOString(),
+                }),
+              ),
             };
           } catch (e) {
             set.status = 500;

--- a/osn/core/src/routes/organisation.ts
+++ b/osn/core/src/routes/organisation.ts
@@ -1,0 +1,396 @@
+import type { Organisation, User } from "@osn/db/schema";
+import { DbLive, type Db } from "@osn/db/service";
+import { Effect, Layer } from "effect";
+import { Elysia, t } from "elysia";
+
+import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
+import { createAuthService, type AuthConfig } from "../services/auth";
+import { createOrganisationService } from "../services/organisation";
+
+// ---------------------------------------------------------------------------
+// Rate limiter
+// ---------------------------------------------------------------------------
+
+const ORG_RATE_LIMIT_MAX = 60;
+const ORG_RATE_LIMIT_WINDOW_MS = 60_000;
+
+export function createDefaultOrgRateLimiter(): RateLimiterBackend {
+  return createRateLimiter({
+    maxRequests: ORG_RATE_LIMIT_MAX,
+    windowMs: ORG_RATE_LIMIT_WINDOW_MS,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractToken(authorization: string | undefined): string | null {
+  if (!authorization) return null;
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+function safeError(e: unknown): string {
+  if (e instanceof Error) {
+    if ("_tag" in e && (e._tag === "OrgError" || e._tag === "NotFoundError")) {
+      return (e as { message: string }).message;
+    }
+  }
+  return "Request failed";
+}
+
+// TypeBox schemas
+const HandleParam = t.Object({
+  handle: t.String({ minLength: 1, maxLength: 30, pattern: "^[a-z0-9_]+$" }),
+});
+
+const MemberHandleParams = t.Object({
+  handle: t.String({ minLength: 1, maxLength: 30, pattern: "^[a-z0-9_]+$" }),
+  userHandle: t.String({ minLength: 1, maxLength: 30, pattern: "^[a-z0-9_]+$" }),
+});
+
+const PaginationQuery = t.Object({
+  limit: t.Optional(t.String()),
+  offset: t.Optional(t.String()),
+});
+
+function userProjection(u: User) {
+  return {
+    handle: u.handle,
+    displayName: u.displayName ?? null,
+  };
+}
+
+function orgProjection(o: Organisation) {
+  return {
+    handle: o.handle,
+    name: o.name,
+    description: o.description ?? null,
+    avatarUrl: o.avatarUrl ?? null,
+    createdAt: o.createdAt.toISOString(),
+    updatedAt: o.updatedAt.toISOString(),
+  };
+}
+
+function parsePagination(query: { limit?: string; offset?: string }) {
+  const limit = query.limit !== undefined ? parseInt(query.limit, 10) : undefined;
+  const offset = query.offset !== undefined ? parseInt(query.offset, 10) : undefined;
+  return {
+    limit: Number.isFinite(limit) ? limit : undefined,
+    offset: Number.isFinite(offset) ? offset : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route factory
+// ---------------------------------------------------------------------------
+
+export function createOrganisationRoutes(
+  authConfig: AuthConfig,
+  dbLayer: Layer.Layer<Db> = DbLive,
+  loggerLayer: Layer.Layer<never> = Layer.empty,
+  rateLimiter: RateLimiterBackend = createDefaultOrgRateLimiter(),
+) {
+  if (typeof rateLimiter?.check !== "function") {
+    throw new Error("Org rateLimiter must have a check() method");
+  }
+
+  const auth = createAuthService(authConfig);
+  const org = createOrganisationService();
+
+  const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
+    Effect.runPromise(
+      eff.pipe(Effect.provide(dbLayer), Effect.provide(loggerLayer)) as Effect.Effect<
+        A,
+        never,
+        never
+      >,
+    );
+
+  async function requireAuth(
+    authorization: string | undefined,
+    set: { status?: number | string },
+  ): Promise<{ userId: string; handle: string } | null> {
+    const token = extractToken(authorization);
+    if (!token) {
+      set.status = 401;
+      return null;
+    }
+    try {
+      return await Effect.runPromise(Effect.orDie(auth.verifyAccessToken(token)));
+    } catch {
+      set.status = 401;
+      return null;
+    }
+  }
+
+  async function requireRateLimit(
+    userId: string,
+    set: { status?: number | string },
+  ): Promise<boolean> {
+    let allowed: boolean;
+    try {
+      allowed = await rateLimiter.check(userId);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
+      set.status = 429;
+      return false;
+    }
+    return true;
+  }
+
+  async function resolveHandle(
+    handle: string,
+    set: { status?: number | string },
+  ): Promise<User | null> {
+    try {
+      const user = await run(auth.findUserByHandle(handle));
+      if (!user) {
+        set.status = 404;
+        return null;
+      }
+      return user;
+    } catch {
+      set.status = 500;
+      return null;
+    }
+  }
+
+  async function resolveOrg(
+    handle: string,
+    set: { status?: number | string },
+  ): Promise<Organisation | null> {
+    try {
+      const organisation = await run(org.getOrganisationByHandle(handle));
+      if (!organisation) {
+        set.status = 404;
+        return null;
+      }
+      return organisation;
+    } catch {
+      set.status = 500;
+      return null;
+    }
+  }
+
+  return (
+    new Elysia({ prefix: "/organisations" })
+      // -----------------------------------------------------------------------
+      // Organisation CRUD
+      // -----------------------------------------------------------------------
+      .post(
+        "/",
+        async ({ body, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          try {
+            const organisation = await run(
+              org.createOrganisation(caller.userId, body.handle, body.name, body.description),
+            );
+            set.status = 201;
+            return { ok: true, organisation: orgProjection(organisation) };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        {
+          body: t.Object({
+            handle: t.String({ minLength: 1, maxLength: 30, pattern: "^[a-z0-9_]+$" }),
+            name: t.String({ minLength: 1, maxLength: 100 }),
+            description: t.Optional(t.String({ maxLength: 500 })),
+          }),
+        },
+      )
+      .get(
+        "/",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          try {
+            const list = await run(
+              org.listUserOrganisations(caller.userId, parsePagination(query)),
+            );
+            return { organisations: list.map(orgProjection) };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
+      .get(
+        "/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          return { organisation: orgProjection(organisation) };
+        },
+        { params: HandleParam },
+      )
+      .patch(
+        "/:handle",
+        async ({ params, body, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          try {
+            const updated = await run(org.updateOrganisation(organisation.id, caller.userId, body));
+            return { ok: true, organisation: orgProjection(updated) };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        {
+          params: HandleParam,
+          body: t.Object({
+            name: t.Optional(t.String({ minLength: 1, maxLength: 100 })),
+            description: t.Optional(t.String({ maxLength: 500 })),
+          }),
+        },
+      )
+      .delete(
+        "/:handle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          try {
+            await run(org.deleteOrganisation(organisation.id, caller.userId));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        { params: HandleParam },
+      )
+      // -----------------------------------------------------------------------
+      // Member management
+      // -----------------------------------------------------------------------
+      .post(
+        "/:handle/members/:userHandle",
+        async ({ params, body, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          const target = await resolveHandle(params.userHandle, set);
+          if (!target) return { error: "User not found" };
+
+          try {
+            await run(org.addMember(organisation.id, caller.userId, target.id, body.role));
+            set.status = 201;
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        {
+          params: MemberHandleParams,
+          body: t.Object({
+            role: t.Union([t.Literal("admin"), t.Literal("member")]),
+          }),
+        },
+      )
+      .delete(
+        "/:handle/members/:userHandle",
+        async ({ params, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          const target = await resolveHandle(params.userHandle, set);
+          if (!target) return { error: "User not found" };
+
+          try {
+            await run(org.removeMember(organisation.id, caller.userId, target.id));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        { params: MemberHandleParams },
+      )
+      .patch(
+        "/:handle/members/:userHandle",
+        async ({ params, body, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          if (!(await requireRateLimit(caller.userId, set))) return { error: "Too many requests" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          const target = await resolveHandle(params.userHandle, set);
+          if (!target) return { error: "User not found" };
+
+          try {
+            await run(org.updateMemberRole(organisation.id, caller.userId, target.id, body.role));
+            return { ok: true };
+          } catch (e) {
+            set.status = 400;
+            return { error: safeError(e) };
+          }
+        },
+        {
+          params: MemberHandleParams,
+          body: t.Object({
+            role: t.Union([t.Literal("admin"), t.Literal("member")]),
+          }),
+        },
+      )
+      .get(
+        "/:handle/members",
+        async ({ params, query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+
+          const organisation = await resolveOrg(params.handle, set);
+          if (!organisation) return { error: "Organisation not found" };
+
+          try {
+            const list = await run(org.listMembers(organisation.id, parsePagination(query)));
+            return {
+              members: list.map((m) => ({
+                ...userProjection(m.user),
+                role: m.role,
+                joinedAt: m.joinedAt.toISOString(),
+              })),
+            };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { params: HandleParam, query: PaginationQuery },
+      )
+  );
+}

--- a/osn/core/src/services/organisation.ts
+++ b/osn/core/src/services/organisation.ts
@@ -1,6 +1,6 @@
 import { organisations, organisationMembers, users } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
 import { withOrgMemberOp, withOrgOp } from "../metrics";
@@ -64,8 +64,8 @@ export function createOrganisationService() {
     Effect.gen(function* () {
       const { db } = yield* Db;
 
-      // Check handle uniqueness across users and organisations
-      const [existingUser, existingOrg] = yield* Effect.tryPromise({
+      // P-W1: parallelise all pre-insert checks (handle user, handle org, owner exists)
+      const [existingUser, existingOrg, ownerRows] = yield* Effect.tryPromise({
         try: () =>
           Promise.all([
             db.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1),
@@ -74,19 +74,15 @@ export function createOrganisationService() {
               .from(organisations)
               .where(eq(organisations.handle, handle))
               .limit(1),
+            db.select({ id: users.id }).from(users).where(eq(users.id, ownerId)).limit(1),
           ]),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
+      // S-H2: use generic message to avoid confirming handle existence
       if (existingUser.length > 0 || existingOrg.length > 0) {
-        return yield* Effect.fail(new OrgError({ message: "Handle already taken" }));
+        return yield* Effect.fail(new OrgError({ message: "Handle unavailable" }));
       }
-
-      // Verify owner exists
-      const ownerRows = yield* Effect.tryPromise({
-        try: () => db.select({ id: users.id }).from(users).where(eq(users.id, ownerId)).limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
 
       if (ownerRows.length === 0) {
         return yield* Effect.fail(new OrgError({ message: "Owner not found" }));
@@ -94,6 +90,7 @@ export function createOrganisationService() {
 
       const ts = now();
       const orgId = genId("org_");
+      const desc = description ?? null;
 
       // Insert org + owner as admin in a single transaction
       yield* Effect.tryPromise({
@@ -103,7 +100,7 @@ export function createOrganisationService() {
               id: orgId,
               handle,
               name,
-              description: description ?? null,
+              description: desc,
               avatarUrl: null,
               ownerId,
               createdAt: ts,
@@ -120,12 +117,17 @@ export function createOrganisationService() {
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      const rows = yield* Effect.tryPromise({
-        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
-      return rows[0];
+      // P-I1: construct return value from known inputs instead of re-fetching
+      return {
+        id: orgId,
+        handle,
+        name,
+        description: desc,
+        avatarUrl: null,
+        ownerId,
+        createdAt: ts,
+        updatedAt: ts,
+      };
     }).pipe(withOrgOp("create"));
 
   const getOrganisation = (
@@ -203,7 +205,8 @@ export function createOrganisationService() {
         );
       }
 
-      const setClause: Record<string, unknown> = { updatedAt: now() };
+      const ts = now();
+      const setClause: Record<string, unknown> = { updatedAt: ts };
       if (updates.name !== undefined) setClause.name = updates.name;
       if (updates.description !== undefined) setClause.description = updates.description;
 
@@ -212,12 +215,14 @@ export function createOrganisationService() {
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      const updated = yield* Effect.tryPromise({
-        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
-      return updated[0];
+      // P-W6: construct return from known state instead of re-fetching
+      const org = orgRows[0];
+      return {
+        ...org,
+        name: updates.name ?? org.name,
+        description: updates.description ?? org.description,
+        updatedAt: ts,
+      };
     }).pipe(withOrgOp("update"));
 
   const deleteOrganisation = (
@@ -263,27 +268,29 @@ export function createOrganisationService() {
       const limit = clampLimit(options.limit);
       const offset = options.offset ?? 0;
 
-      const memberRows = yield* Effect.tryPromise({
+      // P-W4: single JOIN query instead of two-step lookup
+      const rows = yield* Effect.tryPromise({
         try: () =>
           db
-            .select({ organisationId: organisationMembers.organisationId })
+            .select({
+              id: organisations.id,
+              handle: organisations.handle,
+              name: organisations.name,
+              description: organisations.description,
+              avatarUrl: organisations.avatarUrl,
+              ownerId: organisations.ownerId,
+              createdAt: organisations.createdAt,
+              updatedAt: organisations.updatedAt,
+            })
             .from(organisationMembers)
+            .innerJoin(organisations, eq(organisationMembers.organisationId, organisations.id))
             .where(eq(organisationMembers.userId, userId))
             .limit(limit)
             .offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      if (memberRows.length === 0) return [];
-
-      const orgIds = memberRows.map((r) => r.organisationId);
-
-      const orgs = yield* Effect.tryPromise({
-        try: () => db.select().from(organisations).where(inArray(organisations.id, orgIds)),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
-      return orgs;
+      return rows;
     }).pipe(Effect.withSpan("org.list_by_user"));
 
   // -------------------------------------------------------------------------
@@ -299,64 +306,46 @@ export function createOrganisationService() {
     Effect.gen(function* () {
       const { db } = yield* Db;
 
-      // Check org exists
-      const orgRows = yield* Effect.tryPromise({
-        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+      // P-W2: parallelise all pre-insert checks
+      const [orgRows, callerMember, targetRows, existing] = yield* Effect.tryPromise({
+        try: () =>
+          Promise.all([
+            db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+            db
+              .select()
+              .from(organisationMembers)
+              .where(
+                and(
+                  eq(organisationMembers.organisationId, orgId),
+                  eq(organisationMembers.userId, callerId),
+                  eq(organisationMembers.role, "admin"),
+                ),
+              )
+              .limit(1),
+            db.select({ id: users.id }).from(users).where(eq(users.id, targetUserId)).limit(1),
+            db
+              .select()
+              .from(organisationMembers)
+              .where(
+                and(
+                  eq(organisationMembers.organisationId, orgId),
+                  eq(organisationMembers.userId, targetUserId),
+                ),
+              )
+              .limit(1),
+          ]),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
       if (orgRows.length === 0) {
         return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
       }
-
-      // Check caller is admin
-      const callerMember = yield* Effect.tryPromise({
-        try: () =>
-          db
-            .select()
-            .from(organisationMembers)
-            .where(
-              and(
-                eq(organisationMembers.organisationId, orgId),
-                eq(organisationMembers.userId, callerId),
-                eq(organisationMembers.role, "admin"),
-              ),
-            )
-            .limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
       if (callerMember.length === 0) {
         return yield* Effect.fail(new OrgError({ message: "Only admins can add members" }));
       }
-
-      // Check target user exists
-      const targetRows = yield* Effect.tryPromise({
-        try: () =>
-          db.select({ id: users.id }).from(users).where(eq(users.id, targetUserId)).limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
       if (targetRows.length === 0) {
         return yield* Effect.fail(new OrgError({ message: "Target user not found" }));
       }
-
-      // Check not already a member
-      const existing = yield* Effect.tryPromise({
-        try: () =>
-          db
-            .select()
-            .from(organisationMembers)
-            .where(
-              and(
-                eq(organisationMembers.organisationId, orgId),
-                eq(organisationMembers.userId, targetUserId),
-              ),
-            )
-            .limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
       if (existing.length > 0) {
         return yield* Effect.fail(new OrgError({ message: "User is already a member" }));
       }
@@ -532,32 +521,41 @@ export function createOrganisationService() {
         return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
       }
 
-      const memberRows = yield* Effect.tryPromise({
+      // P-W5: single JOIN query instead of two-step lookup
+      const rows = yield* Effect.tryPromise({
         try: () =>
           db
-            .select()
+            .select({
+              id: users.id,
+              handle: users.handle,
+              email: users.email,
+              displayName: users.displayName,
+              avatarUrl: users.avatarUrl,
+              createdAt: users.createdAt,
+              updatedAt: users.updatedAt,
+              role: organisationMembers.role,
+              joinedAt: organisationMembers.createdAt,
+            })
             .from(organisationMembers)
+            .innerJoin(users, eq(organisationMembers.userId, users.id))
             .where(eq(organisationMembers.organisationId, orgId))
             .limit(limit)
             .offset(offset),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      if (memberRows.length === 0) return [];
-
-      const userIds = memberRows.map((m) => m.userId);
-      const roleMap = new Map(memberRows.map((m) => [m.userId, m.role]));
-      const joinedMap = new Map(memberRows.map((m) => [m.userId, m.createdAt]));
-
-      const memberUsers = yield* Effect.tryPromise({
-        try: () => db.select().from(users).where(inArray(users.id, userIds)),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-
-      return memberUsers.map((u) => ({
-        user: u,
-        role: roleMap.get(u.id) ?? "member",
-        joinedAt: joinedMap.get(u.id) ?? new Date(),
+      return rows.map((r) => ({
+        user: {
+          id: r.id,
+          handle: r.handle,
+          email: r.email,
+          displayName: r.displayName,
+          avatarUrl: r.avatarUrl,
+          createdAt: r.createdAt,
+          updatedAt: r.updatedAt,
+        },
+        role: r.role,
+        joinedAt: r.joinedAt,
       }));
     }).pipe(Effect.withSpan("org.member.list"));
 

--- a/osn/core/src/services/organisation.ts
+++ b/osn/core/src/services/organisation.ts
@@ -1,0 +1,604 @@
+import { organisations, organisationMembers, users } from "@osn/db/schema";
+import { Db } from "@osn/db/service";
+import { and, eq, inArray } from "drizzle-orm";
+import { Data, Effect } from "effect";
+
+import { withOrgMemberOp, withOrgOp } from "../metrics";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class OrgError extends Data.TaggedError("OrgError")<{
+  readonly message: string;
+}> {}
+
+export class NotFoundError extends Data.TaggedError("NotFoundError")<{
+  readonly message: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ListOptions {
+  limit?: number;
+  offset?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function genId(prefix: string): string {
+  return prefix + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function now(): Date {
+  return new Date();
+}
+
+function clampLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? 50, 1), 100);
+}
+
+// ---------------------------------------------------------------------------
+// Organisation service factory
+// ---------------------------------------------------------------------------
+
+export function createOrganisationService() {
+  // -------------------------------------------------------------------------
+  // Organisation CRUD
+  // -------------------------------------------------------------------------
+
+  const createOrganisation = (
+    ownerId: string,
+    handle: string,
+    name: string,
+    description?: string,
+  ): Effect.Effect<typeof organisations.$inferSelect, OrgError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Check handle uniqueness across users and organisations
+      const [existingUser, existingOrg] = yield* Effect.tryPromise({
+        try: () =>
+          Promise.all([
+            db.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1),
+            db
+              .select({ id: organisations.id })
+              .from(organisations)
+              .where(eq(organisations.handle, handle))
+              .limit(1),
+          ]),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (existingUser.length > 0 || existingOrg.length > 0) {
+        return yield* Effect.fail(new OrgError({ message: "Handle already taken" }));
+      }
+
+      // Verify owner exists
+      const ownerRows = yield* Effect.tryPromise({
+        try: () => db.select({ id: users.id }).from(users).where(eq(users.id, ownerId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (ownerRows.length === 0) {
+        return yield* Effect.fail(new OrgError({ message: "Owner not found" }));
+      }
+
+      const ts = now();
+      const orgId = genId("org_");
+
+      // Insert org + owner as admin in a single transaction
+      yield* Effect.tryPromise({
+        try: () =>
+          db.transaction(async (tx) => {
+            await tx.insert(organisations).values({
+              id: orgId,
+              handle,
+              name,
+              description: description ?? null,
+              avatarUrl: null,
+              ownerId,
+              createdAt: ts,
+              updatedAt: ts,
+            });
+            await tx.insert(organisationMembers).values({
+              id: genId("orgm_"),
+              organisationId: orgId,
+              userId: ownerId,
+              role: "admin",
+              createdAt: ts,
+            });
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const rows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return rows[0];
+    }).pipe(withOrgOp("create"));
+
+  const getOrganisation = (
+    orgId: string,
+  ): Effect.Effect<typeof organisations.$inferSelect, NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      return rows[0];
+    }).pipe(Effect.withSpan("org.get"));
+
+  const getOrganisationByHandle = (
+    handle: string,
+  ): Effect.Effect<typeof organisations.$inferSelect | null, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.handle, handle)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return rows.length > 0 ? rows[0] : null;
+    }).pipe(Effect.withSpan("org.get_by_handle"));
+
+  const updateOrganisation = (
+    orgId: string,
+    callerId: string,
+    updates: { name?: string; description?: string },
+  ): Effect.Effect<
+    typeof organisations.$inferSelect,
+    OrgError | NotFoundError | DatabaseError,
+    Db
+  > =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Check org exists
+      const orgRows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      // Check caller is admin
+      const memberRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, callerId),
+                eq(organisationMembers.role, "admin"),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (memberRows.length === 0) {
+        return yield* Effect.fail(
+          new OrgError({ message: "Only admins can update the organisation" }),
+        );
+      }
+
+      const setClause: Record<string, unknown> = { updatedAt: now() };
+      if (updates.name !== undefined) setClause.name = updates.name;
+      if (updates.description !== undefined) setClause.description = updates.description;
+
+      yield* Effect.tryPromise({
+        try: () => db.update(organisations).set(setClause).where(eq(organisations.id, orgId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const updated = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return updated[0];
+    }).pipe(withOrgOp("update"));
+
+  const deleteOrganisation = (
+    orgId: string,
+    callerId: string,
+  ): Effect.Effect<void, OrgError | NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      const orgRows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      if (orgRows[0].ownerId !== callerId) {
+        return yield* Effect.fail(
+          new OrgError({ message: "Only the owner can delete the organisation" }),
+        );
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.transaction(async (tx) => {
+            await tx
+              .delete(organisationMembers)
+              .where(eq(organisationMembers.organisationId, orgId));
+            await tx.delete(organisations).where(eq(organisations.id, orgId));
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    }).pipe(withOrgOp("delete"));
+
+  const listUserOrganisations = (
+    userId: string,
+    options: ListOptions = {},
+  ): Effect.Effect<(typeof organisations.$inferSelect)[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
+      const memberRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ organisationId: organisationMembers.organisationId })
+            .from(organisationMembers)
+            .where(eq(organisationMembers.userId, userId))
+            .limit(limit)
+            .offset(offset),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (memberRows.length === 0) return [];
+
+      const orgIds = memberRows.map((r) => r.organisationId);
+
+      const orgs = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(inArray(organisations.id, orgIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return orgs;
+    }).pipe(Effect.withSpan("org.list_by_user"));
+
+  // -------------------------------------------------------------------------
+  // Membership management
+  // -------------------------------------------------------------------------
+
+  const addMember = (
+    orgId: string,
+    callerId: string,
+    targetUserId: string,
+    role: "admin" | "member",
+  ): Effect.Effect<void, OrgError | NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Check org exists
+      const orgRows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      // Check caller is admin
+      const callerMember = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, callerId),
+                eq(organisationMembers.role, "admin"),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (callerMember.length === 0) {
+        return yield* Effect.fail(new OrgError({ message: "Only admins can add members" }));
+      }
+
+      // Check target user exists
+      const targetRows = yield* Effect.tryPromise({
+        try: () =>
+          db.select({ id: users.id }).from(users).where(eq(users.id, targetUserId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (targetRows.length === 0) {
+        return yield* Effect.fail(new OrgError({ message: "Target user not found" }));
+      }
+
+      // Check not already a member
+      const existing = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, targetUserId),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (existing.length > 0) {
+        return yield* Effect.fail(new OrgError({ message: "User is already a member" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(organisationMembers).values({
+            id: genId("orgm_"),
+            organisationId: orgId,
+            userId: targetUserId,
+            role,
+            createdAt: now(),
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    }).pipe(withOrgMemberOp("add"));
+
+  const removeMember = (
+    orgId: string,
+    callerId: string,
+    targetUserId: string,
+  ): Effect.Effect<void, OrgError | NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Check org exists
+      const orgRows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      // Cannot remove the owner
+      if (orgRows[0].ownerId === targetUserId) {
+        return yield* Effect.fail(new OrgError({ message: "Cannot remove the owner" }));
+      }
+
+      // Check caller is admin
+      const callerMember = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, callerId),
+                eq(organisationMembers.role, "admin"),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (callerMember.length === 0) {
+        return yield* Effect.fail(new OrgError({ message: "Only admins can remove members" }));
+      }
+
+      // Check target is a member
+      const targetMember = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, targetUserId),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (targetMember.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Member not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.delete(organisationMembers).where(eq(organisationMembers.id, targetMember[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    }).pipe(withOrgMemberOp("remove"));
+
+  const updateMemberRole = (
+    orgId: string,
+    callerId: string,
+    targetUserId: string,
+    newRole: "admin" | "member",
+  ): Effect.Effect<void, OrgError | NotFoundError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+
+      // Check org exists
+      const orgRows = yield* Effect.tryPromise({
+        try: () => db.select().from(organisations).where(eq(organisations.id, orgId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      // Cannot change the owner's role
+      if (orgRows[0].ownerId === targetUserId) {
+        return yield* Effect.fail(new OrgError({ message: "Cannot change the owner's role" }));
+      }
+
+      // Only the owner can promote/demote
+      if (orgRows[0].ownerId !== callerId) {
+        return yield* Effect.fail(new OrgError({ message: "Only the owner can change roles" }));
+      }
+
+      // Check target is a member
+      const targetMember = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, targetUserId),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (targetMember.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Member not found" }));
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .update(organisationMembers)
+            .set({ role: newRole })
+            .where(eq(organisationMembers.id, targetMember[0].id)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    }).pipe(withOrgMemberOp("update_role"));
+
+  const listMembers = (
+    orgId: string,
+    options: ListOptions = {},
+  ): Effect.Effect<
+    { user: typeof users.$inferSelect; role: string; joinedAt: Date }[],
+    NotFoundError | DatabaseError,
+    Db
+  > =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
+      // Check org exists
+      const orgRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ id: organisations.id })
+            .from(organisations)
+            .where(eq(organisations.id, orgId))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (orgRows.length === 0) {
+        return yield* Effect.fail(new NotFoundError({ message: "Organisation not found" }));
+      }
+
+      const memberRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(organisationMembers)
+            .where(eq(organisationMembers.organisationId, orgId))
+            .limit(limit)
+            .offset(offset),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (memberRows.length === 0) return [];
+
+      const userIds = memberRows.map((m) => m.userId);
+      const roleMap = new Map(memberRows.map((m) => [m.userId, m.role]));
+      const joinedMap = new Map(memberRows.map((m) => [m.userId, m.createdAt]));
+
+      const memberUsers = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, userIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return memberUsers.map((u) => ({
+        user: u,
+        role: roleMap.get(u.id) ?? "member",
+        joinedAt: joinedMap.get(u.id) ?? new Date(),
+      }));
+    }).pipe(Effect.withSpan("org.member.list"));
+
+  const getMemberRole = (
+    orgId: string,
+    userId: string,
+  ): Effect.Effect<"admin" | "member" | null, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ role: organisationMembers.role })
+            .from(organisationMembers)
+            .where(
+              and(
+                eq(organisationMembers.organisationId, orgId),
+                eq(organisationMembers.userId, userId),
+              ),
+            )
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return null;
+      return rows[0].role as "admin" | "member";
+    }).pipe(Effect.withSpan("org.member.role_check"));
+
+  return {
+    createOrganisation,
+    getOrganisation,
+    getOrganisationByHandle,
+    updateOrganisation,
+    deleteOrganisation,
+    listUserOrganisations,
+    addMember,
+    removeMember,
+    updateMemberRole,
+    listMembers,
+    getMemberRole,
+  };
+}
+
+export type OrganisationService = ReturnType<typeof createOrganisationService>;

--- a/osn/core/tests/helpers/db.ts
+++ b/osn/core/tests/helpers/db.ts
@@ -73,6 +73,31 @@ export function createTestLayer() {
       updated_at INTEGER NOT NULL
     )
   `);
+  sqlite.run(`
+    CREATE TABLE organisations (
+      id TEXT PRIMARY KEY,
+      handle TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      description TEXT,
+      avatar_url TEXT,
+      owner_id TEXT NOT NULL REFERENCES users(id),
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  sqlite.run(`CREATE INDEX organisations_owner_idx ON organisations (owner_id)`);
+  sqlite.run(`
+    CREATE TABLE organisation_members (
+      id TEXT PRIMARY KEY,
+      organisation_id TEXT NOT NULL REFERENCES organisations(id),
+      user_id TEXT NOT NULL REFERENCES users(id),
+      role TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE (organisation_id, user_id)
+    )
+  `);
+  sqlite.run(`CREATE INDEX org_members_org_idx ON organisation_members (organisation_id)`);
+  sqlite.run(`CREATE INDEX org_members_user_idx ON organisation_members (user_id)`);
   const db = drizzle(sqlite, { schema });
   return Layer.succeed(Db, { db });
 }

--- a/osn/core/tests/routes/organisation-internal.test.ts
+++ b/osn/core/tests/routes/organisation-internal.test.ts
@@ -1,0 +1,220 @@
+import {
+  generateArcKeyPair,
+  exportKeyToJwk,
+  createArcToken,
+  clearPublicKeyCache,
+} from "@osn/crypto";
+import { serviceAccounts } from "@osn/db/schema";
+import { Db } from "@osn/db/service";
+import type { Db as DbTag } from "@osn/db/service";
+import { Effect } from "effect";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createInternalOrganisationRoutes } from "../../src/routes/organisation-internal";
+import { createAuthService } from "../../src/services/auth";
+import { createOrganisationService } from "../../src/services/organisation";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("internal organisation routes (ARC-protected)", () => {
+  let layer: ReturnType<typeof createTestLayer>;
+  let app: ReturnType<typeof createInternalOrganisationRoutes>;
+  let auth: ReturnType<typeof createAuthService>;
+  let org: ReturnType<typeof createOrganisationService>;
+
+  const runWithLayer = <A>(eff: Effect.Effect<A, unknown, DbTag>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+  async function setupArcService(
+    serviceId: string = "pulse-api",
+    scopes: string = "org:read",
+    audience: string = "osn-core",
+  ): Promise<{ token: string; keyPair: CryptoKeyPair }> {
+    const kp = await generateArcKeyPair();
+    const pubJwk = await exportKeyToJwk(kp.publicKey);
+    const now = new Date();
+
+    await runWithLayer(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        yield* Effect.tryPromise({
+          try: () =>
+            db.insert(serviceAccounts).values({
+              serviceId,
+              publicKeyJwk: pubJwk,
+              allowedScopes: scopes,
+              createdAt: now,
+              updatedAt: now,
+            }),
+          catch: (e) => e,
+        });
+      }),
+    );
+
+    const token = await createArcToken(kp.privateKey, {
+      iss: serviceId,
+      aud: audience,
+      scope: scopes,
+    });
+
+    return { token, keyPair: kp };
+  }
+
+  async function registerUser(email: string, handle: string): Promise<string> {
+    const user = await runWithLayer(auth.registerUser(email, handle));
+    return user.id;
+  }
+
+  beforeEach(() => {
+    clearPublicKeyCache();
+    layer = createTestLayer();
+    app = createInternalOrganisationRoutes(layer);
+    auth = createAuthService(config);
+    org = createOrganisationService();
+  });
+
+  // -------------------------------------------------------------------------
+  // ARC auth guard
+  // -------------------------------------------------------------------------
+
+  describe("ARC auth guard", () => {
+    it("returns 401 without authorization header", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/organisations/internal/user-orgs?userId=test"),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with Bearer token instead of ARC token", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/organisations/internal/user-orgs?userId=test", {
+          headers: { Authorization: "Bearer some-jwt" },
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with invalid ARC token", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/organisations/internal/user-orgs?userId=test", {
+          headers: { Authorization: "ARC not-a-valid-token" },
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with wrong scope", async () => {
+      const { keyPair: kp } = await setupArcService("pulse-api", "org:read", "osn-core");
+      const badToken = await createArcToken(kp.privateKey, {
+        iss: "pulse-api",
+        aud: "osn-core",
+        scope: "graph:read",
+      });
+
+      const res = await app.handle(
+        new Request("http://localhost/organisations/internal/user-orgs?userId=test", {
+          headers: { Authorization: `ARC ${badToken}` },
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with wrong audience", async () => {
+      const { keyPair: kp } = await setupArcService("pulse-api", "org:read", "osn-core");
+      const badToken = await createArcToken(kp.privateKey, {
+        iss: "pulse-api",
+        aud: "wrong-service",
+        scope: "org:read",
+      });
+
+      const res = await app.handle(
+        new Request("http://localhost/organisations/internal/user-orgs?userId=test", {
+          headers: { Authorization: `ARC ${badToken}` },
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /organisations/internal/user-orgs
+  // -------------------------------------------------------------------------
+
+  describe("GET /organisations/internal/user-orgs", () => {
+    it("returns org IDs for a user with orgs", async () => {
+      const { token } = await setupArcService();
+      const userId = await registerUser("alice@example.com", "alice");
+      await runWithLayer(org.createOrganisation(userId, "acme", "Acme Corp"));
+      await runWithLayer(org.createOrganisation(userId, "globex", "Globex Corp"));
+
+      const res = await app.handle(
+        new Request(`http://localhost/organisations/internal/user-orgs?userId=${userId}`, {
+          headers: { Authorization: `ARC ${token}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { organisationIds: string[] };
+      expect(json.organisationIds).toHaveLength(2);
+    });
+
+    it("returns empty list for user with no orgs", async () => {
+      const { token } = await setupArcService();
+      const userId = await registerUser("alice@example.com", "alice");
+
+      const res = await app.handle(
+        new Request(`http://localhost/organisations/internal/user-orgs?userId=${userId}`, {
+          headers: { Authorization: `ARC ${token}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { organisationIds: string[] };
+      expect(json.organisationIds).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /organisations/internal/membership
+  // -------------------------------------------------------------------------
+
+  describe("GET /organisations/internal/membership", () => {
+    it("returns role for an org member", async () => {
+      const { token } = await setupArcService();
+      const userId = await registerUser("alice@example.com", "alice");
+      const organisation = await runWithLayer(org.createOrganisation(userId, "acme", "Acme Corp"));
+
+      const res = await app.handle(
+        new Request(
+          `http://localhost/organisations/internal/membership?orgId=${organisation.id}&userId=${userId}`,
+          { headers: { Authorization: `ARC ${token}` } },
+        ),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { role: string | null };
+      expect(json.role).toBe("admin");
+    });
+
+    it("returns null for a non-member", async () => {
+      const { token } = await setupArcService();
+      const alice = await registerUser("alice@example.com", "alice");
+      const bob = await registerUser("bob@example.com", "bob");
+      const organisation = await runWithLayer(org.createOrganisation(alice, "acme", "Acme Corp"));
+
+      const res = await app.handle(
+        new Request(
+          `http://localhost/organisations/internal/membership?orgId=${organisation.id}&userId=${bob}`,
+          { headers: { Authorization: `ARC ${token}` } },
+        ),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { role: string | null };
+      expect(json.role).toBeNull();
+    });
+  });
+});

--- a/osn/core/tests/routes/organisation.test.ts
+++ b/osn/core/tests/routes/organisation.test.ts
@@ -237,6 +237,42 @@ describe("organisation routes", () => {
     expect(res.status).toBe(400);
   });
 
+  it("DELETE /organisations/:handle → 400 for non-owner admin", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    // Add bob as admin
+    await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${bob.token}` },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("DELETE /organisations/:handle deletes the org", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
 

--- a/osn/core/tests/routes/organisation.test.ts
+++ b/osn/core/tests/routes/organisation.test.ts
@@ -1,0 +1,502 @@
+import type { Db } from "@osn/db/service";
+import { Effect, Layer } from "effect";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import type { RateLimiterBackend } from "../../src/lib/rate-limit";
+import { createOrganisationRoutes } from "../../src/routes/organisation";
+import { createAuthService } from "../../src/services/auth";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("organisation routes", () => {
+  let layer: ReturnType<typeof createTestLayer>;
+  let orgApp: ReturnType<typeof createOrganisationRoutes>;
+  let auth: ReturnType<typeof createAuthService>;
+
+  beforeEach(() => {
+    layer = createTestLayer();
+    orgApp = createOrganisationRoutes(config, layer);
+    auth = createAuthService(config);
+  });
+
+  const runWithLayer = <A>(eff: Effect.Effect<A, unknown, Db>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+  async function registerAndGetToken(
+    email: string,
+    handle: string,
+  ): Promise<{ userId: string; token: string }> {
+    const user = await runWithLayer(auth.registerUser(email, handle));
+    const tokens = await runWithLayer(
+      auth.issueTokens(user.id, user.email, user.handle, user.displayName),
+    );
+    return { userId: user.id, token: tokens.accessToken };
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth guard
+  // -------------------------------------------------------------------------
+
+  it("returns 401 without token on POST /organisations", async () => {
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer not-a-valid-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------------
+  // Organisation CRUD
+  // -------------------------------------------------------------------------
+
+  it("POST /organisations → 201 creates an org", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp", description: "A company" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { ok: boolean; organisation: { handle: string } };
+    expect(json.ok).toBe(true);
+    expect(json.organisation.handle).toBe("acme");
+  });
+
+  it("POST /organisations → 400 when handle taken by user", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "alice", name: "Alice Org" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /organisations lists caller's orgs", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { organisations: { handle: string }[] };
+    expect(json.organisations).toHaveLength(1);
+    expect(json.organisations[0].handle).toBe("acme");
+  });
+
+  it("GET /organisations/:handle returns the org", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { organisation: { name: string } };
+    expect(json.organisation.name).toBe("Acme Corp");
+  });
+
+  it("GET /organisations/:handle → 404 for unknown org", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/nonexistent", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /organisations/:handle updates the org", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Acme Inc" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; organisation: { name: string } };
+    expect(json.organisation.name).toBe("Acme Inc");
+  });
+
+  it("PATCH /organisations/:handle → 400 for non-admin", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    // Add bob as member
+    await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${bob.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Hacked" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("DELETE /organisations/:handle deletes the org", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    // Should be gone
+    const getRes = await orgApp.handle(
+      new Request("http://localhost/organisations/acme", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(getRes.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // Member management
+  // -------------------------------------------------------------------------
+
+  it("POST /organisations/:handle/members/:userHandle → 201 adds a member", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("DELETE /organisations/:handle/members/:userHandle removes a member", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("PATCH /organisations/:handle/members/:userHandle updates role", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /organisations/:handle/members lists members", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/bob", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { members: { handle: string; role: string }[] };
+    expect(json.members).toHaveLength(2);
+    const aliceMember = json.members.find((m) => m.handle === "alice");
+    expect(aliceMember?.role).toBe("admin");
+    const bobMember = json.members.find((m) => m.handle === "bob");
+    expect(bobMember?.role).toBe("member");
+  });
+
+  it("POST /organisations/:handle/members/:userHandle → 404 for unknown user", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members/nobody", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role: "member" }),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiter dependency injection
+  // -------------------------------------------------------------------------
+
+  describe("rate limiter dependency injection", () => {
+    it("uses the injected rate limiter on write operations", async () => {
+      const rejectAll: RateLimiterBackend = { check: () => false };
+      const freshOrg = createOrganisationRoutes(config, layer, Layer.empty, rejectAll);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+
+      const res = await freshOrg.handle(
+        new Request("http://localhost/organisations", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${alice.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+        }),
+      );
+      expect(res.status).toBe(429);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Too many requests");
+    });
+
+    it("does not rate-limit read operations", async () => {
+      const rejectAll: RateLimiterBackend = { check: () => false };
+      const freshOrg = createOrganisationRoutes(config, layer, Layer.empty, rejectAll);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+
+      const res = await freshOrg.handle(
+        new Request("http://localhost/organisations", {
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("fails closed when the backend rejects", async () => {
+      const failing: RateLimiterBackend = {
+        check: () => Promise.reject(new Error("Redis connection refused")),
+      };
+      const freshOrg = createOrganisationRoutes(config, layer, Layer.empty, failing);
+      const alice = await registerAndGetToken("alice@example.com", "alice");
+
+      const res = await freshOrg.handle(
+        new Request("http://localhost/organisations", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${alice.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+        }),
+      );
+      expect(res.status).toBe(429);
+    });
+  });
+});

--- a/osn/core/tests/services/organisation.test.ts
+++ b/osn/core/tests/services/organisation.test.ts
@@ -183,6 +183,14 @@ describe("deleteOrganisation", () => {
       expect(error.message).toContain("owner");
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  it.effect("fails when org does not exist", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(org.deleteOrganisation("org_nonexistent", alice.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 describe("listUserOrganisations", () => {
@@ -258,6 +266,16 @@ describe("addMember", () => {
       expect(error.message).toContain("Target user not found");
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  it.effect("fails when org does not exist", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(
+        org.addMember("org_nonexistent", alice.id, alice.id, "member"),
+      );
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 describe("removeMember", () => {
@@ -301,6 +319,14 @@ describe("removeMember", () => {
       const { alice, organisation } = yield* setupOrgWithOwner;
       const bob = yield* registerUser("bob@example.com", "bob");
       const error = yield* Effect.flip(org.removeMember(organisation.id, alice.id, bob.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when org does not exist", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(org.removeMember("org_nonexistent", alice.id, alice.id));
       expect(error._tag).toBe("NotFoundError");
     }).pipe(Effect.provide(createTestLayer())),
   );
@@ -355,6 +381,27 @@ describe("updateMemberRole", () => {
       );
       expect(error._tag).toBe("OrgError");
       expect(error.message).toContain("owner's role");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when org does not exist", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(
+        org.updateMemberRole("org_nonexistent", alice.id, alice.id, "admin"),
+      );
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when target member not found", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const error = yield* Effect.flip(
+        org.updateMemberRole(organisation.id, alice.id, bob.id, "admin"),
+      );
+      expect(error._tag).toBe("NotFoundError");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });

--- a/osn/core/tests/services/organisation.test.ts
+++ b/osn/core/tests/services/organisation.test.ts
@@ -1,0 +1,421 @@
+import { it, expect, describe } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { createAuthService } from "../../src/services/auth";
+import { createOrganisationService } from "../../src/services/organisation";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+const auth = createAuthService(config);
+const org = createOrganisationService();
+
+/** Register a user and return them. */
+const registerUser = (email: string, handle: string, displayName?: string) =>
+  auth.registerUser(email, handle, displayName);
+
+/** Register two users. */
+const setupTwoUsers = Effect.gen(function* () {
+  const alice = yield* registerUser("alice@example.com", "alice", "Alice");
+  const bob = yield* registerUser("bob@example.com", "bob", "Bob");
+  return { alice, bob };
+});
+
+/** Register a user and create an org owned by them. */
+const setupOrgWithOwner = Effect.gen(function* () {
+  const alice = yield* registerUser("alice@example.com", "alice", "Alice");
+  const organisation = yield* org.createOrganisation(alice.id, "acme", "Acme Corp");
+  return { alice, organisation };
+});
+
+// ---------------------------------------------------------------------------
+// Organisation CRUD
+// ---------------------------------------------------------------------------
+
+describe("createOrganisation", () => {
+  it.effect("creates an organisation and adds owner as admin", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const organisation = yield* org.createOrganisation(
+        alice.id,
+        "acme",
+        "Acme Corp",
+        "A company",
+      );
+
+      expect(organisation.handle).toBe("acme");
+      expect(organisation.name).toBe("Acme Corp");
+      expect(organisation.description).toBe("A company");
+      expect(organisation.ownerId).toBe(alice.id);
+
+      // Owner should be an admin member
+      const role = yield* org.getMemberRole(organisation.id, alice.id);
+      expect(role).toBe("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when handle is already taken by a user", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(org.createOrganisation(alice.id, "alice", "Alice Org"));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when handle is already taken by another org", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      yield* org.createOrganisation(alice.id, "acme", "Acme Corp");
+      const error = yield* Effect.flip(org.createOrganisation(alice.id, "acme", "Another Acme"));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when owner does not exist", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        org.createOrganisation("usr_nonexistent", "acme", "Acme Corp"),
+      );
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("Owner not found");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("getOrganisation", () => {
+  it.effect("returns the organisation by id", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const found = yield* org.getOrganisation(organisation.id);
+      expect(found.handle).toBe("acme");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when not found", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(org.getOrganisation("org_nonexistent"));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("getOrganisationByHandle", () => {
+  it.effect("returns the organisation by handle", () =>
+    Effect.gen(function* () {
+      yield* setupOrgWithOwner;
+      const found = yield* org.getOrganisationByHandle("acme");
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe("Acme Corp");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("returns null when not found", () =>
+    Effect.gen(function* () {
+      const found = yield* org.getOrganisationByHandle("nonexistent");
+      expect(found).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("updateOrganisation", () => {
+  it.effect("updates name and description when caller is admin", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const updated = yield* org.updateOrganisation(organisation.id, alice.id, {
+        name: "Acme Inc",
+        description: "Updated",
+      });
+      expect(updated.name).toBe("Acme Inc");
+      expect(updated.description).toBe("Updated");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when caller is not an admin", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      // Add bob as regular member
+      yield* org.addMember(organisation.id, organisation.ownerId, bob.id, "member");
+      const error = yield* Effect.flip(
+        org.updateOrganisation(organisation.id, bob.id, { name: "Hacked" }),
+      );
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when org does not exist", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const error = yield* Effect.flip(
+        org.updateOrganisation("org_nonexistent", alice.id, { name: "X" }),
+      );
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("deleteOrganisation", () => {
+  it.effect("deletes org and all members when caller is owner", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      yield* org.deleteOrganisation(organisation.id, alice.id);
+      const found = yield* org.getOrganisationByHandle("acme");
+      expect(found).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when caller is admin but not owner", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, organisation.ownerId, bob.id, "admin");
+      const error = yield* Effect.flip(org.deleteOrganisation(organisation.id, bob.id));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("listUserOrganisations", () => {
+  it.effect("returns all orgs the user belongs to", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      yield* org.createOrganisation(alice.id, "acme", "Acme Corp");
+      yield* org.createOrganisation(alice.id, "globex", "Globex Corp");
+
+      const list = yield* org.listUserOrganisations(alice.id);
+      const handles = list.map((o) => o.handle).toSorted();
+      expect(handles).toEqual(["acme", "globex"]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("returns empty when user has no orgs", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerUser("alice@example.com", "alice");
+      const list = yield* org.listUserOrganisations(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Membership management
+// ---------------------------------------------------------------------------
+
+describe("addMember", () => {
+  it.effect("adds a user as a member", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "member");
+
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBe("member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when caller is not admin", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const carol = yield* registerUser("carol@example.com", "carol");
+      yield* org.addMember(organisation.id, organisation.ownerId, bob.id, "member");
+
+      const error = yield* Effect.flip(org.addMember(organisation.id, bob.id, carol.id, "member"));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when user is already a member", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "member");
+
+      const error = yield* Effect.flip(org.addMember(organisation.id, alice.id, bob.id, "member"));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("already a member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when target user does not exist", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const error = yield* Effect.flip(
+        org.addMember(organisation.id, alice.id, "usr_nonexistent", "member"),
+      );
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("Target user not found");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("removeMember", () => {
+  it.effect("removes a member", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "member");
+      yield* org.removeMember(organisation.id, alice.id, bob.id);
+
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when trying to remove the owner", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const error = yield* Effect.flip(org.removeMember(organisation.id, alice.id, alice.id));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when caller is not admin", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const carol = yield* registerUser("carol@example.com", "carol");
+      yield* org.addMember(organisation.id, organisation.ownerId, bob.id, "member");
+      yield* org.addMember(organisation.id, organisation.ownerId, carol.id, "member");
+
+      const error = yield* Effect.flip(org.removeMember(organisation.id, bob.id, carol.id));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when member not found", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const error = yield* Effect.flip(org.removeMember(organisation.id, alice.id, bob.id));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("updateMemberRole", () => {
+  it.effect("owner can promote member to admin", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "member");
+      yield* org.updateMemberRole(organisation.id, alice.id, bob.id, "admin");
+
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBe("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("owner can demote admin to member", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "admin");
+      yield* org.updateMemberRole(organisation.id, alice.id, bob.id, "member");
+
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBe("member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when non-owner tries to change roles", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const carol = yield* registerUser("carol@example.com", "carol");
+      yield* org.addMember(organisation.id, organisation.ownerId, bob.id, "admin");
+      yield* org.addMember(organisation.id, organisation.ownerId, carol.id, "member");
+
+      const error = yield* Effect.flip(
+        org.updateMemberRole(organisation.id, bob.id, carol.id, "admin"),
+      );
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when trying to change owner's role", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const error = yield* Effect.flip(
+        org.updateMemberRole(organisation.id, alice.id, alice.id, "member"),
+      );
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner's role");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("listMembers", () => {
+  it.effect("returns all members with roles", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "member");
+
+      const members = yield* org.listMembers(organisation.id);
+      expect(members).toHaveLength(2);
+      const handles = members.map((m) => m.user.handle).toSorted();
+      expect(handles).toEqual(["alice", "bob"]);
+      const aliceMember = members.find((m) => m.user.handle === "alice");
+      expect(aliceMember?.role).toBe("admin");
+      const bobMember = members.find((m) => m.user.handle === "bob");
+      expect(bobMember?.role).toBe("member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when org not found", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(org.listMembers("org_nonexistent"));
+      expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+describe("getMemberRole", () => {
+  it.effect("returns null for non-members", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerUser("bob@example.com", "bob");
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// User can belong to many organisations
+// ---------------------------------------------------------------------------
+
+describe("multi-org membership", () => {
+  it.effect("user can be a member of multiple orgs", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      const org1 = yield* org.createOrganisation(alice.id, "org_one", "Org One");
+      const org2 = yield* org.createOrganisation(alice.id, "org_two", "Org Two");
+      yield* org.addMember(org1.id, alice.id, bob.id, "member");
+      yield* org.addMember(org2.id, alice.id, bob.id, "admin");
+
+      const bobOrgs = yield* org.listUserOrganisations(bob.id);
+      expect(bobOrgs).toHaveLength(2);
+
+      const role1 = yield* org.getMemberRole(org1.id, bob.id);
+      const role2 = yield* org.getMemberRole(org2.id, bob.id);
+      expect(role1).toBe("member");
+      expect(role2).toBe("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/osn/core/tests/services/organisation.test.ts
+++ b/osn/core/tests/services/organisation.test.ts
@@ -65,7 +65,7 @@ describe("createOrganisation", () => {
       const alice = yield* registerUser("alice@example.com", "alice");
       const error = yield* Effect.flip(org.createOrganisation(alice.id, "alice", "Alice Org"));
       expect(error._tag).toBe("OrgError");
-      expect(error.message).toContain("Handle already taken");
+      expect(error.message).toContain("Handle unavailable");
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -75,7 +75,7 @@ describe("createOrganisation", () => {
       yield* org.createOrganisation(alice.id, "acme", "Acme Corp");
       const error = yield* Effect.flip(org.createOrganisation(alice.id, "acme", "Another Acme"));
       expect(error._tag).toBe("OrgError");
-      expect(error.message).toContain("Handle already taken");
+      expect(error.message).toContain("Handle unavailable");
     }).pipe(Effect.provide(createTestLayer())),
   );
 

--- a/osn/db/src/schema/index.ts
+++ b/osn/db/src/schema/index.ts
@@ -124,3 +124,49 @@ export const serviceAccounts = sqliteTable("service_accounts", {
 
 export type ServiceAccount = typeof serviceAccounts.$inferSelect;
 export type NewServiceAccount = typeof serviceAccounts.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Organisations
+// ---------------------------------------------------------------------------
+
+export const organisations = sqliteTable(
+  "organisations",
+  {
+    id: text("id").primaryKey(), // "org_" prefix
+    handle: text("handle").notNull().unique(), // shared namespace with user handles
+    name: text("name").notNull(),
+    description: text("description"),
+    avatarUrl: text("avatar_url"),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [index("organisations_owner_idx").on(t.ownerId)],
+);
+
+export const organisationMembers = sqliteTable(
+  "organisation_members",
+  {
+    id: text("id").primaryKey(), // "orgm_" prefix
+    organisationId: text("organisation_id")
+      .notNull()
+      .references(() => organisations.id),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    role: text("role", { enum: ["admin", "member"] }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    unique("org_members_pair_idx").on(t.organisationId, t.userId),
+    index("org_members_org_idx").on(t.organisationId),
+    index("org_members_user_idx").on(t.userId),
+  ],
+);
+
+export type Organisation = typeof organisations.$inferSelect;
+export type NewOrganisation = typeof organisations.$inferInsert;
+export type OrganisationMember = typeof organisationMembers.$inferSelect;
+export type NewOrganisationMember = typeof organisationMembers.$inferInsert;

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -49,6 +49,12 @@ export type GraphCloseFriendAction = "add" | "remove";
 /** Event lifecycle states (mirrors Pulse events schema). */
 export type EventStatus = "upcoming" | "ongoing" | "finished" | "cancelled";
 
+/** Organisation CRUD actions. */
+export type OrgAction = "create" | "update" | "delete";
+
+/** Organisation membership state-changing actions. */
+export type OrgMemberAction = "add" | "remove" | "update_role";
+
 /** Auth endpoints subject to IP-based rate limiting (S-H1). */
 export type AuthRateLimitedEndpoint =
   | "register_begin"

--- a/shared/observability/src/metrics/index.ts
+++ b/shared/observability/src/metrics/index.ts
@@ -29,5 +29,7 @@ export {
   type GraphConnectionAction,
   type GraphBlockAction,
   type GraphCloseFriendAction,
+  type OrgAction,
+  type OrgMemberAction,
   type EventStatus,
 } from "./attrs";

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -74,9 +74,12 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] Social graph data model (connections, close friends, blocks) — 209 tests
 - [x] Handle system — registration, real-time availability check, email/handle sign-in toggle
 - [x] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
+- [x] Organisation support — schema (`organisations`, `organisation_members`), Effect service, REST routes, ARC internal routes, observability metrics, 355 tests
 - [ ] Per-app vs global blocking logic (deferred — global blocking across all OSN apps for now)
 - [ ] Interest profile selection (onboarding)
 - [ ] Third-party app authorization flow
+- [ ] Organisation frontend — management UI in Pulse or standalone `@osn/social` Tauri app
+- [ ] Unified `handles` reservation table (user + org handles share namespace; currently enforced at service layer — see Deferred Decisions)
 
 ---
 
@@ -122,7 +125,7 @@ Signal Protocol lives in `@osn/crypto`, not `zap/`.
 
 ### M3 — Organisation chats (the differentiator)
 
-- [ ] `organisations` table in `@osn/db` (verified flag, owner user, allowed scopes, public profile)
+- [x] `organisations` + `organisation_members` tables in `@osn/db` (owner, handle, admin/member roles; verified flag deferred)
 - [ ] Verification flow (manual review for now; document the criteria)
 - [ ] `org_chats` and `org_agents` schemas in `@zap/db` — assignment, queue, status (open/pending/resolved), SLA timestamps
 - [ ] Organisation-side dashboard (separate `@zap/app` view, role-gated): inbox, agent assignment, transcript export, analytics
@@ -400,6 +403,14 @@ Address **High** items before any non-local deployment.
 - [x] S-L28 — `createClientFromUrl()` used eager ioredis connection, allowing zombie connections on health-check failure. Fixed: `lazyConnect: true` + explicit `connect()` / `disconnect()` lifecycle via `ConnectableRedisClient` interface. — see [[redis]]
 - [ ] S-L29 — `/graph/internal/*` routes mounted under open CORS (`Access-Control-Allow-Origin: *`). S2S endpoints should not be browser-reachable. Restrict CORS or mount on an internal-only port. — see [[arc-tokens]]
 - [ ] S-L30 — `createInternalGraphRoutes` does not accept a `loggerLayer` — ARC auth failures and route errors produce no structured log entries. Add observability layer matching `createGraphRoutes` pattern. — see [[arc-tokens]], [[observability/overview]]
+- [x] S-H2 (org) — Handle enumeration via "Handle already taken" message — fixed: changed to "Handle unavailable"
+- [ ] S-H1 (org) — `listMembers` service returns full `User` rows (including `email`, `id`). Route layer correctly applies `userProjection`, but service contract should restrict fields for defence-in-depth.
+- [ ] S-M1 (org) — `GET /organisations/:handle/members` has no membership gate — any authenticated user can list any org's members. Add membership check or document as intentional public access.
+- [x] S-M2 (org) — No `org:write` scope constant for future internal mutation endpoints — fixed: `_SCOPE_ORG_WRITE` constant added
+- [ ] S-M3 (org) — `getOrganisation` service returns `ownerId` internal ID. User-facing routes project it away but future consumers may leak it.
+- [x] S-L4 (org) — No `maxLength` on internal route query params — fixed: added `maxLength: 50`
+- [ ] S-L1 (org) — Org creation rate limit (60/min) shared with member ops; consider tighter limit for creation specifically
+- [ ] S-L3 (org) — TOCTOU gap in handle uniqueness check (DB UNIQUE constraint catches duplicates; user sees generic `DatabaseError` in race case instead of clean `OrgError`)
 
 ---
 
@@ -441,6 +452,13 @@ Address **High** items before any non-local deployment.
 - [x] P-W13 — Same root cause as S-M28: `getConnectionIds` / `getCloseFriendIds` capped at 100, silently truncating membership sets. Fixed jointly with S-M28 by raising the bound to `MAX_EVENT_GUESTS`.
 - [x] P-W14 — `MapPreview` and Leaflet (~150KB + CSS) shipped on every Pulse cold start because the route, the page component, and Leaflet itself were all static imports from `App.tsx`. Fixed in the full-event-view PR with two complementary changes: (1) `EventDetailPage` and `SettingsPage` are now route-level `lazy()`-loaded in `App.tsx`, and (2) `MapPreview` itself dynamic-imports Leaflet inside `onMount` so events without coordinates never pay for the chunk at all.
 - [x] P-W15 — Observability plugin had a no-op `context.with(ctxWithSpan, () => {})` call in `onRequest` that tore the activated OTel context back down immediately — the broken line made service-level `Effect.withSpan` calls root spans instead of children of the HTTP request span, breaking parent-based sampling and trace correlation. Fixed: line removed, OTel `Context` with the server span is now stashed on `REQUEST_STATE` and exposed via `getRequestContext(request)` as an explicit escape hatch for callers that want parent linkage. Documented in code why Elysia hooks cannot wrap the handler invocation via `context.with(...)` directly (separate hook invocations, not a single enclosing scope).
+- [x] P-W1 (org) — Sequential queries in `createOrganisation` — fixed: parallelised handle + owner checks in single `Promise.all`
+- [x] P-W2 (org) — Sequential queries in `addMember` — fixed: parallelised all four pre-insert checks
+- [ ] P-W3 (org) — Sequential queries in `removeMember`/`updateMemberRole` could be parallelised (org exists + caller/target checks)
+- [x] P-W4 (org) — `listUserOrganisations` two-step query — fixed: replaced with single `innerJoin` query
+- [x] P-W5 (org) — `listMembers` two-step query — fixed: replaced with single `innerJoin` query
+- [x] P-W6 (org) — `updateOrganisation` re-fetched org after update — fixed: constructs return from known state
+- [x] P-I1 (org) — `createOrganisation` re-fetched inserted org — fixed: constructs return from known inputs
 
 ### Info
 


### PR DESCRIPTION
## Summary
- Introduces organisations as a distinct entity type in OSN, separate from users
- Users can create organisations, manage members (add/remove), and assign admin/member roles
- A user can belong to many organisations; organisation handles share the user handle namespace
- Schema: `organisations` + `organisation_members` tables in `@osn/db`
- Service: Effect-based CRUD + membership management with authorization checks in `@osn/core`
- Routes: REST endpoints at `/organisations/*` with Bearer auth + per-user rate limiting
- Internal: ARC-protected S2S read endpoints for cross-service org lookups (`org:read` scope)
- Observability: `osn.org.operations` + `osn.org.member.operations` counters with bounded attribute unions
- 355 tests across 14 test files in `@osn/core` (up from 340/13)

## Workspaces affected
- `@osn/db` (minor) — new schema tables
- `@osn/core` (minor) — new service, routes, metrics, tests
- `@osn/app` (patch) — mounts new routes + Redis rate limiter
- `@shared/observability` (patch) — new `OrgAction` + `OrgMemberAction` attribute types

## Decisions & issues

**[S-H2 (org)]** — Handle enumeration via error message
- **Issue:** `createOrganisation` returned "Handle already taken", confirming whether a handle existed.
- **Why:** Information disclosure — attackers could probe handles to enumerate users/orgs.
- **Solution:** Changed message to "Handle unavailable".
- **Rationale:** Generic message avoids confirming existence; handle availability check is the proper UX channel.

**[S-H1 (org)]** — Service layer returns full User rows including email
- **Issue:** `listMembers` service returns `typeof users.$inferSelect` (all columns including `email`).
- **Why:** Defence-in-depth concern — route layer correctly applies `userProjection`, but future consumers may not.
- **Solution:** Deferred to TODO.md. Fixing requires changing the service return type which impacts all consumers.
- **Rationale:** Current routes are safe; logged as follow-up to push projection into the service layer.

**[S-M1 (org)]** — No membership gate on `GET /:handle/members`
- **Issue:** Any authenticated user can list any org's member roster.
- **Why:** Broken access control if orgs are intended to be private.
- **Solution:** Deferred — requires a design decision on public vs private org visibility model.
- **Rationale:** Initial implementation treats orgs as public entities (handles are public namespace). Logged to TODO.md for when org privacy settings are added.

**[S-M2 (org)]** — No `org:write` scope for future internal mutation endpoints
- **Issue:** Only `org:read` scope was defined; future S2S write endpoints might reuse read scope.
- **Why:** Scope creep risk on the ARC trust boundary.
- **Solution:** Added `_SCOPE_ORG_WRITE = "org:write"` constant now, even though unused.
- **Rationale:** Establishes convention early, consistent with graph internal routes pattern.

**[S-L4 (org)]** — No maxLength on internal route query params
- **Issue:** `userId` and `orgId` accepted unbounded string lengths.
- **Why:** Defence-in-depth — Drizzle uses parameterised queries so no injection risk, but unbounded input wastes memory.
- **Solution:** Added `maxLength: 50` on all internal route query params.
- **Rationale:** Matches expected ID format length with margin.

**[P-W1/W2 (org)]** — Sequential queries that could be parallelised
- **Issue:** `createOrganisation` and `addMember` ran 3-4 independent DB reads sequentially.
- **Why:** Each org creation/member addition paid unnecessary latency from sequential round-trips.
- **Solution:** Combined independent reads into single `Promise.all` calls.
- **Rationale:** All checks are independent reads from different tables; no data dependencies between them.

**[P-W4/W5 (org)]** — Two-step queries instead of JOINs
- **Issue:** `listUserOrganisations` and `listMembers` used SELECT-then-inArray pattern (two round-trips).
- **Why:** Extra round-trip per list call; second query was unbounded (no LIMIT).
- **Solution:** Replaced with single `innerJoin` queries with proper pagination.
- **Rationale:** Single query plan, correct pagination, eliminates the unbounded second fetch.

**[P-W6/P-I1 (org)]** — Redundant re-fetches after insert/update
- **Issue:** `createOrganisation` re-fetched the inserted row; `updateOrganisation` re-fetched after update.
- **Why:** Unnecessary DB round-trips when all column values are known.
- **Solution:** Construct return values from known inputs/state.
- **Rationale:** All fields are controlled by the caller; no DB-generated defaults to fetch.

**[P-W3 (org)]** — Sequential queries in removeMember/updateMemberRole
- **Issue:** Similar to P-W1/W2 but for remove/update-role operations.
- **Why:** Lower priority — these operations need the org row to check ownership before proceeding.
- **Solution:** Deferred to TODO.md — the org existence check feeds into the owner check, so full parallelisation requires restructuring.
- **Rationale:** The data dependency (ownerId needed for authorization) limits parallelisation benefit.

**[S-L1 (org)]** — Rate limit too permissive for org creation
- **Issue:** 60 req/min shared across all org write ops (creation, member management).
- **Why:** Org creation is expensive (transaction with two inserts) and expected to be rare.
- **Solution:** Deferred — the shared limit is appropriate for member management frequency. A separate tighter limit for creation alone would require splitting the rate limiter.
- **Rationale:** Logged to TODO.md; the current limit matches the graph write rate limit pattern.

**[Handle namespace]** — Unified handles reservation table
- **Issue:** Handle uniqueness across users and orgs enforced at service layer, not DB level.
- **Why:** Two concurrent creates could theoretically both pass the check (TOCTOU), though the DB UNIQUE constraint on each table catches same-table duplicates.
- **Solution:** Deferred — a unified `handles` table is the long-term fix but requires migrating user registration to also insert into it.
- **Rationale:** Service-layer check is sufficient for current scale; logged as deferred decision in TODO.md.

## Test plan
- [x] All 355 `@osn/core` tests pass (14 files)
- [x] Full monorepo test suite passes (14 tasks, all green)
- [x] Type-check passes across all 16 packages
- [x] oxlint + oxfmt clean
- [x] Changeset validates (`bunx changeset status`)
- [ ] Verify org CRUD via REST: create, get, list, update, delete
- [ ] Verify member management: add, remove, role change, list
- [ ] Verify authorization: non-admin cannot modify, non-owner cannot delete/change roles
- [ ] Verify handle namespace: cannot create org with existing user handle
- [ ] Verify rate limiting on write endpoints (429 when exceeded)
- [ ] Verify ARC-protected internal endpoints require valid token with `org:read` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)