### PR TITLE
fix(observability): add local env tier, port safety, and email validation

### DIFF
--- a/.changeset/local-env-port-safety.md
+++ b/.changeset/local-env-port-safety.md
@@ -1,0 +1,11 @@
+---
+"@shared/observability": minor
+"@osn/core": patch
+"@osn/app": patch
+"@osn/ui": patch
+"@pulse/api": patch
+"@pulse/app": patch
+"@zap/api": patch
+---
+
+Add four-tier environment model (local/dev/staging/production). Local env gets debug log level and OTP codes printed to terminal; all other environments default to info. Disable SO_REUSEPORT on all servers so stale processes cause EADDRINUSE errors instead of silently intercepting requests. Add email validation message to registration form. Remove Vite devtools plugin.

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "osn/app": {
       "name": "@osn/app",
-      "version": "0.3.5",
+      "version": "0.3.9",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -33,7 +33,7 @@
     },
     "osn/client": {
       "name": "@osn/client",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "effect": "^3.19.19",
       },
@@ -49,7 +49,7 @@
     },
     "osn/core": {
       "name": "@osn/core",
-      "version": "0.14.1",
+      "version": "0.16.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/crypto": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "osn/crypto": {
       "name": "@osn/crypto",
-      "version": "0.2.7",
+      "version": "0.2.11",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -86,7 +86,7 @@
     },
     "osn/db": {
       "name": "@osn/db",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.0",
@@ -117,7 +117,7 @@
     },
     "osn/ui": {
       "name": "@osn/ui",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@kobalte/core": "^0.13.11",
         "@osn/client": "workspace:*",
@@ -143,7 +143,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.9.1",
+      "version": "0.9.5",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -165,7 +165,7 @@
     },
     "pulse/app": {
       "name": "@pulse/app",
-      "version": "0.7.2",
+      "version": "0.7.10",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -185,7 +185,6 @@
         "@solidjs/testing-library": "^0.8.10",
         "@tauri-apps/cli": "^2",
         "@types/leaflet": "^1.9.12",
-        "@vitejs/devtools": "^0.1.13",
         "@vitest/coverage-istanbul": "^4.1.0",
         "happy-dom": "^20.8.4",
         "typescript": "^5.9.3",
@@ -226,7 +225,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.2.6",
+      "version": "0.2.10",
       "dependencies": {
         "@effect/opentelemetry": "^0.63.0",
         "@opentelemetry/api": "^1.9.0",
@@ -267,7 +266,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.3.1",
+      "version": "0.3.5",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",

--- a/osn/app/.env.example
+++ b/osn/app/.env.example
@@ -21,7 +21,18 @@ OSN_JWT_SECRET=change-me-to-a-secure-random-secret-at-least-32-chars
 OSN_ACCESS_TOKEN_TTL=3600
 OSN_REFRESH_TOKEN_TTL=2592000
 
-# Email provider (optional — set to enable OTP/magic link sending)
+# Observability
+# OSN_ENV=local                        # local | dev | staging | production (default: local)
+# OSN_LOG_LEVEL=debug                  # trace | debug | info | warn | error | fatal (default: debug in local, info elsewhere)
+# OTEL_EXPORTER_OTLP_ENDPOINT=         # OTLP HTTP endpoint (disabled if unset)
+# OTEL_EXPORTER_OTLP_HEADERS=          # OTLP auth headers (key=value,key=value)
+# OSN_TRACE_SAMPLE_RATIO=1.0           # 0.0–1.0 (default: 1.0 dev, 0.1 prod)
+
+# Redis (optional — falls back to in-memory rate limiters)
+# REDIS_URL=redis://localhost:6379
+# REDIS_REQUIRED=false                 # true = exit if Redis fails to connect
+
+# Email provider (optional — OTP codes print to server logs when unset in dev)
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USER=

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -66,7 +66,7 @@ const app = new Elysia()
   .use(createProfileRoutes(authConfig, DbLive, observabilityLayer, profileRateLimiters));
 
 if (process.env.NODE_ENV !== "test") {
-  app.listen(port);
+  app.listen({ port, reusePort: false });
   void Effect.runPromise(
     Effect.logInfo("osn-app listening").pipe(
       Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),

--- a/osn/core/src/services/auth.ts
+++ b/osn/core/src/services/auth.ts
@@ -506,8 +506,8 @@ export function createAuthService(config: AuthConfig) {
    *    abuse can't grow it without bound (S-M2 / P-W1).
    *  - Refuses to overwrite a non-expired pending entry, preventing an
    *    attacker from resetting a victim's in-progress OTP (S-M2).
-   *  - The dev-only `Effect.logDebug` of the OTP is gated on
-   *    `OSN_ENV` being unset or `"dev"` (S-M3 / S-L2).
+   *  - The local-only `Effect.logDebug` of the OTP is gated on
+   *    `OSN_ENV` being unset or `"local"` (S-M3 / S-L2).
    *
    * Validation errors (bad email format, bad handle format, reserved handle)
    * are still surfaced as ValidationError / AuthError because they're not
@@ -583,13 +583,13 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
-        // S-M3: only print the OTP to logs in dev environments. The guard
-        // uses OSN_ENV (not NODE_ENV) so staging is excluded — defence in
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "local") {
+        // S-M3: only print the OTP to logs in local environments. The guard
+        // uses OSN_ENV (not NODE_ENV) so dev/staging/prod are excluded — defence in
         // depth alongside the log-level minimum (S-L2). Values are
         // interpolated into the message string (not annotations) so the
         // redacting logger doesn't scrub them.
-        yield* Effect.logDebug(`[OSN dev] Registration OTP for ${normalisedEmail}: ${code}`);
+        yield* Effect.logDebug(`[OSN local] Registration OTP for ${normalisedEmail}: ${code}`);
       }
 
       metricAuthOtpSent("registration");
@@ -1321,11 +1321,11 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
-        // Dev-only fallback when no email sender is configured. Guard uses
-        // OSN_ENV (not NODE_ENV) so staging is excluded (S-L2). See the
-        // matching block in beginRegistration for the interpolation rationale.
-        yield* Effect.logDebug(`[OSN dev] OTP for ${profile.email}: ${code}`);
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "local") {
+        // Local-only fallback when no email sender is configured. Guard uses
+        // OSN_ENV (not NODE_ENV) so dev/staging/prod are excluded (S-L2). See
+        // the matching block in beginRegistration for the interpolation rationale.
+        yield* Effect.logDebug(`[OSN local] OTP for ${profile.email}: ${code}`);
       }
 
       metricAuthOtpSent("login");
@@ -1443,11 +1443,11 @@ export function createAuthService(config: AuthConfig) {
             ),
           catch: (cause) => new AuthError({ message: `Failed to send email: ${String(cause)}` }),
         });
-      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "dev") {
-        // Dev-only fallback when no email sender is configured. Guard uses
-        // OSN_ENV (not NODE_ENV) so staging is excluded (S-L2). See the
-        // matching block in beginRegistration for the interpolation rationale.
-        yield* Effect.logDebug(`[OSN dev] Magic link for ${profile.email}: ${magicUrl}`);
+      } else if (!process.env["OSN_ENV"] || process.env["OSN_ENV"] === "local") {
+        // Local-only fallback when no email sender is configured. Guard uses
+        // OSN_ENV (not NODE_ENV) so dev/staging/prod are excluded (S-L2). See
+        // the matching block in beginRegistration for the interpolation rationale.
+        yield* Effect.logDebug(`[OSN local] Magic link for ${profile.email}: ${magicUrl}`);
       }
 
       metricAuthMagicLinkSent("ok");

--- a/osn/core/tests/services/auth.test.ts
+++ b/osn/core/tests/services/auth.test.ts
@@ -694,7 +694,7 @@ describe("verifyAccessToken", () => {
 //      a future PR that wraps the call with Effect.annotateLogs({ code }).
 // ---------------------------------------------------------------------------
 
-describe("dev-mode Effect.logDebug fallback", () => {
+describe("local-mode Effect.logDebug fallback", () => {
   /**
    * Install a capture logger in place of Effect's default, returning an
    * array that will be populated with every emitted message string.
@@ -714,7 +714,6 @@ describe("dev-mode Effect.logDebug fallback", () => {
   it.effect("beginRegistration logs the OTP via Effect.logDebug when sendEmail is unset", () =>
     Effect.gen(function* () {
       const { captured, loggerLayer } = captureLogs();
-      // config has no sendEmail — the dev-fallback branch is reached.
       const svc = createAuthService(config);
 
       yield* svc
@@ -729,7 +728,6 @@ describe("dev-mode Effect.logDebug fallback", () => {
 
   it.effect("beginOtp logs the login code via Effect.logDebug when sendEmail is unset", () =>
     Effect.gen(function* () {
-      // beginOtp requires the user to exist already — register first.
       yield* auth.registerProfile("dev-login@example.com", "devlogin");
 
       const { captured, loggerLayer } = captureLogs();

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -194,6 +194,9 @@ export function Register(props: RegisterProps) {
               value={email()}
               onInput={(e) => setEmail(e.currentTarget.value)}
             />
+            <Show when={email() && !EMAIL_RE.test(email())}>
+              <span class="text-destructive text-xs">Please enter a valid email address</span>
+            </Show>
           </div>
 
           <div class="flex flex-col gap-1">

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
-    "dev:pulse": "turbo dev --filter=@pulse/api --filter=@pulse/app --filter=@osn/core --filter=@zap/api",
-    "dev:zap": "turbo dev --filter=@zap/api --filter=@osn/core",
+    "dev:pulse": "turbo dev --filter=@pulse/api --filter=@pulse/app --filter=@osn/app --filter=@zap/api",
+    "dev:zap": "turbo dev --filter=@zap/api --filter=@osn/app",
     "dev:osn": "turbo dev --filter=@osn/core --filter=@osn/app",
-    "dev:apis": "turbo dev --filter=@osn/core --filter=@pulse/api --filter=@zap/api",
+    "dev:apis": "turbo dev --filter=@osn/app --filter=@pulse/api --filter=@zap/api",
     "dev:landing": "turbo dev --filter=@osn/landing",
     "lint": "oxlint -c oxlintrc.json .",
     "check": "turbo check",

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -21,7 +21,7 @@ const app = new Elysia()
 const port = process.env.PORT || 3001;
 
 if (process.env.NODE_ENV !== "test") {
-  app.listen(port);
+  app.listen({ port, reusePort: false });
   // One structured info log at boot, routed through the observability layer
   // so it picks up resource attributes + redaction. Using Effect.runPromise
   // because the layer is Effect-scoped.

--- a/pulse/app/package.json
+++ b/pulse/app/package.json
@@ -36,7 +36,6 @@
     "@tauri-apps/cli": "^2",
     "@types/leaflet": "^1.9.12",
     "@vitest/coverage-istanbul": "^4.1.0",
-    "@vitejs/devtools": "^0.1.13",
     "happy-dom": "^20.8.4",
     "typescript": "^5.9.3",
     "vite": "^8.0.8",

--- a/pulse/app/vite.config.ts
+++ b/pulse/app/vite.config.ts
@@ -1,5 +1,4 @@
 import tailwindcss from "@tailwindcss/vite";
-import { DevTools } from "@vitejs/devtools";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 
@@ -7,8 +6,8 @@ import solid from "vite-plugin-solid";
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
-export default defineConfig(async ({ command }) => ({
-  plugins: [...(command === "serve" ? [DevTools()] : []), tailwindcss(), solid()],
+export default defineConfig(async () => ({
+  plugins: [tailwindcss(), solid()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //

--- a/shared/observability/src/config.ts
+++ b/shared/observability/src/config.ts
@@ -7,7 +7,7 @@
  * is present.
  */
 
-export type DeploymentEnvironment = "dev" | "staging" | "production";
+export type DeploymentEnvironment = "local" | "dev" | "staging" | "production";
 
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 
@@ -40,8 +40,11 @@ const parseEnv = (value: string | undefined): DeploymentEnvironment => {
     case "staging":
     case "stage":
       return "staging";
-    default:
+    case "dev":
+    case "development":
       return "dev";
+    default:
+      return "local";
   }
 };
 
@@ -55,7 +58,7 @@ const parseLogLevel = (value: string | undefined, env: DeploymentEnvironment): L
     case "fatal":
       return value;
     default:
-      return env === "dev" ? "debug" : "info";
+      return env === "local" ? "debug" : "info";
   }
 };
 
@@ -123,8 +126,8 @@ export const loadConfig = (overrides: ConfigOverrides = {}): ObservabilityConfig
   // S-L3: if anything claims we're in production, require an explicit
   // `OSN_ENV=production` — `NODE_ENV` alone is not sufficient because
   // Bun leaves it empty by default and a missing env would silently
-  // classify as `dev` (pretty logs + 100% trace sampling + any future
-  // dev-only code paths). Conversely, if the operator DID set
+  // classify as `local` (pretty logs + debug level + 100% trace sampling
+  // + any local-only code paths). Conversely, if the operator DID set
   // `OSN_ENV=production` but an override tries to force it elsewhere,
   // that's a bug we want to hear about.
   if (process.env.OSN_ENV === "production" && env !== "production") {

--- a/shared/observability/src/logger/layer.ts
+++ b/shared/observability/src/logger/layer.ts
@@ -39,7 +39,8 @@ const makeRedactingLogger = (base: Logger.Logger<unknown, void>): Logger.Logger<
  * in `../index.ts`).
  */
 export const makeLoggerLayer = (config: ObservabilityConfig): Layer.Layer<never> => {
-  const baseLogger = config.env === "production" ? Logger.jsonLogger : Logger.prettyLogger();
+  const baseLogger =
+    config.env === "local" || config.env === "dev" ? Logger.prettyLogger() : Logger.jsonLogger;
   const redacting = makeRedactingLogger(baseLogger);
   return Layer.mergeAll(
     Logger.replace(Logger.defaultLogger, redacting),

--- a/shared/observability/tests/config.test.ts
+++ b/shared/observability/tests/config.test.ts
@@ -30,12 +30,12 @@ describe("loadConfig", () => {
     }
   });
 
-  it("defaults to dev env when nothing is set", () => {
+  it("defaults to local env when nothing is set", () => {
     const cfg = loadConfig();
-    expect(cfg.env).toBe("dev");
+    expect(cfg.env).toBe("local");
     expect(cfg.logLevel).toBe("debug");
     expect(cfg.otlpEndpoint).toBeUndefined();
-    expect(cfg.traceSampleRatio).toBe(1.0); // dev default
+    expect(cfg.traceSampleRatio).toBe(1.0); // local default
     expect(cfg.serviceNamespace).toBe("osn");
   });
 
@@ -88,11 +88,18 @@ describe("loadConfig", () => {
   // S-L3: production env mismatch guard
   it("throws when OSN_ENV=production but the override disagrees", () => {
     process.env.OSN_ENV = "production";
-    expect(() => loadConfig({ env: "dev" })).toThrow(/production/);
+    expect(() => loadConfig({ env: "local" })).toThrow(/production/);
   });
 
-  it("does not throw when OSN_ENV is unset and override is dev", () => {
-    expect(() => loadConfig({ env: "dev" })).not.toThrow();
+  it("does not throw when OSN_ENV is unset and override is local", () => {
+    expect(() => loadConfig({ env: "local" })).not.toThrow();
+  });
+
+  it("parses OSN_ENV=dev", () => {
+    process.env.OSN_ENV = "dev";
+    const cfg = loadConfig();
+    expect(cfg.env).toBe("dev");
+    expect(cfg.logLevel).toBe("info");
   });
 
   it("uses overrides over env", () => {
@@ -114,7 +121,7 @@ describe("loadConfig", () => {
     process.env.OSN_LOG_LEVEL = "debug";
     expect(loadConfig().logLevel).toBe("debug");
     process.env.OSN_LOG_LEVEL = "junk";
-    expect(loadConfig().logLevel).toBe("debug"); // dev env defaults to debug
+    expect(loadConfig().logLevel).toBe("debug"); // local env defaults to debug
   });
 
   it("defaults log level to info in production", () => {

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -18,7 +18,7 @@ const app = new Elysia()
 const port = process.env.PORT || 3002;
 
 if (process.env.NODE_ENV !== "test") {
-  app.listen(port);
+  app.listen({ port, reusePort: false });
   void Effect.runPromise(
     Effect.logInfo("zap-api listening").pipe(
       Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),


### PR DESCRIPTION
## Summary

- **Four-tier environment model** (`local`/`dev`/`staging`/`production`): `local` gets debug log level + OTP codes in terminal; all deployed environments default to info. Unset `OSN_ENV` defaults to `local` instead of `dev`.
- **Port safety**: disable Bun's `SO_REUSEPORT` on all three servers (`osn/app`, `pulse/api`, `zap/api`) so stale processes cause a loud `EADDRINUSE` crash instead of silently intercepting requests
- **Email validation**: show inline error message in registration form when email format is invalid
- **Remove Vite devtools**: strip `@vitejs/devtools` from `pulse/app`
- **Fix dev scripts**: `dev:pulse`, `dev:zap`, `dev:apis` now run `@osn/app` (the actual server) instead of `@osn/core` (the library)

## Test plan

- [x] `bun run --cwd shared/observability test:run` — 80 tests pass
- [x] `bun run --cwd osn/core test:run` — 418 tests pass
- [x] `bun run --cwd osn/ui test:run` — 65 tests pass
- [x] Type check passes across all 15 packages
- [ ] Manual: `bun run dev:pulse` → register with fresh email → OTP appears in terminal
- [ ] Manual: start server twice on same port → second instance crashes with `EADDRINUSE`
- [ ] Manual: type invalid email in registration form → red error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)