### PR TITLE
feat(core): Profile CRUD — multi-account Phase 3

### DIFF
--- a/.changeset/profile-crud-p3.md
+++ b/.changeset/profile-crud-p3.md
@@ -1,0 +1,17 @@
+---
+"@osn/core": minor
+"@shared/observability": patch
+---
+
+feat: Profile CRUD (multi-account P3) — create, delete, set default
+
+Adds `createProfileService()` with three operations:
+- `createProfile`: creates a new profile under an existing account, enforces `maxProfiles` limit (fixes S-L1), validates handle against both user and org namespaces
+- `deleteProfile`: cascade-deletes all profile-owned data (connections, close friends, blocks, org memberships) in a single transaction, guards against deleting the last profile or org-owning profiles
+- `setDefaultProfile`: changes which profile is the default for token refresh
+
+Three new REST routes: `POST /profiles/create`, `POST /profiles/delete`, `POST /profiles/:profileId/default` with per-endpoint rate limiting (5/min create+delete, 10/min set-default).
+
+Observability: `ProfileCrudAction` bounded union, `osn.profile.crud.operations` counter, `osn.profile.crud.duration` histogram, `withProfileCrud` span+metric wrapper.
+
+Resolves S-L1 (maxProfiles enforcement) and S-L2 (email dedup confirmed clean).

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -5,9 +5,11 @@ import {
   createInternalGraphRoutes,
   createOrganisationRoutes,
   createInternalOrganisationRoutes,
+  createProfileRoutes,
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
   createRedisOrgRateLimiter,
+  createRedisProfileRateLimiters,
 } from "@osn/core";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
@@ -49,6 +51,7 @@ const redisClient = await initRedisClient({
 const authRateLimiters = createRedisAuthRateLimiters(redisClient);
 const graphRateLimiter = createRedisGraphRateLimiter(redisClient);
 const orgRateLimiter = createRedisOrgRateLimiter(redisClient);
+const profileRateLimiters = createRedisProfileRateLimiters(redisClient);
 
 const app = new Elysia()
   .use(cors())
@@ -59,7 +62,8 @@ const app = new Elysia()
   .use(createGraphRoutes(authConfig, DbLive, observabilityLayer, graphRateLimiter))
   .use(createInternalGraphRoutes(DbLive))
   .use(createOrganisationRoutes(authConfig, DbLive, observabilityLayer, orgRateLimiter))
-  .use(createInternalOrganisationRoutes(DbLive));
+  .use(createInternalOrganisationRoutes(DbLive))
+  .use(createProfileRoutes(authConfig, DbLive, observabilityLayer, profileRateLimiters));
 
 if (process.env.NODE_ENV !== "test") {
   app.listen(port);

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -11,11 +11,16 @@ export { createOrganisationRoutes, createDefaultOrgRateLimiter } from "./routes/
 export { createInternalOrganisationRoutes } from "./routes/organisation-internal";
 export { createOrganisationService } from "./services/organisation";
 export type { OrganisationService } from "./services/organisation";
+export { createProfileRoutes, createDefaultProfileRateLimiters } from "./routes/profile";
+export type { ProfileRateLimiters } from "./routes/profile";
+export { createProfileService } from "./services/profile";
+export type { ProfileService } from "./services/profile";
 export { createRateLimiter, getClientIp, type RateLimiterBackend } from "./lib/rate-limit";
 export {
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
   createRedisOrgRateLimiter,
+  createRedisProfileRateLimiters,
 } from "./lib/redis-rate-limiters";
 export { requireArc } from "./lib/arc-middleware";
 export type { ArcCaller } from "./lib/arc-middleware";

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -15,6 +15,7 @@ import { createRedisRateLimiter } from "@shared/redis";
 import type { RedisClient } from "@shared/redis";
 
 import type { AuthRateLimiters } from "../routes/auth";
+import type { ProfileRateLimiters } from "../routes/profile";
 import type { RateLimiterBackend } from "./rate-limit";
 
 const ONE_MINUTE_MS = 60_000;
@@ -67,4 +68,19 @@ export function createRedisOrgRateLimiter(client: RedisClient): RateLimiterBacke
     maxRequests: 60,
     windowMs: ONE_MINUTE_MS,
   });
+}
+
+/**
+ * Build all 3 profile CRUD rate limiters backed by a shared Redis client.
+ * Namespace convention: `profile:{action}`.
+ */
+export function createRedisProfileRateLimiters(client: RedisClient): ProfileRateLimiters {
+  const rl = (namespace: string, maxRequests: number): RateLimiterBackend =>
+    createRedisRateLimiter(client, { namespace, maxRequests, windowMs: ONE_MINUTE_MS });
+
+  return {
+    profileCreate: rl("profile:create", 5),
+    profileDelete: rl("profile:delete", 5),
+    profileSetDefault: rl("profile:set_default", 10),
+  };
 }

--- a/osn/core/src/metrics.ts
+++ b/osn/core/src/metrics.ts
@@ -21,6 +21,7 @@ import type {
   GraphConnectionAction,
   OrgAction,
   OrgMemberAction,
+  ProfileCrudAction,
   ProfileSwitchAction,
   RegisterStep,
   Result,
@@ -44,6 +45,8 @@ export const OSN_METRICS = {
   orgOps: "osn.org.operations",
   orgMemberOps: "osn.org.member.operations",
   profileSwitchAttempts: "osn.auth.profile_switch.attempts",
+  profileCrudOps: "osn.profile.crud.operations",
+  profileCrudDuration: "osn.profile.crud.duration",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -63,6 +66,7 @@ type GraphCloseFriendAttrs = { action: GraphCloseFriendAction; result: Result };
 type OrgAttrs = { action: OrgAction; result: Result };
 type OrgMemberAttrs = { action: OrgMemberAction; result: Result };
 type ProfileSwitchAttrs = { action: ProfileSwitchAction; result: Result };
+type ProfileCrudAttrs = { action: ProfileCrudAction; result: Result };
 
 // ---------------------------------------------------------------------------
 // Counters / histograms
@@ -158,6 +162,19 @@ const profileSwitchAttempts = createCounter<ProfileSwitchAttrs>({
   name: OSN_METRICS.profileSwitchAttempts,
   description: "Profile switch/list attempts by action and outcome",
   unit: "{attempt}",
+});
+
+const profileCrudOps = createCounter<ProfileCrudAttrs>({
+  name: OSN_METRICS.profileCrudOps,
+  description: "Profile CRUD operations by action and outcome",
+  unit: "{operation}",
+});
+
+const profileCrudDuration = createHistogram<ProfileCrudAttrs>({
+  name: OSN_METRICS.profileCrudDuration,
+  description: "Profile CRUD operation duration by action",
+  unit: "s",
+  boundaries: LATENCY_BUCKETS_SECONDS,
 });
 
 // ---------------------------------------------------------------------------
@@ -379,6 +396,26 @@ export const withProfileSwitch =
         Effect.all([
           Effect.sync(() => profileSwitchAttempts.inc({ action, result: classifyError(e) })),
           Effect.logError("auth.profile operation failed", { action, ...safeErrorSummary(e) }),
+        ]),
+      ),
+    );
+
+export const withProfileCrud =
+  (action: ProfileCrudAction) =>
+  <A, E, Ctx>(effect: Effect.Effect<A, E, Ctx>): Effect.Effect<A, E, Ctx> =>
+    effect.pipe(
+      measureSeconds((seconds, outcome) => {
+        profileCrudDuration.record(seconds, {
+          action,
+          result: outcome === "ok" ? "ok" : "error",
+        });
+      }),
+      Effect.withSpan(`profile.${action}`),
+      Effect.tap(() => Effect.sync(() => profileCrudOps.inc({ action, result: "ok" }))),
+      Effect.tapError((e) =>
+        Effect.all([
+          Effect.sync(() => profileCrudOps.inc({ action, result: classifyError(e) })),
+          Effect.logError("profile.crud operation failed", { action, ...safeErrorSummary(e) }),
         ]),
       ),
     );

