### PR TITLE
feat(auth): multi-account P2 — two-tier tokens and profile switching

### DIFF
--- a/.changeset/multi-account-p2-auth-refactor.md
+++ b/.changeset/multi-account-p2-auth-refactor.md
@@ -1,0 +1,18 @@
+---
+"@osn/core": minor
+"@shared/observability": patch
+---
+
+Multi-account P2: two-tier token model and profile switching
+
+Refresh tokens are now scoped to accounts (sub=accountId), access tokens remain scoped to profiles (sub=profileId). This enables profile switching without re-authentication.
+
+New endpoints:
+- `POST /profiles/switch` — switch to a different profile under the same account
+- `GET /profiles` — list all profiles for the authenticated account
+
+New service functions: `switchProfile`, `listAccountProfiles`, `verifyRefreshToken`, `findDefaultProfile`.
+
+New metric: `osn.auth.profile_switch.attempts` with bounded `ProfileSwitchAction` attribute union.
+
+Breaking: existing refresh tokens (profile-scoped) will fail on refresh — users must re-authenticate once.

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -20,7 +20,7 @@ import type { RateLimiterBackend } from "./rate-limit";
 const ONE_MINUTE_MS = 60_000;
 
 /**
- * Build all 11 auth rate limiters backed by a shared Redis client.
+ * Build all 13 auth rate limiters backed by a shared Redis client.
  * Namespace convention: `auth:{endpoint_name}` — produces Redis keys like
  * `rl:auth:register_begin:192.168.1.1`.
  */
@@ -40,6 +40,8 @@ export function createRedisAuthRateLimiters(client: RedisClient): AuthRateLimite
     passkeyLoginComplete: rl("auth:passkey_login_complete", 10),
     passkeyRegisterBegin: rl("auth:passkey_register_begin", 10),
     passkeyRegisterComplete: rl("auth:passkey_register_complete", 10),
+    profileSwitch: rl("auth:profile_switch", 10),
+    profileList: rl("auth:profile_list", 10),
   };
 }
 

--- a/osn/core/src/metrics.ts
+++ b/osn/core/src/metrics.ts
@@ -21,6 +21,7 @@ import type {
   GraphConnectionAction,
   OrgAction,
   OrgMemberAction,
+  ProfileSwitchAction,
   RegisterStep,
   Result,
 } from "@shared/observability/metrics";
@@ -42,6 +43,7 @@ export const OSN_METRICS = {
   graphCloseFriendOps: "osn.graph.close_friend.operations",
   orgOps: "osn.org.operations",
   orgMemberOps: "osn.org.member.operations",
+  profileSwitchAttempts: "osn.auth.profile_switch.attempts",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -60,6 +62,7 @@ type GraphBlockAttrs = { action: GraphBlockAction; result: Result };
 type GraphCloseFriendAttrs = { action: GraphCloseFriendAction; result: Result };
 type OrgAttrs = { action: OrgAction; result: Result };
 type OrgMemberAttrs = { action: OrgMemberAction; result: Result };
+type ProfileSwitchAttrs = { action: ProfileSwitchAction; result: Result };
 
 // ---------------------------------------------------------------------------
 // Counters / histograms
@@ -149,6 +152,12 @@ const orgMemberOps = createCounter<OrgMemberAttrs>({
   name: OSN_METRICS.orgMemberOps,
   description: "Organisation membership state changes",
   unit: "{operation}",
+});
+
+const profileSwitchAttempts = createCounter<ProfileSwitchAttrs>({
+  name: OSN_METRICS.profileSwitchAttempts,
+  description: "Profile switch/list attempts by action and outcome",
+  unit: "{attempt}",
 });
 
 // ---------------------------------------------------------------------------
@@ -356,6 +365,20 @@ export const withOrgMemberOp =
         Effect.all([
           Effect.sync(() => orgMemberOps.inc({ action, result: classifyError(e) })),
           Effect.logError("org.member operation failed", { action, ...safeErrorSummary(e) }),
+        ]),
+      ),
+    );
+
+export const withProfileSwitch =
+  (action: ProfileSwitchAction) =>
+  <A, E, Ctx>(effect: Effect.Effect<A, E, Ctx>): Effect.Effect<A, E, Ctx> =>
+    effect.pipe(
+      Effect.withSpan(`auth.profile.${action}`),
+      Effect.tap(() => Effect.sync(() => profileSwitchAttempts.inc({ action, result: "ok" }))),
+      Effect.tapError((e) =>
+        Effect.all([
+          Effect.sync(() => profileSwitchAttempts.inc({ action, result: classifyError(e) })),
+          Effect.logError("auth.profile operation failed", { action, ...safeErrorSummary(e) }),
         ]),
       ),
     );

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -38,6 +38,8 @@ export type AuthRateLimiters = Readonly<{
   passkeyLoginComplete: RateLimiterBackend;
   passkeyRegisterBegin: RateLimiterBackend;
   passkeyRegisterComplete: RateLimiterBackend;
+  profileSwitch: RateLimiterBackend;
+  profileList: RateLimiterBackend;
 }>;
 
 /**
@@ -59,6 +61,8 @@ export function createDefaultAuthRateLimiters(): AuthRateLimiters {
     passkeyLoginComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
     passkeyRegisterBegin: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
     passkeyRegisterComplete: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    profileSwitch: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+    profileList: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
   };
 }
 
@@ -901,6 +905,57 @@ export function createAuthRoutes(
         },
         {
           query: t.Object({ token: t.String() }),
+        },
+      )
+      // -------------------------------------------------------------------------
+      // Profile switching (P2 — multi-account)
+      // -------------------------------------------------------------------------
+      .get("/profiles", async ({ headers, set }) => {
+        const rlErr = await rateLimit(headers, "profile_list", rl.profileList);
+        if (rlErr) {
+          set.status = 429;
+          return rlErr;
+        }
+        const authHeader = headers["authorization"];
+        if (!authHeader?.startsWith("Bearer ")) {
+          set.status = 401;
+          return { error: "Missing or invalid Authorization header" };
+        }
+        const token = authHeader.slice(7);
+        try {
+          return await run(auth.listAccountProfiles(token));
+        } catch (e) {
+          const { status, body } = publicError(e);
+          set.status = status;
+          return body;
+        }
+      })
+      .post(
+        "/profiles/switch",
+        async ({ body, headers, set }) => {
+          const rlErr = await rateLimit(headers, "profile_switch", rl.profileSwitch);
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
+          }
+          try {
+            const result = await run(auth.switchProfile(body.refresh_token, body.profile_id));
+            return {
+              access_token: result.accessToken,
+              expires_in: result.expiresIn,
+              profile: result.profile,
+            };
+          } catch (e) {
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
+          }
+        },
+        {
+          body: t.Object({
+            refresh_token: t.String(),
+            profile_id: t.String(),
+          }),
         },
       )
       // -------------------------------------------------------------------------

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -910,26 +910,28 @@ export function createAuthRoutes(
       // -------------------------------------------------------------------------
       // Profile switching (P2 — multi-account)
       // -------------------------------------------------------------------------
-      .get("/profiles", async ({ headers, set }) => {
-        const rlErr = await rateLimit(headers, "profile_list", rl.profileList);
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        const authHeader = headers["authorization"];
-        if (!authHeader?.startsWith("Bearer ")) {
-          set.status = 401;
-          return { error: "Missing or invalid Authorization header" };
-        }
-        const token = authHeader.slice(7);
-        try {
-          return await run(auth.listAccountProfiles(token));
-        } catch (e) {
-          const { status, body } = publicError(e);
-          set.status = status;
-          return body;
-        }
-      })
+      .post(
+        "/profiles/list",
+        async ({ body, headers, set }) => {
+          const rlErr = await rateLimit(headers, "profile_list", rl.profileList);
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
+          }
+          try {
+            return await run(auth.listAccountProfiles(body.refresh_token));
+          } catch (e) {
+            const { status, body: errBody } = publicError(e);
+            set.status = status;
+            return errBody;
+          }
+        },
+        {
+          body: t.Object({
+            refresh_token: t.String(),
+          }),
+        },
+      )
       .post(
         "/profiles/switch",
         async ({ body, headers, set }) => {
@@ -954,7 +956,7 @@ export function createAuthRoutes(
         {
           body: t.Object({
             refresh_token: t.String(),
-            profile_id: t.String(),
+            profile_id: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
           }),
         },
       )

--- a/osn/core/src/services/auth.ts
+++ b/osn/core/src/services/auth.ts
@@ -16,7 +16,7 @@ import type {
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/server";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 import { SignJWT, jwtVerify } from "jose";
 
@@ -115,6 +115,28 @@ interface PendingRegistration {
 const MAX_PENDING_REGISTRATIONS = 10_000;
 // Max OTP guesses against a single pending entry before it is wiped.
 const MAX_OTP_ATTEMPTS = 5;
+
+// Per-account profile-switch rate limiting (S-M3). Fixed window:
+// max 20 switches per hour per account. Module-level so it survives
+// across request boundaries (same as OTP / challenge stores).
+const PROFILE_SWITCH_MAX = 20;
+const PROFILE_SWITCH_WINDOW_MS = 3_600_000; // 1 hour
+const profileSwitchCounts = new Map<string, { count: number; resetAt: number }>();
+
+function checkProfileSwitchLimit(accountId: string): boolean {
+  const currentMs = Date.now();
+  const entry = profileSwitchCounts.get(accountId);
+  if (!entry || currentMs >= entry.resetAt) {
+    profileSwitchCounts.set(accountId, {
+      count: 1,
+      resetAt: currentMs + PROFILE_SWITCH_WINDOW_MS,
+    });
+    return true;
+  }
+  if (entry.count >= PROFILE_SWITCH_MAX) return false;
+  entry.count++;
+  return true;
+}
 
 // keyed by accountId for registration, by email for login
 const registrationChallenges = new Map<string, ChallengeEntry>();
@@ -877,15 +899,20 @@ export function createAuthService(config: AuthConfig) {
         try: () => verifyJwt(token, config.jwtSecret),
         catch: () => new AuthError({ message: "Invalid or expired refresh token" }),
       });
-      if (payload["type"] !== "refresh" || typeof payload["sub"] !== "string") {
+      if (
+        payload["type"] !== "refresh" ||
+        payload["scope"] !== "account" ||
+        typeof payload["sub"] !== "string"
+      ) {
         return yield* Effect.fail(new AuthError({ message: "Invalid token type" }));
       }
       return { accountId: payload["sub"] };
     });
 
   /**
-   * Finds the default profile for an account. Falls back to the first profile
-   * if no profile has `isDefault = true` (defensive — registration always sets one).
+   * Finds the default profile for an account. Uses DESC ordering on isDefault
+   * so the default profile sorts first (true=1 before false=0), then takes
+   * limit(1). Falls back to the first profile if none has isDefault=true.
    */
   const findDefaultProfile = (
     accountId: string,
@@ -899,15 +926,13 @@ export function createAuthService(config: AuthConfig) {
             .from(users)
             .innerJoin(accounts, eq(users.accountId, accounts.id))
             .where(eq(users.accountId, accountId))
-            .orderBy(users.isDefault)
-            .limit(2),
+            .orderBy(desc(users.isDefault))
+            .limit(1),
         catch: (cause) => new DatabaseError({ cause }),
       });
