### PR TITLE
feat(auth): let users add biometrics after registration

### DIFF
--- a/.changeset/add-biometrics-post-registration.md
+++ b/.changeset/add-biometrics-post-registration.md
@@ -1,0 +1,7 @@
+---
+"@osn/client": minor
+"@osn/ui": minor
+"@osn/social": minor
+---
+
+Let users add additional biometrics (passkeys) after registration. Registration already required enrolling a first passkey; Settings now exposes a Security tab with an "Add passkey" button that runs the step-up-gated WebAuthn registration ceremony, plus the existing list / rename / delete surface. `PasskeysClient` gains `registerBegin` / `registerComplete` so the Settings surface can call `/passkey/register/begin` + `/complete` directly.

--- a/osn/client/src/passkeys.ts
+++ b/osn/client/src/passkeys.ts
@@ -47,6 +47,24 @@ export interface PasskeysClient {
     id: string;
     stepUpToken: string;
   }): Promise<{ success: true; remaining: number }>;
+  /**
+   * Begin enrolment of an additional passkey for the signed-in account.
+   * Hits the same `/passkey/register/begin` endpoint used by first-passkey
+   * bootstrap; `stepUpToken` is REQUIRED here (S-H1) because the account
+   * already has ≥1 credential — a stolen access token alone must not
+   * bind a new authenticator.
+   */
+  registerBegin(input: {
+    accessToken: string;
+    profileId: string;
+    stepUpToken: string;
+  }): Promise<unknown>;
+  /** Submit the WebAuthn attestation produced by the browser ceremony. */
+  registerComplete(input: {
+    accessToken: string;
+    profileId: string;
+    attestation: unknown;
+  }): Promise<{ passkeyId: string }>;
 }
 
 function authHeaders(accessToken: string): HeadersInit {
@@ -106,6 +124,41 @@ export function createPasskeysClient(config: PasskeysClientConfig): PasskeysClie
         throw new PasskeysError(json.error ?? `Request failed: ${res.status}`);
       }
       return { success: true, remaining: typeof json.remaining === "number" ? json.remaining : 0 };
+    },
+    registerBegin: async (input) => {
+      const res = await fetch(`${base}/passkey/register/begin`, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          ...authHeaders(input.accessToken),
+          "X-Step-Up-Token": input.stepUpToken,
+        },
+        body: JSON.stringify({
+          profileId: input.profileId,
+          step_up_token: input.stepUpToken,
+        }),
+      });
+      const json = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        throw new PasskeysError(json.error ?? `Request failed: ${res.status}`);
+      }
+      return json;
+    },
+    registerComplete: async (input) => {
+      const res = await fetch(`${base}/passkey/register/complete`, {
+        method: "POST",
+        credentials: "include",
+        headers: authHeaders(input.accessToken),
+        body: JSON.stringify({
+          profileId: input.profileId,
+          attestation: input.attestation,
+        }),
+      });
+      const json = (await res.json()) as { passkeyId?: string; error?: string };
+      if (!res.ok || typeof json.passkeyId !== "string") {
+        throw new PasskeysError(json.error ?? `Request failed: ${res.status}`);
+      }
+      return { passkeyId: json.passkeyId };
     },
   };
 }

--- a/osn/client/tests/passkeys.test.ts
+++ b/osn/client/tests/passkeys.test.ts
@@ -174,4 +174,73 @@ describe("createPasskeysClient", () => {
       ).rejects.toBeInstanceOf(PasskeysError);
     });
   });
