### PR TITLE
fix(pulse/api): boot in local dev without INTERNAL_SERVICE_SECRET

### DIFF
--- a/.changeset/fix-arc-key-rotation-local-dev.md
+++ b/.changeset/fix-arc-key-rotation-local-dev.md
@@ -1,0 +1,5 @@
+---
+"@pulse/api": patch
+---
+
+Allow `pulse-api` to boot in local dev when `INTERNAL_SERVICE_SECRET` is unset. Registration is skipped with a warning log; S2S calls to `osn/api` will fail until the secret is configured. Non-local environments (`OSN_ENV != "local"`) still throw on startup as before.

--- a/pulse/api/.env.example
+++ b/pulse/api/.env.example
@@ -16,7 +16,11 @@ OSN_API_URL=http://localhost:4000
 # On startup, pulse-api generates an ephemeral P-256 key pair and calls
 #   POST /graph/internal/register-service
 # to register its public key with osn/api.
-# Leave unset to skip registration (unit tests, CI without a live osn/api).
+#
+# Required in any non-local environment (OSN_ENV != "local") — pulse-api
+# refuses to boot without it. In local dev (OSN_ENV unset or "local") it
+# may be left unset: registration is skipped with a warning so the server
+# still boots, but any S2S call to osn/api will fail until you set it.
 INTERNAL_SERVICE_SECRET=change-me-to-a-shared-random-secret
 
 # Key TTL and rotation buffer.

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -33,18 +33,36 @@ if (process.env.NODE_ENV !== "test") {
   app.listen({ port, reusePort: false });
 
   // Register our ephemeral public key with osn/api and schedule automatic
-  // rotation. Exits the process if INTERNAL_SERVICE_SECRET is unset.
-  void startKeyRotation().catch((err: unknown) => {
-    void Effect.runPromise(
-      Effect.logError("pulse-api: failed to start ARC key rotation", err).pipe(
-        Effect.annotateLogs({ service: SERVICE_NAME }),
-        Effect.provide(Logger.pretty),
-        Effect.provide(observabilityLayer),
-      ),
+  // rotation. Exits the process if INTERNAL_SERVICE_SECRET is unset in a
+  // non-local environment; in local dev a missing secret logs a warning
+  // and lets the server boot so unrelated work isn't blocked by S2S setup.
+  void startKeyRotation()
+    .then((registered) =>
+      registered
+        ? undefined
+        : Effect.runPromise(
+            Effect.logWarning(
+              "pulse-api: ARC key registration skipped — INTERNAL_SERVICE_SECRET is unset. " +
+                "S2S calls to osn/api will fail until you set INTERNAL_SERVICE_SECRET in pulse/api/.env " +
+                "(matching the value in osn/api/.env).",
+            ).pipe(
+              Effect.annotateLogs({ service: SERVICE_NAME }),
+              Effect.provide(Logger.pretty),
+              Effect.provide(observabilityLayer),
+            ),
+          ).catch(() => undefined),
     )
-      .catch(() => {})
-      .finally(() => process.exit(1));
-  });
+    .catch((err: unknown) => {
+      void Effect.runPromise(
+        Effect.logError("pulse-api: failed to start ARC key rotation", err).pipe(
+          Effect.annotateLogs({ service: SERVICE_NAME }),
+          Effect.provide(Logger.pretty),
+          Effect.provide(observabilityLayer),
+        ),
+      )
+        .catch(() => {})
+        .finally(() => process.exit(1));
+    });
 
   // One structured info log at boot, routed through the observability layer
   // so it picks up resource attributes + redaction. Using Effect.runPromise

--- a/pulse/api/src/services/graphBridge.ts
+++ b/pulse/api/src/services/graphBridge.ts
@@ -130,13 +130,27 @@ async function osPost<T>(path: string, body: unknown): Promise<T> {
 // ---------------------------------------------------------------------------
 
 /**
- * Registers the current public key with osn/api on startup.
- * Requires INTERNAL_SERVICE_SECRET — throws if unset so the misconfiguration
- * is caught immediately at boot rather than failing silently (S-L101).
+ * True when the process is running in a local developer environment
+ * (`OSN_ENV` unset or `"local"`). Mirrors the convention used elsewhere
+ * in osn/api so all services agree on what counts as "local".
  */
-async function registerWithOsnApi(): Promise<void> {
+function isLocalEnv(): boolean {
+  return !process.env.OSN_ENV || process.env.OSN_ENV === "local";
+}
+
+/**
+ * Registers the current public key with osn/api on startup.
+ *
+ * Returns `false` when `INTERNAL_SERVICE_SECRET` is unset in a local dev
+ * environment — the caller logs a warning and the process continues so
+ * developers can boot pulse-api without a fully wired osn/api. Throws in
+ * any non-local environment so misconfiguration is caught immediately at
+ * boot rather than failing silently on the first S2S call (S-L101).
+ */
+async function registerWithOsnApi(): Promise<boolean> {
   const secret = process.env.INTERNAL_SERVICE_SECRET;
   if (!secret) {
+    if (isLocalEnv()) return false;
     throw new Error(
       "INTERNAL_SERVICE_SECRET must be set — pulse-api cannot register its ARC key without it",
     );
@@ -162,6 +176,8 @@ async function registerWithOsnApi(): Promise<void> {
   if (!res.ok) {
     throw new Error(`pulse-api failed to register with osn/api: HTTP ${res.status}`);
   }
+
+  return true;
 }
 
 /**
@@ -221,13 +237,19 @@ async function rotateKey(): Promise<void> {
  * Registers the service's ephemeral public key with osn/api and schedules
  * automatic key rotation. Call once at startup.
  *
- * Throws if `INTERNAL_SERVICE_SECRET` is unset — misconfiguration is surfaced
- * immediately at boot rather than failing silently on the first S2S call.
+ * Returns `true` on success, `false` when registration was skipped because
+ * `INTERNAL_SERVICE_SECRET` is unset in a local dev environment (caller
+ * should log a warning so the developer knows S2S calls will fail until
+ * they configure the shared secret). Throws in any non-local environment
+ * — misconfiguration must be surfaced immediately at boot rather than
+ * failing silently on the first S2S call.
  */
-export async function startKeyRotation(): Promise<void> {
-  await registerWithOsnApi();
+export async function startKeyRotation(): Promise<boolean> {
+  const registered = await registerWithOsnApi();
+  if (!registered) return false;
   const { expiresAt } = await initKeys();
   scheduleRotation(expiresAt);
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/pulse/api/tests/services/graphBridge.test.ts
+++ b/pulse/api/tests/services/graphBridge.test.ts
@@ -203,9 +203,26 @@ describe("startKeyRotation", () => {
     vi.useRealTimers();
   });
 
-  it("throws when INTERNAL_SERVICE_SECRET is unset", async () => {
+  it("throws when INTERNAL_SERVICE_SECRET is unset in a non-local environment", async () => {
     vi.unstubAllEnvs(); // undo beforeEach stub so the env var is absent
+    vi.stubEnv("OSN_ENV", "production");
     await expect(startKeyRotation()).rejects.toThrow("INTERNAL_SERVICE_SECRET must be set");
+  });
+
+  it("returns false (and makes no HTTP call) when the secret is unset in local dev", async () => {
+    vi.unstubAllEnvs(); // remove the SECRET stub
+    // OSN_ENV unset → treated as local
+    const spy = vi.spyOn(globalThis, "fetch");
+    await expect(startKeyRotation()).resolves.toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when OSN_ENV=local and the secret is unset", async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("OSN_ENV", "local");
+    const spy = vi.spyOn(globalThis, "fetch");
+    await expect(startKeyRotation()).resolves.toBe(false);
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it("makes a POST to /graph/internal/register-service with correct shape", async () => {
@@ -216,7 +233,7 @@ describe("startKeyRotation", () => {
       }),
     );
 
-    await startKeyRotation();
+    await expect(startKeyRotation()).resolves.toBe(true);
 
     expect(spy).toHaveBeenCalledOnce();
     const [url, init] = spy.mock.calls[0]!;

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -248,7 +248,7 @@ Open findings only. Completed fixes archived in [[changelog/security-fixes]].
 - [x] S-L40 — `publicKeyCacheSize`, `_setPublicKeyCacheMaxSizeForTest`, `_resetPublicKeyCacheMaxSize` re-exported from `@shared/crypto` public index.ts (test-only symbols in public API). **Fixed** — removed from `index.ts`; tests import direct from `../src/arc` — see [[arc-tokens]]
 - [ ] S-L14 — `assertion: t.Any()` on passkey routes — add TypeBox shape validation
 - [ ] S-L15 — No reserved-handle blocklist in DB
-- [x] S-L101 — `registerWithOsnApi()` silently returned early when `INTERNAL_SERVICE_SECRET` unset. **Fixed** — now throws, caught at startup by `index.ts` — see [[arc-tokens]]
+- [x] S-L101 — `registerWithOsnApi()` silently returned early when `INTERNAL_SERVICE_SECRET` unset. **Fixed** — throws in non-local envs (`OSN_ENV != "local"`) so misconfiguration is caught at boot; in local dev logs a warning and boots anyway to unblock developer workflows — see [[arc-tokens]]
 - [x] S-M1 (auth) — ~~`pkceStore` unbounded + no expiry sweep~~ — **Obsolete**: `pkceStore` deleted with PKCE cleanup (Phase 5b)
 - [x] S-M2 (auth) — ~~`/authorize` has no rate limiter~~ — **Obsolete**: `/authorize` route deleted with PKCE cleanup (Phase 5b)
 - [ ] S-M4 (auth) — No startup assertion that `OSN_JWT_PRIVATE_KEY` has `sign` usage — assert `key.usages.includes("sign")` after import in `loadJwtKeyPair`

--- a/wiki/systems/arc-tokens.md
+++ b/wiki/systems/arc-tokens.md
@@ -186,7 +186,10 @@ Ephemeral key auto-rotation is the only supported strategy. Pre-distributed stab
 4. Schedules rotation `KEY_ROTATION_BUFFER_HOURS` (default 2h) before expiry
 5. On rotation: registers the new key BEFORE swapping the signing singleton — zero downtime
 
-Throws at startup if `INTERNAL_SERVICE_SECRET` is unset — misconfiguration is surfaced immediately rather than failing silently on the first S2S call.
+Behaviour when `INTERNAL_SERVICE_SECRET` is unset:
+
+- **Non-local env** (`OSN_ENV != "local"`): throws at startup so misconfiguration is caught immediately rather than failing silently on the first S2S call.
+- **Local dev** (`OSN_ENV` unset or `"local"`): registration is skipped, a warning is logged, and the server still boots. Any S2S call to `osn/api` will fail until the secret is configured — useful for unrelated local work that doesn't need the social graph bridge.
 
 Env vars: `INTERNAL_SERVICE_SECRET`, `KEY_TTL_HOURS` (default 24), `KEY_ROTATION_BUFFER_HOURS` (default 2).
 


### PR DESCRIPTION
## Summary
- `pulse-api` no longer crashes at boot when `INTERNAL_SERVICE_SECRET` is unset in a local developer environment (`OSN_ENV` unset or `"local"`). Registration is skipped, a warning is logged, and the server continues so unrelated local work isn't blocked by S2S setup.
- Non-local environments (`OSN_ENV != "local"`) still throw at boot — the original `S-L101` fail-fast guarantee for misconfiguration in staging/production is preserved.
- `startKeyRotation()` return type changed from `Promise<void>` to `Promise<boolean>` (`true` = registered, `false` = skipped).

## Workspaces affected
- `@pulse/api` (patch changeset)

## Decisions & issues

**[approach] Local-dev skip vs. strict throw**
- **Issue:** The previous code threw unconditionally if `INTERNAL_SERVICE_SECRET` was unset, crashing `pulse-api` at boot and blocking `bun run dev:pulse` for developers who hadn't yet wired the shared secret in both `pulse/api/.env` and `osn/api/.env`. `.env.example` also contradicted the code by saying "leave unset to skip registration".
- **Why:** Developer onboarding friction; contradiction between documented and actual behaviour made the failure mode confusing.
- **Solution:** Added `isLocalEnv()` helper (matches the `!OSN_ENV || OSN_ENV === "local"` convention already used five times in `osn/api`). `registerWithOsnApi()` returns `false` and `startKeyRotation()` short-circuits before `initKeys()`/`scheduleRotation()` when unset in local dev. Any non-local env still throws.
- **Rationale:** Fail-fast in deployed environments is non-negotiable (`S-L101`). Fail-soft in local dev is safe because the follow-on S2S calls would fail at `osn/api` with 401 anyway — developers who don't need the graph bridge can work around it, and the warning text names the exact env var + file paths to set.

**[S-L1] `OSN_ENV` not trimmed/lowercased**
- **Issue:** `isLocalEnv()` does not normalise `OSN_ENV`, so `"Local"` or `" local "` would be classified as non-local.
- **Why:** Defensive consistency.
- **Solution:** Not changed in this PR.
- **Rationale:** The misclassification is fail-closed (throws rather than skips), so there's no security impact. All five existing callsites in `osn/api/src/services/auth.ts` use the same raw `=== "local"` comparison — normalising one without the others would be a divergence. Tracked as a potential future cleanup; not worth the churn on its own.

**[S-L2] Single warning log may scroll off**
- **Issue:** The skip warning is a single `Effect.logWarning` line that can scroll off in a busy dev terminal.
- **Solution:** Kept as-is; warning text is explicit ("`S2S calls to osn/api will fail until you set INTERNAL_SERVICE_SECRET in pulse/api/.env (matching the value in osn/api/.env)`") and developers hitting a 401 will trace back to the boot log.
- **Rationale:** Adding a boot banner would be gratuitous for a recoverable local-dev misconfig.

**[T-S1] No test for unexpected `OSN_ENV` values**
- **Issue:** Only `unset`, `"local"`, and `"production"` are exercised. Values like `"staging"`, `"LOCAL"`, `""` would all take the throw branch but aren't pinned by tests.
- **Solution:** Not added in this PR.
- **Rationale:** Current tests cover the contract documented in `wiki/systems/arc-tokens.md`. The suggested parametrised case is a nice-to-have hardening test; can be added as a follow-up if the environment-classification contract ever gets refactored.

**[T-U1] Boot handler in `index.ts` untested**
- **Issue:** The `.then(registered => ...)` / `.catch(... process.exit(1))` branches in `pulse/api/src/index.ts` have no unit coverage.
- **Solution:** Not addressed — matches existing pulse-api pattern of keeping `index.ts` thin and gated behind `NODE_ENV !== "test"`.
- **Rationale:** Extracting the handler into a testable helper would add indirection for two small branches. The warning text and exit behaviour are exercised manually via `bun run dev:pulse` with/without the secret set.

## Test plan
- [ ] `bun run --cwd pulse/api test:run` — 210 tests pass (new tests: throw when `OSN_ENV=production` + secret unset; skip with `OSN_ENV` unset or `"local"` + secret unset; happy path returns `true`)
- [ ] `bun run --cwd pulse/api check` — passes
- [ ] `bun run check` — full monorepo type-check passes (pre-push hook)
- [ ] Manual: `bun run dev:pulse` without `INTERNAL_SERVICE_SECRET` boots and logs the warning instead of crashing
- [ ] Manual: `bun run dev:pulse` with matching `INTERNAL_SERVICE_SECRET` in both `pulse/api/.env` and `osn/api/.env` registers the key and starts the rotation timer as before
- [ ] Manual: with `OSN_ENV=production` and `INTERNAL_SERVICE_SECRET` unset, boot still exits with the clear error (fail-fast preserved)

https://claude.ai/code/session_01EXVdmmQQw8hmHWEg3JqWYj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXVdmmQQw8hmHWEg3JqWYj)_