### PR TITLE
feat(auth): switch access token signing to ES256, expose JWKS endpoint

### DIFF
--- a/.changeset/jwks-es256-access-tokens.md
+++ b/.changeset/jwks-es256-access-tokens.md
@@ -1,0 +1,13 @@
+---
+"@shared/crypto": minor
+"@shared/observability": patch
+"@osn/api": minor
+"@pulse/api": minor
+---
+
+Switch OSN access token signing from HS256 to ES256 and expose a JWKS endpoint.
+
+- `@shared/crypto`: add `thumbprintKid(publicKey)` helper (RFC 7638 SHA-256 thumbprint)
+- `@shared/observability`: add `JwksCacheResult` metric attribute type
+- `@osn/api`: replace `AuthConfig.jwtSecret` with `jwtPrivateKey`, `jwtPublicKey`, `jwtKid`, `jwtPublicKeyJwk`; add `GET /.well-known/jwks.json`; update OIDC discovery with `jwks_uri`; ephemeral key pair in local dev when env vars are unset
+- `@pulse/api`: replace symmetric JWT verification with JWKS-backed ES256 verification; add in-process JWKS key cache with 5-minute TTL and rotation-aware refresh; remove `OSN_JWT_SECRET` dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+RES
 
 **ARC Tokens** — S2S auth via self-issued ES256 JWTs. Lives in `@shared/crypto`. See `[[wiki/systems/arc-tokens]]`.
 
+**User Access Tokens** — ES256 JWTs issued by `@osn/api` on login. Public key exposed at `GET /.well-known/jwks.json`. Downstream services (e.g. `@pulse/api`) verify via JWKS fetch — no shared secret. `AuthConfig` takes `jwtPrivateKey`, `jwtPublicKey`, `jwtKid`, `jwtPublicKeyJwk` (not `jwtSecret`). Env vars: `OSN_JWT_PRIVATE_KEY` / `OSN_JWT_PUBLIC_KEY` (base64 JWK JSON); ephemeral pair generated in local dev when unset. `thumbprintKid(publicKey)` from `@shared/crypto` computes the RFC 7638 kid. Downstream: set `OSN_JWKS_URL` in each service; must be HTTPS in non-local envs.
+
 **Observability** — OpenTelemetry end-to-end, shipped to Grafana Cloud. Three golden rules: no `console.*`, no raw OTel constructors, no unbounded metric attributes. See `[[wiki/observability/overview]]`.
 
 **Rate Limiting** — Per-IP fixed-window on all auth endpoints; per-user on graph writes, org writes, and `/recommendations/connections` reads. Two backends: Redis-backed when `REDIS_URL` is set (cross-process, survives restarts), in-memory fallback when unset (local dev). See `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]`.

--- a/osn/api/src/index.ts
+++ b/osn/api/src/index.ts
@@ -1,5 +1,6 @@
 import { cors } from "@elysiajs/cors";
 import { DbLive } from "@osn/db/service";
+import { generateArcKeyPair, importKeyFromJwk, thumbprintKid } from "@shared/crypto";
 import { healthRoutes, initObservability, observabilityPlugin } from "@shared/observability";
 import { Effect, Logger } from "effect";
 import { Elysia } from "elysia";
@@ -23,20 +24,61 @@ import { createRecommendationRoutes } from "./routes/recommendations";
 const SERVICE_NAME = "osn-api";
 const port = Number(process.env.PORT) || 4000;
 
-// S-L2: Fail at startup in production when the JWT signing secret is not set.
-if (process.env.NODE_ENV === "production" && !process.env.OSN_JWT_SECRET) {
-  throw new Error("OSN_JWT_SECRET must be set in production");
-}
-
 // Initialise observability (logger, tracing, metrics) before building the app.
 const { layer: observabilityLayer } = initObservability({ serviceName: SERVICE_NAME });
+
+// ---------------------------------------------------------------------------
+// JWT key pair — ES256 (ECDSA P-256)
+//
+// In production, OSN_JWT_PRIVATE_KEY and OSN_JWT_PUBLIC_KEY must be set to
+// base64-encoded JWK JSON. Generate once with:
+//   node -e "const {subtle}=globalThis.crypto; subtle.generateKey({name:'ECDSA',namedCurve:'P-256'},true,['sign','verify']).then(async k=>{const {exportJWK}=await import('jose');console.log('private:',btoa(JSON.stringify(await exportJWK(k.privateKey))));console.log('public:',btoa(JSON.stringify(await exportJWK(k.publicKey))))})"
+//
+// In local dev without these vars, an ephemeral key pair is generated (tokens
+// are invalidated on restart — acceptable for local development).
+// ---------------------------------------------------------------------------
+
+async function loadJwtKeyPair() {
+  const { exportJWK } = await import("jose");
+  const rawPriv = process.env.OSN_JWT_PRIVATE_KEY;
+  const rawPub = process.env.OSN_JWT_PUBLIC_KEY;
+
+  if (process.env.NODE_ENV === "production" && (!rawPriv || !rawPub)) {
+    throw new Error("OSN_JWT_PRIVATE_KEY and OSN_JWT_PUBLIC_KEY must be set in production");
+  }
+
+  if (rawPriv && rawPub) {
+    const privateKey = await importKeyFromJwk(JSON.parse(atob(rawPriv)) as Record<string, unknown>);
+    const publicKey = await importKeyFromJwk(JSON.parse(atob(rawPub)) as Record<string, unknown>);
+    const kid = await thumbprintKid(publicKey);
+    const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+    return { privateKey, publicKey, kid, jwtPublicKeyJwk };
+  }
+
+  // Ephemeral dev pair — warn via Effect logger after observability is ready.
+  const { privateKey, publicKey } = await generateArcKeyPair();
+  const kid = await thumbprintKid(publicKey);
+  const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+  return { privateKey, publicKey, kid, jwtPublicKeyJwk, ephemeral: true };
+}
+
+const {
+  privateKey: jwtPrivateKey,
+  publicKey: jwtPublicKey,
+  kid: jwtKid,
+  jwtPublicKeyJwk,
+  ephemeral: jwtEphemeral,
+} = await loadJwtKeyPair();
 
 const authConfig = {
   rpId: process.env.OSN_RP_ID || "localhost",
   rpName: process.env.OSN_RP_NAME || "OSN",
   origin: process.env.OSN_ORIGIN || "http://localhost:5173",
   issuerUrl: process.env.OSN_ISSUER_URL || `http://localhost:${port}`,
-  jwtSecret: process.env.OSN_JWT_SECRET || "dev-secret-change-in-prod",
+  jwtPrivateKey,
+  jwtPublicKey,
+  jwtKid,
+  jwtPublicKeyJwk,
   accessTokenTtl: Number(process.env.OSN_ACCESS_TOKEN_TTL) || 3600,
   refreshTokenTtl: Number(process.env.OSN_REFRESH_TOKEN_TTL) || 2592000,
 };
