### PR TITLE
perf(crypto): LRU eviction for publicKeyCache + tokenCache

### DIFF
--- a/.changeset/lru-public-key-cache.md
+++ b/.changeset/lru-public-key-cache.md
@@ -1,0 +1,5 @@
+---
+"@shared/crypto": patch
+---
+
+Upgrade `publicKeyCache` from FIFO to LRU eviction. On every cache hit the entry is re-inserted at the tail of the Map so the least-recently-used key is evicted under key-rotation churn rather than the oldest-inserted one (P-W25).

--- a/shared/crypto/src/arc.ts
+++ b/shared/crypto/src/arc.ts
@@ -242,6 +242,9 @@ const publicKeyCache = new Map<
 >();
 const PUBLIC_KEY_CACHE_TTL_SECONDS = 300; // 5 min
 
+// Mutable cap — overrideable in tests via _setPublicKeyCacheMaxSizeForTest.
+let _publicKeyCacheMaxSize = MAX_CACHE_SIZE;
+
 /**
  * Resolves a service's public key from the `service_account_keys` table by `kid`.
  * Also validates that `serviceId == issuer` and the token's scopes are within
@@ -275,6 +278,10 @@ export const resolvePublicKey = (
           }
         }
       }
+      // LRU touch: re-insert at the end of the Map so this entry is the
+      // most-recently-used and survives the next eviction sweep (P-W25).
+      publicKeyCache.delete(kid);
+      publicKeyCache.set(kid, cached);
       metricArcPublicKeyCacheHit(issuer);
       return cached.key;
     }
@@ -339,10 +346,11 @@ export const resolvePublicKey = (
     });
 
     // Cache the resolved CryptoKey with its allowedScopes for scope validation on future hits.
-    // Enforce size cap — evict the oldest entry when full (P-W100).
-    if (publicKeyCache.size >= MAX_CACHE_SIZE) {
-      const oldest = publicKeyCache.keys().next().value;
-      if (oldest !== undefined) publicKeyCache.delete(oldest);
+    // LRU eviction: the Map preserves insertion/access order; deleting the first
+    // key removes the least-recently-used entry (P-W25).
+    if (publicKeyCache.size >= _publicKeyCacheMaxSize) {
+      const lru = publicKeyCache.keys().next().value;
+      if (lru !== undefined) publicKeyCache.delete(lru);
     }
     publicKeyCache.set(kid, { key, allowedScopes, expiresAt: now + PUBLIC_KEY_CACHE_TTL_SECONDS });
 
@@ -363,6 +371,24 @@ export function clearPublicKeyCache(): void {
  */
 export function evictPublicKeyCacheEntry(kid: string): void {
   publicKeyCache.delete(kid);
+}
+
+/** Returns the current public key cache size. Useful for testing. */
+export function publicKeyCacheSize(): number {
+  return publicKeyCache.size;
+}
+
+/**
+ * Overrides the public key cache max size. **Tests only** — restores to
+ * MAX_CACHE_SIZE in the same afterEach that calls clearPublicKeyCache().
+ */
+export function _setPublicKeyCacheMaxSizeForTest(n: number): void {
+  _publicKeyCacheMaxSize = n;
+}
+
+/** Resets the public key cache max size to the production default. */
+export function _resetPublicKeyCacheMaxSize(): void {
+  _publicKeyCacheMaxSize = MAX_CACHE_SIZE;
 }
 
 // ---------------------------------------------------------------------------

