### PR TITLE
feat(client): Multi-account P4 — Client SDK profile management

### DIFF
--- a/.changeset/multi-account-p4-client-sdk.md
+++ b/.changeset/multi-account-p4-client-sdk.md
@@ -1,0 +1,5 @@
+---
+"@osn/client": minor
+---
+
+Multi-account P4: Client SDK profile management — multi-session storage model with per-profile access tokens, profile list/switch/create/delete methods, SolidJS context integration, and legacy session migration.

--- a/osn/client/src/errors.ts
+++ b/osn/client/src/errors.ts
@@ -20,3 +20,7 @@ export class StateMismatchError extends Data.TaggedError("StateMismatchError")<{
   readonly expected: string;
   readonly received: string;
 }> {}
+
+export class ProfileManagementError extends Data.TaggedError("ProfileManagementError")<{
+  readonly cause: unknown;
+}> {}

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Layer } from "effect";
 
 import {
   AuthorizationError,
+  ProfileManagementError,
   StateMismatchError,
   StorageError,
   TokenExchangeError,
@@ -9,12 +10,43 @@ import {
 } from "./errors";
 import { generateCodeChallenge, generateCodeVerifier } from "./pkce";
 import { Storage } from "./storage";
-import { parseTokenResponse } from "./tokens";
-import type { Session } from "./tokens";
+import { extractJwtSub, parseTokenResponse } from "./tokens";
+import type { AccountSession, PublicProfile, Session } from "./tokens";
 
-const SESSION_KEY = "@osn/client:session";
+const ACCOUNT_SESSION_KEY = "@osn/client:account_session";
+const LEGACY_SESSION_KEY = "@osn/client:session";
 const VERIFIER_KEY = "@osn/client:pkce_verifier";
 const STATE_KEY = "@osn/client:state";
+
+/** Build a Session from the active profile's cached token. Returns null if expired or missing. */
+function toSession(account: AccountSession): Session | null {
+  const profileToken = account.profileTokens[account.activeProfileId];
+  if (!profileToken || Date.now() >= profileToken.expiresAt) return null;
+  return {
+    accessToken: profileToken.accessToken,
+    refreshToken: account.refreshToken,
+    idToken: account.idToken,
+    expiresAt: profileToken.expiresAt,
+    scopes: account.scopes,
+  };
+}
+
+/** Create a fresh AccountSession from a Session (used by handleCallback / setSession). */
+function sessionToAccountSession(session: Session): AccountSession {
+  const profileId = extractJwtSub(session.accessToken) ?? "default";
+  return {
+    refreshToken: session.refreshToken ?? "",
+    activeProfileId: profileId,
+    profileTokens: {
+      [profileId]: {
+        accessToken: session.accessToken,
+        expiresAt: session.expiresAt,
+      },
+    },
+    scopes: session.scopes,
+    idToken: session.idToken,
+  };
+}
 
 export interface OsnAuthConfig {
   issuerUrl: string;
@@ -49,6 +81,29 @@ export interface OsnAuthService {
    * the standalone registration client and bypasses the PKCE callback).
    */
   readonly setSession: (session: Session) => Effect.Effect<void, StorageError>;
+
+  readonly listProfiles: () => Effect.Effect<
+    PublicProfile[],
+    ProfileManagementError | StorageError
+  >;
+
+  readonly switchProfile: (
+    profileId: string,
+  ) => Effect.Effect<
+    { session: Session; profile: PublicProfile },
+    ProfileManagementError | StorageError
+  >;
+
+  readonly createProfile: (
+    handle: string,
+    displayName?: string,
+  ) => Effect.Effect<PublicProfile, ProfileManagementError | StorageError>;
+
+  readonly deleteProfile: (
+    profileId: string,
+  ) => Effect.Effect<void, ProfileManagementError | StorageError>;
+
+  readonly getActiveProfile: () => Effect.Effect<string | null, StorageError>;
 }
 
 export class OsnAuth extends Context.Tag("@osn/client/OsnAuth")<OsnAuth, OsnAuthService>() {}
@@ -58,6 +113,52 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
     OsnAuth,
     Effect.gen(function* () {
       const storage = yield* Storage;
+
+      // ---------------------------------------------------------------------------
+      // Internal helpers for the multi-key account session model
+      // ---------------------------------------------------------------------------
+
+      const saveAccountSession = (account: AccountSession) =>
+        storage.set(ACCOUNT_SESSION_KEY, JSON.stringify(account));
+
+      /** Read account session from storage, migrating from the legacy single-key format if needed. */
+      const getAccountSession = () =>
+        Effect.gen(function* () {
+          const raw = yield* storage.get(ACCOUNT_SESSION_KEY);
+          if (raw) return JSON.parse(raw) as AccountSession;
+
+          // Attempt migration from legacy single-key storage
+          const legacy = yield* storage.get(LEGACY_SESSION_KEY);
+          if (!legacy) return null;
+
+          const legacySession = JSON.parse(legacy) as Session;
+          if (!legacySession.refreshToken) {
+            yield* storage.remove(LEGACY_SESSION_KEY);
+            return null;
+          }
+
+          const profileId = extractJwtSub(legacySession.accessToken) ?? "default";
+          const account: AccountSession = {
+            refreshToken: legacySession.refreshToken,
+            activeProfileId: profileId,
+            profileTokens: {
+              [profileId]: {
+                accessToken: legacySession.accessToken,
+                expiresAt: legacySession.expiresAt,
+              },
+            },
+            scopes: legacySession.scopes,
+            idToken: legacySession.idToken,
+          };
+
+          yield* saveAccountSession(account);
+          yield* storage.remove(LEGACY_SESSION_KEY);
+          return account;
+        });
+
+      // ---------------------------------------------------------------------------
+      // Existing auth methods (updated for multi-key storage)
+      // ---------------------------------------------------------------------------
 
       const startLogin = (params: { redirectUri: string; scopes?: string[] }) =>
         Effect.gen(function* () {
@@ -119,7 +220,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             catch: (cause) => new TokenExchangeError({ cause }),
           });
 
-          yield* storage.set(SESSION_KEY, JSON.stringify(session));
+          yield* saveAccountSession(sessionToAccountSession(session));
           yield* storage.remove(VERIFIER_KEY);
           yield* storage.remove(STATE_KEY);
 
@@ -128,20 +229,15 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
 
       const getSession = () =>
         Effect.gen(function* () {
-          const raw = yield* storage.get(SESSION_KEY);
-          if (!raw) return null;
-          const session = JSON.parse(raw) as Session;
-          if (Date.now() >= session.expiresAt) {
-            yield* storage.remove(SESSION_KEY);
-            return null;
-          }
-          return session;
+          const account = yield* getAccountSession();
+          if (!account) return null;
+          return toSession(account);
         });
 
       const refreshSession = () =>
         Effect.gen(function* () {
-          const session = yield* getSession();
-          if (!session?.refreshToken) {
+          const account = yield* getAccountSession();
+          if (!account?.refreshToken) {
             return yield* Effect.fail(
               new TokenRefreshError({ cause: "No refresh token available" }),
             );
@@ -154,7 +250,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: new URLSearchParams({
                   grant_type: "refresh_token",
-                  refresh_token: session.refreshToken!,
+                  refresh_token: account.refreshToken,
                   client_id: config.clientId,
                 }).toString(),
               }).then((r) => r.json() as Promise<unknown>),
@@ -166,15 +262,189 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             catch: (cause) => new TokenRefreshError({ cause }),
           });
 
-          yield* storage.set(SESSION_KEY, JSON.stringify(next));
+          const profileId = extractJwtSub(next.accessToken) ?? account.activeProfileId;
+          account.profileTokens[profileId] = {
+            accessToken: next.accessToken,
+            expiresAt: next.expiresAt,
+          };
+          if (next.refreshToken) account.refreshToken = next.refreshToken;
+          account.scopes = next.scopes;
+          account.idToken = next.idToken;
+
+          yield* saveAccountSession(account);
           return next;
         });
 
-      const logout = () => storage.remove(SESSION_KEY);
+      const logout = () =>
+        Effect.gen(function* () {
+          yield* storage.remove(ACCOUNT_SESSION_KEY);
+          yield* storage.remove(LEGACY_SESSION_KEY);
+        });
 
-      const setSession = (session: Session) => storage.set(SESSION_KEY, JSON.stringify(session));
+      const setSession = (session: Session) => saveAccountSession(sessionToAccountSession(session));
 
-      return { startLogin, handleCallback, getSession, refreshSession, logout, setSession };
+      // ---------------------------------------------------------------------------
+      // Profile management methods (P4)
+      // ---------------------------------------------------------------------------
+
+      const listProfiles = () =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          if (!account?.refreshToken) {
+            return yield* Effect.fail(
+              new ProfileManagementError({ cause: "No session available" }),
+            );
+          }
+
+          const res = yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.issuerUrl}/profiles/list`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ refresh_token: account.refreshToken }),
+              }).then((r) => {
+                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+                return r.json() as Promise<{ profiles: PublicProfile[] }>;
+              }),
+            catch: (cause) => new ProfileManagementError({ cause }),
+          });
+
+          return res.profiles;
+        });
+
+      const switchProfile = (profileId: string) =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          if (!account?.refreshToken) {
+            return yield* Effect.fail(
+              new ProfileManagementError({ cause: "No session available" }),
+            );
+          }
+
+          const res = yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.issuerUrl}/profiles/switch`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  refresh_token: account.refreshToken,
+                  profile_id: profileId,
+                }),
+              }).then((r) => {
+                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+                return r.json() as Promise<{
+                  access_token: string;
+                  expires_in: number;
+                  profile: PublicProfile;
+                }>;
+              }),
+            catch: (cause) => new ProfileManagementError({ cause }),
+          });
+
+          const expiresAt = Date.now() + res.expires_in * 1000;
+          account.profileTokens[profileId] = {
+            accessToken: res.access_token,
+            expiresAt,
+          };
+          account.activeProfileId = profileId;
+          yield* saveAccountSession(account);
+
+          const session: Session = {
+            accessToken: res.access_token,
+            refreshToken: account.refreshToken,
+            idToken: account.idToken,
+            expiresAt,
+            scopes: account.scopes,
+          };
+
+          return { session, profile: res.profile };
+        });
+
+      const createProfile = (handle: string, displayName?: string) =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          if (!account?.refreshToken) {
+            return yield* Effect.fail(
+              new ProfileManagementError({ cause: "No session available" }),
+            );
+          }
+
+          const body: Record<string, string> = {
+            refresh_token: account.refreshToken,
+            handle,
+          };
+          if (displayName !== undefined) body.display_name = displayName;
+
+          const res = yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.issuerUrl}/profiles/create`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+              }).then((r) => {
+                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+                return r.json() as Promise<{ profile: PublicProfile }>;
+              }),
+            catch: (cause) => new ProfileManagementError({ cause }),
+          });
+
+          return res.profile;
+        });
+
+      const deleteProfile = (profileId: string) =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          if (!account?.refreshToken) {
+            return yield* Effect.fail(
+              new ProfileManagementError({ cause: "No session available" }),
+            );
+          }
+
+          yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.issuerUrl}/profiles/delete`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  refresh_token: account.refreshToken,
+                  profile_id: profileId,
+                }),
+              }).then((r) => {
+                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+                return r.json() as Promise<unknown>;
+              }),
+            catch: (cause) => new ProfileManagementError({ cause }),
+          });
+
+          delete account.profileTokens[profileId];
+          if (account.activeProfileId === profileId) {
+            const remaining = Object.keys(account.profileTokens);
+            if (remaining.length > 0) {
+              account.activeProfileId = remaining[0]!;
+            }
+          }
+          yield* saveAccountSession(account);
+        });
+
+      const getActiveProfile = () =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          return account?.activeProfileId ?? null;
+        });
+
+      return {
+        startLogin,
+        handleCallback,
+        getSession,
+        refreshSession,
+        logout,
+        setSession,
+        listProfiles,
+        switchProfile,
+        createProfile,
+        deleteProfile,
+        getActiveProfile,
+      };
     }),
   );
 }

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -10,7 +10,15 @@ import {
 } from "./errors";
 import { generateCodeChallenge, generateCodeVerifier } from "./pkce";
 import { Storage } from "./storage";