@@ -85,7 +127,14 @@ const app = new Elysia()
 if (process.env.NODE_ENV !== "test") {
   app.listen({ port, reusePort: false });
   void Effect.runPromise(
-    Effect.logInfo("osn-app listening").pipe(
+    Effect.gen(function* () {
+      if (jwtEphemeral) {
+        yield* Effect.logWarning(
+          "Using ephemeral JWT key pair — tokens will be invalidated on restart. Set OSN_JWT_PRIVATE_KEY and OSN_JWT_PUBLIC_KEY for persistent keys.",
+        );
+      }
+      yield* Effect.logInfo("osn-app listening");
+    }).pipe(
       Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),
       Effect.provide(Logger.pretty),
       Effect.provide(observabilityLayer),

--- a/osn/api/src/index.ts
+++ b/osn/api/src/index.ts
@@ -43,8 +43,14 @@ async function loadJwtKeyPair() {
   const rawPriv = process.env.OSN_JWT_PRIVATE_KEY;
   const rawPub = process.env.OSN_JWT_PUBLIC_KEY;
 
-  if (process.env.NODE_ENV === "production" && (!rawPriv || !rawPub)) {
-    throw new Error("OSN_JWT_PRIVATE_KEY and OSN_JWT_PUBLIC_KEY must be set in production");
+  // S-H2: use OSN_ENV (the project's canonical env discriminator) rather than
+  // NODE_ENV. A staging deploy with NODE_ENV=development would silently fall
+  // through to an ephemeral key pair and issue tokens that can't survive restarts.
+  const nonLocal = process.env.OSN_ENV && process.env.OSN_ENV !== "local";
+  if (nonLocal && (!rawPriv || !rawPub)) {
+    throw new Error(
+      "OSN_JWT_PRIVATE_KEY and OSN_JWT_PUBLIC_KEY must be set in non-local environments",
+    );
   }
 
   if (rawPriv && rawPub) {

--- a/osn/api/src/metrics.ts
+++ b/osn/api/src/metrics.ts
@@ -25,7 +25,6 @@ import type {
   ProfileSwitchAction,
   RegisterStep,
   Result,
-  JwksCacheResult,
 } from "@shared/observability/metrics";
 import { Effect } from "effect";
 

--- a/osn/api/src/metrics.ts
+++ b/osn/api/src/metrics.ts
@@ -25,11 +25,13 @@ import type {
   ProfileSwitchAction,
   RegisterStep,
   Result,
+  JwksCacheResult,
 } from "@shared/observability/metrics";
 import { Effect } from "effect";
 
 /** Canonical metric name consts — grep-able, refactor-safe. */
 export const OSN_METRICS = {
+  authJwksServed: "osn.auth.jwks.served",
   authRegisterAttempts: "osn.auth.register.attempts",
   authRegisterDuration: "osn.auth.register.duration",
   authLoginAttempts: "osn.auth.login.attempts",
@@ -422,3 +424,15 @@ export const withProfileCrud =
 
 export const metricAuthRateLimited = (endpoint: AuthRateLimitedEndpoint): void =>
   authRateLimited.inc({ endpoint });
+
+// ---------------------------------------------------------------------------
+// JWKS
+// ---------------------------------------------------------------------------
+
+const authJwksServed = createCounter<Record<never, never>>({
+  name: OSN_METRICS.authJwksServed,
+  description: "JWKS public key endpoint served (GET /.well-known/jwks.json)",
+  unit: "{request}",
+});
+
+export const metricAuthJwksServed = (): void => authJwksServed.inc({});

--- a/osn/api/src/routes/auth.ts
+++ b/osn/api/src/routes/auth.ts
@@ -6,7 +6,7 @@ import { Elysia, t } from "elysia";
 
 import { verifyPkceChallenge } from "../lib/crypto";
 import { buildAuthorizeHtml } from "../lib/html";
-import { metricAuthRateLimited } from "../metrics";
+import { metricAuthJwksServed, metricAuthRateLimited } from "../metrics";
 import { createAuthService, type AuthConfig } from "../services/auth";
 
 // In-memory PKCE challenge store (keyed by state)
@@ -969,10 +969,20 @@ export function createAuthRoutes(
         issuer: authConfig.issuerUrl,
         authorization_endpoint: `${authConfig.issuerUrl}/authorize`,
         token_endpoint: `${authConfig.issuerUrl}/token`,
+        jwks_uri: `${authConfig.issuerUrl}/.well-known/jwks.json`,
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code", "refresh_token"],
         code_challenge_methods_supported: ["S256"],
         scopes_supported: ["openid", "profile", "email"],
+        id_token_signing_alg_values_supported: ["ES256"],
       }))
+      .get("/.well-known/jwks.json", () => {
+        metricAuthJwksServed();
+        return {
+          keys: [
+            { ...authConfig.jwtPublicKeyJwk, use: "sig", alg: "ES256", kid: authConfig.jwtKid },
+          ],
+        };
+      })
   );
 }

--- a/osn/api/src/routes/auth.ts
+++ b/osn/api/src/routes/auth.ts
@@ -107,6 +107,22 @@ export function createAuthRoutes(
     }
   }
 
+  // P-I2: pre-build the static JWKS response once at route construction time.
+  // The key does not change during the server's lifetime — no need to allocate
+  // a new object (and spread-copy all JWK fields) on every request.
+  // S-L2: include key_ops alongside use for RFC 7517 compliance.
+  const jwksResponse = {
+    keys: [
+      {
+        ...authConfig.jwtPublicKeyJwk,
+        use: "sig",
+        alg: "ES256",
+        kid: authConfig.jwtKid,
+        key_ops: ["verify"],
+      },
+    ],
+  } as const;
+
   const auth = createAuthService(authConfig);
 
   const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
@@ -976,13 +992,11 @@ export function createAuthRoutes(
         scopes_supported: ["openid", "profile", "email"],
         id_token_signing_alg_values_supported: ["ES256"],
       }))
-      .get("/.well-known/jwks.json", () => {
+      .get("/.well-known/jwks.json", ({ set }) => {
+        // S-H1: explicit caching contract — aligns with pulse-side JWKS_CACHE_TTL_MS (5 min).
+        set.headers["cache-control"] = "public, max-age=300, stale-while-revalidate=60";
         metricAuthJwksServed();
-        return {
-          keys: [
-            { ...authConfig.jwtPublicKeyJwk, use: "sig", alg: "ES256", kid: authConfig.jwtKid },
-          ],
-        };
+        return jwksResponse;
       })
   );
 }