--- a/osn/core/src/routes/profile.ts
+++ b/osn/core/src/routes/profile.ts
@@ -1,0 +1,191 @@
+import { DbLive, type Db } from "@osn/db/service";
+import type { AuthRateLimitedEndpoint } from "@shared/observability/metrics";
+import { Effect, Layer } from "effect";
+import { Elysia, t } from "elysia";
+
+import { createRateLimiter, getClientIp, type RateLimiterBackend } from "../lib/rate-limit";
+import { metricAuthRateLimited } from "../metrics";
+import { createAuthService, type AuthConfig } from "../services/auth";
+import { createProfileService } from "../services/profile";
+
+// ---------------------------------------------------------------------------
+// Rate limiter types
+// ---------------------------------------------------------------------------
+
+export type ProfileRateLimiters = Readonly<{
+  profileCreate: RateLimiterBackend;
+  profileDelete: RateLimiterBackend;
+  profileSetDefault: RateLimiterBackend;
+}>;
+
+export function createDefaultProfileRateLimiters(): ProfileRateLimiters {
+  return {
+    profileCreate: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
+    profileDelete: createRateLimiter({ maxRequests: 5, windowMs: 60_000 }),
+    profileSetDefault: createRateLimiter({ maxRequests: 10, windowMs: 60_000 }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route factory
+// ---------------------------------------------------------------------------
+
+export function createProfileRoutes(
+  authConfig: AuthConfig,
+  dbLayer: Layer.Layer<Db> = DbLive,
+  loggerLayer: Layer.Layer<never> = Layer.empty,
+  rateLimiters: ProfileRateLimiters = createDefaultProfileRateLimiters(),
+) {
+  for (const [key, backend] of Object.entries(rateLimiters)) {
+    if (typeof (backend as RateLimiterBackend)?.check !== "function") {
+      throw new Error(`ProfileRateLimiters.${key} must have a check() method`);
+    }
+  }
+
+  const auth = createAuthService(authConfig);
+  const profile = createProfileService(auth);
+
+  const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
+    Effect.runPromise(
+      eff.pipe(Effect.provide(dbLayer), Effect.provide(loggerLayer)) as Effect.Effect<
+        A,
+        never,
+        never
+      >,
+    );
+
+  function publicError(e: unknown): { status: number; body: { error: string; message?: string } } {
+    const tag = (() => {
+      const seen = new Set<unknown>();
+      const queue: unknown[] = [e];
+      while (queue.length) {
+        const node = queue.shift();
+        if (!node || typeof node !== "object" || seen.has(node)) continue;
+        seen.add(node);
+        const tagValue = (node as { _tag?: unknown })._tag;
+        if (typeof tagValue === "string") return tagValue;
+        for (const v of Object.values(node)) queue.push(v);
+      }
+      return null;
+    })();
+
+    void Effect.runPromise(
+      Effect.logError("profile route error").pipe(
+        Effect.annotateLogs({ tag: tag ?? "unknown" }),
+        Effect.provide(loggerLayer),
+      ),
+    );
+
+    switch (tag) {
+      case "ValidationError":
+        return { status: 400, body: { error: "invalid_request" } };
+      case "AuthError":
+        return { status: 400, body: { error: "invalid_request" } };
+      case "DatabaseError":
+        return { status: 500, body: { error: "internal_error" } };
+      default:
+        return { status: 400, body: { error: "invalid_request" } };
+    }
+  }
+
+  const rl = rateLimiters;
+
+  async function rateLimit(
+    headers: Record<string, string | undefined>,
+    endpoint: AuthRateLimitedEndpoint,
+    limiter: RateLimiterBackend,
+  ): Promise<{ error: string } | null> {
+    const ip = getClientIp(headers);
+    let allowed: boolean;
+    try {
+      allowed = await limiter.check(ip);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
+      metricAuthRateLimited(endpoint);
+      return { error: "rate_limited" };
+    }
+    return null;
+  }
+
+  return new Elysia({ prefix: "" })
+    .post(
+      "/profiles/create",
+      async ({ body, headers, set }) => {
+        const rlErr = await rateLimit(headers, "profile_create", rl.profileCreate);
+        if (rlErr) {
+          set.status = 429;
+          return rlErr;
+        }
+        try {
+          const result = await run(
+            profile.createProfile(body.refresh_token, body.handle, body.display_name),
+          );
+          set.status = 201;
+          return { profile: result };
+        } catch (e) {
+          const { status, body: errBody } = publicError(e);
+          set.status = status;
+          return errBody;
+        }
+      },
+      {
+        body: t.Object({
+          refresh_token: t.String(),
+          handle: t.String(),
+          display_name: t.Optional(t.String()),
+        }),
+      },
+    )
+    .post(
+      "/profiles/delete",
+      async ({ body, headers, set }) => {
+        const rlErr = await rateLimit(headers, "profile_delete", rl.profileDelete);
+        if (rlErr) {
+          set.status = 429;
+          return rlErr;
+        }
+        try {
+          await run(profile.deleteProfile(body.refresh_token, body.profile_id));
+          return { deleted: true };
+        } catch (e) {
+          const { status, body: errBody } = publicError(e);
+          set.status = status;
+          return errBody;
+        }
+      },
+      {
+        body: t.Object({
+          refresh_token: t.String(),
+          profile_id: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
+        }),
+      },
+    )
+    .post(
+      "/profiles/:profileId/default",
+      async ({ body, params, headers, set }) => {
+        const rlErr = await rateLimit(headers, "profile_set_default", rl.profileSetDefault);
+        if (rlErr) {
+          set.status = 429;
+          return rlErr;
+        }
+        try {
+          const result = await run(profile.setDefaultProfile(body.refresh_token, params.profileId));
+          return { profile: result };
+        } catch (e) {
+          const { status, body: errBody } = publicError(e);
+          set.status = status;
+          return errBody;
+        }
+      },
+      {
+        params: t.Object({
+          profileId: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
+        }),
+        body: t.Object({
+          refresh_token: t.String(),
+        }),
+      },
+    );
+}

--- a/osn/core/src/services/profile.ts
+++ b/osn/core/src/services/profile.ts
@@ -97,57 +97,71 @@ export function createProfileService(authService: AuthService) {
       const { accountId } = yield* authService.verifyRefreshToken(refreshToken);
       const { db } = yield* Db;
 
-      // Parallel pre-checks: account limits + handle availability
-      const [accountRows, profileCount, existingHandle, existingOrgHandle] =
-        yield* Effect.tryPromise({
-          try: () =>
-            Promise.all([
-              db
-                .select({ maxProfiles: accounts.maxProfiles, email: accounts.email })
-                .from(accounts)
-                .where(eq(accounts.id, accountId))
-                .limit(1),
-              db
-                .select({ count: sql<number>`COUNT(*)` })
-                .from(users)
-                .where(eq(users.accountId, accountId)),
-              db.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1),
-              db
-                .select({ id: organisations.id })
-                .from(organisations)
-                .where(eq(organisations.handle, handle))
-                .limit(1),
-            ]),
-          catch: (cause) => new DatabaseError({ cause }),
-        });
-
+      // Pre-check: account exists + get email/maxProfiles (needed outside txn for return value)
+      const accountRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ maxProfiles: accounts.maxProfiles, email: accounts.email })
+            .from(accounts)
+            .where(eq(accounts.id, accountId))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
       const account = accountRows[0];
       if (!account) {
         return yield* Effect.fail(new AuthError({ message: "Account not found" }));
-      }
-      if (profileCount[0]!.count >= account.maxProfiles) {
-        return yield* Effect.fail(new AuthError({ message: "Maximum profiles reached" }));
-      }
-      if (existingHandle.length > 0 || existingOrgHandle.length > 0) {
-        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
       }
 
       const id = genId("usr_");
       const ts = now();
       const dn = displayName ?? null;
 
+      // Atomic check-and-insert inside a transaction (S-H1, S-M2):
+      // - maxProfiles count and handle availability are re-checked inside the txn
+      // - UNIQUE constraint on users.handle is the final safety net
       yield* Effect.tryPromise({
         try: () =>
-          db.insert(users).values({
-            id,
-            accountId,
-            handle,
-            displayName: dn,
-            isDefault: false,
-            createdAt: ts,
-            updatedAt: ts,
+          db.transaction(async (tx) => {
+            const [profileCount, existingHandle, existingOrgHandle] = await Promise.all([
+              tx
+                .select({ count: sql<number>`COUNT(*)` })
+                .from(users)
+                .where(eq(users.accountId, accountId)),
+              tx.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1),
+              tx
+                .select({ id: organisations.id })
+                .from(organisations)
+                .where(eq(organisations.handle, handle))
+                .limit(1),
+            ]);
+
+            if (profileCount[0]!.count >= account.maxProfiles) {
+              throw new AuthError({ message: "Maximum profiles reached" });
+            }
+            if (existingHandle.length > 0 || existingOrgHandle.length > 0) {
+              throw new AuthError({ message: "Handle already taken" });
+            }
+
+            await tx.insert(users).values({
+              id,
+              accountId,
+              handle,
+              displayName: dn,
+              isDefault: false,
+              createdAt: ts,
+              updatedAt: ts,
+            });
           }),
-        catch: (cause) => new DatabaseError({ cause }),
+        catch: (cause) => {
+          // Re-throw tagged errors (AuthError thrown inside the txn)
+          if (cause instanceof AuthError) return cause;
+          // Map UNIQUE constraint violations to a friendly error
+          const msg = cause instanceof Error ? cause.message : String(cause);
+          if (msg.includes("UNIQUE constraint failed")) {
+            return new AuthError({ message: "Handle already taken" });
+          }
+          return new DatabaseError({ cause });
+        },
       });
 
       return { id, handle, email: account.email, displayName: dn, avatarUrl: null };
@@ -211,59 +225,58 @@ export function createProfileService(authService: AuthService) {
 
       const wasDefault = profile.isDefault;
 
-      // Cascade delete in a single transaction
+      // Atomic cascade delete + default-promotion in a single transaction (S-H2, P-W1, P-W2).
+      // Independent deletes are parallelised; the profile row delete runs last (FK safety).
+      // Default-promotion is inside the txn to prevent an account with no default.
       yield* Effect.tryPromise({
         try: () =>
           db.transaction(async (tx) => {
-            await tx
-              .delete(closeFriends)
-              .where(
-                or(
-                  eq(closeFriends.profileId, targetProfileId),
-                  eq(closeFriends.friendId, targetProfileId),
+            await Promise.all([
+              tx
+                .delete(closeFriends)
+                .where(
+                  or(
+                    eq(closeFriends.profileId, targetProfileId),
+                    eq(closeFriends.friendId, targetProfileId),
+                  ),
                 ),
-              );
-            await tx
-              .delete(connections)
-              .where(
-                or(
-                  eq(connections.requesterId, targetProfileId),
-                  eq(connections.addresseeId, targetProfileId),
+              tx
+                .delete(connections)
+                .where(
+                  or(
+                    eq(connections.requesterId, targetProfileId),
+                    eq(connections.addresseeId, targetProfileId),
+                  ),
                 ),
-              );
-            await tx
-              .delete(blocks)
-              .where(
-                or(eq(blocks.blockerId, targetProfileId), eq(blocks.blockedId, targetProfileId)),
-              );
-            await tx
-              .delete(organisationMembers)
-              .where(eq(organisationMembers.profileId, targetProfileId));
+              tx
+                .delete(blocks)
+                .where(
+                  or(eq(blocks.blockerId, targetProfileId), eq(blocks.blockedId, targetProfileId)),
+                ),
+              tx
+                .delete(organisationMembers)
+                .where(eq(organisationMembers.profileId, targetProfileId)),
+            ]);
             await tx.delete(users).where(eq(users.id, targetProfileId));
+
+            // Promote another profile to default if the deleted one was default
+            if (wasDefault) {
+              const remaining = await tx
+                .select({ id: users.id })
+                .from(users)
+                .where(eq(users.accountId, accountId))
+                .orderBy(asc(users.createdAt))
+                .limit(1);
+              if (remaining.length > 0) {
+                await tx
+                  .update(users)
+                  .set({ isDefault: true, updatedAt: now() })
+                  .where(eq(users.id, remaining[0]!.id));
+              }
+            }
           }),
         catch: (cause) => new DatabaseError({ cause }),
       });
-
-      // Promote another profile to default if the deleted one was default
-      if (wasDefault) {
-        yield* Effect.tryPromise({
-          try: async () => {
-            const remaining = await db
-              .select({ id: users.id })
-              .from(users)
-              .where(eq(users.accountId, accountId))
-              .orderBy(asc(users.createdAt))
-              .limit(1);
-            if (remaining.length > 0) {
-              await db
-                .update(users)
-                .set({ isDefault: true, updatedAt: now() })
-                .where(eq(users.id, remaining[0]!.id));
-            }
-          },
-          catch: (cause) => new DatabaseError({ cause }),
-        });
-      }
     }).pipe(withProfileCrud("delete"));
 
   /**

--- a/osn/core/src/services/profile.ts
+++ b/osn/core/src/services/profile.ts
@@ -1,0 +1,320 @@
+import {
+  accounts,
+  blocks,
+  closeFriends,
+  connections,
+  organisations,
+  organisationMembers,
+  users,
+} from "@osn/db/schema";
+import { Db } from "@osn/db/service";
+import { and, asc, eq, or, sql } from "drizzle-orm";
+import { Data, Effect, Schema } from "effect";
+
+import { withProfileCrud } from "../metrics";
+import type { AuthService, PublicProfile } from "./auth";
+
+// ---------------------------------------------------------------------------
+// Errors (re-exported from auth for convenience)
+// ---------------------------------------------------------------------------
+
+export class AuthError extends Data.TaggedError("AuthError")<{
+  readonly message: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+export class ValidationError extends Data.TaggedError("ValidationError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function genId(prefix: string): string {
+  return prefix + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function now(): Date {
+  return new Date();
+}
+
+const HandleSchema = Schema.String.pipe(
+  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
+    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
+  }),
+);
+
+const RESERVED_HANDLES = new Set([
+  "me",
+  "admin",
+  "api",
+  "support",
+  "help",
+  "osn",
+  "pulse",
+  "messaging",
+  "auth",
+  "login",
+  "logout",
+  "register",
+  "signup",
+  "signin",
+  "about",
+  "terms",
+  "privacy",
+  "status",
+  "null",
+  "undefined",
+]);
+
+// ---------------------------------------------------------------------------
+// Profile service factory
+// ---------------------------------------------------------------------------
+
+export function createProfileService(authService: AuthService) {
+  /**
+   * Creates a new profile under the account identified by the refresh token.
+   * Enforces `maxProfiles` limit (S-L1) and validates handle availability
+   * against both user and organisation handles (shared namespace).
+   */
+  const createProfile = (
+    refreshToken: string,
+    handle: string,
+    displayName?: string,
+  ): Effect.Effect<PublicProfile, AuthError | ValidationError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+        Effect.mapError((cause) => new ValidationError({ cause })),
+      );
+      if (RESERVED_HANDLES.has(handle)) {
+        return yield* Effect.fail(new AuthError({ message: "Handle is reserved" }));
+      }
+
+      const { accountId } = yield* authService.verifyRefreshToken(refreshToken);
+      const { db } = yield* Db;
+
+      // Parallel pre-checks: account limits + handle availability
+      const [accountRows, profileCount, existingHandle, existingOrgHandle] =
+        yield* Effect.tryPromise({
+          try: () =>
+            Promise.all([
+              db
+                .select({ maxProfiles: accounts.maxProfiles, email: accounts.email })
+                .from(accounts)
+                .where(eq(accounts.id, accountId))
+                .limit(1),
+              db
+                .select({ count: sql<number>`COUNT(*)` })
+                .from(users)
+                .where(eq(users.accountId, accountId)),
+              db.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1),
+              db
+                .select({ id: organisations.id })
+                .from(organisations)
+                .where(eq(organisations.handle, handle))
+                .limit(1),
+            ]),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+
+      const account = accountRows[0];
+      if (!account) {
+        return yield* Effect.fail(new AuthError({ message: "Account not found" }));
+      }
+      if (profileCount[0]!.count >= account.maxProfiles) {
+        return yield* Effect.fail(new AuthError({ message: "Maximum profiles reached" }));
+      }
+      if (existingHandle.length > 0 || existingOrgHandle.length > 0) {
+        return yield* Effect.fail(new AuthError({ message: "Handle already taken" }));
+      }
+
+      const id = genId("usr_");
+      const ts = now();
+      const dn = displayName ?? null;
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(users).values({
+            id,
+            accountId,
+            handle,
+            displayName: dn,
+            isDefault: false,
+            createdAt: ts,
+            updatedAt: ts,
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return { id, handle, email: account.email, displayName: dn, avatarUrl: null };
+    }).pipe(withProfileCrud("create"));
+
+  /**
+   * Deletes a profile and cascade-deletes all owned social graph data.
+   * Cannot delete the last profile on an account or a profile that owns
+   * an organisation (ownership must be transferred first).
+   *
+   * Cross-DB data (Pulse RSVPs, Zap chat members) is not cleaned up here —
+   * orphaned rows are inert. A `profile.deleted` domain event will handle
+   * cross-service cleanup in a later phase.
+   */
+  const deleteProfile = (
+    refreshToken: string,
+    targetProfileId: string,
+  ): Effect.Effect<void, AuthError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { accountId } = yield* authService.verifyRefreshToken(refreshToken);
+
+      const profile = yield* authService.findProfileById(targetProfileId);
+      if (!profile) {
+        return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
+      }
+      if (profile.accountId !== accountId) {
+        return yield* Effect.fail(
+          new AuthError({ message: "Profile does not belong to this account" }),
+        );
+      }
+
+      const { db } = yield* Db;
+
+      // Parallel pre-checks: profile count + org ownership
+      const [countResult, ownedOrgs] = yield* Effect.tryPromise({
+        try: () =>
+          Promise.all([
+            db
+              .select({ count: sql<number>`COUNT(*)` })
+              .from(users)
+              .where(eq(users.accountId, accountId)),
+            db
+              .select({ id: organisations.id })
+              .from(organisations)
+              .where(eq(organisations.ownerId, targetProfileId))
+              .limit(1),
+          ]),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (countResult[0]!.count <= 1) {
+        return yield* Effect.fail(new AuthError({ message: "Cannot delete the last profile" }));
+      }
+      if (ownedOrgs.length > 0) {
+        return yield* Effect.fail(
+          new AuthError({
+            message: "Transfer organisation ownership before deleting this profile",
+          }),
+        );
+      }
+
+      const wasDefault = profile.isDefault;
+
+      // Cascade delete in a single transaction
+      yield* Effect.tryPromise({
+        try: () =>
+          db.transaction(async (tx) => {
+            await tx
+              .delete(closeFriends)
+              .where(
+                or(
+                  eq(closeFriends.profileId, targetProfileId),
+                  eq(closeFriends.friendId, targetProfileId),
+                ),
+              );
+            await tx
+              .delete(connections)
+              .where(
+                or(
+                  eq(connections.requesterId, targetProfileId),
+                  eq(connections.addresseeId, targetProfileId),
+                ),
+              );
+            await tx
+              .delete(blocks)
+              .where(
+                or(eq(blocks.blockerId, targetProfileId), eq(blocks.blockedId, targetProfileId)),
+              );
+            await tx
+              .delete(organisationMembers)
+              .where(eq(organisationMembers.profileId, targetProfileId));
+            await tx.delete(users).where(eq(users.id, targetProfileId));
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      // Promote another profile to default if the deleted one was default
+      if (wasDefault) {
+        yield* Effect.tryPromise({
+          try: async () => {
+            const remaining = await db
+              .select({ id: users.id })
+              .from(users)
+              .where(eq(users.accountId, accountId))
+              .orderBy(asc(users.createdAt))
+              .limit(1);
+            if (remaining.length > 0) {
+              await db
+                .update(users)
+                .set({ isDefault: true, updatedAt: now() })
+                .where(eq(users.id, remaining[0]!.id));
+            }
+          },
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+      }
+    }).pipe(withProfileCrud("delete"));
+
+  /**
+   * Changes which profile is the default for an account. The default profile
+   * is used when issuing tokens via `refreshTokens()`.
+   */
+  const setDefaultProfile = (
+    refreshToken: string,
+    targetProfileId: string,
+  ): Effect.Effect<PublicProfile, AuthError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { accountId } = yield* authService.verifyRefreshToken(refreshToken);
+
+      const profile = yield* authService.findProfileById(targetProfileId);
+      if (!profile) {
+        return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
+      }
+      if (profile.accountId !== accountId) {
+        return yield* Effect.fail(
+          new AuthError({ message: "Profile does not belong to this account" }),
+        );
+      }
+
+      const { db } = yield* Db;
+      const ts = now();
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.transaction(async (tx) => {
+            await tx
+              .update(users)
+              .set({ isDefault: false, updatedAt: ts })
+              .where(and(eq(users.accountId, accountId), eq(users.isDefault, true)));
+            await tx
+              .update(users)
+              .set({ isDefault: true, updatedAt: ts })
+              .where(eq(users.id, targetProfileId));
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return {
+        id: profile.id,
+        handle: profile.handle,
+        email: profile.email,
+        displayName: profile.displayName,
+        avatarUrl: profile.avatarUrl,
+      };
+    }).pipe(withProfileCrud("set_default"));
+
+  return { createProfile, deleteProfile, setDefaultProfile };
+}
+
+export type ProfileService = ReturnType<typeof createProfileService>;

--- a/osn/core/tests/routes/profile.test.ts
+++ b/osn/core/tests/routes/profile.test.ts
@@ -1,0 +1,179 @@
+import { Effect } from "effect";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createProfileRoutes } from "../../src/routes/profile";
+import { createAuthService } from "../../src/services/auth";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("profile routes", () => {
+  let profileApp: ReturnType<typeof createProfileRoutes>;
+  let layer: ReturnType<typeof createTestLayer>;
+  let auth: ReturnType<typeof createAuthService>;
+
+  beforeEach(() => {
+    layer = createTestLayer();
+    profileApp = createProfileRoutes(config, layer);
+    auth = createAuthService(config);
+  });
+
+  /** Helper: register + get refresh token via service layer. */
+  async function getRefreshToken(email: string, handle: string): Promise<string> {
+    const profile = await Effect.runPromise(
+      auth.registerProfile(email, handle).pipe(Effect.provide(layer)),
+    );
+    const tokens = await Effect.runPromise(
+      auth
+        .issueTokens(
+          profile.id,
+          profile.accountId,
+          profile.email,
+          profile.handle,
+          profile.displayName,
+        )
+        .pipe(Effect.provide(layer)),
+    );
+    return tokens.refreshToken;
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /profiles/create
+  // -------------------------------------------------------------------------
+  describe("POST /profiles/create", () => {
+    it("returns 201 on success with profile data", async () => {
+      const rt = await getRefreshToken("pc@test.com", "pcuser");
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "pc_alt" }),
+        }),
+      );
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as { profile: { id: string; handle: string } };
+      expect(json.profile.handle).toBe("pc_alt");
+      expect(json.profile.id).toMatch(/^usr_/);
+    });
+
+    it("returns 400 for invalid handle", async () => {
+      const rt = await getRefreshToken("bad@test.com", "baduser");
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "BADHANDLE" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid refresh token", async () => {
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: "bad-token", handle: "somehandle" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /profiles/delete
+  // -------------------------------------------------------------------------
+  describe("POST /profiles/delete", () => {
+    it("returns 200 on success", async () => {
+      const rt = await getRefreshToken("pd@test.com", "pduser");
+      // Create a second profile first
+      const createRes = await profileApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "pd_alt" }),
+        }),
+      );
+      const { profile: created } = (await createRes.json()) as {
+        profile: { id: string };
+      };
+
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/delete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, profile_id: created.id }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { deleted: boolean };
+      expect(json.deleted).toBe(true);
+    });
+
+    it("returns 400 for deleting the last profile", async () => {
+      const p = await Effect.runPromise(
+        auth.registerProfile("lastrd@test.com", "lastrduser").pipe(Effect.provide(layer)),
+      );
+      const tokens = await Effect.runPromise(
+        auth
+          .issueTokens(p.id, p.accountId, p.email, p.handle, p.displayName)
+          .pipe(Effect.provide(layer)),
+      );
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/delete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: tokens.refreshToken, profile_id: p.id }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /profiles/:profileId/default
+  // -------------------------------------------------------------------------
+  describe("POST /profiles/:profileId/default", () => {
+    it("returns 200 on success with profile data", async () => {
+      const rt = await getRefreshToken("sd@test.com", "sduser");
+      const createRes = await profileApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "sd_alt" }),
+        }),
+      );
+      const { profile: created } = (await createRes.json()) as {
+        profile: { id: string; handle: string };
+      };
+
+      const res = await profileApp.handle(
+        new Request(`http://localhost/profiles/${created.id}/default`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { profile: { id: string; handle: string } };
+      expect(json.profile.handle).toBe("sd_alt");
+    });
+
+    it("returns 400 for invalid refresh token", async () => {
+      const res = await profileApp.handle(
+        new Request("http://localhost/profiles/usr_000000000000/default", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: "bad-token" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/osn/core/tests/routes/profile.test.ts
+++ b/osn/core/tests/routes/profile.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach } from "vitest";
 
+import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createProfileRoutes } from "../../src/routes/profile";
 import { createAuthService } from "../../src/services/auth";
 import { createTestLayer } from "../helpers/db";
@@ -174,6 +175,159 @@ describe("profile routes", () => {
         }),
       );
       expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiting (T-R1)
+  // -------------------------------------------------------------------------
+  describe("rate limiting", () => {
+    it("returns 429 after exceeding rate limit on /profiles/create", async () => {
+      const freshApp = createProfileRoutes(config, layer);
+      const rt = await getRefreshToken("rl1@test.com", "rl1user");
+      // profileCreate allows 5 req/min
+      for (let i = 0; i < 5; i++) {
+        // eslint-disable-next-line no-await-in-loop -- sequential dispatch required for rate-limit correctness
+        await freshApp.handle(
+          new Request("http://localhost/profiles/create", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+            body: JSON.stringify({ refresh_token: rt, handle: `rl1_alt${i}` }),
+          }),
+        );
+      }
+      const blocked = await freshApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+          body: JSON.stringify({ refresh_token: rt, handle: "rl1_blocked" }),
+        }),
+      );
+      expect(blocked.status).toBe(429);
+      const json = (await blocked.json()) as { error: string };
+      expect(json.error).toBe("rate_limited");
+    });
+
+    it("returns 429 after exceeding rate limit on /profiles/delete", async () => {
+      const freshApp = createProfileRoutes(config, layer);
+      const rt = await getRefreshToken("rl2@test.com", "rl2user");
+      // profileDelete allows 5 req/min — fire 5 requests (they may fail as 400, that's fine)
+      for (let i = 0; i < 5; i++) {
+        // eslint-disable-next-line no-await-in-loop -- sequential dispatch required for rate-limit correctness
+        await freshApp.handle(
+          new Request("http://localhost/profiles/delete", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "x-forwarded-for": "2.2.2.2" },
+            body: JSON.stringify({ refresh_token: rt, profile_id: `usr_00000000000${i}` }),
+          }),
+        );
+      }
+      const blocked = await freshApp.handle(
+        new Request("http://localhost/profiles/delete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "2.2.2.2" },
+          body: JSON.stringify({ refresh_token: rt, profile_id: "usr_000000000099" }),
+        }),
+      );
+      expect(blocked.status).toBe(429);
+    });
+
+    it("returns 429 after exceeding rate limit on /profiles/:profileId/default", async () => {
+      const freshApp = createProfileRoutes(config, layer);
+      const rt = await getRefreshToken("rl3@test.com", "rl3user");
+      // profileSetDefault allows 10 req/min
+      for (let i = 0; i < 10; i++) {
+        // eslint-disable-next-line no-await-in-loop -- sequential dispatch required for rate-limit correctness
+        await freshApp.handle(
+          new Request("http://localhost/profiles/usr_000000000000/default", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "x-forwarded-for": "3.3.3.3" },
+            body: JSON.stringify({ refresh_token: rt }),
+          }),
+        );
+      }
+      const blocked = await freshApp.handle(
+        new Request("http://localhost/profiles/usr_000000000000/default", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "3.3.3.3" },
+          body: JSON.stringify({ refresh_token: rt }),
+        }),
+      );
+      expect(blocked.status).toBe(429);
+    });
+
+    it("rate limits are per-IP — different IPs are independent", async () => {
+      const freshApp = createProfileRoutes(config, layer);
+      const rt = await getRefreshToken("rl4@test.com", "rl4user");
+      // Exhaust limit for IP A
+      for (let i = 0; i < 5; i++) {
+        // eslint-disable-next-line no-await-in-loop -- sequential dispatch required for rate-limit correctness
+        await freshApp.handle(
+          new Request("http://localhost/profiles/create", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "x-forwarded-for": "10.0.0.1" },
+            body: JSON.stringify({ refresh_token: rt, handle: `rl4_a${i}` }),
+          }),
+        );
+      }
+      // IP A is blocked
+      const blockedA = await freshApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "10.0.0.1" },
+          body: JSON.stringify({ refresh_token: rt, handle: "rl4_blocked" }),
+        }),
+      );
+      expect(blockedA.status).toBe(429);
+      // IP B is not blocked
+      const allowedB = await freshApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-forwarded-for": "10.0.0.2" },
+          body: JSON.stringify({ refresh_token: rt, handle: "rl4_b" }),
+        }),
+      );
+      expect(allowedB.status).not.toBe(429);
+    });
+
+    it("uses injected reject-all rate limiter", async () => {
+      const rejectAll: RateLimiterBackend = { check: async () => false };
+      const freshApp = createProfileRoutes(config, layer, undefined, {
+        profileCreate: rejectAll,
+        profileDelete: rejectAll,
+        profileSetDefault: rejectAll,
+      });
+      const rt = await getRefreshToken("rl5@test.com", "rl5user");
+      const res = await freshApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "rl5_alt" }),
+        }),
+      );
+      expect(res.status).toBe(429);
+    });
+
+    it("fails closed when rate limiter backend throws (S-M1)", async () => {
+      const brokenBackend: RateLimiterBackend = {
+        check: async () => {
+          throw new Error("Redis connection refused");
+        },
+      };
+      const freshApp = createProfileRoutes(config, layer, undefined, {
+        profileCreate: brokenBackend,
+        profileDelete: brokenBackend,
+        profileSetDefault: brokenBackend,
+      });
+      const rt = await getRefreshToken("rl6@test.com", "rl6user");
+      const res = await freshApp.handle(
+        new Request("http://localhost/profiles/create", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: rt, handle: "rl6_alt" }),
+        }),
+      );
+      expect(res.status).toBe(429);
     });
   });
 });