-import { extractJwtSub, parseTokenResponse } from "./tokens";
+import {
+  decodeAccountSession,
+  decodeCreateProfileResponse,
+  decodeListProfilesResponse,
+  decodeSession,
+  decodeSwitchProfileResponse,
+  extractJwtSub,
+  parseTokenResponse,
+} from "./tokens";
 import type { AccountSession, PublicProfile, Session } from "./tokens";
 
 const ACCOUNT_SESSION_KEY = "@osn/client:account_session";
@@ -46,6 +54,16 @@ function sessionToAccountSession(session: Session): AccountSession {
     scopes: session.scopes,
     idToken: session.idToken,
   };
+}
+
+/** Remove expired profile tokens from an AccountSession, except the active profile. (S-M2, P-W3) */
+function pruneExpiredTokens(account: AccountSession): void {
+  const now = Date.now();
+  for (const id of Object.keys(account.profileTokens)) {
+    if (id !== account.activeProfileId && account.profileTokens[id]!.expiresAt <= now) {
+      delete account.profileTokens[id];
+    }
+  }
 }
 
 export interface OsnAuthConfig {
@@ -114,26 +132,60 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
     Effect.gen(function* () {
       const storage = yield* Storage;
 
+      // P-W1: In-memory cache to avoid redundant storage reads + JSON.parse
+      // undefined = not loaded, null = no session, AccountSession = loaded
+      let cache: AccountSession | null | undefined;
+
       // ---------------------------------------------------------------------------
       // Internal helpers for the multi-key account session model
       // ---------------------------------------------------------------------------
 
-      const saveAccountSession = (account: AccountSession) =>
-        storage.set(ACCOUNT_SESSION_KEY, JSON.stringify(account));
+      const saveAccountSession = (account: AccountSession) => {
+        pruneExpiredTokens(account);
+        cache = account;
+        return storage.set(ACCOUNT_SESSION_KEY, JSON.stringify(account));
+      };
 
       /** Read account session from storage, migrating from the legacy single-key format if needed. */
       const getAccountSession = () =>
         Effect.gen(function* () {
+          // P-W1: Return cached value if available
+          if (cache !== undefined) return cache;
+
           const raw = yield* storage.get(ACCOUNT_SESSION_KEY);
-          if (raw) return JSON.parse(raw) as AccountSession;
+          if (raw) {
+            // S-H2: Validate storage data against schema before consuming
+            try {
+              const account = decodeAccountSession(JSON.parse(raw)) as AccountSession;
+              cache = account;
+              return account;
+            } catch {
+              yield* storage.remove(ACCOUNT_SESSION_KEY);
+              cache = null;
+              return null;
+            }
+          }
 
           // Attempt migration from legacy single-key storage
           const legacy = yield* storage.get(LEGACY_SESSION_KEY);
-          if (!legacy) return null;
+          if (!legacy) {
+            cache = null;
+            return null;
+          }
 
-          const legacySession = JSON.parse(legacy) as Session;
+          // S-H2: Validate legacy session data
+          let legacySession: Session;
+          try {
+            legacySession = decodeSession(JSON.parse(legacy)) as Session;
+          } catch {
+            yield* storage.remove(LEGACY_SESSION_KEY);
+            cache = null;
+            return null;
+          }
+
           if (!legacySession.refreshToken) {
             yield* storage.remove(LEGACY_SESSION_KEY);
+            cache = null;
             return null;
           }
 
@@ -277,6 +329,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
 
       const logout = () =>
         Effect.gen(function* () {
+          cache = null;
           yield* storage.remove(ACCOUNT_SESSION_KEY);
           yield* storage.remove(LEGACY_SESSION_KEY);
         });
@@ -287,6 +340,11 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
       // Profile management methods (P4)
       // ---------------------------------------------------------------------------
 
+      // S-H1: These endpoints currently require the refresh token in the request
+      // body (server API design from P2/P3). A follow-up should migrate the server
+      // to accept Bearer access-token auth instead, reducing refresh-token exposure.
+      // Tracked in wiki/TODO.md security backlog.
+
       const listProfiles = () =>
         Effect.gen(function* () {
           const account = yield* getAccountSession();
@@ -296,20 +354,21 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             );
           }
 
+          // S-M4: Validate response schema
           const res = yield* Effect.tryPromise({
-            try: () =>
-              fetch(`${config.issuerUrl}/profiles/list`, {
+            try: async () => {
+              const r = await fetch(`${config.issuerUrl}/profiles/list`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ refresh_token: account.refreshToken }),
-              }).then((r) => {
-                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
-                return r.json() as Promise<{ profiles: PublicProfile[] }>;
-              }),
+              });
+              if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+              return decodeListProfilesResponse(await r.json());
+            },
             catch: (cause) => new ProfileManagementError({ cause }),
           });
 
-          return res.profiles;
+          return res.profiles as PublicProfile[];
         });
 
       const switchProfile = (profileId: string) =>
