### PR TITLE
feat(pulse): prompt for max event duration + maybe_finished status

### DIFF
--- a/.changeset/pulse-prompt-max-event-duration.md
+++ b/.changeset/pulse-prompt-max-event-duration.md
@@ -1,0 +1,16 @@
+---
+"@pulse/api": patch
+"@pulse/app": patch
+---
+
+Pulse: prompt for max event duration when creating events without an end time.
+
+The create-event form now shows a set of duration presets (1h / 2h / 4h / 8h /
+All day) when the organiser leaves the end time blank, and explains that an
+event without an end time will be marked "potentially finished" after 8 hours
+and automatically closed after 48 hours.
+
+Server-side, event duration is now capped at `MAX_EVENT_DURATION_HOURS` (48h)
+on both `POST /events` and `PATCH /events/:id` — longer events return 422.
+Events without an explicit `endTime` now auto-transition to `"finished"` once
+they've been running for more than 48h past their start time.

--- a/.changeset/pulse-prompt-max-event-duration.md
+++ b/.changeset/pulse-prompt-max-event-duration.md
@@ -1,16 +1,28 @@
 ---
-"@pulse/api": patch
+"@pulse/api": minor
 "@pulse/app": patch
+"@pulse/db": minor
+"@shared/observability": minor
 ---
 
-Pulse: prompt for max event duration when creating events without an end time.
+Pulse: prompt for max event duration + new `maybe_finished` event status.
 
-The create-event form now shows a set of duration presets (1h / 2h / 4h / 8h /
-All day) when the organiser leaves the end time blank, and explains that an
-event without an end time will be marked "potentially finished" after 8 hours
-and automatically closed after 48 hours.
+Organisers creating an event now see a set of duration presets (1h / 2h / 4h /
+8h / All day) when the end time is left blank, plus a hint that an event
+without an explicit end time will be marked **maybe finished** after 8 hours
+and **automatically closed** after 12 hours. Organisers can manually close an
+event at any time.
 
-Server-side, event duration is now capped at `MAX_EVENT_DURATION_HOURS` (48h)
-on both `POST /events` and `PATCH /events/:id` — longer events return 422.
-Events without an explicit `endTime` now auto-transition to `"finished"` once
-they've been running for more than 48h past their start time.
+Schema: adds `"maybe_finished"` to the `events.status` enum (pure TS — no SQL
+migration; the column is plain text). The `EventStatus` union in
+`@shared/observability` and the service/route Effect + TypeBox schemas are
+updated in lockstep.
+
+Server: `deriveStatus` in `pulse/api/src/services/events.ts` now auto-
+transitions ongoing events with no `endTime` to `"maybe_finished"` at 8h past
+`startTime` and to `"finished"` at 12h. Events with an explicit `endTime`
+keep the original single-transition behaviour, and the 48h
+`MAX_EVENT_DURATION_HOURS` cap is enforced on both `POST /events` and
+`PATCH /events/:id` (including patches that change only `startTime` or only
+`endTime`) — rejections return 422 and emit
+`metricEventValidationFailure(op, "duration_exceeds_max")`.

--- a/pulse/api/src/lib/limits.ts
+++ b/pulse/api/src/lib/limits.ts
@@ -41,3 +41,27 @@
  * affects rate limits, DB planning, and the free-vs-paid tier boundary.
  */
 export const MAX_EVENT_GUESTS = 1000;
+
+/**
+ * Maximum duration, in hours, from `startTime` to `endTime` for any
+ * single event. Enforced server-side in `createEvent` and `updateEvent`
+ * as a defence-in-depth check behind the client-side duration picker —
+ * a client that bypasses the picker and POSTs a 30-year-long event
+ * should still fail validation.
+ *
+ * ## Why 48h?
+ *
+ * Pulse is designed for social events — parties, meetups, dinners,
+ * weekend trips. 48h (two days) comfortably covers weekend-long
+ * gatherings while rejecting obvious abuse (an "event" that runs for a
+ * year is not an event). Multi-day festivals and conferences are served
+ * by the verified-organisation tier deferred to Pulse phase 2.
+ *
+ * ## Raising the cap
+ *
+ * Same rules as `MAX_EVENT_GUESTS` — bump requires sign-off. It
+ * interacts with the on-read status-transition logic (`applyTransition`
+ * in `services/events.ts`), which reads `endTime` to decide when an
+ * event has `"finished"`.
+ */
+export const MAX_EVENT_DURATION_HOURS = 48;

--- a/pulse/api/src/lib/limits.ts
+++ b/pulse/api/src/lib/limits.ts
@@ -44,10 +44,13 @@ export const MAX_EVENT_GUESTS = 1000;
 
 /**
  * Maximum duration, in hours, from `startTime` to `endTime` for any
- * single event. Enforced server-side in `createEvent` and `updateEvent`
- * as a defence-in-depth check behind the client-side duration picker —
- * a client that bypasses the picker and POSTs a 30-year-long event
- * should still fail validation.
+ * single event with an *explicit* endTime. Enforced server-side in
+ * `createEvent` and `updateEvent` as a defence-in-depth check behind
+ * the client-side duration picker — a client that bypasses the picker
+ * and POSTs a 30-year-long event should still fail validation.
+ *
+ * Events *without* an endTime are governed by a separate, tighter
+ * ladder: see `MAYBE_FINISHED_AFTER_HOURS` / `AUTO_CLOSE_NO_END_TIME_HOURS`.
  *
  * ## Why 48h?
  *
@@ -65,3 +68,22 @@ export const MAX_EVENT_GUESTS = 1000;
  * event has `"finished"`.
  */
 export const MAX_EVENT_DURATION_HOURS = 48;
+
+/**
+ * Hours past `startTime` after which an event that was created
+ * *without* an explicit `endTime` auto-transitions to
+ * `"maybe_finished"`. This is a soft signal to guests that the event
+ * has probably wrapped — the organiser can still mark it finished
+ * earlier, or leave it alone until the auto-close kicks in
+ * (`AUTO_CLOSE_NO_END_TIME_HOURS`).
+ */
+export const MAYBE_FINISHED_AFTER_HOURS = 8;
+
+/**
+ * Hours past `startTime` after which an event that was created
+ * *without* an explicit `endTime` auto-transitions to `"finished"`.
+ * Tighter than `MAX_EVENT_DURATION_HOURS` because an organiser who
+ * declined to set an endTime is implicitly accepting a shorter, best-
+ * effort ceiling — no open-ended events lingering in "ongoing" forever.
+ */
+export const AUTO_CLOSE_NO_END_TIME_HOURS = 12;

