### PR TITLE
feat(pulse): optional price + currency on events

### DIFF
--- a/.changeset/pulse-event-price-field.md
+++ b/.changeset/pulse-event-price-field.md
@@ -1,0 +1,11 @@
+---
+"@pulse/db": minor
+"@pulse/api": minor
+"@pulse/app": patch
+---
+
+Add optional `price` to Pulse events.
+
+- `events.price_amount` (integer, nullable, minor units) + `events.price_currency` (text, nullable, ISO 4217) columns.
+- API accepts `priceAmount` in major units (decimal, cap 99999.99) + `priceCurrency` from a curated allowlist (USD, EUR, GBP, CAD, AUD, JPY). Enforced "both set or both null" invariant at the service layer.
+- Create-event form gets a price + currency input; badge shows "Free" when unset or 0, otherwise `Intl.NumberFormat`-formatted value.

--- a/pulse/api/src/lib/currency.ts
+++ b/pulse/api/src/lib/currency.ts
@@ -1,0 +1,52 @@
+/**
+ * Price + currency handling for Pulse events.
+ *
+ * Prices are stored in minor units (cents/pence/yen) as an integer on the
+ * `events.price_amount` column, paired with an ISO 4217 code on
+ * `events.price_currency`. Both must be set or both null — enforced in the
+ * Effect Schema decoder in `services/events.ts`.
+ *
+ * Display rule: `price_amount` null OR 0 → "Free". Otherwise format via
+ * `Intl.NumberFormat` using the currency.
+ */
+
+export const SUPPORTED_CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD", "JPY"] as const;
+
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+const CURRENCY_EXPONENT: Record<SupportedCurrency, number> = {
+  USD: 2,
+  EUR: 2,
+  GBP: 2,
+  CAD: 2,
+  AUD: 2,
+  JPY: 0,
+};
+
+/** Max displayable price in major units — shared cap across all currencies. */
+export const MAX_PRICE_MAJOR = 99999.99;
+
+/** Max storable price in minor units. Derived from MAX_PRICE_MAJOR × 100. */
+export const MAX_PRICE_MINOR = 9_999_999;
+
+export const isSupportedCurrency = (value: unknown): value is SupportedCurrency =>
+  typeof value === "string" && (SUPPORTED_CURRENCIES as readonly string[]).includes(value);
+
+export const currencyExponent = (currency: SupportedCurrency): number =>
+  CURRENCY_EXPONENT[currency];
+
+/**
+ * Convert a major-unit input (e.g. 18.50 USD) to minor units (1850).
+ * Rounds half-up to the currency's exponent to avoid float drift.
+ * Returns null for null, 0, or invalid numbers.
+ */
+export const toMinorUnits = (major: number, currency: SupportedCurrency): number => {
+  const exp = currencyExponent(currency);
+  const scale = 10 ** exp;
+  return Math.round(major * scale);
+};
+
+export const fromMinorUnits = (minor: number, currency: SupportedCurrency): number => {
+  const exp = currencyExponent(currency);
+  return minor / 10 ** exp;
+};

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -3,6 +3,7 @@ import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 import { decodeProtectedHeader, jwtVerify } from "jose";
 