@@ -321,32 +380,31 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             );
           }
 
+          // S-M4: Validate response schema
           const res = yield* Effect.tryPromise({
-            try: () =>
-              fetch(`${config.issuerUrl}/profiles/switch`, {
+            try: async () => {
+              const r = await fetch(`${config.issuerUrl}/profiles/switch`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                   refresh_token: account.refreshToken,
                   profile_id: profileId,
                 }),
-              }).then((r) => {
-                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
-                return r.json() as Promise<{
-                  access_token: string;
-                  expires_in: number;
-                  profile: PublicProfile;
-                }>;
-              }),
+              });
+              if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+              return decodeSwitchProfileResponse(await r.json());
+            },
             catch: (cause) => new ProfileManagementError({ cause }),
           });
 
+          // S-L1: Use server-authoritative profile ID, not caller-supplied
+          const serverProfileId = (res.profile as PublicProfile).id;
           const expiresAt = Date.now() + res.expires_in * 1000;
-          account.profileTokens[profileId] = {
+          account.profileTokens[serverProfileId] = {
             accessToken: res.access_token,
             expiresAt,
           };
-          account.activeProfileId = profileId;
+          account.activeProfileId = serverProfileId;
           yield* saveAccountSession(account);
 
           const session: Session = {
@@ -357,7 +415,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             scopes: account.scopes,
           };
 
-          return { session, profile: res.profile };
+          return { session, profile: res.profile as PublicProfile };
         });
 
       const createProfile = (handle: string, displayName?: string) =>
@@ -375,20 +433,21 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
           };
           if (displayName !== undefined) body.display_name = displayName;
 
+          // S-M4: Validate response schema
           const res = yield* Effect.tryPromise({
-            try: () =>
-              fetch(`${config.issuerUrl}/profiles/create`, {
+            try: async () => {
+              const r = await fetch(`${config.issuerUrl}/profiles/create`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(body),
-              }).then((r) => {
-                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
-                return r.json() as Promise<{ profile: PublicProfile }>;
-              }),
+              });
+              if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+              return decodeCreateProfileResponse(await r.json());
+            },
             catch: (cause) => new ProfileManagementError({ cause }),
           });
 
-          return res.profile;
+          return res.profile as PublicProfile;
         });
 
       const deleteProfile = (profileId: string) =>
@@ -401,27 +460,26 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
           }
 
           yield* Effect.tryPromise({
-            try: () =>
-              fetch(`${config.issuerUrl}/profiles/delete`, {
+            try: async () => {
+              const r = await fetch(`${config.issuerUrl}/profiles/delete`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                   refresh_token: account.refreshToken,
                   profile_id: profileId,
                 }),
-              }).then((r) => {
-                if (!r.ok) throw new Error(`Request failed: ${r.status}`);
-                return r.json() as Promise<unknown>;
-              }),
+              });
+              if (!r.ok) throw new Error(`Request failed: ${r.status}`);
+              return (await r.json()) as unknown;
+            },
             catch: (cause) => new ProfileManagementError({ cause }),
           });
 
           delete account.profileTokens[profileId];
+          // S-M3: Handle deletion of the active profile gracefully
           if (account.activeProfileId === profileId) {
             const remaining = Object.keys(account.profileTokens);
-            if (remaining.length > 0) {
-              account.activeProfileId = remaining[0]!;
-            }
+            account.activeProfileId = remaining.length > 0 ? remaining[0]! : "";
           }
           yield* saveAccountSession(account);
         });
