### PR TITLE
feat(auth): server-side sessions with revocation (Copenhagen Book C1)

### DIFF
--- a/.changeset/server-side-sessions.md
+++ b/.changeset/server-side-sessions.md
@@ -1,0 +1,12 @@
+---
+"@osn/db": minor
+"@osn/api": minor
+"@osn/client": patch
+---
+
+feat(auth): server-side sessions with revocation (Copenhagen Book C1)
+
+Replace stateless JWT refresh tokens with opaque server-side session tokens.
+Session tokens use 160-bit entropy, stored as SHA-256 hashes in the new `sessions` table.
+Sliding-window expiry, single-session and account-wide revocation, `POST /logout` endpoint.
+Removes deprecated `User`/`NewUser` type aliases and legacy client session migration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+RES
 
 **User Access Tokens** — ES256 JWTs issued by `@osn/api` on login. Public key exposed at `GET /.well-known/jwks.json`. Downstream services (e.g. `@pulse/api`) verify via JWKS fetch — no shared secret. `AuthConfig` takes `jwtPrivateKey`, `jwtPublicKey`, `jwtKid`, `jwtPublicKeyJwk` (not `jwtSecret`). Env vars: `OSN_JWT_PRIVATE_KEY` / `OSN_JWT_PUBLIC_KEY` (base64 JWK JSON); ephemeral pair generated in local dev when unset. `thumbprintKid(publicKey)` from `@shared/crypto` computes the RFC 7638 kid. Downstream: set `OSN_JWKS_URL` in each service; must be HTTPS in non-local envs.
 
+**Server-side Sessions (Copenhagen Book C1)** — Session tokens (refresh tokens) are opaque (`ses_` + 40 hex chars, 160-bit entropy). Server stores only SHA-256(token) in the `sessions` table — DB leak does not expose valid tokens. Sliding-window expiry: 30 days, extended when <15 days remain. `invalidateSession(token)` revokes one session; `invalidateAccountSessions(accountId)` revokes all. `POST /logout` endpoint for server-side session destruction. See `[[wiki/systems/identity-model]]`.
+
 **Observability** — OpenTelemetry end-to-end, shipped to Grafana Cloud. Three golden rules: no `console.*`, no raw OTel constructors, no unbounded metric attributes. See `[[wiki/observability/overview]]`.
 
 **Rate Limiting** — Per-IP fixed-window on all auth endpoints; per-user on graph writes, org writes, and `/recommendations/connections` reads. Two backends: Redis-backed when `REDIS_URL` is set (cross-process, survives restarts), in-memory fallback when unset (local dev). See `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]`.

--- a/osn/api/src/routes/auth.ts
+++ b/osn/api/src/routes/auth.ts
@@ -979,6 +979,30 @@ export function createAuthRoutes(
         },
       )
       // -------------------------------------------------------------------------