+
+  describe("registerBegin", () => {
+    it("POSTs /passkey/register/begin with bearer + X-Step-Up-Token + body step_up_token + profileId", async () => {
+      const options = { challenge: "chal_xyz" };
+      const { calls } = stubFetch(() => jsonResponse(options));
+      const result = await client.registerBegin({
+        accessToken: "acc_abc",
+        profileId: "prof_123",
+        stepUpToken: "stpup_xyz",
+      });
+      expect(result).toEqual(options);
+      expect(calls[0]!.url).toBe("https://osn.example.com/passkey/register/begin");
+      expect(calls[0]!.init?.method).toBe("POST");
+      const h = headerMap(calls[0]!.init);
+      expect(h["authorization"]).toBe("Bearer acc_abc");
+      expect(h["content-type"]).toBe("application/json");
+      expect(h["x-step-up-token"]).toBe("stpup_xyz");
+      expect(JSON.parse(calls[0]!.init!.body as string)).toEqual({
+        profileId: "prof_123",
+        step_up_token: "stpup_xyz",
+      });
+      expect(calls[0]!.init?.credentials).toBe("include");
+    });
+
+    it("throws PasskeysError on 403 (step-up missing server-side)", async () => {
+      stubFetch(() => jsonResponse({ error: "step_up_required" }, { status: 403 }));
+      await expect(
+        client.registerBegin({
+          accessToken: "t",
+          profileId: "prof",
+          stepUpToken: "s",
+        }),
+      ).rejects.toBeInstanceOf(PasskeysError);
+    });
+  });
+
+  describe("registerComplete", () => {
+    it("POSTs /passkey/register/complete with bearer and body { profileId, attestation }", async () => {
+      const attestation = { id: "cred_abc" };
+      const { calls } = stubFetch(() => jsonResponse({ passkeyId: "pk_new" }));
+      const result = await client.registerComplete({
+        accessToken: "acc_abc",
+        profileId: "prof_123",
+        attestation,
+      });
+      expect(result).toEqual({ passkeyId: "pk_new" });
+      expect(calls[0]!.url).toBe("https://osn.example.com/passkey/register/complete");
+      expect(calls[0]!.init?.method).toBe("POST");
+      const h = headerMap(calls[0]!.init);
+      expect(h["authorization"]).toBe("Bearer acc_abc");
+      expect(h["content-type"]).toBe("application/json");
+      expect(JSON.parse(calls[0]!.init!.body as string)).toEqual({
+        profileId: "prof_123",
+        attestation,
+      });
+      expect(calls[0]!.init?.credentials).toBe("include");
+    });
+
+    it("throws PasskeysError when the body is missing passkeyId", async () => {
+      stubFetch(() => jsonResponse({ error: "bad_attestation" }, { status: 400 }));
+      await expect(
+        client.registerComplete({
+          accessToken: "t",
+          profileId: "prof",
+          attestation: {},
+        }),
+      ).rejects.toBeInstanceOf(PasskeysError);
+    });
+  });
 });

--- a/osn/client/tests/passkeys.test.ts
+++ b/osn/client/tests/passkeys.test.ts
@@ -208,6 +208,21 @@ describe("createPasskeysClient", () => {
         }),
       ).rejects.toBeInstanceOf(PasskeysError);
     });