@@ -429,7 +487,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
       const getActiveProfile = () =>
         Effect.gen(function* () {
           const account = yield* getAccountSession();
-          return account?.activeProfileId ?? null;
+          return account?.activeProfileId || null;
         });
 
       return {

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect";
 import {
   createContext,
+  createEffect,
   createResource,
   createSignal,
   useContext,
@@ -48,16 +49,34 @@ export function AuthProvider(props: AuthProviderProps) {
     run(Effect.flatMap(OsnAuth, (auth) => auth.getSession())),
   );
 
+  // P-W2: Gate profiles on session — only fetch when a session exists.
+  // SolidJS createResource with a source signal only fires the fetcher when
+  // the source is truthy, preventing wasted requests for unauthenticated users.
   const [profiles, { mutate: mutateProfiles, refetch: refetchProfiles }] = createResource<
-    PublicProfile[] | null
-  >(() => run(Effect.flatMap(OsnAuth, (auth) => auth.listProfiles())).catch(() => null));
+    PublicProfile[] | null,
+    Session | null
+  >(
+    () => session() ?? null,
+    (sess) => {
+      if (!sess) return Promise.resolve(null);
+      return run(Effect.flatMap(OsnAuth, (auth) => auth.listProfiles()));
+    },
+  );
 
   const [activeProfileId, setActiveProfileId] = createSignal<string | null>(null);
 
-  // Initialise active profile ID on mount
-  run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
-    .then(setActiveProfileId)
-    .catch(() => {});
+  // S-L2: Derive activeProfileId reactively from session state instead of
+  // a fire-and-forget initialisation call.
+  createEffect(() => {
+    const sess = session();
+    if (sess) {
+      run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile())).then(setActiveProfileId, () =>
+        setActiveProfileId(null),
+      );
+    } else if (sess === null) {
+      setActiveProfileId(null);
+    }
+  });
 
   const login = (redirectUri: string, scopes?: string[]) => {
     run(
@@ -78,28 +97,23 @@ export function AuthProvider(props: AuthProviderProps) {
     setActiveProfileId(null);
   };
 
+  // P-I2: Await refetches for consistent state before returning
   const handleCallback = async (params: { code: string; state: string; redirectUri: string }) => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.handleCallback(params)));
     await refetchSession();
-    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
-      .then(setActiveProfileId)
-      .catch(() => {});
-    refetchProfiles();
+    await refetchProfiles();
   };
 
   const adoptSession = async (next: Session) => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.setSession(next)));
     await refetchSession();
-    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
-      .then(setActiveProfileId)
-      .catch(() => {});
-    refetchProfiles();
+    await refetchProfiles();
   };
 
   const switchProfile = async (profileId: string) => {
     const result = await run(Effect.flatMap(OsnAuth, (auth) => auth.switchProfile(profileId)));
     await refetchSession();
-    setActiveProfileId(profileId);
+    setActiveProfileId(result.profile.id);
     return result;
   };
 
@@ -107,17 +121,14 @@ export function AuthProvider(props: AuthProviderProps) {
     const profile = await run(
       Effect.flatMap(OsnAuth, (auth) => auth.createProfile(handle, displayName)),
     );
-    refetchProfiles();
+    await refetchProfiles();
     return profile;
   };
 
   const deleteProfile = async (profileId: string) => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.deleteProfile(profileId)));
     await refetchSession();
-    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
-      .then(setActiveProfileId)
-      .catch(() => {});
-    refetchProfiles();
+    await refetchProfiles();
   };
 
   return (

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -2,17 +2,21 @@ import { Effect, Layer } from "effect";
 import {
   createContext,
   createResource,
+  createSignal,
   useContext,
+  type Accessor,
   type ParentProps,
   type Resource,
 } from "solid-js";
 
 import { OsnAuth, createOsnAuthLive, type OsnAuthConfig } from "../service";
 import { StorageLive } from "../storage";
-import type { Session } from "../tokens";
+import type { PublicProfile, Session } from "../tokens";
 
 interface AuthContextValue {
   session: Resource<Session | null>;
+  profiles: Resource<PublicProfile[] | null>;
+  activeProfileId: Accessor<string | null>;
   login: (redirectUri: string, scopes?: string[]) => void;
   logout: () => Promise<void>;
   handleCallback: (params: { code: string; state: string; redirectUri: string }) => Promise<void>;
@@ -21,6 +25,9 @@ interface AuthContextValue {
    * out-of-band source) and refetches the session resource so the UI updates.
    */
   adoptSession: (session: Session) => Promise<void>;
+  switchProfile: (profileId: string) => Promise<{ session: Session; profile: PublicProfile }>;
+  createProfile: (handle: string, displayName?: string) => Promise<PublicProfile>;
+  deleteProfile: (profileId: string) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextValue>();
@@ -37,9 +44,20 @@ export function AuthProvider(props: AuthProviderProps) {
       Effect.provide(eff, layer).pipe(Effect.orDie) as Effect.Effect<A, never, never>,
     );
 
-  const [session, { refetch }] = createResource<Session | null>(() =>
+  const [session, { refetch: refetchSession }] = createResource<Session | null>(() =>
     run(Effect.flatMap(OsnAuth, (auth) => auth.getSession())),
   );
+
+  const [profiles, { mutate: mutateProfiles, refetch: refetchProfiles }] = createResource<
+    PublicProfile[] | null
+  >(() => run(Effect.flatMap(OsnAuth, (auth) => auth.listProfiles())).catch(() => null));
+
+  const [activeProfileId, setActiveProfileId] = createSignal<string | null>(null);
+
+  // Initialise active profile ID on mount
+  run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
+    .then(setActiveProfileId)
+    .catch(() => {});
 
   const login = (redirectUri: string, scopes?: string[]) => {
     run(
@@ -55,21 +73,68 @@ export function AuthProvider(props: AuthProviderProps) {
 
   const logout = async () => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.logout()));
-    refetch();
+    await refetchSession();
+    mutateProfiles(null);
+    setActiveProfileId(null);
   };
 
   const handleCallback = async (params: { code: string; state: string; redirectUri: string }) => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.handleCallback(params)));
-    refetch();
+    await refetchSession();
+    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
+      .then(setActiveProfileId)
+      .catch(() => {});
+    refetchProfiles();
   };
 
   const adoptSession = async (next: Session) => {
     await run(Effect.flatMap(OsnAuth, (auth) => auth.setSession(next)));
-    refetch();
+    await refetchSession();
+    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
+      .then(setActiveProfileId)
+      .catch(() => {});
+    refetchProfiles();
+  };
+
+  const switchProfile = async (profileId: string) => {
+    const result = await run(Effect.flatMap(OsnAuth, (auth) => auth.switchProfile(profileId)));
+    await refetchSession();
+    setActiveProfileId(profileId);
+    return result;
+  };
+
+  const createProfile = async (handle: string, displayName?: string) => {
+    const profile = await run(
+      Effect.flatMap(OsnAuth, (auth) => auth.createProfile(handle, displayName)),
+    );
+    refetchProfiles();
+    return profile;
+  };
+
+  const deleteProfile = async (profileId: string) => {
+    await run(Effect.flatMap(OsnAuth, (auth) => auth.deleteProfile(profileId)));
+    await refetchSession();
+    run(Effect.flatMap(OsnAuth, (auth) => auth.getActiveProfile()))
+      .then(setActiveProfileId)
+      .catch(() => {});
+    refetchProfiles();
   };
 
   return (
-    <AuthContext.Provider value={{ session, login, logout, handleCallback, adoptSession }}>
+    <AuthContext.Provider
+      value={{
+        session,
+        profiles,
+        activeProfileId,
+        login,
+        logout,
+        handleCallback,
+        adoptSession,
+        switchProfile,
+        createProfile,
+        deleteProfile,
+      }}
+    >
       {props.children}
     </AuthContext.Provider>
   );