--- a/shared/crypto/src/arc.ts
+++ b/shared/crypto/src/arc.ts
@@ -235,11 +235,21 @@ export async function verifyArcToken(
 // Public key resolution (Effect-based, requires Db)
 // ---------------------------------------------------------------------------
 
-/** In-memory cache for resolved CryptoKeys (kid → { key, allowedScopes, expiresAt }). */
+/**
+ * In-memory cache for resolved CryptoKeys.
+ * `allowedScopes` is stored as a pre-parsed `Set<string>` to avoid
+ * re-splitting the comma string on every cache-hit scope check (P-W2).
+ */
 const publicKeyCache = new Map<
   string,
-  { key: CryptoKey; allowedScopes: string; expiresAt: number }
+  { key: CryptoKey; allowedScopes: Set<string>; expiresAt: number }
 >();
+/**
+ * Last-access timestamps for LRU eviction (P-W1).
+ * Updated on every cache hit; scanned only at insert time (DB-miss path).
+ * Avoids the Map delete+re-insert on the hot cache-hit path.
+ */
+const publicKeyLastAccess = new Map<string, number>();
 const PUBLIC_KEY_CACHE_TTL_SECONDS = 300; // 5 min
 
 // Mutable cap — overrideable in tests via _setPublicKeyCacheMaxSizeForTest.
@@ -267,9 +277,8 @@ export const resolvePublicKey = (
     const cached = publicKeyCache.get(kid);
     if (cached && cached.expiresAt > now) {
       if (tokenScopes && tokenScopes.length > 0) {
-        const allowed = normaliseScopes(cached.allowedScopes);
         for (const s of tokenScopes) {
-          if (!allowed.includes(s.trim().toLowerCase())) {
+          if (!cached.allowedScopes.has(s.trim().toLowerCase())) {
             return yield* Effect.fail(
               new ArcTokenError({
                 message: `Service "${issuer}" not authorised for scope: ${s}`,
@@ -278,10 +287,10 @@ export const resolvePublicKey = (
           }
         }
       }
-      // LRU touch: re-insert at the end of the Map so this entry is the
-      // most-recently-used and survives the next eviction sweep (P-W25).
-      publicKeyCache.delete(kid);
-      publicKeyCache.set(kid, cached);
+      // LRU touch: record access time in ms (P-W1). Side-map write is O(1)
+      // and avoids Map delete+re-insert on the hot cache-hit path. Using
+      // Date.now() (ms) gives sub-second precision for test determinism.
+      publicKeyLastAccess.set(kid, Date.now());
       metricArcPublicKeyCacheHit(issuer);
       return cached.key;
     }
@@ -345,14 +354,30 @@ export const resolvePublicKey = (
       catch: (cause) => new ArcTokenError({ message: `Invalid public key for ${issuer}`, cause }),
     });
 
-    // Cache the resolved CryptoKey with its allowedScopes for scope validation on future hits.
-    // LRU eviction: the Map preserves insertion/access order; deleting the first
-    // key removes the least-recently-used entry (P-W25).
+    // Cache the resolved CryptoKey. Store allowedScopes as a Set for O(1)
+    // hit-path scope checks (P-W2). LRU eviction scans the side-timestamp map
+    // to find the least-recently-used entry (P-W1) — O(n) but only on the
+    // slow DB-miss path.
     if (publicKeyCache.size >= _publicKeyCacheMaxSize) {
-      const lru = publicKeyCache.keys().next().value;
-      if (lru !== undefined) publicKeyCache.delete(lru);
+      let lruKid: string | undefined;
+      let lruTime = Infinity;
+      for (const [k, t] of publicKeyLastAccess) {
+        if (t < lruTime) {
+          lruTime = t;
+          lruKid = k;
+        }
+      }
+      if (lruKid !== undefined) {
+        publicKeyCache.delete(lruKid);
+        publicKeyLastAccess.delete(lruKid);
+      }
     }
-    publicKeyCache.set(kid, { key, allowedScopes, expiresAt: now + PUBLIC_KEY_CACHE_TTL_SECONDS });
+    publicKeyCache.set(kid, {
+      key,
+      allowedScopes: new Set(normaliseScopes(allowedScopes)),
+      expiresAt: now + PUBLIC_KEY_CACHE_TTL_SECONDS,
+    });
+    publicKeyLastAccess.set(kid, Date.now());
 
     return key;
   });
@@ -362,6 +387,7 @@ export const resolvePublicKey = (
  */
 export function clearPublicKeyCache(): void {
   publicKeyCache.clear();
+  publicKeyLastAccess.clear();
 }
 
 /**
@@ -371,6 +397,7 @@ export function clearPublicKeyCache(): void {
  */
 export function evictPublicKeyCacheEntry(kid: string): void {
   publicKeyCache.delete(kid);
+  publicKeyLastAccess.delete(kid);
 }
 
 /** Returns the current public key cache size. Useful for testing. */
@@ -401,6 +428,7 @@ interface CachedToken {
 }
 
 const tokenCache = new Map<string, CachedToken>();
+const tokenLastAccess = new Map<string, number>();
 
 function cacheKey(kid: string, iss: string, aud: string, scope: string): string {
   return `${kid}:${iss}:${aud}:${scope}`;
@@ -426,6 +454,7 @@ export async function getOrCreateArcToken(
 
   const cached = tokenCache.get(key);
   if (cached && cached.expiresAt - CACHE_REISSUE_BUFFER_SECONDS > now) {
+    tokenLastAccess.set(key, Date.now());
     metricArcTokenCacheHit(claims.iss);
     return cached.token;
   }
@@ -433,13 +462,24 @@ export async function getOrCreateArcToken(
   metricArcTokenCacheMiss(claims.iss);
   const token = await createArcToken(privateKey, claims, ttl);
 
-  // Enforce max cache size — evict oldest entry if full
+  // Enforce max cache size — evict LRU entry if full (P-I2).
   if (tokenCache.size >= MAX_CACHE_SIZE) {
-    const oldest = tokenCache.keys().next().value;
-    if (oldest !== undefined) tokenCache.delete(oldest);
+    let lruKey: string | undefined;
+    let lruTime = Infinity;
+    for (const [k, t] of tokenLastAccess) {
+      if (t < lruTime) {
+        lruTime = t;
+        lruKey = k;
+      }
+    }
+    if (lruKey !== undefined) {
+      tokenCache.delete(lruKey);
+      tokenLastAccess.delete(lruKey);
+    }
   }
 
   tokenCache.set(key, { token, expiresAt: now + ttl });
+  tokenLastAccess.set(key, Date.now());
   return token;
 }
 
@@ -448,6 +488,7 @@ export async function getOrCreateArcToken(
  */
 export function clearTokenCache(): void {
   tokenCache.clear();
+  tokenLastAccess.clear();
   _lastEvictionMs = 0; // reset debounce so the next auto-sweep fires immediately
 }
 
@@ -465,7 +506,10 @@ function maybeSweepExpiredTokens(): void {
   _lastEvictionMs = nowMs;
   const now = Math.floor(nowMs / 1000);
   for (const [key, entry] of tokenCache) {
-    if (entry.expiresAt <= now) tokenCache.delete(key);
+    if (entry.expiresAt <= now) {
+      tokenCache.delete(key);
+      tokenLastAccess.delete(key);
+    }
   }
 }
 
@@ -478,7 +522,10 @@ export function evictExpiredTokens(): void {
   _lastEvictionMs = Date.now();
   const now = Math.floor(Date.now() / 1000);
   for (const [key, entry] of tokenCache) {
-    if (entry.expiresAt <= now) tokenCache.delete(key);
+    if (entry.expiresAt <= now) {
+      tokenCache.delete(key);
+      tokenLastAccess.delete(key);
+    }
   }
 }
 

--- a/shared/crypto/src/index.ts
+++ b/shared/crypto/src/index.ts
@@ -16,9 +16,6 @@ export {
   resolvePublicKey,
   clearPublicKeyCache,
   evictPublicKeyCacheEntry,
-  publicKeyCacheSize,
-  _setPublicKeyCacheMaxSizeForTest,
-  _resetPublicKeyCacheMaxSize,
   // Token cache
   getOrCreateArcToken,
   clearTokenCache,

--- a/shared/crypto/src/index.ts
+++ b/shared/crypto/src/index.ts
@@ -16,6 +16,9 @@ export {
   resolvePublicKey,
   clearPublicKeyCache,
   evictPublicKeyCacheEntry,
+  publicKeyCacheSize,
+  _setPublicKeyCacheMaxSizeForTest,
+  _resetPublicKeyCacheMaxSize,
   // Token cache
   getOrCreateArcToken,
   clearTokenCache,

--- a/shared/crypto/tests/arc.test.ts
+++ b/shared/crypto/tests/arc.test.ts
@@ -3,11 +3,14 @@ import { serviceAccounts, serviceAccountKeys } from "@osn/db";
 import { Db } from "@osn/db/service";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import {
   generateArcKeyPair,
   exportKeyToJwk,
+  publicKeyCacheSize,
+  _setPublicKeyCacheMaxSizeForTest,
+  _resetPublicKeyCacheMaxSize,
   importKeyFromJwk,
   createArcToken,
   verifyArcToken,
@@ -640,4 +643,124 @@ describe("resolvePublicKey", () => {
       expect(error.message).toContain("Unknown or invalid key");
     }).pipe(Effect.provide(createTestLayer())),
   );
+});
+
+// ---------------------------------------------------------------------------
+// P-W25: publicKeyCache LRU eviction
+// ---------------------------------------------------------------------------
+
+describe("publicKeyCache LRU eviction", () => {
+  /** Insert a service account + key into the DB and resolve its public key (warm the cache). */
+  async function seedAndResolve(
+    layer: ReturnType<typeof createTestLayer>,
+    serviceId: string,
+    keyId: string,
+  ): Promise<CryptoKey> {
+    const run = <A>(eff: Effect.Effect<A, unknown, Db>) =>
+      Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+    const kp = await generateArcKeyPair();
+    const jwk = await exportKeyToJwk(kp.publicKey);
+    const now = new Date();
+
+    await run(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        yield* Effect.tryPromise({
+          try: () =>
+            db.insert(serviceAccounts).values({
+              serviceId,
+              allowedScopes: "graph:read",
+              createdAt: now,
+              updatedAt: now,
+            }),
+          catch: (e) => e,
+        });
+        yield* Effect.tryPromise({
+          try: () =>
+            db.insert(serviceAccountKeys).values({
+              keyId,
+              serviceId,
+              publicKeyJwk: jwk,
+              registeredAt: now,
+              expiresAt: null,
+              revokedAt: null,
+            }),
+          catch: (e) => e,
+        });
+      }),
+    );
+
+    return run(resolvePublicKey(keyId, serviceId));
+  }
+
+  beforeEach(() => {
+    clearPublicKeyCache();
+    _setPublicKeyCacheMaxSizeForTest(3);
+  });
+
+  afterEach(() => {
+    clearPublicKeyCache();
+    _resetPublicKeyCacheMaxSize();
+  });
+
+  it("evicts the least-recently-used entry, not the first-inserted one", async () => {
+    const layer = createTestLayer();
+    const run = <A>(eff: Effect.Effect<A, unknown, Db>) =>
+      Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+    // Fill cache to max (3): A, B, C inserted in order → A is oldest/LRU
+    await seedAndResolve(layer, "svc-a", "key-a");
+    await seedAndResolve(layer, "svc-b", "key-b");
+    await seedAndResolve(layer, "svc-c", "key-c");
+    expect(publicKeyCacheSize()).toBe(3);
+
+    // Delete B from the DB so it cannot be re-resolved after cache eviction.
+    // This lets us distinguish "evicted and gone" from "evicted but re-fetched from DB".
+    await run(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        yield* Effect.tryPromise({
+          try: () => db.delete(serviceAccountKeys).where(eq(serviceAccountKeys.keyId, "key-b")),
+          catch: (e) => e,
+        });
+      }),
+    );
+
+    // Touch A — makes A the MRU; B is now the LRU
+    await run(resolvePublicKey("key-a", "svc-a"));
+
+    // Insert D — should evict B (LRU), not A (recently touched)
+    await seedAndResolve(layer, "svc-d", "key-d");
+    expect(publicKeyCacheSize()).toBe(3);
+
+    // A, C, D remain in cache; B was the LRU and is now gone from both cache and DB
+    const [resA, resB, resC, resD] = await Promise.all([
+      Effect.runPromise(
+        Effect.either(resolvePublicKey("key-a", "svc-a")).pipe(Effect.provide(layer)),
+      ),
+      Effect.runPromise(
+        Effect.either(resolvePublicKey("key-b", "svc-b")).pipe(Effect.provide(layer)),
+      ),
+      Effect.runPromise(
+        Effect.either(resolvePublicKey("key-c", "svc-c")).pipe(Effect.provide(layer)),
+      ),
+      Effect.runPromise(
+        Effect.either(resolvePublicKey("key-d", "svc-d")).pipe(Effect.provide(layer)),
+      ),
+    ]);
+
+    expect(resA._tag).toBe("Right"); // A survived (was touched → MRU)
+    expect(resB._tag).toBe("Left"); // B evicted (was LRU) and deleted from DB
+    expect(resC._tag).toBe("Right"); // C survived
+    expect(resD._tag).toBe("Right"); // D just inserted
+  });
+
+  it("cache size stays bounded at the configured max", async () => {
+    const layer = createTestLayer();
+    for (let i = 0; i < 6; i++) {
+      await seedAndResolve(layer, `svc-${i}`, `key-${i}`);
+    }
+    expect(publicKeyCacheSize()).toBe(3);
+  });
 });

--- a/shared/crypto/tests/arc.test.ts
+++ b/shared/crypto/tests/arc.test.ts
@@ -758,9 +758,13 @@ describe("publicKeyCache LRU eviction", () => {
 
   it("cache size stays bounded at the configured max", async () => {
     const layer = createTestLayer();
-    for (let i = 0; i < 6; i++) {
-      await seedAndResolve(layer, `svc-${i}`, `key-${i}`);
-    }
+    // Insert sequentially so eviction order is deterministic
+    await seedAndResolve(layer, "svc-0", "key-0");
+    await seedAndResolve(layer, "svc-1", "key-1");
+    await seedAndResolve(layer, "svc-2", "key-2");
+    await seedAndResolve(layer, "svc-3", "key-3");
+    await seedAndResolve(layer, "svc-4", "key-4");
+    await seedAndResolve(layer, "svc-5", "key-5");
     expect(publicKeyCacheSize()).toBe(3);
   });
 });

--- a/shared/crypto/tests/arc.test.ts
+++ b/shared/crypto/tests/arc.test.ts
@@ -767,4 +767,64 @@ describe("publicKeyCache LRU eviction", () => {
     await seedAndResolve(layer, "svc-5", "key-5");
     expect(publicKeyCacheSize()).toBe(3);
   });
+
+  // T-S1: a scope-denied cache hit must NOT promote the entry to MRU
+  it("scope-failure hit does not update lastAccess — entry still gets evicted (T-S1)", async () => {
+    const layer = createTestLayer();
+    const run = <A>(eff: Effect.Effect<A, unknown, Db>) =>
+      Effect.runPromise(eff.pipe(Effect.provide(layer)) as Effect.Effect<A, never, never>);
+
+    // Fill cache: A (oldest), B, C — A's lastAccess is the earliest
+    await seedAndResolve(layer, "ts1-svc-a", "ts1-key-a");
+    await seedAndResolve(layer, "ts1-svc-b", "ts1-key-b");
+    await seedAndResolve(layer, "ts1-svc-c", "ts1-key-c");
+    expect(publicKeyCacheSize()).toBe(3);
+
+    // Delete A from DB so we can detect eviction (cache miss → DB miss → error)
+    await run(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        yield* Effect.tryPromise({
+          try: () => db.delete(serviceAccountKeys).where(eq(serviceAccountKeys.keyId, "ts1-key-a")),
+          catch: (e) => e,
+        });
+      }),
+    );
+
+    // Scope-denied hit on A — "graph:write" not in allowedScopes ("graph:read")
+    // This should NOT update lastAccess for A; A remains the LRU candidate
+    await run(
+      Effect.gen(function* () {
+        const err = yield* Effect.flip(resolvePublicKey("ts1-key-a", "ts1-svc-a", ["graph:write"]));
+        expect(err._tag).toBe("ArcTokenError");
+      }),
+    );
+
+    // Insert D → eviction must pick A (lowest lastAccess), not B or C
+    await seedAndResolve(layer, "ts1-svc-d", "ts1-key-d");
+    expect(publicKeyCacheSize()).toBe(3);
+
+    // A evicted and not in DB → fails; B, C, D survive
+    const resA = await Effect.runPromise(
+      Effect.either(resolvePublicKey("ts1-key-a", "ts1-svc-a")).pipe(Effect.provide(layer)),
+    );
+    const resB = await Effect.runPromise(
+      Effect.either(resolvePublicKey("ts1-key-b", "ts1-svc-b")).pipe(Effect.provide(layer)),
+    );
+    expect(resA._tag).toBe("Left"); // A was evicted and deleted from DB
+    expect(resB._tag).toBe("Right"); // B survived — was not LRU
+  });
+
+  // T-S2: cap=1 boundary — only one entry fits at a time
+  it("cap=1: second entry evicts first, size stays 1 (T-S2)", async () => {
+    clearPublicKeyCache();
+    _setPublicKeyCacheMaxSizeForTest(1);
+
+    const layer = createTestLayer();
+    await seedAndResolve(layer, "t2-svc-a", "t2-key-a");
+    expect(publicKeyCacheSize()).toBe(1);
+
+    await seedAndResolve(layer, "t2-svc-b", "t2-key-b");
+    expect(publicKeyCacheSize()).toBe(1);
+  });
 });

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -228,6 +228,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-L11 — Failed OAuth callback leaves PKCE verifier in `localStorage`
 - [ ] S-L12 — `REDIRECT_URI` from `window.location.origin` — prefer explicit env var
 - [ ] S-L13 — PKCE `state` not validated against stored nonce
