### PR TITLE
fix(observability): default dev log level to debug

### DIFF
--- a/.changeset/dev-log-level-debug.md
+++ b/.changeset/dev-log-level-debug.md
@@ -1,0 +1,5 @@
+---
+"@shared/observability": patch
+---
+
+Default log level to debug in dev environment so OTP codes and magic-link URLs are visible without manual OSN_LOG_LEVEL configuration.

--- a/.changeset/dev-log-level-debug.md
+++ b/.changeset/dev-log-level-debug.md
@@ -1,5 +1,6 @@
 ---
 "@shared/observability": patch
+"@osn/core": patch
 ---
 
-Default log level to debug in dev environment so OTP codes and magic-link URLs are visible without manual OSN_LOG_LEVEL configuration.
+Default log level to debug in dev environment so OTP codes and magic-link URLs are visible without manual OSN_LOG_LEVEL configuration. Tighten OTP/magic-link debug guard from NODE_ENV to OSN_ENV so staging is also excluded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,17 @@ jobs:
 
       - name: Test
         run: bun run test
+
+  ci:
+    name: CI
+    if: always()
+    needs: [lint, typecheck, build-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "❌ One or more CI jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "✅ All CI jobs passed"

--- a/osn/core/src/services/auth.ts
+++ b/osn/core/src/services/auth.ts
@@ -507,7 +507,7 @@ export function createAuthService(config: AuthConfig) {
    *  - Refuses to overwrite a non-expired pending entry, preventing an
    *    attacker from resetting a victim's in-progress OTP (S-M2).
    *  - The dev-only `Effect.logDebug` of the OTP is gated on
-   *    `NODE_ENV !== "production"` (S-M3).
+   *    `OSN_ENV` being unset or `"dev"` (S-M3 / S-L2).
    *
    * Validation errors (bad email format, bad handle format, reserved handle)
    * are still surfaced as ValidationError / AuthError because they're not
@@ -583,11 +583,12 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (process.env["NODE_ENV"] !== "production") {
-        // S-M3: only print the OTP to logs in non-production environments.
-        // Values are interpolated into the message string (not annotations) so
-        // the redacting logger doesn't scrub them — the whole point of this
-        // dev-only log is to expose the code so the developer can act on it.
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
+        // S-M3: only print the OTP to logs in dev environments. The guard
+        // uses OSN_ENV (not NODE_ENV) so staging is excluded — defence in
+        // depth alongside the log-level minimum (S-L2). Values are
+        // interpolated into the message string (not annotations) so the
+        // redacting logger doesn't scrub them.
         yield* Effect.logDebug(`[OSN dev] Registration OTP for ${normalisedEmail}: ${code}`);
       }
 
@@ -1320,10 +1321,10 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (process.env["NODE_ENV"] !== "production") {
-        // Dev-only fallback when no email sender is configured. See the
-        // matching block in beginRegistration for why values are interpolated
-        // into the message string instead of using log annotations.
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
+        // Dev-only fallback when no email sender is configured. Guard uses
+        // OSN_ENV (not NODE_ENV) so staging is excluded (S-L2). See the
+        // matching block in beginRegistration for the interpolation rationale.
         yield* Effect.logDebug(`[OSN dev] OTP for ${profile.email}: ${code}`);
       }
 
@@ -1442,10 +1443,10 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (process.env["NODE_ENV"] !== "production") {
-        // Dev-only fallback when no email sender is configured. See the
-        // matching block in beginRegistration for why values are interpolated
-        // into the message string instead of using log annotations.
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
+        // Dev-only fallback when no email sender is configured. Guard uses
+        // OSN_ENV (not NODE_ENV) so staging is excluded (S-L2). See the
+        // matching block in beginRegistration for the interpolation rationale.
         yield* Effect.logDebug(`[OSN dev] Magic link for ${profile.email}: ${magicUrl}`);
       }
 

--- a/shared/observability/src/config.ts
+++ b/shared/observability/src/config.ts
@@ -45,7 +45,7 @@ const parseEnv = (value: string | undefined): DeploymentEnvironment => {
   }
 };
 
-const parseLogLevel = (value: string | undefined): LogLevel => {
+const parseLogLevel = (value: string | undefined, env: DeploymentEnvironment): LogLevel => {
   switch (value) {
     case "trace":
     case "debug":
@@ -55,7 +55,7 @@ const parseLogLevel = (value: string | undefined): LogLevel => {
     case "fatal":
       return value;
     default:
-      return "info";
+      return env === "dev" ? "debug" : "info";
   }
 };
 
@@ -142,7 +142,7 @@ export const loadConfig = (overrides: ConfigOverrides = {}): ObservabilityConfig
     serviceNamespace: "osn",
     serviceInstanceId: instanceId(serviceName),
     env,
-    logLevel: parseLogLevel(process.env.OSN_LOG_LEVEL),
+    logLevel: parseLogLevel(process.env.OSN_LOG_LEVEL, env),
     otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
     otlpHeaders: parseHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS),
     traceSampleRatio: parseSampleRatio(

--- a/shared/observability/tests/config.test.ts
+++ b/shared/observability/tests/config.test.ts
@@ -33,7 +33,7 @@ describe("loadConfig", () => {
   it("defaults to dev env when nothing is set", () => {
     const cfg = loadConfig();
     expect(cfg.env).toBe("dev");
-    expect(cfg.logLevel).toBe("info");
+    expect(cfg.logLevel).toBe("debug");
     expect(cfg.otlpEndpoint).toBeUndefined();
     expect(cfg.traceSampleRatio).toBe(1.0); // dev default
     expect(cfg.serviceNamespace).toBe("osn");
@@ -114,6 +114,11 @@ describe("loadConfig", () => {
     process.env.OSN_LOG_LEVEL = "debug";
     expect(loadConfig().logLevel).toBe("debug");
     process.env.OSN_LOG_LEVEL = "junk";
+    expect(loadConfig().logLevel).toBe("debug"); // dev env defaults to debug
+  });
+
+  it("defaults log level to info in production", () => {
+    process.env.OSN_ENV = "production";
     expect(loadConfig().logLevel).toBe("info");
   });
 });

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -173,7 +173,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 ### High
 
 - [ ] S-H1 (client) — Refresh token sent in JSON body to `/profiles/list`, `/profiles/switch`, `/profiles/create`, `/profiles/delete`. Migrate server endpoints to accept Bearer access-token auth instead, reducing refresh-token exposure surface — see [[identity-model]], [[arc-tokens]]
-- [ ] S-H21 — Dev-mode `console.log` of OTP codes + recipient email in `osn/core/src/services/auth.ts`. Replace with `Effect.logDebug` + structured annotations. Deferred to console migration PR.
+- [x] S-H21 — Dev-mode `console.log` of OTP codes + recipient email in `osn/core/src/services/auth.ts`. **Fixed** — already uses `Effect.logDebug` (not `console.log`); guard tightened to `OSN_ENV` in log-level-debug PR.
 
 ### Medium
 
@@ -210,7 +210,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-L3 — Tauri CSP is `null` — allowlist `photon.komoot.io`, `maps.google.com`, `*.tile.openstreetmap.org`
 - [ ] S-L4 — `createdByAvatar` always null — no avatar claim in JWT
 - [ ] S-L7 — `jwtSecret` falls back to `"dev-secret"` — throw at startup in production
-- [ ] S-L8 — OTP codes and magic link URLs logged to stdout — guard with `NODE_ENV`
+- [x] S-L8 — OTP codes and magic link URLs logged to stdout. **Fixed** — guard tightened to `OSN_ENV` (excludes staging); dev log level defaults to debug so codes are visible without manual config.
 - [ ] S-L9 — `imageUrl` allows `data:` URIs — add CSP `img-src` header
 - [ ] S-L10 — SimpleWebAuthn loaded from unpkg CDN without SRI hash
 - [ ] S-L11 — Failed OAuth callback leaves PKCE verifier in `localStorage`

--- a/wiki/observability/logging.md
+++ b/wiki/observability/logging.md
@@ -8,7 +8,7 @@ related:
   - "[[tracing]]"
   - "[[metrics]]"
 packages: ["@shared/observability"]
-last-reviewed: 2026-04-12
+last-reviewed: 2026-04-15
 ---
 
 # Logging
@@ -19,8 +19,8 @@ Use `Effect.logInfo` / `Effect.logWarn` / `Effect.logError` inside Effect pipeli
 
 | Level | When to use | Production? |
 |-------|-------------|-------------|
-| `Effect.logDebug` | Dev-only diagnostics (OTP codes, magic-link URLs, internal state dumps) | Never emitted -- minimum level is `Info` unless explicitly overridden |
-| `Effect.logInfo` | Normal operations worth recording: service boot, significant state transitions, successful completions of multi-step flows | Yes -- the default minimum level in both dev and production |
+| `Effect.logDebug` | Dev-only diagnostics (OTP codes, magic-link URLs, internal state dumps) | Never emitted in production (minimum level is `Info`). Emitted in dev by default (minimum level is `Debug`). |
+| `Effect.logInfo` | Normal operations worth recording: service boot, significant state transitions, successful completions of multi-step flows | Yes -- the default minimum level in production. Dev defaults to `Debug`. |
 | `Effect.logWarning` | Degraded but recoverable conditions: rate limit tripped, retryable upstream failure, deprecated code path hit | Yes |
 | `Effect.logError` | Failures that need operator attention: unhandled exceptions, database errors, authentication verification failures | Yes |
 

--- a/wiki/observability/logging.md
+++ b/wiki/observability/logging.md
@@ -77,7 +77,7 @@ Redaction is non-negotiable, but the deny-list is kept minimal. The logger layer
 
 ## Dev-mode OTP/magic-link logging
 
-Dev-mode OTP/magic-link logging uses `Effect.logDebug` gated on `NODE_ENV !== "production"`. The OTP code, email, and magic link URL are interpolated into the message string (not annotations) so the redacting logger doesn't scrub them -- the whole point of the dev log is to expose those values to the developer. In production these branches never run because `config.sendEmail` is wired up.
+Dev-mode OTP/magic-link logging uses `Effect.logDebug` gated on `OSN_ENV` being unset or `"dev"` (S-L2). The guard excludes both staging and production, providing defence in depth alongside the log-level minimum. The OTP code, email, and magic link URL are interpolated into the message string (not annotations) so the redacting logger doesn't scrub them -- the whole point of the dev log is to expose those values to the developer. In production these branches never run because `config.sendEmail` is wired up.
 
 ## Route-level logger wiring
 


### PR DESCRIPTION
## Summary
- Default log level to `debug` in dev environment so `Effect.logDebug` output (OTP codes, magic-link URLs) is visible when running `bun run dev` without needing to manually set `OSN_LOG_LEVEL`
- Tighten the OTP/magic-link debug guard from `NODE_ENV !== "production"` to `OSN_ENV`-based check, excluding staging (S-L2)
- Production and staging still default to `info` log level

## Workspaces affected
- `@shared/observability` (patch) — `parseLogLevel` now env-aware
- `@osn/core` (patch) — auth.ts debug guard tightened

## Decisions & issues

**[S-L2] — Staging environment not excluded by NODE_ENV guard**
- **Issue:** The existing OTP/magic-link `Effect.logDebug` calls in `auth.ts` were gated on `process.env["NODE_ENV"] !== "production"`, which passes in staging (`NODE_ENV=staging`).
- **Why:** If a staging deployment had `sendEmail` unconfigured and `OSN_LOG_LEVEL=debug` set for debugging, plaintext OTP codes and magic-link tokens would appear in logs — these are authentication secrets.
- **Solution:** Changed all three guards to `!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev"`, so the branch is only reachable when `OSN_ENV` is unset (local dev) or explicitly `"dev"`.
- **Rationale:** Defence in depth — the log-level minimum is a secondary control; the primary call-site guard should be at least as restrictive. `OSN_ENV` is the canonical env indicator per S-L3 in the observability config.

**[S-L1] — Staging log level default confirmed correct**
- **Issue:** Security review flagged whether staging also defaults to `debug`.
- **Why:** Would expose OTP codes in staging logs if the call-site guard were also loose.
- **Solution:** No action needed — `parseLogLevel` returns `"info"` for any env that is not `"dev"`.
- **Rationale:** Both defences (log level + call-site guard) now exclude staging independently.

**[S-H21 / S-L8] — Resolved existing security backlog items**
- **Issue:** S-H21 flagged dev-mode `console.log` of OTP codes; S-L8 flagged OTP codes logged to stdout without proper guarding.
- **Why:** These were open security backlog items in TODO.md.
- **Solution:** S-H21 was already resolved (code uses `Effect.logDebug`, not `console.log`). S-L8 is now resolved by the `OSN_ENV` guard tightening + dev log level default.
- **Rationale:** Both items are marked as fixed in TODO.md.

## Test plan
- [x] `bun run --cwd shared/observability test:run` — 79 tests pass (config defaults, log level parsing, production vs dev)
- [x] `bun run --cwd osn/core test:run` — 418 tests pass (including dev-mode logDebug fallback suite)
- [x] `bun run check` — all 15 packages type-check clean
- [ ] Run `bun run dev`, trigger registration OTP — verify code appears in console without setting `OSN_LOG_LEVEL`
- [ ] Set `OSN_LOG_LEVEL=info` and verify debug output is suppressed
- [ ] Set `OSN_ENV=staging` and verify OTP debug branch is skipped even with `OSN_LOG_LEVEL=debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)