--- a/osn/client/src/tokens.ts
+++ b/osn/client/src/tokens.ts
@@ -53,12 +53,71 @@ export interface AccountSession {
   idToken: string | null;
 }
 
+// ---------------------------------------------------------------------------
+// Schema validation (S-H2, S-M4)
+// ---------------------------------------------------------------------------
+
+const SessionSchema = Schema.Struct({
+  accessToken: Schema.String,
+  refreshToken: Schema.NullOr(Schema.String),
+  idToken: Schema.NullOr(Schema.String),
+  expiresAt: Schema.Number,
+  scopes: Schema.Array(Schema.String),
+});
+
+export const decodeSession = Schema.decodeUnknownSync(SessionSchema);
+
+const ProfileTokenSchema = Schema.Struct({
+  accessToken: Schema.String,
+  expiresAt: Schema.Number,
+});
+
+const AccountSessionSchema = Schema.Struct({
+  refreshToken: Schema.String,
+  activeProfileId: Schema.String,
+  profileTokens: Schema.Record({ key: Schema.String, value: ProfileTokenSchema }),
+  scopes: Schema.Array(Schema.String),
+  idToken: Schema.NullOr(Schema.String),
+});
+
+export const decodeAccountSession = Schema.decodeUnknownSync(AccountSessionSchema);
+
+const PublicProfileSchema = Schema.Struct({
+  id: Schema.String,
+  handle: Schema.String,
+  email: Schema.String,
+  displayName: Schema.NullOr(Schema.String),
+  avatarUrl: Schema.NullOr(Schema.String),
+});
+
+const ListProfilesResponseSchema = Schema.Struct({
+  profiles: Schema.Array(PublicProfileSchema),
+});
+
+export const decodeListProfilesResponse = Schema.decodeUnknownSync(ListProfilesResponseSchema);
+
+const SwitchProfileResponseSchema = Schema.Struct({
+  access_token: Schema.String,
+  expires_in: Schema.Number,
+  profile: PublicProfileSchema,
+});
+
+export const decodeSwitchProfileResponse = Schema.decodeUnknownSync(SwitchProfileResponseSchema);
+
+const CreateProfileResponseSchema = Schema.Struct({
+  profile: PublicProfileSchema,
+});
+
+export const decodeCreateProfileResponse = Schema.decodeUnknownSync(CreateProfileResponseSchema);
+
 /** Extract the `sub` claim from a JWT payload without cryptographic verification. */
 export function extractJwtSub(jwt: string): string | null {
   try {
     const payload = jwt.split(".")[1];
     if (!payload) return null;
-    const decoded = JSON.parse(atob(payload)) as { sub?: string };
+    // S-M1: JWT payloads use Base64URL encoding (RFC 7515) — convert to standard Base64
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = JSON.parse(atob(base64)) as { sub?: string };
     return decoded.sub ?? null;
   } catch {
     return null;

--- a/osn/client/src/tokens.ts
+++ b/osn/client/src/tokens.ts
@@ -30,3 +30,37 @@ export function parseTokenResponse(raw: unknown): Session {
     scopes: t.scope ? t.scope.split(" ") : [],
   };
 }
+
+export interface PublicProfile {
+  id: string;
+  handle: string;
+  email: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface ProfileToken {
+  accessToken: string;
+  /** Unix timestamp (ms) when the access token expires */
+  expiresAt: number;
+}
+
+export interface AccountSession {
+  refreshToken: string;
+  activeProfileId: string;
+  profileTokens: Record<string, ProfileToken>;
+  scopes: string[];
+  idToken: string | null;
+}
+
+/** Extract the `sub` claim from a JWT payload without cryptographic verification. */
+export function extractJwtSub(jwt: string): string | null {
+  try {
+    const payload = jwt.split(".")[1];
+    if (!payload) return null;
+    const decoded = JSON.parse(atob(payload)) as { sub?: string };
+    return decoded.sub ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/osn/client/tests/profiles.test.ts
+++ b/osn/client/tests/profiles.test.ts
@@ -1,0 +1,408 @@
+import { it, expect } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { vi } from "vitest";
+
+import { OsnAuth, createOsnAuthLive } from "../src/service";
+import { Storage, createMemoryStorage } from "../src/storage";
+
+const config = { issuerUrl: "https://osn.example.com", clientId: "test-client" };
+
+function createTestLayer() {
+  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+}
+
+/** Build a fake JWT whose payload contains the given `sub` claim. */
+function fakeJwt(sub: string): string {
+  const header = btoa(JSON.stringify({ alg: "ES256", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ sub, iat: Date.now() }));
+  return `${header}.${payload}.fake_signature`;
+}
+
+function seedSession(profileId = "usr_aaaaaaaaaaaa") {
+  return Effect.flatMap(OsnAuth, (auth) =>
+    auth.setSession({
+      accessToken: fakeJwt(profileId),
+      refreshToken: "ref_account",
+      idToken: null,
+      expiresAt: Date.now() + 60_000,
+      scopes: ["openid", "profile"],
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getActiveProfile
+// ---------------------------------------------------------------------------
+
+it.effect("getActiveProfile returns null before login", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBeNull();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("getActiveProfile returns the profile ID after setSession", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    yield* seedSession("usr_aaaaaaaaaaaa");
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBe("usr_aaaaaaaaaaaa");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// getSession reconstructs from account session model
+// ---------------------------------------------------------------------------
+
+it.effect("getSession returns a Session reconstructed from the account session", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    yield* seedSession("usr_aaaaaaaaaaaa");
+    const session = yield* auth.getSession();
+    expect(session).not.toBeNull();
+    expect(session?.refreshToken).toBe("ref_account");
+    expect(session?.scopes).toEqual(["openid", "profile"]);
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// Legacy session migration
+// ---------------------------------------------------------------------------
+
+it.effect("migrates a legacy single-key session to the account session model", () => {
+  const memStorage = createMemoryStorage();
+  const testLayer = Layer.merge(
+    createOsnAuthLive(config).pipe(Layer.provide(memStorage)),
+    memStorage,
+  );
+
+  return Effect.gen(function* () {
+    const storage = yield* Storage;
+    const auth = yield* OsnAuth;
+
+    // Write a legacy-format session directly to storage (bypassing the service)
+    const legacySession = {
+      accessToken: fakeJwt("usr_legacy_user"),
+      refreshToken: "ref_legacy",
+      idToken: "id_legacy",
+      expiresAt: Date.now() + 60_000,
+      scopes: ["openid"],
+    };
+    yield* storage.set("@osn/client:session", JSON.stringify(legacySession));
+
+    // getSession should trigger migration
+    const session = yield* auth.getSession();
+    expect(session?.refreshToken).toBe("ref_legacy");
+
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBe("usr_legacy_user");
+
+    // Legacy key should be cleaned up
+    const legacy = yield* storage.get("@osn/client:session");
+    expect(legacy).toBeNull();
+
+    // New key should exist
+    const newKey = yield* storage.get("@osn/client:account_session");
+    expect(newKey).not.toBeNull();
+  }).pipe(Effect.provide(testLayer));
+});
+
+// ---------------------------------------------------------------------------
+// listProfiles
+// ---------------------------------------------------------------------------
+
+it.effect("listProfiles calls POST /profiles/list and returns the profiles", () =>
+  Effect.gen(function* () {
+    const profiles = [
+      {
+        id: "usr_aaaaaaaaaaaa",
+        handle: "alice",
+        email: "a@b.com",
+        displayName: null,
+        avatarUrl: null,
+      },
+      {
+        id: "usr_bbbbbbbbbbbb",
+        handle: "bob",
+        email: "a@b.com",
+        displayName: "Bob",
+        avatarUrl: null,
+      },
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ profiles }),
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    yield* seedSession();
+    const result = yield* auth.listProfiles();
+
+    expect(result).toEqual(profiles);
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "https://osn.example.com/profiles/list",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("listProfiles fails with ProfileManagementError when no session exists", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    const error = yield* Effect.flip(auth.listProfiles());
+    expect(error._tag).toBe("ProfileManagementError");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// switchProfile
+// ---------------------------------------------------------------------------
+
+it.effect("switchProfile updates the active profile and caches the new access token", () =>
+  Effect.gen(function* () {
+    const newProfileId = "usr_bbbbbbbbbbbb";
+    const newAccessToken = fakeJwt(newProfileId);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: newAccessToken,
+            expires_in: 3600,
+            profile: {
+              id: newProfileId,
+              handle: "alt",
+              email: "a@b.com",
+              displayName: null,
+              avatarUrl: null,
+            },
+          }),
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    yield* seedSession("usr_aaaaaaaaaaaa");
+
+    const { session, profile } = yield* auth.switchProfile(newProfileId);
+
+    expect(session.accessToken).toBe(newAccessToken);
+    expect(profile.id).toBe(newProfileId);
+    expect(profile.handle).toBe("alt");
+
+    // Active profile should be updated
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBe(newProfileId);
+
+    // getSession should return the switched profile's session
+    const currentSession = yield* auth.getSession();
+    expect(currentSession?.accessToken).toBe(newAccessToken);
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// createProfile
+// ---------------------------------------------------------------------------
+
+it.effect("createProfile calls POST /profiles/create and returns the new profile", () =>
+  Effect.gen(function* () {
+    const newProfile = {
+      id: "usr_cccccccccccc",
+      handle: "charlie",
+      email: "a@b.com",
+      displayName: "Charlie",
+      avatarUrl: null,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ profile: newProfile }),
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    yield* seedSession();
+    const result = yield* auth.createProfile("charlie", "Charlie");
+
+    expect(result).toEqual(newProfile);
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]!.body as string);
+    expect(body.handle).toBe("charlie");
+    expect(body.display_name).toBe("Charlie");
+    expect(body.refresh_token).toBe("ref_account");
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("createProfile omits display_name when not provided", () =>
+  Effect.gen(function* () {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            profile: {
+              id: "usr_cccccccccccc",
+              handle: "charlie",
+              email: "a@b.com",
+              displayName: null,
+              avatarUrl: null,
+            },
+          }),
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    yield* seedSession();
+    yield* auth.createProfile("charlie");
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]!.body as string);
+    expect(body.display_name).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// deleteProfile
+// ---------------------------------------------------------------------------
+
+it.effect("deleteProfile removes the profile token from storage", () =>
+  Effect.gen(function* () {
+    const profileToDelete = "usr_bbbbbbbbbbbb";
+
+    vi.stubGlobal("fetch", vi.fn());
+
+    // First mock: switchProfile to cache a second profile token
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: fakeJwt(profileToDelete),
+          expires_in: 3600,
+          profile: {
+            id: profileToDelete,
+            handle: "alt",
+            email: "a@b.com",
+            displayName: null,
+            avatarUrl: null,
+          },
+        }),
+    } as Response);
+
+    // Second mock: switch back to original
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: fakeJwt("usr_aaaaaaaaaaaa"),
+          expires_in: 3600,
+          profile: {
+            id: "usr_aaaaaaaaaaaa",
+            handle: "main",
+            email: "a@b.com",
+            displayName: null,
+            avatarUrl: null,
+          },
+        }),
+    } as Response);
+
+    // Third mock: deleteProfile
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ deleted: true }),
+    } as Response);
+
+    const auth = yield* OsnAuth;
+    yield* seedSession("usr_aaaaaaaaaaaa");
+
+    // Switch to second profile (caches its token)
+    yield* auth.switchProfile(profileToDelete);
+    // Switch back
+    yield* auth.switchProfile("usr_aaaaaaaaaaaa");
+
+    // Delete the second profile
+    yield* auth.deleteProfile(profileToDelete);
+
+    // Active profile should still be the original
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBe("usr_aaaaaaaaaaaa");
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("deleteProfile switches active profile when deleting the current one", () =>
+  Effect.gen(function* () {
+    vi.stubGlobal("fetch", vi.fn());
+
+    // Mock: switchProfile to a second profile
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: fakeJwt("usr_bbbbbbbbbbbb"),
+          expires_in: 3600,
+          profile: {
+            id: "usr_bbbbbbbbbbbb",
+            handle: "alt",
+            email: "a@b.com",
+            displayName: null,
+            avatarUrl: null,
+          },
+        }),
+    } as Response);
+
+    // Mock: deleteProfile
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ deleted: true }),
+    } as Response);
+
+    const auth = yield* OsnAuth;
+    yield* seedSession("usr_aaaaaaaaaaaa");
+
+    // Switch to second profile
+    yield* auth.switchProfile("usr_bbbbbbbbbbbb");
+    expect(yield* auth.getActiveProfile()).toBe("usr_bbbbbbbbbbbb");
+
+    // Delete the active (second) profile
+    yield* auth.deleteProfile("usr_bbbbbbbbbbbb");
+
+    // Should have fallen back to the original profile
+    const active = yield* auth.getActiveProfile();
+    expect(active).toBe("usr_aaaaaaaaaaaa");
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// logout clears everything
+// ---------------------------------------------------------------------------
+
+it.effect("logout clears both account session and legacy keys", () =>
+  Effect.gen(function* () {
+    const auth = yield* OsnAuth;
+    yield* seedSession();
+
+    yield* auth.logout();
+
+    expect(yield* auth.getSession()).toBeNull();
+    expect(yield* auth.getActiveProfile()).toBeNull();
+  }).pipe(Effect.provide(createTestLayer())),
+);