--- a/osn/core/tests/services/profile.test.ts
+++ b/osn/core/tests/services/profile.test.ts
@@ -95,6 +95,39 @@ describe("createProfile", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("rejects empty handle", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("empty@test.com", "emptyuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, ""));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("accepts 30-character handle (boundary)", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("bound@test.com", "bounduser");
+      const handle30 = "a".repeat(30);
+      const result = yield* profile.createProfile(refreshToken, handle30);
+      expect(result.handle).toBe(handle30);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects 31-character handle (over boundary)", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("over@test.com", "overuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "a".repeat(31)));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects handle with special characters", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("spec@test.com", "specuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "user-name"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("rejects handle that collides with organisation handle", () =>
     Effect.gen(function* () {
       const { profile: owner, refreshToken } = yield* setupAccount("orgcol@test.com", "orgcoluser");

--- a/osn/core/tests/services/profile.test.ts
+++ b/osn/core/tests/services/profile.test.ts
@@ -1,0 +1,271 @@
+import { it, expect, describe } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { createAuthService } from "../../src/services/auth";
+import { createGraphService } from "../../src/services/graph";
+import { createOrganisationService } from "../../src/services/organisation";
+import { createProfileService } from "../../src/services/profile";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+const auth = createAuthService(config);
+const profile = createProfileService(auth);
+const graph = createGraphService();
+const org = createOrganisationService();
+
+/** Register an account + profile, then get a refresh token for the account. */
+function setupAccount(email: string, handle: string, displayName?: string) {
+  return Effect.gen(function* () {
+    const p = yield* auth.registerProfile(email, handle, displayName);
+    const tokens = yield* auth.issueTokens(p.id, p.accountId, p.email, p.handle, p.displayName);
+    return { profile: p, refreshToken: tokens.refreshToken };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// createProfile
+// ---------------------------------------------------------------------------
+
+describe("createProfile", () => {
+  it.effect("creates a new profile with usr_ prefix and isDefault false", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("alice@test.com", "alice");
+      const newProfile = yield* profile.createProfile(refreshToken, "alice_alt", "Alt");
+      expect(newProfile.id).toMatch(/^usr_/);
+      expect(newProfile.handle).toBe("alice_alt");
+      expect(newProfile.displayName).toBe("Alt");
+      expect(newProfile.email).toBe("alice@test.com");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("creates profile without displayName", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("bob@test.com", "bob");
+      const newProfile = yield* profile.createProfile(refreshToken, "bob_alt");
+      expect(newProfile.displayName).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("enforces maxProfiles limit", () =>
+    Effect.gen(function* () {
+      // Register creates account with maxProfiles=5, plus the first profile
+      const { refreshToken } = yield* setupAccount("max@test.com", "maxuser");
+      // Create 4 more to hit the limit of 5
+      yield* profile.createProfile(refreshToken, "max_alt2");
+      yield* profile.createProfile(refreshToken, "max_alt3");
+      yield* profile.createProfile(refreshToken, "max_alt4");
+      yield* profile.createProfile(refreshToken, "max_alt5");
+      // 6th should fail
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "max_alt6"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Maximum profiles reached");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects reserved handles", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("res@test.com", "resuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "admin"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Handle is reserved");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects invalid handle format", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("inv@test.com", "invuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "BadHandle"));
+      expect(error._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects duplicate handle against existing user", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("dup@test.com", "dupuser");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "dupuser"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rejects handle that collides with organisation handle", () =>
+    Effect.gen(function* () {
+      const { profile: owner, refreshToken } = yield* setupAccount("orgcol@test.com", "orgcoluser");
+      yield* org.createOrganisation(owner.id, "myorg", "My Org");
+      const error = yield* Effect.flip(profile.createProfile(refreshToken, "myorg"));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Handle already taken");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid refresh token", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(profile.createProfile("bad-token", "newhandle"));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("does not expose accountId in the returned profile", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("noleak@test.com", "noleak");
+      const newProfile = yield* profile.createProfile(refreshToken, "noleak_alt");
+      expect(newProfile).not.toHaveProperty("accountId");
+      expect(newProfile).not.toHaveProperty("createdAt");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// deleteProfile
+// ---------------------------------------------------------------------------
+
+describe("deleteProfile", () => {
+  it.effect("deletes a profile and cascades graph edges", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("del@test.com", "deluser");
+      const alt = yield* profile.createProfile(refreshToken, "del_alt");
+
+      // Create a connection between the two profiles
+      yield* graph.sendConnectionRequest(main.id, alt.id);
+      yield* graph.acceptConnection(alt.id, main.id);
+
+      // Add close friend
+      yield* graph.addCloseFriend(main.id, alt.id);
+
+      // Delete the alt profile
+      yield* profile.deleteProfile(refreshToken, alt.id);
+
+      // Verify the profile is gone — list should show only one profile
+      const { profiles } = yield* auth.listAccountProfiles(refreshToken);
+      expect(profiles).toHaveLength(1);
+      expect(profiles[0]!.id).toBe(main.id);
+
+      // Verify connections are cleaned up — main should have no connections
+      const connections = yield* graph.listConnections(main.id);
+      expect(connections).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("cascades blocks and org memberships", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("casc@test.com", "cascuser");
+      const alt = yield* profile.createProfile(refreshToken, "casc_alt");
+
+      // Create an org owned by main, add alt as member
+      const myOrg = yield* org.createOrganisation(main.id, "cascorg", "Cascade Org");
+      yield* org.addMember(myOrg.id, main.id, alt.id, "member");
+
+      // Block from another account
+      const { profile: other } = yield* setupAccount("blocker@test.com", "blocker");
+      yield* graph.blockProfile(other.id, alt.id);
+
+      // Delete alt
+      yield* profile.deleteProfile(refreshToken, alt.id);
+
+      // Org membership should be gone
+      const members = yield* org.listMembers(myOrg.id);
+      expect(members.filter((m) => m.profile.id === alt.id)).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("cannot delete the last profile on an account", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("last@test.com", "lastuser");
+      const error = yield* Effect.flip(profile.deleteProfile(refreshToken, main.id));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Cannot delete the last profile");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("cannot delete profile owned by different account", () =>
+    Effect.gen(function* () {
+      const { refreshToken: rt1 } = yield* setupAccount("own1@test.com", "own1");
+      const { profile: other } = yield* setupAccount("own2@test.com", "own2");
+      const error = yield* Effect.flip(profile.deleteProfile(rt1, other.id));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("does not belong to this account");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("cannot delete profile that owns an organisation", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("orgown@test.com", "orgowner");
+      yield* profile.createProfile(refreshToken, "orgown_alt");
+      yield* org.createOrganisation(main.id, "ownedorg", "Owned Org");
+      const error = yield* Effect.flip(profile.deleteProfile(refreshToken, main.id));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Transfer organisation ownership");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("promotes another profile to default if deleted profile was default", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("prom@test.com", "promuser");
+      yield* profile.createProfile(refreshToken, "prom_alt");
+
+      // Main is default, delete it
+      yield* profile.deleteProfile(refreshToken, main.id);
+
+      // The alt should now be default
+      const { profiles } = yield* auth.listAccountProfiles(refreshToken);
+      expect(profiles).toHaveLength(1);
+      expect(profiles[0]!.handle).toBe("prom_alt");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid refresh token", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(profile.deleteProfile("bad-token", "usr_000000000000"));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// setDefaultProfile
+// ---------------------------------------------------------------------------
+
+describe("setDefaultProfile", () => {
+  it.effect("sets a new default profile and clears the old one", () =>
+    Effect.gen(function* () {
+      const { refreshToken } = yield* setupAccount("def@test.com", "defuser");
+      const alt = yield* profile.createProfile(refreshToken, "def_alt");
+
+      const result = yield* profile.setDefaultProfile(refreshToken, alt.id);
+      expect(result.id).toBe(alt.id);
+      expect(result.handle).toBe("def_alt");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("succeeds when target is already default (idempotent)", () =>
+    Effect.gen(function* () {
+      const { profile: main, refreshToken } = yield* setupAccount("idem@test.com", "idemuser");
+      const result = yield* profile.setDefaultProfile(refreshToken, main.id);
+      expect(result.id).toBe(main.id);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("cannot set default for profile on different account", () =>
+    Effect.gen(function* () {
+      const { refreshToken: rt1 } = yield* setupAccount("sdef1@test.com", "sdef1");
+      const { profile: other } = yield* setupAccount("sdef2@test.com", "sdef2");
+      const error = yield* Effect.flip(profile.setDefaultProfile(rt1, other.id));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("does not belong to this account");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("fails with invalid refresh token", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(profile.setDefaultProfile("bad-token", "usr_000000000000"));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -58,6 +58,12 @@ export type OrgMemberAction = "add" | "remove" | "update_role";
 /** Profile switching actions (P2 multi-account). */
 export type ProfileSwitchAction = "switch" | "list";
 
+/** Profile CRUD actions (P3 multi-account). */
+export type ProfileCrudAction = "create" | "delete" | "set_default";
+
+/** Tables affected by cascade profile delete (P3). */
+export type ProfileDeleteCascadeTable = "connections" | "close_friends" | "blocks" | "org_members";
+
 /** Auth endpoints subject to IP-based rate limiting (S-H1). */
 export type AuthRateLimitedEndpoint =
   | "register_begin"
@@ -72,4 +78,7 @@ export type AuthRateLimitedEndpoint =
   | "passkey_register_begin"
   | "passkey_register_complete"
   | "profile_switch"
-  | "profile_list";
+  | "profile_list"
+  | "profile_create"
+  | "profile_delete"
+  | "profile_set_default";

--- a/shared/observability/src/metrics/index.ts
+++ b/shared/observability/src/metrics/index.ts
@@ -33,4 +33,6 @@ export {
   type OrgMemberAction,
   type EventStatus,
   type ProfileSwitchAction,
+  type ProfileCrudAction,
+  type ProfileDeleteCascadeTable,
 } from "./attrs";

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -4,7 +4,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 
 ## Up Next
 
-- [ ] Multi-account P3 — Profile CRUD: `createProfileService()` (create, list, delete, set default), `/profiles` routes, handle validation against `maxProfiles`, cascade-delete profile data
+- [x] Multi-account P3 — Profile CRUD: `createProfileService()` (create, delete, set default), `/profiles` routes, `maxProfiles` enforcement (S-L1), cascade-delete profile data, observability (counter + histogram + spans)
 - [ ] Multi-account P4 — Client SDK: multi-session storage (`@osn/client:account_session`, `@osn/client:active_profile`, per-profile access tokens), `listProfiles()`, `switchProfile()`, `createProfile()`, `deleteProfile()` methods on `OsnAuthService`
 - [ ] Multi-account P5 — Profile UI: profile switcher component in `@osn/ui`, profile creation form, onboarding for additional profiles
 - [ ] Multi-account P6 — Privacy audit: verify `accountId` never leaks in API responses / tokens / logs, rate-limit per-profile (not per-account), pen-test correlation attacks between profiles
@@ -33,7 +33,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 
 ## OSN Core (`osn/app` + `osn/core`)
 
-- [ ] Multi-account profile CRUD (P3) — create/list/delete profiles, maxProfiles enforcement
+- [x] Multi-account profile CRUD (P3) — create/delete/set-default profiles, maxProfiles enforcement, cascade delete, observability
 - [ ] Multi-account client SDK (P4) — multi-session storage, profile switching
 - [ ] Multi-account UI (P5) — profile switcher component
 - [ ] Multi-account privacy audit (P6) — accountId leak verification, per-profile rate limits
@@ -196,8 +196,8 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-M4 (zap) — Non-atomic cross-DB writes in `zapBridge.provisionEventChat`
 - [ ] S-M5 (zap) — `addEventChatMember` does not verify chat is type "event"
 - [ ] S-M6 (zap) — Truncated UUIDs (12 hex chars = 48 bits)
-- [ ] S-L1 (multi) — `maxProfiles` column set to 5 but never enforced. Deferred to P3
-- [ ] S-L2 (multi) — Email duplication between `accounts.email` and `users.email`. Transitional
+- [x] S-L1 (multi) — `maxProfiles` column set to 5 but never enforced. **Fixed in P3** — `createProfile` checks count vs `accounts.maxProfiles`
+- [x] S-L2 (multi) — Email duplication between `accounts.email` and `users.email`. **Resolved** — `users` table has no `email` column; all email access via JOIN to `accounts`
 - [ ] S-H1 (org) — `listMembers` service returns full profile rows; route projects, but service should restrict
 - [ ] S-M1 (org) — `GET /organisations/:handle/members` has no membership gate
 - [ ] S-M3 (org) — `getOrganisation` returns `ownerId` internal ID

--- a/wiki/systems/identity-model.md
+++ b/wiki/systems/identity-model.md
@@ -11,6 +11,7 @@ packages:
   - "@osn/core"
 last-reviewed: 2026-04-14
 p2-completed: 2026-04-14
+p3-completed: 2026-04-14
 ---
 
 # Identity Model
@@ -56,7 +57,7 @@ The `accounts` table is the **authentication principal** — the entity that log
 |--------|------|-------|
 | `id` | `text PK` | `acc_` prefix + 12 hex chars |
 | `email` | `text UNIQUE` | Login credential — the only place email lives |
-| `maxProfiles` | `integer` | Default 5; enforcement lands in P3 |
+| `maxProfiles` | `integer` | Default 5; enforced by `createProfile` in P3 |
 | `createdAt` | `timestamp` | |
 | `updatedAt` | `timestamp` | |
 
@@ -108,7 +109,7 @@ Organisations are independent entities that are **composed of profiles, not acco
 
 **Key invariants:**
 - Multiple profiles from the same account **can be in the same org** — one might be admin, another a member. This is by design.
-- Org ownership is per-profile. Deleting a profile that owns an org requires ownership transfer (enforcement deferred to P3).
+- Org ownership is per-profile. Deleting a profile that owns an org requires ownership transfer first (enforced in P3).
 - The `listMembers` service return **never includes `accountId`** — defence in depth against correlation leakage.
 
 ## Token Model
@@ -160,7 +161,7 @@ POST /register/complete → OTP →
 |-------|--------|-------|
 | P1: Schema + terminology | ✅ Done | `accounts` table, `userId` → `profileId`, seed data, email dedup, service/route/test rename from "user" → "profile" terminology |
 | P2: Auth refactor | ✅ Done | Two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `POST /profiles/list`, `verifyRefreshToken`, `findDefaultProfile`, scope claim validation, per-account rate limiting |
-| P3: Profile CRUD | Planned | Create/list/delete profiles, maxProfiles enforcement |
+| P3: Profile CRUD | ✅ Done | `createProfile` (maxProfiles enforcement, S-L1), `deleteProfile` (cascade delete graph+org data), `setDefaultProfile`, three REST routes, `withProfileCrud` observability wrapper, S-L2 resolved |
 | P4: Client SDK | Planned | Multi-session storage, profile switcher methods |
 | P5: UI | Planned | Profile switcher component |
 | P6: Privacy audit | Planned | Verify accountId never leaks, pen-test correlation attacks |


### PR DESCRIPTION
## Summary
- Add `createProfileService()` with `createProfile`, `deleteProfile`, and `setDefaultProfile` operations
- Three new REST routes: `POST /profiles/create`, `POST /profiles/delete`, `POST /profiles/:profileId/default` with per-endpoint IP rate limiting (5/min create+delete, 10/min set-default)
- `createProfile` enforces `maxProfiles` limit inside an atomic transaction (fixes S-L1), validates handles against both user and org namespaces
- `deleteProfile` cascade-deletes connections, close friends, blocks, and org memberships in a single atomic transaction with default-promotion
- Observability: `ProfileCrudAction` bounded union, `osn.profile.crud.operations` counter, `osn.profile.crud.duration` histogram, `withProfileCrud` span+metric wrapper
- Resolves S-L1 (maxProfiles enforcement) and S-L2 (email dedup confirmed clean)
- 410 tests green (25 new: 23 service + 12 route including rate limit + boundary tests)

## Workspaces affected
- `@osn/core` (minor) — new profile service, routes, metrics, tests
- `@shared/observability` (patch) — new `ProfileCrudAction` + `ProfileDeleteCascadeTable` attr unions, 3 new rate limit endpoint values
- `@osn/app` — mounts new profile routes + Redis rate limiters

## Decisions & issues

**[S-H1] — TOCTOU race on handle uniqueness (check-then-insert)**
- **Issue:** `createProfile` checked handle availability then inserted in separate statements, creating a race window.
- **Why:** Two concurrent requests with the same handle could both pass the check. The DB UNIQUE constraint would reject one, but as a 500 `DatabaseError` instead of a friendly 400.
- **Solution:** Wrapped check + insert in a single Drizzle transaction. Also catch `UNIQUE constraint failed` in the error handler and map to `AuthError("Handle already taken")`.
- **Rationale:** Atomic check-and-insert eliminates the race. The UNIQUE constraint catch is defence-in-depth for any remaining edge cases.

**[S-H2 / P-W2] — Default profile promotion outside cascade transaction**
- **Issue:** After cascade-deleting a profile, the "promote another profile to default" logic ran as a separate DB operation outside the transaction.
- **Why:** If the process crashed between the commit and the promotion, the account would have no default profile, breaking `refreshTokens()` and locking the user out.
- **Solution:** Moved the promotion SELECT+UPDATE inside the cascade-delete transaction.
- **Rationale:** Either the entire delete+promote succeeds atomically or nothing does. Eliminates the partial-failure window.

**[S-M2] — TOCTOU race on maxProfiles count bypass**
- **Issue:** The profile count check and insert were not atomic. Two concurrent requests could both read count=4 (max=5) and both insert, resulting in 6 profiles.
- **Why:** Unlike the handle race, there is no DB-level constraint enforcing maxProfiles, so the application-level check was the only guard.
- **Solution:** Count check now runs inside the same transaction as the insert (same fix as S-H1).
- **Rationale:** Serializable transaction prevents concurrent over-creation.

**[P-W1] — Sequential cascade deletes**
- **Issue:** Five DELETE statements ran sequentially inside the cascade transaction.
- **Why:** Independent deletes on different tables don't depend on each other. Sequential execution adds unnecessary latency, especially after migration to Postgres.
- **Solution:** Parallelised the four independent deletes with `Promise.all`, then run the profile row delete last (FK safety).
- **Rationale:** Reduces wall-clock time from 5 sequential round-trips to 2 (1 parallel batch + 1 final delete).

**[S-M1] — Refresh token in POST body (pre-existing)**
- **Issue:** All profile routes accept refresh tokens in the POST body.
- **Why:** Consistent with existing `/profiles/switch` and `/profiles/list` endpoints.
- **Solution:** No action — pre-existing pattern, deferred to P6 privacy audit.
- **Rationale:** Changing token transport is out of scope for this PR.

**[S-L1] — Truncated UUID entropy (pre-existing)**
- **Issue:** `genId` uses 12 hex chars (48 bits) from `crypto.randomUUID()`.
- **Why:** Already tracked as S-M6 in security backlog. Profile IDs are not secrets.
- **Solution:** No action — consistent with existing codebase.
- **Rationale:** Collision risk is negligible at current scale; tracked separately.

**[S-L2] — Email in profile response enables cross-profile correlation**
- **Issue:** `PublicProfile` includes the shared account email across all profiles.
- **Why:** In a multi-profile system, the shared email enables correlation between profiles.
- **Solution:** No action — consistent with existing `PublicProfile` shape. Deferred to P6 privacy audit.
- **Rationale:** Changing the response shape is a breaking API change out of scope for P3.

**[T-R1] — No rate limiting tests for profile routes**
- **Issue:** Initial implementation had zero rate limit test coverage on the three new endpoints.
- **Why:** Every other route factory in osn/core has comprehensive rate-limit tests.
- **Solution:** Added 6 rate limit tests: exhaustion on all 3 endpoints, per-IP independence, reject-all injection, and fail-closed on backend error.
- **Rationale:** Matches the quality bar established by auth and graph route tests.

**[T-E1] — Handle boundary values untested**
- **Issue:** HandleSchema regex boundary conditions were not covered (empty, 30-char, 31-char, special chars).
- **Why:** Boundary values are the most likely source of off-by-one bugs in validation.
- **Solution:** Added 4 boundary tests to the service test suite.
- **Rationale:** Documents the exact validation contract and guards against regressions.

**[T-S1 / T-E2 / T-U1 / T-R2 / T-S2 / T-E3] — Lower-severity test gaps (deferred)**
- **Issue:** Various low-severity test gaps: `isDefault` flag not verified at data layer, error body assertions, Elysia schema validation, displayName edge values.
- **Why:** These are defensive hardening, not correctness gaps.
- **Solution:** Noted for follow-up; not blocking for this PR.
- **Rationale:** High and medium test gaps were addressed. Remaining items are low severity and can be added incrementally.

## Test plan
- [ ] Verify `POST /profiles/create` creates a profile with `usr_` prefix and correct fields
- [ ] Verify `POST /profiles/create` rejects invalid/reserved/duplicate handles with 400
- [ ] Verify `POST /profiles/create` enforces maxProfiles limit (create 5, 6th fails)
- [ ] Verify `POST /profiles/delete` cascade-deletes connections, close friends, blocks, org memberships
- [ ] Verify `POST /profiles/delete` rejects deleting last profile or org-owning profile
- [ ] Verify `POST /profiles/delete` promotes another profile to default when deleting the default
- [ ] Verify `POST /profiles/:profileId/default` switches the default profile
- [ ] Verify all three endpoints return 429 after exceeding rate limits
- [ ] Verify rate limits are per-IP and fail-closed on backend error
- [ ] Verify `accountId` never appears in any API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)