+      // Logout (server-side session destruction — Copenhagen Book C1)
+      // -------------------------------------------------------------------------
+      .post(
+        "/logout",
+        async ({ body, set }) => {
+          const { refresh_token } = body;
+          if (!refresh_token) {
+            set.status = 400;
+            return { error: "invalid_request" };
+          }
+          try {
+            await run(auth.invalidateSession(refresh_token));
+          } catch {
+            // Swallow — don't leak whether the session existed
+          }
+          return { success: true };
+        },
+        {
+          body: t.Object({
+            refresh_token: t.String(),
+          }),
+        },
+      )
+      // -------------------------------------------------------------------------
       // OIDC discovery (minimal)
       // -------------------------------------------------------------------------
       .get("/.well-known/openid-configuration", () => ({

--- a/osn/api/src/services/auth.ts
+++ b/osn/api/src/services/auth.ts
@@ -1,6 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
-import { accounts, users, passkeys } from "@osn/db/schema";
+import { accounts, sessions, users, passkeys } from "@osn/db/schema";
 import type { Profile } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 import {
@@ -221,6 +221,31 @@ function sweepExpired<T extends { expiresAt: number }>(map: Map<string, T>): voi
   for (const [key, entry] of map) {
     if (entry.expiresAt <= nowMs) map.delete(key);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Session token helpers (Copenhagen Book C1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates an opaque session token: 20 random bytes (160-bit entropy),
+ * hex-encoded with a `ses_` prefix for developer ergonomics.
+ * The raw token is held by the client; the server stores only its SHA-256 hash.
+ */
+function generateSessionToken(): string {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  return "ses_" + Buffer.from(bytes).toString("hex");
+}
+
+/**
+ * SHA-256 hash of the raw session token. This is what gets stored in the
+ * sessions table as the primary key. A DB leak does not expose valid tokens
+ * because the token has 160 bits of entropy — brute-forcing the preimage
+ * of SHA-256 is infeasible.
+ */
+function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
 }
 
 const EmailSchema = Schema.String.pipe(
@@ -755,15 +780,18 @@ export function createAuthService(config: AuthConfig) {
   // Token issuance
   // -------------------------------------------------------------------------
 
-  const issueTokens = (
+  /**
+   * Signs a short-lived ES256 access token JWT. Used by both initial login
+   * (via `issueTokens`) and token refresh / profile switch (standalone).
+   */
+  const issueAccessToken = (
     profileId: string,
-    accountId: string,
     email: string,
     handle: string,
     displayName: string | null,
   ) =>
     Effect.tryPromise({
-      try: async () => {
+      try: () => {
         const payload: Record<string, unknown> = {
           sub: profileId,
           email,
@@ -771,19 +799,45 @@ export function createAuthService(config: AuthConfig) {
           scope: "openid profile",
         };
         if (displayName !== null) payload["displayName"] = displayName;
-
-        const [accessToken, refreshToken] = await Promise.all([
-          signJwt(payload, config.jwtPrivateKey, config.jwtKid, accessTokenTtl),
-          signJwt(
-            { sub: accountId, type: "refresh", scope: "account" },
-            config.jwtPrivateKey,
-            config.jwtKid,
-            refreshTokenTtl,
-          ),
-        ]);
-        return { accessToken, refreshToken, expiresIn: accessTokenTtl };
+        return signJwt(payload, config.jwtPrivateKey, config.jwtKid, accessTokenTtl);
       },
       catch: (cause) => new AuthError({ message: String(cause) }),
+    });
+
+  /**
+   * Full token issuance: creates a server-side session row and returns an
+   * opaque session token (the "refresh token") alongside a short-lived
+   * access token JWT. The session token is what the client persists; the
+   * server only stores its SHA-256 hash (Copenhagen Book C1).
+   */
+  const issueTokens = (
+    profileId: string,
+    accountId: string,
+    email: string,
+    handle: string,
+    displayName: string | null,
+  ): Effect.Effect<TokenSet, AuthError | DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const accessToken = yield* issueAccessToken(profileId, email, handle, displayName);
+
+      // Generate opaque session token + store SHA-256 hash in DB
+      const sessionToken = generateSessionToken();
+      const sessionId = hashSessionToken(sessionToken);
+      const nowSec = Math.floor(Date.now() / 1000);
+
+      const { db } = yield* Db;
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(sessions).values({
+            id: sessionId,
+            accountId,
+            expiresAt: nowSec + refreshTokenTtl,
+            createdAt: nowSec,
+          }),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return { accessToken, refreshToken: sessionToken, expiresIn: accessTokenTtl };
     });
 
   // -------------------------------------------------------------------------
@@ -901,27 +955,57 @@ export function createAuthService(config: AuthConfig) {
     });
 
   // -------------------------------------------------------------------------
-  // Token refresh
+  // Token refresh (server-side sessions — Copenhagen Book C1)
   // -------------------------------------------------------------------------
 
   /**
-   * Verifies a refresh token and extracts the accountId. Shared by
-   * `refreshTokens`, `switchProfile`, and `listAccountProfiles`.
+   * Verifies a session token by looking up its SHA-256 hash in the sessions
+   * table. Implements sliding-window expiry: when less than half the TTL
+   * remains, `expiresAt` is extended by the full TTL from now.
+   *
+   * Shared by `refreshTokens`, `switchProfile`, and `listAccountProfiles`.
    */
-  const verifyRefreshToken = (token: string): Effect.Effect<{ accountId: string }, AuthError> =>
+  const verifyRefreshToken = (
+    token: string,
+  ): Effect.Effect<{ accountId: string }, AuthError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      const payload = yield* Effect.tryPromise({
-        try: () => verifyJwt(token, config.jwtPublicKey),
-        catch: () => new AuthError({ message: "Invalid or expired refresh token" }),
+      const sessionId = hashSessionToken(token);
+      const { db } = yield* Db;
+
+      const result = yield* Effect.tryPromise({
+        try: () => db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
       });
-      if (
-        payload["type"] !== "refresh" ||
-        payload["scope"] !== "account" ||
-        typeof payload["sub"] !== "string"
-      ) {
-        return yield* Effect.fail(new AuthError({ message: "Invalid token type" }));
+      const session = result[0];
+      if (!session) {
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired session" }));
       }
-      return { accountId: payload["sub"] };
+
+      const nowSec = Math.floor(Date.now() / 1000);
+
+      // Expired — clean up lazily
+      if (nowSec >= session.expiresAt) {
+        yield* Effect.tryPromise({
+          try: () => db.delete(sessions).where(eq(sessions.id, sessionId)),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired session" }));
+      }
+
+      // Sliding window: extend when less than half the TTL remains
+      const halfTtl = Math.floor(refreshTokenTtl / 2);
+      if (session.expiresAt - nowSec < halfTtl) {
+        yield* Effect.tryPromise({
+          try: () =>
+            db
+              .update(sessions)
+              .set({ expiresAt: nowSec + refreshTokenTtl })
+              .where(eq(sessions.id, sessionId)),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+      }
+
+      return { accountId: session.accountId };
     });
 
   /**
@@ -950,26 +1034,31 @@ export function createAuthService(config: AuthConfig) {
       return { ...row.profile, email: row.account.email };
     });
 
+  /**
+   * Refreshes a session: verifies the session token (with sliding-window
+   * extension), finds the default profile, and issues a new access token.
+   * The session token itself is unchanged — the same opaque token is returned.
+   */
   const refreshTokens = (
-    refreshToken: string,
+    sessionToken: string,
   ): Effect.Effect<
     { accessToken: string; refreshToken: string; expiresIn: number },
     AuthError | DatabaseError,
     Db
   > =>
     Effect.gen(function* () {
-      const { accountId } = yield* verifyRefreshToken(refreshToken);
+      const { accountId } = yield* verifyRefreshToken(sessionToken);
       const profile = yield* findDefaultProfile(accountId);
       if (!profile) {
         return yield* Effect.fail(new AuthError({ message: "Profile not found" }));
       }
-      return yield* issueTokens(
+      const accessToken = yield* issueAccessToken(
         profile.id,
-        accountId,
         profile.email,
         profile.handle,
         profile.displayName,
       );
+      return { accessToken, refreshToken: sessionToken, expiresIn: accessTokenTtl };
     }).pipe(withAuthTokenRefresh);
 
   // -------------------------------------------------------------------------
@@ -1584,24 +1673,52 @@ export function createAuthService(config: AuthConfig) {
           new AuthError({ message: "Profile does not belong to this account" }),
         );
       }
-      // Issue only a new access token — the refresh token is account-scoped and unchanged.
-      const payload: Record<string, unknown> = {
-        sub: profile.id,
-        email: profile.email,
-        handle: profile.handle,
-        scope: "openid profile",
-      };
-      if (profile.displayName !== null) payload["displayName"] = profile.displayName;
-      const accessToken = yield* Effect.tryPromise({
-        try: () => signJwt(payload, config.jwtPrivateKey, config.jwtKid, accessTokenTtl),
-        catch: (cause) => new AuthError({ message: String(cause) }),
-      });
+      // Issue only a new access token — the session token is account-scoped and unchanged.
+      const accessToken = yield* issueAccessToken(
+        profile.id,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
       return {
         accessToken,
         expiresIn: accessTokenTtl,
         profile: toPublicProfile(profile, profile.email),
       };
     }).pipe(withProfileSwitch("switch"));
+
+  // -------------------------------------------------------------------------
+  // Session invalidation (Copenhagen Book C1 — revocation)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Invalidates a single session by deleting its DB row. Used by the
+   * `/logout` endpoint. Silently succeeds if the session doesn't exist
+   * (idempotent — don't leak whether a session was valid).
+   */
+  const invalidateSession = (sessionToken: string): Effect.Effect<void, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const sessionId = hashSessionToken(sessionToken);
+      const { db } = yield* Db;
+      yield* Effect.tryPromise({
+        try: () => db.delete(sessions).where(eq(sessions.id, sessionId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
+
+  /**
+   * Invalidates ALL sessions for an account. Used when a security event
+   * demands full session revocation (e.g. passkey registration, email
+   * change, account compromise). See auth improvements H1.
+   */
+  const invalidateAccountSessions = (accountId: string): Effect.Effect<void, DatabaseError, Db> =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      yield* Effect.tryPromise({
+        try: () => db.delete(sessions).where(eq(sessions.accountId, accountId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+    });
 
   return {
     findProfileByEmail,
@@ -1634,6 +1751,8 @@ export function createAuthService(config: AuthConfig) {
     verifyMagic,
     verifyMagicDirect,
     validateRedirectUri,
+    invalidateSession,
+    invalidateAccountSessions,
   };
 }
 

--- a/osn/api/tests/helpers/db.ts
+++ b/osn/api/tests/helpers/db.ts
@@ -78,6 +78,15 @@ export function createTestLayer() {
   sqlite.run(`CREATE INDEX blocks_blocker_idx ON blocks (blocker_id)`);
   sqlite.run(`CREATE INDEX blocks_blocked_idx ON blocks (blocked_id)`);
   sqlite.run(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      account_id TEXT NOT NULL REFERENCES accounts(id),
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  sqlite.run(`CREATE INDEX sessions_account_idx ON sessions (account_id)`);
+  sqlite.run(`
     CREATE TABLE service_accounts (
       service_id TEXT PRIMARY KEY,
       allowed_scopes TEXT NOT NULL,

--- a/osn/api/tests/routes/auth.test.ts
+++ b/osn/api/tests/routes/auth.test.ts
@@ -912,13 +912,15 @@ describe("auth routes", () => {
         svc.registerProfile("quinn@example.com", "quinn").pipe(Effect.provide(layer)),
       );
       const tokens = await Effect.runPromise(
-        svc.issueTokens(
-          profile.id,
-          profile.accountId,
-          profile.email,
-          profile.handle,
-          profile.displayName,
-        ),
+        svc
+          .issueTokens(
+            profile.id,
+            profile.accountId,
+            profile.email,
+            profile.handle,
+            profile.displayName,
+          )
+          .pipe(Effect.provide(layer)),
       );
       const res = await app.handle(
         new Request("http://localhost/passkey/register/begin", {

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -935,7 +935,7 @@ describe("login OTP attempt limit", () => {
 // ---------------------------------------------------------------------------
 
 describe("two-tier token model (P2)", () => {
-  it.effect("refresh token sub claim is the accountId, not the profileId", () =>
+  it.effect("verifyRefreshToken resolves the accountId from a session token", () =>
     Effect.gen(function* () {
       const profile = yield* auth.registerProfile("tier@example.com", "tier", "Tier");
       const tokens = yield* auth.issueTokens(
@@ -945,7 +945,7 @@ describe("two-tier token model (P2)", () => {
         profile.handle,
         profile.displayName,
       );
-      // Verify the refresh token — its sub should be the accountId
+      // Session token (opaque) should resolve to the correct accountId
       const { accountId } = yield* auth.verifyRefreshToken(tokens.refreshToken);
       expect(accountId).toBe(profile.accountId);
       // Access token sub should still be profileId
@@ -954,7 +954,21 @@ describe("two-tier token model (P2)", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("refreshTokens resolves the default profile from account-scoped refresh token", () =>
+  it.effect("session token is opaque with ses_ prefix", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("sesprefix@example.com", "sesprefix");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      expect(tokens.refreshToken).toMatch(/^ses_[0-9a-f]{40}$/);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("refreshTokens resolves the default profile from account-scoped session token", () =>
     Effect.gen(function* () {
       const profile = yield* auth.registerProfile("refresh2@example.com", "refresh2");
       const tokens = yield* auth.issueTokens(
@@ -968,6 +982,21 @@ describe("two-tier token model (P2)", () => {
       const claims = yield* auth.verifyAccessToken(refreshed.accessToken);
       expect(claims.profileId).toBe(profile.id);
       expect(claims.handle).toBe("refresh2");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("refreshTokens returns the same session token (no rotation yet)", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("sametoken@example.com", "sametoken");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const refreshed = yield* auth.refreshTokens(tokens.refreshToken);
+      expect(refreshed.refreshToken).toBe(tokens.refreshToken);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -988,7 +1017,7 @@ describe("two-tier token model (P2)", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  it.effect("rejects an access token used as a refresh token (type mismatch)", () =>
+  it.effect("rejects a random string used as a session token", () =>
     Effect.gen(function* () {
       const profile = yield* auth.registerProfile("typemix@example.com", "typemix");
       const tokens = yield* auth.issueTokens(
@@ -998,14 +1027,14 @@ describe("two-tier token model (P2)", () => {
         profile.handle,
         profile.displayName,
       );
-      // Access token has no type: "refresh" claim — must be rejected
+      // An access token (JWT) is not a valid session token — must be rejected
       const switchErr = yield* Effect.flip(auth.switchProfile(tokens.accessToken, profile.id));
       expect(switchErr._tag).toBe("AuthError");
-      expect(switchErr.message).toContain("Invalid token type");
+      expect(switchErr.message).toContain("Invalid or expired session");
 
       const listErr = yield* Effect.flip(auth.listAccountProfiles(tokens.accessToken));
       expect(listErr._tag).toBe("AuthError");
-      expect(listErr.message).toContain("Invalid token type");
+      expect(listErr.message).toContain("Invalid or expired session");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });
@@ -1107,6 +1136,186 @@ describe("listAccountProfiles (P2)", () => {
     Effect.gen(function* () {
       const error = yield* Effect.flip(auth.listAccountProfiles("not.a.token"));
       expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Server-side sessions (Copenhagen Book C1)
+// ---------------------------------------------------------------------------
+
+describe("server-side sessions (C1)", () => {
+  it.effect("invalidateSession makes the session token unusable", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("revoke@example.com", "revoke");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+
+      // Session works before invalidation
+      const { accountId } = yield* auth.verifyRefreshToken(tokens.refreshToken);
+      expect(accountId).toBe(profile.accountId);
+
+      // Invalidate
+      yield* auth.invalidateSession(tokens.refreshToken);
+
+      // Session no longer works
+      const error = yield* Effect.flip(auth.verifyRefreshToken(tokens.refreshToken));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Invalid or expired session");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("invalidateSession is idempotent (no error on double-invalidate)", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("idem@example.com", "idem");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      yield* auth.invalidateSession(tokens.refreshToken);
+      // Second invalidation should not throw
+      yield* auth.invalidateSession(tokens.refreshToken);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("invalidateAccountSessions revokes all sessions for an account", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("revokeall@example.com", "revokeall");
+
+      // Issue two separate sessions
+      const tokens1 = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const tokens2 = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+
+      // Both work
+      yield* auth.verifyRefreshToken(tokens1.refreshToken);
+      yield* auth.verifyRefreshToken(tokens2.refreshToken);
+
+      // Revoke all
+      yield* auth.invalidateAccountSessions(profile.accountId);
+
+      // Both fail
+      const err1 = yield* Effect.flip(auth.verifyRefreshToken(tokens1.refreshToken));
+      expect(err1._tag).toBe("AuthError");
+      const err2 = yield* Effect.flip(auth.verifyRefreshToken(tokens2.refreshToken));
+      expect(err2._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("invalidated session cannot be used for refreshTokens", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("norefresh@example.com", "norefresh");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      yield* auth.invalidateSession(tokens.refreshToken);
+
+      const error = yield* Effect.flip(auth.refreshTokens(tokens.refreshToken));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("invalidated session cannot be used for switchProfile", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("noswitch@example.com", "noswitch");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      yield* auth.invalidateSession(tokens.refreshToken);
+
+      const error = yield* Effect.flip(auth.switchProfile(tokens.refreshToken, profile.id));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("invalidated session cannot be used for listAccountProfiles", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("nolist@example.com", "nolist");
+      const tokens = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      yield* auth.invalidateSession(tokens.refreshToken);
+
+      const error = yield* Effect.flip(auth.listAccountProfiles(tokens.refreshToken));
+      expect(error._tag).toBe("AuthError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("each issueTokens call creates a distinct session", () =>
+    Effect.gen(function* () {
+      const profile = yield* auth.registerProfile("distinct@example.com", "distinct");
+      const t1 = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      const t2 = yield* auth.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+      // Different session tokens
+      expect(t1.refreshToken).not.toBe(t2.refreshToken);
+
+      // Invalidating one doesn't affect the other
+      yield* auth.invalidateSession(t1.refreshToken);
+      const { accountId } = yield* auth.verifyRefreshToken(t2.refreshToken);
+      expect(accountId).toBe(profile.accountId);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("expired session is cleaned up and rejected on verify", () =>
+    Effect.gen(function* () {
+      // Use a 0-second TTL to create an instantly-expired session
+      const svc = createAuthService({ ...config, refreshTokenTtl: 0 });
+      const profile = yield* svc.registerProfile("expired@example.com", "expired");
+      const tokens = yield* svc.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+      );
+
+      // Should be expired immediately
+      const error = yield* Effect.flip(svc.verifyRefreshToken(tokens.refreshToken));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Invalid or expired session");
     }).pipe(Effect.provide(createTestLayer())),
   );
 });

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -14,7 +14,6 @@ import {
   decodeAccountSession,
   decodeCreateProfileResponse,
   decodeListProfilesResponse,
-  decodeSession,
   decodeSwitchProfileResponse,
   extractJwtSub,
   parseTokenResponse,
@@ -22,7 +21,6 @@ import {
 import type { AccountSession, PublicProfile, Session } from "./tokens";
 
 const ACCOUNT_SESSION_KEY = "@osn/client:account_session";
-const LEGACY_SESSION_KEY = "@osn/client:session";
 const VERIFIER_KEY = "@osn/client:pkce_verifier";
 const STATE_KEY = "@osn/client:state";
 
@@ -146,7 +144,6 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
         return storage.set(ACCOUNT_SESSION_KEY, JSON.stringify(account));
       };
 
-      /** Read account session from storage, migrating from the legacy single-key format if needed. */
       const getAccountSession = () =>
         Effect.gen(function* () {
           // P-W1: Return cached value if available
@@ -166,46 +163,8 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             }
           }
 
-          // Attempt migration from legacy single-key storage
-          const legacy = yield* storage.get(LEGACY_SESSION_KEY);
-          if (!legacy) {
-            cache = null;
-            return null;
-          }
-
-          // S-H2: Validate legacy session data
-          let legacySession: Session;
-          try {
-            legacySession = decodeSession(JSON.parse(legacy)) as Session;
-          } catch {
-            yield* storage.remove(LEGACY_SESSION_KEY);
-            cache = null;
-            return null;
-          }
-
-          if (!legacySession.refreshToken) {
-            yield* storage.remove(LEGACY_SESSION_KEY);
-            cache = null;
-            return null;
-          }
-
-          const profileId = extractJwtSub(legacySession.accessToken) ?? "default";
-          const account: AccountSession = {
-            refreshToken: legacySession.refreshToken,
-            activeProfileId: profileId,
-            profileTokens: {
-              [profileId]: {
-                accessToken: legacySession.accessToken,
-                expiresAt: legacySession.expiresAt,
-              },
-            },
-            scopes: legacySession.scopes,
-            idToken: legacySession.idToken,
-          };
-
-          yield* saveAccountSession(account);
-          yield* storage.remove(LEGACY_SESSION_KEY);
-          return account;
+          cache = null;
+          return null;
         });
 
       // ---------------------------------------------------------------------------
@@ -331,7 +290,6 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
         Effect.gen(function* () {
           cache = null;
           yield* storage.remove(ACCOUNT_SESSION_KEY);
-          yield* storage.remove(LEGACY_SESSION_KEY);
         });
 
       const setSession = (session: Session) => saveAccountSession(sessionToAccountSession(session));

--- a/osn/client/tests/profiles.test.ts
+++ b/osn/client/tests/profiles.test.ts
@@ -67,48 +67,6 @@ it.effect("getSession returns a Session reconstructed from the account session",
 );
 
 // ---------------------------------------------------------------------------
-// Legacy session migration
-// ---------------------------------------------------------------------------
-
-it.effect("migrates a legacy single-key session to the account session model", () => {
-  const memStorage = createMemoryStorage();
-  const testLayer = Layer.merge(
-    createOsnAuthLive(config).pipe(Layer.provide(memStorage)),
-    memStorage,
-  );
-
-  return Effect.gen(function* () {
-    const storage = yield* Storage;
-    const auth = yield* OsnAuth;
-
-    // Write a legacy-format session directly to storage (bypassing the service)
-    const legacySession = {
-      accessToken: fakeJwt("usr_legacy_user"),
-      refreshToken: "ref_legacy",
-      idToken: "id_legacy",
-      expiresAt: Date.now() + 60_000,
-      scopes: ["openid"],
-    };
-    yield* storage.set("@osn/client:session", JSON.stringify(legacySession));
-
-    // getSession should trigger migration
-    const session = yield* auth.getSession();
-    expect(session?.refreshToken).toBe("ref_legacy");
-
-    const active = yield* auth.getActiveProfile();
-    expect(active).toBe("usr_legacy_user");
-
-    // Legacy key should be cleaned up
-    const legacy = yield* storage.get("@osn/client:session");
-    expect(legacy).toBeNull();
-
-    // New key should exist
-    const newKey = yield* storage.get("@osn/client:account_session");
-    expect(newKey).not.toBeNull();
-  }).pipe(Effect.provide(testLayer));
-});
-
-// ---------------------------------------------------------------------------
 // listProfiles
 // ---------------------------------------------------------------------------
 

--- a/osn/client/tests/profiles.test.ts
+++ b/osn/client/tests/profiles.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect";
 import { vi } from "vitest";
 
 import { OsnAuth, createOsnAuthLive } from "../src/service";
-import { Storage, createMemoryStorage } from "../src/storage";
+import { createMemoryStorage } from "../src/storage";
 
 const config = { issuerUrl: "https://osn.example.com", clientId: "test-client" };
 

--- a/osn/db/src/schema/index.ts
+++ b/osn/db/src/schema/index.ts
@@ -55,10 +55,6 @@ export const passkeys = sqliteTable(
 
 export type Profile = typeof users.$inferSelect;
 export type NewProfile = typeof users.$inferInsert;
-/** @deprecated Use `Profile` — kept for migration compatibility. */
-export type User = Profile;
-/** @deprecated Use `NewProfile` — kept for migration compatibility. */
-export type NewUser = NewProfile;
 export type Passkey = typeof passkeys.$inferSelect;
 export type NewPasskey = typeof passkeys.$inferInsert;
 
@@ -179,6 +175,38 @@ export const serviceAccountKeys = sqliteTable(
 
 export type ServiceAccountKey = typeof serviceAccountKeys.$inferSelect;
 export type NewServiceAccountKey = typeof serviceAccountKeys.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Sessions (server-side session store — Copenhagen Book C1)
+//
+// Refresh tokens are opaque (20 random bytes, hex-encoded, `ses_` prefix).
+// The raw token is held by the client; the server stores only the SHA-256
+// hash as the primary key. A database leak therefore does not expose valid
+// session tokens (same principle as password hashing, but SHA-256 suffices
+// because the token already has 160 bits of entropy).
+//
+// Sliding-window expiry: when less than half the TTL remains, `expiresAt`
+// is extended to `now + TTL` on the next verification.
+// ---------------------------------------------------------------------------
+
+export const sessions = sqliteTable(
+  "sessions",
+  {
+    /** SHA-256(raw session token), hex-encoded */
+    id: text("id").primaryKey(),
+    accountId: text("account_id")
+      .notNull()
+      .references(() => accounts.id),
+    /** Unix seconds */
+    expiresAt: integer("expires_at").notNull(),
+    /** Unix seconds */
+    createdAt: integer("created_at").notNull(),
+  },
+  (t) => [index("sessions_account_idx").on(t.accountId)],
+);
+
+export type Session = typeof sessions.$inferSelect;
+export type NewSession = typeof sessions.$inferInsert;
 
 // ---------------------------------------------------------------------------
 // Organisations

--- a/osn/db/src/seed.ts
+++ b/osn/db/src/seed.ts
@@ -11,7 +11,7 @@ import {
 } from "./schema";
 import type {
   NewAccount,
-  NewUser,
+  NewProfile,
   NewConnection,
   NewCloseFriend,
   NewOrganisation,
@@ -75,9 +75,9 @@ export function buildSeedAccounts(now: Date): NewAccount[] {
  * acc_seed_multi owns 3 profiles to exercise multi-account features:
  *   usr_seed_multi_main (default), usr_seed_multi_alt, usr_seed_multi_work
  */
-export function buildSeedUsers(now: Date): NewUser[] {
+export function buildSeedUsers(now: Date): NewProfile[] {
   /** Shorthand: single-profile account (1:1 mapping) */
-  const solo = (name: string, displayName: string): NewUser => ({
+  const solo = (name: string, displayName: string): NewProfile => ({
     id: `usr_seed_${name}`,
     accountId: `acc_seed_${name}`,
     handle: name,

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -14,6 +14,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] Zap rate limiting on write endpoints (S-M1) — see [[rate-limiting]]
 - [ ] Recommendations SQL aggregation + caching (P-W6/P-W7) — next step after the in-JS fan-out cap shipped in this PR — see [[social-graph]]
 - [ ] Factor shared `authGet/Post/Patch/Delete` helpers in `@osn/client` (P-I1)
+- [ ] Auth Improvements Phase 1: Server-side sessions + refresh token rotation + session invalidation (C1/C2/H1)
 
 ---
 
@@ -136,7 +137,7 @@ OSN's messaging app. Stack matches Pulse (Bun, Tauri+Solid, Elysia+Eden, Drizzle
 
 ### Database (`osn/db`, `pulse/db`)
 
-- [ ] OSN Core: session schema (JWT-based for now; DB storage deferred)
+- [x] OSN Core: session schema — server-side sessions with SHA-256 hashed opaque tokens (Copenhagen Book C1)
 - [ ] Pulse: event series schema
 - [ ] Add indexes on `status` and `category` columns in pulse-db events schema
 
@@ -308,6 +309,31 @@ Open findings only. Completed fixes archived in [[changelog/performance-fixes]].
 - [ ] P-I15 — `rsvpCounts` calls `loadEvent(eventId)` redundantly (route already gates via `loadVisibleEvent`)
 - [ ] P-I1 (client) — Duplicated `authGet`/`authPost`/`authPatch`/`authDelete` helpers across `graph.ts`, `organisations.ts`, `recommendations.ts`. Factor to `@osn/client/src/lib/auth-fetch.ts` parameterised by error-class constructor — see [[component-library]]
 - [ ] P-I4 (social) — List pages (`ConnectionsPage`, `OrganisationsPage`) have no pagination UI. Server supports `limit`/`offset` but users with &gt;50 connections silently lose visibility. Add infinite-scroll via `IntersectionObserver` or paginator
+
+---
+
+## Auth Improvements (Copenhagen Book Audit)
+
+Findings from auditing OSN auth against [The Copenhagen Book](https://thecopenhagenbook.com/) by pilcrowonpaper. Organised in priority phases.
+
+### Phase 1 — Session Revocation (Critical)
+- [ ] C1: Server-side session table in `osn/db` — store hashed refresh tokens, enable revocation — see [[identity-model]]
+- [ ] C2: Refresh token rotation on `/token` refresh grant — new token each refresh, detect reuse — see [[identity-model]]
+- [ ] H1: Invalidate all sessions on security events (passkey registration, email change) — see [[identity-model]]
+
+### Phase 2 — Token Storage + Transport (Critical)
+- [ ] C3: Move refresh tokens from `localStorage` to `HttpOnly; Secure; SameSite=Lax` cookies (BFF pattern) — see [[identity-model]]
+- [ ] M1: Add Origin header validation middleware (required once cookies carry auth state) — see [[rate-limiting]]
+
+### Phase 3 — Defense-in-Depth (High)
+- [ ] H2: SHA-256 hash magic link tokens before storage in `magicStore` — see [[identity-model]]
+- [ ] H3: SHA-256 hash OTP codes before storage in `pendingRegistrations` — see [[identity-model]]
+- [ ] H4: Migrate `@zap/api` from shared-secret JWT verification to JWKS-based (align with Pulse) — see [[arc-tokens]]
+
+### Phase 4 — Hardening (Medium)
+- [ ] M2: Recovery codes for passkey-primary users (40+ bits entropy, Argon2id hashed) — see [[identity-model]]
+- [ ] M3: Email max length validation (≤255 chars) in `EmailSchema`
+- [ ] M5: Increase registration OTP from 6-digit to 8-digit (or 6-char alphanumeric)
 
 ---
 

--- a/wiki/systems/identity-model.md
+++ b/wiki/systems/identity-model.md
@@ -10,7 +10,7 @@ packages:
   - "@osn/db"
   - "@osn/core"
   - "@osn/client"
-last-reviewed: 2026-04-15
+last-reviewed: 2026-04-17
 p4-completed: 2026-04-14
 p2-completed: 2026-04-14
 p3-completed: 2026-04-14
@@ -118,17 +118,32 @@ Organisations are independent entities that are **composed of profiles, not acco
 
 ## Token Model
 
-| Token | Bound to | `sub` claim | TTL | Purpose |
-|-------|----------|-------------|-----|---------|
-| Access | Profile | `profileId` | 1 hour | Authorize API calls as a specific profile |
-| Refresh | Account | `accountId` | 30 days | Re-issue access tokens; enables profile switching without re-authentication |
-| Enrollment | Account | `accountId` | 5 min | Passkey registration after signup |
+| Token | Bound to | Format | TTL | Purpose |
+|-------|----------|--------|-----|---------|
+| Access | Profile | ES256 JWT (`sub` = profileId) | 1 hour | Authorize API calls as a specific profile |
+| Session (refresh) | Account | Opaque `ses_` + 40 hex chars (160-bit entropy) | 30 days (sliding) | Re-issue access tokens; enables profile switching without re-authentication |
+| Enrollment | Account | ES256 JWT (`sub` = accountId) | 5 min | Passkey registration after signup |
 
-The two-tier token model (P2) scopes refresh tokens to accounts and access tokens to profiles. Refresh tokens include a `scope: "account"` claim that is explicitly validated on verification.
+### Server-side sessions (Copenhagen Book C1)
+
+Session tokens (formerly "refresh tokens") are **opaque** — not JWTs. The server stores only the **SHA-256 hash** of each token in the `sessions` table. A database leak does not expose valid tokens because the tokens have 160 bits of entropy.
+
+**Sliding-window expiry:** when less than half the TTL remains (< 15 days), the session's `expiresAt` is extended by the full TTL from now. This matches the Copenhagen Book's recommended pattern.
+
+**Revocation:** `invalidateSession(token)` deletes a single session row; `invalidateAccountSessions(accountId)` deletes all sessions for an account (used for security events). `POST /logout` exposes single-session invalidation.
+
+**Sessions table:**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `text PK` | SHA-256(raw token), hex-encoded |
+| `account_id` | `text FK → accounts.id` | The owning account |
+| `expires_at` | `integer` | Unix seconds |
+| `created_at` | `integer` | Unix seconds |
 
 Two profile management endpoints:
-- `POST /profiles/switch` — present the account-scoped refresh token + target `profileId` in the request body; receive a new access token for that profile. Per-account rate limited (20 switches/hr).
-- `POST /profiles/list` — present the refresh token in the request body; receive all profiles for the account. Refresh tokens are never sent via `Authorization` headers to avoid conflation with access tokens.
+- `POST /profiles/switch` — present the session token + target `profileId` in the request body; receive a new access token for that profile. Per-account rate limited (20 switches/hr).
+- `POST /profiles/list` — present the session token in the request body; receive all profiles for the account. Session tokens are never sent via `Authorization` headers to avoid conflation with access tokens.
 
 ## Client Storage Model (P4)
 


### PR DESCRIPTION
## Summary

Audited OSN auth against [The Copenhagen Book](https://thecopenhagenbook.com/) by pilcrowonpaper. This PR implements the highest-priority finding (C1): **server-side session revocation**.

- **Opaque session tokens** replace stateless JWT refresh tokens — `ses_` prefix + 40 hex chars (160-bit entropy from `crypto.getRandomValues`)
- **SHA-256 hashed** before DB storage — a database leak does not expose valid session tokens
- **`sessions` table** in `@osn/db` with `account_id` FK and sliding-window expiry
- **Sliding-window expiry** — 30-day TTL, extended when less than 15 days remain (Copenhagen Book pattern)
- **Revocation** — `invalidateSession(token)` for single-session, `invalidateAccountSessions(accountId)` for account-wide (security events)
- **`POST /logout`** endpoint for server-side session destruction
- **Dead code removal** (no deployments yet):
  - Deprecated `User`/`NewUser` type aliases → `seed.ts` migrated to `NewProfile`
  - Legacy single-key session migration in `@osn/client`

### Auth Improvements Roadmap (added to TODO.md)

| Phase | Scope | Status |
|-------|-------|--------|
| **1 — Session Revocation** | C1: server-side sessions, C2: refresh token rotation, H1: invalidate on security events | **C1 done (this PR)** |
| 2 — Token Storage | C3: HttpOnly cookies (BFF), M1: Origin header validation | Planned |
| 3 — Defense-in-Depth | H2/H3: hash OTPs + magic links, H4: Zap JWKS migration | Planned |
| 4 — Hardening | M2: recovery codes, M3: email length, M5: 8-digit OTP | Planned |

## Test plan

- [x] 460/460 OSN API tests pass (8 new session tests added)
- [x] 97/97 client SDK tests pass (legacy migration test removed)
- [x] 53/53 DB tests pass
- [x] 16/16 type checks pass
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)