+
+    // T-U1: locks the pass-through contract — `registerBegin` does not
+    // validate the WebAuthn options shape, it just forwards whatever the
+    // server returns on 2xx. If we ever tighten that into a shape check
+    // (e.g. require a `challenge` field), this test fails loudly and
+    // forces the change to be intentional.
+    it("passes an empty 2xx body through unchanged (pass-through contract)", async () => {
+      stubFetch(() => jsonResponse({}));
+      const result = await client.registerBegin({
+        accessToken: "t",
+        profileId: "prof",
+        stepUpToken: "s",
+      });
+      expect(result).toEqual({});
+    });
   });
 
   describe("registerComplete", () => {
@@ -234,6 +249,20 @@ describe("createPasskeysClient", () => {
 
     it("throws PasskeysError when the body is missing passkeyId", async () => {
       stubFetch(() => jsonResponse({ error: "bad_attestation" }, { status: 400 }));
+      await expect(
+        client.registerComplete({
+          accessToken: "t",
+          profileId: "prof",
+          attestation: {},
+        }),
+      ).rejects.toBeInstanceOf(PasskeysError);
+    });
+
+    // T-E1: the negative test above hits `!res.ok` before the missing-
+    // passkeyId guard is even reached. Cover the guard directly: a 2xx
+    // with a non-string `passkeyId` must still surface as PasskeysError.
+    it("throws PasskeysError on 2xx when passkeyId is absent / wrong type", async () => {
+      stubFetch(() => jsonResponse({ ok: true }, { status: 200 }));
       await expect(
         client.registerComplete({
           accessToken: "t",

--- a/osn/social/src/components/SecuritySection.tsx
+++ b/osn/social/src/components/SecuritySection.tsx
@@ -1,0 +1,36 @@
+import { PasskeysView } from "@osn/ui/auth/PasskeysView";
+import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
+
+import { passkeysClient, stepUpClient } from "../lib/authClients";
+
+/**
+ * Security section of the Settings page — passkey list / add / rename /
+ * delete. Lives in its own module so the Settings route can code-split
+ * the `@simplewebauthn/browser` dependency; visitors who never open
+ * the Security tab don't pay the parse cost.
+ */
+export interface SecuritySectionProps {
+  accessToken: string;
+  profileId: string;
+}
+
+export default function SecuritySection(props: SecuritySectionProps) {
+  return (
+    <PasskeysView
+      client={passkeysClient}
+      stepUpClient={stepUpClient}
+      accessToken={props.accessToken}
+      profileId={props.profileId}
+      runPasskeyCeremony={(options: unknown) =>
+        startAuthentication({
+          optionsJSON: options as Parameters<typeof startAuthentication>[0]["optionsJSON"],
+        })
+      }
+      runPasskeyRegistration={(options: unknown) =>
+        startRegistration({
+          optionsJSON: options as Parameters<typeof startRegistration>[0]["optionsJSON"],
+        })
+      }
+    />
+  );
+}

--- a/osn/social/src/lib/authClients.ts
+++ b/osn/social/src/lib/authClients.ts
@@ -1,7 +1,15 @@
-import { createLoginClient, createRecoveryClient, createRegistrationClient } from "@osn/client";
+import {
+  createLoginClient,
+  createPasskeysClient,
+  createRecoveryClient,
+  createRegistrationClient,
+  createStepUpClient,
+} from "@osn/client";
 
 import { OSN_ISSUER_URL } from "./auth";
 
 export const registrationClient = createRegistrationClient({ issuerUrl: OSN_ISSUER_URL });
 export const loginClient = createLoginClient({ issuerUrl: OSN_ISSUER_URL });
 export const recoveryClient = createRecoveryClient({ issuerUrl: OSN_ISSUER_URL });
+export const passkeysClient = createPasskeysClient({ issuerUrl: OSN_ISSUER_URL });
+export const stepUpClient = createStepUpClient({ issuerUrl: OSN_ISSUER_URL });

--- a/osn/social/src/pages/SettingsPage.tsx
+++ b/osn/social/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from "@osn/client/solid";
-import { PasskeysView } from "@osn/ui/auth/PasskeysView";
 import { ProfileOnboarding } from "@osn/ui/auth/ProfileOnboarding";
 import { clsx } from "@osn/ui/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
@@ -7,11 +6,14 @@ import { Button } from "@osn/ui/ui/button";
 import { Card } from "@osn/ui/ui/card";
 import { Input } from "@osn/ui/ui/input";
 import { Label } from "@osn/ui/ui/label";
-import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { createMemo, createSignal, For, lazy, Show, Suspense } from "solid-js";
 
-import { passkeysClient, registrationClient, stepUpClient } from "../lib/authClients";
+import { registrationClient } from "../lib/authClients";
 import { getTokenClaims, profileInitials, safeAvatarUrl } from "../lib/utils";
+
+// Code-split the Security section so `@simplewebauthn/browser` is only
+// fetched when the user opens that tab (P-I1).
+const SecuritySection = lazy(() => import("../components/SecuritySection"));
 
 type Section = "profile" | "account" | "security" | "apps";
 
@@ -154,24 +156,9 @@ export function SettingsPage() {
                 <p class="text-muted-foreground text-sm">Sign in to manage your passkeys.</p>
               }
             >
-              <PasskeysView
-                client={passkeysClient}
-                stepUpClient={stepUpClient}
-                accessToken={accessToken()!}
-                profileId={claims().profileId!}
-                runPasskeyCeremony={(options: unknown) =>
-                  startAuthentication({
-                    optionsJSON: options as Parameters<
-                      typeof startAuthentication
-                    >[0]["optionsJSON"],
-                  })
-                }
-                runPasskeyRegistration={(options: unknown) =>
-                  startRegistration({
-                    optionsJSON: options as Parameters<typeof startRegistration>[0]["optionsJSON"],
-                  })
-                }
-              />
+              <Suspense fallback={<p class="text-muted-foreground text-sm">Loading…</p>}>
+                <SecuritySection accessToken={accessToken()!} profileId={claims().profileId!} />
+              </Suspense>
             </Show>
           </Card>
         </Show>

--- a/osn/social/src/pages/SettingsPage.tsx
+++ b/osn/social/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@osn/client/solid";
+import { PasskeysView } from "@osn/ui/auth/PasskeysView";
 import { ProfileOnboarding } from "@osn/ui/auth/ProfileOnboarding";
 import { clsx } from "@osn/ui/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@osn/ui/ui/avatar";
@@ -6,16 +7,18 @@ import { Button } from "@osn/ui/ui/button";
 import { Card } from "@osn/ui/ui/card";
 import { Input } from "@osn/ui/ui/input";
 import { Label } from "@osn/ui/ui/label";
+import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { createMemo, createSignal, For, Show } from "solid-js";
 
-import { registrationClient } from "../lib/authClients";
+import { passkeysClient, registrationClient, stepUpClient } from "../lib/authClients";
 import { getTokenClaims, profileInitials, safeAvatarUrl } from "../lib/utils";
 
-type Section = "profile" | "account" | "apps";
+type Section = "profile" | "account" | "security" | "apps";
 
 const SECTIONS: { value: Section; label: string }[] = [
   { value: "profile", label: "Profile" },
   { value: "account", label: "Account" },
+  { value: "security", label: "Security" },
   { value: "apps", label: "Connected apps" },
 ];
 
@@ -139,6 +142,37 @@ export function SettingsPage() {
                 Delete account (coming soon)
               </Button>
             </div>
+          </Card>
+        </Show>
+
+        {/* Security section — manage passkeys (add / rename / delete). */}
+        <Show when={section() === "security"}>
+          <Card class="flex flex-col gap-3 p-5">
+            <Show
+              when={accessToken() && claims().profileId}
+              fallback={
+                <p class="text-muted-foreground text-sm">Sign in to manage your passkeys.</p>
+              }
+            >
+              <PasskeysView
+                client={passkeysClient}
+                stepUpClient={stepUpClient}
+                accessToken={accessToken()!}
+                profileId={claims().profileId!}
+                runPasskeyCeremony={(options: unknown) =>
+                  startAuthentication({
+                    optionsJSON: options as Parameters<
+                      typeof startAuthentication
+                    >[0]["optionsJSON"],
+                  })
+                }
+                runPasskeyRegistration={(options: unknown) =>
+                  startRegistration({
+                    optionsJSON: options as Parameters<typeof startRegistration>[0]["optionsJSON"],
+                  })
+                }
+              />
+            </Show>
           </Card>
         </Show>
 

--- a/osn/ui/package.json
+++ b/osn/ui/package.json
@@ -12,6 +12,7 @@
     "./auth/SignIn": "./src/auth/SignIn.tsx",
     "./auth/StepUpDialog": "./src/auth/StepUpDialog.tsx",
     "./auth/CreateProfileForm": "./src/auth/CreateProfileForm.tsx",
+    "./auth/PasskeysView": "./src/auth/PasskeysView.tsx",
     "./auth/ProfileOnboarding": "./src/auth/ProfileOnboarding.tsx",
     "./auth/ProfileSwitcher": "./src/auth/ProfileSwitcher.tsx",
     "./lib/utils": "./src/lib/utils.ts",

--- a/osn/ui/src/auth/PasskeysView.tsx
+++ b/osn/ui/src/auth/PasskeysView.tsx
@@ -27,10 +27,22 @@ export interface PasskeysViewProps {
   stepUpClient: StepUpClient;
   accessToken: string;
   /**
+   * Profile ID used for passkey enrolment. Required to surface the "Add
+   * passkey" button; without it, enrolment stays hidden and only the
+   * list / rename / delete surface renders.
+   */
+  profileId?: string;
+  /**
    * Executes the browser-side WebAuthn assertion for the step-up ceremony.
    * Kept caller-side so `@osn/ui` doesn't pull `@simplewebauthn/browser`.
    */
   runPasskeyCeremony?: (options: unknown) => Promise<unknown>;
+  /**
+   * Executes the browser-side WebAuthn attestation ceremony for adding a
+   * new passkey. Same caller-side pattern as `runPasskeyCeremony` so this
+   * package doesn't pull in `@simplewebauthn/browser`.
+   */
+  runPasskeyRegistration?: (options: unknown) => Promise<unknown>;
 }
 
 function formatTs(ts: number | null): string {
@@ -44,7 +56,10 @@ function friendlyLabel(p: PasskeySummary): string {
   return "Device passkey";
 }
 
-type PendingAction = { kind: "rename"; id: string; label: string } | { kind: "delete"; id: string };
+type PendingAction =
+  | { kind: "rename"; id: string; label: string }
+  | { kind: "delete"; id: string }
+  | { kind: "add" };
 
 export function PasskeysView(props: PasskeysViewProps) {
   const [reloadKey, setReloadKey] = createSignal(0);
@@ -91,6 +106,13 @@ export function PasskeysView(props: PasskeysViewProps) {
     setPending({ kind: "delete", id });
   }
 
+  function requestAdd() {
+    if (locked()) return;
+    if (!props.profileId || !props.runPasskeyRegistration) return;
+    setError(null);
+    setPending({ kind: "add" });
+  }
+
   async function handleStepUp(token: StepUpToken) {
     const action = pending();
     if (!action) return;
@@ -105,17 +127,36 @@ export function PasskeysView(props: PasskeysViewProps) {
           stepUpToken: token.token,
         });
         cancelEdit();
-      } else {
+      } else if (action.kind === "delete") {
         await props.client.delete({
           accessToken: props.accessToken,
           id: action.id,
           stepUpToken: token.token,
         });
+      } else {
+        // kind === "add" — guarded by requestAdd().
+        const profileId = props.profileId!;
+        const runRegistration = props.runPasskeyRegistration!;
+        const options = await props.client.registerBegin({
+          accessToken: props.accessToken,
+          profileId,
+          stepUpToken: token.token,
+        });
+        const attestation = await runRegistration(options);
+        await props.client.registerComplete({
+          accessToken: props.accessToken,
+          profileId,
+          attestation,
+        });
       }
       setReloadKey((k) => k + 1);
     } catch (e) {
       const fallback =
-        action.kind === "rename" ? "Couldn't rename passkey" : "Couldn't delete passkey";
+        action.kind === "rename"
+          ? "Couldn't rename passkey"
+          : action.kind === "delete"
+            ? "Couldn't delete passkey"
+            : "Couldn't add passkey";
       setError(e instanceof Error ? e.message : fallback);
     } finally {
       setBusy(false);
@@ -131,6 +172,11 @@ export function PasskeysView(props: PasskeysViewProps) {
     <div class="flex flex-col gap-3">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Passkeys</h2>
+        <Show when={props.profileId && props.runPasskeyRegistration}>
+          <Button size="sm" onClick={requestAdd} disabled={locked()}>
+            Add passkey
+          </Button>
+        </Show>
       </div>
       <Show when={error()}>{(msg) => <p class="text-destructive text-sm">{msg()}</p>}</Show>
       <Show when={passkeys.loading}>

--- a/osn/ui/tests/auth/PasskeysView.test.tsx
+++ b/osn/ui/tests/auth/PasskeysView.test.tsx
@@ -17,6 +17,8 @@ interface PasskeysStub {
   list: ReturnType<typeof vi.fn>;
   rename: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
+  registerBegin: ReturnType<typeof vi.fn>;
+  registerComplete: ReturnType<typeof vi.fn>;
 }
 
 interface StepUpStub {
@@ -30,6 +32,8 @@ const makePasskeys = (): PasskeysStub => ({
   list: vi.fn(),
   rename: vi.fn(),
   delete: vi.fn(),
+  registerBegin: vi.fn(),
+  registerComplete: vi.fn(),
 });
 
 const makeStepUp = (): StepUpStub => ({
@@ -219,6 +223,104 @@ describe("PasskeysView", () => {
     fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
 
     await waitFor(() => expect(screen.getByText(/Passkey not found/)).toBeTruthy());
+  });
+
+  it("hides the Add-passkey button when profileId / runPasskeyRegistration are missing", async () => {
+    pk.list.mockResolvedValue({ passkeys: passkeyRows });
+    render(() => (
+      <PasskeysView client={asPasskeys(pk)} stepUpClient={asStepUp(su)} accessToken="acc" />
+    ));
+    await waitFor(() => screen.getAllByRole("button", { name: /^Rename$/ }));
+    expect(screen.queryByRole("button", { name: /Add passkey/i })).toBeNull();
+  });
+
+  it("add-passkey flow: step-up → registerBegin(stepUpToken) → browser ceremony → registerComplete → reload", async () => {
+    pk.list.mockResolvedValueOnce({ passkeys: passkeyRows });
+    pk.list.mockResolvedValueOnce({
+      passkeys: [
+        ...passkeyRows,
+        {
+          id: "pk_ccccccccccccc",
+          label: null,
+          aaguid: null,
+          transports: null,
+          backupEligible: false,
+          backupState: false,
+          createdAt: 1_700_001_000,
+          lastUsedAt: null,
+        },
+      ],
+    });
+    pk.registerBegin.mockResolvedValue({ challenge: "chal" });
+    pk.registerComplete.mockResolvedValue({ passkeyId: "pk_ccccccccccccc" });
+    su.otpBegin.mockResolvedValue({ sent: true });
+    su.otpComplete.mockResolvedValue(stepUpToken);
+
+    const runRegistration = vi.fn().mockResolvedValue({ id: "cred_abc" });
+
+    render(() => (
+      <PasskeysView
+        client={asPasskeys(pk)}
+        stepUpClient={asStepUp(su)}
+        accessToken="acc"
+        profileId="prof_123"
+        runPasskeyRegistration={runRegistration}
+      />
+    ));
+
+    await waitFor(() => screen.getByRole("button", { name: /Add passkey/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Add passkey/i }));
+
+    // Step-up dialog — use OTP factor.
+    await waitFor(() => screen.getByRole("button", { name: /Email me a code/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Email me a code/i }));
+    const codeInput = await waitFor(() => screen.getByLabelText(/code/i) as HTMLInputElement);
+    fireEvent.input(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
+
+    await waitFor(() =>
+      expect(pk.registerBegin).toHaveBeenCalledWith({
+        accessToken: "acc",
+        profileId: "prof_123",
+        stepUpToken: stepUpToken.token,
+      }),
+    );
+    expect(runRegistration).toHaveBeenCalledWith({ challenge: "chal" });
+    expect(pk.registerComplete).toHaveBeenCalledWith({
+      accessToken: "acc",
+      profileId: "prof_123",
+      attestation: { id: "cred_abc" },
+    });
+    // Reload after add.
+    await waitFor(() => expect(pk.list).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces add-passkey errors in a destructive banner", async () => {
+    pk.list.mockResolvedValue({ passkeys: passkeyRows });
+    pk.registerBegin.mockRejectedValue(new Error("Attestation rejected"));
+    su.otpBegin.mockResolvedValue({ sent: true });
+    su.otpComplete.mockResolvedValue(stepUpToken);
+
+    render(() => (
+      <PasskeysView
+        client={asPasskeys(pk)}
+        stepUpClient={asStepUp(su)}
+        accessToken="acc"
+        profileId="prof_123"
+        runPasskeyRegistration={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => screen.getByRole("button", { name: /Add passkey/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Add passkey/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Email me a code/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Email me a code/i }));
+    const codeInput = await waitFor(() => screen.getByLabelText(/code/i) as HTMLInputElement);
+    fireEvent.input(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
+
+    await waitFor(() => expect(screen.getByText(/Attestation rejected/)).toBeTruthy());
+    expect(pk.registerComplete).not.toHaveBeenCalled();
   });
 
   // S-L1: while a step-up is in flight, every Rename / Delete button on the

--- a/osn/ui/tests/auth/PasskeysView.test.tsx
+++ b/osn/ui/tests/auth/PasskeysView.test.tsx
@@ -323,6 +323,70 @@ describe("PasskeysView", () => {
     expect(pk.registerComplete).not.toHaveBeenCalled();
   });
 
+  // T-E2: most likely real-world failure shape — the user dismisses the
+  // browser's WebAuthn prompt. registerBegin already resolved, so we must
+  // surface the error AND release the `busy` / `pending` lock so the Add
+  // button is clickable again.
+  it("re-enables Add passkey after the browser ceremony is cancelled", async () => {
+    pk.list.mockResolvedValue({ passkeys: passkeyRows });
+    pk.registerBegin.mockResolvedValue({ challenge: "chal" });
+    su.otpBegin.mockResolvedValue({ sent: true });
+    su.otpComplete.mockResolvedValue(stepUpToken);
+    const runRegistration = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+
+    render(() => (
+      <PasskeysView
+        client={asPasskeys(pk)}
+        stepUpClient={asStepUp(su)}
+        accessToken="acc"
+        profileId="prof_123"
+        runPasskeyRegistration={runRegistration}
+      />
+    ));
+
+    await waitFor(() => screen.getByRole("button", { name: /Add passkey/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Add passkey/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Email me a code/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Email me a code/i }));
+    const codeInput = await waitFor(() => screen.getByLabelText(/code/i) as HTMLInputElement);
+    fireEvent.input(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
+
+    await waitFor(() => expect(screen.getByText(/NotAllowedError/)).toBeTruthy());
+    expect(pk.registerComplete).not.toHaveBeenCalled();
+    // finally-block cleanup: the Add button must be clickable again.
+    const addButton = screen.getByRole("button", {
+      name: /Add passkey/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(addButton.disabled).toBe(false));
+  });
+
+  // T-S1: the S-L1 lock must cover the Add button too — a rename/delete
+  // step-up in flight must not allow a second ceremony to kick off.
+  it("disables Add passkey while a rename/delete step-up is in flight (T-S1)", async () => {
+    pk.list.mockResolvedValue({ passkeys: passkeyRows });
+    su.otpBegin.mockResolvedValue({ sent: true });
+
+    render(() => (
+      <PasskeysView
+        client={asPasskeys(pk)}
+        stepUpClient={asStepUp(su)}
+        accessToken="acc"
+        profileId="prof_123"
+        runPasskeyRegistration={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => screen.getAllByRole("button", { name: /^Delete$/ }));
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete$/ })[0]!);
+    await waitFor(() => screen.getByRole("button", { name: /Email me a code/i }));
+
+    const addButton = screen.getByRole("button", {
+      name: /Add passkey/i,
+    }) as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+  });
+
   // S-L1: while a step-up is in flight, every Rename / Delete button on the
   // page is disabled to prevent a rapid double-click swapping the pending id.
   it("locks every Rename/Delete button while a step-up is in flight (S-L1)", async () => {

--- a/wiki/apps/social.md
+++ b/wiki/apps/social.md
@@ -37,7 +37,7 @@ No Tauri wrapper yet — the app ships as a web build only. Tauri wrapping is tr
 | `/discover` | `DiscoverPage` | Friends-of-friends recommendations (`GET /recommendations/connections`) |
 | `/organisations` | `OrganisationsPage` | Orgs the user owns or belongs to; create new |
 | `/organisations/:id` | `OrgDetailPage` | Org detail + member management |
-| `/settings` | `SettingsPage` | Profile management, account section, sessions, passkeys, security events |
+| `/settings` | `SettingsPage` | Profile / Account / **Security** (passkey add/rename/delete, step-up gated) / Connected apps tabs. The Security tab is lazy-loaded (`SecuritySection` chunk) so `@simplewebauthn/browser` only ships when opened. |
 
 ## Client surface
 

--- a/wiki/systems/passkey-primary.md
+++ b/wiki/systems/passkey-primary.md
@@ -34,7 +34,10 @@ holds cradle-to-grave:
   codes are NOT a substitute credential — they are the "my device is gone"
   escape hatch only.
 - **Rotation.** Users who want to remove a compromised passkey enroll the
-  replacement first, then delete the old one. No transitional states.
+  replacement first via Settings → Security → "Add passkey", then delete
+  the old one. The add-passkey flow is step-up gated (passkey or OTP AMR)
+  so a stolen access token can't silently bind a new authenticator — see
+  "Step-up gating on register" below.
 
 ## Login surface
 
@@ -58,6 +61,13 @@ UI surface (`@osn/ui/auth`):
 - `<Register>` — WebAuthn-gated. Registration is blocked at the start if the
   environment lacks WebAuthn support; completion is blocked until first-
   credential enrollment succeeds.
+- `<PasskeysView>` (`@osn/ui/auth/PasskeysView`) — Settings → Security
+  surface. Lists the account's credentials; supports rename (step-up
+  gated, S-M2), delete (last-passkey guarded), and **Add passkey** (step-up
+  gated via the same `/passkey/register/*` endpoints the registration
+  flow uses). `@osn/social` mounts it behind a lazy-loaded
+  `SecuritySection` so `@simplewebauthn/browser` only ships when the tab
+  is opened.
 
 ## Accepting security keys
 


### PR DESCRIPTION
## Summary
- Settings gains a **Security** tab exposing passkey management: list, rename, delete, and a new **Add passkey** button so users can enrol additional biometrics (e.g. to add Touch ID on a laptop after signing up with Face ID on their phone).
- Registration already required first-passkey enrolment (`<Register>` step 3); this PR closes the complementary post-registration path — nothing for registration flow itself changes.
- `PasskeysClient` gains `registerBegin` / `registerComplete` so the Settings surface can hit the same `/passkey/register/{begin,complete}` endpoints used during bootstrap. The server already step-up-gates these routes when the account has ≥1 passkey (S-H1), which is always true post-registration.
- `SecuritySection` is code-split so `@simplewebauthn/browser` only ships when the tab is opened.

## Workspaces affected
- `@osn/client` — new `registerBegin` / `registerComplete` methods
- `@osn/ui` — new `Add passkey` button on `PasskeysView`; `./auth/PasskeysView` export
- `@osn/social` — Settings `Security` tab + lazy-loaded `SecuritySection`

## Decisions & issues

**[approach]** — Extend `PasskeysClient` vs. reuse `RegistrationClient`
- **Issue:** Adding a passkey post-registration hits the same endpoints as first-passkey bootstrap. Option A: reuse `RegistrationClient.passkeyRegisterBegin/Complete`; Option B: add dedicated methods on `PasskeysClient`.
- **Why:** Mounting a `RegistrationClient` inside Settings felt semantically wrong — the component's responsibility is "manage passkeys", not "register".
- **Solution:** Added `registerBegin` / `registerComplete` on `PasskeysClient`. Same underlying endpoints, cleaner abstraction boundary.
- **Rationale:** Keeps `PasskeysView` dependent on one client, matches the sibling `list` / `rename` / `delete` shape, and lets the Settings surface wire up through one factory in `authClients.ts`.

**[T-U1]** — `registerBegin` pass-through contract not locked
- **Issue:** The happy-path test only asserted `result === options`; no explicit test documenting that `registerBegin` returns the server body unchanged without shape validation.
- **Why:** A future tightening to validate WebAuthn options (e.g. require a `challenge` field) would silently pass if this isn't pinned.
- **Solution:** Added a test that stubs a `{}` 2xx response and asserts the client returns `{}` — locks the "pass-through" contract.
- **Rationale:** Mirrors the intent in the test-file header ("catches silent drift") and forces any future validation tightening to be intentional.

**[T-E1]** — `registerComplete` 2xx-missing-`passkeyId` branch untested
- **Issue:** The only negative test used a 400 response, which hits `!res.ok` before the `typeof json.passkeyId !== "string"` guard fires.
- **Why:** Leaves the second half of the validation guard uncovered.
- **Solution:** Added a `status: 200` + `{ ok: true }` test that expects `PasskeysError`.
- **Rationale:** Matches the pattern used for `list`'s "missing passkeys array" test.

**[T-E2]** — User-cancel of the WebAuthn prompt in the Add flow
- **Issue:** The add-passkey error-path test rejected at `registerBegin`; the `registerBegin` resolves / `runPasskeyRegistration` rejects branch wasn't covered (this is the highest-frequency real-world failure mode — users dismissing the biometric prompt).
- **Why:** A regression here could leave the UI stuck with the Add button disabled if `busy` / `pending` aren't released on rejection.
- **Solution:** Added a test that rejects `runPasskeyRegistration` with `NotAllowedError`, asserts the banner surfaces the error AND the Add button is re-enabled.
- **Rationale:** Covers the `finally` cleanup contract and the most likely real-world failure.

**[T-S1]** — Add-passkey button not asserted disabled during another pending action
- **Issue:** The existing S-L1 lock test only iterated Rename/Delete buttons and didn't render the Add button (no `profileId`). The new button binds to `disabled={locked()}` but we never verified it.
- **Why:** Same double-click race as S-L1 — a rename/delete ceremony in flight must not admit a second action.
- **Solution:** Added a test that renders with `profileId + runPasskeyRegistration`, clicks Delete to open the step-up dialog, then asserts the Add-passkey button is `disabled`.
- **Rationale:** Extends S-L1 to the new surface.

**[P-I1]** — `@simplewebauthn/browser` eagerly imported into SettingsPage
- **Issue:** The initial implementation had `import { startRegistration, startAuthentication } from "@simplewebauthn/browser"` at module scope in `SettingsPage.tsx`, so Profile / Account / Connected-apps tab visitors paid the parse cost.
- **Why:** Partially undoes the careful caller-side deferral pattern that keeps `@osn/ui` itself free of the dep.
- **Solution:** Extracted `SecuritySection.tsx` that owns the `@simplewebauthn/browser` import; `SettingsPage` loads it via `lazy()` + `<Suspense>`. Vite emits `SecuritySection-*.js` as a dedicated 6.6 KB / 2.2 KB-gz chunk.
- **Rationale:** Mirrors the deferral pattern already used by `@osn/ui` (`runPasskeyCeremony`/`runPasskeyRegistration` callbacks); no behaviour change.

**[security review]** — No findings
- **Issue:** Parallel security review surfaced zero concerns.
- **Why:** XSS / token-leak / replay / CSRF / cookie-handling / trust-boundary checks all passed. Labels flow through Solid text interpolation (escaped), step-up tokens are single-use server-side (`StepUpJtiStore`, already in main), `pending` clears in `finally` so cancelled ceremonies don't leak state, and all requests use `credentials: "include"` + bearer.
- **Solution:** Dismissed — no action required.
- **Rationale:** The backend already enforces every invariant this UI depends on (S-H1 step-up gate, cookie-derived session, rate limits). This PR is a pure consumer.

## Test plan
- [ ] Register a new account — confirm the existing passkey step still blocks completion (no regression).
- [ ] Sign in with the new account → Settings → Security. Confirm the list shows the bootstrap passkey.
- [ ] Click **Add passkey**. Confirm step-up dialog opens (passkey or email OTP).
- [ ] Complete step-up with OTP; confirm browser's WebAuthn prompt appears; enrol a second credential.
- [ ] Confirm the list now shows two passkeys and the banner security event is recorded.
- [ ] Cancel the browser WebAuthn prompt on a fresh attempt; confirm the Add button re-enables and the banner surfaces the error.
- [ ] Start a Delete/Rename step-up, then try clicking Add — confirm it's disabled until the in-flight action settles.
- [ ] Open Network tab, select Settings tab **without** clicking Security; confirm `@simplewebauthn/browser` (or `SecuritySection-*.js`) is **not** fetched. Click Security; confirm the chunk loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155teHTVZM3g9AeCfxjuosC)_