--- a/pulse/app/tests/components/AuthProviderAdoptSession.test.tsx
+++ b/pulse/app/tests/components/AuthProviderAdoptSession.test.tsx
@@ -63,10 +63,12 @@ describe("AuthProvider.adoptSession", () => {
     });
 
     // And the session must have been written through to localStorage so a
-    // page reload would still see it.
-    const stored = localStorage.getItem("@osn/client:session");
+    // page reload would still see it. P4 stores under the account_session key.
+    const stored = localStorage.getItem("@osn/client:account_session");
     expect(stored).not.toBeNull();
-    expect(JSON.parse(stored!).accessToken).toBe("acc_adopt");
+    const account = JSON.parse(stored!);
+    const activeToken = account.profileTokens[account.activeProfileId];
+    expect(activeToken.accessToken).toBe("acc_adopt");
   });
 
   it("overwrites a previously adopted session", async () => {

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -5,7 +5,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 ## Up Next
 
 - [x] Multi-account P3 — Profile CRUD: `createProfileService()` (create, delete, set default), `/profiles` routes, `maxProfiles` enforcement (S-L1), cascade-delete profile data, observability (counter + histogram + spans)
-- [ ] Multi-account P4 — Client SDK: multi-session storage (`@osn/client:account_session`, `@osn/client:active_profile`, per-profile access tokens), `listProfiles()`, `switchProfile()`, `createProfile()`, `deleteProfile()` methods on `OsnAuthService`
+- [x] Multi-account P4 — Client SDK: multi-session storage (`@osn/client:account_session`), `listProfiles()`, `switchProfile()`, `createProfile()`, `deleteProfile()`, `getActiveProfile()` methods on `OsnAuthService`, SolidJS `AuthContext` integration, legacy session migration, schema validation
 - [ ] Multi-account P5 — Profile UI: profile switcher component in `@osn/ui`, profile creation form, onboarding for additional profiles
 - [ ] Multi-account P6 — Privacy audit: verify `accountId` never leaks in API responses / tokens / logs, rate-limit per-profile (not per-account), pen-test correlation attacks between profiles
 - [ ] Provision Grafana Cloud free tier + wire `OTEL_EXPORTER_OTLP_ENDPOINT` + headers into deploy env — see [[observability-setup]]
@@ -34,7 +34,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 ## OSN Core (`osn/app` + `osn/core`)
 
 - [x] Multi-account profile CRUD (P3) — create/delete/set-default profiles, maxProfiles enforcement, cascade delete, observability
-- [ ] Multi-account client SDK (P4) — multi-session storage, profile switching
+- [x] Multi-account client SDK (P4) — multi-session storage, profile switching, schema validation, security hardening
 - [ ] Multi-account UI (P5) — profile switcher component
 - [ ] Multi-account privacy audit (P6) — accountId leak verification, per-profile rate limits
 - [ ] Per-app vs global blocking logic (deferred — global blocking across all OSN apps for now)
@@ -172,6 +172,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 
 ### High
 
+- [ ] S-H1 (client) — Refresh token sent in JSON body to `/profiles/list`, `/profiles/switch`, `/profiles/create`, `/profiles/delete`. Migrate server endpoints to accept Bearer access-token auth instead, reducing refresh-token exposure surface — see [[identity-model]], [[arc-tokens]]
 - [ ] S-H21 — Dev-mode `console.log` of OTP codes + recipient email in `osn/core/src/services/auth.ts`. Replace with `Effect.logDebug` + structured annotations. Deferred to console migration PR.
 
 ### Medium

--- a/wiki/systems/identity-model.md
+++ b/wiki/systems/identity-model.md
@@ -9,7 +9,9 @@ related:
 packages:
   - "@osn/db"
   - "@osn/core"
+  - "@osn/client"
 last-reviewed: 2026-04-14
+p4-completed: 2026-04-14
 p2-completed: 2026-04-14
 p3-completed: 2026-04-14
 ---
@@ -126,6 +128,33 @@ Two profile management endpoints:
 - `POST /profiles/switch` — present the account-scoped refresh token + target `profileId` in the request body; receive a new access token for that profile. Per-account rate limited (20 switches/hr).
 - `POST /profiles/list` — present the refresh token in the request body; receive all profiles for the account. Refresh tokens are never sent via `Authorization` headers to avoid conflation with access tokens.
 
+## Client Storage Model (P4)
+
+`@osn/client` stores the multi-profile session under a single `localStorage` key:
+
+| Key | Shape | Purpose |
+|-----|-------|---------|
+| `@osn/client:account_session` | `AccountSession` JSON | Refresh token, active profile ID, per-profile access tokens, scopes, ID token |
+
+The `AccountSession` structure:
+
+```typescript
+interface AccountSession {
+  refreshToken: string;           // Account-scoped (shared across profiles)
+  activeProfileId: string;        // Currently active profile
+  profileTokens: Record<string, ProfileToken>;  // Per-profile access tokens
+  scopes: string[];
+  idToken: string | null;
+}
+```
+
+**Design decisions:**
+- Single-key storage (not multi-key) avoids the need for `keys()` enumeration on logout and simplifies atomic writes.
+- Expired profile tokens are pruned on every `saveAccountSession` call (except the active profile's token, which is kept for identity tracking).
+- An in-memory cache avoids redundant `localStorage.getItem` + `JSON.parse` round-trips within the same service instance.
+- All storage reads are validated against Effect Schema (`decodeAccountSession`) — malformed data is discarded rather than consumed.
+- Legacy sessions (pre-P4, stored under `@osn/client:session`) are migrated transparently on the first `getSession()` call.
+
 ## Registration Flow
 
 ```
@@ -162,6 +191,6 @@ POST /register/complete → OTP →
 | P1: Schema + terminology | ✅ Done | `accounts` table, `userId` → `profileId`, seed data, email dedup, service/route/test rename from "user" → "profile" terminology |
 | P2: Auth refactor | ✅ Done | Two-tier tokens (refresh=account, access=profile), `POST /profiles/switch`, `POST /profiles/list`, `verifyRefreshToken`, `findDefaultProfile`, scope claim validation, per-account rate limiting |
 | P3: Profile CRUD | ✅ Done | `createProfile` (maxProfiles enforcement, S-L1), `deleteProfile` (cascade delete graph+org data), `setDefaultProfile`, three REST routes, `withProfileCrud` observability wrapper, S-L2 resolved |
-| P4: Client SDK | Planned | Multi-session storage, profile switcher methods |
+| P4: Client SDK | ✅ Done | Multi-session `AccountSession` storage in `@osn/client`, `listProfiles` / `switchProfile` / `createProfile` / `deleteProfile` / `getActiveProfile` methods, SolidJS `AuthContext` integration (`profiles` resource, `activeProfileId` signal), legacy session migration, Effect Schema validation on storage reads + API responses, Base64URL JWT parsing, expired token pruning |
 | P5: UI | Planned | Profile switcher component |
 | P6: Privacy audit | Planned | Verify accountId never leaks, pen-test correlation attacks |


### PR DESCRIPTION
## Summary
- Transform `@osn/client` from single-session storage to a multi-profile `AccountSession` model with per-profile access tokens, enabling profile switching without re-authentication
- Add five new methods to `OsnAuthService`: `listProfiles`, `switchProfile`, `createProfile`, `deleteProfile`, `getActiveProfile` — all backed by server endpoints shipped in P2/P3
- Extend SolidJS `AuthContext` with `profiles` resource, `activeProfileId` signal, and profile management wrappers
- Transparent migration from legacy single-key storage on first `getSession()` call — existing apps (Pulse) continue working without code changes
- Comprehensive security hardening: Effect Schema validation on storage reads + API responses, Base64URL JWT parsing, expired token pruning, server-authoritative profile IDs

## Workspaces affected
- `@osn/client` (minor version bump)
- `@osn/ui`, `@pulse/app` (dependent patch bumps via changeset)

## Decisions & issues

**[S-H1 — Refresh token in request body]**
- **Issue:** Profile management endpoints receive the refresh token in JSON body, increasing its exposure surface.
- **Why:** Refresh tokens are high-value secrets; each additional endpoint that accepts them is another opportunity for logging leaks.
- **Solution:** Deferred — requires coordinated server-side change to accept Bearer access-token auth instead. Added to security backlog in `wiki/TODO.md`.
- **Rationale:** Server API was shipped in P2/P3 and is already in use. Changing it is a separate cross-workspace PR.

**[S-H2 — Unchecked JSON.parse on storage data]**
- **Issue:** `getAccountSession()` used `JSON.parse(raw) as AccountSession` without runtime validation. `localStorage` is writable by any same-origin script.
- **Why:** Malformed or malicious data would propagate silently (prototype pollution, type confusion).
- **Solution:** Added Effect Schema decoders (`decodeAccountSession`, `decodeSession`) — malformed data is discarded, not consumed.
- **Rationale:** Consistent with the project's schema-layers convention; `parseTokenResponse` already uses Schema.

**[S-M1 — Base64URL JWT parsing]**
- **Issue:** `extractJwtSub` used `atob()` which doesn't handle Base64URL encoding (RFC 7515).
- **Why:** JWTs with `-` or `_` in the payload would silently fail, falling back to `"default"` profile ID — potential token cross-contamination.
- **Solution:** Convert Base64URL → standard Base64 before decoding (`-` → `+`, `_` → `/`).
- **Rationale:** One-line fix that ensures reliable `sub` extraction from all valid JWTs.

**[S-M2 / P-W3 — Expired token accumulation]**
- **Issue:** `profileTokens` record accumulated stale entries indefinitely.
- **Why:** Growing storage blob increases `JSON.stringify`/`JSON.parse` cost and retains sensitive tokens longer than necessary.
- **Solution:** `pruneExpiredTokens()` runs on every `saveAccountSession` — removes expired tokens except the active profile's.
- **Rationale:** Pruning at write time keeps the stored blob compact without a separate cleanup mechanism.

**[S-M3 — Last-profile deletion inconsistency]**
- **Issue:** Deleting the active profile when no other profiles remain left `activeProfileId` pointing at the deleted ID.
- **Why:** `getActiveProfile()` would return a stale ID while `getSession()` returns null — inconsistent state.
- **Solution:** Set `activeProfileId` to empty string when no profiles remain; `getActiveProfile` returns `null` for falsy values.
- **Rationale:** Server prevents deleting the last profile (400), but client should handle edge cases gracefully.

**[S-M4 — Unvalidated API responses]**
- **Issue:** Profile endpoint responses were cast with `as Promise<...>` without runtime validation.
- **Why:** A compromised or buggy server could return unexpected shapes that propagate silently.
- **Solution:** Added Effect Schema decoders for all profile endpoint responses (`decodeListProfilesResponse`, `decodeSwitchProfileResponse`, `decodeCreateProfileResponse`).
- **Rationale:** Defense-in-depth at the trust boundary, consistent with `parseTokenResponse`.

**[S-L1 — Caller-supplied vs server-authoritative profile ID]**
- **Issue:** `switchProfile` used the caller's `profileId` as the storage key instead of the server's `profile.id`.
- **Why:** If the server returns a different profile than requested, the token would be stored under the wrong key.
- **Solution:** Use `res.profile.id` as the canonical key and `activeProfileId`.
- **Rationale:** Server is the authority on profile identity.

**[P-W1 — Redundant storage reads]**
- **Issue:** Every profile method called `getAccountSession()` independently, causing redundant `localStorage.getItem` + `JSON.parse`.
- **Why:** Sequential operations (e.g., `deleteProfile` → `getSession` → `getActiveProfile`) caused 3 redundant reads per user action.
- **Solution:** Added in-memory cache in the service closure; invalidated on writes and logout.
- **Rationale:** Single-threaded browser environment means the cache stays consistent without cross-tab coordination.

**[P-W2 — Eager profile fetch for unauthenticated users]**
- **Issue:** `profiles` resource fired `POST /profiles/list` immediately on mount, even for unauthenticated users.
- **Why:** Wasted HTTP request on every page load for visitors without a session.
- **Solution:** Used SolidJS source-signal pattern — `createResource(() => session(), fetcher)` — fetcher only runs when session is truthy.
- **Rationale:** Idiomatic SolidJS pattern for dependent resources.

**[S-L2 / P-I2 — Silent error swallowing and fire-and-forget promises]**
- **Issue:** `.catch(() => {})` on `getActiveProfile` calls and un-awaited `refetchProfiles()` calls.
- **Why:** Errors were invisible; un-awaited refetches could race with user interactions.
- **Solution:** Replaced fire-and-forget init with reactive `createEffect` that derives `activeProfileId` from session changes. Awaited all `refetchProfiles()` calls.
- **Rationale:** Observable failures and consistent state on function return.

## Test plan
- [x] All 56 existing + new tests pass (`bun run --cwd osn/client test:run`)
- [x] Full monorepo type check passes (16/16 tasks)
- [x] 0 lint warnings (oxlint)
- [x] Pre-commit + pre-push hooks pass
- [ ] Verify Pulse app still works with the new storage model (backward compat via migration)
- [ ] Test profile switch flow end-to-end with a running OSN Core server
- [ ] Test fresh login → `getSession` → `listProfiles` → `switchProfile` flow
- [ ] Test legacy session migration: log in with old client, upgrade, verify session survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)