+import { MAX_PRICE_MAJOR } from "../lib/currency";
 import { resolvePublicKeyForKid, refreshPublicKeyForKid } from "../lib/jwks-cache";
 import { MAX_EVENT_GUESTS } from "../lib/limits";
 import {
@@ -37,6 +38,24 @@ const guestListVisibilityEnum = t.Optional(
 const joinPolicyEnum = t.Optional(t.Union([t.Literal("open"), t.Literal("guest_list")]));
 const commsChannelsSchema = t.Optional(
   t.Array(t.Union([t.Literal("sms"), t.Literal("email")]), { minItems: 1, maxItems: 2 }),
+);
+const priceAmountSchema = t.Optional(
+  t.Nullable(t.Number({ minimum: 0, maximum: MAX_PRICE_MAJOR })),
+);
+// Must be a static union of literals so Eden treaty can narrow the
+// client-side body type. Keep in sync with SUPPORTED_CURRENCIES in
+// ../lib/currency.ts.
+const priceCurrencySchema = t.Optional(
+  t.Nullable(
+    t.Union([
+      t.Literal("USD"),
+      t.Literal("EUR"),
+      t.Literal("GBP"),
+      t.Literal("CAD"),
+      t.Literal("AUD"),
+      t.Literal("JPY"),
+    ]),
+  ),
 );
 const rsvpStatusEnum = t.Union([
   t.Literal("going"),
@@ -270,6 +289,8 @@ export const createEventsRoutes = (
             joinPolicy: joinPolicyEnum,
             allowInterested: t.Optional(t.Boolean()),
             commsChannels: commsChannelsSchema,
+            priceAmount: priceAmountSchema,
+            priceCurrency: priceCurrencySchema,
           }),
         },
       )
@@ -331,6 +352,8 @@ export const createEventsRoutes = (
             joinPolicy: joinPolicyEnum,
             allowInterested: t.Optional(t.Boolean()),
             commsChannels: commsChannelsSchema,
+            priceAmount: priceAmountSchema,
+            priceCurrency: priceCurrencySchema,
           }),
         },
       )

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -5,6 +5,12 @@ import { and, eq, gte, lte, or, type SQL } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
 import {
+  MAX_PRICE_MAJOR,
+  SUPPORTED_CURRENCIES,
+  toMinorUnits,
+  type SupportedCurrency,
+} from "../lib/currency";
+import {
   metricEventCreated,
   metricEventDeleted,
   metricEventStatusTransition,
@@ -64,6 +70,31 @@ const LocationString = Schema.String.pipe(Schema.maxLength(500));
 const VenueString = Schema.String.pipe(Schema.maxLength(500));
 const CategoryString = Schema.String.pipe(Schema.maxLength(100));
 
+// Price input is a major-unit decimal (e.g. 18.50 USD). The service
+// converts to minor units before INSERT. Cap at MAX_PRICE_MAJOR shared
+// across all currencies.
+const PriceAmountMajor = Schema.Number.pipe(
+  Schema.between(0, MAX_PRICE_MAJOR, {
+    message: () => `price must be between 0 and ${MAX_PRICE_MAJOR}`,
+  }),
+);
+const CurrencySchema = Schema.Literal(...SUPPORTED_CURRENCIES);
+
+// Enforce "both set or both null" invariant. `undefined` on both is fine
+// (price not being changed); otherwise they must pair up.
+const priceInvariant = <
+  T extends { priceAmount?: number | null; priceCurrency?: SupportedCurrency | null },
+>(
+  s: T,
+): boolean => {
+  const amountProvided = "priceAmount" in s && s.priceAmount !== undefined;
+  const currencyProvided = "priceCurrency" in s && s.priceCurrency !== undefined;
+  if (amountProvided !== currencyProvided) return false;
+  if (!amountProvided) return true;
+  // Both provided — either both null (clear) or both non-null (set).
+  return (s.priceAmount === null) === (s.priceCurrency === null);
+};
+
 const InsertEventSchema = Schema.Struct({
   title: TitleString,
   description: Schema.optional(DescriptionString),
@@ -81,7 +112,13 @@ const InsertEventSchema = Schema.Struct({
   joinPolicy: Schema.optional(JoinPolicyEnum),
   allowInterested: Schema.optional(Schema.Boolean),
   commsChannels: Schema.optional(CommsChannelsSchema),
-});
+  priceAmount: Schema.optional(Schema.NullOr(PriceAmountMajor)),
+  priceCurrency: Schema.optional(Schema.NullOr(CurrencySchema)),
+}).pipe(
+  Schema.filter(priceInvariant, {
+    message: () => "priceAmount and priceCurrency must both be set or both be null",
+  }),
+);
 
 const UpdateEventSchema = Schema.Struct({
   title: Schema.optional(TitleString),
@@ -100,7 +137,13 @@ const UpdateEventSchema = Schema.Struct({
   joinPolicy: Schema.optional(JoinPolicyEnum),
   allowInterested: Schema.optional(Schema.Boolean),
   commsChannels: Schema.optional(CommsChannelsSchema),
-});
+  priceAmount: Schema.optional(Schema.NullOr(PriceAmountMajor)),
+  priceCurrency: Schema.optional(Schema.NullOr(CurrencySchema)),
+}).pipe(
+  Schema.filter(priceInvariant, {
+    message: () => "priceAmount and priceCurrency must both be set or both be null",
+  }),
+);
 
 interface ListEventsParams {
   status?: "upcoming" | "ongoing" | "finished" | "cancelled";
@@ -263,7 +306,13 @@ export const createEvent = (
     // Serialise the commsChannels array to JSON text for the DB column.
     // The schema default is `'["email"]'` so only overwrite when the
     // caller explicitly provided a value.
-    const { commsChannels, ...rest } = validated;
+    const { commsChannels, priceAmount, priceCurrency, ...rest } = validated;
+    const priceFields =
+      priceAmount != null && priceCurrency != null
+        ? { priceAmount: toMinorUnits(priceAmount, priceCurrency), priceCurrency }
+        : priceAmount === null && priceCurrency === null
+          ? { priceAmount: null, priceCurrency: null }
+          : {};
     const row = {
       ...rest,
       ...creator,
@@ -271,6 +320,7 @@ export const createEvent = (
       createdAt: now,
       updatedAt: now,
       ...(commsChannels ? { commsChannels: JSON.stringify(commsChannels) } : {}),
+      ...priceFields,
     };
 
     yield* Effect.tryPromise({
@@ -305,11 +355,18 @@ export const updateEvent = (
     );
 
     const now = new Date();
-    const { commsChannels, ...rest } = validated;
+    const { commsChannels, priceAmount, priceCurrency, ...rest } = validated;
+    const priceFields =
+      priceAmount != null && priceCurrency != null
+        ? { priceAmount: toMinorUnits(priceAmount, priceCurrency), priceCurrency }
+        : priceAmount === null && priceCurrency === null
+          ? { priceAmount: null, priceCurrency: null }
+          : {};
     const update = {
       ...rest,
       updatedAt: now,
       ...(commsChannels ? { commsChannels: JSON.stringify(commsChannels) } : {}),
+      ...priceFields,
     };
     yield* Effect.tryPromise({
       try: () => db.update(events).set(update).where(eq(events.id, id)),

--- a/pulse/api/tests/helpers/db.ts
+++ b/pulse/api/tests/helpers/db.ts
@@ -20,6 +20,8 @@ export function createTestLayer() {
       end_time INTEGER,
       status TEXT NOT NULL DEFAULT 'upcoming',
       image_url TEXT,
+      price_amount INTEGER,
+      price_currency TEXT,
       latitude REAL,
       longitude REAL,
       visibility TEXT NOT NULL DEFAULT 'public',
@@ -92,6 +94,8 @@ export interface SeedEventInput {
   allowInterested?: boolean;
   commsChannels?: ("sms" | "email")[];
   chatId?: string;
+  priceAmount?: number | null;
+  priceCurrency?: string | null;
 }
 
 export const seedEvent = (input: SeedEventInput): Effect.Effect<Event, never, Db> =>
@@ -112,6 +116,8 @@ export const seedEvent = (input: SeedEventInput): Effect.Effect<Event, never, Db
       endTime: input.endTime ? new Date(input.endTime) : null,
       status: input.status ?? "upcoming",
       imageUrl: null,
+      priceAmount: input.priceAmount ?? null,
+      priceCurrency: input.priceCurrency ?? null,
       visibility: input.visibility ?? "public",
       guestListVisibility: input.guestListVisibility ?? "public",
       joinPolicy: input.joinPolicy ?? "open",

--- a/pulse/api/tests/lib/currency.test.ts
+++ b/pulse/api/tests/lib/currency.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MAX_PRICE_MAJOR,
+  MAX_PRICE_MINOR,
+  SUPPORTED_CURRENCIES,
+  currencyExponent,
+  fromMinorUnits,
+  isSupportedCurrency,
+  toMinorUnits,
+} from "../../src/lib/currency";
+
+describe("toMinorUnits", () => {
+  it("converts USD decimals to cents (integer)", () => {
+    expect(toMinorUnits(18.5, "USD")).toBe(1850);
+  });
+
+  it("converts USD whole numbers to cents", () => {
+    expect(toMinorUnits(10, "USD")).toBe(1000);
+  });
+
+  it("treats JPY as zero-exponent (major === minor)", () => {
+    expect(toMinorUnits(500, "JPY")).toBe(500);
+  });
+
+  it("rounds half-up on USD sub-cent input", () => {
+    expect(toMinorUnits(18.505, "USD")).toBe(1851);
+  });
+
+  it("rounds half-down correctly", () => {
+    expect(toMinorUnits(18.504, "USD")).toBe(1850);
+  });
+
+  it("handles 0", () => {
+    expect(toMinorUnits(0, "USD")).toBe(0);
+  });
+});
+
+describe("fromMinorUnits", () => {
+  it("converts USD cents to decimal", () => {
+    expect(fromMinorUnits(1850, "USD")).toBe(18.5);
+  });
+
+  it("treats JPY as zero-exponent (minor === major)", () => {
+    expect(fromMinorUnits(500, "JPY")).toBe(500);
+  });
+
+  it("round-trips through toMinorUnits / fromMinorUnits for USD", () => {
+    expect(fromMinorUnits(toMinorUnits(18.5, "USD"), "USD")).toBe(18.5);
+  });
+
+  it("round-trips through toMinorUnits / fromMinorUnits for JPY", () => {
+    expect(fromMinorUnits(toMinorUnits(500, "JPY"), "JPY")).toBe(500);
+  });
+});
+
+describe("currencyExponent", () => {
+  it("returns 2 for USD/EUR/GBP/CAD/AUD", () => {
+    expect(currencyExponent("USD")).toBe(2);
+    expect(currencyExponent("EUR")).toBe(2);
+    expect(currencyExponent("GBP")).toBe(2);
+    expect(currencyExponent("CAD")).toBe(2);
+    expect(currencyExponent("AUD")).toBe(2);
+  });
+
+  it("returns 0 for JPY", () => {
+    expect(currencyExponent("JPY")).toBe(0);
+  });
+});
+
+describe("isSupportedCurrency", () => {
+  it("accepts every code in SUPPORTED_CURRENCIES", () => {
+    for (const c of SUPPORTED_CURRENCIES) {
+      expect(isSupportedCurrency(c)).toBe(true);
+    }
+  });
+
+  it("is case-sensitive (lowercase rejected)", () => {
+    expect(isSupportedCurrency("usd")).toBe(false);
+  });
+
+  it("rejects unknown codes", () => {
+    expect(isSupportedCurrency("XYZ")).toBe(false);
+  });
+
+  it("rejects non-strings", () => {
+    expect(isSupportedCurrency(null)).toBe(false);
+    expect(isSupportedCurrency(undefined)).toBe(false);
+    expect(isSupportedCurrency(123)).toBe(false);
+    expect(isSupportedCurrency({})).toBe(false);
+  });
+});
+
+describe("price caps", () => {
+  it("MAX_PRICE_MAJOR × 100 === MAX_PRICE_MINOR (USD assumption)", () => {
+    expect(MAX_PRICE_MAJOR * 100).toBe(MAX_PRICE_MINOR);
+  });
+
+  it("cap converted via toMinorUnits stays within MAX_PRICE_MINOR", () => {
+    expect(toMinorUnits(MAX_PRICE_MAJOR, "USD")).toBe(MAX_PRICE_MINOR);
+  });
+});

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -147,6 +147,88 @@ describe("events routes", () => {
     expect(body.event.imageUrl).toBe("https://example.com/image.jpg");
   });
 
+  it("POST /events stores price as minor units", async () => {
+    const res = await post(
+      app,
+      "/events",
+      {
+        title: "Paid event",
+        startTime: FUTURE,
+        priceAmount: 18.5,
+        priceCurrency: "USD",
+      },
+      aliceToken,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      event: { priceAmount: number | null; priceCurrency: string | null };
+    };
+    expect(body.event.priceAmount).toBe(1850);
+    expect(body.event.priceCurrency).toBe("USD");
+  });
+
+  it("POST /events returns null price fields when omitted", async () => {
+    const res = await post(app, "/events", { title: "Free event", startTime: FUTURE }, aliceToken);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      event: { priceAmount: number | null; priceCurrency: string | null };
+    };
+    expect(body.event.priceAmount).toBeNull();
+    expect(body.event.priceCurrency).toBeNull();
+  });
+
+  it("POST /events returns 422 for priceAmount > 99999.99", async () => {
+    const res = await post(
+      app,
+      "/events",
+      {
+        title: "Too pricey",
+        startTime: FUTURE,
+        priceAmount: 100000,
+        priceCurrency: "USD",
+      },
+      aliceToken,
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("POST /events returns 422 for unsupported currency", async () => {
+    const res = await post(
+      app,
+      "/events",
+      {
+        title: "Bad ccy",
+        startTime: FUTURE,
+        priceAmount: 10,
+        priceCurrency: "XYZ",
+      },
+      aliceToken,
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("PATCH /events/:id clears price when both fields null", async () => {
+    const createRes = await post(
+      app,
+      "/events",
+      { title: "Paid", startTime: FUTURE, priceAmount: 10, priceCurrency: "USD" },
+      aliceToken,
+    );
+    const { event } = (await createRes.json()) as { event: { id: string } };
+    const res = await patch(
+      app,
+      `/events/${event.id}`,
+      { priceAmount: null, priceCurrency: null },
+      aliceToken,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      event: { priceAmount: number | null; priceCurrency: string | null };
+    };
+    expect(body.event.priceAmount).toBeNull();
+    expect(body.event.priceCurrency).toBeNull();
+  });
+
   it("PATCH /events/:id updates event and returns 200", async () => {
     const createRes = await post(
       app,

--- a/pulse/api/tests/services/calendar.test.ts
+++ b/pulse/api/tests/services/calendar.test.ts
@@ -17,6 +17,8 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     endTime: null,
     status: "upcoming",
     imageUrl: null,
+    priceAmount: null,
+    priceCurrency: null,
     visibility: "public",
     guestListVisibility: "public",
     joinPolicy: "open",

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -480,3 +480,125 @@ it.effect("listEvents shows private events to their own creator", () =>
     }),
   ),
 );
+
+// ---------------------------------------------------------------------------
+// Price fields
+// ---------------------------------------------------------------------------
+
+it.effect("createEvent stores price as minor units (USD 18.50 → 1850)", () =>
+  provide(
+    Effect.gen(function* () {
+      const event = yield* createEvent(
+        { title: "Paid", startTime: FUTURE, priceAmount: 18.5, priceCurrency: "USD" },
+        ALICE,
+      );
+      expect(event.priceAmount).toBe(1850);
+      expect(event.priceCurrency).toBe("USD");
+    }),
+  ),
+);
+
+it.effect("createEvent stores JPY as minor units at 0 exponent (¥500 → 500)", () =>
+  provide(
+    Effect.gen(function* () {
+      const event = yield* createEvent(
+        { title: "Yen", startTime: FUTURE, priceAmount: 500, priceCurrency: "JPY" },
+        ALICE,
+      );
+      expect(event.priceAmount).toBe(500);
+      expect(event.priceCurrency).toBe("JPY");
+    }),
+  ),
+);
+
+it.effect("createEvent leaves price null when omitted", () =>
+  provide(
+    Effect.gen(function* () {
+      const event = yield* createEvent({ title: "Free", startTime: FUTURE }, ALICE);
+      expect(event.priceAmount).toBeNull();
+      expect(event.priceCurrency).toBeNull();
+    }),
+  ),
+);
+
+it.effect("createEvent rejects priceAmount > 99999.99", () =>
+  provide(
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        createEvent(
+          { title: "Too pricey", startTime: FUTURE, priceAmount: 100000, priceCurrency: "USD" },
+          ALICE,
+        ),
+      );
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("createEvent rejects priceAmount without priceCurrency", () =>
+  provide(
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        createEvent({ title: "Dangling price", startTime: FUTURE, priceAmount: 10 }, ALICE),
+      );
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("createEvent rejects priceCurrency without priceAmount", () =>
+  provide(
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        createEvent({ title: "Dangling currency", startTime: FUTURE, priceCurrency: "USD" }, ALICE),
+      );
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("createEvent rejects unsupported currency", () =>
+  provide(
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        createEvent(
+          { title: "Bad ccy", startTime: FUTURE, priceAmount: 10, priceCurrency: "XYZ" },
+          ALICE,
+        ),
+      );
+      expect(error._tag).toBe("ValidationError");
+    }),
+  ),
+);
+
+it.effect("updateEvent clears price when both fields set to null", () =>
+  provide(
+    Effect.gen(function* () {
+      const created = yield* createEvent(
+        { title: "Paid", startTime: FUTURE, priceAmount: 10, priceCurrency: "USD" },
+        ALICE,
+      );
+      const updated = yield* updateEvent(
+        created.id,
+        { priceAmount: null, priceCurrency: null },
+        "usr_alice",
+      );
+      expect(updated.priceAmount).toBeNull();
+      expect(updated.priceCurrency).toBeNull();
+    }),
+  ),
+);
+
+it.effect("updateEvent leaves price unchanged when fields omitted", () =>
+  provide(
+    Effect.gen(function* () {
+      const created = yield* createEvent(
+        { title: "Paid", startTime: FUTURE, priceAmount: 10, priceCurrency: "USD" },
+        ALICE,
+      );
+      const updated = yield* updateEvent(created.id, { title: "Still paid" }, "usr_alice");
+      expect(updated.priceAmount).toBe(1000);
+      expect(updated.priceCurrency).toBe("USD");
+    }),
+  ),
+);

--- a/pulse/api/tests/services/zapBridge.test.ts
+++ b/pulse/api/tests/services/zapBridge.test.ts
@@ -28,6 +28,8 @@ function createDualTestLayer() {
       end_time INTEGER,
       status TEXT NOT NULL DEFAULT 'upcoming',
       image_url TEXT,
+      price_amount INTEGER,
+      price_currency TEXT,
       latitude REAL,
       longitude REAL,
       visibility TEXT NOT NULL DEFAULT 'public',

--- a/pulse/app/src/components/CreateEventForm.tsx
+++ b/pulse/app/src/components/CreateEventForm.tsx
@@ -9,6 +9,7 @@ import { createSignal, createMemo, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { api } from "../lib/api";
+import { formatPrice } from "../lib/formatPrice";
 import { LocationInput } from "../lib/LocationInput";
 import { toDatetimeLocal, isEndBeforeOrAtStart } from "../lib/utils";
 import { InfoPopover } from "./InfoPopover";
@@ -17,6 +18,10 @@ type Visibility = "public" | "private";
 type GuestListVisibility = "public" | "connections" | "private";
 type JoinPolicy = "open" | "guest_list";
 type CommsChannel = "sms" | "email";
+
+const CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD", "JPY"] as const;
+type Currency = (typeof CURRENCIES)[number];
+const MAX_PRICE_MAJOR = 99999.99;
 
 export function CreateEventForm(props: {
   accessToken: string | null;
@@ -35,7 +40,30 @@ export function CreateEventForm(props: {
   const [joinPolicy, setJoinPolicy] = createSignal<JoinPolicy>("open");
   const [allowInterested, setAllowInterested] = createSignal(true);
   const [commsChannels, setCommsChannels] = createSignal<Set<CommsChannel>>(new Set(["email"]));
+  const [priceInput, setPriceInput] = createSignal("");
+  const [priceCurrency, setPriceCurrency] = createSignal<Currency>("USD");
   const [submitting, setSubmitting] = createSignal(false);
+
+  const parsedPrice = createMemo(() => {
+    const raw = priceInput().trim();
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : NaN;
+  });
+  const priceError = createMemo(() => {
+    const p = parsedPrice();
+    if (p === null) return "";
+    if (Number.isNaN(p)) return "Enter a valid number";
+    if (p < 0) return "Price cannot be negative";
+    if (p > MAX_PRICE_MAJOR) return `Max price is ${MAX_PRICE_MAJOR}`;
+    return "";
+  });
+  const pricePreview = createMemo(() => {
+    const p = parsedPrice();
+    if (p === null || Number.isNaN(p) || p === 0) return "Free";
+    const exp = priceCurrency() === "JPY" ? 0 : 2;
+    return formatPrice(Math.round(p * 10 ** exp), priceCurrency());
+  });
 
   const endTimeError = createMemo(() =>
     isEndBeforeOrAtStart(startTime(), endTime()) ? "End time must be after start time" : "",
@@ -55,11 +83,13 @@ export function CreateEventForm(props: {
 
   async function handleSubmit(e: SubmitEvent) {
     e.preventDefault();
-    if (endTimeError() || commsError()) return;
+    if (endTimeError() || commsError() || priceError()) return;
     setSubmitting(true);
     try {
       const headers: Record<string, string> = {};
       if (props.accessToken) headers["Authorization"] = `Bearer ${props.accessToken}`;
+      const p = parsedPrice();
+      const includePrice = p !== null && !Number.isNaN(p) && p > 0;
       const { error } = await api.events.post(
         {
           title: title(),
@@ -74,6 +104,8 @@ export function CreateEventForm(props: {
           joinPolicy: joinPolicy(),
           allowInterested: allowInterested(),
           commsChannels: Array.from(commsChannels()),
+          priceAmount: includePrice ? p : undefined,
+          priceCurrency: includePrice ? priceCurrency() : undefined,
         },
         { headers },
       );
@@ -159,6 +191,45 @@ export function CreateEventForm(props: {
             onInput={(e) => setDescription(e.currentTarget.value)}
             class="resize-none"
           />
+        </div>
+
+        {/* Price */}
+        <div class="flex flex-col gap-1">
+          <div class="flex items-center">
+            <Label for="priceAmount">Price</Label>
+            <InfoPopover
+              label="About event price"
+              body="Optional. Leave blank (or 0) for free events. Shown as a badge on the event card."
+            />
+          </div>
+          <div class="flex gap-2">
+            <Input
+              id="priceAmount"
+              type="number"
+              inputmode="decimal"
+              min={0}
+              max={MAX_PRICE_MAJOR}
+              step={priceCurrency() === "JPY" ? 1 : 0.01}
+              placeholder="0"
+              value={priceInput()}
+              onInput={(e) => setPriceInput(e.currentTarget.value)}
+              class={priceError() ? "border-destructive flex-1" : "flex-1"}
+            />
+            <select
+              aria-label="Currency"
+              class="border-input bg-background rounded-md border px-2 text-sm"
+              value={priceCurrency()}
+              onChange={(e) => setPriceCurrency(e.currentTarget.value as Currency)}
+            >
+              {CURRENCIES.map((c) => (
+                <option value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+          <p class="text-muted-foreground text-xs">Preview: {pricePreview()}</p>
+          <Show when={priceError()}>
+            {(err) => <p class="text-destructive text-xs">{err()}</p>}
+          </Show>
         </div>
 
         {/* Event visibility */}

--- a/pulse/app/src/components/EventCard.tsx
+++ b/pulse/app/src/components/EventCard.tsx
@@ -4,6 +4,7 @@ import { Card } from "@osn/ui/ui/card";
 import { A } from "@solidjs/router";
 import { Show } from "solid-js";
 
+import { formatPrice } from "../lib/formatPrice";
 import type { EventItem } from "../lib/types";
 import { formatTime } from "../lib/utils";
 
@@ -55,6 +56,9 @@ export function EventCard(props: {
                 {props.event.category}
               </Badge>
             </Show>
+            <Badge variant="outline">
+              {formatPrice(props.event.priceAmount, props.event.priceCurrency)}
+            </Badge>
             <span
               class={`text-xs ${props.event.status === "ongoing" ? "font-semibold text-green-600" : props.event.status === "cancelled" ? "text-destructive" : "text-muted-foreground"}`}
             >

--- a/pulse/app/src/lib/formatPrice.ts
+++ b/pulse/app/src/lib/formatPrice.ts
@@ -18,6 +18,29 @@ const EXPONENT: Record<string, number> = {
   JPY: 0,
 };
 
+// P-I1: cache formatters instead of reconstructing on every call. With
+// ~6 currencies × a small number of locales this caps at a handful of
+// entries; keeps the helper cheap on long feeds.
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(
+  locale: string | undefined,
+  currency: string,
+  exp: number,
+): Intl.NumberFormat {
+  const key = `${locale ?? ""}|${currency}|${exp}`;
+  const cached = formatterCache.get(key);
+  if (cached) return cached;
+  const fmt = new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: exp,
+    maximumFractionDigits: exp,
+  });
+  formatterCache.set(key, fmt);
+  return fmt;
+}
+
 export function formatPrice(
   amount: number | null | undefined,
   currency: string | null | undefined,
@@ -27,12 +50,7 @@ export function formatPrice(
   const exp = EXPONENT[currency] ?? 2;
   const major = amount / 10 ** exp;
   try {
-    return new Intl.NumberFormat(locale, {
-      style: "currency",
-      currency,
-      minimumFractionDigits: exp,
-      maximumFractionDigits: exp,
-    }).format(major);
+    return getFormatter(locale, currency, exp).format(major);
   } catch {
     return `${currency} ${major.toFixed(exp)}`;
   }

--- a/pulse/app/src/lib/formatPrice.ts
+++ b/pulse/app/src/lib/formatPrice.ts
@@ -1,0 +1,39 @@
+/**
+ * Format an event price for display.
+ *
+ * Events store price in minor units (cents/pence/yen). Free events have
+ * both fields null. The rule: null OR 0 → "Free". Otherwise format via
+ * Intl with the stored ISO currency.
+ *
+ * Kept deliberately permissive on the currency arg — the API restricts
+ * to the SUPPORTED_CURRENCIES allowlist, but this helper accepts any
+ * string so legacy / future codes don't crash the UI.
+ */
+const EXPONENT: Record<string, number> = {
+  USD: 2,
+  EUR: 2,
+  GBP: 2,
+  CAD: 2,
+  AUD: 2,
+  JPY: 0,
+};
+
+export function formatPrice(
+  amount: number | null | undefined,
+  currency: string | null | undefined,
+  locale?: string,
+): string {
+  if (amount == null || amount === 0 || !currency) return "Free";
+  const exp = EXPONENT[currency] ?? 2;
+  const major = amount / 10 ** exp;
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: exp,
+      maximumFractionDigits: exp,
+    }).format(major);
+  } catch {
+    return `${currency} ${major.toFixed(exp)}`;
+  }
+}

--- a/pulse/app/src/pages/EventDetailPage.tsx
+++ b/pulse/app/src/pages/EventDetailPage.tsx
@@ -10,6 +10,7 @@ import { EventChatPlaceholder } from "../components/EventChatPlaceholder";
 import { MapPreview } from "../components/MapPreview";
 import { RsvpSection } from "../components/RsvpSection";
 import { api } from "../lib/api";
+import { formatPrice } from "../lib/formatPrice";
 import { apiBaseUrl } from "../lib/rsvps";
 import { formatTime, getProfileIdFromToken } from "../lib/utils";
 
@@ -30,6 +31,8 @@ interface EventDetail {
   guestListVisibility: "public" | "connections" | "private";
   joinPolicy: "open" | "guest_list";
   allowInterested: boolean;
+  priceAmount: number | null;
+  priceCurrency: string | null;
   createdByProfileId: string;
   createdByName: string | null;
 }
@@ -84,6 +87,7 @@ export function EventDetailPage() {
                       {e().category}
                     </Badge>
                   </Show>
+                  <Badge variant="outline">{formatPrice(e().priceAmount, e().priceCurrency)}</Badge>
                   <span
                     class={`text-xs ${
                       e().status === "ongoing"

--- a/pulse/app/tests/components/CreateEventForm.test.tsx
+++ b/pulse/app/tests/components/CreateEventForm.test.tsx
@@ -240,6 +240,66 @@ describe("CreateEventForm", () => {
     expect(body.commsChannels).toEqual(expect.arrayContaining(["email", "sms"]));
   });
 
+  it("price blank → submit omits priceAmount/priceCurrency", async () => {
+    mockPost.mockResolvedValue({ error: null });
+    const { getByLabelText, getByText } = render(() => (
+      <CreateEventForm accessToken={null} onSuccess={() => {}} onCancel={() => {}} />
+    ));
+    fireEvent.input(getByLabelText("Title"), { target: { value: "Event" } });
+    fireEvent.input(getByLabelText("Start time"), { target: { value: "2030-06-01T10:00" } });
+    fireEvent.submit(getByText("Create").closest("form")!);
+    await Promise.resolve();
+    await Promise.resolve();
+    const [body] = mockPost.mock.calls[0] as [Record<string, unknown>];
+    expect(body.priceAmount).toBeUndefined();
+    expect(body.priceCurrency).toBeUndefined();
+  });
+
+  it("price 0 → submit omits priceAmount/priceCurrency (free)", async () => {
+    mockPost.mockResolvedValue({ error: null });
+    const { getByLabelText, getByText } = render(() => (
+      <CreateEventForm accessToken={null} onSuccess={() => {}} onCancel={() => {}} />
+    ));
+    fireEvent.input(getByLabelText("Title"), { target: { value: "Event" } });
+    fireEvent.input(getByLabelText("Start time"), { target: { value: "2030-06-01T10:00" } });
+    fireEvent.input(getByLabelText("Price"), { target: { value: "0" } });
+    fireEvent.submit(getByText("Create").closest("form")!);
+    await Promise.resolve();
+    await Promise.resolve();
+    const [body] = mockPost.mock.calls[0] as [Record<string, unknown>];
+    expect(body.priceAmount).toBeUndefined();
+    expect(body.priceCurrency).toBeUndefined();
+  });
+
+  it("price 18.50 + default currency → submit includes priceAmount + priceCurrency", async () => {
+    mockPost.mockResolvedValue({ error: null });
+    const { getByLabelText, getByText } = render(() => (
+      <CreateEventForm accessToken={null} onSuccess={() => {}} onCancel={() => {}} />
+    ));
+    fireEvent.input(getByLabelText("Title"), { target: { value: "Event" } });
+    fireEvent.input(getByLabelText("Start time"), { target: { value: "2030-06-01T10:00" } });
+    fireEvent.input(getByLabelText("Price"), { target: { value: "18.50" } });
+    fireEvent.submit(getByText("Create").closest("form")!);
+    await Promise.resolve();
+    await Promise.resolve();
+    const [body] = mockPost.mock.calls[0] as [Record<string, unknown>];
+    expect(body.priceAmount).toBe(18.5);
+    expect(body.priceCurrency).toBe("USD");
+  });
+
+  it("price > 99999.99 → validation error shown, does NOT call api.events.post", async () => {
+    const { getByLabelText, getByText, queryByText } = render(() => (
+      <CreateEventForm accessToken={null} onSuccess={() => {}} onCancel={() => {}} />
+    ));
+    fireEvent.input(getByLabelText("Title"), { target: { value: "Event" } });
+    fireEvent.input(getByLabelText("Start time"), { target: { value: "2030-06-01T10:00" } });
+    fireEvent.input(getByLabelText("Price"), { target: { value: "100000" } });
+    expect(queryByText(/Max price/)).toBeTruthy();
+    fireEvent.submit(getByText("Create").closest("form")!);
+    await Promise.resolve();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
   it("button shows 'Creating…' while mockPost is pending", async () => {
     // Never-resolving promise
     mockPost.mockReturnValue(new Promise(() => {}));

--- a/pulse/app/tests/components/EventCard.test.tsx
+++ b/pulse/app/tests/components/EventCard.test.tsx
@@ -249,4 +249,46 @@ describe("EventCard", () => {
     fireEvent.click(getByText("Deleting…"));
     expect(onDelete).not.toHaveBeenCalled();
   });
+
+  it("renders 'Free' badge when priceAmount is null", () => {
+    const { getByText } = render(() => (
+      <EventCard
+        event={{ ...mockEvent, priceAmount: null, priceCurrency: null }}
+        onDelete={() => {}}
+      />
+    ));
+    expect(getByText("Free")).toBeTruthy();
+  });
+
+  it("renders 'Free' badge when priceAmount is 0", () => {
+    const { getByText } = render(() => (
+      <EventCard
+        event={{ ...mockEvent, priceAmount: 0, priceCurrency: "USD" }}
+        onDelete={() => {}}
+      />
+    ));
+    expect(getByText("Free")).toBeTruthy();
+  });
+
+  it("renders formatted USD price from minor units", () => {
+    const { getByText } = render(() => (
+      <EventCard
+        event={{ ...mockEvent, priceAmount: 1850, priceCurrency: "USD" }}
+        onDelete={() => {}}
+      />
+    ));
+    // Intl output varies by locale but USD always uses the $ glyph + 18.50
+    const badge = getByText(/\$18\.50/);
+    expect(badge).toBeTruthy();
+  });
+
+  it("renders JPY as zero-decimal", () => {
+    const { getByText } = render(() => (
+      <EventCard
+        event={{ ...mockEvent, priceAmount: 500, priceCurrency: "JPY" }}
+        onDelete={() => {}}
+      />
+    ));
+    expect(getByText(/500/)).toBeTruthy();
+  });
 });

--- a/pulse/app/tests/lib/formatPrice.test.ts
+++ b/pulse/app/tests/lib/formatPrice.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+
+import { formatPrice } from "../../src/lib/formatPrice";
+
+describe("formatPrice", () => {
+  it("returns 'Free' when amount is null", () => {
+    expect(formatPrice(null, "USD")).toBe("Free");
+  });
+
+  it("returns 'Free' when amount is undefined", () => {
+    expect(formatPrice(undefined, "USD")).toBe("Free");
+  });
+
+  it("returns 'Free' when amount is 0 (explicit free marker)", () => {
+    expect(formatPrice(0, "USD")).toBe("Free");
+  });
+
+  it("returns 'Free' when currency is null", () => {
+    expect(formatPrice(1850, null)).toBe("Free");
+  });
+
+  it("returns 'Free' when currency is undefined", () => {
+    expect(formatPrice(1850, undefined)).toBe("Free");
+  });
+
+  it("formats USD minor units with 2 decimal places", () => {
+    expect(formatPrice(1850, "USD", "en-US")).toBe("$18.50");
+  });
+
+  it("formats JPY as zero-decimal", () => {
+    // Intl uses a narrow no-break space (U+00A0) between symbol and digits for
+    // JPY in en-US — match permissively on the number + symbol.
+    const out = formatPrice(500, "JPY", "en-US");
+    expect(out).toMatch(/500/);
+    expect(out).toMatch(/¥/);
+    expect(out).not.toMatch(/500\./); // no decimals for JPY
+  });
+
+  it("formats GBP with pound symbol", () => {
+    expect(formatPrice(1500, "GBP", "en-GB")).toBe("£15.00");
+  });
+
+  it("uses 2dp exponent for unknown currencies (defensive fallback)", () => {
+    // "ZZZ" is a real ISO-4217 reserved code accepted by Intl. The helper's
+    // EXPONENT table doesn't list it, so it should fall back to 2dp.
+    const out = formatPrice(1000, "ZZZ", "en-US");
+    // Either Intl renders it (with the code as the symbol) or the catch
+    // block fires — both produce "10.00" in the string.
+    expect(out).toMatch(/10\.00/);
+  });
+
+  it("falls back to '<currency> <major>' when Intl throws", () => {
+    // "XX" is <3 chars and guaranteed to throw in Intl.NumberFormat.
+    expect(formatPrice(1850, "XX")).toBe("XX 18.50");
+  });
+});

--- a/pulse/app/tests/lib/formatPrice.test.ts
+++ b/pulse/app/tests/lib/formatPrice.test.ts
@@ -54,4 +54,13 @@ describe("formatPrice", () => {
     // "XX" is <3 chars and guaranteed to throw in Intl.NumberFormat.
     expect(formatPrice(1850, "XX")).toBe("XX 18.50");
   });
+
+  it("returns stable output across repeated calls (formatter cache)", () => {
+    const a = formatPrice(1850, "USD", "en-US");
+    const b = formatPrice(1850, "USD", "en-US");
+    const c = formatPrice(2500, "USD", "en-US");
+    expect(a).toBe(b);
+    expect(a).toBe("$18.50");
+    expect(c).toBe("$25.00");
+  });
 });

--- a/pulse/app/tests/pages/EventDetailPage.test.tsx
+++ b/pulse/app/tests/pages/EventDetailPage.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { cleanup, render as _baseRender, waitFor } from "@solidjs/testing-library";
+import type { JSX } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { wrapRouter } from "../helpers/router";
+
+// Stable params for every render — the page uses `useParams<{id}>()`.
+// `wrapRouter` mounts a MemoryRouter that doesn't drive a specific path,
+// so we mock @solidjs/router here to inject the event id.
+vi.mock("@solidjs/router", async () => {
+  const actual = await vi.importActual<typeof import("@solidjs/router")>("@solidjs/router");
+  return { ...actual, useParams: () => ({ id: "evt_1" }) };
+});
+
+vi.mock("@osn/client/solid", () => ({
+  useAuth: () => ({ session: () => null, profiles: () => null, createProfile: vi.fn() }),
+}));
+
+// Sub-components pulled in by the page — stub them to simple markers so
+// the test focuses on the header card + price badge.
+vi.mock("../../src/components/AddToCalendarButton", () => ({
+  AddToCalendarButton: () => <div data-testid="cal-stub" />,
+}));
+vi.mock("../../src/components/CommsSummary", () => ({
+  CommsSummary: () => <div data-testid="comms-stub" />,
+}));
+vi.mock("../../src/components/EventChatPlaceholder", () => ({
+  EventChatPlaceholder: () => <div data-testid="chat-stub" />,
+}));
+vi.mock("../../src/components/MapPreview", () => ({
+  MapPreview: () => <div data-testid="map-stub" />,
+}));
+vi.mock("../../src/components/RsvpSection", () => ({
+  RsvpSection: () => <div data-testid="rsvp-stub" />,
+}));
+vi.mock("../../src/lib/rsvps", () => ({ apiBaseUrl: "http://localhost:3001" }));
+
+type EventShape = {
+  id: string;
+  title: string;
+  status: "upcoming" | "ongoing" | "finished" | "cancelled";
+  startTime: string;
+  priceAmount: number | null;
+  priceCurrency: string | null;
+  visibility?: "public" | "private";
+  category?: string | null;
+};
+
+const mockGet = vi.fn();
+vi.mock("../../src/lib/api", () => ({
+  api: {
+    events: (_params: { id: string }) => ({
+      get: (...args: unknown[]) => mockGet(...args),
+    }),
+  },
+}));
+
+import { EventDetailPage } from "../../src/pages/EventDetailPage";
+
+const render: typeof _baseRender = ((factory: () => JSX.Element) =>
+  _baseRender(wrapRouter(factory))) as unknown as typeof _baseRender;
+
+function makeEvent(overrides: Partial<EventShape>): EventShape {
+  return {
+    id: "evt_1",
+    title: "Event",
+    status: "upcoming",
+    startTime: "2030-06-01T10:00:00.000Z",
+    priceAmount: null,
+    priceCurrency: null,
+    ...overrides,
+  };
+}
+
+describe("EventDetailPage price badge", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders 'Free' when priceAmount is null", async () => {
+    mockGet.mockResolvedValue({
+      data: { event: makeEvent({ priceAmount: null, priceCurrency: null }) },
+      error: null,
+    });
+    const { findByText } = render(() => <EventDetailPage />);
+    expect(await findByText("Free")).toBeTruthy();
+  });
+
+  it("renders 'Free' when priceAmount is 0", async () => {
+    mockGet.mockResolvedValue({
+      data: { event: makeEvent({ priceAmount: 0, priceCurrency: "USD" }) },
+      error: null,
+    });
+    const { findByText } = render(() => <EventDetailPage />);
+    expect(await findByText("Free")).toBeTruthy();
+  });
+
+  it("renders formatted USD price from minor units", async () => {
+    mockGet.mockResolvedValue({
+      data: { event: makeEvent({ priceAmount: 1850, priceCurrency: "USD" }) },
+      error: null,
+    });
+    const { findByText } = render(() => <EventDetailPage />);
+    expect(await findByText(/\$18\.50/)).toBeTruthy();
+  });
+
+  it("shows 'Event not found' when API returns error", async () => {
+    mockGet.mockResolvedValue({ data: null, error: new Error("fail") });
+    const { findByText } = render(() => <EventDetailPage />);
+    await waitFor(() => {
+      expect(findByText(/Event not found/)).toBeTruthy();
+    });
+  });
+});

--- a/pulse/db/src/schema/events.ts
+++ b/pulse/db/src/schema/events.ts
@@ -17,6 +17,12 @@ export const events = sqliteTable(
       .notNull()
       .default("upcoming"),
     imageUrl: text("image_url"),
+    // ── Price ─────────────────────────────────────────────────────────────
+    // Stored in minor units (cents/pence/etc.) so "$18.50" = 1850. Use a
+    // currency-aware formatter at display time. Both columns set or both
+    // null — enforced at the service layer. null OR 0 → "Free".
+    priceAmount: integer("price_amount"),
+    priceCurrency: text("price_currency"),
     // ── Discovery ─────────────────────────────────────────────────────────
     // "public"  → surfaces in discovery / algorithm feeds
     // "private" → only reachable via direct link or invite

--- a/pulse/db/src/seed.ts
+++ b/pulse/db/src/seed.ts
@@ -82,6 +82,8 @@ export function buildSeedEvents(now: Date): NewEvent[] {
       startTime: d(-3),
       endTime: new Date(dMs(-3) + 3 * 3_600_000),
       status: "finished",
+      priceAmount: 1800,
+      priceCurrency: "USD",
     }),
     evt("evt_seed_finished2", U.omar, {
       title: "Vintage Vinyl Swap Meet",
@@ -158,6 +160,8 @@ export function buildSeedEvents(now: Date): NewEvent[] {
       startTime: d(2),
       endTime: new Date(dMs(2) + 3 * 3_600_000),
       status: "upcoming",
+      priceAmount: 2500,
+      priceCurrency: "USD",
     }),
     evt("evt_seed_upcoming2", U.bob, {
       title: "Community 5K Run",
@@ -182,6 +186,8 @@ export function buildSeedEvents(now: Date): NewEvent[] {
       startTime: d(8),
       endTime: new Date(dMs(8) + 4 * 3_600_000),
       status: "upcoming",
+      priceAmount: 1500,
+      priceCurrency: "USD",
     }),
     evt("evt_seed_upcoming4", U.bob, {
       title: "Photography Walk – Street Portraits",
@@ -207,6 +213,8 @@ export function buildSeedEvents(now: Date): NewEvent[] {
       startTime: d(18),
       endTime: new Date(dMs(18) + 2.5 * 3_600_000),
       status: "upcoming",
+      priceAmount: 1200,
+      priceCurrency: "USD",
     }),
     evt("evt_seed_upcoming6", U.charlie, {
       title: "Board Game Night",
@@ -255,6 +263,8 @@ export function buildSeedEvents(now: Date): NewEvent[] {
       startTime: d(7),
       endTime: new Date(dMs(7) + 5 * 3_600_000),
       status: "upcoming",
+      priceAmount: 3500,
+      priceCurrency: "USD",
     }),
   ];
 }

--- a/pulse/db/tests/schema.test.ts
+++ b/pulse/db/tests/schema.test.ts
@@ -20,6 +20,8 @@ function createTestDb() {
       end_time INTEGER,
       status TEXT NOT NULL DEFAULT 'upcoming',
       image_url TEXT,
+      price_amount INTEGER,
+      price_currency TEXT,
       latitude REAL,
       longitude REAL,
       visibility TEXT NOT NULL DEFAULT 'public',
@@ -130,10 +132,30 @@ describe("events schema", () => {
     expect(row!.category).toBeNull();
     expect(row!.endTime).toBeNull();
     expect(row!.imageUrl).toBeNull();
+    expect(row!.priceAmount).toBeNull();
+    expect(row!.priceCurrency).toBeNull();
     expect(row!.latitude).toBeNull();
     expect(row!.longitude).toBeNull();
     expect(row!.createdByName).toBeNull();
     expect(row!.createdByAvatar).toBeNull();
+  });
+
+  it("round-trips priceAmount + priceCurrency", async () => {
+    const db = createTestDb();
+    const now = new Date();
+    await db.insert(schema.events).values({
+      id: "evt_price",
+      title: "Paid Event",
+      startTime: now,
+      priceAmount: 1850,
+      priceCurrency: "USD",
+      createdByProfileId: "usr_alice",
+      createdAt: now,
+      updatedAt: now,
+    });
+    const [row] = await db.select().from(schema.events).where(eq(schema.events.id, "evt_price"));
+    expect(row!.priceAmount).toBe(1850);
+    expect(row!.priceCurrency).toBe("USD");
   });
 
   it("visibility/guestListVisibility/joinPolicy/allowInterested/commsChannels default correctly", async () => {

--- a/pulse/db/tests/seed.test.ts
+++ b/pulse/db/tests/seed.test.ts
@@ -20,6 +20,8 @@ function createTestDb() {
       end_time INTEGER,
       status TEXT NOT NULL DEFAULT 'upcoming',
       image_url TEXT,
+      price_amount INTEGER,
+      price_currency TEXT,
       latitude REAL,
       longitude REAL,
       visibility TEXT NOT NULL DEFAULT 'public',

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -36,7 +36,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] Venue pages
 - [ ] Real SMS/email comms providers — `sendBlast` is stubbed (writes to `event_comms`); plug in actual delivery
 - [ ] Tighten Tauri CSP to allowlist `*.tile.openstreetmap.org` for Leaflet tile loads (rolls into S-L3)
-- [ ] Drizzle: extract shared `createSchemaSql()` helper so adding a column is a one-file change (currently hand-rolled in 3 places)
+- [ ] Drizzle: extract shared `createSchemaSql()` helper so adding a column is a one-file change (currently hand-rolled in 4 places — `pulse/db/tests/schema.test.ts`, `pulse/db/tests/seed.test.ts`, `pulse/api/tests/helpers/db.ts`, `pulse/api/tests/services/zapBridge.test.ts`)
 - [ ] Verified-organisation tier (Phase 2): org accounts can run events over `MAX_EVENT_GUESTS` (1000) via per-event support flow
 
 ---

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -30,7 +30,6 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] "What's on today" default view
 - [ ] Prompt for max event duration when creating events without an endTime
 - [ ] Event discovery (location, category, datetime, friends, interests)
-- [ ] Add `price` field to events schema (`text`, nullable — free events = null, otherwise display string like "$18" or "$8 entry")
 - [ ] Recurring events (series + instances)
 - [ ] Event group chats (via Zap once M2 lands — placeholder shipped)
 - [ ] Organizer tools (moderation, blacklists)

--- a/wiki/apps/pulse.md
+++ b/wiki/apps/pulse.md
@@ -77,6 +77,21 @@ Every direct-fetch route (`GET /events/:id`, `/ics`, `/comms`, `/rsvps`, `/rsvps
 
 Events can be exported in iCal format for calendar integration.
 
+### Pricing
+
+Events can optionally carry a price. Two columns on `events`:
+
+- `price_amount` — `integer`, nullable. Stored in **minor units** (cents/pence/yen) so `$18.50 = 1850`. Never a float.
+- `price_currency` — `text`, nullable. ISO 4217 code from a curated allowlist: `USD, EUR, GBP, CAD, AUD, JPY`.
+
+Invariant: both columns set, or both null. Enforced in the Effect Schema `priceInvariant` filter in `pulse/api/src/services/events.ts` — the HTTP boundary also validates via TypeBox, but the service-layer filter is the authoritative check.
+
+Display rule: `price_amount` null **or** `0` → render `"Free"`. Otherwise format via `Intl.NumberFormat` using the stored currency. The `formatPrice` helper in `pulse/app/src/lib/formatPrice.ts` caches formatters so long feeds don't pay per-render allocation.
+
+Max price: `99999.99` in major units (= `9_999_999` minor for 2dp currencies; = `99999` for JPY after the cap-before-conversion check). Over that → HTTP 422.
+
+Currency allowlist and caps live in `pulse/api/src/lib/currency.ts` — see `SUPPORTED_CURRENCIES`, `MAX_PRICE_MAJOR`, and `toMinorUnits` / `fromMinorUnits`.
+
 ### Communications
 
 Event organisers can send communications to attendees.

--- a/wiki/changelog/completed-features.md
+++ b/wiki/changelog/completed-features.md
@@ -8,12 +8,17 @@ related:
   - "[[zap]]"
   - "[[redis]]"
   - "[[identity-model]]"
-last-reviewed: 2026-04-22
+last-reviewed: 2026-04-24
 ---
 
 # Completed Features
 
 Archived completed feature work from [[TODO]]. For open work see [[TODO]].
+
+## Pulse event pricing (2026-04-24)
+
+- **Price + currency on events.** New `price_amount` (integer, minor units, nullable) + `price_currency` (ISO 4217 text, nullable) columns on the Pulse `events` table. Effect Schema invariant enforces "both set or both null"; service converts major→minor units before insert. Curated currency allowlist `[USD, EUR, GBP, CAD, AUD, JPY]` lives in `pulse/api/src/lib/currency.ts`. Cap: `99999.99` major units.
+- **UI.** `CreateEventForm` gets a price input + currency select with live "Free"/formatted preview. `EventCard` and `EventDetailPage` render a badge: "Free" when null or 0, otherwise `Intl.NumberFormat`-formatted. Helper memoises formatters so long feeds don't reconstruct on every render (P-I1 from perf review). See `[[pulse]]`.
 
 ## Auth improvements — Phase 5b (passkey-primary, M-PK, 2026-04-22)
 


### PR DESCRIPTION
## Summary
- Adds optional `price_amount` (integer, minor units) + `price_currency` (ISO 4217) columns to the Pulse `events` table, with a curated currency allowlist `[USD, EUR, GBP, CAD, AUD, JPY]` and a shared cap of `99999.99` major units (= `9_999_999` minor for 2dp currencies).
- Effect Schema enforces a "both set or both null" invariant; service converts major→minor units before insert. Elysia TypeBox mirrors the validation at the HTTP boundary.
- `CreateEventForm` gains a number input + currency select with a live "Free"/formatted preview; `EventCard` and `EventDetailPage` render a badge (Free when null/0, otherwise `Intl.NumberFormat`-formatted).

## Workspaces affected
- `@pulse/db` (minor) — schema columns + seed
- `@pulse/api` (minor) — `currency.ts` helper, Effect Schema + filter, route body
- `@pulse/app` (patch) — `formatPrice` helper, form input, badge rendering

## Decisions & issues

**[design] Storage shape — integer minor units + ISO 4217 code**
- **Issue:** Had to pick a storage format for monetary values.
- **Why:** Floats are unsafe for money (`0.1 + 0.2` drift, accumulation error). A free-form text field (original TODO spec) would render inconsistently and defeat any future filtering / sorting.
- **Solution:** Two columns — `price_amount INTEGER` in minor units (cents/pence/yen) + `price_currency TEXT` (ISO 4217). `toMinorUnits` / `fromMinorUnits` helpers use a per-currency exponent table.
- **Rationale:** Matches Stripe / Paddle convention, round-trips exactly, and makes zero-decimal currencies (JPY) trivially work.

**[design] Both-or-neither invariant via `Schema.filter`**
- **Issue:** A row could end up with `price_amount` set but `price_currency` null (or vice versa), which would be unrenderable.
- **Why:** Two independent nullable columns can represent nonsensical states; the app would have to guard on every read.
- **Solution:** `priceInvariant` filter on both `InsertEventSchema` and `UpdateEventSchema` rejects any shape where exactly one of the two is null/absent. Both-null (explicit clear) and both-set are the only valid states.
- **Rationale:** Pushes the contract to the boundary so the DB write and every downstream consumer can trust the pairing.

**[design] Curated currency allowlist**
- **Issue:** Accepting any ISO 4217 code would let users configure currencies the UI can't render cleanly.
- **Why:** Currency exponent tables vary (e.g. BHD = 3dp), and the client formatter needs to know each currency's minor-unit precision up front.
- **Solution:** Static `SUPPORTED_CURRENCIES = [USD, EUR, GBP, CAD, AUD, JPY]` enforced at both HTTP (TypeBox literal union) and service (Effect `Schema.Literal`) layers.
- **Rationale:** Predictable rendering, small surface area to audit, easy to extend later by appending to the tuple.

**[design] 7-digit cap including decimals**
- **Issue:** Needed a price cap to prevent abuse and keep the integer safely within `Number.MAX_SAFE_INTEGER`.
- **Why:** Pulse is intentionally for social / community events — a $100k+ ticket is out of scope and suggests misuse. Unbounded prices also complicate any future rate-limit or fraud signal.
- **Solution:** Major-unit cap `99999.99` (`MAX_PRICE_MAJOR`), converted once via `Math.round(99999.99 * 100) = 9_999_999` (`MAX_PRICE_MINOR`). JPY goes via the same major cap but stores `99999` after the 0-exponent conversion.
- **Rationale:** 7 digits keeps the integer tiny (well below 2^53), covers all realistic pricing, and is trivially communicated to users.

**[P-I1] `Intl.NumberFormat` re-allocated on every `formatPrice` call**
- **Issue:** `formatPrice` constructed a fresh `new Intl.NumberFormat(...)` on every invocation. Called from `EventCard`, `EventDetailPage`, and the `CreateEventForm` live preview, each render on a long feed allocated N formatters.
- **Why:** Formatter construction is ~10–50× slower than `.format()` on a cached instance. Sub-ms at today's scale but scales linearly with feed size and is pure waste.
- **Solution:** Module-level `Map<string, Intl.NumberFormat>` keyed by `locale|currency|exp`; `getFormatter` returns cached or constructs + stores. API of `formatPrice` unchanged.
- **Rationale:** Formatters are immutable for a given key, so caching is safe. Cap is ~6 currencies × a few locales = tiny memory.

**[T-M1 / T-U1 / T-U2 / T-S1] Coverage gaps surfaced by review-tests**
- **Issue:** The new `formatPrice` helper was tested only indirectly via `EventCard`; `currency.ts`'s `fromMinorUnits`, `isSupportedCurrency`, and half-up rounding were unasserted; `EventDetailPage` had no test file at all.
- **Why:** Untested branches rot silently. Specifically, the `Intl.NumberFormat` try/catch fallback in `formatPrice` and the half-up rounding comment on `toMinorUnits` were contract-by-comment only.
- **Solution:** Three new test files — `pulse/app/tests/lib/formatPrice.test.ts`, `pulse/api/tests/lib/currency.test.ts`, and `pulse/app/tests/pages/EventDetailPage.test.tsx` — pinning every branch and round-trip invariant.
- **Rationale:** Pure-function tests are cheap and catch exactly the regressions that integration tests won't (e.g. flipping `||` to `&&` in `formatPrice`'s short-circuit).

**[observability] Net-zero instrumentation**
- **Issue:** Needed to decide whether price deserves logs, spans, or metrics.
- **Why:** Rule 3 in `wiki/observability/overview` forbids unbounded metric attributes; price is free-text and currency is a 6-value enum.
- **Solution:** No changes to `pulse/api/src/metrics.ts`. Existing `events.create` / `events.update` spans cover the field; currency is NOT an attribute (even though bounded — no monitoring use case).
- **Rationale:** Price is display-safe and low-risk; instrumenting the column adds noise without improving any signal.

**[security] No findings**
- **Issue:** Full parallel security review (auth, injection, invariant bypass, overflow, origin guard, logs).
- **Why:** Any of those would be a merge blocker.
- **Solution:** N/A — cleared.
- **Rationale:** Inputs are validated on both boundaries; POST and PATCH retain their existing auth + ownership gates; Drizzle parameterisation + integer-only storage rule out injection; `Math.round(99999.99 * 100)` is well within safe-integer bounds.

## Test plan
- [ ] `bun run --cwd pulse/db test:run` — 36 tests pass (includes round-trip test for both price columns + default-null assertion).
- [ ] `bun run --cwd pulse/api test:run` — 242 tests pass (service: 9 new price paths; route: 5 new price paths; pure-fn: `currency.test.ts`).
- [ ] `bun run --cwd pulse/app test:run` — 241 tests pass (`formatPrice.test.ts`, `EventDetailPage.test.tsx`, plus 4 card tests + 4 form tests).
- [ ] `bun run build` — all 17 workspaces build green.
- [ ] Manual: create a paid event ($18.50 USD), a JPY event (¥500), and a free event via the form; verify badges render correctly on the card + detail page; verify the preview updates live as the price changes.
- [ ] Manual: PATCH an event with `{priceAmount: null, priceCurrency: null}` via a curl; verify the badge flips back to "Free".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDXg5PRA1kpjfmYpTbQSiH)_