+- [x] S-L40 — `publicKeyCacheSize`, `_setPublicKeyCacheMaxSizeForTest`, `_resetPublicKeyCacheMaxSize` re-exported from `@shared/crypto` public index.ts (test-only symbols in public API). **Fixed** — removed from `index.ts`; tests import direct from `../src/arc` — see [[arc-tokens]]
 - [ ] S-L14 — `assertion: t.Any()` on passkey routes — add TypeBox shape validation
 - [ ] S-L15 — No reserved-handle blocklist in DB
 - [x] S-L101 — `registerWithOsnApi()` silently returned early when `INTERNAL_SERVICE_SECRET` unset. **Fixed** — now throws, caught at startup by `index.ts` — see [[arc-tokens]]
@@ -267,7 +268,10 @@ Open findings only. Completed fixes archived in [[changelog/performance-fixes]].
 - [ ] P-W10 — `RegistrationClient.checkHandle` has no `AbortController` — debounced bursts leave multiple in-flight requests
 - [ ] P-W11 — `beginRegistration` issues two parallel queries instead of single `WHERE email = ? OR handle = ?`
 - [ ] P-W22 — Two `Effect.runPromise` calls per internal graph request — consolidate when S2S throughput grows — see [[arc-tokens]]
-- [ ] P-W25 — `publicKeyCache` uses FIFO eviction; upgrade to LRU so the most-recently-used keys are kept under churn — see [[arc-tokens]]
+- [x] P-W25 — `publicKeyCache` uses FIFO eviction; upgrade to LRU so the most-recently-used keys are kept under churn. **Fixed** — side-timestamp map (`publicKeyLastAccess`) records last-access in ms; O(1) touch on hit, O(n) scan only at eviction (DB-miss path) — see [[arc-tokens]]
+- [x] P-W26 — `publicKeyCache` hit path used Map delete+re-insert for LRU touch (O(log n) + allocation on hot path). **Fixed** — replaced with `publicKeyLastAccess.set(kid, Date.now())` (single map write) — see [[arc-tokens]]
+- [x] P-W27 — `allowedScopes` stored as raw comma-separated string; split+includes on every cache-hit scope check. **Fixed** — stored as `Set<string>` parsed once at DB-miss time; hit path uses `Set.has()` O(1) — see [[arc-tokens]]
+- [x] P-I16 — `tokenCache` used FIFO eviction (insertion-order head eviction). **Fixed** — `tokenLastAccess` side-map added; `getOrCreateArcToken` evicts true LRU entry on overflow; sweep/clear functions maintain the side map — see [[arc-tokens]]
 - [ ] P-W23 — `tailwind-merge` (~12-14 KB) in initial bundle — see [[component-library]]
 - [ ] P-W24 — `cn()` with signal reads replaces `classList` — avoid in `<For>` loops — see [[component-library]]
 - [x] P-W3 (org) — Sequential queries in `removeMember` and `updateOrganisation` could be parallelised. **Fixed** — `callerMember`+`targetMember` in `removeMember` and `orgRows`+`memberRows` in `updateOrganisation` now use `Effect.all({ concurrency: 2 })`. `resolveOrg`+`resolveHandle` in the three member routes now run via `Promise.all`

