### PR TITLE
feat: launch @osn/social app with recommendations backend

### DIFF
--- a/.changeset/osn-social-app.md
+++ b/.changeset/osn-social-app.md
@@ -1,0 +1,12 @@
+---
+"@osn/social": minor
+"@osn/core": minor
+"@osn/client": minor
+"@osn/app": patch
+---
+
+Add `@osn/social` app — identity and social graph management UI. Add
+`recommendations` service and route to `@osn/core`. Add `graph` and
+`organisations` client modules with Solid `GraphProvider` and `OrgProvider`.
+Fix dropdown menu not opening by wrapping `DropdownMenuLabel` in
+`DropdownMenuGroup` (required by Kobalte).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Monorepo organised by domain. Four directories, four prefixes — see `[[wiki/ar
 
 | Dir | Prefix | What lives here |
 |-----|--------|-----------------|
-| `osn/` | `@osn/*` | Identity stack (auth, graph, organisations, SDK, crypto, landing) |
+| `osn/` | `@osn/*` | Identity stack (auth, graph, organisations, recommendations, SDK, crypto, landing, social app) |
 | `pulse/` | `@pulse/*` | Events stack (app, API, DB) |
 | `zap/` | `@zap/*` | Messaging stack (API on port 3002, DB) |
 | `shared/` | `@shared/*` | Cross-cutting utilities |
@@ -88,7 +88,7 @@ Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+RES
 
 **Observability** — OpenTelemetry end-to-end, shipped to Grafana Cloud. Three golden rules: no `console.*`, no raw OTel constructors, no unbounded metric attributes. See `[[wiki/observability/overview]]`.
 
-**Rate Limiting** — Per-IP fixed-window on all auth endpoints; per-user on graph writes. Two backends: Redis-backed when `REDIS_URL` is set (cross-process, survives restarts), in-memory fallback when unset (local dev). See `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]`.
+**Rate Limiting** — Per-IP fixed-window on all auth endpoints; per-user on graph writes, org writes, and `/recommendations/connections` reads. Two backends: Redis-backed when `REDIS_URL` is set (cross-process, survives restarts), in-memory fallback when unset (local dev). See `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]`.
 
 **Testing** — `it.effect` + `createTestLayer()` for service tests; `createXxxRoutes(createTestLayer())` for route tests. All in-memory SQLite. See `[[wiki/conventions/testing-patterns]]`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "osn/app": {
       "name": "@osn/app",
-      "version": "0.3.9",
+      "version": "0.3.11",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/core": "workspace:*",
@@ -49,7 +49,7 @@
     },
     "osn/core": {
       "name": "@osn/core",
-      "version": "0.16.2",
+      "version": "0.16.4",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@osn/crypto": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "osn/crypto": {
       "name": "@osn/crypto",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -115,9 +115,33 @@
         "typescript": "^5.9.3",
       },
     },
+    "osn/social": {
+      "name": "@osn/social",
+      "version": "0.1.0",
+      "dependencies": {
+        "@osn/client": "workspace:*",
+        "@osn/ui": "workspace:*",
+        "@simplewebauthn/browser": "^13.3.0",
+        "@solidjs/router": "^0.16.0",
+        "@tailwindcss/vite": "^4.2.1",
+        "solid-js": "^1.9.3",
+        "solid-toast": "^0.5.0",
+        "tailwindcss": "^4.2.1",
+      },
+      "devDependencies": {
+        "@shared/typescript-config": "workspace:*",
+        "@solidjs/testing-library": "^0.8.10",
+        "@vitest/coverage-istanbul": "^4.1.0",
+        "happy-dom": "^20.8.4",
+        "typescript": "^5.9.3",
+        "vite": "^8.0.8",
+        "vite-plugin-solid": "^2.11.0",
+        "vitest": "^4.1.2",
+      },
+    },
     "osn/ui": {
       "name": "@osn/ui",
-      "version": "0.5.1",
+      "version": "0.7.0",
       "dependencies": {
         "@kobalte/core": "^0.13.11",
         "@osn/client": "workspace:*",
@@ -143,7 +167,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.9.5",
+      "version": "0.9.7",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -165,7 +189,7 @@
     },
     "pulse/app": {
       "name": "@pulse/app",
-      "version": "0.7.10",
+      "version": "0.8.0",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -225,7 +249,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.2.10",
+      "version": "0.3.0",
       "dependencies": {
         "@effect/opentelemetry": "^0.63.0",
         "@opentelemetry/api": "^1.9.0",
@@ -266,7 +290,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "dependencies": {
         "@elysiajs/cors": "^1.4.0",
         "@elysiajs/eden": "^1.2.0",
@@ -646,6 +670,8 @@
     "@osn/db": ["@osn/db@workspace:osn/db"],
 
     "@osn/landing": ["@osn/landing@workspace:osn/landing"],
+
+    "@osn/social": ["@osn/social@workspace:osn/social"],
 
     "@osn/ui": ["@osn/ui@workspace:osn/ui"],
 

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -11,6 +11,7 @@ import {
   createRedisGraphRateLimiter,
   createRedisOrgRateLimiter,
   createRedisProfileRateLimiters,
+  createRedisRecommendationRateLimiter,
 } from "@osn/core";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
@@ -53,6 +54,7 @@ const authRateLimiters = createRedisAuthRateLimiters(redisClient);
 const graphRateLimiter = createRedisGraphRateLimiter(redisClient);
 const orgRateLimiter = createRedisOrgRateLimiter(redisClient);
 const profileRateLimiters = createRedisProfileRateLimiters(redisClient);
+const recommendationRateLimiter = createRedisRecommendationRateLimiter(redisClient);
 
 const app = new Elysia()
   .use(cors())
@@ -65,7 +67,9 @@ const app = new Elysia()
   .use(createOrganisationRoutes(authConfig, DbLive, observabilityLayer, orgRateLimiter))
   .use(createInternalOrganisationRoutes(DbLive))
   .use(createProfileRoutes(authConfig, DbLive, observabilityLayer, profileRateLimiters))
-  .use(createRecommendationRoutes(authConfig, DbLive, observabilityLayer));
+  .use(
+    createRecommendationRoutes(authConfig, DbLive, observabilityLayer, recommendationRateLimiter),
+  );
 
 if (process.env.NODE_ENV !== "test") {
   app.listen({ port, reusePort: false });

--- a/osn/app/src/index.ts
+++ b/osn/app/src/index.ts
@@ -6,6 +6,7 @@ import {
   createOrganisationRoutes,
   createInternalOrganisationRoutes,
   createProfileRoutes,
+  createRecommendationRoutes,
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,
   createRedisOrgRateLimiter,
@@ -63,7 +64,8 @@ const app = new Elysia()
   .use(createInternalGraphRoutes(DbLive))
   .use(createOrganisationRoutes(authConfig, DbLive, observabilityLayer, orgRateLimiter))
   .use(createInternalOrganisationRoutes(DbLive))
-  .use(createProfileRoutes(authConfig, DbLive, observabilityLayer, profileRateLimiters));
+  .use(createProfileRoutes(authConfig, DbLive, observabilityLayer, profileRateLimiters))
+  .use(createRecommendationRoutes(authConfig, DbLive, observabilityLayer));
 
 if (process.env.NODE_ENV !== "test") {
   app.listen({ port, reusePort: false });

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -1,0 +1,194 @@
+/**
+ * Plain-fetch client for the social graph API. No Effect — mirrors the
+ * pattern in `./login.ts`. Each method calls the OSN core REST API with
+ * Bearer token auth.
+ */
+
+export interface GraphClientConfig {
+  /** OSN issuer base URL, e.g. http://localhost:4000 */
+  issuerUrl: string;
+}
+
+export interface ConnectionEntry {
+  handle: string;
+  displayName: string | null;
+  connectedAt: string;
+}
+
+export interface PendingRequestEntry {
+  handle: string;
+  displayName: string | null;
+  requestedAt: string;
+}
+
+export interface ProfileEntry {
+  handle: string;
+  displayName: string | null;
+}
+
+export interface ConnectionStatus {
+  status: "none" | "pending_outgoing" | "pending_incoming" | "connected";
+}
+
+export class GraphClientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GraphClientError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal fetch helpers
+// ---------------------------------------------------------------------------
+
+async function authGet<T>(url: string, token: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authDelete<T>(url: string, token: string): Promise<T> {
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+// ---------------------------------------------------------------------------
+// Query string helper
+// ---------------------------------------------------------------------------
+
+function qs(options?: { limit?: number; offset?: number }): string {
+  if (!options) return "";
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  const str = params.toString();
+  return str ? `?${str}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// Client interface & factory
+// ---------------------------------------------------------------------------
+
+export interface GraphClient {
+  listConnections(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ connections: ConnectionEntry[] }>;
+  listPendingRequests(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ pending: PendingRequestEntry[] }>;
+  listCloseFriends(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ closeFriends: ProfileEntry[] }>;
+  listBlocks(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ blocks: ProfileEntry[] }>;
+  getConnectionStatus(token: string, handle: string): Promise<ConnectionStatus>;
+  sendConnectionRequest(token: string, handle: string): Promise<{ ok: true }>;
+  acceptConnection(token: string, handle: string): Promise<{ ok: true }>;
+  rejectConnection(token: string, handle: string): Promise<{ ok: true }>;
+  removeConnection(token: string, handle: string): Promise<{ ok: true }>;
+  addCloseFriend(token: string, handle: string): Promise<{ ok: true }>;
+  removeCloseFriend(token: string, handle: string): Promise<{ ok: true }>;
+  blockProfile(token: string, handle: string): Promise<{ ok: true }>;
+  unblockProfile(token: string, handle: string): Promise<{ ok: true }>;
+}
+
+export function createGraphClient(config: GraphClientConfig): GraphClient {
+  const base = `${config.issuerUrl.replace(/\/$/, "")}/graph`;
+
+  return {
+    listConnections: (token, options) =>
+      authGet<{ connections: ConnectionEntry[] }>(`${base}/connections${qs(options)}`, token),
+
+    listPendingRequests: (token, options) =>
+      authGet<{ pending: PendingRequestEntry[] }>(
+        `${base}/connections/pending${qs(options)}`,
+        token,
+      ),
+
+    listCloseFriends: (token, options) =>
+      authGet<{ closeFriends: ProfileEntry[] }>(`${base}/close-friends${qs(options)}`, token),
+
+    listBlocks: (token, options) =>
+      authGet<{ blocks: ProfileEntry[] }>(`${base}/blocks${qs(options)}`, token),
+
+    getConnectionStatus: (token, handle) =>
+      authGet<ConnectionStatus>(`${base}/connections/${encodeURIComponent(handle)}`, token),
+
+    sendConnectionRequest: (token, handle) =>
+      authPost<{ ok: true }>(`${base}/connections/${encodeURIComponent(handle)}`, token),
+
+    acceptConnection: (token, handle) =>
+      authPatch<{ ok: true }>(`${base}/connections/${encodeURIComponent(handle)}`, token, {
+        action: "accept",
+      }),
+
+    rejectConnection: (token, handle) =>
+      authPatch<{ ok: true }>(`${base}/connections/${encodeURIComponent(handle)}`, token, {
+        action: "reject",
+      }),
+
+    removeConnection: (token, handle) =>
+      authDelete<{ ok: true }>(`${base}/connections/${encodeURIComponent(handle)}`, token),
+
+    addCloseFriend: (token, handle) =>
+      authPost<{ ok: true }>(`${base}/close-friends/${encodeURIComponent(handle)}`, token),
+
+    removeCloseFriend: (token, handle) =>
+      authDelete<{ ok: true }>(`${base}/close-friends/${encodeURIComponent(handle)}`, token),
+
+    blockProfile: (token, handle) =>
+      authPost<{ ok: true }>(`${base}/blocks/${encodeURIComponent(handle)}`, token),
+
+    unblockProfile: (token, handle) =>
+      authDelete<{ ok: true }>(`${base}/blocks/${encodeURIComponent(handle)}`, token),
+  };
+}

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -41,13 +41,34 @@ export class GraphClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse response body as JSON, returning null if the body isn't JSON.
+ * Prevents SyntaxError from surfacing to UI toasts (S-L2).
+ */
+async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
+  try {
+    return (await res.json()) as T & { error?: string };
+  } catch {
+    return null;
+  }
+}
+
+/** Cap server-supplied error strings before surfacing to the UI (S-L2). */
+function safeErrorMessage(value: unknown, status: number): string {
+  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
+  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+}
+
 async function authGet<T>(url: string, token: string): Promise<T> {
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new GraphClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -61,9 +82,12 @@ async function authPost<T>(url: string, token: string, body?: unknown): Promise<
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new GraphClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -77,9 +101,12 @@ async function authPatch<T>(url: string, token: string, body: unknown): Promise<
     },
     body: JSON.stringify(body),
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new GraphClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -89,9 +116,12 @@ async function authDelete<T>(url: string, token: string): Promise<T> {
     method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new GraphClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new GraphClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }

--- a/osn/client/src/index.ts
+++ b/osn/client/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./errors";
+export * from "./graph";
 export * from "./login";
+export * from "./organisations";
 export * from "./pkce";
 export * from "./register";
 export * from "./service";

--- a/osn/client/src/index.ts
+++ b/osn/client/src/index.ts
@@ -3,6 +3,7 @@ export * from "./graph";
 export * from "./login";
 export * from "./organisations";
 export * from "./pkce";
+export * from "./recommendations";
 export * from "./register";
 export * from "./service";
 export * from "./storage";

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -42,13 +42,31 @@ export class OrgClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
+/** Parse response body as JSON, returning null if the body isn't JSON (S-L2). */
+async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
+  try {
+    return (await res.json()) as T & { error?: string };
+  } catch {
+    return null;
+  }
+}
+
+/** Cap server-supplied error strings before surfacing to the UI (S-L2). */
+function safeErrorMessage(value: unknown, status: number): string {
+  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
+  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+}
+
 async function authGet<T>(url: string, token: string): Promise<T> {
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new OrgClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -62,9 +80,12 @@ async function authPost<T>(url: string, token: string, body?: unknown): Promise<
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new OrgClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -78,9 +99,12 @@ async function authPatch<T>(url: string, token: string, body: unknown): Promise<
     },
     body: JSON.stringify(body),
   });
-  const json = (await res.json()) as T & { error?: string };
+  const json = await safeJson<T>(res);
   if (!res.ok) {
-    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
+  }
+  if (json === null) {
+    throw new OrgClientError(`Invalid response: ${res.status}`);
   }
   return json;
 }
@@ -91,8 +115,8 @@ async function authDelete(url: string, token: string): Promise<void> {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
-    const json = (await res.json()) as { error?: string };
-    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+    const json = await safeJson<Record<string, unknown>>(res);
+    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
   }
 }
 

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -1,0 +1,192 @@
+/**
+ * Plain-fetch client for the organisations API. No Effect — mirrors the
+ * pattern in `./login.ts`. Each method calls the OSN core REST API with
+ * Bearer token auth.
+ */
+
+export interface OrgClientConfig {
+  /** OSN issuer base URL, e.g. http://localhost:4000 */
+  issuerUrl: string;
+}
+
+export interface OrgSummary {
+  id: string;
+  handle: string;
+  name: string;
+  description: string | null;
+  avatarUrl: string | null;
+  ownerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrgMember {
+  profile: {
+    id: string;
+    handle: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+  };
+  role: "admin" | "member";
+  joinedAt: string;
+}
+
+export class OrgClientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OrgClientError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal fetch helpers
+// ---------------------------------------------------------------------------
+
+async function authGet<T>(url: string, token: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+  return json;
+}
+
+async function authDelete(url: string, token: string): Promise<void> {
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const json = (await res.json()) as { error?: string };
+    throw new OrgClientError(json.error ?? `Request failed: ${res.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query string helper
+// ---------------------------------------------------------------------------
+
+function qs(options?: { limit?: number; offset?: number }): string {
+  if (!options) return "";
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  const str = params.toString();
+  return str ? `?${str}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// Client interface & factory
+// ---------------------------------------------------------------------------
+
+export interface OrgClient {
+  listMyOrgs(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ organisations: OrgSummary[] }>;
+  getOrg(token: string, orgId: string): Promise<OrgSummary>;
+  createOrg(
+    token: string,
+    data: { handle: string; name: string; description?: string },
+  ): Promise<OrgSummary>;
+  updateOrg(
+    token: string,
+    orgId: string,
+    data: { name?: string; description?: string },
+  ): Promise<OrgSummary>;
+  deleteOrg(token: string, orgId: string): Promise<void>;
+  listMembers(
+    token: string,
+    orgId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ members: OrgMember[] }>;
+  addMember(
+    token: string,
+    orgId: string,
+    profileId: string,
+    role: "admin" | "member",
+  ): Promise<void>;
+  removeMember(token: string, orgId: string, profileId: string): Promise<void>;
+  updateMemberRole(
+    token: string,
+    orgId: string,
+    profileId: string,
+    role: "admin" | "member",
+  ): Promise<void>;
+}
+
+export function createOrgClient(config: OrgClientConfig): OrgClient {
+  const base = `${config.issuerUrl.replace(/\/$/, "")}/organisations`;
+
+  return {
+    listMyOrgs: (token, options) =>
+      authGet<{ organisations: OrgSummary[] }>(`${base}${qs(options)}`, token),
+
+    getOrg: (token, orgId) => authGet<OrgSummary>(`${base}/${encodeURIComponent(orgId)}`, token),
+
+    createOrg: (token, data) => authPost<OrgSummary>(base, token, data),
+
+    updateOrg: (token, orgId, data) =>
+      authPatch<OrgSummary>(`${base}/${encodeURIComponent(orgId)}`, token, data),
+
+    deleteOrg: (token, orgId) => authDelete(`${base}/${encodeURIComponent(orgId)}`, token),
+
+    listMembers: (token, orgId, options) =>
+      authGet<{ members: OrgMember[] }>(
+        `${base}/${encodeURIComponent(orgId)}/members${qs(options)}`,
+        token,
+      ),
+
+    addMember: (token, orgId, profileId, role) =>
+      authPost(`${base}/${encodeURIComponent(orgId)}/members`, token, { profileId, role }).then(
+        () => undefined,
+      ),
+
+    removeMember: (token, orgId, profileId) =>
+      authDelete(
+        `${base}/${encodeURIComponent(orgId)}/members/${encodeURIComponent(profileId)}`,
+        token,
+      ),
+
+    updateMemberRole: (token, orgId, profileId, role) =>
+      authPatch(
+        `${base}/${encodeURIComponent(orgId)}/members/${encodeURIComponent(profileId)}`,
+        token,
+        { role },
+      ).then(() => undefined),
+  };
+}

--- a/osn/client/src/recommendations.ts
+++ b/osn/client/src/recommendations.ts
@@ -1,0 +1,67 @@
+/**
+ * Plain-fetch client for the recommendations API. Mirrors the pattern in
+ * `./graph.ts` and `./organisations.ts`.
+ */
+
+export interface RecommendationClientConfig {
+  /** OSN issuer base URL, e.g. http://localhost:4000 */
+  issuerUrl: string;
+}
+
+export interface Suggestion {
+  handle: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  mutualCount: number;
+}
+
+export class RecommendationClientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RecommendationClientError";
+  }
+}
+
+async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
+  try {
+    return (await res.json()) as T & { error?: string };
+  } catch {
+    return null;
+  }
+}
+
+function safeErrorMessage(value: unknown, status: number): string {
+  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
+  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+}
+
+export interface RecommendationClient {
+  suggestConnections(
+    token: string,
+    options?: { limit?: number },
+  ): Promise<{ suggestions: Suggestion[] }>;
+}
+
+export function createRecommendationClient(
+  config: RecommendationClientConfig,
+): RecommendationClient {
+  const base = `${config.issuerUrl.replace(/\/$/, "")}/recommendations`;
+
+  return {
+    suggestConnections: async (token, options) => {
+      const limit = options?.limit;
+      const qs = limit !== undefined ? `?limit=${encodeURIComponent(String(limit))}` : "";
+      const res = await fetch(`${base}/connections${qs}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await safeJson<{ suggestions: Suggestion[] }>(res);
+      if (!res.ok) {
+        throw new RecommendationClientError(safeErrorMessage(json?.error, res.status));
+      }
+      if (json === null) {
+        throw new RecommendationClientError(`Invalid response: ${res.status}`);
+      }
+      return json;
+    },
+  };
+}

--- a/osn/client/src/solid/graph-context.tsx
+++ b/osn/client/src/solid/graph-context.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import { createGraphClient, type GraphClient, type GraphClientConfig } from "../graph";
+
+const GraphContext = createContext<GraphClient>();
+
+export function GraphProvider(props: ParentProps & { config: GraphClientConfig }) {
+  const client = createGraphClient(props.config);
+  return <GraphContext.Provider value={client}>{props.children}</GraphContext.Provider>;
+}
+
+export function useGraph(): GraphClient {
+  const ctx = useContext(GraphContext);
+  if (!ctx) throw new Error("useGraph must be used within <GraphProvider>");
+  return ctx;
+}

--- a/osn/client/src/solid/index.ts
+++ b/osn/client/src/solid/index.ts
@@ -1,1 +1,3 @@
 export { AuthProvider, AuthContext, useAuth } from "./context";
+export { GraphProvider, useGraph } from "./graph-context";
+export { OrgProvider, useOrgs } from "./org-context";

--- a/osn/client/src/solid/org-context.tsx
+++ b/osn/client/src/solid/org-context.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import { createOrgClient, type OrgClient, type OrgClientConfig } from "../organisations";
+
+const OrgContext = createContext<OrgClient>();
+
+export function OrgProvider(props: ParentProps & { config: OrgClientConfig }) {
+  const client = createOrgClient(props.config);
+  return <OrgContext.Provider value={client}>{props.children}</OrgContext.Provider>;
+}
+
+export function useOrgs(): OrgClient {
+  const ctx = useContext(OrgContext);
+  if (!ctx) throw new Error("useOrgs must be used within <OrgProvider>");
+  return ctx;
+}

--- a/osn/client/tests/graph.test.ts
+++ b/osn/client/tests/graph.test.ts
@@ -154,6 +154,39 @@ describe("createGraphClient — error surface", () => {
     );
     await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toThrow(/Request failed/);
   });
+
+  it("throws GraphClientError (not SyntaxError) when the error body is not JSON (S-L2)", async () => {
+    // E.g. a proxy returns an HTML error page. The client must not leak
+    // the SyntaxError from res.json() to the caller.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+      }),
+    );
+    await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toBeInstanceOf(
+      GraphClientError,
+    );
+  });
+
+  it("throws GraphClientError when a 200 response body is not JSON (S-L2)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+      }),
+    );
+    await expect(client.listConnections(TOKEN)).rejects.toBeInstanceOf(GraphClientError);
+  });
+
+  it("truncates long error strings (S-L2)", async () => {
+    const long = "x".repeat(500);
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: long }) });
+    await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toThrow(/^x{200}…$/);
+  });
 });
 
 describe("createGraphClient — configuration", () => {

--- a/osn/client/tests/graph.test.ts
+++ b/osn/client/tests/graph.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createGraphClient, GraphClientError } from "../src/graph";
+
+const client = createGraphClient({ issuerUrl: "https://osn.example.com" });
+const base = "https://osn.example.com/graph";
+const TOKEN = "test-token";
+
+function mockFetch(response: { ok: boolean; json: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+}
+
+function expectAuthHeader(call: Parameters<typeof fetch>) {
+  const init = call[1] as RequestInit;
+  const headers = init.headers as Record<string, string>;
+  expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createGraphClient — listConnections", () => {
+  it("GETs /graph/connections with Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ connections: [] }) });
+    await client.listConnections(TOKEN);
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/connections`);
+    expect((call[1] as RequestInit).method).toBeUndefined(); // fetch defaults to GET
+    expectAuthHeader(call);
+  });
+
+  it("serialises limit/offset as query params", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ connections: [] }) });
+    await client.listConnections(TOKEN, { limit: 20, offset: 40 });
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections?limit=20&offset=40`);
+  });
+
+  it("throws GraphClientError on non-2xx", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "boom" }) });
+    await expect(client.listConnections(TOKEN)).rejects.toBeInstanceOf(GraphClientError);
+  });
+});
+
+describe("createGraphClient — listPendingRequests / listCloseFriends / listBlocks", () => {
+  it("hits the correct paths", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ pending: [] }) });
+    await client.listPendingRequests(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections/pending`);
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ closeFriends: [] }),
+    } as Response);
+    await client.listCloseFriends(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[1]![0]).toBe(`${base}/close-friends`);
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ blocks: [] }),
+    } as Response);
+    await client.listBlocks(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[2]![0]).toBe(`${base}/blocks`);
+  });
+});
+
+describe("createGraphClient — connection mutations", () => {
+  it("getConnectionStatus GETs /graph/connections/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ status: "connected" }) });
+    const result = await client.getConnectionStatus(TOKEN, "alice");
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections/alice`);
+    expect(result.status).toBe("connected");
+  });
+
+  it("sendConnectionRequest POSTs /graph/connections/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.sendConnectionRequest(TOKEN, "alice");
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/connections/alice`);
+    expect((call[1] as RequestInit).method).toBe("POST");
+  });
+
+  it("acceptConnection PATCHes with action=accept", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.acceptConnection(TOKEN, "alice");
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect((call[1] as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({ action: "accept" });
+  });
+
+  it("rejectConnection PATCHes with action=reject", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.rejectConnection(TOKEN, "alice");
+    expect(JSON.parse((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).body as string)).toEqual({
+      action: "reject",
+    });
+  });
+
+  it("removeConnection DELETEs /graph/connections/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.removeConnection(TOKEN, "alice");
+    expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("URL-encodes handles with special chars", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.sendConnectionRequest(TOKEN, "alice bob");
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections/alice%20bob`);
+  });
+});
+
+describe("createGraphClient — close friends & blocks", () => {
+  it("addCloseFriend POSTs /graph/close-friends/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.addCloseFriend(TOKEN, "alice");
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/close-friends/alice`);
+    expect((call[1] as RequestInit).method).toBe("POST");
+  });
+
+  it("removeCloseFriend DELETEs /graph/close-friends/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.removeCloseFriend(TOKEN, "alice");
+    expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("blockProfile POSTs /graph/blocks/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.blockProfile(TOKEN, "alice");
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/blocks/alice`);
+  });
+
+  it("unblockProfile DELETEs /graph/blocks/:handle", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await client.unblockProfile(TOKEN, "alice");
+    expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+});
+
+describe("createGraphClient — error surface", () => {
+  it("surfaces server-supplied error messages", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Already connected" }) });
+    await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toThrow("Already connected");
+  });
+
+  it("falls back to a generic message when the server omits one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({}),
+      }),
+    );
+    await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toThrow(/Request failed/);
+  });
+});
+
+describe("createGraphClient — configuration", () => {
+  it("strips a trailing slash from issuerUrl", async () => {
+    const trimmed = createGraphClient({ issuerUrl: "https://osn.example.com/" });
+    mockFetch({ ok: true, json: () => Promise.resolve({ connections: [] }) });
+    await trimmed.listConnections(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections`);
+  });
+});

--- a/osn/client/tests/organisations.test.ts
+++ b/osn/client/tests/organisations.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createOrgClient, OrgClientError } from "../src/organisations";
+
+const client = createOrgClient({ issuerUrl: "https://osn.example.com" });
+const base = "https://osn.example.com/organisations";
+const TOKEN = "test-token";
+
+function mockFetch(response: { ok: boolean; status?: number; json: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createOrgClient — listing & reads", () => {
+  it("listMyOrgs GETs /organisations with Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ organisations: [] }) });
+    await client.listMyOrgs(TOKEN);
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(base);
+    const headers = (call[1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("listMyOrgs serialises limit/offset query params", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ organisations: [] }) });
+    await client.listMyOrgs(TOKEN, { limit: 10, offset: 5 });
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}?limit=10&offset=5`);
+  });
+
+  it("getOrg GETs /organisations/:id with URL encoding", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ id: "org_1" }) });
+    await client.getOrg(TOKEN, "org with space");
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/org%20with%20space`);
+  });
+
+  it("listMembers GETs /organisations/:id/members", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ members: [] }) });
+    await client.listMembers(TOKEN, "org_1", { limit: 5 });
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/org_1/members?limit=5`);
+  });
+});
+
+describe("createOrgClient — mutations", () => {
+  it("createOrg POSTs /organisations with the payload", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ id: "org_1" }) });
+    await client.createOrg(TOKEN, { handle: "acme", name: "ACME" });
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(base);
+    expect((call[1] as RequestInit).method).toBe("POST");
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({
+      handle: "acme",
+      name: "ACME",
+    });
+  });
+
+  it("updateOrg PATCHes /organisations/:id", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ id: "org_1" }) });
+    await client.updateOrg(TOKEN, "org_1", { name: "Renamed" });
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/org_1`);
+    expect((call[1] as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({ name: "Renamed" });
+  });
+
+  it("deleteOrg DELETEs /organisations/:id and resolves to undefined", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({}) });
+    const result = await client.deleteOrg(TOKEN, "org_1");
+    expect(result).toBeUndefined();
+    expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+});
+
+describe("createOrgClient — member mutations", () => {
+  it("addMember POSTs with {profileId, role} and resolves to undefined", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({}) });
+    const result = await client.addMember(TOKEN, "org_1", "usr_1", "admin");
+    expect(result).toBeUndefined();
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/org_1/members`);
+    expect((call[1] as RequestInit).method).toBe("POST");
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({
+      profileId: "usr_1",
+      role: "admin",
+    });
+  });
+
+  it("removeMember DELETEs /organisations/:id/members/:profileId", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({}) });
+    await client.removeMember(TOKEN, "org_1", "usr_1");
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/org_1/members/usr_1`);
+    expect((call[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("updateMemberRole PATCHes with {role} and resolves to undefined", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({}) });
+    const result = await client.updateMemberRole(TOKEN, "org_1", "usr_1", "member");
+    expect(result).toBeUndefined();
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/org_1/members/usr_1`);
+    expect((call[1] as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({ role: "member" });
+  });
+});
+
+describe("createOrgClient — error surface", () => {
+  it("throws OrgClientError on non-2xx GET", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Not found" }) });
+    await expect(client.getOrg(TOKEN, "org_1")).rejects.toBeInstanceOf(OrgClientError);
+  });
+
+  it("throws OrgClientError on non-2xx DELETE (reads error body)", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
+    await expect(client.deleteOrg(TOKEN, "org_1")).rejects.toThrow("Forbidden");
+  });
+
+  it("falls back to a generic message when the server omits one", async () => {
+    mockFetch({ ok: false, status: 500, json: () => Promise.resolve({}) });
+    await expect(client.createOrg(TOKEN, { handle: "x", name: "X" })).rejects.toThrow(
+      /Request failed/,
+    );
+  });
+});
+
+describe("createOrgClient — configuration", () => {
+  it("strips a trailing slash from issuerUrl", async () => {
+    const trimmed = createOrgClient({ issuerUrl: "https://osn.example.com/" });
+    mockFetch({ ok: true, json: () => Promise.resolve({ organisations: [] }) });
+    await trimmed.listMyOrgs(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(base);
+  });
+});

--- a/osn/client/tests/recommendations.test.ts
+++ b/osn/client/tests/recommendations.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createRecommendationClient, RecommendationClientError } from "../src/recommendations";
+
+const client = createRecommendationClient({ issuerUrl: "https://osn.example.com" });
+const base = "https://osn.example.com/recommendations";
+const TOKEN = "test-token";
+
+function mockFetch(response: { ok: boolean; status?: number; json: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createRecommendationClient", () => {
+  it("GETs /recommendations/connections with Bearer auth and no limit by default", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ suggestions: [] }) });
+    await client.suggestConnections(TOKEN);
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/connections`);
+    const headers = (call[1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("appends ?limit when provided", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ suggestions: [] }) });
+    await client.suggestConnections(TOKEN, { limit: 20 });
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections?limit=20`);
+  });
+
+  it("returns the parsed suggestions list", async () => {
+    const suggestions = [
+      { handle: "alice", displayName: "Alice", avatarUrl: null, mutualCount: 3 },
+    ];
+    mockFetch({ ok: true, json: () => Promise.resolve({ suggestions }) });
+    const result = await client.suggestConnections(TOKEN);
+    expect(result.suggestions).toEqual(suggestions);
+  });
+
+  it("throws RecommendationClientError with server message on non-2xx", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Too many requests" }) });
+    await expect(client.suggestConnections(TOKEN)).rejects.toBeInstanceOf(
+      RecommendationClientError,
+    );
+    await expect(client.suggestConnections(TOKEN)).rejects.toThrow("Too many requests");
+  });
+
+  it("surfaces RecommendationClientError (not SyntaxError) when error body is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+      }),
+    );
+    await expect(client.suggestConnections(TOKEN)).rejects.toBeInstanceOf(
+      RecommendationClientError,
+    );
+  });
+
+  it("strips trailing slash from issuerUrl", async () => {
+    const trimmed = createRecommendationClient({ issuerUrl: "https://osn.example.com/" });
+    mockFetch({ ok: true, json: () => Promise.resolve({ suggestions: [] }) });
+    await trimmed.suggestConnections(TOKEN);
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections`);
+  });
+});

--- a/osn/client/tests/solid/graph-context.test.ts
+++ b/osn/client/tests/solid/graph-context.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { useGraph } from "../../src/solid/graph-context";
+
+describe("useGraph", () => {
+  it("throws when called without a GraphProvider", () => {
+    // With no GraphProvider wrapping the call, useContext returns the
+    // default (undefined) and useGraph() must throw a clear error.
+    expect(() => useGraph()).toThrow(/GraphProvider/);
+  });
+});

--- a/osn/client/tests/solid/org-context.test.ts
+++ b/osn/client/tests/solid/org-context.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { useOrgs } from "../../src/solid/org-context";
+
+describe("useOrgs", () => {
+  it("throws when called without an OrgProvider", () => {
+    // Mirrors the graph-context invariant: using the hook outside its
+    // provider must fail fast rather than silently returning undefined.
+    expect(() => useOrgs()).toThrow(/OrgProvider/);
+  });
+});

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -15,7 +15,10 @@ export { createProfileRoutes, createDefaultProfileRateLimiters } from "./routes/
 export type { ProfileRateLimiters } from "./routes/profile";
 export { createProfileService } from "./services/profile";
 export type { ProfileService } from "./services/profile";
-export { createRecommendationRoutes } from "./routes/recommendations";
+export {
+  createRecommendationRoutes,
+  createDefaultRecommendationRateLimiter,
+} from "./routes/recommendations";
 export { createRecommendationService } from "./services/recommendations";
 export type { RecommendationService } from "./services/recommendations";
 export { createRateLimiter, getClientIp, type RateLimiterBackend } from "./lib/rate-limit";
@@ -24,6 +27,7 @@ export {
   createRedisGraphRateLimiter,
   createRedisOrgRateLimiter,
   createRedisProfileRateLimiters,
+  createRedisRecommendationRateLimiter,
 } from "./lib/redis-rate-limiters";
 export { requireArc } from "./lib/arc-middleware";
 export type { ArcCaller } from "./lib/arc-middleware";

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -15,6 +15,9 @@ export { createProfileRoutes, createDefaultProfileRateLimiters } from "./routes/
 export type { ProfileRateLimiters } from "./routes/profile";
 export { createProfileService } from "./services/profile";
 export type { ProfileService } from "./services/profile";
+export { createRecommendationRoutes } from "./routes/recommendations";
+export { createRecommendationService } from "./services/recommendations";
+export type { RecommendationService } from "./services/recommendations";
 export { createRateLimiter, getClientIp, type RateLimiterBackend } from "./lib/rate-limit";
 export {
   createRedisAuthRateLimiters,

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -71,6 +71,21 @@ export function createRedisOrgRateLimiter(client: RedisClient): RateLimiterBacke
 }
 
 /**
+ * Build the recommendations rate limiter backed by Redis.
+ * Namespace: `recs:read` — key is the authenticated user ID.
+ *
+ * Tighter budget than graph/org writes because each request runs an
+ * expensive FOF fan-out.
+ */
+export function createRedisRecommendationRateLimiter(client: RedisClient): RateLimiterBackend {
+  return createRedisRateLimiter(client, {
+    namespace: "recs:read",
+    maxRequests: 20,
+    windowMs: ONE_MINUTE_MS,
+  });
+}
+
+/**
  * Build all 3 profile CRUD rate limiters backed by a shared Redis client.
  * Namespace convention: `profile:{action}`.
  */

--- a/osn/core/src/routes/recommendations.ts
+++ b/osn/core/src/routes/recommendations.ts
@@ -1,0 +1,73 @@
+import { DbLive, type Db } from "@osn/db/service";
+import { Effect, Layer } from "effect";
+import { Elysia, t } from "elysia";
+
+import { createAuthService, type AuthConfig } from "../services/auth";
+import { createRecommendationService } from "../services/recommendations";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractToken(authorization: string | undefined): string | null {
+  if (!authorization) return null;
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Recommendation routes
+// ---------------------------------------------------------------------------
+
+export function createRecommendationRoutes(
+  authConfig: AuthConfig,
+  dbLayer: Layer.Layer<Db> = DbLive,
+  /** See `createAuthRoutes` — same semantics. */
+  loggerLayer: Layer.Layer<never> = Layer.empty,
+) {
+  const auth = createAuthService(authConfig);
+  const recommendations = createRecommendationService();
+
+  const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
+    Effect.runPromise(
+      eff.pipe(Effect.provide(dbLayer), Effect.provide(loggerLayer)) as Effect.Effect<
+        A,
+        never,
+        never
+      >,
+    );
+
+  async function requireAuth(
+    authorization: string | undefined,
+    set: { status?: number | string },
+  ): Promise<{ profileId: string; handle: string } | null> {
+    const token = extractToken(authorization);
+    if (!token) {
+      set.status = 401;
+      return null;
+    }
+    try {
+      return await Effect.runPromise(Effect.orDie(auth.verifyAccessToken(token)));
+    } catch {
+      set.status = 401;
+      return null;
+    }
+  }
+
+  return new Elysia({ prefix: "/recommendations" }).get(
+    "/connections",
+    async ({ query, headers, set }) => {
+      const caller = await requireAuth(headers.authorization, set);
+      if (!caller) return { error: "Unauthorized" };
+      try {
+        const limit = query.limit ? parseInt(query.limit, 10) : 10;
+        const suggestions = await run(recommendations.suggestConnections(caller.profileId, limit));
+        return { suggestions };
+      } catch {
+        set.status = 500;
+        return { error: "Request failed" };
+      }
+    },
+    { query: t.Object({ limit: t.Optional(t.String()) }) },
+  );
+}

--- a/osn/core/src/routes/recommendations.ts
+++ b/osn/core/src/routes/recommendations.ts
@@ -2,8 +2,28 @@ import { DbLive, type Db } from "@osn/db/service";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
+import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createRecommendationService } from "../services/recommendations";
+
+// ---------------------------------------------------------------------------
+// Rate limiter — per-user fixed window
+//
+// Recommendations requests each run a FOF fan-out query that can return many
+// rows; tighter budget than graph/org writes to limit DoS and graph-inference
+// enumeration (S-H1).
+// ---------------------------------------------------------------------------
+
+const RECOMMENDATIONS_RATE_LIMIT_MAX = 20;
+const RECOMMENDATIONS_RATE_LIMIT_WINDOW_MS = 60_000;
+
+/** Default in-memory recommendations rate limiter. Override for Redis. */
+export function createDefaultRecommendationRateLimiter(): RateLimiterBackend {
+  return createRateLimiter({
+    maxRequests: RECOMMENDATIONS_RATE_LIMIT_MAX,
+    windowMs: RECOMMENDATIONS_RATE_LIMIT_WINDOW_MS,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -24,7 +44,16 @@ export function createRecommendationRoutes(
   dbLayer: Layer.Layer<Db> = DbLive,
   /** See `createAuthRoutes` — same semantics. */
   loggerLayer: Layer.Layer<never> = Layer.empty,
+  /**
+   * Per-user rate limiter for the (expensive) FOF fan-out read. Supply a
+   * Redis-backed backend in production via `createRedisRecommendationRateLimiter`.
+   */
+  rateLimiter: RateLimiterBackend = createDefaultRecommendationRateLimiter(),
 ) {
+  if (typeof rateLimiter?.check !== "function") {
+    throw new Error("Recommendations rateLimiter must have a check() method");
+  }
+
   const auth = createAuthService(authConfig);
   const recommendations = createRecommendationService();
 
@@ -54,13 +83,35 @@ export function createRecommendationRoutes(
     }
   }
 
+  // Fail-closed: if the limiter backend rejects, treat as limited.
+  async function requireRateLimit(
+    profileId: string,
+    set: { status?: number | string },
+  ): Promise<boolean> {
+    let allowed: boolean;
+    try {
+      allowed = await rateLimiter.check(profileId);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
+      set.status = 429;
+      return false;
+    }
+    return true;
+  }
+
   return new Elysia({ prefix: "/recommendations" }).get(
     "/connections",
     async ({ query, headers, set }) => {
       const caller = await requireAuth(headers.authorization, set);
       if (!caller) return { error: "Unauthorized" };
+      if (!(await requireRateLimit(caller.profileId, set))) {
+        return { error: "Rate limit exceeded" };
+      }
       try {
-        const limit = query.limit ? parseInt(query.limit, 10) : 10;
+        // Schema guarantees limit is a finite integer in [1, 50] when present.
+        const limit = query.limit ?? 10;
         const suggestions = await run(recommendations.suggestConnections(caller.profileId, limit));
         return { suggestions };
       } catch {
@@ -68,6 +119,12 @@ export function createRecommendationRoutes(
         return { error: "Request failed" };
       }
     },
-    { query: t.Object({ limit: t.Optional(t.String()) }) },
+    {
+      query: t.Object({
+        // Elysia's t.Numeric coerces the string query param to a number and
+        // validates bounds at the HTTP boundary (S-M1 / P-W1).
+        limit: t.Optional(t.Numeric({ minimum: 1, maximum: 50 })),
+      }),
+    },
   );
 }

--- a/osn/core/src/services/recommendations.ts
+++ b/osn/core/src/services/recommendations.ts
@@ -1,0 +1,169 @@
+import { blocks, connections, users } from "@osn/db/schema";
+import { Db } from "@osn/db/service";
+import { and, eq, inArray, or } from "drizzle-orm";
+import { Data, Effect } from "effect";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class RecommendationError extends Data.TaggedError("RecommendationError")<{
+  readonly message: string;
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly cause: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Suggestion {
+  handle: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  mutualCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Recommendation service factory
+// ---------------------------------------------------------------------------
+
+export function createRecommendationService() {
+  /**
+   * Suggest "people you may know" based on mutual connections (friends-of-friends).
+   *
+   * Algorithm:
+   * 1. Get all profile IDs the caller is connected to (accepted only).
+   * 2. Get all blocked profile IDs (both directions).
+   * 3. For each of the caller's connections, find *their* connections.
+   * 4. Exclude self, existing connections, and blocked profiles.
+   * 5. Count mutual connections per candidate and sort descending.
+   * 6. Hydrate top results with profile data.
+   */
+  const suggestConnections = (
+    profileId: string,
+    limit = 10,
+  ): Effect.Effect<Suggestion[], DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const safeLimit = Math.min(Math.max(limit, 1), 50);
+
+      // Step 1: Get my accepted connection IDs
+      const myConnectionRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              and(
+                eq(connections.status, "accepted"),
+                or(eq(connections.requesterId, profileId), eq(connections.addresseeId, profileId)),
+              ),
+            ),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const myConnectionIds = myConnectionRows.map((r) =>
+        r.requesterId === profileId ? r.addresseeId : r.requesterId,
+      );
+
+      if (myConnectionIds.length === 0) return [];
+
+      // Step 2: Get blocks (both directions)
+      const blockRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(blocks)
+            .where(or(eq(blocks.blockerId, profileId), eq(blocks.blockedId, profileId))),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const blockedIds = blockRows.map((r) =>
+        r.blockerId === profileId ? r.blockedId : r.blockerId,
+      );
+
+      const excludeIds = new Set([profileId, ...myConnectionIds, ...blockedIds]);
+
+      // Step 3: For each of my connections, find THEIR accepted connections
+      const fofRows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(
+              and(
+                eq(connections.status, "accepted"),
+                or(
+                  inArray(connections.requesterId, myConnectionIds),
+                  inArray(connections.addresseeId, myConnectionIds),
+                ),
+              ),
+            ),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      // Step 4: Aggregate candidates, counting mutual connections
+      const mutualCounts = new Map<string, number>();
+
+      for (const row of fofRows) {
+        // Determine which side is the mutual friend and which is the candidate
+        const isMutualRequester = myConnectionIds.includes(row.requesterId);
+        const isMutualAddressee = myConnectionIds.includes(row.addresseeId);
+
+        // Both sides could be my connections — skip (that's just a connection between two of my friends)
+        if (isMutualRequester && isMutualAddressee) continue;
+
+        const candidateId = isMutualRequester ? row.addresseeId : row.requesterId;
+
+        if (excludeIds.has(candidateId)) continue;
+
+        mutualCounts.set(candidateId, (mutualCounts.get(candidateId) ?? 0) + 1);
+      }
+
+      if (mutualCounts.size === 0) return [];
+
+      // Step 5: Sort by mutual count descending and take top N
+      const sorted = [...mutualCounts.entries()]
+        .toSorted((a, b) => b[1] - a[1])
+        .slice(0, safeLimit);
+
+      const candidateIds = sorted.map(([id]) => id);
+
+      // Step 6: Hydrate with profile info
+      const profiles = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({
+              id: users.id,
+              handle: users.handle,
+              displayName: users.displayName,
+              avatarUrl: users.avatarUrl,
+            })
+            .from(users)
+            .where(inArray(users.id, candidateIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      const profileMap = new Map(profiles.map((p) => [p.id, p]));
+
+      return sorted
+        .map(([id, mutualCount]) => {
+          const p = profileMap.get(id);
+          if (!p) return null;
+          return {
+            handle: p.handle,
+            displayName: p.displayName,
+            avatarUrl: p.avatarUrl,
+            mutualCount,
+          };
+        })
+        .filter((s): s is Suggestion => s !== null);
+    }).pipe(Effect.withSpan("recommendations.suggest_connections"));
+
+  return { suggestConnections };
+}
+
+export type RecommendationService = ReturnType<typeof createRecommendationService>;

--- a/osn/core/src/services/recommendations.ts
+++ b/osn/core/src/services/recommendations.ts
@@ -16,6 +16,25 @@ export class DatabaseError extends Data.TaggedError("DatabaseError")<{
 }> {}
 
 // ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+/**
+ * Caller's connection list is capped before we expand to friends-of-friends.
+ * Prevents a hub user with thousands of connections from producing an
+ * unbounded FOF fan-out (P-C1). Tuned for the "enough candidates to produce
+ * a good top-N list" sweet spot.
+ */
+const MAX_MY_CONNECTIONS_FOR_FOF = 500;
+
+/**
+ * Hard cap on the FOF fan-out row count. Worst-case defence alongside
+ * MAX_MY_CONNECTIONS_FOR_FOF — a viral cluster with very dense connections
+ * would still be bounded by this limit.
+ */
+const MAX_FOF_FANOUT_ROWS = 10_000;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -35,9 +54,9 @@ export function createRecommendationService() {
    * Suggest "people you may know" based on mutual connections (friends-of-friends).
    *
    * Algorithm:
-   * 1. Get all profile IDs the caller is connected to (accepted only).
+   * 1. Get up to MAX_MY_CONNECTIONS_FOR_FOF accepted connections of the caller.
    * 2. Get all blocked profile IDs (both directions).
-   * 3. For each of the caller's connections, find *their* connections.
+   * 3. For each of the caller's connections, find *their* connections (capped).
    * 4. Exclude self, existing connections, and blocked profiles.
    * 5. Count mutual connections per candidate and sort descending.
    * 6. Hydrate top results with profile data.
@@ -48,20 +67,27 @@ export function createRecommendationService() {
   ): Effect.Effect<Suggestion[], DatabaseError, Db> =>
     Effect.gen(function* () {
       const { db } = yield* Db;
-      const safeLimit = Math.min(Math.max(limit, 1), 50);
+      // Defence-in-depth: the Elysia schema enforces [1, 50], but non-HTTP
+      // callers might pass NaN / Infinity / negatives. Coerce any non-finite
+      // input back to the default before clamping.
+      const safeLimit = Math.min(Math.max(Number.isFinite(limit) ? limit : 10, 1), 50);
 
-      // Step 1: Get my accepted connection IDs
+      // Step 1: Get my accepted connection IDs (capped to bound fan-out).
       const myConnectionRows = yield* Effect.tryPromise({
         try: () =>
           db
-            .select()
+            .select({
+              requesterId: connections.requesterId,
+              addresseeId: connections.addresseeId,
+            })
             .from(connections)
             .where(
               and(
                 eq(connections.status, "accepted"),
                 or(eq(connections.requesterId, profileId), eq(connections.addresseeId, profileId)),
               ),
-            ),
+            )
+            .limit(MAX_MY_CONNECTIONS_FOR_FOF),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
@@ -71,11 +97,14 @@ export function createRecommendationService() {
 
       if (myConnectionIds.length === 0) return [];
 
-      // Step 2: Get blocks (both directions)
+      // Step 2: Get blocks (both directions).
       const blockRows = yield* Effect.tryPromise({
         try: () =>
           db
-            .select()
+            .select({
+              blockerId: blocks.blockerId,
+              blockedId: blocks.blockedId,
+            })
             .from(blocks)
             .where(or(eq(blocks.blockerId, profileId), eq(blocks.blockedId, profileId))),
         catch: (cause) => new DatabaseError({ cause }),
@@ -85,13 +114,19 @@ export function createRecommendationService() {
         r.blockerId === profileId ? r.blockedId : r.blockerId,
       );
 
-      const excludeIds = new Set([profileId, ...myConnectionIds, ...blockedIds]);
+      // Set for O(1) membership lookup in the aggregation loop (P-W2).
+      const myConnectionIdSet = new Set(myConnectionIds);
+      const excludeIds = new Set<string>([profileId, ...myConnectionIds, ...blockedIds]);
 
-      // Step 3: For each of my connections, find THEIR accepted connections
+      // Step 3: For each of my connections, find THEIR accepted connections.
+      // Capped fan-out bounds worst-case aggregation cost.
       const fofRows = yield* Effect.tryPromise({
         try: () =>
           db
-            .select()
+            .select({
+              requesterId: connections.requesterId,
+              addresseeId: connections.addresseeId,
+            })
             .from(connections)
             .where(
               and(
@@ -101,19 +136,19 @@ export function createRecommendationService() {
                   inArray(connections.addresseeId, myConnectionIds),
                 ),
               ),
-            ),
+            )
+            .limit(MAX_FOF_FANOUT_ROWS),
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      // Step 4: Aggregate candidates, counting mutual connections
+      // Step 4: Aggregate candidates, counting mutual connections.
       const mutualCounts = new Map<string, number>();
 
       for (const row of fofRows) {
-        // Determine which side is the mutual friend and which is the candidate
-        const isMutualRequester = myConnectionIds.includes(row.requesterId);
-        const isMutualAddressee = myConnectionIds.includes(row.addresseeId);
+        const isMutualRequester = myConnectionIdSet.has(row.requesterId);
+        const isMutualAddressee = myConnectionIdSet.has(row.addresseeId);
 
-        // Both sides could be my connections — skip (that's just a connection between two of my friends)
+        // Both sides are my connections — edge between two of my friends.
         if (isMutualRequester && isMutualAddressee) continue;
 
         const candidateId = isMutualRequester ? row.addresseeId : row.requesterId;
@@ -125,14 +160,14 @@ export function createRecommendationService() {
 
       if (mutualCounts.size === 0) return [];
 
-      // Step 5: Sort by mutual count descending and take top N
+      // Step 5: Sort by mutual count descending and take top N.
       const sorted = [...mutualCounts.entries()]
         .toSorted((a, b) => b[1] - a[1])
         .slice(0, safeLimit);
 
       const candidateIds = sorted.map(([id]) => id);
 
-      // Step 6: Hydrate with profile info
+      // Step 6: Hydrate with profile info.
       const profiles = yield* Effect.tryPromise({
         try: () =>
           db

--- a/osn/core/tests/routes/recommendations.test.ts
+++ b/osn/core/tests/routes/recommendations.test.ts
@@ -131,25 +131,45 @@ describe("recommendations routes", () => {
     expect(res.status).toBe(200);
   });
 
-  it("handles a non-numeric ?limit without 500ing (T-S1)", async () => {
-    // parseInt("abc") === NaN — route must not error; service clamps via
-    // Math.max/min which return NaN, slice(0, NaN) returns [] — so we accept
-    // a 200 with empty suggestions rather than a 500.
+  it("rejects a non-numeric ?limit at the HTTP boundary (S-M1/P-W1)", async () => {
+    // With t.Numeric in the schema, Elysia returns 422 for non-numeric
+    // input rather than silently collapsing to an empty result.
     const alice = await registerAndGetToken("a@e.com", "alice");
-    const bob = await registerAndGetToken("b@e.com", "bob");
-    const dana = await registerAndGetToken("d@e.com", "dana");
-    await connect(alice.token, "bob", bob.token, "alice");
-    await connect(bob.token, "dana", dana.token, "bob");
 
     const res = await recsApp.handle(
       new Request("http://localhost/recommendations/connections?limit=abc", {
         headers: { Authorization: `Bearer ${alice.token}` },
       }),
     );
-    expect(res.status).toBe(200);
-    const json = (await res.json()) as { suggestions: unknown[] };
-    // Bounded behaviour: either empty (NaN collapse) or at most the default.
-    expect(Array.isArray(json.suggestions)).toBe(true);
-    expect(json.suggestions.length).toBeLessThanOrEqual(10);
+    expect(res.status).toBe(422);
+  });
+
+  it("rejects a too-large ?limit at the HTTP boundary", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections?limit=1000", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiting (S-H1/P-C2)
+  // -------------------------------------------------------------------------
+
+  it("returns 429 when the rate limiter rejects", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    // Build an app with a limiter that always fails closed.
+    const { createRecommendationRoutes: mkRoutes } =
+      await import("../../src/routes/recommendations");
+    const alwaysRejected = { check: () => Promise.resolve(false) };
+    const limitedApp = mkRoutes(config, layer, undefined, alwaysRejected);
+    const res = await limitedApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(429);
   });
 });

--- a/osn/core/tests/routes/recommendations.test.ts
+++ b/osn/core/tests/routes/recommendations.test.ts
@@ -1,0 +1,155 @@
+import type { Db } from "@osn/db/service";
+import { Effect } from "effect";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createGraphRoutes } from "../../src/routes/graph";
+import { createRecommendationRoutes } from "../../src/routes/recommendations";
+import { createAuthService } from "../../src/services/auth";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+describe("recommendations routes", () => {
+  let layer: ReturnType<typeof createTestLayer>;
+  let recsApp: ReturnType<typeof createRecommendationRoutes>;
+  let graphApp: ReturnType<typeof createGraphRoutes>;
+  let auth: ReturnType<typeof createAuthService>;
+
+  beforeEach(() => {
+    layer = createTestLayer();
+    recsApp = createRecommendationRoutes(config, layer);
+    graphApp = createGraphRoutes(config, layer);
+    auth = createAuthService(config);
+  });
+
+  const runWithLayer = <A>(eff: Effect.Effect<A, unknown, Db>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+  async function registerAndGetToken(
+    email: string,
+    handle: string,
+  ): Promise<{ profileId: string; token: string }> {
+    const user = await runWithLayer(auth.registerProfile(email, handle));
+    const tokens = await runWithLayer(
+      auth.issueTokens(user.id, user.accountId, user.email, user.handle, user.displayName),
+    );
+    return { profileId: user.id, token: tokens.accessToken };
+  }
+
+  /** Bidirectionally connect two profiles via the graph routes. */
+  async function connect(tokenA: string, handleB: string, tokenB: string, handleA: string) {
+    await graphApp.handle(
+      new Request(`http://localhost/graph/connections/${handleB}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${tokenA}` },
+      }),
+    );
+    await graphApp.handle(
+      new Request(`http://localhost/graph/connections/${handleA}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${tokenB}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      }),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth guard
+  // -------------------------------------------------------------------------
+
+  it("returns 401 without token", async () => {
+    const res = await recsApp.handle(new Request("http://localhost/recommendations/connections"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: "Bearer not-a-valid-token" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it("returns [] when the caller has no connections", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { suggestions: unknown[] };
+    expect(json.suggestions).toEqual([]);
+  });
+
+  it("returns FOF suggestions with mutual counts", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const bob = await registerAndGetToken("b@e.com", "bob");
+    const dana = await registerAndGetToken("d@e.com", "dana");
+    await connect(alice.token, "bob", bob.token, "alice");
+    await connect(bob.token, "dana", dana.token, "bob");
+
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      suggestions: Array<{ handle: string; mutualCount: number }>;
+    };
+    expect(json.suggestions).toHaveLength(1);
+    expect(json.suggestions[0]!.handle).toBe("dana");
+    expect(json.suggestions[0]!.mutualCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Limit parsing (T-S1)
+  // -------------------------------------------------------------------------
+
+  it("accepts a numeric ?limit query param", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections?limit=5", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("handles a non-numeric ?limit without 500ing (T-S1)", async () => {
+    // parseInt("abc") === NaN — route must not error; service clamps via
+    // Math.max/min which return NaN, slice(0, NaN) returns [] — so we accept
+    // a 200 with empty suggestions rather than a 500.
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const bob = await registerAndGetToken("b@e.com", "bob");
+    const dana = await registerAndGetToken("d@e.com", "dana");
+    await connect(alice.token, "bob", bob.token, "alice");
+    await connect(bob.token, "dana", dana.token, "bob");
+
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections?limit=abc", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { suggestions: unknown[] };
+    // Bounded behaviour: either empty (NaN collapse) or at most the default.
+    expect(Array.isArray(json.suggestions)).toBe(true);
+    expect(json.suggestions.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/osn/core/tests/services/recommendations.test.ts
+++ b/osn/core/tests/services/recommendations.test.ts
@@ -1,0 +1,176 @@
+import { it, expect, describe } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { createAuthService } from "../../src/services/auth";
+import { createGraphService } from "../../src/services/graph";
+import { createRecommendationService } from "../../src/services/recommendations";
+import { createTestLayer } from "../helpers/db";
+
+const config = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+  jwtSecret: "test-secret-at-least-32-characters-long",
+};
+
+const auth = createAuthService(config);
+const graph = createGraphService();
+const recs = createRecommendationService();
+
+// Connect two users bidirectionally (request + accept).
+const connect = (a: string, b: string) =>
+  Effect.gen(function* () {
+    yield* graph.sendConnectionRequest(a, b);
+    yield* graph.acceptConnection(b, a);
+  });
+
+describe("suggestConnections", () => {
+  it.effect("returns [] when caller has no connections", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("alice@example.com", "alice");
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result).toEqual([]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("surfaces friends-of-friends with correct mutual count", () =>
+    Effect.gen(function* () {
+      // alice <-> bob, alice <-> charlie; bob <-> dana; charlie <-> dana
+      // alice should be suggested dana with mutualCount = 2
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const charlie = yield* auth.registerProfile("c@e.com", "charlie");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      yield* connect(alice.id, bob.id);
+      yield* connect(alice.id, charlie.id);
+      yield* connect(bob.id, dana.id);
+      yield* connect(charlie.id, dana.id);
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.handle).toBe("dana");
+      expect(result[0]!.mutualCount).toBe(2);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("excludes existing connections of the caller", () =>
+    Effect.gen(function* () {
+      // alice <-> bob, alice <-> dana, bob <-> dana
+      // dana is already connected to alice — should NOT appear as suggestion
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      yield* connect(alice.id, bob.id);
+      yield* connect(alice.id, dana.id);
+      yield* connect(bob.id, dana.id);
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result).toEqual([]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("excludes the caller from their own suggestions", () =>
+    Effect.gen(function* () {
+      // alice <-> bob, bob <-> alice — ensure caller never suggests self
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      yield* connect(alice.id, bob.id);
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result.map((s) => s.handle)).not.toContain("alice");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("excludes blocked profiles (either direction)", () =>
+    Effect.gen(function* () {
+      // alice <-> bob; bob <-> dana; alice blocks dana -> dana should not appear
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      yield* connect(alice.id, bob.id);
+      yield* connect(bob.id, dana.id);
+      yield* graph.blockProfile(alice.id, dana.id);
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result.map((s) => s.handle)).not.toContain("dana");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("sorts suggestions by mutual count descending", () =>
+    Effect.gen(function* () {
+      // alice <-> bob, alice <-> charlie
+      // bob <-> dana (dana has 1 mutual via bob)
+      // bob <-> eli, charlie <-> eli (eli has 2 mutuals)
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const charlie = yield* auth.registerProfile("c@e.com", "charlie");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      const eli = yield* auth.registerProfile("e@e.com", "eli");
+      yield* connect(alice.id, bob.id);
+      yield* connect(alice.id, charlie.id);
+      yield* connect(bob.id, dana.id);
+      yield* connect(bob.id, eli.id);
+      yield* connect(charlie.id, eli.id);
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result).toHaveLength(2);
+      expect(result[0]!.handle).toBe("eli");
+      expect(result[0]!.mutualCount).toBe(2);
+      expect(result[1]!.handle).toBe("dana");
+      expect(result[1]!.mutualCount).toBe(1);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("clamps limit to a maximum of 50", () =>
+    Effect.gen(function* () {
+      // Register alice + 1 friend + 60 friends-of-friend. Verify even when
+      // caller asks for 1000, result length is at most 50.
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      yield* connect(alice.id, bob.id);
+
+      for (let i = 0; i < 60; i++) {
+        const fof = yield* auth.registerProfile(`u${i}@e.com`, `u${i}`);
+        yield* connect(bob.id, fof.id);
+      }
+
+      const result = yield* recs.suggestConnections(alice.id, 1000);
+      expect(result.length).toBe(50);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("clamps limit to a minimum of 1 when passed 0 or negative", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      yield* connect(alice.id, bob.id);
+      yield* connect(bob.id, dana.id);
+
+      const zero = yield* recs.suggestConnections(alice.id, 0);
+      const neg = yield* recs.suggestConnections(alice.id, -5);
+      expect(zero.length).toBe(1);
+      expect(neg.length).toBe(1);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect(
+    "does not surface friend-of-friend edges that are between two of the caller's own friends",
+    () =>
+      Effect.gen(function* () {
+        // alice <-> bob, alice <-> charlie, bob <-> charlie
+        // The bob<->charlie edge is between two of alice's friends — it should
+        // NOT generate a spurious self-suggestion or inflate any count.
+        const alice = yield* auth.registerProfile("a@e.com", "alice");
+        const bob = yield* auth.registerProfile("b@e.com", "bob");
+        const charlie = yield* auth.registerProfile("c@e.com", "charlie");
+        yield* connect(alice.id, bob.id);
+        yield* connect(alice.id, charlie.id);
+        yield* connect(bob.id, charlie.id);
+
+        const result = yield* recs.suggestConnections(alice.id);
+        expect(result).toEqual([]);
+      }).pipe(Effect.provide(createTestLayer())),
+  );
+});

--- a/osn/social/index.html
+++ b/osn/social/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OSN</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/src/index.tsx" type="module"></script>
+  </body>
+</html>

--- a/osn/social/package.json
+++ b/osn/social/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@osn/social",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OSN Social - Identity and social network management",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 1422",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "tsc --noEmit"
+  },
+  "license": "GPL-3.0",
+  "dependencies": {
+    "@osn/client": "workspace:*",
+    "@osn/ui": "workspace:*",
+    "@simplewebauthn/browser": "^13.3.0",
+    "@solidjs/router": "^0.16.0",
+    "@tailwindcss/vite": "^4.2.1",
+    "solid-js": "^1.9.3",
+    "solid-toast": "^0.5.0",
+    "tailwindcss": "^4.2.1"
+  },
+  "devDependencies": {
+    "@shared/typescript-config": "workspace:*",
+    "@solidjs/testing-library": "^0.8.10",
+    "@vitest/coverage-istanbul": "^4.1.0",
+    "happy-dom": "^20.8.4",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.8",
+    "vite-plugin-solid": "^2.11.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/osn/social/package.json
+++ b/osn/social/package.json
@@ -8,7 +8,9 @@
     "dev": "vite --port 1422",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
   },
   "license": "GPL-3.0",
   "dependencies": {

--- a/osn/social/src/App.css
+++ b/osn/social/src/App.css
@@ -1,0 +1,79 @@
+@import "tailwindcss";
+@source "../../../osn/ui/src";
+
+@custom-variant base (:where(&));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive-foreground: oklch(0.985 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive-foreground: oklch(0.985 0 0);
+}
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+}

--- a/osn/social/src/App.tsx
+++ b/osn/social/src/App.tsx
@@ -1,0 +1,57 @@
+import { AuthProvider } from "@osn/client/solid";
+import { MagicLinkHandler } from "@osn/ui/auth/MagicLinkHandler";
+import { Route, Router } from "@solidjs/router";
+import { lazy } from "solid-js";
+import { Toaster } from "solid-toast";
+
+import { CallbackHandler } from "./components/CallbackHandler";
+import { Sidebar } from "./components/Sidebar";
+import { OSN_CLIENT_ID, OSN_ISSUER_URL } from "./lib/auth";
+import { loginClient } from "./lib/authClients";
+
+import "./App.css";
+
+const ConnectionsPage = lazy(() =>
+  import("./pages/ConnectionsPage").then((m) => ({ default: m.ConnectionsPage })),
+);
+const DiscoverPage = lazy(() =>
+  import("./pages/DiscoverPage").then((m) => ({ default: m.DiscoverPage })),
+);
+const OrganisationsPage = lazy(() =>
+  import("./pages/OrganisationsPage").then((m) => ({ default: m.OrganisationsPage })),
+);
+const OrgDetailPage = lazy(() =>
+  import("./pages/OrgDetailPage").then((m) => ({ default: m.OrgDetailPage })),
+);
+const SettingsPage = lazy(() =>
+  import("./pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
+);
+
+function Layout(props: { children?: import("solid-js").JSX.Element }) {
+  return (
+    <div class="flex h-screen overflow-hidden">
+      <Sidebar />
+      <div class="flex flex-1 flex-col overflow-y-auto">
+        <CallbackHandler />
+        <MagicLinkHandler client={loginClient} />
+        {props.children}
+      </div>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AuthProvider config={{ issuerUrl: OSN_ISSUER_URL, clientId: OSN_CLIENT_ID }}>
+      <Router root={Layout}>
+        <Route path="/" component={ConnectionsPage} />
+        <Route path="/connections" component={ConnectionsPage} />
+        <Route path="/discover" component={DiscoverPage} />
+        <Route path="/organisations" component={OrganisationsPage} />
+        <Route path="/organisations/:id" component={OrgDetailPage} />
+        <Route path="/settings" component={SettingsPage} />
+      </Router>
+    </AuthProvider>
+  );
+}

--- a/osn/social/src/App.tsx
+++ b/osn/social/src/App.tsx
@@ -32,7 +32,6 @@ function Layout(props: { children?: import("solid-js").JSX.Element }) {
     <div class="flex h-screen overflow-hidden">
       <Sidebar />
       <div class="flex flex-1 flex-col overflow-y-auto">
-        <CallbackHandler />
         <MagicLinkHandler client={loginClient} />
         {props.children}
       </div>
@@ -51,6 +50,7 @@ export default function App() {
         <Route path="/organisations" component={OrganisationsPage} />
         <Route path="/organisations/:id" component={OrgDetailPage} />
         <Route path="/settings" component={SettingsPage} />
+        <Route path="/callback" component={CallbackHandler} />
       </Router>
     </AuthProvider>
   );

--- a/osn/social/src/components/CallbackHandler.tsx
+++ b/osn/social/src/components/CallbackHandler.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from "@osn/client/solid";
+import { onMount } from "solid-js";
+
+import { REDIRECT_URI } from "../lib/auth";
+
+export function CallbackHandler() {
+  const { handleCallback } = useAuth();
+
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (code && state) {
+      handleCallback({ code, state, redirectUri: REDIRECT_URI() }).then(() => {
+        window.history.replaceState({}, "", window.location.pathname);
+        return undefined;
+      });
+    }
+  });
+
+  return null;
+}

--- a/osn/social/src/components/CallbackHandler.tsx
+++ b/osn/social/src/components/CallbackHandler.tsx
@@ -1,22 +1,38 @@
 import { useAuth } from "@osn/client/solid";
+import { useNavigate } from "@solidjs/router";
 import { onMount } from "solid-js";
+import { toast } from "solid-toast";
 
 import { REDIRECT_URI } from "../lib/auth";
 
+/**
+ * Mounts at the dedicated `/callback` route (P-I3). On mount, parses the
+ * `code` + `state` from the URL, completes the OAuth exchange, surfaces
+ * any failure to the user via a toast (S-M2), and redirects home.
+ */
 export function CallbackHandler() {
   const { handleCallback } = useAuth();
+  const navigate = useNavigate();
 
   onMount(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
     const state = params.get("state");
 
-    if (code && state) {
-      handleCallback({ code, state, redirectUri: REDIRECT_URI() }).then(() => {
-        window.history.replaceState({}, "", window.location.pathname);
-        return undefined;
-      });
+    if (!code || !state) {
+      navigate("/", { replace: true });
+      return;
     }
+
+    handleCallback({ code, state, redirectUri: REDIRECT_URI() })
+      .catch((err: unknown) => {
+        toast.error(err instanceof Error ? err.message : "Sign-in failed");
+      })
+      .finally(() => {
+        // Clear auth params from the URL regardless of outcome so the
+        // code/state cannot be bookmarked or re-sent on refresh.
+        navigate("/", { replace: true });
+      });
   });
 
   return null;

--- a/osn/social/src/components/Sidebar.tsx
+++ b/osn/social/src/components/Sidebar.tsx
@@ -1,0 +1,308 @@
+import type { PublicProfile } from "@osn/client";
+import { useAuth } from "@osn/client/solid";
+import { Register } from "@osn/ui/auth/Register";
+import { SignIn } from "@osn/ui/auth/SignIn";
+import { clsx } from "@osn/ui/lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
+import { Button } from "@osn/ui/ui/button";
+import { Dialog, DialogContent } from "@osn/ui/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@osn/ui/ui/dropdown-menu";
+import { A, useLocation } from "@solidjs/router";
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { toast } from "solid-toast";
+
+import { registrationClient, loginClient } from "../lib/authClients";
+import { getTokenClaims, profileInitials } from "../lib/utils";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: () => import("solid-js").JSX.Element;
+}
+
+function IconConnections() {
+  return (
+    <svg
+      class="h-[18px] w-[18px]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
+function IconDiscover() {
+  return (
+    <svg
+      class="h-[18px] w-[18px]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      <line x1="11" y1="8" x2="11" y2="14" />
+      <line x1="8" y1="11" x2="14" y2="11" />
+    </svg>
+  );
+}
+
+function IconOrganisations() {
+  return (
+    <svg
+      class="h-[18px] w-[18px]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M18 21a8 8 0 0 0-16 0" />
+      <circle cx="10" cy="8" r="5" />
+      <path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3" />
+    </svg>
+  );
+}
+
+function IconSettings() {
+  return (
+    <svg
+      class="h-[18px] w-[18px]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/connections", label: "Connections", icon: IconConnections },
+  { href: "/discover", label: "Discover", icon: IconDiscover },
+  { href: "/organisations", label: "Organisations", icon: IconOrganisations },
+  { href: "/settings", label: "Settings", icon: IconSettings },
+];
+
+export function Sidebar() {
+  const location = useLocation();
+  const { session, logout, profiles, activeProfileId, switchProfile } = useAuth();
+
+  const [showRegister, setShowRegister] = createSignal(false);
+  const [showSignIn, setShowSignIn] = createSignal(false);
+  const [showSwitcher, setShowSwitcher] = createSignal(false);
+  const [switching, setSwitching] = createSignal(false);
+
+  const accessToken = () => session()?.accessToken ?? null;
+  const claims = createMemo(() => getTokenClaims(accessToken()));
+  const activeProfile = createMemo(
+    () => profiles()?.find((p) => p.id === activeProfileId()) ?? null,
+  );
+
+  function isActive(href: string): boolean {
+    return location.pathname === href || location.pathname.startsWith(href + "/");
+  }
+
+  async function handleSwitch(profile: PublicProfile) {
+    if (switching() || profile.id === activeProfileId()) return;
+    setSwitching(true);
+    try {
+      const result = await switchProfile(profile.id);
+      setShowSwitcher(false);
+      toast.success(`Switched to @${result.profile.handle}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to switch profile");
+    } finally {
+      setSwitching(false);
+    }
+  }
+
+  return (
+    <>
+      <aside class="border-border flex h-screen w-60 shrink-0 flex-col border-r">
+        {/* Logo */}
+        <div class="flex items-center gap-2 px-5 pt-6 pb-2">
+          <span class="text-foreground text-lg font-semibold tracking-tight">OSN</span>
+          <span class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Social
+          </span>
+        </div>
+
+        {/* Navigation */}
+        <nav class="flex flex-1 flex-col gap-0.5 px-3 pt-4">
+          <For each={NAV_ITEMS}>
+            {(item) => (
+              <A
+                href={item.href}
+                class={clsx(
+                  "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors",
+                  isActive(item.href)
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                {item.icon()}
+                {item.label}
+              </A>
+            )}
+          </For>
+        </nav>
+
+        {/* User section */}
+        <div class="border-border border-t px-3 py-3">
+          <Show
+            when={session()}
+            fallback={
+              <div class="flex flex-col gap-1.5">
+                <Button
+                  size="sm"
+                  class="w-full"
+                  onClick={() => {
+                    setShowSignIn(false);
+                    setShowRegister(true);
+                  }}
+                >
+                  Create account
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  class="w-full"
+                  onClick={() => {
+                    setShowRegister(false);
+                    setShowSignIn(true);
+                  }}
+                >
+                  Sign in
+                </Button>
+              </div>
+            }
+          >
+            <DropdownMenu>
+              <DropdownMenuTrigger class="hover:bg-muted flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 outline-none transition-colors">
+                <Avatar class="h-8 w-8">
+                  <Show when={activeProfile()?.avatarUrl}>
+                    {(url) => <AvatarImage src={url()} alt={activeProfile()!.handle} />}
+                  </Show>
+                  <AvatarFallback class="text-[10px]">
+                    {profileInitials(activeProfile())}
+                  </AvatarFallback>
+                </Avatar>
+                <div class="flex min-w-0 flex-1 flex-col">
+                  <span class="text-foreground truncate text-[13px] font-medium">
+                    {activeProfile()?.displayName || `@${claims().handle ?? "..."}`}
+                  </span>
+                  <Show when={activeProfile()?.displayName}>
+                    <span class="text-muted-foreground truncate text-[11px]">
+                      @{claims().handle}
+                    </span>
+                  </Show>
+                </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent class="w-52">
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel class="text-muted-foreground font-normal">
+                    @{claims().handle ?? "..."}
+                  </DropdownMenuLabel>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => setShowSwitcher(true)}>
+                  Switch profile
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => logout()}>Log out</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </Show>
+        </div>
+      </aside>
+
+      {/* Auth dialogs */}
+      <Dialog open={showRegister() && !session()} onOpenChange={setShowRegister}>
+        <DialogContent class="max-w-sm p-0">
+          <Register client={registrationClient} onCancel={() => setShowRegister(false)} />
+        </DialogContent>
+      </Dialog>
+      <Dialog open={showSignIn() && !session()} onOpenChange={setShowSignIn}>
+        <DialogContent class="max-w-sm p-0">
+          <SignIn
+            client={loginClient}
+            onCancel={() => setShowSignIn(false)}
+            onSuccess={() => setShowSignIn(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Profile switcher */}
+      <Dialog open={showSwitcher()} onOpenChange={setShowSwitcher}>
+        <DialogContent class="max-w-xs">
+          <div class="flex flex-col gap-1 py-2">
+            <p class="text-foreground mb-2 px-3 text-sm font-semibold">Switch profile</p>
+            <For each={profiles() ?? []}>
+              {(profile) => {
+                const active = () => profile.id === activeProfileId();
+                return (
+                  <button
+                    type="button"
+                    class={clsx(
+                      "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                      active()
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted text-foreground",
+                    )}
+                    disabled={switching()}
+                    onClick={() => handleSwitch(profile)}
+                  >
+                    <Avatar class="h-7 w-7">
+                      <Show when={profile.avatarUrl}>
+                        {(url) => <AvatarImage src={url()} alt={profile.handle} />}
+                      </Show>
+                      <AvatarFallback class="text-[10px]">
+                        {profileInitials(profile)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span class="flex-1 truncate">
+                      @{profile.handle}
+                      <Show when={profile.displayName}>
+                        <span class="text-muted-foreground ml-1 text-xs">
+                          ({profile.displayName})
+                        </span>
+                      </Show>
+                    </span>
+                    <Show when={active()}>
+                      <span class="text-primary text-xs">&#10003;</span>
+                    </Show>
+                  </button>
+                );
+              }}
+            </For>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/osn/social/src/components/Sidebar.tsx
+++ b/osn/social/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { registrationClient, loginClient } from "../lib/authClients";
-import { getTokenClaims, profileInitials } from "../lib/utils";
+import { getTokenClaims, profileInitials, safeAvatarUrl } from "../lib/utils";
 
 interface NavItem {
   href: string;
@@ -205,8 +205,15 @@ export function Sidebar() {
             <DropdownMenu>
               <DropdownMenuTrigger class="hover:bg-muted flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 outline-none transition-colors">
                 <Avatar class="h-8 w-8">
-                  <Show when={activeProfile()?.avatarUrl}>
-                    {(url) => <AvatarImage src={url()} alt={activeProfile()!.handle} />}
+                  <Show when={safeAvatarUrl(activeProfile()?.avatarUrl)}>
+                    {(url) => (
+                      <AvatarImage
+                        src={url()}
+                        alt={activeProfile()!.handle}
+                        referrerpolicy="no-referrer"
+                        loading="lazy"
+                      />
+                    )}
                   </Show>
                   <AvatarFallback class="text-[10px]">
                     {profileInitials(activeProfile())}
@@ -278,8 +285,15 @@ export function Sidebar() {
                     onClick={() => handleSwitch(profile)}
                   >
                     <Avatar class="h-7 w-7">
-                      <Show when={profile.avatarUrl}>
-                        {(url) => <AvatarImage src={url()} alt={profile.handle} />}
+                      <Show when={safeAvatarUrl(profile.avatarUrl)}>
+                        {(url) => (
+                          <AvatarImage
+                            src={url()}
+                            alt={profile.handle}
+                            referrerpolicy="no-referrer"
+                            loading="lazy"
+                          />
+                        )}
                       </Show>
                       <AvatarFallback class="text-[10px]">
                         {profileInitials(profile)}

--- a/osn/social/src/index.tsx
+++ b/osn/social/src/index.tsx
@@ -1,0 +1,6 @@
+/* @refresh reload */
+import { render } from "solid-js/web";
+
+import App from "./App";
+
+render(() => <App />, document.getElementById("root") as HTMLElement);

--- a/osn/social/src/lib/api.ts
+++ b/osn/social/src/lib/api.ts
@@ -1,33 +1,7 @@
-import { createGraphClient, createOrgClient } from "@osn/client";
+import { createGraphClient, createOrgClient, createRecommendationClient } from "@osn/client";
 
 import { OSN_ISSUER_URL } from "./auth";
 
 export const graphClient = createGraphClient({ issuerUrl: OSN_ISSUER_URL });
 export const orgClient = createOrgClient({ issuerUrl: OSN_ISSUER_URL });
-
-const base = OSN_ISSUER_URL.replace(/\/$/, "");
-
-export async function fetchRecommendations(
-  token: string,
-  limit = 10,
-): Promise<{
-  suggestions: {
-    handle: string;
-    displayName: string | null;
-    avatarUrl: string | null;
-    mutualCount: number;
-  }[];
-}> {
-  const res = await fetch(`${base}/recommendations/connections?limit=${limit}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
-  return res.json() as Promise<{
-    suggestions: {
-      handle: string;
-      displayName: string | null;
-      avatarUrl: string | null;
-      mutualCount: number;
-    }[];
-  }>;
-}
+export const recommendationClient = createRecommendationClient({ issuerUrl: OSN_ISSUER_URL });

--- a/osn/social/src/lib/api.ts
+++ b/osn/social/src/lib/api.ts
@@ -1,0 +1,33 @@
+import { createGraphClient, createOrgClient } from "@osn/client";
+
+import { OSN_ISSUER_URL } from "./auth";
+
+export const graphClient = createGraphClient({ issuerUrl: OSN_ISSUER_URL });
+export const orgClient = createOrgClient({ issuerUrl: OSN_ISSUER_URL });
+
+const base = OSN_ISSUER_URL.replace(/\/$/, "");
+
+export async function fetchRecommendations(
+  token: string,
+  limit = 10,
+): Promise<{
+  suggestions: {
+    handle: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    mutualCount: number;
+  }[];
+}> {
+  const res = await fetch(`${base}/recommendations/connections?limit=${limit}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<{
+    suggestions: {
+      handle: string;
+      displayName: string | null;
+      avatarUrl: string | null;
+      mutualCount: number;
+    }[];
+  }>;
+}

--- a/osn/social/src/lib/auth.ts
+++ b/osn/social/src/lib/auth.ts
@@ -1,0 +1,4 @@
+export const OSN_ISSUER_URL = import.meta.env.VITE_OSN_ISSUER_URL ?? "http://localhost:4000";
+export const OSN_CLIENT_ID = import.meta.env.VITE_OSN_CLIENT_ID ?? "social";
+export const REDIRECT_URI = () =>
+  import.meta.env.VITE_REDIRECT_URI ?? `${window.location.origin}/callback`;

--- a/osn/social/src/lib/authClients.ts
+++ b/osn/social/src/lib/authClients.ts
@@ -1,0 +1,6 @@
+import { createLoginClient, createRegistrationClient } from "@osn/client";
+
+import { OSN_ISSUER_URL } from "./auth";
+
+export const registrationClient = createRegistrationClient({ issuerUrl: OSN_ISSUER_URL });
+export const loginClient = createLoginClient({ issuerUrl: OSN_ISSUER_URL });

--- a/osn/social/src/lib/utils.ts
+++ b/osn/social/src/lib/utils.ts
@@ -1,0 +1,32 @@
+import type { PublicProfile } from "@osn/client";
+
+export function profileInitials(profile: PublicProfile | null): string {
+  if (!profile) return "?";
+  const name = profile.displayName || profile.handle;
+  return name.slice(0, 2).toUpperCase();
+}
+
+function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(atob(accessToken.split(".")[1]!)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export interface TokenClaims {
+  profileId: string | null;
+  email: string | null;
+  handle: string | null;
+  displayName: string | null;
+}
+
+export function getTokenClaims(accessToken: string | null): TokenClaims {
+  const payload = decodeJwtPayload(accessToken ?? "");
+  return {
+    profileId: typeof payload?.sub === "string" ? payload.sub : null,
+    email: typeof payload?.email === "string" ? payload.email : null,
+    handle: typeof payload?.handle === "string" ? payload.handle : null,
+    displayName: typeof payload?.displayName === "string" ? payload.displayName : null,
+  };
+}

--- a/osn/social/src/lib/utils.ts
+++ b/osn/social/src/lib/utils.ts
@@ -6,6 +6,16 @@ export function profileInitials(profile: PublicProfile | null): string {
   return name.slice(0, 2).toUpperCase();
 }
 
+/**
+ * Only allow http(s) avatar URLs. Defense-in-depth against a
+ * hypothetical server-side regression that lets users set avatarUrl to
+ * a data: or other URL scheme (S-L3).
+ */
+export function safeAvatarUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url.startsWith("https://") || url.startsWith("http://") ? url : null;
+}
+
 function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
   try {
     return JSON.parse(atob(accessToken.split(".")[1]!)) as Record<string, unknown>;

--- a/osn/social/src/pages/ConnectionsPage.tsx
+++ b/osn/social/src/pages/ConnectionsPage.tsx
@@ -1,0 +1,336 @@
+import type { ConnectionEntry, PendingRequestEntry, ProfileEntry } from "@osn/client";
+import { useAuth } from "@osn/client/solid";
+import { clsx } from "@osn/ui/lib/utils";
+import { Avatar, AvatarFallback } from "@osn/ui/ui/avatar";
+import { Badge } from "@osn/ui/ui/badge";
+import { Button } from "@osn/ui/ui/button";
+import { createResource, createSignal, For, Show } from "solid-js";
+import { toast } from "solid-toast";
+
+import { graphClient } from "../lib/api";
+
+type Tab = "all" | "pending" | "close-friends" | "blocked";
+
+const TABS: { value: Tab; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "close-friends", label: "Close friends" },
+  { value: "blocked", label: "Blocked" },
+];
+
+export function ConnectionsPage() {
+  const { session } = useAuth();
+  const token = () => session()?.accessToken ?? "";
+  const [tab, setTab] = createSignal<Tab>("all");
+
+  const [connections, { refetch: refetchConnections }] = createResource(
+    () => (token() && tab() === "all" ? token() : false),
+    (t) => graphClient.listConnections(t as string),
+  );
+
+  const [pending, { refetch: refetchPending }] = createResource(
+    () => (token() && tab() === "pending" ? token() : false),
+    (t) => graphClient.listPendingRequests(t as string),
+  );
+
+  const [closeFriends, { refetch: refetchCloseFriends }] = createResource(
+    () => (token() && tab() === "close-friends" ? token() : false),
+    (t) => graphClient.listCloseFriends(t as string),
+  );
+
+  const [blocked] = createResource(
+    () => (token() && tab() === "blocked" ? token() : false),
+    (t) => graphClient.listBlocks(t as string),
+  );
+
+  async function removeConnection(handle: string) {
+    try {
+      await graphClient.removeConnection(token(), handle);
+      toast.success(`Removed @${handle}`);
+      refetchConnections();
+    } catch {
+      toast.error("Failed to remove connection");
+    }
+  }
+
+  async function acceptRequest(handle: string) {
+    try {
+      await graphClient.acceptConnection(token(), handle);
+      toast.success(`Accepted @${handle}`);
+      refetchPending();
+      refetchConnections();
+    } catch {
+      toast.error("Failed to accept request");
+    }
+  }
+
+  async function rejectRequest(handle: string) {
+    try {
+      await graphClient.rejectConnection(token(), handle);
+      refetchPending();
+    } catch {
+      toast.error("Failed to reject request");
+    }
+  }
+
+  async function toggleCloseFriend(handle: string, isClose: boolean) {
+    try {
+      if (isClose) {
+        await graphClient.removeCloseFriend(token(), handle);
+        toast.success(`Removed @${handle} from close friends`);
+      } else {
+        await graphClient.addCloseFriend(token(), handle);
+        toast.success(`Added @${handle} to close friends`);
+      }
+      refetchCloseFriends();
+    } catch {
+      toast.error("Failed to update close friend");
+    }
+  }
+
+  async function unblock(handle: string) {
+    try {
+      await graphClient.unblockProfile(token(), handle);
+      toast.success(`Unblocked @${handle}`);
+    } catch {
+      toast.error("Failed to unblock");
+    }
+  }
+
+  return (
+    <main class="mx-auto w-full max-w-2xl px-8 py-8">
+      <div class="mb-6">
+        <h1 class="text-foreground text-xl font-semibold tracking-tight">Connections</h1>
+        <p class="text-muted-foreground mt-1 text-sm">People in your social network on OSN.</p>
+      </div>
+
+      <Show
+        when={session()}
+        fallback={
+          <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+            Sign in to view your connections.
+          </div>
+        }
+      >
+        {/* Tab bar */}
+        <div class="border-border mb-6 flex gap-1 border-b">
+          <For each={TABS}>
+            {(t) => (
+              <button
+                type="button"
+                class={clsx(
+                  "border-b-2 px-3 pb-2.5 text-[13px] font-medium transition-colors",
+                  tab() === t.value
+                    ? "border-foreground text-foreground"
+                    : "text-muted-foreground hover:text-foreground border-transparent",
+                )}
+                onClick={() => setTab(t.value)}
+              >
+                {t.label}
+              </button>
+            )}
+          </For>
+        </div>
+
+        {/* All connections */}
+        <Show when={tab() === "all"}>
+          <Show when={!connections.loading} fallback={<LoadingSkeleton count={3} />}>
+            <Show
+              when={(connections()?.connections.length ?? 0) > 0}
+              fallback={
+                <EmptyState message="No connections yet. Discover people to connect with." />
+              }
+            >
+              <div class="flex flex-col gap-1">
+                <For each={connections()?.connections}>
+                  {(conn: ConnectionEntry) => (
+                    <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                      <Avatar class="h-9 w-9">
+                        <AvatarFallback class="text-xs">
+                          {conn.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground text-sm font-medium">
+                          {conn.displayName || `@${conn.handle}`}
+                        </p>
+                        <Show when={conn.displayName}>
+                          <p class="text-muted-foreground text-xs">@{conn.handle}</p>
+                        </Show>
+                      </div>
+                      <div class="flex items-center gap-1.5">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="text-muted-foreground h-7 text-xs"
+                          onClick={() => toggleCloseFriend(conn.handle, false)}
+                        >
+                          Close friend
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="text-destructive h-7 text-xs"
+                          onClick={() => removeConnection(conn.handle)}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </Show>
+
+        {/* Pending requests */}
+        <Show when={tab() === "pending"}>
+          <Show when={!pending.loading} fallback={<LoadingSkeleton count={2} />}>
+            <Show
+              when={(pending()?.pending.length ?? 0) > 0}
+              fallback={<EmptyState message="No pending connection requests." />}
+            >
+              <div class="flex flex-col gap-1">
+                <For each={pending()?.pending}>
+                  {(req: PendingRequestEntry) => (
+                    <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                      <Avatar class="h-9 w-9">
+                        <AvatarFallback class="text-xs">
+                          {req.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground text-sm font-medium">
+                          {req.displayName || `@${req.handle}`}
+                        </p>
+                        <p class="text-muted-foreground text-xs">
+                          Requested {new Date(req.requestedAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div class="flex items-center gap-1.5">
+                        <Button
+                          size="sm"
+                          class="h-7 text-xs"
+                          onClick={() => acceptRequest(req.handle)}
+                        >
+                          Accept
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="text-muted-foreground h-7 text-xs"
+                          onClick={() => rejectRequest(req.handle)}
+                        >
+                          Decline
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </Show>
+
+        {/* Close friends */}
+        <Show when={tab() === "close-friends"}>
+          <Show when={!closeFriends.loading} fallback={<LoadingSkeleton count={2} />}>
+            <Show
+              when={(closeFriends()?.closeFriends.length ?? 0) > 0}
+              fallback={
+                <EmptyState message="No close friends yet. Add connections as close friends to see them here." />
+              }
+            >
+              <div class="flex flex-col gap-1">
+                <For each={closeFriends()?.closeFriends}>
+                  {(friend: ProfileEntry) => (
+                    <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                      <Avatar class="h-9 w-9">
+                        <AvatarFallback class="text-xs">
+                          {friend.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground text-sm font-medium">
+                          {friend.displayName || `@${friend.handle}`}
+                        </p>
+                        <Show when={friend.displayName}>
+                          <p class="text-muted-foreground text-xs">@{friend.handle}</p>
+                        </Show>
+                      </div>
+                      <Badge variant="secondary" class="text-[11px]">
+                        Close friend
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        class="text-muted-foreground h-7 text-xs"
+                        onClick={() => toggleCloseFriend(friend.handle, true)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </Show>
+
+        {/* Blocked */}
+        <Show when={tab() === "blocked"}>
+          <Show when={!blocked.loading} fallback={<LoadingSkeleton count={1} />}>
+            <Show
+              when={(blocked()?.blocks.length ?? 0) > 0}
+              fallback={<EmptyState message="You haven't blocked anyone." />}
+            >
+              <div class="flex flex-col gap-1">
+                <For each={blocked()?.blocks}>
+                  {(profile: ProfileEntry) => (
+                    <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                      <Avatar class="h-9 w-9">
+                        <AvatarFallback class="text-xs">
+                          {profile.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground text-sm font-medium">@{profile.handle}</p>
+                      </div>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        class="h-7 text-xs"
+                        onClick={() => unblock(profile.handle)}
+                      >
+                        Unblock
+                      </Button>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </Show>
+      </Show>
+    </main>
+  );
+}
+
+function EmptyState(props: { message: string }) {
+  return (
+    <div class="text-muted-foreground border-border rounded-lg border border-dashed py-12 text-center text-sm">
+      {props.message}
+    </div>
+  );
+}
+
+function LoadingSkeleton(props: { count: number }) {
+  return (
+    <div class="flex flex-col gap-2">
+      {Array.from({ length: props.count }, () => (
+        <div class="bg-muted/50 h-14 animate-pulse rounded-lg" />
+      ))}
+    </div>
+  );
+}

--- a/osn/social/src/pages/ConnectionsPage.tsx
+++ b/osn/social/src/pages/ConnectionsPage.tsx
@@ -23,25 +23,56 @@ export function ConnectionsPage() {
   const token = () => session()?.accessToken ?? "";
   const [tab, setTab] = createSignal<Tab>("all");
 
-  const [connections, { refetch: refetchConnections }] = createResource(
-    () => (token() && tab() === "all" ? token() : false),
-    (t) => graphClient.listConnections(t as string),
+  // Single keyed resource for all four tabs (P-W5). Rapid tab-switching
+  // produces a single in-flight request at a time thanks to Solid's
+  // source-change cancellation semantics, rather than firing one request
+  // per tab entered.
+  type TabPayload =
+    | { kind: "all"; data: Awaited<ReturnType<typeof graphClient.listConnections>> }
+    | { kind: "pending"; data: Awaited<ReturnType<typeof graphClient.listPendingRequests>> }
+    | { kind: "close-friends"; data: Awaited<ReturnType<typeof graphClient.listCloseFriends>> }
+    | { kind: "blocked"; data: Awaited<ReturnType<typeof graphClient.listBlocks>> };
+
+  const [payload, { refetch: refetchPayload }] = createResource<
+    TabPayload | undefined,
+    { tab: Tab; token: string }
+  >(
+    () => (token() ? { tab: tab(), token: token() } : undefined),
+    async ({ tab: t, token: tk }): Promise<TabPayload> => {
+      switch (t) {
+        case "all":
+          return { kind: "all", data: await graphClient.listConnections(tk) };
+        case "pending":
+          return { kind: "pending", data: await graphClient.listPendingRequests(tk) };
+        case "close-friends":
+          return { kind: "close-friends", data: await graphClient.listCloseFriends(tk) };
+        case "blocked":
+          return { kind: "blocked", data: await graphClient.listBlocks(tk) };
+      }
+    },
   );
 
-  const [pending, { refetch: refetchPending }] = createResource(
-    () => (token() && tab() === "pending" ? token() : false),
-    (t) => graphClient.listPendingRequests(t as string),
-  );
+  // Narrowed accessors — each returns the tab's payload when active, else null.
+  const connections = () =>
+    payload()?.kind === "all"
+      ? (payload() as Extract<TabPayload, { kind: "all" }>).data
+      : undefined;
+  const pending = () =>
+    payload()?.kind === "pending"
+      ? (payload() as Extract<TabPayload, { kind: "pending" }>).data
+      : undefined;
+  const closeFriends = () =>
+    payload()?.kind === "close-friends"
+      ? (payload() as Extract<TabPayload, { kind: "close-friends" }>).data
+      : undefined;
+  const blocked = () =>
+    payload()?.kind === "blocked"
+      ? (payload() as Extract<TabPayload, { kind: "blocked" }>).data
+      : undefined;
 
-  const [closeFriends, { refetch: refetchCloseFriends }] = createResource(
-    () => (token() && tab() === "close-friends" ? token() : false),
-    (t) => graphClient.listCloseFriends(t as string),
-  );
-
-  const [blocked] = createResource(
-    () => (token() && tab() === "blocked" ? token() : false),
-    (t) => graphClient.listBlocks(t as string),
-  );
+  const refetchConnections = refetchPayload;
+  const refetchPending = refetchPayload;
+  const refetchCloseFriends = refetchPayload;
 
   async function removeConnection(handle: string) {
     try {
@@ -134,9 +165,9 @@ export function ConnectionsPage() {
 
         {/* All connections */}
         <Show when={tab() === "all"}>
-          <Show when={!connections.loading} fallback={<LoadingSkeleton count={3} />}>
+          <Show when={!payload.loading} fallback={<LoadingSkeleton count={3} />}>
             <Show
-              when={(connections()?.connections.length ?? 0) > 0}
+              when={(connections()?.connections?.length ?? 0) > 0}
               fallback={
                 <EmptyState message="No connections yet. Discover people to connect with." />
               }
@@ -186,7 +217,7 @@ export function ConnectionsPage() {
 
         {/* Pending requests */}
         <Show when={tab() === "pending"}>
-          <Show when={!pending.loading} fallback={<LoadingSkeleton count={2} />}>
+          <Show when={!payload.loading} fallback={<LoadingSkeleton count={2} />}>
             <Show
               when={(pending()?.pending.length ?? 0) > 0}
               fallback={<EmptyState message="No pending connection requests." />}
@@ -235,7 +266,7 @@ export function ConnectionsPage() {
 
         {/* Close friends */}
         <Show when={tab() === "close-friends"}>
-          <Show when={!closeFriends.loading} fallback={<LoadingSkeleton count={2} />}>
+          <Show when={!payload.loading} fallback={<LoadingSkeleton count={2} />}>
             <Show
               when={(closeFriends()?.closeFriends.length ?? 0) > 0}
               fallback={
@@ -280,7 +311,7 @@ export function ConnectionsPage() {
 
         {/* Blocked */}
         <Show when={tab() === "blocked"}>
-          <Show when={!blocked.loading} fallback={<LoadingSkeleton count={1} />}>
+          <Show when={!payload.loading} fallback={<LoadingSkeleton count={1} />}>
             <Show
               when={(blocked()?.blocks.length ?? 0) > 0}
               fallback={<EmptyState message="You haven't blocked anyone." />}

--- a/osn/social/src/pages/DiscoverPage.tsx
+++ b/osn/social/src/pages/DiscoverPage.tsx
@@ -4,7 +4,8 @@ import { Button } from "@osn/ui/ui/button";
 import { createResource, createSignal, For, Show } from "solid-js";
 import { toast } from "solid-toast";
 
-import { fetchRecommendations, graphClient } from "../lib/api";
+import { graphClient, recommendationClient } from "../lib/api";
+import { safeAvatarUrl } from "../lib/utils";
 
 export function DiscoverPage() {
   const { session } = useAuth();
@@ -12,7 +13,7 @@ export function DiscoverPage() {
 
   const [recommendations, { refetch }] = createResource(
     () => token() || false,
-    (t) => fetchRecommendations(t as string, 20),
+    (t) => recommendationClient.suggestConnections(t as string, { limit: 20 }),
   );
 
   const [sending, setSending] = createSignal<Set<string>>(new Set());
@@ -75,8 +76,15 @@ export function DiscoverPage() {
                   <div class="border-border hover:bg-muted/30 flex flex-col gap-3 rounded-lg border p-4 transition-colors">
                     <div class="flex items-center gap-3">
                       <Avatar class="h-10 w-10">
-                        <Show when={suggestion.avatarUrl}>
-                          {(url) => <AvatarImage src={url()} alt={suggestion.handle} />}
+                        <Show when={safeAvatarUrl(suggestion.avatarUrl)}>
+                          {(url) => (
+                            <AvatarImage
+                              src={url()}
+                              alt={suggestion.handle}
+                              referrerpolicy="no-referrer"
+                              loading="lazy"
+                            />
+                          )}
                         </Show>
                         <AvatarFallback class="text-xs">
                           {suggestion.handle.slice(0, 2).toUpperCase()}

--- a/osn/social/src/pages/DiscoverPage.tsx
+++ b/osn/social/src/pages/DiscoverPage.tsx
@@ -1,0 +1,116 @@
+import { useAuth } from "@osn/client/solid";
+import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
+import { Button } from "@osn/ui/ui/button";
+import { createResource, createSignal, For, Show } from "solid-js";
+import { toast } from "solid-toast";
+
+import { fetchRecommendations, graphClient } from "../lib/api";
+
+export function DiscoverPage() {
+  const { session } = useAuth();
+  const token = () => session()?.accessToken ?? "";
+
+  const [recommendations, { refetch }] = createResource(
+    () => token() || false,
+    (t) => fetchRecommendations(t as string, 20),
+  );
+
+  const [sending, setSending] = createSignal<Set<string>>(new Set());
+
+  async function connect(handle: string) {
+    setSending((s) => new Set(s).add(handle));
+    try {
+      await graphClient.sendConnectionRequest(token(), handle);
+      toast.success(`Request sent to @${handle}`);
+      refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send request");
+    } finally {
+      setSending((s) => {
+        const next = new Set(s);
+        next.delete(handle);
+        return next;
+      });
+    }
+  }
+
+  return (
+    <main class="mx-auto w-full max-w-2xl px-8 py-8">
+      <div class="mb-6">
+        <h1 class="text-foreground text-xl font-semibold tracking-tight">Discover</h1>
+        <p class="text-muted-foreground mt-1 text-sm">
+          People you may know based on mutual connections.
+        </p>
+      </div>
+
+      <Show
+        when={session()}
+        fallback={
+          <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+            Sign in to discover people.
+          </div>
+        }
+      >
+        <Show
+          when={!recommendations.loading}
+          fallback={
+            <div class="grid gap-3 sm:grid-cols-2">
+              {Array.from({ length: 4 }, () => (
+                <div class="bg-muted/50 h-28 animate-pulse rounded-lg" />
+              ))}
+            </div>
+          }
+        >
+          <Show
+            when={(recommendations()?.suggestions.length ?? 0) > 0}
+            fallback={
+              <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+                No suggestions yet. Connect with more people to get recommendations.
+              </div>
+            }
+          >
+            <div class="grid gap-3 sm:grid-cols-2">
+              <For each={recommendations()?.suggestions}>
+                {(suggestion) => (
+                  <div class="border-border hover:bg-muted/30 flex flex-col gap-3 rounded-lg border p-4 transition-colors">
+                    <div class="flex items-center gap-3">
+                      <Avatar class="h-10 w-10">
+                        <Show when={suggestion.avatarUrl}>
+                          {(url) => <AvatarImage src={url()} alt={suggestion.handle} />}
+                        </Show>
+                        <AvatarFallback class="text-xs">
+                          {suggestion.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground truncate text-sm font-medium">
+                          {suggestion.displayName || `@${suggestion.handle}`}
+                        </p>
+                        <Show when={suggestion.displayName}>
+                          <p class="text-muted-foreground truncate text-xs">@{suggestion.handle}</p>
+                        </Show>
+                      </div>
+                    </div>
+                    <div class="flex items-center justify-between">
+                      <span class="text-muted-foreground text-xs">
+                        {suggestion.mutualCount} mutual{suggestion.mutualCount !== 1 ? "s" : ""}
+                      </span>
+                      <Button
+                        size="sm"
+                        class="h-7 text-xs"
+                        disabled={sending().has(suggestion.handle)}
+                        onClick={() => connect(suggestion.handle)}
+                      >
+                        {sending().has(suggestion.handle) ? "Sending..." : "Connect"}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </Show>
+    </main>
+  );
+}

--- a/osn/social/src/pages/OrgDetailPage.tsx
+++ b/osn/social/src/pages/OrgDetailPage.tsx
@@ -7,10 +7,11 @@ import { Input } from "@osn/ui/ui/input";
 import { Label } from "@osn/ui/ui/label";
 import { Textarea } from "@osn/ui/ui/textarea";
 import { useParams, useNavigate } from "@solidjs/router";
-import { createResource, createSignal, For, Show } from "solid-js";
+import { createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { orgClient } from "../lib/api";
+import { safeAvatarUrl } from "../lib/utils";
 
 export function OrgDetailPage() {
   const params = useParams<{ id: string }>();
@@ -18,23 +19,30 @@ export function OrgDetailPage() {
   const { session } = useAuth();
   const token = () => session()?.accessToken ?? "";
 
-  const [org, { refetch: refetchOrg }] = createResource(
-    () => (token() && params.id ? { token: token(), id: params.id } : false),
-    (args) =>
-      orgClient.getOrg(
-        (args as { token: string; id: string }).token,
-        (args as { token: string; id: string }).id,
-      ),
-  );
+  // Stable memoised source key (P-W4). Returning a fresh object per read
+  // makes Solid's === equality check always fail, triggering a refetch
+  // on every signal tick. A string key is referentially stable per
+  // (token, id) pair so the resource only refetches when one changes.
+  const resourceKey = createMemo(() => {
+    const t = token();
+    const id = params.id;
+    return t && id ? `${t}|${id}` : false;
+  });
 
-  const [members, { refetch: refetchMembers }] = createResource(
-    () => (token() && params.id ? { token: token(), id: params.id } : false),
-    (args) =>
-      orgClient.listMembers(
-        (args as { token: string; id: string }).token,
-        (args as { token: string; id: string }).id,
-      ),
-  );
+  const parseKey = (key: string): { token: string; id: string } => {
+    const sep = key.indexOf("|");
+    return { token: key.slice(0, sep), id: key.slice(sep + 1) };
+  };
+
+  const [org, { refetch: refetchOrg }] = createResource(resourceKey, (key) => {
+    const { token, id } = parseKey(key as string);
+    return orgClient.getOrg(token, id);
+  });
+
+  const [members, { refetch: refetchMembers }] = createResource(resourceKey, (key) => {
+    const { token, id } = parseKey(key as string);
+    return orgClient.listMembers(token, id);
+  });
 
   const [showEdit, setShowEdit] = createSignal(false);
   const [editName, setEditName] = createSignal("");
@@ -106,8 +114,15 @@ export function OrgDetailPage() {
             <div class="mb-8 flex items-start justify-between">
               <div class="flex items-center gap-4">
                 <Avatar class="h-14 w-14">
-                  <Show when={orgData().avatarUrl}>
-                    {(url) => <AvatarImage src={url()} alt={orgData().name} />}
+                  <Show when={safeAvatarUrl(orgData().avatarUrl)}>
+                    {(url) => (
+                      <AvatarImage
+                        src={url()}
+                        alt={orgData().name}
+                        referrerpolicy="no-referrer"
+                        loading="lazy"
+                      />
+                    )}
                   </Show>
                   <AvatarFallback>{orgData().name.slice(0, 2).toUpperCase()}</AvatarFallback>
                 </Avatar>
@@ -151,8 +166,15 @@ export function OrgDetailPage() {
                     {(member) => (
                       <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
                         <Avatar class="h-8 w-8">
-                          <Show when={member.profile.avatarUrl}>
-                            {(url) => <AvatarImage src={url()} alt={member.profile.handle} />}
+                          <Show when={safeAvatarUrl(member.profile.avatarUrl)}>
+                            {(url) => (
+                              <AvatarImage
+                                src={url()}
+                                alt={member.profile.handle}
+                                referrerpolicy="no-referrer"
+                                loading="lazy"
+                              />
+                            )}
                           </Show>
                           <AvatarFallback class="text-[10px]">
                             {member.profile.handle.slice(0, 2).toUpperCase()}

--- a/osn/social/src/pages/OrgDetailPage.tsx
+++ b/osn/social/src/pages/OrgDetailPage.tsx
@@ -1,0 +1,235 @@
+import { useAuth } from "@osn/client/solid";
+import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
+import { Badge } from "@osn/ui/ui/badge";
+import { Button } from "@osn/ui/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@osn/ui/ui/dialog";
+import { Input } from "@osn/ui/ui/input";
+import { Label } from "@osn/ui/ui/label";
+import { Textarea } from "@osn/ui/ui/textarea";
+import { useParams, useNavigate } from "@solidjs/router";
+import { createResource, createSignal, For, Show } from "solid-js";
+import { toast } from "solid-toast";
+
+import { orgClient } from "../lib/api";
+
+export function OrgDetailPage() {
+  const params = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { session } = useAuth();
+  const token = () => session()?.accessToken ?? "";
+
+  const [org, { refetch: refetchOrg }] = createResource(
+    () => (token() && params.id ? { token: token(), id: params.id } : false),
+    (args) =>
+      orgClient.getOrg(
+        (args as { token: string; id: string }).token,
+        (args as { token: string; id: string }).id,
+      ),
+  );
+
+  const [members, { refetch: refetchMembers }] = createResource(
+    () => (token() && params.id ? { token: token(), id: params.id } : false),
+    (args) =>
+      orgClient.listMembers(
+        (args as { token: string; id: string }).token,
+        (args as { token: string; id: string }).id,
+      ),
+  );
+
+  const [showEdit, setShowEdit] = createSignal(false);
+  const [editName, setEditName] = createSignal("");
+  const [editDesc, setEditDesc] = createSignal("");
+  const [saving, setSaving] = createSignal(false);
+
+  function openEdit() {
+    const o = org();
+    if (o) {
+      setEditName(o.name);
+      setEditDesc(o.description ?? "");
+      setShowEdit(true);
+    }
+  }
+
+  async function handleSave(e: Event) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await orgClient.updateOrg(token(), params.id, {
+        name: editName(),
+        description: editDesc() || undefined,
+      });
+      toast.success("Organisation updated");
+      setShowEdit(false);
+      refetchOrg();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to update");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete this organisation? This cannot be undone.")) return;
+    try {
+      await orgClient.deleteOrg(token(), params.id);
+      toast.success("Organisation deleted");
+      navigate("/organisations");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete");
+    }
+  }
+
+  async function removeMember(profileId: string, handle: string) {
+    try {
+      await orgClient.removeMember(token(), params.id, profileId);
+      toast.success(`Removed @${handle}`);
+      refetchMembers();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove member");
+    }
+  }
+
+  return (
+    <main class="mx-auto w-full max-w-2xl px-8 py-8">
+      <Show
+        when={!org.loading && org()}
+        fallback={
+          <div class="flex flex-col gap-3">
+            <div class="bg-muted/50 h-8 w-48 animate-pulse rounded" />
+            <div class="bg-muted/50 h-5 w-64 animate-pulse rounded" />
+          </div>
+        }
+      >
+        {(orgData) => (
+          <>
+            {/* Header */}
+            <div class="mb-8 flex items-start justify-between">
+              <div class="flex items-center gap-4">
+                <Avatar class="h-14 w-14">
+                  <Show when={orgData().avatarUrl}>
+                    {(url) => <AvatarImage src={url()} alt={orgData().name} />}
+                  </Show>
+                  <AvatarFallback>{orgData().name.slice(0, 2).toUpperCase()}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <h1 class="text-foreground text-xl font-semibold tracking-tight">
+                    {orgData().name}
+                  </h1>
+                  <p class="text-muted-foreground text-sm">@{orgData().handle}</p>
+                  <Show when={orgData().description}>
+                    <p class="text-muted-foreground mt-1 text-sm">{orgData().description}</p>
+                  </Show>
+                </div>
+              </div>
+              <div class="flex gap-1.5">
+                <Button variant="secondary" size="sm" onClick={openEdit}>
+                  Edit
+                </Button>
+                <Button variant="ghost" size="sm" class="text-destructive" onClick={handleDelete}>
+                  Delete
+                </Button>
+              </div>
+            </div>
+
+            {/* Members */}
+            <div>
+              <div class="mb-3 flex items-center justify-between">
+                <h2 class="text-foreground text-sm font-semibold">Members</h2>
+              </div>
+              <Show
+                when={!members.loading}
+                fallback={
+                  <div class="flex flex-col gap-2">
+                    {Array.from({ length: 2 }, () => (
+                      <div class="bg-muted/50 h-12 animate-pulse rounded-lg" />
+                    ))}
+                  </div>
+                }
+              >
+                <div class="flex flex-col gap-1">
+                  <For each={members()?.members}>
+                    {(member) => (
+                      <div class="hover:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                        <Avatar class="h-8 w-8">
+                          <Show when={member.profile.avatarUrl}>
+                            {(url) => <AvatarImage src={url()} alt={member.profile.handle} />}
+                          </Show>
+                          <AvatarFallback class="text-[10px]">
+                            {member.profile.handle.slice(0, 2).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div class="min-w-0 flex-1">
+                          <p class="text-foreground text-sm font-medium">
+                            {member.profile.displayName || `@${member.profile.handle}`}
+                          </p>
+                          <Show when={member.profile.displayName}>
+                            <p class="text-muted-foreground text-xs">@{member.profile.handle}</p>
+                          </Show>
+                        </div>
+                        <Badge variant="secondary" class="text-[11px]">
+                          {member.role}
+                        </Badge>
+                        <Show when={member.role !== "admin"}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            class="text-muted-foreground h-7 text-xs"
+                            onClick={() => removeMember(member.profile.id, member.profile.handle)}
+                          >
+                            Remove
+                          </Button>
+                        </Show>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </>
+        )}
+      </Show>
+
+      {/* Edit dialog */}
+      <Dialog open={showEdit()} onOpenChange={setShowEdit}>
+        <DialogContent class="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit organisation</DialogTitle>
+          </DialogHeader>
+          <form class="flex flex-col gap-4 pt-2" onSubmit={handleSave}>
+            <div class="flex flex-col gap-1.5">
+              <Label for="edit-name">Name</Label>
+              <Input
+                id="edit-name"
+                value={editName()}
+                onInput={(e) => setEditName(e.currentTarget.value)}
+                required
+              />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <Label for="edit-desc">Description</Label>
+              <Textarea
+                id="edit-desc"
+                value={editDesc()}
+                onInput={(e) => setEditDesc(e.currentTarget.value)}
+                rows={2}
+              />
+            </div>
+            <div class="flex justify-end gap-2 pt-1">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowEdit(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={saving()}>
+                {saving() ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/osn/social/src/pages/OrganisationsPage.tsx
+++ b/osn/social/src/pages/OrganisationsPage.tsx
@@ -1,0 +1,195 @@
+import { useAuth } from "@osn/client/solid";
+import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
+import { Button } from "@osn/ui/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@osn/ui/ui/dialog";
+import { Input } from "@osn/ui/ui/input";
+import { Label } from "@osn/ui/ui/label";
+import { Textarea } from "@osn/ui/ui/textarea";
+import { A } from "@solidjs/router";
+import { createResource, createSignal, For, Show } from "solid-js";
+import { toast } from "solid-toast";
+
+import { orgClient } from "../lib/api";
+
+export function OrganisationsPage() {
+  const { session } = useAuth();
+  const token = () => session()?.accessToken ?? "";
+
+  const [orgs, { refetch }] = createResource(
+    () => token() || false,
+    (t) => orgClient.listMyOrgs(t as string),
+  );
+
+  const [showCreate, setShowCreate] = createSignal(false);
+  const [creating, setCreating] = createSignal(false);
+  const [handle, setHandle] = createSignal("");
+  const [name, setName] = createSignal("");
+  const [description, setDescription] = createSignal("");
+
+  async function handleCreate(e: Event) {
+    e.preventDefault();
+    if (!handle() || !name()) return;
+    setCreating(true);
+    try {
+      await orgClient.createOrg(token(), {
+        handle: handle(),
+        name: name(),
+        description: description() || undefined,
+      });
+      toast.success(`Created ${name()}`);
+      setShowCreate(false);
+      setHandle("");
+      setName("");
+      setDescription("");
+      refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create organisation");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <main class="mx-auto w-full max-w-2xl px-8 py-8">
+      <div class="mb-6 flex items-center justify-between">
+        <div>
+          <h1 class="text-foreground text-xl font-semibold tracking-tight">Organisations</h1>
+          <p class="text-muted-foreground mt-1 text-sm">Groups and teams you belong to.</p>
+        </div>
+        <Show when={session()}>
+          <Button size="sm" onClick={() => setShowCreate(true)}>
+            Create
+          </Button>
+        </Show>
+      </div>
+
+      <Show
+        when={session()}
+        fallback={
+          <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+            Sign in to view your organisations.
+          </div>
+        }
+      >
+        <Show
+          when={!orgs.loading}
+          fallback={
+            <div class="flex flex-col gap-2">
+              {Array.from({ length: 2 }, () => (
+                <div class="bg-muted/50 h-20 animate-pulse rounded-lg" />
+              ))}
+            </div>
+          }
+        >
+          <Show
+            when={(orgs()?.organisations.length ?? 0) > 0}
+            fallback={
+              <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+                You're not part of any organisations yet.
+              </div>
+            }
+          >
+            <div class="flex flex-col gap-2">
+              <For each={orgs()?.organisations}>
+                {(org) => (
+                  <A
+                    href={`/organisations/${org.id}`}
+                    class="border-border hover:bg-muted/30 flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors"
+                  >
+                    <Avatar class="h-10 w-10">
+                      <Show when={org.avatarUrl}>
+                        {(url) => <AvatarImage src={url()} alt={org.name} />}
+                      </Show>
+                      <AvatarFallback class="text-xs">
+                        {org.name.slice(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div class="min-w-0 flex-1">
+                      <p class="text-foreground text-sm font-medium">{org.name}</p>
+                      <p class="text-muted-foreground text-xs">@{org.handle}</p>
+                    </div>
+                    <Show when={org.description}>
+                      <p class="text-muted-foreground hidden max-w-48 truncate text-xs sm:block">
+                        {org.description}
+                      </p>
+                    </Show>
+                    <svg
+                      class="text-muted-foreground h-4 w-4 shrink-0"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="m9 18 6-6-6-6" />
+                    </svg>
+                  </A>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </Show>
+
+      {/* Create org dialog */}
+      <Dialog open={showCreate()} onOpenChange={setShowCreate}>
+        <DialogContent class="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Create organisation</DialogTitle>
+          </DialogHeader>
+          <form class="flex flex-col gap-4 pt-2" onSubmit={handleCreate}>
+            <div class="flex flex-col gap-1.5">
+              <Label for="org-handle">Handle</Label>
+              <Input
+                id="org-handle"
+                placeholder="my-org"
+                value={handle()}
+                onInput={(e) =>
+                  setHandle(e.currentTarget.value.toLowerCase().replace(/[^a-z0-9_]/g, ""))
+                }
+                required
+              />
+              <p class="text-muted-foreground text-[11px]">
+                Lowercase letters, numbers, and underscores only.
+              </p>
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <Label for="org-name">Name</Label>
+              <Input
+                id="org-name"
+                placeholder="My Organisation"
+                value={name()}
+                onInput={(e) => setName(e.currentTarget.value)}
+                required
+              />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <Label for="org-desc">Description</Label>
+              <Textarea
+                id="org-desc"
+                placeholder="What's this organisation about?"
+                value={description()}
+                onInput={(e) => setDescription(e.currentTarget.value)}
+                rows={2}
+              />
+            </div>
+            <div class="flex justify-end gap-2 pt-1">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowCreate(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={creating() || !handle() || !name()}>
+                {creating() ? "Creating..." : "Create"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/osn/social/src/pages/OrganisationsPage.tsx
+++ b/osn/social/src/pages/OrganisationsPage.tsx
@@ -10,6 +10,7 @@ import { createResource, createSignal, For, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { orgClient } from "../lib/api";
+import { safeAvatarUrl } from "../lib/utils";
 
 export function OrganisationsPage() {
   const { session } = useAuth();
@@ -97,8 +98,15 @@ export function OrganisationsPage() {
                     class="border-border hover:bg-muted/30 flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors"
                   >
                     <Avatar class="h-10 w-10">
-                      <Show when={org.avatarUrl}>
-                        {(url) => <AvatarImage src={url()} alt={org.name} />}
+                      <Show when={safeAvatarUrl(org.avatarUrl)}>
+                        {(url) => (
+                          <AvatarImage
+                            src={url()}
+                            alt={org.name}
+                            referrerpolicy="no-referrer"
+                            loading="lazy"
+                          />
+                        )}
                       </Show>
                       <AvatarFallback class="text-xs">
                         {org.name.slice(0, 2).toUpperCase()}

--- a/osn/social/src/pages/SettingsPage.tsx
+++ b/osn/social/src/pages/SettingsPage.tsx
@@ -1,0 +1,179 @@
+import { useAuth } from "@osn/client/solid";
+import { ProfileOnboarding } from "@osn/ui/auth/ProfileOnboarding";
+import { clsx } from "@osn/ui/lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
+import { Button } from "@osn/ui/ui/button";
+import { Card } from "@osn/ui/ui/card";
+import { Input } from "@osn/ui/ui/input";
+import { Label } from "@osn/ui/ui/label";
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import { registrationClient } from "../lib/authClients";
+import { getTokenClaims, profileInitials } from "../lib/utils";
+
+type Section = "profile" | "account" | "apps";
+
+const SECTIONS: { value: Section; label: string }[] = [
+  { value: "profile", label: "Profile" },
+  { value: "account", label: "Account" },
+  { value: "apps", label: "Connected apps" },
+];
+
+export function SettingsPage() {
+  const { session, profiles, activeProfileId } = useAuth();
+  const [section, setSection] = createSignal<Section>("profile");
+
+  const accessToken = () => session()?.accessToken ?? null;
+  const claims = createMemo(() => getTokenClaims(accessToken()));
+  const activeProfile = createMemo(
+    () => profiles()?.find((p) => p.id === activeProfileId()) ?? null,
+  );
+
+  return (
+    <main class="mx-auto w-full max-w-2xl px-8 py-8">
+      <div class="mb-6">
+        <h1 class="text-foreground text-xl font-semibold tracking-tight">Settings</h1>
+        <p class="text-muted-foreground mt-1 text-sm">Manage your OSN identity and account.</p>
+      </div>
+
+      <Show
+        when={session()}
+        fallback={
+          <div class="text-muted-foreground border-border rounded-lg border border-dashed py-16 text-center text-sm">
+            Sign in to manage your settings.
+          </div>
+        }
+      >
+        {/* Profile onboarding banner */}
+        <div class="mb-4">
+          <ProfileOnboarding checkHandle={registrationClient.checkHandle} dismissible />
+        </div>
+
+        {/* Section tabs */}
+        <div class="border-border mb-6 flex gap-1 border-b">
+          <For each={SECTIONS}>
+            {(s) => (
+              <button
+                type="button"
+                class={clsx(
+                  "border-b-2 px-3 pb-2.5 text-[13px] font-medium transition-colors",
+                  section() === s.value
+                    ? "border-foreground text-foreground"
+                    : "text-muted-foreground hover:text-foreground border-transparent",
+                )}
+                onClick={() => setSection(s.value)}
+              >
+                {s.label}
+              </button>
+            )}
+          </For>
+        </div>
+
+        {/* Profile section */}
+        <Show when={section() === "profile"}>
+          <Card class="flex flex-col gap-5 p-5">
+            <div class="flex items-center gap-4">
+              <Avatar class="h-16 w-16">
+                <Show when={activeProfile()?.avatarUrl}>
+                  {(url) => <AvatarImage src={url()} alt={claims().handle ?? ""} />}
+                </Show>
+                <AvatarFallback class="text-lg">{profileInitials(activeProfile())}</AvatarFallback>
+              </Avatar>
+              <div>
+                <p class="text-foreground font-medium">
+                  {activeProfile()?.displayName || `@${claims().handle}`}
+                </p>
+                <p class="text-muted-foreground text-sm">@{claims().handle}</p>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+              <Label class="text-muted-foreground text-xs">Handle</Label>
+              <Input value={`@${claims().handle ?? ""}`} disabled class="bg-muted/50 text-sm" />
+              <p class="text-muted-foreground text-[11px]">Handles cannot be changed.</p>
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+              <Label class="text-muted-foreground text-xs">Display name</Label>
+              <Input
+                value={activeProfile()?.displayName ?? ""}
+                disabled
+                placeholder="No display name set"
+                class="text-sm"
+              />
+              <p class="text-muted-foreground text-[11px]">Profile editing coming soon.</p>
+            </div>
+          </Card>
+        </Show>
+
+        {/* Account section */}
+        <Show when={section() === "account"}>
+          <Card class="flex flex-col gap-5 p-5">
+            <div class="flex flex-col gap-1.5">
+              <Label class="text-muted-foreground text-xs">Email</Label>
+              <Input value={claims().email ?? ""} disabled class="bg-muted/50 text-sm" />
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+              <Label class="text-muted-foreground text-xs">Profile ID</Label>
+              <Input
+                value={claims().profileId ?? ""}
+                disabled
+                class="bg-muted/50 font-mono text-xs"
+              />
+            </div>
+
+            <div class="border-border border-t pt-4">
+              <h3 class="text-foreground text-sm font-semibold">Danger zone</h3>
+              <p class="text-muted-foreground mb-3 mt-1 text-xs">
+                Account deletion is permanent and cannot be undone.
+              </p>
+              <Button variant="ghost" size="sm" class="text-destructive" disabled>
+                Delete account (coming soon)
+              </Button>
+            </div>
+          </Card>
+        </Show>
+
+        {/* Connected apps section */}
+        <Show when={section() === "apps"}>
+          <Card class="flex flex-col gap-4 p-5">
+            <p class="text-muted-foreground text-sm">
+              Apps connected to your OSN account can access parts of your identity and social graph.
+            </p>
+
+            {/* Static list of known apps for now */}
+            <div class="flex flex-col gap-2">
+              <div class="border-border flex items-center justify-between rounded-lg border px-4 py-3">
+                <div>
+                  <p class="text-foreground text-sm font-medium">Pulse</p>
+                  <p class="text-muted-foreground text-xs">
+                    Events platform — reads your profile and connections
+                  </p>
+                </div>
+                <Button variant="secondary" size="sm" class="h-7 text-xs" disabled>
+                  Connected
+                </Button>
+              </div>
+              <div class="border-border flex items-center justify-between rounded-lg border px-4 py-3">
+                <div>
+                  <p class="text-foreground text-sm font-medium">Zap</p>
+                  <p class="text-muted-foreground text-xs">
+                    Messaging — reads your profile and connections
+                  </p>
+                </div>
+                <Button variant="secondary" size="sm" class="h-7 text-xs" disabled>
+                  Connected
+                </Button>
+              </div>
+            </div>
+
+            <p class="text-muted-foreground text-[11px]">
+              App authorization management and scope controls coming soon.
+            </p>
+          </Card>
+        </Show>
+      </Show>
+    </main>
+  );
+}

--- a/osn/social/src/pages/SettingsPage.tsx
+++ b/osn/social/src/pages/SettingsPage.tsx
@@ -9,7 +9,7 @@ import { Label } from "@osn/ui/ui/label";
 import { createMemo, createSignal, For, Show } from "solid-js";
 
 import { registrationClient } from "../lib/authClients";
-import { getTokenClaims, profileInitials } from "../lib/utils";
+import { getTokenClaims, profileInitials, safeAvatarUrl } from "../lib/utils";
 
 type Section = "profile" | "account" | "apps";
 
@@ -74,8 +74,15 @@ export function SettingsPage() {
           <Card class="flex flex-col gap-5 p-5">
             <div class="flex items-center gap-4">
               <Avatar class="h-16 w-16">
-                <Show when={activeProfile()?.avatarUrl}>
-                  {(url) => <AvatarImage src={url()} alt={claims().handle ?? ""} />}
+                <Show when={safeAvatarUrl(activeProfile()?.avatarUrl)}>
+                  {(url) => (
+                    <AvatarImage
+                      src={url()}
+                      alt={claims().handle ?? ""}
+                      referrerpolicy="no-referrer"
+                      loading="lazy"
+                    />
+                  )}
                 </Show>
                 <AvatarFallback class="text-lg">{profileInitials(activeProfile())}</AvatarFallback>
               </Avatar>

--- a/osn/social/tests/components/Sidebar.test.tsx
+++ b/osn/social/tests/components/Sidebar.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { AuthContext } from "@osn/client/solid";
+import { MemoryRouter, Route } from "@solidjs/router";
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Sidebar } from "../../src/components/Sidebar";
+
+/**
+ * Mount <Sidebar /> inside a MemoryRouter + a mocked AuthContext with a
+ * signed-in session, so the avatar dropdown renders (rather than the
+ * "Create account / Sign in" fallback).
+ */
+function renderSidebar() {
+  const authValue = {
+    session: Object.assign(
+      () => ({
+        accessToken: "tkn",
+        refreshToken: "r",
+        idToken: null,
+        expiresAt: Date.now() + 60_000,
+        scopes: [],
+      }),
+      {
+        state: "ready",
+        loading: false,
+        error: undefined,
+        latest: null,
+        refetch: () => {},
+        mutate: () => {},
+      },
+    ),
+    profiles: Object.assign(
+      () => [
+        {
+          id: "usr_1",
+          handle: "alice",
+          displayName: "Alice",
+          email: "a@b.com",
+          avatarUrl: null,
+        },
+      ],
+      {
+        state: "ready",
+        loading: false,
+        error: undefined,
+        latest: null,
+        refetch: () => {},
+        mutate: () => {},
+      },
+    ),
+    activeProfileId: () => "usr_1",
+    login: () => undefined,
+    logout: () => Promise.resolve(),
+    handleCallback: () => Promise.resolve(),
+    adoptSession: () => Promise.resolve(),
+    switchProfile: () =>
+      Promise.resolve({
+        session: {
+          accessToken: "t",
+          refreshToken: "r",
+          idToken: null,
+          expiresAt: 0,
+          scopes: [],
+        },
+        profile: {
+          id: "usr_1",
+          handle: "alice",
+          displayName: "Alice",
+          email: "a@b.com",
+          avatarUrl: null,
+        },
+      }),
+    createProfile: () =>
+      Promise.resolve({
+        id: "usr_1",
+        handle: "alice",
+        displayName: "Alice",
+        email: "a@b.com",
+        avatarUrl: null,
+      }),
+    deleteProfile: () => Promise.resolve(),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocked AuthContext; full interface fidelity not required for this test
+  const value = authValue as any;
+
+  return render(() => (
+    <AuthContext.Provider value={value}>
+      <MemoryRouter>
+        <Route path="*" component={Sidebar} />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  ));
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<Sidebar /> — authenticated avatar menu", () => {
+  it("renders the avatar dropdown trigger without throwing", () => {
+    // Sanity-mount the authenticated sidebar end-to-end (AuthContext +
+    // MemoryRouter + Kobalte dropdown). Validates that the auth
+    // integration and nav scaffolding don't regress at render time. The
+    // full open-and-click interaction is not asserted here — Kobalte's
+    // trigger relies on pointer-capture semantics that happy-dom does
+    // not reproduce faithfully.
+    const result = renderSidebar();
+    const trigger = result.getByRole("button", { expanded: false });
+    expect(trigger).toBeDefined();
+    // The active profile's display name is rendered inside the trigger.
+    expect(trigger.textContent).toContain("Alice");
+  });
+
+  it("renders the four primary nav links", () => {
+    const result = renderSidebar();
+    expect(result.getByText("Connections")).toBeDefined();
+    expect(result.getByText("Discover")).toBeDefined();
+    expect(result.getByText("Organisations")).toBeDefined();
+    expect(result.getByText("Settings")).toBeDefined();
+  });
+});
+
+describe("<Sidebar /> — unauthenticated", () => {
+  it("shows Create account and Sign in buttons when no session", () => {
+    const authValue = {
+      session: Object.assign(() => null, {
+        state: "ready",
+        loading: false,
+        error: undefined,
+        latest: null,
+        refetch: () => {},
+        mutate: () => {},
+      }),
+      profiles: Object.assign(() => null, {
+        state: "ready",
+        loading: false,
+        error: undefined,
+        latest: null,
+        refetch: () => {},
+        mutate: () => {},
+      }),
+      activeProfileId: () => null,
+      login: () => undefined,
+      logout: () => Promise.resolve(),
+      handleCallback: () => Promise.resolve(),
+      adoptSession: () => Promise.resolve(),
+      switchProfile: () => Promise.reject(new Error("no session")),
+      createProfile: () => Promise.reject(new Error("no session")),
+      deleteProfile: () => Promise.resolve(),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocked AuthContext
+    const value = authValue as any;
+
+    const result = render(() => (
+      <AuthContext.Provider value={value}>
+        <MemoryRouter>
+          <Route path="*" component={Sidebar} />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    ));
+
+    expect(result.getByText("Create account")).toBeDefined();
+    expect(result.getByText("Sign in")).toBeDefined();
+  });
+});

--- a/osn/social/tsconfig.json
+++ b/osn/social/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@shared/typescript-config/solid.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["bun-types"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/osn/social/tsconfig.node.json
+++ b/osn/social/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/osn/social/vite.config.ts
+++ b/osn/social/vite.config.ts
@@ -1,0 +1,28 @@
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+// @ts-expect-error process is a nodejs global
+const host = process.env.TAURI_DEV_HOST;
+
+// https://vite.dev/config/
+export default defineConfig(async () => ({
+  plugins: [tailwindcss(), solid()],
+
+  clearScreen: false,
+  server: {
+    port: 1422,
+    strictPort: true,
+    host: host || false,
+    hmr: host
+      ? {
+          protocol: "ws",
+          host,
+          port: 1423,
+        }
+      : undefined,
+    watch: {
+      ignored: ["**/src-tauri/**"],
+    },
+  },
+}));

--- a/osn/social/vitest.config.ts
+++ b/osn/social/vitest.config.ts
@@ -1,0 +1,16 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [solid()],
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "istanbul",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/index.tsx", "src/lib/auth.ts", "src/App.tsx"],
+      reporter: ["text", "html"],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:pulse": "turbo dev --filter=@pulse/api --filter=@pulse/app --filter=@osn/app --filter=@zap/api",
     "dev:zap": "turbo dev --filter=@zap/api --filter=@osn/app",
     "dev:osn": "turbo dev --filter=@osn/core --filter=@osn/app",
+    "dev:social": "turbo dev --filter=@osn/social --filter=@osn/app",
     "dev:apis": "turbo dev --filter=@osn/app --filter=@pulse/api --filter=@zap/api",
     "dev:landing": "turbo dev --filter=@osn/landing",
     "lint": "oxlint -c oxlintrc.json .",

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -12,6 +12,8 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] Build first observability dashboards (HTTP RED, auth funnel, ARC verification, events CRUD) — see [[observability/overview]]
 - [ ] Zap route-level tests + zapBridge tests (T-R1, T-M1 from review)
 - [ ] Zap rate limiting on write endpoints (S-M1) — see [[rate-limiting]]
+- [ ] Recommendations SQL aggregation + caching (P-W6/P-W7) — next step after the in-JS fan-out cap shipped in this PR — see [[social-graph]]
+- [ ] Factor shared `authGet/Post/Patch/Delete` helpers in `@osn/client` (P-I1)
 
 ---
 
@@ -40,7 +42,8 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] Per-app vs global blocking logic (deferred — global blocking across all OSN apps for now)
 - [ ] Interest profile selection (onboarding)
 - [ ] Third-party app authorization flow
-- [ ] Organisation frontend — management UI in Pulse or standalone `@osn/social` Tauri app
+- [x] Organisation frontend — standalone `@osn/social` app delivered (2026-04-16); Tauri wrapping deferred
+- [ ] Recommendations SQL aggregation + compound indexes (P-W7) — push FOF counting into DB, add `connections(status, requester_id)` + `connections(status, addressee_id)` — see [[social-graph]]
 - [ ] Unified `handles` reservation table (user + org handles share namespace; currently enforced at service layer — see Deferred Decisions)
 
 ---

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -228,6 +228,8 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-L3 (zap) — Admin can remove themselves leaving chat with no admin
 - [ ] S-L1 (org) — Org creation rate limit (60/min) shared with member ops
 - [ ] S-L3 (org) — TOCTOU gap in handle uniqueness check
+- [ ] S-L1 (social) — Access tokens in `localStorage` via `StorageLive` — XSS = token exfiltration. Inherited from `@osn/client`; revisit alongside S-M20 by moving to HttpOnly cookie BFF or `sessionStorage` with tight TTL — see [[identity-model]]
+- [ ] S-L4 (recs) — `mutualCount` discloses graph-inference signal; adversary with many test accounts can combine counts to deduce third-party connection sets. Consider bucketing (e.g. "10+") above a threshold — see [[social-graph]]
 
 ---
 
@@ -251,6 +253,8 @@ Open findings only. Completed fixes archived in [[changelog/performance-fixes]].
 - [ ] P-W23 — `tailwind-merge` (~12-14 KB) in initial bundle — see [[component-library]]
 - [ ] P-W24 — `cn()` with signal reads replaces `classList` — avoid in `<For>` loops — see [[component-library]]
 - [ ] P-W3 (org) — Sequential queries in `removeMember`/`updateMemberRole` could be parallelised
+- [ ] P-W6 (recs) — No caching/pagination contract on `/recommendations/connections`. Every request re-runs the FOF pipeline. Add short-lived per-caller cache (5-15 min) and/or `generated_at` timestamp so clients can detect cached responses — see [[social-graph]]
+- [ ] P-W7 (recs) — FOF aggregation in JS after capping fan-out (current). Next step: push aggregation to SQL via `SELECT candidate_id, COUNT(*) FROM (...) GROUP BY candidate_id ORDER BY count DESC LIMIT ?`. Add compound indexes `connections(status, requester_id)` + `connections(status, addressee_id)` — see [[social-graph]]
 
 ### Info
 
@@ -271,6 +275,8 @@ Open findings only. Completed fixes archived in [[changelog/performance-fixes]].
 - [ ] P-I9 — Graph list endpoints load entire result set before slicing — add DB-level `LIMIT`/`OFFSET`
 - [ ] P-I14 — `GET /events/:id/ics` has no `Cache-Control` / `ETag` headers
 - [ ] P-I15 — `rsvpCounts` calls `loadEvent(eventId)` redundantly (route already gates via `loadVisibleEvent`)
+- [ ] P-I1 (client) — Duplicated `authGet`/`authPost`/`authPatch`/`authDelete` helpers across `graph.ts`, `organisations.ts`, `recommendations.ts`. Factor to `@osn/client/src/lib/auth-fetch.ts` parameterised by error-class constructor — see [[component-library]]
+- [ ] P-I4 (social) — List pages (`ConnectionsPage`, `OrganisationsPage`) have no pagination UI. Server supports `limit`/`offset` but users with &gt;50 connections silently lose visibility. Add infinite-scroll via `IntersectionObserver` or paginator
 
 ---
 

--- a/wiki/apps/social.md
+++ b/wiki/apps/social.md
@@ -1,0 +1,77 @@
+---
+title: Social
+description: OSN Social app — identity and social-graph management UI
+tags: [app, identity, social-graph]
+status: active
+packages:
+  - "@osn/social"
+related:
+  - "[[osn-core]]"
+  - "[[social-graph]]"
+  - "[[identity-model]]"
+  - "[[rate-limiting]]"
+last-reviewed: 2026-04-16
+---
+
+# Social
+
+`@osn/social` is a SolidJS web app for managing your OSN identity and social graph. It is the first surface dedicated to the cross-app identity layer — separate from Pulse (events) and Zap (messaging), which remain responsible for their own domain UI.
+
+## Architecture
+
+```
+@osn/social (SolidJS + Vite, port 1422)
+  ├── SolidJS frontend (src/)
+  ├── Consumes @osn/client, @osn/ui
+  └── Talks to @osn/core (port 4000) directly over REST
+```
+
+No Tauri wrapper yet — the app ships as a web build only. Tauri wrapping is tracked in `wiki/TODO.md` as a Phase 2 item.
+
+## Pages
+
+| Route | Component | Purpose |
+|---|---|---|
+| `/` + `/connections` | `ConnectionsPage` | All connections, pending requests, close friends, blocks (tabbed) |
+| `/discover` | `DiscoverPage` | Friends-of-friends recommendations (`GET /recommendations/connections`) |
+| `/organisations` | `OrganisationsPage` | Orgs the user owns or belongs to; create new |
+| `/organisations/:id` | `OrgDetailPage` | Org detail + member management |
+| `/settings` | `SettingsPage` | Profile management, account section, apps |
+| `/callback` | `CallbackHandler` | OAuth2 redirect target (PKCE code exchange) |
+
+## Client surface
+
+Pages talk to `@osn/core` via three plain-fetch clients factored out of `@osn/client`:
+
+- `createGraphClient` — connections, pending requests, close friends, blocks (`osn/client/src/graph.ts`)
+- `createOrgClient` — org CRUD and membership (`osn/client/src/organisations.ts`)
+- `createRecommendationClient` — friends-of-friends suggestions (`osn/client/src/recommendations.ts`)
+
+All three share the same hardening: `authGet/authPost/authPatch/authDelete` with `safeJson` wrapping (no `SyntaxError` leakage), capped error strings, and per-module typed error classes. These helpers are currently duplicated per module; factoring is tracked as P-I1.
+
+## Dev
+
+```bash
+bun run dev:social       # starts @osn/social + @osn/app (core) together
+bun run --cwd osn/social dev   # social only (:1422)
+```
+
+Environment variables (all prefixed `VITE_`):
+
+- `VITE_OSN_ISSUER_URL` — defaults to `http://localhost:4000`
+- `VITE_OSN_CLIENT_ID` — defaults to `social`
+- `VITE_REDIRECT_URI` — defaults to `${origin}/callback`
+
+## Auth
+
+Uses `AuthProvider` from `@osn/client/solid` with the standard OSN OAuth2 + PKCE flow. Access and refresh tokens live in `localStorage` via `StorageLive` — the same pattern as other OSN Solid apps (tracked as a defence-in-depth follow-up; see `wiki/TODO.md` → S-L1 (social)).
+
+The `CallbackHandler` (scoped to `/callback`) completes the code exchange, surfaces any failure via `solid-toast`, and always redirects home so the URL never retains the `code`/`state` params.
+
+## Rate limits
+
+Per-user Redis-backed limiter on the recommendations endpoint (20 req/min, fail-closed) — see `[[rate-limiting]]` and `createRedisRecommendationRateLimiter` in `@osn/core`.
+
+## Testing
+
+`osn/social/tests/` — currently covers the sidebar mount path under `AuthContext` + `MemoryRouter` using `@solidjs/testing-library` + `happy-dom`. The full open-and-click interaction for the Kobalte dropdown is not asserted; Kobalte's trigger relies on pointer-capture semantics that happy-dom does not reproduce faithfully.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -44,6 +44,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 ## Apps
 
 - [[osn-core]] — identity/auth stack (@osn/core + @osn/app)
+- [[social]] — identity & social-graph management UI (@osn/social)
 - [[pulse]] — events app (@pulse/app + @pulse/api + @pulse/db)
 - [[zap]] — messaging app (placeholder, M0-M5 roadmap)
 - [[landing]] — marketing site (@osn/landing)

--- a/wiki/systems/rate-limiting.md
+++ b/wiki/systems/rate-limiting.md
@@ -27,7 +27,7 @@ packages:
   - "@osn/core"
   - "@shared/redis"
   - "@osn/app"
-last-reviewed: 2026-04-12
+last-reviewed: 2026-04-16
 ---
 
 # Rate Limiting
@@ -108,7 +108,7 @@ Send `maxRequests + 1` requests and assert the last returns 429.
 | `/register/begin`, `/otp/begin`, `/magic/begin`, `/login/otp/begin`, `/login/magic/begin` | 5 | OTP/email send -- prevents email bombing |
 | `/register/complete`, `/otp/complete`, `/magic/verify`, `/login/otp/complete`, `/login/passkey/begin`, `/login/passkey/complete`, `/passkey/register/begin`, `/passkey/register/complete`, `/handle/:handle` | 10 | Verify/complete -- slightly higher to allow legitimate retries |
 
-Graph write endpoints are rate-limited at 60 requests per user per minute (S-M16).
+Graph write endpoints are rate-limited at 60 requests per user per minute (S-M16). Recommendations reads (`/recommendations/connections`) are rate-limited at 20 requests per user per minute — tighter because each call runs an FOF fan-out query (S-H1/P-C2).
 
 ## Config
 

--- a/wiki/systems/social-graph.md
+++ b/wiki/systems/social-graph.md
@@ -17,7 +17,7 @@ related:
 packages:
   - "@osn/core"
   - "@osn/db"
-last-reviewed: 2026-04-13
+last-reviewed: 2026-04-16
 ---
 
 # Social Graph
@@ -103,10 +103,33 @@ The `:handle` route parameter uses TypeBox `HandleParam` with regex + length bou
 - Missing index on `close_friends.friend_id` added as `close_friends_friend_idx` (P-W16)
 - `removeConnection` and `blockProfile` wrapped in DB transactions (P-W17)
 
+## Recommendations (friends-of-friends)
+
+`createRecommendationService()` powers the "People You May Know" surface in `@osn/social`. Algorithm:
+
+1. Fetch up to **500 accepted connections** of the caller (cap bounds fan-out).
+2. Fetch blocks in both directions.
+3. Fan out to the caller's friends' accepted connections (capped at **10 000 rows**).
+4. Aggregate mutual counts in JS with an O(1) `Set` on the caller's direct connections, excluding self / existing connections / blocked.
+5. Sort by count desc, slice to the requested `limit` (bounded `[1, 50]` at the HTTP boundary).
+6. Hydrate the top N with `users` rows for `handle`/`displayName`/`avatarUrl`.
+
+Current shape prioritises correctness + bounded cost over peak throughput. Next steps tracked in `wiki/TODO.md`:
+
+- **P-W6** — short-lived per-caller cache (5-15 min) so a Discover-page visit doesn't re-run the pipeline.
+- **P-W7** — push aggregation to SQL (`GROUP BY … ORDER BY … LIMIT`) and add compound indexes `connections(status, requester_id)` / `connections(status, addressee_id)`.
+
+Privacy: the endpoint returns `mutualCount` alongside each suggestion. This leaks graph-inference signal — see `wiki/TODO.md` → S-L4 for the bucketing follow-up.
+
+Rate-limited at 20 req/user/min via `createRedisRecommendationRateLimiter` — see [[rate-limiting]].
+
 ## Source Files
 
 - [osn/core/src/services/graph.ts](../osn/core/src/services/graph.ts) -- graph service
+- [osn/core/src/services/recommendations.ts](../osn/core/src/services/recommendations.ts) -- FOF recommendations
 - [osn/core/src/routes/graph.ts](../osn/core/src/routes/graph.ts) -- graph routes
+- [osn/core/src/routes/recommendations.ts](../osn/core/src/routes/recommendations.ts) -- `/recommendations/connections`
 - [osn/db/src/schema.ts](../osn/db/src/schema.ts) -- schema (connections, close_friends, blocks)
 - [osn/core/tests/services/graph.test.ts](../osn/core/tests/services/graph.test.ts) -- service tests
+- [osn/core/tests/services/recommendations.test.ts](../osn/core/tests/services/recommendations.test.ts) -- recommendations tests
 - [osn/core/tests/routes/graph.test.ts](../osn/core/tests/routes/graph.test.ts) -- route tests


### PR DESCRIPTION
## Summary
- Launch `@osn/social`, OSN's identity + social-graph management SolidJS app (connections, discover, organisations, settings).
- Add `/recommendations/connections` friends-of-friends endpoint in `@osn/core` with a capped in-memory aggregation algorithm.
- Add `@osn/client` modules: `graph.ts`, `organisations.ts`, `recommendations.ts` + Solid `GraphProvider`/`OrgProvider` context hooks.
- Harden across the stack: per-user rate limiter on the new endpoint, numeric HTTP validation, safe JSON parsing in clients, avatar URL scheme allow-list, scoped OAuth callback handler.

## Workspaces affected
- `@osn/app` — wires `createRecommendationRoutes` + `createRedisRecommendationRateLimiter`.
- `@osn/core` — new recommendations service + route + Redis limiter factory.
- `@osn/client` — `graph`, `organisations`, `recommendations` fetch clients + Solid providers; safe JSON error parsing.
- `@osn/social` — **new package** (web app, port 1422).

## Decisions & issues

**Kobalte DropdownMenu.GroupLabel requires a Group ancestor** — fix
- **Issue:** The sidebar avatar dropdown never opened when signed in — clicking the avatar did nothing.
- **Why:** `DropdownMenuLabel` wraps Kobalte's `Menu.GroupLabel`, which requires a `Menu.Group` ancestor. Without it the content renders but the open transition breaks.
- **Solution:** Wrapped the label in `<DropdownMenuGroup>` at `osn/social/src/components/Sidebar.tsx:227-231`, matching the existing pulse pattern.
- **Rationale:** One-line fix; no change required to the shared UI component.

**S-H1 / P-C2 — Recommendations endpoint has no rate limiter**
- **Issue:** `/recommendations/connections` was wired without a rate limiter while every other protected endpoint on the server (auth, graph, org, profile) has Redis-backed per-user limits.
- **Why:** The handler runs three DB round-trips including a FOF join; an authenticated attacker could DoS the DB and enumerate the social graph via repeated calls.
- **Solution:** Added `createRedisRecommendationRateLimiter` alongside the other Redis factories; threaded `rateLimiter: RateLimiterBackend` through `createRecommendationRoutes` with a fail-closed `requireRateLimit` helper. Wired in `osn/app/src/index.ts`. Default 20 req/user/min.
- **Rationale:** Matches the established pattern for read-heavy auth-gated endpoints; closes both DoS and enumeration vectors.

**S-M1 / P-W1 — `?limit` accepted NaN/garbage silently**
- **Issue:** The route parsed `limit` as `parseInt(query.limit, 10)` without validation. `?limit=abc` yielded `NaN`, `Math.min/max` propagated it, and `.slice(0, NaN)` returned `[]` — so a typo silently yielded zero suggestions.
- **Why:** Inconsistent UX, clamping intent bypassed, weak HTTP-boundary validation.
- **Solution:** Switched the Elysia schema to `t.Numeric({ minimum: 1, maximum: 50 })`, which coerces and rejects invalid input at the boundary. Kept `Number.isFinite` guard in the service as defence-in-depth.
- **Rationale:** Fails loudly (422) on bad input; matches the handle-validation pattern elsewhere in the codebase.

**P-C1 — Unbounded FOF fan-out**
- **Issue:** The FOF query pulled the caller's friends' connections with no cap. A hub user with thousands of connections could produce 200 k+ rows transferred to JS.
- **Why:** Discover-page hot path; worst-case memory + DB cost.
- **Solution:** Capped `myConnectionIds` at 500 before the fan-out (`LIMIT 500` on the first read) and added `.limit(10_000)` on the fan-out query itself. Also switched the aggregation loop to `Set.has` instead of `Array.includes` (P-W2) and added explicit column projections on all three reads (P-W3).
- **Rationale:** Bounds worst-case cost to ~10 k rows regardless of network density. Full SQL aggregation + compound indexes are tracked as P-W7 in `wiki/TODO.md` — a larger refactor that needs a DB migration.

**S-M2 / P-I3 — CallbackHandler scope + error handling**
- **Issue:** `CallbackHandler` was rendered inside the layout (runs on every route), swallowed `.catch`, and left `code`/`state` params in the URL on failure.
- **Why:** Silent auth failures were invisible to the user and to observability; leftover params could be bookmarked or re-sent on refresh.
- **Solution:** Moved to a dedicated `/callback` route. Added `.catch((err) => toast.error(...))` and `.finally(() => navigate("/", { replace: true }))`.
- **Rationale:** Matches the redirect URI semantics; surfaces failures via the existing toast pattern; keeps auth params off the address bar.

**P-W4 — OrgDetailPage resource source returned fresh object**
- **Issue:** The resource source `() => ({ token: token(), id: params.id })` produced a new object per read, making Solid's default `===` equality always fail.
- **Why:** Every auth-context broadcast triggered two redundant HTTP round-trips (org detail + members).
- **Solution:** Wrapped in `createMemo` returning a stable `${token}|${id}` string key; resource only refetches when one actually changes.
- **Rationale:** Solid's fine-grained reactivity expects stable references for cache-hit semantics.

**P-W5 — ConnectionsPage four-resource tab-switch storm**
- **Issue:** Four separate resources gated on `tab() === "..."` meant rapidly toggling between tabs fired one request per tab visited.
- **Solution:** Collapsed into a single tagged-union resource keyed by `(tab, token)`. Solid's source-change cancellation produces one in-flight request at a time.
- **Rationale:** Fewer requests against the (now rate-limited) graph endpoints; cleaner reactivity model.

**S-L2 — Clients trust server-supplied error strings**
- **Issue:** The `authGet`/`authPost`/`authPatch`/`authDelete` helpers called `res.json()` unconditionally. A non-JSON error body (proxy HTML, gateway) threw a raw `SyntaxError`; long server-supplied error strings surfaced verbatim in UI toasts.
- **Solution:** Added `safeJson` wrapper (returns `null` on parse failure) and `safeErrorMessage` (caps at 200 chars, generic fallback).
- **Rationale:** Prevents stack-trace leakage in the UI; bounds worst-case error string size.

**S-L3 — Avatar URL scheme unchecked**
- **Issue:** User-controlled `avatarUrl` fields fed directly to `<img src>` with no scheme check. Browsers block `javascript:` inside `<img src>` but `data:` still loads and unvalidated external URLs leak referrer.
- **Solution:** Added `safeAvatarUrl()` http/https allow-list; applied at every `<AvatarImage src>` site. Also added `referrerpolicy="no-referrer"` + `loading="lazy"`.
- **Rationale:** Defence-in-depth against a hypothetical server-side regression.

**P-I2 — `fetchRecommendations` bespoke instead of shared client pattern**
- **Issue:** `@osn/social` had its own one-off `fetchRecommendations` helper while siblings (graph/orgs) used factory clients.
- **Solution:** Added `createRecommendationClient` in `@osn/client` mirroring `createGraphClient` / `createOrgClient` with its own typed `RecommendationClientError`. Consumed in `DiscoverPage`.
- **Rationale:** Consistency with established patterns.

**S-L1 (social) — Access tokens in localStorage**
- **Issue:** `@osn/social` inherits `StorageLive` which persists session tokens to `localStorage` — XSS = token exfiltration.
- **Solution:** Dismissed for this PR; filed in `wiki/TODO.md` → S-L1 (social).
- **Rationale:** Codebase-wide pattern that predates this branch; revisiting requires a BFF / HttpOnly-cookie migration that affects all Solid apps.

**S-L4 — `mutualCount` discloses graph-inference signal**
- **Issue:** Returning exact mutual counts allows a large-scale attacker to deduce third-party connection sets.
- **Solution:** Dismissed for this PR; filed in `wiki/TODO.md` → S-L4 (recs).
- **Rationale:** By-design for PYMK UX; bucketing is a product decision deferred.

**P-W6 — No caching on recommendations**
- **Issue:** Every Discover-page visit re-runs the FOF pipeline.
- **Solution:** Dismissed for this PR; filed in `wiki/TODO.md` → P-W6.
- **Rationale:** Requires cache infra (Redis keys with TTL) + product decisions on staleness tolerance.

**P-I1 — Duplicated fetch helpers across clients**
- **Issue:** `authGet/Post/Patch/Delete` are duplicated across `graph.ts`, `organisations.ts`, and `recommendations.ts`.
- **Solution:** Dismissed for this PR; filed in `wiki/TODO.md` → P-I1 (client).
- **Rationale:** Refactor, not a correctness issue; non-blocking.

**P-I4 — Pagination UI missing on list pages**
- **Issue:** Server supports `limit`/`offset` but the list pages silently cap at the default.
- **Solution:** Dismissed for this PR; filed in `wiki/TODO.md` → P-I4 (social).
- **Rationale:** Feature work beyond the launch scope.

## Test plan
- [ ] `bun run check` — full type-check passes
- [ ] `bun run --cwd osn/core test:run` — 435 tests pass (includes 17 new recommendations tests)
- [ ] `bun run --cwd osn/client test:run` — 98 tests pass (includes 20 graph, 14 orgs, 6 recommendations, 2 solid-context tests)
- [ ] `bun run --cwd osn/social test:run` — 3 tests pass (Sidebar mount coverage)
- [ ] `bun run --cwd osn/app test:run` — 10 tests pass
- [ ] `bun run dev:social` starts `@osn/social` on :1422 + `@osn/core` on :4000
- [ ] Manual: sign in as `alice@seed.osn.dev` (seed), verify:
  - Sidebar avatar dropdown opens with Switch profile / Log out
  - `/connections` shows tabbed connections/pending/close-friends/blocked
  - `/discover` shows FOF suggestions
  - `/organisations` lists orgs, supports create
  - `/organisations/:id` supports edit + member ops
  - `/settings` profile management
  - OAuth callback completes at `/callback`, redirects home, clears URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)