--- a/osn/api/src/services/auth.ts
+++ b/osn/api/src/services/auth.ts
@@ -59,8 +59,14 @@ export interface AuthConfig {
   origin: string;
   /** Issuer URL (used as JWT issuer + magic link base) */
   issuerUrl: string;
-  /** JWT signing secret (at least 32 chars) */
-  jwtSecret: string;
+  /** ES256 private key for signing access, refresh, enrollment, and code tokens */
+  jwtPrivateKey: CryptoKey;
+  /** ES256 public key for verifying the above */
+  jwtPublicKey: CryptoKey;
+  /** Key ID (RFC 7638 thumbprint) — included in JWT headers and JWKS */
+  jwtKid: string;
+  /** Public key as JWK object — served at /.well-known/jwks.json */
+  jwtPublicKeyJwk: Record<string, unknown>;
   /** Access token TTL in seconds (default: 3600) */
   accessTokenTtl?: number;
   /** Refresh token TTL in seconds (default: 2592000 = 30 days) */
@@ -163,20 +169,19 @@ function now(): Date {
 
 async function signJwt(
   payload: Record<string, unknown>,
-  secret: string,
+  privateKey: CryptoKey,
+  kid: string,
   ttl: number,
 ): Promise<string> {
-  const key = new TextEncoder().encode(secret);
   return new SignJWT(payload)
-    .setProtectedHeader({ alg: "HS256" })
+    .setProtectedHeader({ alg: "ES256", kid })
     .setIssuedAt()
     .setExpirationTime(Math.floor(Date.now() / 1000) + ttl)
-    .sign(key);
+    .sign(privateKey);
 }
 
-async function verifyJwt(token: string, secret: string): Promise<Record<string, unknown>> {
-  const key = new TextEncoder().encode(secret);
-  const { payload } = await jwtVerify(token, key);
+async function verifyJwt(token: string, publicKey: CryptoKey): Promise<Record<string, unknown>> {
+  const { payload } = await jwtVerify(token, publicKey, { algorithms: ["ES256"] });
   return payload as Record<string, unknown>;
 }
 
@@ -768,10 +773,11 @@ export function createAuthService(config: AuthConfig) {
         if (displayName !== null) payload["displayName"] = displayName;
 
         const [accessToken, refreshToken] = await Promise.all([
-          signJwt(payload, config.jwtSecret, accessTokenTtl),
+          signJwt(payload, config.jwtPrivateKey, config.jwtKid, accessTokenTtl),
           signJwt(
             { sub: accountId, type: "refresh", scope: "account" },
-            config.jwtSecret,
+            config.jwtPrivateKey,
+            config.jwtKid,
             refreshTokenTtl,
           ),
         ]);
@@ -786,7 +792,8 @@ export function createAuthService(config: AuthConfig) {
 
   const issueCode = (profileId: string) =>
     Effect.tryPromise({
-      try: () => signJwt({ sub: profileId, type: "code" }, config.jwtSecret, 120),
+      try: () =>
+        signJwt({ sub: profileId, type: "code" }, config.jwtPrivateKey, config.jwtKid, 120),
       catch: (cause) => new AuthError({ message: String(cause) }),
     });
 
@@ -813,7 +820,8 @@ export function createAuthService(config: AuthConfig) {
         const jti = crypto.randomUUID();
         return signJwt(
           { sub: accountId, type: "passkey-enroll", jti },
-          config.jwtSecret,
+          config.jwtPrivateKey,
+          config.jwtKid,
           enrollmentTokenTtl,
         );
       },
@@ -832,7 +840,7 @@ export function createAuthService(config: AuthConfig) {
   ): Effect.Effect<{ accountId: string }, AuthError> =>
     Effect.gen(function* () {
       const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(token, config.jwtSecret),
+        try: () => verifyJwt(token, config.jwtPublicKey),
         catch: () => new AuthError({ message: "Invalid or expired enrollment token" }),
       });
       if (
@@ -872,7 +880,7 @@ export function createAuthService(config: AuthConfig) {
   > =>
     Effect.gen(function* () {
       const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(code, config.jwtSecret),
+        try: () => verifyJwt(code, config.jwtPublicKey),
         catch: () => new AuthError({ message: "Invalid or expired code" }),
       });
       if (payload["type"] !== "code" || typeof payload["sub"] !== "string") {
@@ -903,7 +911,7 @@ export function createAuthService(config: AuthConfig) {
   const verifyRefreshToken = (token: string): Effect.Effect<{ accountId: string }, AuthError> =>
     Effect.gen(function* () {
       const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(token, config.jwtSecret),
+        try: () => verifyJwt(token, config.jwtPublicKey),
         catch: () => new AuthError({ message: "Invalid or expired refresh token" }),
       });
       if (
@@ -976,7 +984,7 @@ export function createAuthService(config: AuthConfig) {
   > =>
     Effect.gen(function* () {
       const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(token, config.jwtSecret),
+        try: () => verifyJwt(token, config.jwtPublicKey),
         catch: () => new AuthError({ message: "Invalid or expired access token" }),
       });
       if (
@@ -1585,7 +1593,7 @@ export function createAuthService(config: AuthConfig) {
       };
       if (profile.displayName !== null) payload["displayName"] = profile.displayName;
       const accessToken = yield* Effect.tryPromise({
-        try: () => signJwt(payload, config.jwtSecret, accessTokenTtl),
+        try: () => signJwt(payload, config.jwtPrivateKey, config.jwtKid, accessTokenTtl),
         catch: (cause) => new AuthError({ message: String(cause) }),
       });
       return {

--- a/osn/api/tests/helpers/auth-config.ts
+++ b/osn/api/tests/helpers/auth-config.ts
@@ -1,0 +1,28 @@
+import { generateArcKeyPair, thumbprintKid } from "@shared/crypto";
+import { exportJWK } from "jose";
+
+import type { AuthConfig } from "../../src/services/auth";
+
+const BASE_CONFIG = {
+  rpId: "localhost",
+  rpName: "OSN Test",
+  origin: "http://localhost:5173",
+  issuerUrl: "http://localhost:4000",
+} as const;
+
+/**
+ * Generates an ephemeral ES256 key pair for use in tests.
+ * Call once in `beforeAll` and pass the result to route/service factories.
+ */
+export async function makeTestAuthConfig(): Promise<AuthConfig> {
+  const { privateKey, publicKey } = await generateArcKeyPair();
+  const kid = await thumbprintKid(publicKey);
+  const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+  return {
+    ...BASE_CONFIG,
+    jwtPrivateKey: privateKey,
+    jwtPublicKey: publicKey,
+    jwtKid: kid,
+    jwtPublicKeyJwk,
+  };
+}

--- a/osn/api/tests/privacy.test.ts
+++ b/osn/api/tests/privacy.test.ts
@@ -1,9 +1,10 @@
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createAuthRoutes } from "../src/routes/auth";
 import { createProfileRoutes } from "../src/routes/profile";
 import { createAuthService } from "../src/services/auth";
+import { makeTestAuthConfig } from "./helpers/auth-config";
 import { createTestLayer } from "./helpers/db";
 
 /**
@@ -14,13 +15,11 @@ import { createTestLayer } from "./helpers/db";
  * responses, tokens, or WebAuthn ceremony data.
  */
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 /** Recursively check that no key named `accountId` or `account_id` exists. */
 function assertNoAccountId(obj: unknown, path = "$"): void {

--- a/osn/api/tests/routes/auth.test.ts
+++ b/osn/api/tests/routes/auth.test.ts
@@ -1,18 +1,17 @@
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createAuthRoutes, createDefaultAuthRateLimiters } from "../../src/routes/auth";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("auth routes", () => {
   let app: ReturnType<typeof createAuthRoutes>;

--- a/osn/api/tests/routes/graph-internal.test.ts
+++ b/osn/api/tests/routes/graph-internal.test.ts
@@ -9,20 +9,19 @@ import {
 } from "@shared/crypto";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 
 import { createInternalGraphRoutes } from "../../src/routes/graph-internal";
 import { createAuthService } from "../../src/services/auth";
 import { createGraphService } from "../../src/services/graph";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("internal graph routes (ARC-protected)", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/routes/graph.test.ts
+++ b/osn/api/tests/routes/graph.test.ts
@@ -1,20 +1,19 @@
 import type { Db } from "@osn/db/service";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createAuthRoutes } from "../../src/routes/auth";
 import { createGraphRoutes } from "../../src/routes/graph";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("graph routes", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/routes/organisation-internal.test.ts
+++ b/osn/api/tests/routes/organisation-internal.test.ts
@@ -8,20 +8,19 @@ import {
   clearPublicKeyCache,
 } from "@shared/crypto";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createInternalOrganisationRoutes } from "../../src/routes/organisation-internal";
 import { createAuthService } from "../../src/services/auth";
 import { createOrganisationService } from "../../src/services/organisation";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("internal organisation routes (ARC-protected)", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/routes/organisation.test.ts
+++ b/osn/api/tests/routes/organisation.test.ts
@@ -1,19 +1,18 @@
 import type { Db } from "@osn/db/service";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createOrganisationRoutes } from "../../src/routes/organisation";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("organisation routes", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/routes/profile.test.ts
+++ b/osn/api/tests/routes/profile.test.ts
@@ -1,18 +1,17 @@
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createProfileRoutes } from "../../src/routes/profile";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("profile routes", () => {
   let profileApp: ReturnType<typeof createProfileRoutes>;

--- a/osn/api/tests/routes/recommendations.test.ts
+++ b/osn/api/tests/routes/recommendations.test.ts
@@ -1,19 +1,18 @@
 import type { Db } from "@osn/db/service";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createGraphRoutes } from "../../src/routes/graph";
 import { createRecommendationRoutes } from "../../src/routes/recommendations";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("recommendations routes", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/routes/redis-rate-limit-integration.test.ts
+++ b/osn/api/tests/routes/redis-rate-limit-integration.test.ts
@@ -10,7 +10,7 @@
 import { type Db } from "@osn/db/service";
 import { createMemoryClient, createRedisRateLimiter } from "@shared/redis";
 import { Effect } from "effect";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import {
   createRedisAuthRateLimiters,
@@ -19,15 +19,14 @@ import {
 import { createAuthRoutes } from "../../src/routes/auth";
 import { createGraphRoutes } from "../../src/routes/graph";
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
 
 describe("auth routes with Redis-backed rate limiters", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -1,18 +1,18 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Effect, Logger, LogLevel } from "effect";
+import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+let auth: ReturnType<typeof createAuthService>;
 
-const auth = createAuthService(config);
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+  auth = createAuthService(config);
+});
 
 describe("registerProfile", () => {
   it.effect("creates a new user with usr_ prefix and correct fields", () =>

--- a/osn/api/tests/services/graph.test.ts
+++ b/osn/api/tests/services/graph.test.ts
@@ -1,20 +1,20 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Effect } from "effect";
+import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
 import { createGraphService } from "../../src/services/graph";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
-
-const auth = createAuthService(config);
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+let auth: ReturnType<typeof createAuthService>;
 const graph = createGraphService();
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+  auth = createAuthService(config);
+});
 
 /** Register two users and return their IDs. */
 const setupTwoUsers = Effect.gen(function* () {

--- a/osn/api/tests/services/organisation.test.ts
+++ b/osn/api/tests/services/organisation.test.ts
@@ -1,20 +1,20 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Effect } from "effect";
+import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
 import { createOrganisationService } from "../../src/services/organisation";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
-
-const auth = createAuthService(config);
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+let auth: ReturnType<typeof createAuthService>;
 const org = createOrganisationService();
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+  auth = createAuthService(config);
+});
 
 /** Register a user and return them. */
 const registerProfile = (email: string, handle: string, displayName?: string) =>

--- a/osn/api/tests/services/profile.test.ts
+++ b/osn/api/tests/services/profile.test.ts
@@ -1,24 +1,25 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Effect } from "effect";
+import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
 import { createGraphService } from "../../src/services/graph";
 import { createOrganisationService } from "../../src/services/organisation";
 import { createProfileService } from "../../src/services/profile";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
-
-const auth = createAuthService(config);
-const profile = createProfileService(auth);
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+let auth: ReturnType<typeof createAuthService>;
+let profile: ReturnType<typeof createProfileService>;
 const graph = createGraphService();
 const org = createOrganisationService();
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+  auth = createAuthService(config);
+  profile = createProfileService(auth);
+});
 
 /** Register an account + profile, then get a refresh token for the account. */
 function setupAccount(email: string, handle: string, displayName?: string) {

--- a/osn/api/tests/services/recommendations.test.ts
+++ b/osn/api/tests/services/recommendations.test.ts
@@ -1,22 +1,22 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Effect } from "effect";
+import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
 import { createGraphService } from "../../src/services/graph";
 import { createRecommendationService } from "../../src/services/recommendations";
+import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
-const config = {
-  rpId: "localhost",
-  rpName: "OSN Test",
-  origin: "http://localhost:5173",
-  issuerUrl: "http://localhost:4000",
-  jwtSecret: "test-secret-at-least-32-characters-long",
-};
-
-const auth = createAuthService(config);
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+let auth: ReturnType<typeof createAuthService>;
 const graph = createGraphService();
 const recs = createRecommendationService();
+
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+  auth = createAuthService(config);
+});
 
 // Connect two users bidirectionally (request + accept).
 const connect = (a: string, b: string) =>

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -22,10 +22,6 @@ const app = new Elysia()
 const port = process.env.PORT || 3001;
 
 if (process.env.NODE_ENV !== "test") {
-  if (!process.env.OSN_JWT_SECRET) {
-    throw new Error("OSN_JWT_SECRET must be set");
-  }
-
   app.listen({ port, reusePort: false });
 
   // Register our ephemeral public key with osn/api and schedule automatic

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -22,6 +22,14 @@ const app = new Elysia()
 const port = process.env.PORT || 3001;
 
 if (process.env.NODE_ENV !== "test") {
+  // S-H3: fetching public keys over plaintext HTTP in a deployed env allows
+  // any process with network access to serve a forged JWK set. Fail fast.
+  const jwksUrl = process.env.OSN_JWKS_URL ?? "http://localhost:4000/.well-known/jwks.json";
+  const nonLocal = process.env.OSN_ENV && process.env.OSN_ENV !== "local";
+  if (nonLocal && jwksUrl.startsWith("http://")) {
+    throw new Error("OSN_JWKS_URL must use HTTPS in non-local environments");
+  }
+
   app.listen({ port, reusePort: false });
 
   // Register our ephemeral public key with osn/api and schedule automatic

--- a/pulse/api/src/lib/jwks-cache.ts
+++ b/pulse/api/src/lib/jwks-cache.ts
@@ -2,8 +2,13 @@
  * In-process JWKS public key cache for verifying OSN-issued user access tokens.
  *
  * Fetches the OSN API's JWKS endpoint on cache miss and caches resolved
- * CryptoKeys by `kid` for JWKS_CACHE_TTL_MS. On verification failure, the
- * cache is bypassed once (refresh path) to handle key rotation.
+ * CryptoKeys by `${jwksUrl}:${kid}` for JWKS_CACHE_TTL_MS. On verification
+ * failure, the cache is bypassed once (refresh path) to handle key rotation.
+ *
+ * P-W2: bounded to CACHE_MAX_SIZE entries via LRU eviction — mirrors the
+ * pattern in @shared/crypto/arc.ts (PR #63).
+ * S-M3: cache key includes the JWKS URL so keys from different issuers never
+ * collide even if kid values overlap.
  */
 
 import { importKeyFromJwk } from "@shared/crypto";
@@ -12,6 +17,9 @@ import { instrumentedFetch } from "@shared/observability/fetch";
 import { metricJwksCacheLookup } from "../metrics";
 
 const JWKS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// P-W2: realistic key-rotation scenarios will never exceed single digits;
+// cap prevents heap exhaustion from JWTs with crafted kid values.
+const CACHE_MAX_SIZE = 256;
 
 interface CachedKey {
   key: CryptoKey;
@@ -19,17 +27,37 @@ interface CachedKey {
 }
 
 const cache = new Map<string, CachedKey>();
+/** Last-access timestamps for LRU eviction (same pattern as @shared/crypto). */
+const lastAccess = new Map<string, number>();
+
+/** S-M3: include jwksUrl in cache key to isolate keys by issuer. */
+function cacheKey(kid: string, jwksUrl: string): string {
+  return `${jwksUrl}:${kid}`;
+}
+
+function evictLru(): void {
+  let lruKey: string | undefined;
+  let lruTime = Infinity;
+  for (const [k, t] of lastAccess) {
+    if (t < lruTime) {
+      lruTime = t;
+      lruKey = k;
+    }
+  }
+  if (lruKey !== undefined) {
+    cache.delete(lruKey);
+    lastAccess.delete(lruKey);
+  }
+}
 
 async function fetchPublicKey(kid: string, jwksUrl: string): Promise<CryptoKey | null> {
   let res: Response;
   try {
     res = await instrumentedFetch(jwksUrl);
   } catch (err) {
-    // Log without console.* — structured log is emitted by the OTel layer
-    // but we're outside an Effect context here, so we record the metric and
-    // return null to treat it as an auth miss (soft fail).
+    // We're outside an Effect context here so we record the metric and
+    // re-throw so callers can distinguish a network failure from key-not-found.
     metricJwksCacheLookup("miss");
-    // Re-throw so callers know the fetch itself failed (distinct from key-not-found).
     throw err;
   }
 
@@ -65,6 +93,13 @@ async function fetchPublicKey(kid: string, jwksUrl: string): Promise<CryptoKey |
   }
 }
 
+function storeInCache(ck: string, key: CryptoKey): void {
+  if (cache.size >= CACHE_MAX_SIZE) evictLru();
+  const now = Date.now();
+  cache.set(ck, { key, fetchedAt: now });
+  lastAccess.set(ck, now);
+}
+
 /**
  * Returns the CryptoKey for `kid` from the cache or the JWKS endpoint.
  * Returns `null` if the key cannot be resolved (network error, unknown kid, malformed JWK).
@@ -73,16 +108,18 @@ export async function resolvePublicKeyForKid(
   kid: string,
   jwksUrl: string,
 ): Promise<CryptoKey | null> {
+  const ck = cacheKey(kid, jwksUrl);
   const now = Date.now();
-  const cached = cache.get(kid);
+  const cached = cache.get(ck);
   if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    lastAccess.set(ck, now);
     metricJwksCacheLookup("hit");
     return cached.key;
   }
 
   const key = await fetchPublicKey(kid, jwksUrl);
   if (key) {
-    cache.set(kid, { key, fetchedAt: now });
+    storeInCache(ck, key);
     metricJwksCacheLookup("miss");
   }
   return key;
@@ -99,7 +136,7 @@ export async function refreshPublicKeyForKid(
 ): Promise<CryptoKey | null> {
   const key = await fetchPublicKey(kid, jwksUrl);
   if (key) {
-    cache.set(kid, { key, fetchedAt: Date.now() });
+    storeInCache(cacheKey(kid, jwksUrl), key);
     metricJwksCacheLookup("refresh");
   }
   return key;
@@ -108,4 +145,5 @@ export async function refreshPublicKeyForKid(
 /** Clears the key cache. Tests only. */
 export function clearJwksCache(): void {
   cache.clear();
+  lastAccess.clear();
 }

--- a/pulse/api/src/lib/jwks-cache.ts
+++ b/pulse/api/src/lib/jwks-cache.ts
@@ -1,0 +1,111 @@
+/**
+ * In-process JWKS public key cache for verifying OSN-issued user access tokens.
+ *
+ * Fetches the OSN API's JWKS endpoint on cache miss and caches resolved
+ * CryptoKeys by `kid` for JWKS_CACHE_TTL_MS. On verification failure, the
+ * cache is bypassed once (refresh path) to handle key rotation.
+ */
+
+import { importKeyFromJwk } from "@shared/crypto";
+import { instrumentedFetch } from "@shared/observability/fetch";
+
+import { metricJwksCacheLookup } from "../metrics";
+
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CachedKey {
+  key: CryptoKey;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CachedKey>();
+
+async function fetchPublicKey(kid: string, jwksUrl: string): Promise<CryptoKey | null> {
+  let res: Response;
+  try {
+    res = await instrumentedFetch(jwksUrl);
+  } catch (err) {
+    // Log without console.* — structured log is emitted by the OTel layer
+    // but we're outside an Effect context here, so we record the metric and
+    // return null to treat it as an auth miss (soft fail).
+    metricJwksCacheLookup("miss");
+    // Re-throw so callers know the fetch itself failed (distinct from key-not-found).
+    throw err;
+  }
+
+  if (!res.ok) {
+    metricJwksCacheLookup("miss");
+    return null;
+  }
+
+  let body: { keys?: unknown[] };
+  try {
+    body = (await res.json()) as { keys?: unknown[] };
+  } catch {
+    metricJwksCacheLookup("miss");
+    return null;
+  }
+
+  const keys = Array.isArray(body.keys) ? body.keys : [];
+  const jwk = keys.find(
+    (k): k is Record<string, unknown> =>
+      typeof k === "object" && k !== null && (k as Record<string, unknown>)["kid"] === kid,
+  );
+
+  if (!jwk) {
+    metricJwksCacheLookup("miss");
+    return null;
+  }
+
+  try {
+    return await importKeyFromJwk(jwk);
+  } catch {
+    metricJwksCacheLookup("miss");
+    return null;
+  }
+}
+
+/**
+ * Returns the CryptoKey for `kid` from the cache or the JWKS endpoint.
+ * Returns `null` if the key cannot be resolved (network error, unknown kid, malformed JWK).
+ */
+export async function resolvePublicKeyForKid(
+  kid: string,
+  jwksUrl: string,
+): Promise<CryptoKey | null> {
+  const now = Date.now();
+  const cached = cache.get(kid);
+  if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    metricJwksCacheLookup("hit");
+    return cached.key;
+  }
+
+  const key = await fetchPublicKey(kid, jwksUrl);
+  if (key) {
+    cache.set(kid, { key, fetchedAt: now });
+    metricJwksCacheLookup("miss");
+  }
+  return key;
+}
+
+/**
+ * Bypasses the cache and re-fetches the JWKS endpoint for `kid`.
+ * Call this when token verification fails against a cached key — it may have
+ * been rotated. Updates the cache on success.
+ */
+export async function refreshPublicKeyForKid(
+  kid: string,
+  jwksUrl: string,
+): Promise<CryptoKey | null> {
+  const key = await fetchPublicKey(kid, jwksUrl);
+  if (key) {
+    cache.set(kid, { key, fetchedAt: Date.now() });
+    metricJwksCacheLookup("refresh");
+  }
+  return key;
+}
+
+/** Clears the key cache. Tests only. */
+export function clearJwksCache(): void {
+  cache.clear();
+}

--- a/pulse/api/src/metrics.ts
+++ b/pulse/api/src/metrics.ts
@@ -14,7 +14,7 @@ import {
   createHistogram,
   LATENCY_BUCKETS_SECONDS,
 } from "@shared/observability/metrics";
-import type { EventStatus, Result } from "@shared/observability/metrics";
+import type { EventStatus, JwksCacheResult, Result } from "@shared/observability/metrics";
 
 /** Canonical metric name consts — grep-able, refactor-safe. */
 export const PULSE_METRICS = {
@@ -39,6 +39,8 @@ export const PULSE_METRICS = {
   eventAccessDenied: "pulse.events.access.denied",
   // Pulse user settings
   settingsUpdated: "pulse.settings.updated",
+  // JWKS public key cache
+  authJwksCacheLookups: "pulse.auth.jwks_cache.lookups",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -178,6 +180,12 @@ type EventAccessDeniedAttrs = {
 type SettingsUpdatedAttrs = {
   field: "attendance_visibility";
   result: Result;
+};
+
+// --- JWKS cache ---
+
+type JwksCacheLookupAttrs = {
+  result: JwksCacheResult;
 };
 
 // ---------------------------------------------------------------------------
@@ -379,3 +387,14 @@ export const metricEventAccessDenied = (
 
 export const metricSettingsUpdated = (field: "attendance_visibility", result: Result): void =>
   settingsUpdated.inc({ field, result });
+
+// --- JWKS cache ---
+
+const authJwksCacheLookups = createCounter<JwksCacheLookupAttrs>({
+  name: PULSE_METRICS.authJwksCacheLookups,
+  description: "JWKS public key cache lookups by result (hit/miss/refresh)",
+  unit: "{lookup}",
+});
+
+export const metricJwksCacheLookup = (result: JwksCacheResult): void =>
+  authJwksCacheLookups.inc({ result });

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -95,54 +95,26 @@ type Claims = {
 };
 
 /**
- * Resolves public key via provider, verifying with ES256.
- * On verification failure, attempts a cache refresh once (rotation handling).
+ * Verifies token signature with a pre-resolved key. Returns claims or null.
+ * P-W1: accepts pre-decoded kid to avoid re-parsing the JWT header.
  */
-async function verifyTokenWithKey(
-  token: string,
-  resolveKey: (kid: string) => Promise<CryptoKey | null>,
-): Promise<Claims | null> {
-  let header: { kid?: string; alg?: string };
+async function verifyTokenWithKey(token: string, key: CryptoKey): Promise<Claims | null> {
   try {
-    header = decodeProtectedHeader(token);
+    const { payload } = await jwtVerify(token, key, { algorithms: ["ES256"] });
+    const profileId = typeof payload.sub === "string" ? payload.sub : null;
+    if (!profileId) return null;
+    return {
+      profileId,
+      email: typeof payload.email === "string" ? payload.email : null,
+      handle: typeof payload.handle === "string" ? payload.handle : null,
+      displayName: typeof payload.displayName === "string" ? payload.displayName : null,
+    };
   } catch {
     return null;
   }
-
-  if (header.alg !== "ES256" || typeof header.kid !== "string") return null;
-  const kid = header.kid;
-
-  const tryVerify = async (key: CryptoKey): Promise<Claims | null> => {
-    try {
-      const { payload } = await jwtVerify(token, key, { algorithms: ["ES256"] });
-      const profileId = typeof payload.sub === "string" ? payload.sub : null;
-      if (!profileId) return null;
-      return {
-        profileId,
-        email: typeof payload.email === "string" ? payload.email : null,
-        handle: typeof payload.handle === "string" ? payload.handle : null,
-        displayName: typeof payload.displayName === "string" ? payload.displayName : null,
-      };
-    } catch {
-      return null;
-    }
-  };
-
-  const key = await resolveKey(kid);
-  if (!key) return null;
-  return tryVerify(key);
 }
 
 /** Extracts verified claims from a Bearer token. Returns null on any failure. */
-async function extractClaims(
-  authHeader: string | undefined,
-  jwksUrl: string,
-): Promise<Claims | null>;
-async function extractClaims(
-  authHeader: string | undefined,
-  jwksUrl: string,
-  _testKey: CryptoKey,
-): Promise<Claims | null>;
 async function extractClaims(
   authHeader: string | undefined,
   jwksUrl: string,
@@ -151,27 +123,31 @@ async function extractClaims(
   if (!authHeader?.startsWith("Bearer ")) return null;
   const token = authHeader.slice(7);
 
-  if (_testKey) {
-    return verifyTokenWithKey(token, async () => _testKey);
-  }
-
-  // Try cached key first; on failure, refresh once (handles rotation).
+  // P-W1: decode the JWT header exactly once regardless of code path.
   let header: { kid?: string; alg?: string };
   try {
     header = decodeProtectedHeader(token);
   } catch {
     return null;
   }
-  if (typeof header.kid !== "string") return null;
+  if (header.alg !== "ES256" || typeof header.kid !== "string") return null;
   const kid = header.kid;
 
-  const result = await verifyTokenWithKey(token, (k) => resolvePublicKeyForKid(k, jwksUrl));
-  if (result) return result;
+  if (_testKey) {
+    return verifyTokenWithKey(token, _testKey);
+  }
+
+  // Try cached key first; on failure, refresh once (handles rotation).
+  const key = await resolvePublicKeyForKid(kid, jwksUrl);
+  if (key) {
+    const result = await verifyTokenWithKey(token, key);
+    if (result) return result;
+  }
 
   // Verification failed — refresh key in case it was rotated, then retry.
   const freshKey = await refreshPublicKeyForKid(kid, jwksUrl);
   if (!freshKey) return null;
-  return verifyTokenWithKey(token, async () => freshKey);
+  return verifyTokenWithKey(token, freshKey);
 }
 
 const DEFAULT_JWKS_URL = process.env.OSN_JWKS_URL ?? "http://localhost:4000/.well-known/jwks.json";

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -1,8 +1,9 @@
 import { DbLive, type Db } from "@pulse/db/service";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
-import { jwtVerify } from "jose";
+import { decodeProtectedHeader, jwtVerify } from "jose";
 
+import { resolvePublicKeyForKid, refreshPublicKeyForKid } from "../lib/jwks-cache";
 import { MAX_EVENT_GUESTS } from "../lib/limits";
 import {
   metricCalendarIcsGenerated,
@@ -86,42 +87,110 @@ const statusEnum = t.Optional(
   ]),
 );
 
-/** Extracts verified claims from a Bearer token. Returns null on any failure. */
-async function extractClaims(
-  authHeader: string | undefined,
-  secret: Uint8Array,
-): Promise<{
+type Claims = {
   profileId: string;
   email: string | null;
   handle: string | null;
   displayName: string | null;
-} | null> {
-  if (!authHeader?.startsWith("Bearer ")) return null;
+};
+
+/**
+ * Resolves public key via provider, verifying with ES256.
+ * On verification failure, attempts a cache refresh once (rotation handling).
+ */
+async function verifyTokenWithKey(
+  token: string,
+  resolveKey: (kid: string) => Promise<CryptoKey | null>,
+): Promise<Claims | null> {
+  let header: { kid?: string; alg?: string };
   try {
-    const { payload } = await jwtVerify(authHeader.slice(7), secret);
-    const profileId = typeof payload.sub === "string" ? payload.sub : null;
-    if (!profileId) return null;
-    const email = typeof payload.email === "string" ? payload.email : null;
-    const handle = typeof payload.handle === "string" ? payload.handle : null;
-    const displayName = typeof payload.displayName === "string" ? payload.displayName : null;
-    return { profileId, email, handle, displayName };
+    header = decodeProtectedHeader(token);
   } catch {
     return null;
   }
+
+  if (header.alg !== "ES256" || typeof header.kid !== "string") return null;
+  const kid = header.kid;
+
+  const tryVerify = async (key: CryptoKey): Promise<Claims | null> => {
+    try {
+      const { payload } = await jwtVerify(token, key, { algorithms: ["ES256"] });
+      const profileId = typeof payload.sub === "string" ? payload.sub : null;
+      if (!profileId) return null;
+      return {
+        profileId,
+        email: typeof payload.email === "string" ? payload.email : null,
+        handle: typeof payload.handle === "string" ? payload.handle : null,
+        displayName: typeof payload.displayName === "string" ? payload.displayName : null,
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  const key = await resolveKey(kid);
+  if (!key) return null;
+  return tryVerify(key);
 }
+
+/** Extracts verified claims from a Bearer token. Returns null on any failure. */
+async function extractClaims(
+  authHeader: string | undefined,
+  jwksUrl: string,
+): Promise<Claims | null>;
+async function extractClaims(
+  authHeader: string | undefined,
+  jwksUrl: string,
+  _testKey: CryptoKey,
+): Promise<Claims | null>;
+async function extractClaims(
+  authHeader: string | undefined,
+  jwksUrl: string,
+  _testKey?: CryptoKey,
+): Promise<Claims | null> {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7);
+
+  if (_testKey) {
+    return verifyTokenWithKey(token, async () => _testKey);
+  }
+
+  // Try cached key first; on failure, refresh once (handles rotation).
+  let header: { kid?: string; alg?: string };
+  try {
+    header = decodeProtectedHeader(token);
+  } catch {
+    return null;
+  }
+  if (typeof header.kid !== "string") return null;
+  const kid = header.kid;
+
+  const result = await verifyTokenWithKey(token, (k) => resolvePublicKeyForKid(k, jwksUrl));
+  if (result) return result;
+
+  // Verification failed — refresh key in case it was rotated, then retry.
+  const freshKey = await refreshPublicKeyForKid(kid, jwksUrl);
+  if (!freshKey) return null;
+  return verifyTokenWithKey(token, async () => freshKey);
+}
+
+const DEFAULT_JWKS_URL = process.env.OSN_JWKS_URL ?? "http://localhost:4000/.well-known/jwks.json";
 
 export const createEventsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwtSecret: string = process.env.OSN_JWT_SECRET ?? "",
+  jwksUrl: string = DEFAULT_JWKS_URL,
+  _testKey?: CryptoKey,
 ) => {
-  const secretBytes = new TextEncoder().encode(jwtSecret);
-
   return (
     new Elysia({ prefix: "/events" })
       .get(
         "/",
         async ({ query, headers }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const result = await Effect.runPromise(
             listEvents({ ...query, viewerId: claims?.profileId ?? null }).pipe(
               Effect.provide(dbLayer),
@@ -148,7 +217,11 @@ export const createEventsRoutes = (
           // only returned to the organiser or to invited / RSVP'd users.
           // 404 (not 403) for non-authorised viewers so we don't leak
           // existence.
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const result = await Effect.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null).pipe(Effect.provide(dbLayer)),
           );
@@ -171,7 +244,11 @@ export const createEventsRoutes = (
       .post(
         "/",
         async ({ body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -223,7 +300,11 @@ export const createEventsRoutes = (
       .patch(
         "/:id",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -280,7 +361,11 @@ export const createEventsRoutes = (
       .delete(
         "/:id",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -314,7 +399,11 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps",
         async ({ params, query, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const viewerId = claims?.profileId ?? null;
           // Visibility gate first — private events are 404 to non-viewers.
           const event = await Effect.runPromise(
@@ -371,7 +460,11 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps/counts",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           // S-H5: gate counts by visibility — leaking the existence /
           // activity of a private event is its own information disclosure.
           const event = await Effect.runPromise(
@@ -402,7 +495,11 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps/latest",
         async ({ params, query, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const viewerId = claims?.profileId ?? null;
           const event = await Effect.runPromise(
             loadVisibleEvent(params.id, viewerId).pipe(Effect.provide(dbLayer)),
@@ -449,7 +546,11 @@ export const createEventsRoutes = (
       .post(
         "/:id/rsvps",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -487,7 +588,11 @@ export const createEventsRoutes = (
       .post(
         "/:id/invite",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -530,7 +635,11 @@ export const createEventsRoutes = (
           // S-H2: gate ICS export by visibility. Otherwise the file
           // download leaks event metadata (incl. GEO coordinates) for
           // private events to anyone with the URL.
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const event = await Effect.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null).pipe(Effect.provide(dbLayer)),
           );
@@ -557,7 +666,11 @@ export const createEventsRoutes = (
           // S-H3: gate comms by visibility. Blast bodies often contain
           // venue codes, addresses, dress codes — they should never be
           // visible to viewers who can't see the event.
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           const event = await Effect.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null).pipe(Effect.provide(dbLayer)),
           );
@@ -592,7 +705,11 @@ export const createEventsRoutes = (
       .post(
         "/:id/comms/blasts",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], secretBytes);
+          const claims = await extractClaims(
+            headers["authorization"],
+            jwksUrl,
+            _testKey as CryptoKey,
+          );
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -650,13 +767,13 @@ export const createEventsRoutes = (
 
 export const createSettingsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwtSecret: string = process.env.OSN_JWT_SECRET ?? "",
+  jwksUrl: string = DEFAULT_JWKS_URL,
+  _testKey?: CryptoKey,
 ) => {
-  const secretBytes = new TextEncoder().encode(jwtSecret);
   return new Elysia({ prefix: "/me" }).patch(
     "/settings",
     async ({ body, headers, set }) => {
-      const claims = await extractClaims(headers["authorization"], secretBytes);
+      const claims = await extractClaims(headers["authorization"], jwksUrl, _testKey as CryptoKey);
       if (!claims) {
         metricSettingsUpdated("attendance_visibility", "unauthorized");
         set.status = 401;

--- a/pulse/api/tests/routes/events.new.test.ts
+++ b/pulse/api/tests/routes/events.new.test.ts
@@ -1,6 +1,7 @@
+import { generateArcKeyPair } from "@shared/crypto";
 import { Effect } from "effect";
 import { SignJWT } from "jose";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
 
 import { createEventsRoutes, createSettingsRoutes } from "../../src/routes/events";
 import type { ProfileDisplay } from "../../src/services/graphBridge";
@@ -20,12 +21,20 @@ vi.mock("../../src/services/graphBridge", () => ({
 import * as bridge from "../../src/services/graphBridge";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
-const TEST_JWT_SECRET = "test-secret";
+
+let testPrivateKey: CryptoKey;
+let testPublicKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateArcKeyPair();
+  testPrivateKey = pair.privateKey;
+  testPublicKey = pair.publicKey;
+});
 
 async function makeToken(profileId: string): Promise<string> {
   return new SignJWT({ sub: profileId })
-    .setProtectedHeader({ alg: "HS256" })
-    .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+    .setProtectedHeader({ alg: "ES256", kid: "test-kid" })
+    .sign(testPrivateKey);
 }
 
 const json = (body: unknown) => JSON.stringify(body);
@@ -82,7 +91,7 @@ describe("events routes — new config fields", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -188,7 +197,7 @@ describe("RSVP routes", () => {
       ),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
     const res = await post(app, "/events", { title: "Party", startTime: FUTURE }, aliceToken);
@@ -294,7 +303,7 @@ describe("ICS route", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -335,7 +344,7 @@ describe("Comms routes", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
     const res = await post(
@@ -428,7 +437,7 @@ describe("Private event visibility gate", () => {
       ),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
 
@@ -585,7 +594,7 @@ describe("Event text field length caps (S-M3)", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -637,7 +646,7 @@ describe("PATCH /me/settings", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    settingsApp = createSettingsRoutes(layer, TEST_JWT_SECRET);
+    settingsApp = createSettingsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -1,19 +1,28 @@
+import { generateArcKeyPair } from "@shared/crypto";
 import { Effect } from "effect";
 import { SignJWT } from "jose";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
-const TEST_JWT_SECRET = "test-secret";
+
+let testPrivateKey: CryptoKey;
+let testPublicKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateArcKeyPair();
+  testPrivateKey = pair.privateKey;
+  testPublicKey = pair.publicKey;
+});
 
 async function makeToken(profileId: string, email?: string): Promise<string> {
   const payload: Record<string, string> = { sub: profileId };
   if (email) payload.email = email;
   return new SignJWT(payload)
-    .setProtectedHeader({ alg: "HS256" })
-    .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+    .setProtectedHeader({ alg: "ES256", kid: "test-kid" })
+    .sign(testPrivateKey);
 }
 
 const json = (body: unknown) => JSON.stringify(body);
@@ -64,7 +73,7 @@ describe("events routes", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    app = createEventsRoutes(layer, TEST_JWT_SECRET);
+    app = createEventsRoutes(layer, "", testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 

--- a/shared/crypto/src/arc.ts
+++ b/shared/crypto/src/arc.ts
@@ -2,7 +2,7 @@ import { serviceAccounts, serviceAccountKeys } from "@osn/db";
 import { Db } from "@osn/db/service";
 import { and, eq, isNull, gt, or } from "drizzle-orm";
 import { Effect, Data } from "effect";
-import { SignJWT, jwtVerify, importJWK, exportJWK } from "jose";
+import { SignJWT, jwtVerify, importJWK, exportJWK, calculateJwkThumbprint } from "jose";
 
 import {
   classifyArcVerifyError,
@@ -96,6 +96,15 @@ function validateEs256Jwk(jwk: Record<string, unknown>): void {
   if (typeof jwk.x !== "string" || typeof jwk.y !== "string") {
     throw new ArcTokenError({ message: "Invalid JWK: missing x or y coordinates" });
   }
+}
+
+/**
+ * Computes an RFC 7638 SHA-256 JWK thumbprint for a public key.
+ * Stable across restarts for the same key — suitable for use as a `kid`.
+ */
+export async function thumbprintKid(publicKey: CryptoKey): Promise<string> {
+  const jwk = await exportJWK(publicKey);
+  return calculateJwkThumbprint(jwk);
 }
 
 /**

--- a/shared/crypto/src/index.ts
+++ b/shared/crypto/src/index.ts
@@ -9,6 +9,7 @@ export {
   generateArcKeyPair,
   exportKeyToJwk,
   importKeyFromJwk,
+  thumbprintKid,
   // Token lifecycle
   createArcToken,
   verifyArcToken,

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -64,6 +64,9 @@ export type ProfileCrudAction = "create" | "delete" | "set_default";
 /** Tables affected by cascade profile delete (P3). */
 export type ProfileDeleteCascadeTable = "connections" | "close_friends" | "blocks" | "org_members";
 
+/** JWKS public key cache lookup outcomes. */
+export type JwksCacheResult = "hit" | "miss" | "refresh";
+
 /** Auth endpoints subject to IP-based rate limiting (S-H1). */
 export type AuthRateLimitedEndpoint =
   | "register_begin"

--- a/shared/observability/src/metrics/index.ts
+++ b/shared/observability/src/metrics/index.ts
@@ -35,4 +35,5 @@ export {
   type ProfileSwitchAction,
   type ProfileCrudAction,
   type ProfileDeleteCascadeTable,
+  type JwksCacheResult,
 } from "./attrs";

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -142,6 +142,7 @@ OSN's messaging app. Stack matches Pulse (Bun, Tauri+Solid, Elysia+Eden, Drizzle
 
 ### Crypto (`osn/crypto`)
 
+- [x] JWKS endpoint + ES256 access tokens — `GET /.well-known/jwks.json` live in `@osn/api`; `@pulse/api` verifies via JWKS cache — see [[arc-tokens]]
 - [ ] JWKS URL fallback in `resolvePublicKey` for third-party apps (currently first-party only via `service_account_keys`)
 
 ### UI Components (`osn/ui`)
@@ -219,9 +220,9 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-L2 — `Effect.orDie` in `requireAuth` swallows auth errors — replace with `Effect.either` + 401
 - [ ] S-L3 — Tauri CSP is `null` — allowlist `photon.komoot.io`, `maps.google.com`, `*.tile.openstreetmap.org`
 - [ ] S-L4 — `createdByAvatar` always null — no avatar claim in JWT
-- [x] S-L7 — `jwtSecret` falls back to `"dev-secret"` — throw at startup in production. **Fixed**: `OSN_JWT_SECRET` is validated at startup in `pulse/api/src/index.ts` (throws when unset in non-test env)
+- [x] S-L7 — `jwtSecret` falls back to `"dev-secret"` — **Superseded**: symmetric `OSN_JWT_SECRET` removed entirely; replaced by ES256 key pair (`OSN_JWT_PRIVATE_KEY`/`OSN_JWT_PUBLIC_KEY`); startup guard uses `OSN_ENV` — see [[arc-tokens]]
 - [x] S-L29 — `/graph/internal/*` mounted under open CORS. **Fixed** — `cors()` now uses `OSN_CORS_ORIGIN` env var (falls back to `authConfig.origin`); wildcard removed — see [[arc-tokens]]
-- [x] S-L32 — `OSN_JWT_SECRET` in `osn/api` fell back to `"dev-secret-change-in-prod"` at startup. **Fixed** — throws at startup when `NODE_ENV=production` and secret is unset
+- [x] S-L32 — `OSN_JWT_SECRET` in `osn/api` fell back to `"dev-secret-change-in-prod"` at startup. **Superseded**: symmetric secret removed; ES256 key pair required in non-local envs (guarded via `OSN_ENV`) — see [[arc-tokens]]
 - [x] S-L8 — OTP codes and magic link URLs logged to stdout. **Fixed** — guard tightened to `OSN_ENV` (excludes staging); dev log level defaults to debug so codes are visible without manual config.
 - [ ] S-L9 — `imageUrl` allows `data:` URIs — add CSP `img-src` header
 - [ ] S-L10 — SimpleWebAuthn loaded from unpkg CDN without SRI hash
@@ -232,6 +233,10 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [ ] S-L14 — `assertion: t.Any()` on passkey routes — add TypeBox shape validation
 - [ ] S-L15 — No reserved-handle blocklist in DB
 - [x] S-L101 — `registerWithOsnApi()` silently returned early when `INTERNAL_SERVICE_SECRET` unset. **Fixed** — now throws, caught at startup by `index.ts` — see [[arc-tokens]]
+- [ ] S-M1 (auth) — `pkceStore` unbounded + no expiry sweep — add `MAX_PKCE_ENTRIES` cap + `sweepExpired` on insert, or migrate to Redis (Phase 4) — see [[arc-tokens]]
+- [ ] S-M2 (auth) — `/authorize` has no rate limiter — add `authorize: RateLimiterBackend` to `AuthRateLimiters` — see [[rate-limiting]]
+- [ ] S-M4 (auth) — No startup assertion that `OSN_JWT_PRIVATE_KEY` has `sign` usage — assert `key.usages.includes("sign")` after import in `loadJwtKeyPair`
+- [ ] S-L2 (auth) — Wildcard CORS on `@pulse/api` — restrict to known client origins (mirrors OSN_CORS_ORIGIN pattern) — see [[rate-limiting]]
 - [ ] S-L22 — `listRsvps` counts privacy-filtered rows toward `limit` (weak side-channel oracle)
 - [ ] S-L23 — `pkceStore` has no size bound or eviction sweep
 - [ ] S-L24 — `/token` and legacy `POST /register` have no rate limiting
@@ -261,6 +266,7 @@ Open findings only. Completed fixes archived in [[changelog/performance-fixes]].
 - [x] P-W101 — `peekClaims` decoded payload before checking header validity. **Fixed** — header decoded first; payload decode gated on `kid` present — see [[arc-tokens]]
 - [x] P-W102 — `evictExpiredTokens` O(n) scan on every `getOrCreateArcToken` call. **Fixed** — internal debounced sweep (`maybeSweepExpiredTokens`) runs at most once per 30 s; public `evictExpiredTokens` still sweeps immediately — see [[arc-tokens]]
 - [ ] P-W3 — `sendConnectionRequest` two sequential independent DB reads — use `Effect.all` with `concurrency: "unbounded"`
+- [ ] P-W3 (jwks) — `extractClaims` in pulse/api serialises JWKS resolve before DB I/O on read-only routes — parallelise with `Promise.all` for anonymous-capable endpoints — see [[arc-tokens]]
 - [ ] P-W4 — Auth Maps (`otpStore`, `magicStore`, `pkceStore`) never evict expired entries — see [[redis]]
 - [ ] P-W1 (pulse) — Duplicate event DB load per RSVP route: `loadVisibleEvent` fetches the row for the access gate; `listRsvps`/`rsvpCounts` re-fetch the same row internally. Thread the loaded `Event` into service functions — see [[s2s-patterns]]
 - [ ] P-W3 (pulse) — `listTodayEvents` has no `LIMIT` clause; fetches all matching rows for the day into memory — see [[event-access]]


### PR DESCRIPTION
## Summary
- Migrate OSN user access tokens from HS256 (symmetric) to ES256 (asymmetric ECDSA P-256)
- Expose `GET /.well-known/jwks.json` so downstream services can verify tokens without sharing a secret
- Pulse API now fetches public keys from the JWKS endpoint instead of reading a shared `OSN_JWT_SECRET`
- Add in-process JWKS key cache in `pulse/api` with 5-min TTL, LRU eviction cap, and key-rotation refresh path
- Add `thumbprintKid()` to `@shared/crypto` for stable RFC 7638 JWK thumbprint generation
- Expose `JwksCacheResult` metric attribute type from `@shared/observability`
- Local dev uses ephemeral key pairs (logged as warning); non-local envs fail-fast if keys are absent

## Workspaces affected
- `@shared/crypto` — minor: `thumbprintKid()` export
- `@shared/observability` — patch: `JwksCacheResult` attribute type
- `@osn/api` — minor: ES256 signing, JWKS endpoint, `AuthConfig` redesign
- `@pulse/api` — minor: JWKS-based token verification, in-process key cache

## Decisions & issues

**[S-H1] — Cache-Control header missing from JWKS endpoint**
- **Issue:** Without a Cache-Control header, CDNs and proxies cache indefinitely or not at all.
- **Why:** Stale keys block valid tokens; no caching causes thundering-herd on key rotation.
- **Solution:** Added `public, max-age=300, stale-while-revalidate=60` to `/.well-known/jwks.json`.
- **Rationale:** 5-min TTL balances rotation latency with request reduction; `stale-while-revalidate` prevents hard misses during rotation.

**[S-H2] — Wrong environment discriminator (`NODE_ENV` vs `OSN_ENV`)**
- **Issue:** Initial implementation gated key-presence enforcement on `NODE_ENV !== "production"`.
- **Why:** A staging deploy with `NODE_ENV=development` would silently fall through to an ephemeral key pair, issuing tokens that can't survive restarts.
- **Solution:** Switched to `OSN_ENV && OSN_ENV !== "local"` — the canonical project discriminator already used throughout `auth.ts`.
- **Rationale:** `OSN_ENV` is the authoritative four-tier env flag (local/dev/staging/prod); `NODE_ENV` is a build-tool artefact.

**[S-H3] — JWKS URL over plaintext HTTP in deployed envs**
- **Issue:** `pulse/api` would fetch JWKs over `http://` in non-local environments, allowing any on-path process to serve a forged JWK set.
- **Why:** Forged keys = attacker can issue valid-looking tokens, bypassing all auth.
- **Solution:** `pulse/api` startup guard rejects `http://` JWKS URLs when `OSN_ENV` is not `"local"`.
- **Rationale:** Fail-fast at boot is preferable to a runtime auth bypass that would be silent in logs.

**[S-M3] — JWKS cache key collision across issuers**
- **Issue:** Original cache keyed only on `kid`; two issuers with the same `kid` value would collide.
- **Why:** An attacker controlling a second issuer could pre-populate the cache with their own key.
- **Solution:** Cache key is `${jwksUrl}:${kid}`, isolating keys by issuer URL.
- **Rationale:** Minimal change, eliminates the collision entirely.

**[S-M4] — Unbounded JWKS cache (DoS)**
- **Issue:** Crafted JWTs with unique `kid` values could grow the cache without bound.
- **Why:** Heap exhaustion in `pulse/api` process.
- **Solution:** LRU eviction cap of 256 entries, mirroring the pattern from `@shared/crypto/arc.ts` (PR #63).
- **Rationale:** Real key-rotation scenarios never exceed single digits; 256 is generous headroom.

**[S-L2] — CORS wildcard on pulse/api**
- **Issue:** `pulse/api` used `cors()` with no origin restriction.
- **Why:** Any origin could make credentialed requests to Pulse in a browser context.
- **Solution:** Deferred — `pulse/api` does not issue or store credentials; its endpoints are read-by-origin-policy safe. Added to TODO.md backlog (S-L2) for a future tightening pass.
- **Rationale:** Risk is low pre-launch; fixing properly requires knowing the final deploy origin, which isn't settled yet.

**[P-W1] — Double `decodeProtectedHeader` per request**
- **Issue:** Original `verifyTokenWithKey` decoded the JWT header internally; `extractClaims` also decoded it to read `kid`.
- **Why:** Redundant CPU work on every authenticated request.
- **Solution:** Decode once in `extractClaims`, pass resolved `CryptoKey` directly to `verifyTokenWithKey(token, key)`.
- **Rationale:** Simple refactor; `verifyTokenWithKey` signature is cleaner (takes key, not token+resolver).

**[P-I2] — JWKS response object allocated per request**
- **Issue:** `/.well-known/jwks.json` handler constructed a new object on every call.
- **Why:** Pointless allocation for a static response.
- **Solution:** Pre-built `jwksResponse` constant at module init time; handler returns the same reference.
- **Rationale:** Zero-cost fix; key set is immutable until restart.

**[P-W3] — LRU eviction is O(n) scan**
- **Issue:** `evictLru()` iterates all entries in `lastAccess` to find the minimum.
- **Why:** At CACHE_MAX_SIZE=256 this is ~256 iterations per eviction — acceptable now, but linear.
- **Solution:** Deferred — added to TODO.md Performance Backlog (P-W3). A min-heap or doubly-linked list would be O(log n) / O(1).
- **Rationale:** At 256 entries the scan is ~microseconds; not worth the complexity pre-launch.

## Test plan
- [ ] `bun run --cwd osn/api test:run` — all 450 tests pass (ES256 signing + JWKS route covered)
- [ ] `bun run --cwd pulse/api test:run` — 207/208 pass (1 pre-existing unrelated failure)
- [ ] Start `bun run dev:pulse` and log in as `alice@seed.osn.dev` — verify token issued and Pulse accepts it
- [ ] `curl http://localhost:4000/.well-known/jwks.json` — returns `{ keys: [{ kty, crv, x, y, use, alg, kid, key_ops }] }`
- [ ] `curl http://localhost:4000/.well-known/openid-configuration` — verify `jwks_uri` and `id_token_signing_alg_values_supported: ["ES256"]`
- [ ] Restart `osn/api` — ephemeral key warning appears in logs; old Pulse tokens are invalidated (expected in local dev)
- [ ] Set `OSN_ENV=staging` without `OSN_JWT_PRIVATE_KEY` — verify osn/api exits with error at boot
- [ ] Set `OSN_ENV=staging` with `OSN_JWKS_URL=http://...` in pulse/api — verify pulse/api exits with error at boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)