--- a/wiki/systems/arc-tokens.md
+++ b/wiki/systems/arc-tokens.md
@@ -19,8 +19,8 @@ related:
 finding-ids:
   - S-C2
 packages:
-  - "@osn/crypto"
-  - "@osn/core"
+  - "@shared/crypto"
+  - "@osn/api"
   - "@pulse/api"
 last-reviewed: 2026-04-17
 security-fixes:
@@ -30,12 +30,17 @@ security-fixes:
   - S-M101
   - S-M102
   - S-L101
+  - S-L40
 perf-fixes:
   - P-W100
   - P-W101
   - P-W102
   - P-I100
   - P-I101
+  - P-W25
+  - P-W26
+  - P-W27
+  - P-I16
 ---
 
 # ARC Tokens (S2S Auth)
@@ -55,7 +60,7 @@ ARC is OSN's service-to-service authentication token -- an ASAP-style self-issue
 
 ## Location
 
-Lives in `osn/crypto` (`@osn/crypto`). Import from `@osn/crypto/arc`.
+Lives in `shared/crypto` (`@shared/crypto`). Import from `@shared/crypto`.
 
 ## Exports
 


### PR DESCRIPTION
## Summary
- Upgrades `publicKeyCache` in `@shared/crypto` from insertion-order (FIFO) eviction to true LRU via a side-timestamp map (`publicKeyLastAccess`)
- Cache hits write `Date.now()` to the side map (O(1), no Map mutation); eviction scans the side map for the minimum timestamp only on the slow DB-miss path (O(n) but infrequent)
- `allowedScopes` stored as pre-parsed `Set<string>` — hit-path scope check is now `Set.has()` O(1) instead of split+includes
- Applies the same LRU pattern to `tokenCache` via `tokenLastAccess`
- Removes `publicKeyCacheSize`, `_setPublicKeyCacheMaxSizeForTest`, `_resetPublicKeyCacheMaxSize` from the public `index.ts` (test-only symbols; tests import directly from `../src/arc`)
- Adds T-S1 (scope-denied hit must not promote entry to MRU) and T-S2 (cap=1 boundary) tests

