### PR TITLE
feat(ui): add OTP digit input component and fix login token format

### DIFF
--- a/.changeset/otp-input-token-fix.md
+++ b/.changeset/otp-input-token-fix.md
@@ -1,0 +1,6 @@
+---
+"@osn/ui": minor
+"@osn/core": patch
+---
+
+Add 6-digit OTP input component with visual status states and fix login endpoints to return snake_case OAuth token format.

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -66,6 +66,17 @@ export function createDefaultAuthRateLimiters(): AuthRateLimiters {
   };
 }
 
+/** Convert an internal camelCase TokenSet to the snake_case OAuth wire format. */
+function toTokenResponse(ts: { accessToken: string; refreshToken: string; expiresIn: number }) {
+  return {
+    access_token: ts.accessToken,
+    refresh_token: ts.refreshToken,
+    token_type: "Bearer" as const,
+    expires_in: ts.expiresIn,
+    scope: "openid profile",
+  };
+}
+
 export function createAuthRoutes(
   authConfig: AuthConfig,
   dbLayer: Layer.Layer<Db> = DbLive,
@@ -347,13 +358,7 @@ export function createAuthRoutes(
               profileId: result.profileId,
               handle: result.handle,
               email: result.email,
-              session: {
-                access_token: result.accessToken,
-                refresh_token: result.refreshToken,
-                token_type: "Bearer",
-                expires_in: result.expiresIn,
-                scope: "openid profile",
-              },
+              session: toTokenResponse(result),
               enrollment_token: result.enrollmentToken,
             };
           } catch (e) {
@@ -491,13 +496,7 @@ export function createAuthRoutes(
 
             try {
               const tokens = await run(auth.exchangeCode(code));
-              return {
-                access_token: tokens.accessToken,
-                refresh_token: tokens.refreshToken,
-                token_type: "Bearer",
-                expires_in: tokens.expiresIn,
-                scope: "openid profile",
-              };
+              return toTokenResponse(tokens);
             } catch (e) {
               set.status = 400;
               return { error: "invalid_grant", message: String(e) };
@@ -512,13 +511,7 @@ export function createAuthRoutes(
             }
             try {
               const tokens = await run(auth.refreshTokens(refresh_token));
-              return {
-                access_token: tokens.accessToken,
-                refresh_token: tokens.refreshToken,
-                token_type: "Bearer",
-                expires_in: tokens.expiresIn,
-                scope: "openid profile",
-              };
+              return toTokenResponse(tokens);
             } catch (e) {
               set.status = 400;
               return { error: "invalid_grant", message: String(e) };
@@ -817,7 +810,10 @@ export function createAuthRoutes(
             const result = await run(
               auth.completePasskeyLoginDirect(body.identifier, body.assertion),
             );
-            return result;
+            return {
+              session: toTokenResponse(result.session),
+              profile: result.profile,
+            };
           } catch (e) {
             set.status = 400;
             return { error: String(e) };
@@ -862,7 +858,10 @@ export function createAuthRoutes(
           }
           try {
             const result = await run(auth.completeOtpDirect(body.identifier, body.code));
-            return result;
+            return {
+              session: toTokenResponse(result.session),
+              profile: result.profile,
+            };
           } catch (e) {
             set.status = 400;
             return { error: String(e) };
@@ -897,7 +896,10 @@ export function createAuthRoutes(
         async ({ query, set }) => {
           try {
             const result = await run(auth.verifyMagicDirect(query.token));
-            return result;
+            return {
+              session: toTokenResponse(result.session),
+              profile: result.profile,
+            };
           } catch (e) {
             set.status = 400;
             return { error: String(e) };

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -663,11 +663,11 @@ describe("auth routes", () => {
       );
       expect(res.status).toBe(200);
       const json = (await res.json()) as {
-        session: { accessToken: string; refreshToken: string; expiresIn: number };
+        session: { access_token: string; refresh_token: string; expires_in: number };
         profile: { id: string; handle: string; email: string };
       };
-      expect(json.session.accessToken).toBeTruthy();
-      expect(json.session.refreshToken).toBeTruthy();
+      expect(json.session.access_token).toBeTruthy();
+      expect(json.session.refresh_token).toBeTruthy();
       expect(json.profile.handle).toBe("otpdirect");
       expect(json.profile.email).toBe("otp-direct@example.com");
     });
@@ -755,10 +755,10 @@ describe("auth routes", () => {
       );
       expect(res.status).toBe(200);
       const json = (await res.json()) as {
-        session: { accessToken: string };
+        session: { access_token: string };
         profile: { handle: string; email: string };
       };
-      expect(json.session.accessToken).toBeTruthy();
+      expect(json.session.access_token).toBeTruthy();
       expect(json.profile.handle).toBe("magicdirect");
     });
 

--- a/osn/ui/package.json
+++ b/osn/ui/package.json
@@ -20,6 +20,7 @@
     "./ui/checkbox": "./src/components/ui/checkbox.tsx",
     "./ui/dialog": "./src/components/ui/dialog.tsx",
     "./ui/input": "./src/components/ui/input.tsx",
+    "./ui/otp-input": "./src/components/ui/otp-input.tsx",
     "./ui/label": "./src/components/ui/label.tsx",
     "./ui/popover": "./src/components/ui/popover.tsx",
     "./ui/radio-group": "./src/components/ui/radio-group.tsx",

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -39,6 +39,7 @@ export function Register(props: RegisterProps) {
   const [otp, setOtp] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [otpStatus, setOtpStatus] = createSignal<OtpStatus>("idle");
+  const [resendCooldown, setResendCooldown] = createSignal(0);
   const [profileId, setProfileId] = createSignal<string | null>(null);
   const [enrollmentToken, setEnrollmentToken] = createSignal<string | null>(null);
 
@@ -147,8 +148,21 @@ export function Register(props: RegisterProps) {
     }
   }
 
+  function startResendCooldown() {
+    setResendCooldown(30);
+    const id = setInterval(() => {
+      setResendCooldown((n) => {
+        if (n <= 1) {
+          clearInterval(id);
+          return 0;
+        }
+        return n - 1;
+      });
+    }, 1000);
+  }
+
   async function resendCode() {
-    if (busy()) return;
+    if (busy() || resendCooldown() > 0) return;
     setBusy(true);
     try {
       await client.beginRegistration({
@@ -158,6 +172,7 @@ export function Register(props: RegisterProps) {
       });
       setOtp("");
       setOtpStatus("idle");
+      startResendCooldown();
       toast.success("New code sent");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not resend code");
@@ -304,10 +319,10 @@ export function Register(props: RegisterProps) {
             <button
               type="button"
               onClick={resendCode}
-              class="text-primary text-sm font-medium hover:underline"
-              disabled={busy()}
+              class="text-primary text-sm font-medium hover:underline disabled:opacity-50"
+              disabled={busy() || resendCooldown() > 0}
             >
-              Resend code
+              {resendCooldown() > 0 ? `Resend code (${resendCooldown()}s)` : "Resend code"}
             </button>
           </Show>
           <Button variant="ghost" size="sm" onClick={() => setStep("details")}>

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -7,6 +7,7 @@ import { toast } from "solid-toast";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
+import { OtpInput, type OtpStatus } from "../components/ui/otp-input";
 
 type Step = "details" | "verify" | "passkey" | "done";
 
@@ -37,6 +38,7 @@ export function Register(props: RegisterProps) {
   const [displayName, setDisplayName] = createSignal("");
   const [otp, setOtp] = createSignal("");
   const [busy, setBusy] = createSignal(false);
+  const [otpStatus, setOtpStatus] = createSignal<OtpStatus>("idle");
   const [profileId, setProfileId] = createSignal<string | null>(null);
   const [enrollmentToken, setEnrollmentToken] = createSignal<string | null>(null);
 
@@ -119,12 +121,15 @@ export function Register(props: RegisterProps) {
    */
   async function submitOtp(e: Event) {
     e.preventDefault();
-    if (busy() || otp().length !== 6) return;
+    const value = otp();
+    if (busy() || value.length !== 6) return;
     setBusy(true);
+    setOtpStatus("verifying");
     try {
-      const result = await client.completeRegistration({ email: email(), code: otp() });
+      const result = await client.completeRegistration({ email: email(), code: value });
       setProfileId(result.profileId);
       setEnrollmentToken(result.enrollmentToken);
+      setOtpStatus("accepted");
       // Sign them in *now* — passkey enrolment is an upsell, not a gate.
       await adoptSession(result.session);
       toast.success("Email verified");
@@ -135,7 +140,27 @@ export function Register(props: RegisterProps) {
         setStep("done");
       }
     } catch (err) {
+      setOtpStatus("error");
       toast.error(err instanceof Error ? err.message : "Invalid code");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function resendCode() {
+    if (busy()) return;
+    setBusy(true);
+    try {
+      await client.beginRegistration({
+        email: email(),
+        handle: handle(),
+        displayName: displayName().trim() || undefined,
+      });
+      setOtp("");
+      setOtpStatus("idle");
+      toast.success("New code sent");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not resend code");
     } finally {
       setBusy(false);
     }
@@ -256,23 +281,35 @@ export function Register(props: RegisterProps) {
           <p class="text-muted-foreground text-sm">
             We sent a 6-digit code to <strong>{email()}</strong>. Enter it below to verify.
           </p>
-          <div class="flex flex-col gap-1">
-            <Label for="reg-otp">Verification code</Label>
-            <Input
-              id="reg-otp"
-              type="text"
-              inputmode="numeric"
-              autocomplete="one-time-code"
-              maxLength={6}
-              required
-              value={otp()}
-              onInput={(e) => setOtp(e.currentTarget.value.replace(/\D/g, "").slice(0, 6))}
-              class="text-center tracking-[0.5em]"
-            />
-          </div>
+          <OtpInput
+            value={otp()}
+            onChange={setOtp}
+            status={otpStatus()}
+            disabled={busy()}
+            autofocus
+          />
+          <Show when={otpStatus() === "error"}>
+            <p class="text-destructive text-sm">Incorrect code. Please try again</p>
+          </Show>
+          <Show when={otpStatus() === "verifying"}>
+            <p class="text-muted-foreground text-sm">Verifying your code…</p>
+          </Show>
+          <Show when={otpStatus() === "accepted"}>
+            <p class="text-sm text-green-600">Accepted</p>
+          </Show>
           <Button type="submit" disabled={otp().length !== 6 || busy()}>
             {busy() ? "Verifying…" : "Verify email"}
           </Button>
+          <Show when={otpStatus() === "error"}>
+            <button
+              type="button"
+              onClick={resendCode}
+              class="text-primary text-sm font-medium hover:underline"
+              disabled={busy()}
+            >
+              Resend code
+            </button>
+          </Show>
           <Button variant="ghost" size="sm" onClick={() => setStep("details")}>
             ← Use a different email
           </Button>

--- a/osn/ui/src/auth/SignIn.tsx
+++ b/osn/ui/src/auth/SignIn.tsx
@@ -7,6 +7,7 @@ import { toast } from "solid-toast";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
+import { OtpInput, type OtpStatus } from "../components/ui/otp-input";
 import { clsx } from "../lib/utils";
 
 /**
@@ -52,6 +53,7 @@ export function SignIn(props: SignInProps) {
   const [otpCode, setOtpCode] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+  const [otpStatus, setOtpStatus] = createSignal<OtpStatus>("idle");
 
   // If the requested default tab is passkey but the environment doesn't
   // support it, silently fall through to OTP. Done in an onMount to avoid
@@ -65,6 +67,7 @@ export function SignIn(props: SignInProps) {
     setStep("identifier");
     setOtpCode("");
     setError(null);
+    setOtpStatus("idle");
   }
 
   function reportError(e: unknown, fallback: string) {
@@ -117,14 +120,34 @@ export function SignIn(props: SignInProps) {
 
   async function submitOtpCode(e: Event) {
     e.preventDefault();
-    if (busy() || otpCode().length !== 6) return;
+    const value = otpCode();
+    if (busy() || value.length !== 6) return;
+    setBusy(true);
+    setError(null);
+    setOtpStatus("verifying");
+    try {
+      const { session } = await client.otpComplete(identifier().trim(), value);
+      setOtpStatus("accepted");
+      await finishWithSession(session);
+    } catch (err) {
+      setOtpStatus("error");
+      reportError(err, "Invalid code");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function resendOtpCode() {
+    if (busy() || !identifier().trim()) return;
     setBusy(true);
     setError(null);
     try {
-      const { session } = await client.otpComplete(identifier().trim(), otpCode());
-      await finishWithSession(session);
+      await client.otpBegin(identifier().trim());
+      setOtpCode("");
+      setOtpStatus("idle");
+      toast.success("New code sent");
     } catch (err) {
-      reportError(err, "Invalid code");
+      reportError(err, "Couldn't resend code");
     } finally {
       setBusy(false);
     }
@@ -253,23 +276,35 @@ export function SignIn(props: SignInProps) {
             If <strong>{identifier()}</strong> matches an account, we sent a 6-digit code. Enter it
             below.
           </p>
-          <div class="flex flex-col gap-1">
-            <Label for="si-otp-code">Verification code</Label>
-            <Input
-              id="si-otp-code"
-              type="text"
-              inputmode="numeric"
-              autocomplete="one-time-code"
-              maxLength={6}
-              required
-              value={otpCode()}
-              onInput={(e) => setOtpCode(e.currentTarget.value.replace(/\D/g, "").slice(0, 6))}
-              class="text-center tracking-[0.5em]"
-            />
-          </div>
+          <OtpInput
+            value={otpCode()}
+            onChange={setOtpCode}
+            status={otpStatus()}
+            disabled={busy()}
+            autofocus
+          />
+          <Show when={otpStatus() === "error"}>
+            <p class="text-destructive text-sm">Incorrect code. Please try again</p>
+          </Show>
+          <Show when={otpStatus() === "verifying"}>
+            <p class="text-muted-foreground text-sm">Verifying your code…</p>
+          </Show>
+          <Show when={otpStatus() === "accepted"}>
+            <p class="text-sm text-green-600">Accepted</p>
+          </Show>
           <Button type="submit" disabled={busy() || otpCode().length !== 6}>
             {busy() ? "Verifying…" : "Sign in"}
           </Button>
+          <Show when={otpStatus() === "error"}>
+            <button
+              type="button"
+              onClick={resendOtpCode}
+              class="text-primary text-sm font-medium hover:underline"
+              disabled={busy()}
+            >
+              Resend code
+            </button>
+          </Show>
           <Button variant="ghost" size="sm" onClick={() => setStep("identifier")}>
             ← Use a different identifier
           </Button>

--- a/osn/ui/src/auth/SignIn.tsx
+++ b/osn/ui/src/auth/SignIn.tsx
@@ -54,6 +54,7 @@ export function SignIn(props: SignInProps) {
   const [busy, setBusy] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [otpStatus, setOtpStatus] = createSignal<OtpStatus>("idle");
+  const [resendCooldown, setResendCooldown] = createSignal(0);
 
   // If the requested default tab is passkey but the environment doesn't
   // support it, silently fall through to OTP. Done in an onMount to avoid
@@ -137,14 +138,28 @@ export function SignIn(props: SignInProps) {
     }
   }
 
+  function startResendCooldown() {
+    setResendCooldown(30);
+    const id = setInterval(() => {
+      setResendCooldown((n) => {
+        if (n <= 1) {
+          clearInterval(id);
+          return 0;
+        }
+        return n - 1;
+      });
+    }, 1000);
+  }
+
   async function resendOtpCode() {
-    if (busy() || !identifier().trim()) return;
+    if (busy() || !identifier().trim() || resendCooldown() > 0) return;
     setBusy(true);
     setError(null);
     try {
       await client.otpBegin(identifier().trim());
       setOtpCode("");
       setOtpStatus("idle");
+      startResendCooldown();
       toast.success("New code sent");
     } catch (err) {
       reportError(err, "Couldn't resend code");
@@ -299,10 +314,10 @@ export function SignIn(props: SignInProps) {
             <button
               type="button"
               onClick={resendOtpCode}
-              class="text-primary text-sm font-medium hover:underline"
-              disabled={busy()}
+              class="text-primary text-sm font-medium hover:underline disabled:opacity-50"
+              disabled={busy() || resendCooldown() > 0}
             >
-              Resend code
+              {resendCooldown() > 0 ? `Resend code (${resendCooldown()}s)` : "Resend code"}
             </button>
           </Show>
           <Button variant="ghost" size="sm" onClick={() => setStep("identifier")}>

--- a/osn/ui/src/components/ui/otp-input.tsx
+++ b/osn/ui/src/components/ui/otp-input.tsx
@@ -1,0 +1,128 @@
+import { clsx } from "clsx";
+import { createEffect, createSignal, For, onMount, splitProps, type Component } from "solid-js";
+
+type OtpStatus = "idle" | "error" | "verifying" | "accepted";
+
+interface OtpInputProps {
+  /** Current value (up to 6 digits). */
+  value: string;
+  /** Called on every change with the new digit string. */
+  onChange: (value: string) => void;
+  /** Visual status of the input group. */
+  status?: OtpStatus;
+  /** Whether all inputs are disabled. */
+  disabled?: boolean;
+  /** Auto-focus the first input on mount. */
+  autofocus?: boolean;
+}
+
+const LENGTH = 6;
+
+const OtpInput: Component<OtpInputProps> = (props) => {
+  const [local] = splitProps(props, ["value", "onChange", "status", "disabled", "autofocus"]);
+  let inputs: HTMLInputElement[] = [];
+  const [focusedIndex, setFocusedIndex] = createSignal(-1);
+
+  const digits = () => local.value.split("");
+  const status = () => local.status ?? "idle";
+
+  onMount(() => {
+    if (local.autofocus) inputs[0]?.focus();
+  });
+
+  // When status changes to error, focus the first input so user can retry
+  createEffect(() => {
+    if (status() === "error") inputs[0]?.focus();
+  });
+
+  function focusIndex(i: number) {
+    if (i >= 0 && i < LENGTH) inputs[i]?.focus();
+  }
+
+  function handleInput(index: number, e: InputEvent) {
+    const target = e.target as HTMLInputElement;
+    const char = target.value.replace(/\D/g, "").slice(-1);
+    if (!char) return;
+
+    const current = digits();
+    current[index] = char;
+    const next = current.join("").slice(0, LENGTH);
+    local.onChange(next);
+
+    if (index < LENGTH - 1) {
+      focusIndex(index + 1);
+    }
+  }
+
+  function handleKeyDown(index: number, e: KeyboardEvent) {
+    if (e.key === "Backspace") {
+      e.preventDefault();
+      const current = digits();
+      if (current[index]) {
+        current[index] = "";
+        local.onChange(current.join(""));
+      } else if (index > 0) {
+        current[index - 1] = "";
+        local.onChange(current.join(""));
+        focusIndex(index - 1);
+      }
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      focusIndex(index - 1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      focusIndex(index + 1);
+    }
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    e.preventDefault();
+    const pasted = (e.clipboardData?.getData("text") ?? "").replace(/\D/g, "").slice(0, LENGTH);
+    if (!pasted) return;
+    local.onChange(pasted);
+    focusIndex(Math.min(pasted.length, LENGTH - 1));
+  }
+
+  function borderClass(index: number) {
+    const s = status();
+    if (s === "error") return "base:border-red-500";
+    if (s === "accepted") return "base:border-green-600";
+    if (s === "verifying" && focusedIndex() === index)
+      return "base:border-blue-500 base:ring-1 base:ring-blue-500";
+    if (s === "verifying") return "base:border-border";
+    // idle
+    if (focusedIndex() === index) return "base:border-foreground base:ring-1 base:ring-foreground";
+    return "base:border-border";
+  }
+
+  return (
+    <div class="base:flex base:gap-2" role="group" aria-label="Verification code">
+      <For each={Array.from({ length: LENGTH })}>
+        {(_, i) => (
+          <input
+            ref={(el) => (inputs[i()] = el)}
+            type="text"
+            inputmode="numeric"
+            autocomplete={i() === 0 ? "one-time-code" : "off"}
+            maxLength={1}
+            disabled={local.disabled || status() === "verifying" || status() === "accepted"}
+            value={digits()[i()] ?? ""}
+            onInput={(e) => handleInput(i(), e)}
+            onKeyDown={(e) => handleKeyDown(i(), e)}
+            onPaste={handlePaste}
+            onFocus={() => setFocusedIndex(i())}
+            onBlur={() => setFocusedIndex(-1)}
+            aria-label={`Digit ${i() + 1}`}
+            class={clsx(
+              "base:h-12 base:w-12 base:rounded-md base:border-2 base:bg-background base:text-center base:text-lg base:font-medium base:text-foreground base:outline-none base:transition-colors base:disabled:cursor-not-allowed base:disabled:opacity-70",
+              borderClass(i()),
+            )}
+          />
+        )}
+      </For>
+    </div>
+  );
+};
+
+export { OtpInput };
+export type { OtpInputProps, OtpStatus };

--- a/osn/ui/src/components/ui/otp-input.tsx
+++ b/osn/ui/src/components/ui/otp-input.tsx
@@ -17,6 +17,7 @@ interface OtpInputProps {
 }
 
 const LENGTH = 6;
+const INDICES = Array.from({ length: LENGTH });
 
 const OtpInput: Component<OtpInputProps> = (props) => {
   const [local] = splitProps(props, ["value", "onChange", "status", "disabled", "autofocus"]);
@@ -97,7 +98,7 @@ const OtpInput: Component<OtpInputProps> = (props) => {
 
   return (
     <div class="base:flex base:gap-2" role="group" aria-label="Verification code">
-      <For each={Array.from({ length: LENGTH })}>
+      <For each={INDICES}>
         {(_, i) => (
           <input
             ref={(el) => (inputs[i()] = el)}

--- a/osn/ui/tests/auth/Register.test.tsx
+++ b/osn/ui/tests/auth/Register.test.tsx
@@ -213,6 +213,14 @@ describe("Register component", () => {
       });
     }
 
+    /** Type digits into the individual OTP boxes. */
+    function fillOtpDigits(digits: string) {
+      for (let i = 0; i < digits.length && i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: digits[i] } });
+      }
+    }
+
     it("calls beginRegistration with the form values and advances to verify", async () => {
       await advanceToVerify();
       expect(stub.beginRegistration).toHaveBeenCalledWith({
@@ -222,28 +230,39 @@ describe("Register component", () => {
       });
     });
 
-    it("verify submit stays disabled until 6 digits are entered", async () => {
+    it("submit stays disabled until 6 digits are entered", async () => {
       await advanceToVerify();
-      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
-      fireEvent.input(otp, { target: { value: "123" } });
+      fillOtpDigits("123");
       const submit = screen.getByRole("button", {
         name: /Verify email/i,
       }) as HTMLButtonElement;
       expect(submit.disabled).toBe(true);
-
-      fireEvent.input(otp, { target: { value: "123456" } });
-      expect(submit.disabled).toBe(false);
     });
 
-    it("OTP input strips non-digits and clamps to 6", async () => {
+    it("OTP input rejects non-digit characters", async () => {
+      stub.completeRegistration.mockResolvedValue({
+        profileId: "usr_abc",
+        session: sampleSession,
+        enrollmentToken: "enroll_xyz",
+      });
       await advanceToVerify();
-      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
-      fireEvent.input(otp, { target: { value: "12ab34cd5678" } });
-      expect(otp.value).toBe("123456");
+      // Type non-digits into each box — completeRegistration should never fire.
+      for (let i = 0; i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "a" } });
+      }
+      expect(stub.completeRegistration).not.toHaveBeenCalled();
     });
   });
 
   describe("passkey step (supported)", () => {
+    function fillOtpDigits(digits: string) {
+      for (let i = 0; i < digits.length && i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: digits[i] } });
+      }
+    }
+
     async function reachPasskey() {
       stub.checkHandle.mockResolvedValue({ available: true });
       stub.beginRegistration.mockResolvedValue({ sent: true });
@@ -260,10 +279,8 @@ describe("Register component", () => {
       fillHandle("alice");
       await vi.advanceTimersByTimeAsync(350);
       fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
-      await waitFor(() => screen.getByLabelText(/Verification code/));
-      fireEvent.input(screen.getByLabelText(/Verification code/), {
-        target: { value: "123456" },
-      });
+      await waitFor(() => screen.getByLabelText("Digit 1"));
+      fillOtpDigits("123456");
       fireEvent.click(screen.getByRole("button", { name: /Verify email/i }));
       await waitFor(() => screen.getByRole("button", { name: /Create passkey/i }));
     }
@@ -335,10 +352,11 @@ describe("Register component", () => {
       fillHandle("alice");
       await vi.advanceTimersByTimeAsync(350);
       fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
-      await waitFor(() => screen.getByLabelText(/Verification code/));
-      fireEvent.input(screen.getByLabelText(/Verification code/), {
-        target: { value: "123456" },
-      });
+      await waitFor(() => screen.getByLabelText("Digit 1"));
+      for (let i = 0; i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "123456"[i] } });
+      }
       fireEvent.click(screen.getByRole("button", { name: /Verify email/i }));
 
       // adoptSession is called as part of submitOtp, then we jump to done.

--- a/osn/ui/tests/auth/Register.test.tsx
+++ b/osn/ui/tests/auth/Register.test.tsx
@@ -230,13 +230,16 @@ describe("Register component", () => {
       });
     });
 
-    it("submit stays disabled until 6 digits are entered", async () => {
+    it("submit stays disabled until 6 digits are entered, then enables", async () => {
       await advanceToVerify();
       fillOtpDigits("123");
       const submit = screen.getByRole("button", {
         name: /Verify email/i,
       }) as HTMLButtonElement;
       expect(submit.disabled).toBe(true);
+
+      fillOtpDigits("123456");
+      expect(submit.disabled).toBe(false);
     });
 
     it("OTP input rejects non-digit characters", async () => {

--- a/osn/ui/tests/auth/SignIn.test.tsx
+++ b/osn/ui/tests/auth/SignIn.test.tsx
@@ -136,6 +136,13 @@ describe("SignIn component", () => {
   });
 
   describe("OTP mode", () => {
+    function fillOtpDigits(digits: string) {
+      for (let i = 0; i < digits.length && i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: digits[i] } });
+      }
+    }
+
     it("happy path: begin → code entry → complete → adoptSession", async () => {
       stub.otpBegin.mockResolvedValue({ sent: true });
       stub.otpComplete.mockResolvedValue({ session: sampleSession, user: sampleUser });
@@ -145,9 +152,8 @@ describe("SignIn component", () => {
       fillIdentifier("alice@example.com");
       fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
 
-      await waitFor(() => screen.getByLabelText(/Verification code/));
-      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
-      fireEvent.input(otp, { target: { value: "123456" } });
+      await waitFor(() => screen.getByLabelText("Digit 1"));
+      fillOtpDigits("123456");
       fireEvent.click(screen.getByRole("button", { name: /^Sign in$/i }));
 
       await waitFor(() => {
@@ -157,15 +163,18 @@ describe("SignIn component", () => {
       expect(stub.otpComplete).toHaveBeenCalledWith("alice@example.com", "123456");
     });
 
-    it("OTP code input strips non-digits and caps at 6 chars", async () => {
+    it("OTP input rejects non-digit characters", async () => {
       stub.otpBegin.mockResolvedValue({ sent: true });
       render(() => <SignIn client={asClient(stub)} defaultMethod="otp" />);
       fillIdentifier("alice@example.com");
       fireEvent.click(screen.getByRole("button", { name: /Send verification code/i }));
-      await waitFor(() => screen.getByLabelText(/Verification code/));
-      const otp = screen.getByLabelText(/Verification code/) as HTMLInputElement;
-      fireEvent.input(otp, { target: { value: "12ab34cd56789" } });
-      expect(otp.value).toBe("123456");
+      await waitFor(() => screen.getByLabelText("Digit 1"));
+      // Type non-digits into each box — otpComplete should never fire.
+      for (let i = 0; i < 6; i++) {
+        const input = screen.getByLabelText(`Digit ${i + 1}`) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "x" } });
+      }
+      expect(stub.otpComplete).not.toHaveBeenCalled();
     });
   });
 

--- a/osn/ui/tests/components/ui/otp-input.test.tsx
+++ b/osn/ui/tests/components/ui/otp-input.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { render, cleanup, screen, fireEvent } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { OtpInput } from "../../../src/components/ui/otp-input";
+
+function digit(n: number) {
+  return screen.getByLabelText(`Digit ${n}`) as HTMLInputElement;
+}
+
+function renderOtp(initial = "", status?: "idle" | "error" | "verifying" | "accepted") {
+  const [value, setValue] = createSignal(initial);
+  const onChange = vi.fn((v: string) => setValue(v));
+  render(() => <OtpInput value={value()} onChange={onChange} status={status} />);
+  return { value, onChange };
+}
+
+describe("OtpInput", () => {
+  afterEach(() => cleanup());
+
+  it("renders 6 digit inputs", () => {
+    renderOtp();
+    for (let i = 1; i <= 6; i++) {
+      expect(digit(i)).toBeTruthy();
+    }
+  });
+
+  it("typing a digit calls onChange and advances focus", () => {
+    const { onChange } = renderOtp();
+    fireEvent.input(digit(1), { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith("5");
+  });
+
+  it("ignores non-digit characters", () => {
+    const { onChange } = renderOtp();
+    fireEvent.input(digit(1), { target: { value: "a" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("Backspace on filled cell clears it in place", () => {
+    const { onChange } = renderOtp("12");
+    fireEvent.keyDown(digit(1), { key: "Backspace" });
+    expect(onChange).toHaveBeenCalledWith("2");
+  });
+
+  it("Backspace on empty cell moves focus left and clears previous", () => {
+    const { onChange } = renderOtp("1");
+    // Digit 2 is empty, press backspace
+    fireEvent.keyDown(digit(2), { key: "Backspace" });
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("ArrowLeft and ArrowRight do not crash at boundaries", () => {
+    renderOtp();
+    // Should not throw at boundaries
+    fireEvent.keyDown(digit(1), { key: "ArrowLeft" });
+    fireEvent.keyDown(digit(6), { key: "ArrowRight" });
+    // Inputs still present after boundary key events
+    expect(digit(1)).toBeTruthy();
+    expect(digit(6)).toBeTruthy();
+  });
+
+  it("paste fills all digits", () => {
+    const { onChange } = renderOtp();
+    fireEvent.paste(digit(1), {
+      clipboardData: { getData: () => "123456" },
+    });
+    expect(onChange).toHaveBeenCalledWith("123456");
+  });
+
+  it("paste strips non-digits and caps at 6", () => {
+    const { onChange } = renderOtp();
+    fireEvent.paste(digit(1), {
+      clipboardData: { getData: () => "12ab34cd5678" },
+    });
+    expect(onChange).toHaveBeenCalledWith("123456");
+  });
+
+  it("paste with only non-digits does nothing", () => {
+    const { onChange } = renderOtp();
+    fireEvent.paste(digit(1), {
+      clipboardData: { getData: () => "abcdef" },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("inputs are disabled when status is verifying", () => {
+    renderOtp("123456", "verifying");
+    for (let i = 1; i <= 6; i++) {
+      expect(digit(i).disabled).toBe(true);
+    }
+  });
+
+  it("inputs are disabled when status is accepted", () => {
+    renderOtp("123456", "accepted");
+    for (let i = 1; i <= 6; i++) {
+      expect(digit(i).disabled).toBe(true);
+    }
+  });
+
+  it("inputs are enabled when status is idle", () => {
+    renderOtp("", "idle");
+    for (let i = 1; i <= 6; i++) {
+      expect(digit(i).disabled).toBe(false);
+    }
+  });
+});

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -178,7 +178,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 ### Medium
 
 - [ ] S-M1 — `verifyAccessToken` rejects tokens missing `handle` claim — treat missing as `null` during transition
-- [ ] S-M3 — No "resend code" button after registration OTP; SMTP failure = claimed handle with no recovery
+- [x] S-M3 — No "resend code" button after registration OTP; SMTP failure = claimed handle with no recovery — **Fixed**: OTP input component now shows "Resend code" button on error with 30s cooldown
 - [ ] S-M4 — Legacy `POST /register` returns raw `String(catch)` — extend `publicError()` mapper
 - [ ] S-M5 — `displayName` in JWT (1h TTL) — stale after profile update
 - [ ] S-M6 — Wildcard CORS on auth server — restrict to known client origins before deployment

--- a/wiki/architecture/component-library.md
+++ b/wiki/architecture/component-library.md
@@ -20,7 +20,7 @@ related:
 packages:
   - "@osn/ui"
   - "@pulse/app"
-last-reviewed: 2026-04-15
+last-reviewed: 2026-04-16
 ---
 
 # Component Library (Zaidan)
@@ -52,13 +52,14 @@ osn/ui/src/
 │       ├── dialog.tsx         ← Dialog, DialogContent, etc. (Kobalte)
 │       ├── input.tsx          ← Input
 │       ├── label.tsx          ← Label
+│       ├── otp-input.tsx      ← OtpInput (6-digit code verification)
 │       ├── popover.tsx        ← Popover, PopoverTrigger, etc. (Kobalte)
 │       ├── radio-group.tsx    ← RadioGroup, RadioGroupItem (Kobalte)
 │       ├── tabs.tsx           ← Tabs, TabsList, TabsTrigger (Kobalte)
 │       └── textarea.tsx       ← Textarea
 └── auth/
-    ├── Register.tsx           ← uses Button, Input, Label
-    └── SignIn.tsx             ← uses Button, Input, Label, clsx()
+    ├── Register.tsx           ← uses Button, Input, Label, OtpInput
+    └── SignIn.tsx             ← uses Button, Input, Label, OtpInput, clsx()
 ```
 
 Consuming apps import via subpath exports:


### PR DESCRIPTION
## Summary
- Add `OtpInput` component (`@osn/ui`) with 6 individual digit boxes, visual status states (idle, error, verifying, accepted), keyboard navigation, paste support, and 30s resend cooldown
- Fix three login endpoints (`/login/otp/complete`, `/login/passkey/complete`, `/login/magic/verify`) to return snake_case OAuth token format matching what the client expects
- Extract `toTokenResponse()` helper to DRY up all 5 token-returning endpoints in auth routes

## Workspaces affected
- `@osn/ui` (minor) — new OTP input component, updated Register + SignIn forms
- `@osn/core` (patch) — fix token response format on login endpoints

## Decisions & issues

**[Token format direction]** — snake_case on the wire for all token responses
- **Issue:** Login endpoints returned camelCase `TokenSet` but client expected snake_case OAuth format. Registration endpoint already converted correctly.
- **Why:** Inconsistent wire format caused `parseTokenResponse` schema validation to fail with `["access_token"] is missing`.
- **Solution:** Convert all token-returning endpoints to snake_case via shared `toTokenResponse()` helper, matching OAuth convention.
- **Rationale:** OAuth spec mandates snake_case for `/token`; keeping first-party routes consistent avoids two parsers and reduces confusion.

**[No auto-submit on OTP]** — submit button required after entering all 6 digits
- **Issue:** Initial implementation auto-submitted on the 6th digit entry.
- **Why:** Users may make mistakes and shouldn't immediately see an error state.
- **Solution:** Removed `onComplete` auto-submit, added back explicit submit button (disabled until 6 digits filled).
- **Rationale:** User preference — gives people a chance to review before submitting.

**[P-I1]** — `Array.from` in `<For>` loop
- **Issue:** `Array.from({ length: 6 })` created a new array reference on every render, defeating SolidJS fine-grained reactivity.
- **Why:** `<For>` uses referential identity — new ref = unnecessary reconciliation of all 6 children.
- **Solution:** Hoisted to module-level `const INDICES`.
- **Rationale:** Idiomatic SolidJS pattern for fixed-length lists.

**[S-L1 / S-M3]** — Resend code button with cooldown
- **Issue:** No resend button existed (S-M3), and the new one initially had no client-side rate limit guard (S-L1).
- **Why:** Server rate limit exists (5 req/min) but users could burn through it unknowingly; also SMTP failure with no resend = dead end.
- **Solution:** Added "Resend code" button visible on error state, with 30-second cooldown timer showing countdown.
- **Rationale:** Defense-in-depth + clear UX feedback on retry availability.

**[T-R1]** — No route test for `/login/passkey/complete`
- **Issue:** Passkey login complete has no HTTP-level test asserting response shape.
- **Why:** Difficult to test without full WebAuthn ceremony mock in happy-dom.
- **Solution:** Dismissed — tracked for future coverage.
- **Rationale:** OTP and magic link endpoints have response-shape tests covering the shared `toTokenResponse()` path. Passkey-specific test requires more ceremony mocking infrastructure.

**[T-U1]** — Resend functions untested
- **Issue:** `resendCode()` and `resendOtpCode()` have no direct test coverage.
- **Why:** The error-recovery UX path (error → resend → retry) is new.
- **Solution:** Dismissed — tracked for future coverage.
- **Rationale:** The underlying API calls (`beginRegistration`, `otpBegin`) are tested elsewhere. Resend is a thin wrapper; integration testing the full flow is lower priority than the component unit tests we did add.

## Test plan
- [x] `bun run --cwd osn/core test:run` — 418 tests pass
- [x] `bun run --cwd osn/client test:run` — 56 tests pass
- [x] `bun run --cwd osn/ui test:run` — 77 tests pass (12 new OTP component unit tests)
- [x] `bun run build` — all workspaces build
- [x] Type check passes across all 16 packages
- [ ] Manual: start dev, register with OTP — verify 6-digit boxes render, submit button works, error/accepted states display
- [ ] Manual: start dev, sign in with OTP — verify same behavior, resend cooldown shows countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)