### PR TITLE
refactor: remove @osn/core rate-limit shim and update all internal imports

### DIFF
--- a/.changeset/cleanup-osn-core-rate-limit.md
+++ b/.changeset/cleanup-osn-core-rate-limit.md
@@ -1,0 +1,5 @@
+---
+"@osn/core": patch
+---
+
+Remove the `rate-limit.ts` re-export shim and update all internal imports to `@shared/rate-limit` directly. `createRateLimiter`, `getClientIp`, and `RateLimiterBackend` are no longer exported from `@osn/core` — import from `@shared/rate-limit` instead.

--- a/osn/core/src/index.ts
+++ b/osn/core/src/index.ts
@@ -21,7 +21,6 @@ export {
 } from "./routes/recommendations";
 export { createRecommendationService } from "./services/recommendations";
 export type { RecommendationService } from "./services/recommendations";
-export { createRateLimiter, getClientIp, type RateLimiterBackend } from "@shared/rate-limit";
 export {
   createRedisAuthRateLimiters,
   createRedisGraphRateLimiter,

--- a/osn/core/src/lib/rate-limit.ts
+++ b/osn/core/src/lib/rate-limit.ts
@@ -1,4 +1,0 @@
-// Re-exported from @shared/rate-limit for backwards compatibility within this package.
-// External consumers should import from @shared/rate-limit directly.
-export type { RateLimiterBackend, RateLimiterConfig, RateLimiter } from "@shared/rate-limit";
-export { createRateLimiter, getClientIp } from "@shared/rate-limit";

--- a/osn/core/src/lib/redis-rate-limiters.ts
+++ b/osn/core/src/lib/redis-rate-limiters.ts
@@ -11,12 +11,12 @@
  * call sites in auth.ts / graph.ts handle transparently.
  */
 
+import type { RateLimiterBackend } from "@shared/rate-limit";
 import { createRedisRateLimiter } from "@shared/redis";
 import type { RedisClient } from "@shared/redis";
 
 import type { AuthRateLimiters } from "../routes/auth";
 import type { ProfileRateLimiters } from "../routes/profile";
-import type { RateLimiterBackend } from "./rate-limit";
 
 const ONE_MINUTE_MS = 60_000;
 

--- a/osn/core/src/routes/auth.ts
+++ b/osn/core/src/routes/auth.ts
@@ -1,11 +1,11 @@
 import { DbLive, type Db } from "@osn/db/service";
 import type { AuthRateLimitedEndpoint } from "@shared/observability/metrics";
+import { createRateLimiter, getClientIp, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
 import { verifyPkceChallenge } from "../lib/crypto";
 import { buildAuthorizeHtml } from "../lib/html";
-import { createRateLimiter, getClientIp, type RateLimiterBackend } from "../lib/rate-limit";
 import { metricAuthRateLimited } from "../metrics";
 import { createAuthService, type AuthConfig } from "../services/auth";
 

--- a/osn/core/src/routes/graph.ts
+++ b/osn/core/src/routes/graph.ts
@@ -1,9 +1,9 @@
 import type { Profile } from "@osn/db/schema";
 import { DbLive, type Db } from "@osn/db/service";
+import { createRateLimiter, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
-import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createGraphService } from "../services/graph";
 

--- a/osn/core/src/routes/organisation.ts
+++ b/osn/core/src/routes/organisation.ts
@@ -1,9 +1,9 @@
 import type { Organisation, Profile } from "@osn/db/schema";
 import { DbLive, type Db } from "@osn/db/service";
+import { createRateLimiter, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
-import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createOrganisationService } from "../services/organisation";
 

--- a/osn/core/src/routes/profile.ts
+++ b/osn/core/src/routes/profile.ts
@@ -1,9 +1,9 @@
 import { DbLive, type Db } from "@osn/db/service";
 import type { AuthRateLimitedEndpoint } from "@shared/observability/metrics";
+import { createRateLimiter, getClientIp, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
-import { createRateLimiter, getClientIp, type RateLimiterBackend } from "../lib/rate-limit";
 import { metricAuthRateLimited } from "../metrics";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createProfileService } from "../services/profile";

--- a/osn/core/src/routes/recommendations.ts
+++ b/osn/core/src/routes/recommendations.ts
@@ -1,8 +1,8 @@
 import { DbLive, type Db } from "@osn/db/service";
+import { createRateLimiter, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
-import { createRateLimiter, type RateLimiterBackend } from "../lib/rate-limit";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createRecommendationService } from "../services/recommendations";
 

--- a/osn/core/tests/routes/auth.test.ts
+++ b/osn/core/tests/routes/auth.test.ts
@@ -1,7 +1,7 @@
+import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { describe, it, expect, beforeEach } from "vitest";
 
-import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createAuthRoutes, createDefaultAuthRateLimiters } from "../../src/routes/auth";
 import { createAuthService } from "../../src/services/auth";
 import { createTestLayer } from "../helpers/db";

--- a/osn/core/tests/routes/graph.test.ts
+++ b/osn/core/tests/routes/graph.test.ts
@@ -1,8 +1,8 @@
 import type { Db } from "@osn/db/service";
+import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { describe, it, expect, beforeEach } from "vitest";
 
-import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createAuthRoutes } from "../../src/routes/auth";
 import { createGraphRoutes } from "../../src/routes/graph";
 import { createAuthService } from "../../src/services/auth";

--- a/osn/core/tests/routes/organisation.test.ts
+++ b/osn/core/tests/routes/organisation.test.ts
@@ -1,8 +1,8 @@
 import type { Db } from "@osn/db/service";
+import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
 import { describe, it, expect, beforeEach } from "vitest";
 
-import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createOrganisationRoutes } from "../../src/routes/organisation";
 import { createAuthService } from "../../src/services/auth";
 import { createTestLayer } from "../helpers/db";

--- a/osn/core/tests/routes/profile.test.ts
+++ b/osn/core/tests/routes/profile.test.ts
@@ -1,7 +1,7 @@
+import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach } from "vitest";
 
-import type { RateLimiterBackend } from "../../src/lib/rate-limit";
 import { createProfileRoutes } from "../../src/routes/profile";
 import { createAuthService } from "../../src/services/auth";
 import { createTestLayer } from "../helpers/db";


### PR DESCRIPTION
## Summary
- Delete `osn/core/src/lib/rate-limit.ts` (the re-export shim from PR #59)
- Update all 6 internal `@osn/core` source files and 4 test files to import from `@shared/rate-limit` directly
- Remove `createRateLimiter`, `getClientIp`, `RateLimiterBackend` re-export from `@osn/core/src/index.ts` — these are no longer part of `@osn/core`'s public API

## Workspaces affected
- `@osn/core` (patch — breaking: removes rate-limit re-exports from public API)

## Decisions & issues

**[breaking: removing createRateLimiter/getClientIp from @osn/core public API]** — Consumers must import from @shared/rate-limit
- **Issue:** Anyone importing these from `@osn/core` will break.
- **Why:** The only known external consumer was `@zap/api`, fixed in PR #59. No other package imports these from `@osn/core`.
- **Solution:** Removed the re-export. Import from `@shared/rate-limit` directly.
- **Rationale:** Pre-release, no external consumers — CLAUDE.md convention is no backward compat shims.

## Test plan
- [ ] `bun run --cwd osn/core test:run` — 423 tests pass
- [ ] `bun run check` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)