## Workspaces affected
- `@shared/crypto`

## Decisions & issues

**[P-W25]** — FIFO eviction on `publicKeyCache`
- **Issue:** `publicKeyCache` evicted the insertion-order head, not the least-recently-used entry. Frequently-used keys could be evicted while stale ones survived.
- **Why:** Under key rotation churn with many services, FIFO eviction evicts the wrong entries and increases DB round-trips.
- **Solution:** Side-timestamp map (`publicKeyLastAccess: Map<string, number>`) records last-access time in milliseconds on every cache hit. Eviction scans the map for the minimum value.
- **Rationale:** Keeps the hot cache-hit path at O(1) (single map write). The O(n) eviction scan only runs on the DB-miss path which is already doing async DB + JWK import work.

**[P-W26]** — Map delete+re-insert LRU touch on hot path
- **Issue:** Initial LRU implementation used `Map.delete(kid)` + `Map.set(kid, cached)` on every cache hit to maintain insertion order. This allocates on the hot path.
- **Why:** ES `Map` preserves insertion order; re-inserting an entry moves it to the "tail" (MRU position). But the delete+re-insert is unnecessary allocation on the hot path.
- **Solution:** Replaced with `publicKeyLastAccess.set(kid, Date.now())` — a single map value update.
- **Rationale:** Side-map avoids mutation of the primary cache map on every hit.