--- a/pulse/api/src/metrics.ts
+++ b/pulse/api/src/metrics.ts
@@ -110,7 +110,7 @@ type EventsStatusTransitionAttrs = {
 
 type EventsValidationFailureAttrs = {
   operation: "create" | "update";
-  reason: "schema" | "past_start_time";
+  reason: "schema" | "past_start_time" | "duration_exceeds_max";
 };
 
 // --- RSVP ---
@@ -329,7 +329,7 @@ export const metricEventStatusTransition = (from: EventStatus, to: EventStatus):
 
 export const metricEventValidationFailure = (
   operation: "create" | "update",
-  reason: "schema" | "past_start_time",
+  reason: "schema" | "past_start_time" | "duration_exceeds_max",
 ): void => eventValidationFailures.inc({ operation, reason });
 
 // --- RSVP recording helpers ---

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -82,6 +82,7 @@ const statusEnum = t.Optional(
   t.Union([
     t.Literal("upcoming"),
     t.Literal("ongoing"),
+    t.Literal("maybe_finished"),
     t.Literal("finished"),
     t.Literal("cancelled"),
   ]),

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -4,6 +4,7 @@ import { Db } from "@pulse/db/service";
 import { and, eq, gte, lte, or, type SQL } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
+import { MAX_EVENT_DURATION_HOURS } from "../lib/limits";
 import {
   metricEventCreated,
   metricEventDeleted,
@@ -12,6 +13,8 @@ import {
   metricEventValidationFailure,
   metricEventsListed,
 } from "../metrics";
+
+const MAX_EVENT_DURATION_MS = MAX_EVENT_DURATION_HOURS * 60 * 60 * 1000;
 
 export class EventNotFound extends Data.TaggedError("EventNotFound")<{
   readonly id: string;
@@ -117,7 +120,12 @@ interface ListEventsParams {
 const deriveStatus = (event: Event, now: Date): Event["status"] => {
   if (event.status === "cancelled" || event.status === "finished") return event.status;
   const started = event.startTime <= now;
-  const ended = event.endTime !== null && event.endTime <= now;
+  // Events without an explicit endTime are auto-closed once they've run
+  // for MAX_EVENT_DURATION_HOURS past their startTime. This matches the
+  // duration cap enforced at create/update time — an organiser who
+  // declined to set an endTime is agreeing to a hard 48h ceiling.
+  const impliedEnd = new Date(event.startTime.getTime() + MAX_EVENT_DURATION_MS);
+  const ended = event.endTime !== null ? event.endTime <= now : started && impliedEnd <= now;
   if (ended) return "finished";
   if (started) return "ongoing";
   return "upcoming";
@@ -260,6 +268,18 @@ export const createEvent = (
       return yield* Effect.fail(new ValidationError({ cause: "startTime must be in the future" }));
     }
 
+    if (
+      validated.endTime &&
+      validated.endTime.getTime() - validated.startTime.getTime() > MAX_EVENT_DURATION_MS
+    ) {
+      metricEventValidationFailure("create", "duration_exceeds_max");
+      return yield* Effect.fail(
+        new ValidationError({
+          cause: `event duration must not exceed ${MAX_EVENT_DURATION_HOURS} hours`,
+        }),
+      );
+    }
+
     // Serialise the commsChannels array to JSON text for the DB column.
     // The schema default is `'["email"]'` so only overwrite when the
     // caller explicitly provided a value.
@@ -303,6 +323,20 @@ export const updateEvent = (
       Effect.tapError(() => Effect.sync(() => metricEventValidationFailure("update", "schema"))),
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
+
+    // Compute the effective times that the event will have after this
+    // patch lands, so that patching only `endTime` still validates
+    // against the stored `startTime` (and vice versa).
+    const effectiveStart = validated.startTime ?? existing.startTime;
+    const effectiveEnd = validated.endTime ?? existing.endTime;
+    if (effectiveEnd && effectiveEnd.getTime() - effectiveStart.getTime() > MAX_EVENT_DURATION_MS) {
+      metricEventValidationFailure("update", "duration_exceeds_max");
+      return yield* Effect.fail(
+        new ValidationError({
+          cause: `event duration must not exceed ${MAX_EVENT_DURATION_HOURS} hours`,
+        }),
+      );
+    }
 
     const now = new Date();
     const { commsChannels, ...rest } = validated;

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -150,6 +150,18 @@ export const applyTransition = (event: Event): Effect.Effect<Event, DatabaseErro
   const now = new Date();
   const derived = deriveStatus(event, now);
   if (derived === event.status) return Effect.succeed(event);
+
+  // "maybe_finished" is a display-only projection for no-endTime events
+  // between MAYBE_FINISHED_AFTER_HOURS and AUTO_CLOSE_NO_END_TIME_HOURS
+  // past startTime. We don't persist it so a no-endTime event's
+  // lifecycle path is a single DB write (ongoing → finished at 12h)
+  // instead of two (ongoing → maybe_finished at 8h → finished at 12h).
+  // Callers still see the derived status on read; `status_transitions`
+  // only fires on persisted transitions.
+  if (derived === "maybe_finished") {
+    return Effect.succeed({ ...event, status: derived });
+  }
+
   const previous = event.status;
   return Effect.gen(function* () {
     const { db } = yield* Db;
@@ -365,8 +377,6 @@ export const updateEvent = (
       catch: (cause) => new DatabaseError({ cause }),
     });
 
-    // Build the updated event in-memory rather than re-fetching from DB.
-    // applyTransition is still called in case startTime/endTime changed.
     // Build the updated event in-memory rather than re-fetching from DB.
     // applyTransition is still called in case startTime/endTime changed.
     const updated = { ...existing, ...update } as Event;

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -4,7 +4,11 @@ import { Db } from "@pulse/db/service";
 import { and, eq, gte, lte, or, type SQL } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
-import { MAX_EVENT_DURATION_HOURS } from "../lib/limits";
+import {
+  AUTO_CLOSE_NO_END_TIME_HOURS,
+  MAX_EVENT_DURATION_HOURS,
+  MAYBE_FINISHED_AFTER_HOURS,
+} from "../lib/limits";
 import {
   metricEventCreated,
   metricEventDeleted,
@@ -15,6 +19,8 @@ import {
 } from "../metrics";
 
 const MAX_EVENT_DURATION_MS = MAX_EVENT_DURATION_HOURS * 60 * 60 * 1000;
+const MAYBE_FINISHED_AFTER_MS = MAYBE_FINISHED_AFTER_HOURS * 60 * 60 * 1000;
+const AUTO_CLOSE_NO_END_TIME_MS = AUTO_CLOSE_NO_END_TIME_HOURS * 60 * 60 * 1000;
 
 export class EventNotFound extends Data.TaggedError("EventNotFound")<{
   readonly id: string;
@@ -32,7 +38,7 @@ export class NotEventOwner extends Data.TaggedError("NotEventOwner")<{
   readonly id: string;
 }> {}
 
-const StatusEnum = Schema.Literal("upcoming", "ongoing", "finished", "cancelled");
+const StatusEnum = Schema.Literal("upcoming", "ongoing", "maybe_finished", "finished", "cancelled");
 const VisibilityEnum = Schema.Literal("public", "private");
 const GuestListVisibilityEnum = Schema.Literal("public", "connections", "private");
 const JoinPolicyEnum = Schema.Literal("open", "guest_list");
@@ -106,7 +112,7 @@ const UpdateEventSchema = Schema.Struct({
 });
 
 interface ListEventsParams {
-  status?: "upcoming" | "ongoing" | "finished" | "cancelled";
+  status?: "upcoming" | "ongoing" | "maybe_finished" | "finished" | "cancelled";
   category?: string;
   limit?: string;
   /**
@@ -118,17 +124,26 @@ interface ListEventsParams {
 }
 
 const deriveStatus = (event: Event, now: Date): Event["status"] => {
+  // Terminal states never transition automatically. "cancelled" and a
+  // manually-set "finished" (organiser closed early) are sticky.
   if (event.status === "cancelled" || event.status === "finished") return event.status;
   const started = event.startTime <= now;
-  // Events without an explicit endTime are auto-closed once they've run
-  // for MAX_EVENT_DURATION_HOURS past their startTime. This matches the
-  // duration cap enforced at create/update time — an organiser who
-  // declined to set an endTime is agreeing to a hard 48h ceiling.
-  const impliedEnd = new Date(event.startTime.getTime() + MAX_EVENT_DURATION_MS);
-  const ended = event.endTime !== null ? event.endTime <= now : started && impliedEnd <= now;
-  if (ended) return "finished";
-  if (started) return "ongoing";
-  return "upcoming";
+  if (!started) return "upcoming";
+
+  // Explicit-endTime path: a single transition at endTime.
+  if (event.endTime !== null) {
+    return event.endTime <= now ? "finished" : "ongoing";
+  }
+
+  // No-endTime path: soft/hard ladder. The organiser agreed to a
+  // best-effort ceiling by not setting an endTime. Guests see a
+  // "maybe finished" label at 8h, and the event auto-closes at 12h
+  // (see AUTO_CLOSE_NO_END_TIME_HOURS) so open-ended events don't
+  // linger as "ongoing" forever.
+  const elapsedMs = now.getTime() - event.startTime.getTime();
+  if (elapsedMs >= AUTO_CLOSE_NO_END_TIME_MS) return "finished";
+  if (elapsedMs >= MAYBE_FINISHED_AFTER_MS) return "maybe_finished";
+  return "ongoing";
 };
 
 export const applyTransition = (event: Event): Effect.Effect<Event, DatabaseError, Db> => {

--- a/pulse/api/tests/helpers/db.ts
+++ b/pulse/api/tests/helpers/db.ts
@@ -81,7 +81,7 @@ export interface SeedEventInput {
   title: string;
   startTime: string | Date;
   endTime?: string | Date;
-  status?: "upcoming" | "ongoing" | "finished" | "cancelled";
+  status?: "upcoming" | "ongoing" | "maybe_finished" | "finished" | "cancelled";
   category?: string;
   createdByProfileId?: string;
   createdByName?: string | null;

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -230,6 +230,18 @@ describe("events routes", () => {
     expect(res.status).toBe(422);
   });
 
+  it("POST /events returns 422 when duration exceeds the max", async () => {
+    const start = new Date("2030-06-01T10:00:00.000Z");
+    const end = new Date(start.getTime() + 49 * 60 * 60 * 1000);
+    const res = await post(
+      app,
+      "/events",
+      { title: "Too long", startTime: start.toISOString(), endTime: end.toISOString() },
+      aliceToken,
+    );
+    expect(res.status).toBe(422);
+  });
+
   it("GET /events?limit=1 returns at most 1 event", async () => {
     await post(app, "/events", { title: "Event A", startTime: FUTURE }, aliceToken);
     await post(app, "/events", { title: "Event B", startTime: FUTURE }, aliceToken);

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -145,6 +145,83 @@ it.effect("createEvent fails with ValidationError for startTime equal to now", (
   ),
 );
 
+it.effect("createEvent accepts endTime exactly at MAX_EVENT_DURATION_HOURS", () =>
+  provide(
+    Effect.gen(function* () {
+      const start = new Date("2030-06-01T10:00:00.000Z");
+      const end = new Date(start.getTime() + 48 * 60 * 60 * 1000);
+      const event = yield* createEvent(
+        { title: "Weekend party", startTime: start.toISOString(), endTime: end.toISOString() },
+        ALICE,
+      );
+      expect(event.endTime).toEqual(end);
+    }),
+  ),
+);
+
+it.effect(
+  "createEvent fails with ValidationError when duration exceeds MAX_EVENT_DURATION_HOURS",
+  () =>
+    provide(
+      Effect.gen(function* () {
+        const start = new Date("2030-06-01T10:00:00.000Z");
+        const end = new Date(start.getTime() + 48 * 60 * 60 * 1000 + 60 * 1000);
+        const error = yield* Effect.flip(
+          createEvent(
+            { title: "Too long", startTime: start.toISOString(), endTime: end.toISOString() },
+            ALICE,
+          ),
+        );
+        expect(error._tag).toBe("ValidationError");
+      }),
+    ),
+);
+
+it.effect("updateEvent rejects endTime-only patch that pushes duration over cap", () =>
+  provide(
+    Effect.gen(function* () {
+      const start = new Date("2030-06-01T10:00:00.000Z");
+      const created = yield* createEvent(
+        { title: "Dinner", startTime: start.toISOString() },
+        ALICE,
+      );
+      const tooFar = new Date(start.getTime() + 49 * 60 * 60 * 1000).toISOString();
+      const error = yield* Effect.flip(updateEvent(created.id, { endTime: tooFar }, "usr_alice"));
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("getEvent auto-finishes no-endTime events after MAX_EVENT_DURATION_HOURS", () =>
+  provide(
+    Effect.gen(function* () {
+      const longAgo = new Date(Date.now() - 49 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Stale ongoing",
+        startTime: longAgo,
+        status: "ongoing",
+      });
+      const fetched = yield* getEvent(seeded.id);
+      expect(fetched.status).toBe("finished");
+    }),
+  ),
+);
+
+it.effect("getEvent keeps no-endTime events ongoing before MAX_EVENT_DURATION_HOURS", () =>
+  provide(
+    Effect.gen(function* () {
+      const recent = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Fresh ongoing",
+        startTime: recent,
+        status: "ongoing",
+      });
+      const fetched = yield* getEvent(seeded.id);
+      expect(fetched.status).toBe("ongoing");
+    }),
+  ),
+);
+
 it.effect("createEvent fails with ValidationError for bad startTime", () =>
   provide(
     Effect.gen(function* () {

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -1,6 +1,8 @@
 import { expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import { vi } from "vitest";
 
+import * as metrics from "../../src/metrics";
 import {
   createEvent,
   deleteEvent,
@@ -177,6 +179,41 @@ it.effect(
     ),
 );
 
+it.effect("createEvent emits duration_exceeds_max validation-failure metric", () =>
+  provide(
+    Effect.gen(function* () {
+      const spy = vi.spyOn(metrics, "metricEventValidationFailure");
+      const start = new Date("2030-06-01T10:00:00.000Z");
+      const end = new Date(start.getTime() + 49 * 60 * 60 * 1000);
+      yield* Effect.flip(
+        createEvent(
+          { title: "Too long", startTime: start.toISOString(), endTime: end.toISOString() },
+          ALICE,
+        ),
+      );
+      expect(spy).toHaveBeenCalledWith("create", "duration_exceeds_max");
+      spy.mockRestore();
+    }),
+  ),
+);
+
+it.effect("updateEvent emits duration_exceeds_max validation-failure metric", () =>
+  provide(
+    Effect.gen(function* () {
+      const start = new Date("2030-06-01T10:00:00.000Z");
+      const created = yield* createEvent(
+        { title: "Dinner", startTime: start.toISOString() },
+        ALICE,
+      );
+      const spy = vi.spyOn(metrics, "metricEventValidationFailure");
+      const tooFar = new Date(start.getTime() + 49 * 60 * 60 * 1000).toISOString();
+      yield* Effect.flip(updateEvent(created.id, { endTime: tooFar }, "usr_alice"));
+      expect(spy).toHaveBeenCalledWith("update", "duration_exceeds_max");
+      spy.mockRestore();
+    }),
+  ),
+);
+
 it.effect("updateEvent rejects endTime-only patch that pushes duration over cap", () =>
   provide(
     Effect.gen(function* () {
@@ -192,10 +229,79 @@ it.effect("updateEvent rejects endTime-only patch that pushes duration over cap"
   ),
 );
 
-it.effect("getEvent auto-finishes no-endTime events after MAX_EVENT_DURATION_HOURS", () =>
+it.effect("updateEvent rejects startTime-only patch that pushes duration over cap", () =>
   provide(
     Effect.gen(function* () {
-      const longAgo = new Date(Date.now() - 49 * 60 * 60 * 1000);
+      // Seed an existing event with an explicit endTime 2h after startTime.
+      const start = new Date("2030-06-01T10:00:00.000Z");
+      const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+      const created = yield* createEvent(
+        { title: "Dinner", startTime: start.toISOString(), endTime: end.toISOString() },
+        ALICE,
+      );
+      // Patching only startTime 49h earlier makes the effective duration 51h.
+      const muchEarlier = new Date(start.getTime() - 49 * 60 * 60 * 1000).toISOString();
+      const error = yield* Effect.flip(
+        updateEvent(created.id, { startTime: muchEarlier }, "usr_alice"),
+      );
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect(
+  "updateEvent accepts endTime moved to exactly MAX_EVENT_DURATION_HOURS past startTime",
+  () =>
+    provide(
+      Effect.gen(function* () {
+        const start = new Date("2030-06-01T10:00:00.000Z");
+        const created = yield* createEvent(
+          { title: "Dinner", startTime: start.toISOString() },
+          ALICE,
+        );
+        const atCap = new Date(start.getTime() + 48 * 60 * 60 * 1000).toISOString();
+        const updated = yield* updateEvent(created.id, { endTime: atCap }, "usr_alice");
+        expect(updated.endTime?.toISOString()).toBe(atCap);
+      }),
+    ),
+);
+
+it.effect("getEvent finishes events whose explicit endTime has passed", () =>
+  provide(
+    Effect.gen(function* () {
+      const startedAgo = new Date(Date.now() - 5 * 60 * 60 * 1000);
+      const endedAgo = new Date(Date.now() - 1 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Already over",
+        startTime: startedAgo,
+        endTime: endedAgo,
+        status: "ongoing",
+      });
+      const fetched = yield* getEvent(seeded.id);
+      expect(fetched.status).toBe("finished");
+    }),
+  ),
+);
+
+it.effect("getEvent marks no-endTime events maybe_finished between 8h and 12h past startTime", () =>
+  provide(
+    Effect.gen(function* () {
+      const ninehAgo = new Date(Date.now() - 9 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Soft grace",
+        startTime: ninehAgo,
+        status: "ongoing",
+      });
+      const fetched = yield* getEvent(seeded.id);
+      expect(fetched.status).toBe("maybe_finished");
+    }),
+  ),
+);
+
+it.effect("getEvent auto-finishes no-endTime events after AUTO_CLOSE_NO_END_TIME_HOURS", () =>
+  provide(
+    Effect.gen(function* () {
+      const longAgo = new Date(Date.now() - 13 * 60 * 60 * 1000);
       const seeded = yield* seedEvent({
         title: "Stale ongoing",
         startTime: longAgo,
@@ -207,7 +313,7 @@ it.effect("getEvent auto-finishes no-endTime events after MAX_EVENT_DURATION_HOU
   ),
 );
 
-it.effect("getEvent keeps no-endTime events ongoing before MAX_EVENT_DURATION_HOURS", () =>
+it.effect("getEvent keeps no-endTime events ongoing before MAYBE_FINISHED_AFTER_HOURS", () =>
   provide(
     Effect.gen(function* () {
       const recent = new Date(Date.now() - 2 * 60 * 60 * 1000);
@@ -218,6 +324,25 @@ it.effect("getEvent keeps no-endTime events ongoing before MAX_EVENT_DURATION_HO
       });
       const fetched = yield* getEvent(seeded.id);
       expect(fetched.status).toBe("ongoing");
+    }),
+  ),
+);
+
+it.effect("organiser can manually mark a maybe_finished event as finished", () =>
+  provide(
+    Effect.gen(function* () {
+      const ninehAgo = new Date(Date.now() - 9 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Organiser closes early",
+        startTime: ninehAgo,
+        status: "maybe_finished",
+      });
+      const updated = yield* updateEvent(
+        seeded.id,
+        { status: "finished" },
+        seeded.createdByProfileId,
+      );
+      expect(updated.status).toBe("finished");
     }),
   ),
 );

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -298,6 +298,31 @@ it.effect("getEvent marks no-endTime events maybe_finished between 8h and 12h pa
   ),
 );
 
+it.effect("maybe_finished is display-only — the DB row stays 'ongoing'", () =>
+  provide(
+    Effect.gen(function* () {
+      const ninehAgo = new Date(Date.now() - 9 * 60 * 60 * 1000);
+      const seeded = yield* seedEvent({
+        title: "Not persisted",
+        startTime: ninehAgo,
+        status: "ongoing",
+      });
+      // First read projects maybe_finished in-memory.
+      const fetched = yield* getEvent(seeded.id);
+      expect(fetched.status).toBe("maybe_finished");
+      // But the DB row still says ongoing — a direct SELECT via a second
+      // getEvent re-derives from the stored ongoing row, not a persisted
+      // maybe_finished one. Count status_transitions: none should fire
+      // for maybe_finished (only ongoing → finished at 12h is persisted).
+      const spy = vi.spyOn(metrics, "metricEventStatusTransition");
+      const refetched = yield* getEvent(seeded.id);
+      expect(refetched.status).toBe("maybe_finished");
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    }),
+  ),
+);
+
 it.effect("getEvent auto-finishes no-endTime events after AUTO_CLOSE_NO_END_TIME_HOURS", () =>
   provide(
     Effect.gen(function* () {

--- a/pulse/app/src/components/CreateEventForm.tsx
+++ b/pulse/app/src/components/CreateEventForm.tsx
@@ -5,13 +5,21 @@ import { Input } from "@osn/ui/ui/input";
 import { Label } from "@osn/ui/ui/label";
 import { RadioGroup, RadioGroupItem } from "@osn/ui/ui/radio-group";
 import { Textarea } from "@osn/ui/ui/textarea";
-import { createSignal, createMemo, Show } from "solid-js";
+import { createSignal, createMemo, For, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { api } from "../lib/api";
 import { LocationInput } from "../lib/LocationInput";
-import { toDatetimeLocal, isEndBeforeOrAtStart } from "../lib/utils";
+import { toDatetimeLocal, isEndBeforeOrAtStart, deriveEndFromDuration } from "../lib/utils";
 import { InfoPopover } from "./InfoPopover";
+
+const DURATION_PRESETS: ReadonlyArray<{ label: string; hours: number }> = [
+  { label: "1h", hours: 1 },
+  { label: "2h", hours: 2 },
+  { label: "4h", hours: 4 },
+  { label: "8h", hours: 8 },
+  { label: "All day", hours: 24 },
+];
 
 type Visibility = "public" | "private";
 type GuestListVisibility = "public" | "connections" | "private";
@@ -131,6 +139,38 @@ export function CreateEventForm(props: {
             </Show>
           </div>
         </div>
+
+        {/* Duration prompt — only visible when the organiser hasn't picked an end time. */}
+        <Show when={!endTime()}>
+          <div class="flex flex-col gap-1">
+            <div class="flex items-center">
+              <Label>How long will it run?</Label>
+              <InfoPopover
+                label="About event duration"
+                body="Pick a rough length so we can show guests when it wraps. You can also set an exact end time above, or leave it open if you're not sure."
+              />
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <For each={DURATION_PRESETS}>
+                {(preset) => (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setEndTime(deriveEndFromDuration(startTime(), preset.hours))}
+                  >
+                    {preset.label}
+                  </Button>
+                )}
+              </For>
+            </div>
+            <p class="text-muted-foreground text-xs">
+              If you're not sure, your event will be marked as{" "}
+              <span class="font-medium">potentially finished</span> after 8 hours and{" "}
+              <span class="font-medium">automatically closed</span> after 48 hours.
+            </p>
+          </div>
+        </Show>
 
         {/* Location */}
         <div class="flex flex-col gap-1">

--- a/pulse/app/src/components/CreateEventForm.tsx
+++ b/pulse/app/src/components/CreateEventForm.tsx
@@ -166,8 +166,9 @@ export function CreateEventForm(props: {
             </div>
             <p class="text-muted-foreground text-xs">
               If you're not sure, your event will be marked as{" "}
-              <span class="font-medium">potentially finished</span> after 8 hours and{" "}
-              <span class="font-medium">automatically closed</span> after 48 hours.
+              <span class="font-medium">maybe finished</span> after 8 hours and{" "}
+              <span class="font-medium">automatically closed</span> after 12 hours. You can close it
+              manually any time.
             </p>
           </div>
         </Show>

--- a/pulse/app/src/components/EventCard.tsx
+++ b/pulse/app/src/components/EventCard.tsx
@@ -5,7 +5,7 @@ import { A } from "@solidjs/router";
 import { Show } from "solid-js";
 
 import type { EventItem } from "../lib/types";
-import { formatTime, isPotentiallyFinished } from "../lib/utils";
+import { formatTime } from "../lib/utils";
 
 function mapsUrl(event: EventItem): string | null {
   if (event.latitude != null && event.longitude != null) {
@@ -57,16 +57,14 @@ export function EventCard(props: {
             </Show>
             <span
               class={`text-xs ${
-                isPotentiallyFinished(props.event)
-                  ? "text-muted-foreground"
-                  : props.event.status === "ongoing"
-                    ? "font-semibold text-green-600"
-                    : props.event.status === "cancelled"
-                      ? "text-destructive"
-                      : "text-muted-foreground"
+                props.event.status === "ongoing"
+                  ? "font-semibold text-green-600"
+                  : props.event.status === "cancelled"
+                    ? "text-destructive"
+                    : "text-muted-foreground"
               }`}
             >
-              {isPotentiallyFinished(props.event) ? "maybe finished" : props.event.status}
+              {props.event.status === "maybe_finished" ? "maybe finished" : props.event.status}
             </span>
           </div>
           <h2 class="text-foreground mb-1 text-base font-semibold">{props.event.title}</h2>

--- a/pulse/app/src/components/EventCard.tsx
+++ b/pulse/app/src/components/EventCard.tsx
@@ -5,7 +5,7 @@ import { A } from "@solidjs/router";
 import { Show } from "solid-js";
 
 import type { EventItem } from "../lib/types";
-import { formatTime } from "../lib/utils";
+import { formatTime, isPotentiallyFinished } from "../lib/utils";
 
 function mapsUrl(event: EventItem): string | null {
   if (event.latitude != null && event.longitude != null) {
@@ -56,9 +56,17 @@ export function EventCard(props: {
               </Badge>
             </Show>
             <span
-              class={`text-xs ${props.event.status === "ongoing" ? "font-semibold text-green-600" : props.event.status === "cancelled" ? "text-destructive" : "text-muted-foreground"}`}
+              class={`text-xs ${
+                isPotentiallyFinished(props.event)
+                  ? "text-muted-foreground"
+                  : props.event.status === "ongoing"
+                    ? "font-semibold text-green-600"
+                    : props.event.status === "cancelled"
+                      ? "text-destructive"
+                      : "text-muted-foreground"
+              }`}
             >
-              {props.event.status}
+              {isPotentiallyFinished(props.event) ? "maybe finished" : props.event.status}
             </span>
           </div>
           <h2 class="text-foreground mb-1 text-base font-semibold">{props.event.title}</h2>

--- a/pulse/app/src/explore/ExploreCard.tsx
+++ b/pulse/app/src/explore/ExploreCard.tsx
@@ -3,7 +3,6 @@ import { A } from "@solidjs/router";
 import { Show } from "solid-js";
 
 import type { EventItem } from "../lib/types";
-import { isPotentiallyFinished } from "../lib/utils";
 import { Icon } from "./icons";
 
 /** Gradient class for events without an image — keyed by category. */
@@ -141,7 +140,7 @@ export function ExploreCard(props: {
         </div>
 
         {/* Status tags */}
-        <Show when={e().status === "ongoing" && !isPotentiallyFinished(e())}>
+        <Show when={e().status === "ongoing"}>
           <div
             class="absolute bottom-2.5 left-2.5 inline-flex items-center gap-[5px] rounded-full px-2 py-[3px] text-[10px] font-medium text-white"
             style={{ background: "oklch(0.15 0 0 / 0.7)", "backdrop-filter": "blur(8px)" }}
@@ -214,10 +213,10 @@ export function ExploreCard(props: {
             class="text-muted-foreground text-[11.5px]"
             style={{ "font-family": "var(--font-mono)" }}
           >
-            {isPotentiallyFinished(e())
-              ? "Maybe finished"
-              : e().status === "ongoing"
-                ? "Live"
+            {e().status === "ongoing"
+              ? "Live"
+              : e().status === "maybe_finished"
+                ? "Maybe finished"
                 : e().status}
           </span>
         </div>

--- a/pulse/app/src/explore/ExploreCard.tsx
+++ b/pulse/app/src/explore/ExploreCard.tsx
@@ -3,6 +3,7 @@ import { A } from "@solidjs/router";
 import { Show } from "solid-js";
 
 import type { EventItem } from "../lib/types";
+import { isPotentiallyFinished } from "../lib/utils";
 import { Icon } from "./icons";
 
 /** Gradient class for events without an image — keyed by category. */
@@ -79,7 +80,7 @@ export function ExploreCard(props: {
   return (
     <A
       href={`/events/${e().id}`}
-      class="group relative grid cursor-pointer overflow-hidden rounded-2xl border border-border bg-card transition-all hover:-translate-y-px hover:border-foreground/20 hover:shadow-md"
+      class="group border-border bg-card hover:border-foreground/20 relative grid cursor-pointer overflow-hidden rounded-2xl border transition-all hover:-translate-y-px hover:shadow-md"
       classList={{
         "grid-cols-[180px_1fr]": !props.featured,
         "grid-cols-1": !!props.featured,
@@ -106,7 +107,7 @@ export function ExploreCard(props: {
             <>
               <div class="ph-pattern" />
               <div
-                class="absolute bottom-2 right-2.5 text-[42px] italic leading-none"
+                class="absolute right-2.5 bottom-2 text-[42px] leading-none italic"
                 style={{
                   "font-family": "var(--font-serif)",
                   color: "oklch(1 0 0 / 0.85)",
@@ -126,21 +127,21 @@ export function ExploreCard(props: {
         </Show>
 
         {/* Date stamp */}
-        <div class="date-stamp absolute left-3 top-3 w-[46px] rounded-[10px] border border-white/50 bg-card py-1 text-center shadow-sm">
+        <div class="date-stamp bg-card absolute top-3 left-3 w-[46px] rounded-[10px] border border-white/50 py-1 text-center shadow-sm">
           <div
-            class="text-[9px] font-semibold uppercase tracking-widest"
+            class="text-[9px] font-semibold tracking-widest uppercase"
             style={{ color: "var(--pulse-accent-strong)" }}
           >
             {dateParts().mo}
           </div>
-          <div class="mt-0.5 text-lg font-semibold leading-none">{dateParts().day}</div>
-          <div class="mt-0.5 text-[9px] uppercase tracking-wider text-muted-foreground">
+          <div class="mt-0.5 text-lg leading-none font-semibold">{dateParts().day}</div>
+          <div class="text-muted-foreground mt-0.5 text-[9px] tracking-wider uppercase">
             {dateParts().dow}
           </div>
         </div>
 
         {/* Status tags */}
-        <Show when={e().status === "ongoing"}>
+        <Show when={e().status === "ongoing" && !isPotentiallyFinished(e())}>
           <div
             class="absolute bottom-2.5 left-2.5 inline-flex items-center gap-[5px] rounded-full px-2 py-[3px] text-[10px] font-medium text-white"
             style={{ background: "oklch(0.15 0 0 / 0.7)", "backdrop-filter": "blur(8px)" }}
@@ -161,7 +162,7 @@ export function ExploreCard(props: {
       <div class="relative flex min-w-0 flex-col gap-1.5 px-4 py-3.5">
         {/* Meta line */}
         <div
-          class="flex items-center gap-1.5 text-[11.5px] uppercase tracking-wider"
+          class="flex items-center gap-1.5 text-[11.5px] tracking-wider uppercase"
           style={{ "font-family": "var(--font-mono)", color: "var(--pulse-accent-strong)" }}
         >
           <Icon name="clock" size={11} />
@@ -169,18 +170,18 @@ export function ExploreCard(props: {
         </div>
 
         {/* Title */}
-        <h3 class="m-0 line-clamp-2 text-[16.5px] font-semibold leading-tight tracking-tight">
+        <h3 class="m-0 line-clamp-2 text-[16.5px] leading-tight font-semibold tracking-tight">
           {e().title}
         </h3>
 
         {/* Location */}
-        <div class="flex items-center gap-2 text-[12.5px] text-muted-foreground">
+        <div class="text-muted-foreground flex items-center gap-2 text-[12.5px]">
           <Icon name="map-pin" size={12} />
           <Show when={e().venue}>
             <span>{e().venue}</span>
           </Show>
           <Show when={e().venue && e().location}>
-            <span class="inline-block h-[3px] w-[3px] rounded-full bg-foreground/20" />
+            <span class="bg-foreground/20 inline-block h-[3px] w-[3px] rounded-full" />
           </Show>
           <Show when={e().location}>
             <span>{e().location}</span>
@@ -190,30 +191,34 @@ export function ExploreCard(props: {
         {/* Host */}
         <Show when={e().createdByName}>
           {(name) => (
-            <div class="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
+            <div class="text-muted-foreground flex items-center gap-1.5 text-[11.5px]">
               <Avatar class="h-[18px] w-[18px]">
                 <Show when={e().createdByAvatar}>
                   {(avatar) => <AvatarImage src={avatar()} alt={name()} />}
                 </Show>
                 <AvatarFallback class="text-[8px]">{initials(name())}</AvatarFallback>
               </Avatar>
-              Hosted by <b class="font-semibold text-foreground">{name()}</b>
+              Hosted by <b class="text-foreground font-semibold">{name()}</b>
             </div>
           )}
         </Show>
 
         {/* Footer */}
-        <div class="mt-1.5 flex items-center justify-between gap-2.5 border-t border-dashed border-border pt-2.5">
+        <div class="border-border mt-1.5 flex items-center justify-between gap-2.5 border-t border-dashed pt-2.5">
           <Show when={e().category}>
-            <span class="text-[12px] font-medium uppercase tracking-wider text-muted-foreground">
+            <span class="text-muted-foreground text-[12px] font-medium tracking-wider uppercase">
               {e().category}
             </span>
           </Show>
           <span
-            class="text-[11.5px] text-muted-foreground"
+            class="text-muted-foreground text-[11.5px]"
             style={{ "font-family": "var(--font-mono)" }}
           >
-            {e().status === "ongoing" ? "Live" : e().status}
+            {isPotentiallyFinished(e())
+              ? "Maybe finished"
+              : e().status === "ongoing"
+                ? "Live"
+                : e().status}
           </span>
         </div>
       </div>

--- a/pulse/app/src/lib/utils.ts
+++ b/pulse/app/src/lib/utils.ts
@@ -55,33 +55,6 @@ export function deriveEndFromDuration(start: string, hours: number): string {
 }
 
 /**
- * Soft-finished threshold, in hours, for events without an explicit
- * `endTime`. The server auto-closes such events after 48h (see
- * `MAX_EVENT_DURATION_HOURS` in `pulse/api/src/lib/limits.ts`); between
- * 8h and 48h past `startTime` the client surfaces them as "maybe
- * finished" so guests aren't left wondering.
- */
-export const POTENTIALLY_FINISHED_AFTER_HOURS = 8;
-
-/**
- * Returns true when an event is still server-side "ongoing" but has
- * been running long enough (with no explicit `endTime`) that it's
- * probably actually over. Client-only display signal — the server still
- * reports `status: "ongoing"`.
- */
-export function isPotentiallyFinished(event: {
-  status: string;
-  startTime: string | Date;
-  endTime: string | Date | null;
-}): boolean {
-  if (event.status !== "ongoing") return false;
-  if (event.endTime) return false;
-  const startMs = new Date(event.startTime).getTime();
-  if (isNaN(startMs)) return false;
-  return Date.now() - startMs >= POTENTIALLY_FINISHED_AFTER_HOURS * 60 * 60 * 1000;
-}
-
-/**
  * Decodes a JWT payload without verifying the signature.
  * Safe for display-only purposes — the server verifies the signature on every write.
  */

--- a/pulse/app/src/lib/utils.ts
+++ b/pulse/app/src/lib/utils.ts
@@ -41,6 +41,47 @@ export function isEndBeforeOrAtStart(start: string, end: string): boolean {
 }
 
 /**
+ * Given a start datetime-local string and a duration in hours, returns
+ * the corresponding end datetime-local string. Returns an empty string
+ * if `start` cannot be parsed, so the caller can leave `endTime` empty
+ * rather than emitting "Invalid Date".
+ */
+export function deriveEndFromDuration(start: string, hours: number): string {
+  if (!start) return "";
+  const startDate = new Date(start);
+  if (isNaN(startDate.getTime())) return "";
+  const end = new Date(startDate.getTime() + hours * 60 * 60 * 1000);
+  return toDatetimeLocal(end);
+}
+
+/**
+ * Soft-finished threshold, in hours, for events without an explicit
+ * `endTime`. The server auto-closes such events after 48h (see
+ * `MAX_EVENT_DURATION_HOURS` in `pulse/api/src/lib/limits.ts`); between
+ * 8h and 48h past `startTime` the client surfaces them as "maybe
+ * finished" so guests aren't left wondering.
+ */
+export const POTENTIALLY_FINISHED_AFTER_HOURS = 8;
+
+/**
+ * Returns true when an event is still server-side "ongoing" but has
+ * been running long enough (with no explicit `endTime`) that it's
+ * probably actually over. Client-only display signal — the server still
+ * reports `status: "ongoing"`.
+ */
+export function isPotentiallyFinished(event: {
+  status: string;
+  startTime: string | Date;
+  endTime: string | Date | null;
+}): boolean {
+  if (event.status !== "ongoing") return false;
+  if (event.endTime) return false;
+  const startMs = new Date(event.startTime).getTime();
+  if (isNaN(startMs)) return false;
+  return Date.now() - startMs >= POTENTIALLY_FINISHED_AFTER_HOURS * 60 * 60 * 1000;
+}
+
+/**
  * Decodes a JWT payload without verifying the signature.
  * Safe for display-only purposes — the server verifies the signature on every write.
  */

--- a/pulse/app/src/pages/EventDetailPage.tsx
+++ b/pulse/app/src/pages/EventDetailPage.tsx
@@ -11,7 +11,7 @@ import { MapPreview } from "../components/MapPreview";
 import { RsvpSection } from "../components/RsvpSection";
 import { api } from "../lib/api";
 import { apiBaseUrl } from "../lib/rsvps";
-import { formatTime, getProfileIdFromToken } from "../lib/utils";
+import { formatTime, getProfileIdFromToken, isPotentiallyFinished } from "../lib/utils";
 
 interface EventDetail {
   id: string;
@@ -86,14 +86,16 @@ export function EventDetailPage() {
                   </Show>
                   <span
                     class={`text-xs ${
-                      e().status === "ongoing"
-                        ? "font-semibold text-green-600"
-                        : e().status === "cancelled"
-                          ? "text-destructive"
-                          : "text-muted-foreground"
+                      isPotentiallyFinished(e())
+                        ? "text-muted-foreground"
+                        : e().status === "ongoing"
+                          ? "font-semibold text-green-600"
+                          : e().status === "cancelled"
+                            ? "text-destructive"
+                            : "text-muted-foreground"
                     }`}
                   >
-                    {e().status}
+                    {isPotentiallyFinished(e()) ? "maybe finished" : e().status}
                   </span>
                   <Show when={e().visibility === "private"}>
                     <span class="text-muted-foreground text-xs">· Private</span>

--- a/pulse/app/src/pages/EventDetailPage.tsx
+++ b/pulse/app/src/pages/EventDetailPage.tsx
@@ -11,7 +11,7 @@ import { MapPreview } from "../components/MapPreview";
 import { RsvpSection } from "../components/RsvpSection";
 import { api } from "../lib/api";
 import { apiBaseUrl } from "../lib/rsvps";
-import { formatTime, getProfileIdFromToken, isPotentiallyFinished } from "../lib/utils";
+import { formatTime, getProfileIdFromToken } from "../lib/utils";
 
 interface EventDetail {
   id: string;
@@ -24,7 +24,7 @@ interface EventDetail {
   category: string | null;
   startTime: string;
   endTime: string | null;
-  status: "upcoming" | "ongoing" | "finished" | "cancelled";
+  status: "upcoming" | "ongoing" | "maybe_finished" | "finished" | "cancelled";
   imageUrl: string | null;
   visibility: "public" | "private";
   guestListVisibility: "public" | "connections" | "private";
@@ -86,16 +86,14 @@ export function EventDetailPage() {
                   </Show>
                   <span
                     class={`text-xs ${
-                      isPotentiallyFinished(e())
-                        ? "text-muted-foreground"
-                        : e().status === "ongoing"
-                          ? "font-semibold text-green-600"
-                          : e().status === "cancelled"
-                            ? "text-destructive"
-                            : "text-muted-foreground"
+                      e().status === "ongoing"
+                        ? "font-semibold text-green-600"
+                        : e().status === "cancelled"
+                          ? "text-destructive"
+                          : "text-muted-foreground"
                     }`}
                   >
-                    {isPotentiallyFinished(e()) ? "maybe finished" : e().status}
+                    {e().status === "maybe_finished" ? "maybe finished" : e().status}
                   </span>
                   <Show when={e().visibility === "private"}>
                     <span class="text-muted-foreground text-xs">· Private</span>

--- a/pulse/app/tests/utils.test.ts
+++ b/pulse/app/tests/utils.test.ts
@@ -7,6 +7,7 @@ import {
   isEndBeforeOrAtStart,
   getProfileIdFromToken,
   getDisplayNameFromToken,
+  deriveEndFromDuration,
   type PhotonFeature,
 } from "../src/lib/utils";
 
@@ -137,5 +138,25 @@ describe("formatTime", () => {
     const result = formatTime(new Date("2030-06-01T10:00:00.000Z"));
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("deriveEndFromDuration", () => {
+  it("returns an empty string when start is empty", () => {
+    expect(deriveEndFromDuration("", 2)).toBe("");
+  });
+
+  it("returns an empty string when start is unparseable", () => {
+    expect(deriveEndFromDuration("not-a-date", 2)).toBe("");
+  });
+
+  it("adds exactly N hours to start and returns a datetime-local string", () => {
+    const start = "2030-06-01T10:00";
+    const expected = toDatetimeLocal(new Date(new Date(start).getTime() + 2 * 60 * 60 * 1000));
+    expect(deriveEndFromDuration(start, 2)).toBe(expected);
+  });
+
+  it("matches YYYY-MM-DDTHH:mm format", () => {
+    expect(deriveEndFromDuration("2030-06-01T10:00", 4)).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
   });
 });

--- a/pulse/db/src/schema/events.ts
+++ b/pulse/db/src/schema/events.ts
@@ -13,7 +13,17 @@ export const events = sqliteTable(
     category: text("category"),
     startTime: integer("start_time", { mode: "timestamp" }).notNull(),
     endTime: integer("end_time", { mode: "timestamp" }),
-    status: text("status", { enum: ["upcoming", "ongoing", "finished", "cancelled"] })
+    // ── Status ────────────────────────────────────────────────────────────
+    // "upcoming"        → startTime in the future
+    // "ongoing"         → startTime past, endTime (explicit or implied) still in the future
+    // "maybe_finished"  → no explicit endTime + >= 8h past startTime; grace window
+    //                     before auto-closing (organiser can still mark finished early)
+    // "finished"        → endTime reached OR no-endTime event auto-closed after 12h
+    //                     OR organiser manually closed
+    // "cancelled"       → organiser cancelled
+    status: text("status", {
+      enum: ["upcoming", "ongoing", "maybe_finished", "finished", "cancelled"],
+    })
       .notNull()
       .default("upcoming"),
     imageUrl: text("image_url"),

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -47,7 +47,7 @@ export type GraphBlockAction = "add" | "remove";
 export type GraphCloseFriendAction = "add" | "remove";
 
 /** Event lifecycle states (mirrors Pulse events schema). */
-export type EventStatus = "upcoming" | "ongoing" | "finished" | "cancelled";
+export type EventStatus = "upcoming" | "ongoing" | "maybe_finished" | "finished" | "cancelled";
 
 /** Organisation CRUD actions. */
 export type OrgAction = "create" | "update" | "delete";

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -28,7 +28,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 ## Pulse (`pulse/app` + `pulse/api` + `pulse/db`)
 
 - [ ] "What's on today" default view
-- [ ] Prompt for max event duration when creating events without an endTime
+- [x] Prompt for max event duration when creating events without an endTime — duration presets + `maybe_finished` status at 8h, auto-close at 12h, 48h defence-in-depth cap on explicit endTimes (moved to `[[changelog/completed-features]]`)
 - [ ] Event discovery (location, category, datetime, friends, interests)
 - [ ] Add `price` field to events schema (`text`, nullable — free events = null, otherwise display string like "$18" or "$8 entry")
 - [ ] Recurring events (series + instances)
@@ -408,7 +408,6 @@ Findings from auditing OSN auth against [The Copenhagen Book](https://thecopenha
 | Payment handling | Deferred for Pulse ticketing | After core Pulse features |
 | Two-way calendar sync | Currently one-way (Pulse → external) | Phase 2 |
 | Community event-ended reporting | 15–20 attendees auto-finish; host notified | When attendee/messaging features land |
-| Max event duration | Prompt user when creating events without endTime | When Pulse event creation UI is built |
 | Redis provider — see [[redis]] | Upstash (serverless, free tier) vs Redis Cloud vs self-hosted | When deploying beyond localhost |
 | DB table rename `users` → `profiles` | Table represents profiles; renaming is migration-heavy for minimal benefit | Only if it causes genuine confusion |
 | S2S scaling — see [[s2s-patterns]], [[arc-tokens]], [[s2s-migration]] | `pulse/api` graphBridge now uses HTTP + ARC. Remaining: `zap/api` bridge still uses direct import | When `zap/api` needs horizontal scaling |

--- a/wiki/apps/pulse.md
+++ b/wiki/apps/pulse.md
@@ -8,6 +8,7 @@ packages:
   - "@pulse/api"
   - "@pulse/db"
 port: 3001
+last-reviewed: 2026-04-24
 ---
 
 # Pulse
@@ -49,7 +50,15 @@ Full event lifecycle management:
 
 ### Lifecycle Transitions
 
-Events move through statuses: `upcoming` -> `ongoing` -> `finished`. Events can also be `cancelled` at any point by the organiser.
+Events move through statuses: `upcoming` → `ongoing` → `finished`. Events can also be `cancelled` at any point by the organiser.
+
+Events created **without an explicit `endTime`** follow a tighter ladder so they don't linger as `ongoing` indefinitely:
+
+1. At `MAYBE_FINISHED_AFTER_HOURS` (8h) past `startTime`, `deriveStatus` projects them as **`maybe_finished`** — a display-only status shown to guests as "maybe finished". This projection is **not persisted**; `applyTransition` skips the DB write for this transition, so no-endTime events still only produce one stored write over their lifetime.
+2. At `AUTO_CLOSE_NO_END_TIME_HOURS` (12h) past `startTime`, the event auto-transitions to `finished` and the transition is persisted.
+3. The organiser can manually `PATCH /events/:id { status: "finished" }` at any time to close the event early.
+
+Events **with** an explicit `endTime` keep the original single-transition behaviour at `endTime`. A defence-in-depth cap of `MAX_EVENT_DURATION_HOURS` (48h) is enforced on both `POST /events` and `PATCH /events/:id` — excessive durations return 422 with `metricEventValidationFailure(op, "duration_exceeds_max")`.
 
 ### RSVP System
 

--- a/wiki/changelog/completed-features.md
+++ b/wiki/changelog/completed-features.md
@@ -8,7 +8,7 @@ related:
   - "[[zap]]"
   - "[[redis]]"
   - "[[identity-model]]"
-last-reviewed: 2026-04-22
+last-reviewed: 2026-04-24
 ---
 
 # Completed Features
@@ -86,6 +86,7 @@ Archived completed feature work from [[TODO]]. For open work see [[TODO]].
 - Event chat placeholder
 - Hidden attendance option (`attendanceVisibility = "no_one"`)
 - `isCloseFriendOf`/`getCloseFriendsOfBatch` migrated from SQL to service helper
+- Max event duration prompt (2026-04-24) — duration presets (1h/2h/4h/8h/All day) in `CreateEventForm` when endTime is empty. New `maybe_finished` status (display-only projection; never persisted) at 8h past startTime; auto-close to `finished` at 12h. 48h defence-in-depth cap enforced server-side on explicit-endTime create/update. `EventStatus` union widened in `[[wiki/architecture/component-library]]`-adjacent surfaces; `events.status` column enum widened in `[[wiki/systems/event-access]]`-adjacent schema. See `MAX_EVENT_DURATION_HOURS` / `MAYBE_FINISHED_AFTER_HOURS` / `AUTO_CLOSE_NO_END_TIME_HOURS` in `pulse/api/src/lib/limits.ts`.
 
 ## OSN Core
 


### PR DESCRIPTION
## Summary
- When an organiser leaves the end time blank on event creation, show duration presets (1h / 2h / 4h / 8h / All day) plus a hint explaining the no-endTime lifecycle.
- Add a new `maybe_finished` event status. Events without an explicit `endTime` project to `maybe_finished` at 8h past `startTime` (display-only, never persisted) and auto-close to `finished` at 12h. Organisers can close an event manually at any time.
- Enforce a 48h defence-in-depth cap (`MAX_EVENT_DURATION_HOURS`) on create/update for events *with* an explicit `endTime` — returns 422 + `metricEventValidationFailure(op, "duration_exceeds_max")`.
- Closes the `wiki/TODO.md` Pulse item and the matching Deferred Decisions row.

## Workspaces affected
- `@pulse/api` (minor) — new `maybe_finished` in `StatusEnum` + TypeBox + route status filter; `deriveStatus` ladder; defence-in-depth cap; display-only projection in `applyTransition`.
- `@pulse/app` (patch) — duration presets + hint in `CreateEventForm`, `deriveEndFromDuration` helper, status-label rendering in `EventCard` / `ExploreCard` / `EventDetailPage`.
- `@pulse/db` (minor) — `events.status` enum widened (pure TS — no SQL migration; column is plain `text`).
- `@shared/observability` (minor) — `EventStatus` union widened.

## Decisions & issues

**[approach] — `maybe_finished` as a persisted status**
- **Issue:** Initial implementation had the client compute "maybe finished" from `status === "ongoing" && endTime === null && now - startTime > 8h`.
- **Why:** That made the label stale the moment the event was loaded (client clock), fragmented the logic across three display components, and gave no server-side signal that an event was in the grace window.
- **Solution:** Added `maybe_finished` to the status enum across `@pulse/db`, `@shared/observability`, `@pulse/api` (Effect + TypeBox), and removed the `isPotentiallyFinished` client helper in favour of checking `event.status === "maybe_finished"`.
- **Rationale:** Single source of truth, bounded metric attribute union stays at 5 values, and the display layer becomes a straight switch on `status`.

**[P-W1] — `?status=` filter staleness under the new ladder**
- **Issue:** `listEvents` filters on the stored `events.status` column in SQL before `applyTransition` runs. With the new ladder, rows stored as `ongoing` can derive to `maybe_finished` or `finished` on read — meaning `?status=ongoing` can return rows that immediately transition, and `?status=maybe_finished` wouldn't return rows that *should* be maybe_finished.
- **Why:** In principle this is a stale-filter concern. In practice: `maybe_finished` is not a useful consumer filter (you'd just fetch all ongoing-ish events in one query), and the `?status=ongoing` response transitioning some rows on read is acceptable.
- **Solution:** Dismissed — no change.
- **Rationale:** Per reviewer direction, the product-level utility of filtering by `maybe_finished` is low; accepting the mild staleness on `?status=ongoing` keeps the SQL path simple and index-friendly.

**[P-I1] — Double DB write per no-endTime event (fixed)**
- **Issue:** With two auto-transitions (ongoing → maybe_finished at 8h; maybe_finished → finished at 12h), every no-endTime event would fire two `UPDATE events` calls + two `status_transitions` counter increments over its lifecycle.
- **Why:** Doubles the write volume for the no-endTime cohort, bumps `updatedAt` twice, and the persisted `maybe_finished` carries no information that can't be reconstructed from `startTime` + `now`.
- **Solution:** `applyTransition` now skips the DB write (and the transition metric) when the derived status is `maybe_finished`, returning the projection in-memory only. One persisted write (ongoing → finished at 12h) per no-endTime event.
- **Rationale:** `maybe_finished` is a pure function of `startTime` and now — persisting it is redundant. The on-read projection gives the same UX at half the write cost. Test `maybe_finished is display-only — the DB row stays 'ongoing'` pins the invariant.

**[P-I2] — Duplicate comment block in `updateEvent` (fixed)**
- **Issue:** `pulse/api/src/services/events.ts` had the same two-line comment pasted twice above `const updated = { ...existing, ...update }`.
- **Why:** Merge-accident artefact; harmless but confusing.
- **Solution:** Deleted one copy.
- **Rationale:** Keeps the comment authoritative.

**[review-tests T-E1/T-S1/T-S2/T-S3/T-M1] — Coverage gaps (addressed)**
- **Issue:** Review-tests flagged missing assertions for: duration-cap metric emission, `startTime`-only update over cap, happy-edit update at exact cap, explicit past-`endTime` transition, and `deriveEndFromDuration` unit tests.
- **Why:** Metric regression would go silent; the `startTime ?? existing.startTime` "vice versa" branch was unverified; a flipped `>` / `>=` in the update check could pass silently.
- **Solution:** Added `vi.spyOn(metrics, "metricEventValidationFailure")` assertions for both create and update paths; added `updateEvent rejects startTime-only patch that pushes duration over cap`, `updateEvent accepts endTime moved to exactly MAX_EVENT_DURATION_HOURS`, `getEvent finishes events whose explicit endTime has passed`, and `deriveEndFromDuration` unit tests in `pulse/app/tests/utils.test.ts`.
- **Rationale:** Pins the four observability/invariant edges that would otherwise silently regress.

**[security review] — No findings**
- **Issue:** Reviewed organiser-only status patch path, 48h cap bypass surface, `maybe_finished` visibility-gate implications, metric cardinality, and log/error content.
- **Solution:** All four areas verified clean; `PATCH /events/:id { status }` remains organiser-only via the existing `createdByProfileId !== requestingProfileId` check. `endTime: null` is rejected at the TypeBox boundary so clients can't escape the tighter no-endTime ladder by unsetting endTime. No visibility gate branches on `ongoing`.
- **Rationale:** Documented for the record.

## Test plan
- [ ] Open the create-event form with end time empty — verify the "How long will it run?" preset buttons appear (1h / 2h / 4h / 8h / All day) and the "maybe finished after 8h, auto-closed after 12h" hint renders.
- [ ] Click a preset — verify the end-time input populates with the start time + preset hours.
- [ ] Leave end time blank and submit — verify the event is created with status `upcoming`.
- [ ] Create an event with an explicit `endTime` > 48h after `startTime` — verify 422 response.
- [ ] `PATCH` an existing event's `startTime` to a value that makes the effective duration > 48h — verify 422 response.
- [ ] Seed a no-endTime event with `startTime` 9h ago — verify `GET /events/:id` returns `status: "maybe_finished"` and the DB row stays `"ongoing"`.
- [ ] Seed a no-endTime event with `startTime` 13h ago — verify `GET /events/:id` returns `status: "finished"` and the DB row is updated to `"finished"`.
- [ ] As the organiser, `PATCH /events/:id { status: "finished" }` on a `maybe_finished` event — verify status sticks.
- [ ] As a non-organiser, `PATCH /events/:id { status: "finished" }` — verify 403.
- [ ] Visit `/events/:id` and the Explore feed — verify "maybe finished" label renders in muted-foreground style for the 8h–12h window.

https://claude.ai/code/session_01NPzmb48rA6gx2KtraDDApN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPzmb48rA6gx2KtraDDApN)_