-      // isDefault is 0/1 in SQLite; ORDER BY isDefault ASC puts false first.
-      // Pick the default (last if both exist), or the only row.
-      const defaultRow = result.find((r) => r.profile.isDefault) ?? result[0];
-      if (!defaultRow) return null;
-      return { ...defaultRow.profile, email: defaultRow.account.email };
+      const row = result[0];
+      if (!row) return null;
+      return { ...row.profile, email: row.account.email };
     });
 
   const refreshTokens = (
@@ -1522,6 +1547,10 @@ export function createAuthService(config: AuthConfig) {
   > =>
     Effect.gen(function* () {
       const { accountId } = yield* verifyRefreshToken(refreshToken);
+      // Per-account rate limit (S-M3): bounds damage from a stolen refresh token.
+      if (!checkProfileSwitchLimit(accountId)) {
+        return yield* Effect.fail(new AuthError({ message: "Too many profile switches" }));
+      }
       const profile = yield* findProfileById(targetProfileId);
       if (!profile) {
         return yield* Effect.fail(new AuthError({ message: "Profile not found" }));

--- a/osn/core/src/services/auth.ts
+++ b/osn/core/src/services/auth.ts
@@ -27,6 +27,7 @@ import {
   withAuthLogin,
   withAuthRegister,
   withAuthTokenRefresh,
+  withProfileSwitch,
 } from "../metrics";
 
 // ---------------------------------------------------------------------------
@@ -675,7 +676,13 @@ export function createAuthService(config: AuthConfig) {
       // Success: only NOW delete the pending entry.
       pendingRegistrations.delete(key);
 
-      const tokens = yield* issueTokens(id, pending.email, pending.handle, pending.displayName);
+      const tokens = yield* issueTokens(
+        id,
+        accountId,
+        pending.email,
+        pending.handle,
+        pending.displayName,
+      );
       const enrollmentToken = yield* issueEnrollmentToken(accountId);
 
       return {
@@ -716,6 +723,7 @@ export function createAuthService(config: AuthConfig) {
 
   const issueTokens = (
     profileId: string,
+    accountId: string,
     email: string,
     handle: string,
     displayName: string | null,
@@ -732,7 +740,11 @@ export function createAuthService(config: AuthConfig) {
 
         const [accessToken, refreshToken] = await Promise.all([
           signJwt(payload, config.jwtSecret, accessTokenTtl),
-          signJwt({ sub: profileId, type: "refresh" }, config.jwtSecret, refreshTokenTtl),
+          signJwt(
+            { sub: accountId, type: "refresh", scope: "account" },
+            config.jwtSecret,
+            refreshTokenTtl,
+          ),
         ]);
         return { accessToken, refreshToken, expiresIn: accessTokenTtl };
       },
@@ -842,12 +854,61 @@ export function createAuthService(config: AuthConfig) {
       if (!profile) {
         return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
       }
-      return yield* issueTokens(profileId, profile.email, profile.handle, profile.displayName);
+      return yield* issueTokens(
+        profileId,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
     });
 
   // -------------------------------------------------------------------------
   // Token refresh
   // -------------------------------------------------------------------------
+
+  /**
+   * Verifies a refresh token and extracts the accountId. Shared by
+   * `refreshTokens`, `switchProfile`, and `listAccountProfiles`.
+   */
+  const verifyRefreshToken = (token: string): Effect.Effect<{ accountId: string }, AuthError> =>
+    Effect.gen(function* () {
+      const payload = yield* Effect.tryPromise({
+        try: () => verifyJwt(token, config.jwtSecret),
+        catch: () => new AuthError({ message: "Invalid or expired refresh token" }),
+      });
+      if (payload["type"] !== "refresh" || typeof payload["sub"] !== "string") {
+        return yield* Effect.fail(new AuthError({ message: "Invalid token type" }));
+      }
+      return { accountId: payload["sub"] };
+    });
+
+  /**
+   * Finds the default profile for an account. Falls back to the first profile
+   * if no profile has `isDefault = true` (defensive — registration always sets one).
+   */
+  const findDefaultProfile = (
+    accountId: string,
+  ): Effect.Effect<ProfileWithEmail | null, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const result = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ profile: users, account: accounts })
+            .from(users)
+            .innerJoin(accounts, eq(users.accountId, accounts.id))
+            .where(eq(users.accountId, accountId))
+            .orderBy(users.isDefault)
+            .limit(2),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      // isDefault is 0/1 in SQLite; ORDER BY isDefault ASC puts false first.
+      // Pick the default (last if both exist), or the only row.
+      const defaultRow = result.find((r) => r.profile.isDefault) ?? result[0];
+      if (!defaultRow) return null;
+      return { ...defaultRow.profile, email: defaultRow.account.email };
+    });
 
   const refreshTokens = (
     refreshToken: string,
@@ -857,19 +918,18 @@ export function createAuthService(config: AuthConfig) {
     Db
   > =>
     Effect.gen(function* () {
-      const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(refreshToken, config.jwtSecret),
-        catch: () => new AuthError({ message: "Invalid or expired refresh token" }),
-      });
-      if (payload["type"] !== "refresh" || typeof payload["sub"] !== "string") {
-        return yield* Effect.fail(new AuthError({ message: "Invalid token type" }));
-      }
-      const profileId = payload["sub"];
-      const profile = yield* findProfileById(profileId);
+      const { accountId } = yield* verifyRefreshToken(refreshToken);
+      const profile = yield* findDefaultProfile(accountId);
       if (!profile) {
         return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
       }
-      return yield* issueTokens(profileId, profile.email, profile.handle, profile.displayName);
+      return yield* issueTokens(
+        profile.id,
+        accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
     }).pipe(withAuthTokenRefresh);
 
   // -------------------------------------------------------------------------
@@ -1168,6 +1228,7 @@ export function createAuthService(config: AuthConfig) {
       const profile = yield* verifyPasskeyAssertion(identifier, assertion);
       const session = yield* issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -1289,6 +1350,7 @@ export function createAuthService(config: AuthConfig) {
       const profile = yield* verifyOtpCode(identifier, code);
       const session = yield* issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -1404,6 +1466,7 @@ export function createAuthService(config: AuthConfig) {
       const profile = yield* consumeMagicToken(token);
       const session = yield* issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -1411,10 +1474,87 @@ export function createAuthService(config: AuthConfig) {
       return { session, profile: toPublicProfile(profile, profile.email) };
     }).pipe(withAuthLogin("magic_link"));
 
+  // -------------------------------------------------------------------------
+  // Profile switching (P2 — multi-account)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Lists all profiles belonging to the account identified by the refresh token.
+   * Returns `PublicProfile[]` — accountId is never exposed in the response.
+   */
+  const listAccountProfiles = (
+    refreshToken: string,
+  ): Effect.Effect<{ profiles: PublicProfile[] }, AuthError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { accountId } = yield* verifyRefreshToken(refreshToken);
+      const { db } = yield* Db;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ profile: users, account: accounts })
+            .from(users)
+            .innerJoin(accounts, eq(users.accountId, accounts.id))
+            .where(eq(users.accountId, accountId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      if (rows.length === 0) {
+        return yield* Effect.fail(new AuthError({ message: "Account not found" }));
+      }
+      const email = rows[0]!.account.email;
+      return {
+        profiles: rows.map((r) => toPublicProfile(r.profile, email)),
+      };
+    }).pipe(withProfileSwitch("list"));
+
+  /**
+   * Switches to a different profile under the same account. Verifies the
+   * refresh token, confirms the target profile belongs to the same account,
+   * then issues a new access token scoped to that profile. The refresh token
+   * itself is unchanged (it's account-scoped and still valid).
+   */
+  const switchProfile = (
+    refreshToken: string,
+    targetProfileId: string,
+  ): Effect.Effect<
+    { accessToken: string; expiresIn: number; profile: PublicProfile },
+    AuthError | DatabaseError,
+    Db
+  > =>
+    Effect.gen(function* () {
+      const { accountId } = yield* verifyRefreshToken(refreshToken);
+      const profile = yield* findProfileById(targetProfileId);
+      if (!profile) {
+        return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
+      }
+      if (profile.accountId !== accountId) {
+        return yield* Effect.fail(
+          new AuthError({ message: "Profile does not belong to this account" }),
+        );
+      }
+      // Issue only a new access token — the refresh token is account-scoped and unchanged.
+      const payload: Record<string, unknown> = {
+        sub: profile.id,
+        email: profile.email,
+        handle: profile.handle,
+        scope: "openid profile",
+      };
+      if (profile.displayName !== null) payload["displayName"] = profile.displayName;
+      const accessToken = yield* Effect.tryPromise({
+        try: () => signJwt(payload, config.jwtSecret, accessTokenTtl),
+        catch: (cause) => new AuthError({ message: String(cause) }),
+      });
+      return {
+        accessToken,
+        expiresIn: accessTokenTtl,
+        profile: toPublicProfile(profile, profile.email),
+      };
+    }).pipe(withProfileSwitch("switch"));
+
   return {
     findProfileByEmail,
     findProfileByHandle,
     findProfileById,
+    findDefaultProfile,
     resolveIdentifier,
     registerProfile,
     beginRegistration,
@@ -1425,7 +1565,10 @@ export function createAuthService(config: AuthConfig) {
     issueTokens,
     exchangeCode,
     refreshTokens,
+    verifyRefreshToken,
     verifyAccessToken,
+    switchProfile,
+    listAccountProfiles,
     beginPasskeyRegistration,
     completePasskeyRegistration,
     beginPasskeyLogin,

--- a/osn/core/tests/lib/redis-rate-limiters.test.ts
+++ b/osn/core/tests/lib/redis-rate-limiters.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/lib/redis-rate-limiters";
 
 describe("createRedisAuthRateLimiters", () => {
-  it("returns all 11 rate limiter slots", () => {
+  it("returns all 13 rate limiter slots", () => {
     const client = createMemoryClient();
     const limiters = createRedisAuthRateLimiters(client);
 
@@ -23,6 +23,8 @@ describe("createRedisAuthRateLimiters", () => {
       "passkeyLoginComplete",
       "passkeyRegisterBegin",
       "passkeyRegisterComplete",
+      "profileSwitch",
+      "profileList",
     ] as const;
 
     for (const key of expectedKeys) {

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -1447,6 +1447,21 @@ describe("auth routes", () => {
       );
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
+
+    it("rate limits profile list requests", async () => {
+      const denyAll: RateLimiterBackend = { check: () => false };
+      const limiters = { ...createDefaultAuthRateLimiters(), profileList: denyAll };
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      const res = await freshApp.handle(
+        new Request("http://localhost/profiles", {
+          headers: {
+            Authorization: "Bearer any",
+            "x-forwarded-for": "10.10.10.10",
+          },
+        }),
+      );
+      expect(res.status).toBe(429);
+    });
   });
 
   describe("POST /profiles/switch", () => {

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -1385,7 +1385,7 @@ describe("auth routes", () => {
   // Profile switching (P2)
   // -------------------------------------------------------------------------
 
-  describe("GET /profiles", () => {
+  describe("POST /profiles/list", () => {
     async function getRefreshToken(): Promise<{ refreshToken: string; profileId: string }> {
       let captured: string | undefined;
       const verifiedConfig = {
@@ -1424,8 +1424,10 @@ describe("auth routes", () => {
     it("returns the list of profiles for a valid refresh token", async () => {
       const { refreshToken } = await getRefreshToken();
       const res = await app.handle(
-        new Request("http://localhost/profiles", {
-          headers: { Authorization: `Bearer ${refreshToken}` },
+        new Request("http://localhost/profiles/list", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: refreshToken }),
         }),
       );
       expect(res.status).toBe(200);
@@ -1434,15 +1436,12 @@ describe("auth routes", () => {
       expect(json.profiles[0]!.handle).toBe("profilelist");
     });
 
-    it("returns 401 without Authorization header", async () => {
-      const res = await app.handle(new Request("http://localhost/profiles"));
-      expect(res.status).toBe(401);
-    });
-
     it("returns error with an invalid token", async () => {
       const res = await app.handle(
-        new Request("http://localhost/profiles", {
-          headers: { Authorization: "Bearer not.a.valid.token" },
+        new Request("http://localhost/profiles/list", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: "not.a.valid.token" }),
         }),
       );
       expect(res.status).toBeGreaterThanOrEqual(400);
@@ -1453,11 +1452,13 @@ describe("auth routes", () => {
       const limiters = { ...createDefaultAuthRateLimiters(), profileList: denyAll };
       const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
       const res = await freshApp.handle(
-        new Request("http://localhost/profiles", {
+        new Request("http://localhost/profiles/list", {
+          method: "POST",
           headers: {
-            Authorization: "Bearer any",
+            "Content-Type": "application/json",
             "x-forwarded-for": "10.10.10.10",
           },
+          body: JSON.stringify({ refresh_token: "any" }),
         }),
       );
       expect(res.status).toBe(429);
@@ -1534,7 +1535,7 @@ describe("auth routes", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             refresh_token: refreshToken,
-            profile_id: "usr_nonexistent",
+            profile_id: "usr_aabbccddeeff",
           }),
         }),
       );
@@ -1548,7 +1549,7 @@ describe("auth routes", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             refresh_token: "not.a.token",
-            profile_id: "usr_any",
+            profile_id: "usr_aabbccddeeff",
           }),
         }),
       );
@@ -1568,7 +1569,7 @@ describe("auth routes", () => {
           },
           body: JSON.stringify({
             refresh_token: "any",
-            profile_id: "any",
+            profile_id: "usr_aabbccddeeff",
           }),
         }),
       );

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -913,7 +913,13 @@ describe("auth routes", () => {
         svc.registerProfile("quinn@example.com", "quinn").pipe(Effect.provide(layer)),
       );
       const tokens = await Effect.runPromise(
-        svc.issueTokens(profile.id, profile.email, profile.handle, profile.displayName),
+        svc.issueTokens(
+          profile.id,
+          profile.accountId,
+          profile.email,
+          profile.handle,
+          profile.displayName,
+        ),
       );
       const res = await app.handle(
         new Request("http://localhost/passkey/register/begin", {
@@ -1372,6 +1378,186 @@ describe("auth routes", () => {
         );
         expect(res.status).not.toBe(429);
       }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Profile switching (P2)
+  // -------------------------------------------------------------------------
+
+  describe("GET /profiles", () => {
+    async function getRefreshToken(): Promise<{ refreshToken: string; profileId: string }> {
+      let captured: string | undefined;
+      const verifiedConfig = {
+        ...config,
+        sendEmail: async (_to: string, _subject: string, body: string) => {
+          const m = body.match(/code is: (\d{6})/);
+          if (m) captured = m[1];
+        },
+      };
+      const verifiedApp = createAuthRoutes(verifiedConfig, layer);
+      await verifiedApp.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "profiles@example.com",
+            handle: "profilelist",
+            displayName: "Profile List",
+          }),
+        }),
+      );
+      const completeRes = await verifiedApp.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "profiles@example.com", code: captured }),
+        }),
+      );
+      const json = (await completeRes.json()) as {
+        profileId: string;
+        session: { refresh_token: string };
+      };
+      return { refreshToken: json.session.refresh_token, profileId: json.profileId };
+    }
+
+    it("returns the list of profiles for a valid refresh token", async () => {
+      const { refreshToken } = await getRefreshToken();
+      const res = await app.handle(
+        new Request("http://localhost/profiles", {
+          headers: { Authorization: `Bearer ${refreshToken}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { profiles: { id: string; handle: string }[] };
+      expect(json.profiles).toHaveLength(1);
+      expect(json.profiles[0]!.handle).toBe("profilelist");
+    });
+
+    it("returns 401 without Authorization header", async () => {
+      const res = await app.handle(new Request("http://localhost/profiles"));
+      expect(res.status).toBe(401);
+    });
+
+    it("returns error with an invalid token", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/profiles", {
+          headers: { Authorization: "Bearer not.a.valid.token" },
+        }),
+      );
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe("POST /profiles/switch", () => {
+    async function registerAndGetTokens(): Promise<{
+      refreshToken: string;
+      profileId: string;
+    }> {
+      let captured: string | undefined;
+      const verifiedConfig = {
+        ...config,
+        sendEmail: async (_to: string, _subject: string, body: string) => {
+          const m = body.match(/code is: (\d{6})/);
+          if (m) captured = m[1];
+        },
+      };
+      const verifiedApp = createAuthRoutes(verifiedConfig, layer);
+      await verifiedApp.handle(
+        new Request("http://localhost/register/begin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "switch@example.com",
+            handle: "switchrt",
+            displayName: "Switch Test",
+          }),
+        }),
+      );
+      const completeRes = await verifiedApp.handle(
+        new Request("http://localhost/register/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "switch@example.com", code: captured }),
+        }),
+      );
+      const json = (await completeRes.json()) as {
+        profileId: string;
+        session: { refresh_token: string };
+      };
+      return { refreshToken: json.session.refresh_token, profileId: json.profileId };
+    }
+
+    it("switches to an owned profile and returns a new access token", async () => {
+      const { refreshToken, profileId } = await registerAndGetTokens();
+      const res = await app.handle(
+        new Request("http://localhost/profiles/switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            refresh_token: refreshToken,
+            profile_id: profileId,
+          }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as {
+        access_token: string;
+        expires_in: number;
+        profile: { id: string; handle: string };
+      };
+      expect(json.access_token).toBeTruthy();
+      expect(json.expires_in).toBe(3600);
+      expect(json.profile.handle).toBe("switchrt");
+    });
+
+    it("returns error for non-existent profile", async () => {
+      const { refreshToken } = await registerAndGetTokens();
+      const res = await app.handle(
+        new Request("http://localhost/profiles/switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            refresh_token: refreshToken,
+            profile_id: "usr_nonexistent",
+          }),
+        }),
+      );
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it("returns error for invalid refresh token", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/profiles/switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            refresh_token: "not.a.token",
+            profile_id: "usr_any",
+          }),
+        }),
+      );
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it("rate limits profile switch requests", async () => {
+      const denyAll: RateLimiterBackend = { check: () => false };
+      const limiters = { ...createDefaultAuthRateLimiters(), profileSwitch: denyAll };
+      const freshApp = createAuthRoutes(config, layer, Layer.empty, limiters);
+      const res = await freshApp.handle(
+        new Request("http://localhost/profiles/switch", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-forwarded-for": "10.10.10.10",
+          },
+          body: JSON.stringify({
+            refresh_token: "any",
+            profile_id: "any",
+          }),
+        }),
+      );
+      expect(res.status).toBe(429);
     });
   });
 });

--- a/osn/core/tests/routes/graph.test.ts
+++ b/osn/core/tests/routes/graph.test.ts
@@ -39,7 +39,7 @@ describe("graph routes", () => {
   ): Promise<{ profileId: string; token: string }> {
     const user = await runWithLayer(auth.registerProfile(email, handle));
     const tokens = await runWithLayer(
-      auth.issueTokens(user.id, user.email, user.handle, user.displayName),
+      auth.issueTokens(user.id, user.accountId, user.email, user.handle, user.displayName),
     );
     return { profileId: user.id, token: tokens.accessToken };
   }

--- a/osn/core/tests/routes/organisation.test.ts
+++ b/osn/core/tests/routes/organisation.test.ts
@@ -35,7 +35,7 @@ describe("organisation routes", () => {
   ): Promise<{ profileId: string; token: string }> {
     const user = await runWithLayer(auth.registerProfile(email, handle));
     const tokens = await runWithLayer(
-      auth.issueTokens(user.id, user.email, user.handle, user.displayName),
+      auth.issueTokens(user.id, user.accountId, user.email, user.handle, user.displayName),
     );
     return { profileId: user.id, token: tokens.accessToken };
   }

--- a/osn/core/tests/routes/redis-rate-limit-integration.test.ts
+++ b/osn/core/tests/routes/redis-rate-limit-integration.test.ts
@@ -163,7 +163,7 @@ describe("graph routes with Redis-backed rate limiter", () => {
     const alice = await run(auth.registerProfile("alice@test.com", "alice"));
     await run(auth.registerProfile("bob@test.com", "bob"));
     const tokens = await run(
-      auth.issueTokens(alice.id, alice.email, alice.handle, alice.displayName),
+      auth.issueTokens(alice.id, alice.accountId, alice.email, alice.handle, alice.displayName),
     );
 
     const makeRequest = () =>

--- a/osn/core/tests/services/auth.test.ts
+++ b/osn/core/tests/services/auth.test.ts
@@ -983,6 +983,27 @@ describe("two-tier token model (P2)", () => {
       expect(found).toBeNull();
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  it.effect("rejects an access token used as a refresh token (type mismatch)", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("typemix@example.com", "typemix");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      // Access token has no type: "refresh" claim — must be rejected
+      const switchErr = yield* Effect.flip(auth.switchProfile(tokens.accessToken, profile.id));
+      expect(switchErr._tag).toBe("AuthError");
+      expect(switchErr.message).toContain("Invalid token type");
+
+      const listErr = yield* Effect.flip(auth.listAccountProfiles(tokens.accessToken));
+      expect(listErr._tag).toBe("AuthError");
+      expect(listErr.message).toContain("Invalid token type");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/osn/core/tests/services/auth.test.ts
+++ b/osn/core/tests/services/auth.test.ts
@@ -345,7 +345,13 @@ describe("issueEnrollmentToken + verifyEnrollmentToken", () => {
   it.effect("rejects a normal access token (wrong type claim)", () =>
     Effect.gen(function* () {
       yield* auth.registerProfile("typecheck@example.com", "typecheck");
-      const tokens = yield* auth.issueTokens("usr_x", "typecheck@example.com", "typecheck", null);
+      const tokens = yield* auth.issueTokens(
+        "usr_x",
+        "acc_x",
+        "typecheck@example.com",
+        "typecheck",
+        null,
+      );
       const error = yield* Effect.flip(auth.verifyEnrollmentToken(tokens.accessToken));
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
@@ -380,6 +386,7 @@ describe("issueTokens + exchangeCode", () => {
       const profile = yield* auth.registerProfile("ivan@example.com", "ivan", "Ivan");
       const tokens = yield* auth.issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -603,6 +610,7 @@ describe("token refresh", () => {
       const profile = yield* auth.registerProfile("quinn@example.com", "quinn");
       const tokens = yield* auth.issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -627,6 +635,7 @@ describe("verifyAccessToken", () => {
       const profile = yield* auth.registerProfile("rose@example.com", "rose", "Rose");
       const tokens = yield* auth.issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -644,6 +653,7 @@ describe("verifyAccessToken", () => {
       const profile = yield* auth.registerProfile("sam@example.com", "sam");
       const tokens = yield* auth.issueTokens(
         profile.id,
+        profile.accountId,
         profile.email,
         profile.handle,
         profile.displayName,
@@ -911,6 +921,166 @@ describe("login OTP attempt limit", () => {
 
       // Correct code fails (entry wiped)
       const error = yield* Effect.flip(svc.completeOtpDirect("direct@example.com", capturedCode!));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// P2: Two-tier token model
+// ---------------------------------------------------------------------------
+
+describe("two-tier token model (P2)", () => {
+  it.effect("refresh token sub claim is the accountId, not the profileId", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("tier@example.com", "tier", "Tier");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      // Verify the refresh token — its sub should be the accountId
+      const { accountId } = yield* auth.verifyRefreshToken(tokens.refreshToken);
+      expect(accountId).toBe(profile.accountId);
+      // Access token sub should still be profileId
+      const claims = yield* auth.verifyAccessToken(tokens.accessToken);
+      expect(claims.profileId).toBe(profile.id);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("refreshTokens resolves the default profile from account-scoped refresh token", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("refresh2@example.com", "refresh2");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const refreshed = yield* auth.refreshTokens(tokens.refreshToken);
+      const claims = yield* auth.verifyAccessToken(refreshed.accessToken);
+      expect(claims.profileId).toBe(profile.id);
+      expect(claims.handle).toBe("refresh2");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("findDefaultProfile returns the default profile for an account", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("default@example.com", "defaultp");
+      const found = yield* auth.findDefaultProfile(profile.accountId);
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(profile.id);
+      expect(found!.isDefault).toBe(true);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("findDefaultProfile returns null for a nonexistent account", () =>
+    Effect.gen(function* () {
+      const found = yield* auth.findDefaultProfile("acc_nonexistent");
+      expect(found).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// P2: Profile switching
+// ---------------------------------------------------------------------------
+
+describe("switchProfile (P2)", () => {
+  it.effect("issues new access token for target profile", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("switch@example.com", "switchme");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      // Switch to self (same profile) — should work fine
+      const result = yield* auth.switchProfile(tokens.refreshToken, profile.id);
+      expect(result.accessToken).toBeTruthy();
+      expect(result.expiresIn).toBe(3600);
+      expect(result.profile.id).toBe(profile.id);
+      expect(result.profile.handle).toBe("switchme");
+
+      // Verify the new access token is valid
+      const claims = yield* auth.verifyAccessToken(result.accessToken);
+      expect(claims.profileId).toBe(profile.id);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when target profile does not exist", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("switch2@example.com", "switch2");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const error = yield* Effect.flip(auth.switchProfile(tokens.refreshToken, "usr_nonexistent"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Profile not found");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails when target profile belongs to a different account", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("alice_switch@example.com", "alice_switch");
+      const bob = yield* auth.registerProfile("bob_switch@example.com", "bob_switch");
+      const aliceTokens = yield* auth.issueTokens(
+        alice.id,
+        alice.accountId,
+        alice.email,
+        alice.handle,
+        alice.displayName,
+      );
+      // Try to switch to Bob's profile using Alice's refresh token
+      const error = yield* Effect.flip(auth.switchProfile(aliceTokens.refreshToken, bob.id));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("does not belong to this account");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid refresh token", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.switchProfile("not.a.token", "usr_any"));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// P2: listAccountProfiles
+// ---------------------------------------------------------------------------
+
+describe("listAccountProfiles (P2)", () => {
+  it.effect("returns all profiles for the account", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("listme@example.com", "listme", "List Me");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const result = yield* auth.listAccountProfiles(tokens.refreshToken);
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]!.id).toBe(profile.id);
+      expect(result.profiles[0]!.handle).toBe("listme");
+      expect(result.profiles[0]!.displayName).toBe("List Me");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid refresh token", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(auth.listAccountProfiles("not.a.token"));
       expect(error._tag).toBe("AuthError");
     }).pipe(Effect.provide(createTestLayer())),
   );

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -55,6 +55,9 @@ export type OrgAction = "create" | "update" | "delete";
 /** Organisation membership state-changing actions. */
 export type OrgMemberAction = "add" | "remove" | "update_role";
 
+/** Profile switching actions (P2 multi-account). */
+export type ProfileSwitchAction = "switch" | "list";
+
 /** Auth endpoints subject to IP-based rate limiting (S-H1). */
 export type AuthRateLimitedEndpoint =
   | "register_begin"
@@ -67,4 +70,6 @@ export type AuthRateLimitedEndpoint =
   | "passkey_login_begin"
   | "passkey_login_complete"
   | "passkey_register_begin"
-  | "passkey_register_complete";
+  | "passkey_register_complete"
+  | "profile_switch"
+  | "profile_list";

--- a/shared/observability/src/metrics/index.ts
+++ b/shared/observability/src/metrics/index.ts
@@ -32,4 +32,5 @@ export {
   type OrgAction,
   type OrgMemberAction,
   type EventStatus,
+  type ProfileSwitchAction,
 } from "./attrs";

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -6,7 +6,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 - [x] Multi-account P1 — Schema foundation: `accounts` table, `userId` → `profileId` rename across all packages, seed data with multi-profile user (21 accounts, 23 profiles, 2 orgs), registration creates account + profile atomically. 81 files, 700+ tests green.
 - [x] Multi-account P1b — Terminology audit: "user" now only means "the person". All data structures use account/profile/organisation. Renames: `User` → `Profile`, `PublicUser` → `PublicProfile`, `UserWithEmail` → `ProfileWithEmail`, `LoginUser` → `LoginProfile`, `PulseUser` → `PulseProfile`, `UserRsvpStatus` → `RsvpStatus`. All service functions, route params, error messages, wire format keys (`{ session, user }` → `{ session, profile }`), and internal route paths updated. [[identity-model]]
-- [ ] Multi-account P2 — Auth refactor: two-tier token model (refresh = account, access = profile), move `email` exclusively to `accounts` table, profile switching endpoint (`POST /profiles/switch`)
+- [x] Multi-account P2 — Auth refactor: two-tier token model (refresh = account, access = profile), `email` exclusively on `accounts` table (confirmed), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile`. New metrics: `osn.auth.profile_switch.attempts`. Rate-limited. 372 core tests green. [[identity-model]]
 - [ ] Multi-account P3 — Profile CRUD: `createProfileService()` (create, list, delete, set default), `/profiles` routes, handle validation against `maxProfiles`, cascade-delete profile data
 - [ ] Multi-account P4 — Client SDK: multi-session storage (`@osn/client:account_session`, `@osn/client:active_profile`, per-profile access tokens), `listProfiles()`, `switchProfile()`, `createProfile()`, `deleteProfile()` methods on `OsnAuthService`
 - [ ] Multi-account P5 — Profile UI: profile switcher component in `@osn/ui`, profile creation form, onboarding for additional profiles
@@ -82,7 +82,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
 - [x] Organisation support — schema (`organisations`, `organisation_members`), Effect service, REST routes, ARC internal routes, observability metrics, 355 tests
 - [x] Multi-account schema foundation (P1) — `accounts` table, `userId` → `profileId` rename, seed data, 81 files changed
-- [ ] Multi-account auth refactor (P2) — two-tier tokens, email migration to accounts
+- [x] Multi-account auth refactor (P2) — two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile`
 - [ ] Multi-account profile CRUD (P3) — create/list/delete profiles, maxProfiles enforcement
 - [ ] Multi-account client SDK (P4) — multi-session storage, profile switching
 - [ ] Multi-account UI (P5) — profile switcher component

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -6,7 +6,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 
 - [x] Multi-account P1 — Schema foundation: `accounts` table, `userId` → `profileId` rename across all packages, seed data with multi-profile user (21 accounts, 23 profiles, 2 orgs), registration creates account + profile atomically. 81 files, 700+ tests green.
 - [x] Multi-account P1b — Terminology audit: "user" now only means "the person". All data structures use account/profile/organisation. Renames: `User` → `Profile`, `PublicUser` → `PublicProfile`, `UserWithEmail` → `ProfileWithEmail`, `LoginUser` → `LoginProfile`, `PulseUser` → `PulseProfile`, `UserRsvpStatus` → `RsvpStatus`. All service functions, route params, error messages, wire format keys (`{ session, user }` → `{ session, profile }`), and internal route paths updated. [[identity-model]]
-- [x] Multi-account P2 — Auth refactor: two-tier token model (refresh = account, access = profile), `email` exclusively on `accounts` table (confirmed), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile`. New metrics: `osn.auth.profile_switch.attempts`. Rate-limited. 372 core tests green. [[identity-model]]
+- [x] Multi-account P2 — Auth refactor: two-tier token model (refresh = account, access = profile), `email` exclusively on `accounts` table (confirmed), `POST /profiles/switch`, `POST /profiles/list`, `verifyRefreshToken`, `findDefaultProfile`. Scope claim validation on refresh tokens. Per-account rate limiting (20 switches/hr). New metrics: `osn.auth.profile_switch.attempts`. 373 core tests green. [[identity-model]]
 - [ ] Multi-account P3 — Profile CRUD: `createProfileService()` (create, list, delete, set default), `/profiles` routes, handle validation against `maxProfiles`, cascade-delete profile data
 - [ ] Multi-account P4 — Client SDK: multi-session storage (`@osn/client:account_session`, `@osn/client:active_profile`, per-profile access tokens), `listProfiles()`, `switchProfile()`, `createProfile()`, `deleteProfile()` methods on `OsnAuthService`
 - [ ] Multi-account P5 — Profile UI: profile switcher component in `@osn/ui`, profile creation form, onboarding for additional profiles
@@ -82,7 +82,7 @@ Progress tracking and deferred decisions. For full spec see README.md. For code 
 - [x] ARC token verification middleware on internal graph routes (`/graph/internal/*`)
 - [x] Organisation support — schema (`organisations`, `organisation_members`), Effect service, REST routes, ARC internal routes, observability metrics, 355 tests
 - [x] Multi-account schema foundation (P1) — `accounts` table, `userId` → `profileId` rename, seed data, 81 files changed
-- [x] Multi-account auth refactor (P2) — two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile`
+- [x] Multi-account auth refactor (P2) — two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `POST /profiles/list`, `verifyRefreshToken`, `findDefaultProfile`, scope claim validation, per-account rate limiting
 - [ ] Multi-account profile CRUD (P3) — create/list/delete profiles, maxProfiles enforcement
 - [ ] Multi-account client SDK (P4) — multi-session storage, profile switching
 - [ ] Multi-account UI (P5) — profile switcher component
@@ -385,6 +385,9 @@ Address **High** items before any non-local deployment.
 - [x] S-M40 — `@shared/redis` `RedisLive` does not enforce TLS. Fixed: logs warning when `REDIS_URL` lacks `rediss://` and `NODE_ENV=production`. — see [[redis]]
 - [x] S-M41 — `createClientFromUrl()` bypassed the TLS warning established in `RedisLive` (S-M40). Fixed: `initRedisClient()` in `osn/app/src/redis.ts` checks `NODE_ENV=production` + `rediss://` and logs a warning, matching the `RedisLive` posture. — see [[redis]], [[rate-limiting]]
 - [x] S-M42 — `initRedisClient()` logged raw `cause.message` on Redis connection failure, potentially leaking `REDIS_URL` credentials. Fixed: error messages are passed through `sanitizeCause()` before logging, matching the redaction in `RedisLive`. — see [[redis]]
+- [x] S-M44 — `verifyRefreshToken` did not check `scope: "account"` claim — old pre-P2 refresh tokens passed type check by accident. Fixed: guard now requires `scope === "account"`. — see [[identity-model]]
+- [x] S-M45 — `GET /profiles` sent long-lived refresh token in `Authorization: Bearer` header, overloading it with access token semantics. Fixed: changed to `POST /profiles/list` with refresh token in request body. — see [[identity-model]]
+- [x] S-M46 — `POST /profiles/switch` lacked per-account rate limiting; a stolen refresh token could be used from rotating IPs. Fixed: in-memory per-account rate limit (20 switches/hr) via `checkProfileSwitchLimit()`. — see [[identity-model]], [[rate-limiting]]
 
 ### Low
 
@@ -422,6 +425,8 @@ Address **High** items before any non-local deployment.
 - [x] S-L28 — `createClientFromUrl()` used eager ioredis connection, allowing zombie connections on health-check failure. Fixed: `lazyConnect: true` + explicit `connect()` / `disconnect()` lifecycle via `ConnectableRedisClient` interface. — see [[redis]]
 - [ ] S-L29 — `/graph/internal/*` routes mounted under open CORS (`Access-Control-Allow-Origin: *`). S2S endpoints should not be browser-reachable. Restrict CORS or mount on an internal-only port. — see [[arc-tokens]]
 - [ ] S-L30 — `createInternalGraphRoutes` does not accept a `loggerLayer` — ARC auth failures and route errors produce no structured log entries. Add observability layer matching `createGraphRoutes` pattern. — see [[arc-tokens]], [[observability/overview]]
+- [x] S-L31 — No input format validation on `profile_id` in `POST /profiles/switch` — accepted any string. Fixed: TypeBox pattern `^usr_[a-f0-9]{12}$` rejects malformed IDs before DB query. — see [[identity-model]]
+- [x] S-L32 — `findDefaultProfile` ORDER BY relied on SQLite boolean-as-integer storage semantics. Fixed: explicit `desc(users.isDefault)` + `limit(1)` for intent-clear ordering. — see [[identity-model]]
 - [x] S-H2 (org) — Handle enumeration via "Handle already taken" message — fixed: changed to "Handle unavailable"
 - [ ] S-H1 (org) — `listMembers` service returns full profile rows (including `email`, `id`). Route layer correctly applies `profileProjection`, but service contract should restrict fields for defence-in-depth.
 - [ ] S-M1 (org) — `GET /organisations/:handle/members` has no membership gate — any authenticated user can list any org's members. Add membership check or document as intentional public access.

--- a/wiki/systems/identity-model.md
+++ b/wiki/systems/identity-model.md
@@ -10,6 +10,7 @@ packages:
   - "@osn/db"
   - "@osn/core"
 last-reviewed: 2026-04-14
+p2-completed: 2026-04-14
 ---
 
 # Identity Model
@@ -115,10 +116,10 @@ Organisations are independent entities that are **composed of profiles, not acco
 | Token | Bound to | `sub` claim | TTL | Purpose |
 |-------|----------|-------------|-----|---------|
 | Access | Profile | `profileId` | 1 hour | Authorize API calls as a specific profile |
-| Refresh | Profile | `profileId` | 30 days | Re-issue access tokens |
+| Refresh | Account | `accountId` | 30 days | Re-issue access tokens; enables profile switching without re-authentication |
 | Enrollment | Account | `accountId` | 5 min | Passkey registration after signup |
 
-> **PR2 note**: The refresh token will be re-scoped to accounts (not profiles) when the two-tier token model lands. This enables profile switching without re-authentication.
+The two-tier token model (P2) scopes refresh tokens to accounts and access tokens to profiles. This enables `POST /profiles/switch` — clients present the account-scoped refresh token plus a target `profileId`, and receive a new access token for that profile without re-authenticating.
 
 ## Registration Flow
 
@@ -154,7 +155,7 @@ POST /register/complete → OTP →
 | Phase | Status | Scope |
 |-------|--------|-------|
 | P1: Schema + terminology | ✅ Done | `accounts` table, `userId` → `profileId`, seed data, email dedup, service/route/test rename from "user" → "profile" terminology |
-| P2: Auth refactor | Planned | Two-tier tokens (refresh=account, access=profile), profile switching |
+| P2: Auth refactor | ✅ Done | Two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile` |
 | P3: Profile CRUD | Planned | Create/list/delete profiles, maxProfiles enforcement |
 | P4: Client SDK | Planned | Multi-session storage, profile switcher methods |
 | P5: UI | Planned | Profile switcher component |

--- a/wiki/systems/identity-model.md
+++ b/wiki/systems/identity-model.md
@@ -119,7 +119,11 @@ Organisations are independent entities that are **composed of profiles, not acco
 | Refresh | Account | `accountId` | 30 days | Re-issue access tokens; enables profile switching without re-authentication |
 | Enrollment | Account | `accountId` | 5 min | Passkey registration after signup |
 
-The two-tier token model (P2) scopes refresh tokens to accounts and access tokens to profiles. This enables `POST /profiles/switch` — clients present the account-scoped refresh token plus a target `profileId`, and receive a new access token for that profile without re-authenticating.
+The two-tier token model (P2) scopes refresh tokens to accounts and access tokens to profiles. Refresh tokens include a `scope: "account"` claim that is explicitly validated on verification.
+
+Two profile management endpoints:
+- `POST /profiles/switch` — present the account-scoped refresh token + target `profileId` in the request body; receive a new access token for that profile. Per-account rate limited (20 switches/hr).
+- `POST /profiles/list` — present the refresh token in the request body; receive all profiles for the account. Refresh tokens are never sent via `Authorization` headers to avoid conflation with access tokens.
 
 ## Registration Flow
 
@@ -155,7 +159,7 @@ POST /register/complete → OTP →
 | Phase | Status | Scope |
 |-------|--------|-------|
 | P1: Schema + terminology | ✅ Done | `accounts` table, `userId` → `profileId`, seed data, email dedup, service/route/test rename from "user" → "profile" terminology |
-| P2: Auth refactor | ✅ Done | Two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `GET /profiles`, `verifyRefreshToken`, `findDefaultProfile` |
+| P2: Auth refactor | ✅ Done | Two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `POST /profiles/list`, `verifyRefreshToken`, `findDefaultProfile`, scope claim validation, per-account rate limiting |
 | P3: Profile CRUD | Planned | Create/list/delete profiles, maxProfiles enforcement |
 | P4: Client SDK | Planned | Multi-session storage, profile switcher methods |
 | P5: UI | Planned | Profile switcher component |


### PR DESCRIPTION
## Summary
- Refresh tokens now scoped to accounts (`sub=accountId`, `scope=account`), access tokens remain profile-scoped (`sub=profileId`). Enables profile switching without re-authentication.
- New `POST /profiles/switch` endpoint — present refresh token + target `profileId`, receive new access token for that profile. Per-account rate limited (20/hr).
- New `POST /profiles/list` endpoint — present refresh token, receive all profiles for the account. Refresh token passed in body (not `Authorization` header) to avoid conflation with access tokens.
- New service functions: `switchProfile`, `listAccountProfiles`, `verifyRefreshToken`, `findDefaultProfile`.
- New metric: `osn.auth.profile_switch.attempts` with bounded `ProfileSwitchAction` attribute union.
- Breaking: existing refresh tokens (profile-scoped) will fail on refresh — users must re-authenticate once.

## Workspaces affected
- `@osn/core` (minor) — auth service, routes, metrics, rate limiters
- `@shared/observability` (patch) — new `ProfileSwitchAction` type, extended `AuthRateLimitedEndpoint`

## Decisions & issues

**[S-M44]** — `verifyRefreshToken` did not check `scope` claim
- **Issue:** Old pre-P2 refresh tokens (`sub=profileId`, no `scope`) passed the type check and only failed downstream by accident (prefix mismatch).
- **Why:** Defense in depth — the two-tier model's security should not rely on ID prefix conventions.
- **Solution:** Added `payload["scope"] !== "account"` to the guard in `verifyRefreshToken`.
- **Rationale:** Explicit scope validation makes old-token rejection intentional rather than accidental, and prevents future token type additions from bypassing the check.

**[S-M45]** — Refresh token sent via `Authorization: Bearer` header on GET /profiles
- **Issue:** `GET /profiles` overloaded the `Authorization: Bearer` header with a long-lived refresh token, using the same pattern as short-lived access tokens on all other routes.
- **Why:** Logging middleware and proxies that capture `Authorization` headers would capture the 30-day refresh token instead of a 1-hour access token.
- **Solution:** Changed to `POST /profiles/list` with refresh token in the request body, matching the `POST /profiles/switch` design.
- **Rationale:** Keeps refresh tokens out of headers, maintains consistency between the two profile endpoints.

**[S-M46]** — No per-account rate limiting on profile switch
- **Issue:** Per-IP rate limiting (10 req/min) could be bypassed by rotating source IPs with a stolen refresh token.
- **Why:** Bounds damage from a single compromised refresh token.
- **Solution:** Added in-memory per-account fixed-window rate limit (20 switches/hr) via `checkProfileSwitchLimit()`, checked after `verifyRefreshToken` succeeds.
- **Rationale:** Per-account limiting ensures that even with IP rotation, the total switch attempts are bounded by the account.

**[S-L31]** — No input format validation on `profile_id`
- **Issue:** `profile_id` accepted any string, causing unnecessary DB queries for garbage input.
- **Why:** Defense in depth — early rejection provides a clearer API contract.
- **Solution:** Added TypeBox pattern constraint `^usr_[a-f0-9]{12}$` matching the `genId("usr_")` format.
- **Rationale:** Rejects malformed IDs before hitting the database.

**[S-L32 / P-I1]** — `findDefaultProfile` ORDER BY relied on implicit semantics
- **Issue:** Used `orderBy(users.isDefault)` ASC + `limit(2)` + `.find()` in JS. Relied on SQLite boolean-as-integer storage, fetched 2 rows to find 1.
- **Why:** Portability concern for Supabase migration; unnecessary extra row fetch.
- **Solution:** Changed to `desc(users.isDefault)` + `limit(1)`, putting the default profile first.
- **Rationale:** Explicit ordering, single-row fetch, no post-query scan.

**[P-I2]** — `switchProfile` runs two lookups sequentially (dismissed)
- **Issue:** `verifyRefreshToken` and `findProfileById` could theoretically be parallelized.
- **Why:** Sub-ms JWT verify + indexed PK lookup — negligible real-world gain.
- **Solution:** Not applied. The per-account rate limit check (S-M46) depends on `accountId` from `verifyRefreshToken` and must run *before* the DB query to avoid unnecessary work when rate-limited.
- **Rationale:** Parallelizing would execute DB queries even when rate-limited, making the code worse, not better.

**[T-U1]** — Redis rate limiter test only verified 11 of 13 slots
- **Issue:** Test was stale after adding `profileSwitch` and `profileList` limiter slots.
- **Why:** Missing slots in the assertion array would not catch accidental deletion.
- **Solution:** Updated `expectedKeys` array to include all 13 slots.
- **Rationale:** Direct extension of existing test pattern.

**[T-E1]** — `verifyRefreshToken` not tested with access token (type mismatch)
- **Issue:** Tests only passed garbage strings, not valid access tokens with wrong type.
- **Why:** The two-tier model's most critical security property — that access tokens cannot be used as refresh tokens — was untested.
- **Solution:** Added test that calls `switchProfile` and `listAccountProfiles` with an access token, asserting "Invalid token type" error.
- **Rationale:** Directly tests the security boundary between the two token tiers.

**[T-S2]** — No rate-limit test for `POST /profiles/list`
- **Issue:** Rate limiter wiring for the list endpoint was untested.
- **Why:** A wiring mistake would go undetected.
- **Solution:** Added test with deny-all `profileList` limiter asserting 429 response.
- **Rationale:** Mirrors existing rate-limit test pattern for `POST /profiles/switch`.

## Test plan
- [ ] All 1102 tests pass across 14 packages (72 test files)
- [ ] Type check clean across 16 packages, 0 lint warnings
- [ ] `POST /profiles/switch` — valid switch returns new access token
- [ ] `POST /profiles/switch` — cross-account switch rejected
- [ ] `POST /profiles/switch` — invalid/expired refresh token rejected
- [ ] `POST /profiles/switch` — access token rejected as refresh token
- [ ] `POST /profiles/switch` — malformed `profile_id` rejected by TypeBox
- [ ] `POST /profiles/list` — returns all profiles for account
- [ ] `POST /profiles/list` — invalid token rejected
- [ ] Both endpoints rate-limited (per-IP + per-account on switch)
- [ ] Existing login/register/OTP/magic-link/passkey flows unaffected
- [ ] Changeset validates: `@osn/core` minor, `@shared/observability` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)