**[P-W27]** — `allowedScopes` stored as raw string in cache entry
- **Issue:** Cache entries stored `allowedScopes` as a comma-separated string. Every scope check on the cache-hit path called `normaliseScopes()` (split + map + filter) then `Array.includes()`.
- **Why:** Repeated string parsing on every S2S request for multi-scope tokens.
- **Solution:** Stored as `Set<string>` parsed once at DB-miss time. Hit path uses `Set.has()`.
- **Rationale:** O(1) lookup vs O(n) scan; no allocations on the hot path.

**[P-I16]** — `tokenCache` used FIFO eviction
- **Issue:** `getOrCreateArcToken` evicted `tokenCache.keys().next().value` — the insertion-order head — when the cache was full.
- **Why:** Services with many concurrent outbound targets (different `aud`/`scope` combinations) would evict the most-used tokens, not the least-used.
- **Solution:** Added `tokenLastAccess: Map<string, number>` with the same side-timestamp pattern; `clearTokenCache`, `maybeSweepExpiredTokens`, and `evictExpiredTokens` maintain the side map.
- **Rationale:** Consistent LRU semantics across both caches.

**[S-L40]** — Test-only symbols in public `index.ts`
- **Issue:** `publicKeyCacheSize`, `_setPublicKeyCacheMaxSizeForTest`, `_resetPublicKeyCacheMaxSize` were re-exported from `shared/crypto/src/index.ts`.
- **Why:** These are test helpers with `_` prefixes and `ForTest` suffixes — not part of the public API. Exporting them invites misuse in production code.
- **Solution:** Removed from `index.ts`. Tests already imported from `../src/arc` directly so no test changes needed.
- **Rationale:** Minimal blast radius; test coverage unchanged.

## Test plan
- [ ] `bun run --cwd shared/crypto test:run` — all 50 tests pass
- [ ] T-S1: scope-denied hit does not update `lastAccess` → entry is still evicted as LRU when next entry arrives
- [ ] T-S2: cap=1 — second seed evicts first; size stays 1
- [ ] Existing LRU eviction test: touch A after seeding A/B/C; insert D; B (LRU) is evicted not A

🤖 Generated with [Claude Code](https://claude.com/claude-code)