### PR TITLE
refactor(pulse/db): extract @pulse/db/testing helper from hand-rolled DDL

### DIFF
--- a/.changeset/pulse-db-testing-helper.md
+++ b/.changeset/pulse-db-testing-helper.md
@@ -1,0 +1,12 @@
+---
+"@pulse/db": patch
+"@pulse/api": patch
+---
+
+Extract `@pulse/db/testing` helper so adding a column is a one-file change.
+
+- New `@pulse/db/testing` export: `createSchemaSql()` derives `CREATE TABLE` + `CREATE INDEX` statements directly from the live Drizzle schema (FK-respecting topological order), and `applySchema(sqlite)` applies them to an in-memory SQLite handle.
+- Replaces four hand-rolled DDL blocks in `pulse/db/tests/schema.test.ts`, `pulse/db/tests/seed.test.ts`, `pulse/api/tests/helpers/db.ts`, and `pulse/api/tests/services/zapBridge.test.ts` (pulse side) with `applySchema(sqlite)`.
+- Drift-guard regression test asserts every schema table appears in the emitted SQL and that all declared indexes exist in the materialised in-memory database.
+
+No runtime behaviour change — test infrastructure only.

--- a/pulse/api/tests/helpers/db.ts
+++ b/pulse/api/tests/helpers/db.ts
@@ -3,109 +3,13 @@ import { Database } from "bun:sqlite";
 import * as schema from "@pulse/db/schema";
 import { events, type Event } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { applySchema } from "@pulse/db/testing";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Effect, Layer } from "effect";
 
 export function createTestLayer() {
   const sqlite = new Database(":memory:");
-  sqlite.run(`
-    CREATE TABLE event_series (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      latitude REAL,
-      longitude REAL,
-      category TEXT,
-      image_url TEXT,
-      duration_minutes INTEGER,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      rrule TEXT NOT NULL,
-      dtstart INTEGER NOT NULL,
-      until INTEGER,
-      materialized_through INTEGER NOT NULL,
-      timezone TEXT NOT NULL DEFAULT 'UTC',
-      status TEXT NOT NULL DEFAULT 'active',
-      chat_id TEXT,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`CREATE INDEX event_series_created_by_idx ON event_series (created_by_profile_id)`);
-  sqlite.run(`
-    CREATE TABLE events (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      category TEXT,
-      start_time INTEGER NOT NULL,
-      end_time INTEGER,
-      status TEXT NOT NULL DEFAULT 'upcoming',
-      image_url TEXT,
-      price_amount INTEGER,
-      price_currency TEXT,
-      latitude REAL,
-      longitude REAL,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      chat_id TEXT,
-      series_id TEXT REFERENCES event_series(id),
-      instance_override INTEGER NOT NULL DEFAULT 0,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`CREATE INDEX events_visibility_idx ON events (visibility)`);
-  sqlite.run(`CREATE INDEX events_series_id_idx ON events (series_id, start_time)`);
-  sqlite.run(`
-    CREATE TABLE event_rsvps (
-      id TEXT PRIMARY KEY,
-      event_id TEXT NOT NULL REFERENCES events(id),
-      profile_id TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'going',
-      invited_by_profile_id TEXT,
-      created_at INTEGER NOT NULL,
-      UNIQUE (event_id, profile_id)
-    )
-  `);
-  sqlite.run(`CREATE INDEX event_rsvps_event_idx ON event_rsvps (event_id)`);
-  sqlite.run(`CREATE INDEX event_rsvps_profile_idx ON event_rsvps (profile_id)`);
-  sqlite.run(`
-    CREATE TABLE pulse_users (
-      profile_id TEXT PRIMARY KEY,
-      attendance_visibility TEXT NOT NULL DEFAULT 'connections',
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE event_comms (
-      id TEXT PRIMARY KEY,
-      event_id TEXT NOT NULL REFERENCES events(id),
-      channel TEXT NOT NULL,
-      body TEXT NOT NULL,
-      sent_by_profile_id TEXT NOT NULL,
-      sent_at INTEGER,
-      created_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`CREATE INDEX event_comms_event_idx ON event_comms (event_id)`);
+  applySchema(sqlite);
   const db = drizzle(sqlite, { schema });
   return Layer.succeed(Db, { db });
 }

--- a/pulse/api/tests/services/zapBridge.test.ts
+++ b/pulse/api/tests/services/zapBridge.test.ts
@@ -4,6 +4,7 @@ import { it } from "@effect/vitest";
 import * as pulseSchema from "@pulse/db/schema";
 import { events } from "@pulse/db/schema";
 import { Db as PulseDb } from "@pulse/db/service";
+import { applySchema as applyPulseSchema } from "@pulse/db/testing";
 import * as zapSchema from "@zap/db/schema";
 import { chatMembers } from "@zap/db/schema";
 import { Db as ZapDb } from "@zap/db/service";
@@ -16,37 +17,7 @@ import { provisionEventChat, addEventChatMember } from "../../src/services/zapBr
 
 function createDualTestLayer() {
   const pulseSqlite = new Database(":memory:");
-  pulseSqlite.run(`
-    CREATE TABLE events (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      category TEXT,
-      start_time INTEGER NOT NULL,
-      end_time INTEGER,
-      status TEXT NOT NULL DEFAULT 'upcoming',
-      image_url TEXT,
-      price_amount INTEGER,
-      price_currency TEXT,
-      latitude REAL,
-      longitude REAL,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      chat_id TEXT,
-      series_id TEXT,
-      instance_override INTEGER NOT NULL DEFAULT 0,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
+  applyPulseSchema(pulseSqlite);
   const pulseDb = drizzle(pulseSqlite, { schema: pulseSchema });
 
   const zapSqlite = new Database(":memory:");

--- a/pulse/db/package.json
+++ b/pulse/db/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema/index.ts",
-    "./service": "./src/service.ts"
+    "./service": "./src/service.ts",
+    "./testing": "./src/testing.ts"
   },
   "scripts": {
     "db:migrate": "bunx drizzle-kit generate",

--- a/pulse/db/src/testing.ts
+++ b/pulse/db/src/testing.ts
@@ -1,0 +1,133 @@
+import type { Database } from "bun:sqlite";
+
+import { is } from "drizzle-orm";
+import {
+  getTableConfig,
+  SQLiteTable,
+  type AnySQLiteColumn,
+  type SQLiteColumn,
+} from "drizzle-orm/sqlite-core";
+
+import * as schema from "./schema";
+
+/**
+ * Build CREATE TABLE + CREATE INDEX statements for the live Pulse Drizzle
+ * schema, in foreign-key-respecting order. Tests run these against a fresh
+ * in-memory SQLite so that adding a column is a one-file change in
+ * `src/schema/` rather than four hand-rolled DDL blocks.
+ */
+export function createSchemaSql(): string[] {
+  const tables = (Object.values(schema) as unknown[]).filter((value): value is SQLiteTable =>
+    is(value, SQLiteTable),
+  );
+  const sorted = topoSortByForeignKey(tables);
+  const out: string[] = [];
+  for (const table of sorted) {
+    out.push(emitCreateTable(table));
+    for (const idx of getTableConfig(table).indexes) {
+      out.push(emitCreateIndex(idx, table));
+    }
+  }
+  return out;
+}
+
+/**
+ * Apply the full Pulse schema to an in-memory SQLite handle.
+ */
+export function applySchema(sqlite: Database): void {
+  for (const stmt of createSchemaSql()) sqlite.run(stmt);
+}
+
+function topoSortByForeignKey(tables: SQLiteTable[]): SQLiteTable[] {
+  const visited = new Set<string>();
+  const sorted: SQLiteTable[] = [];
+
+  function visit(table: SQLiteTable): void {
+    const cfg = getTableConfig(table);
+    if (visited.has(cfg.name)) return;
+    visited.add(cfg.name);
+    for (const fk of cfg.foreignKeys) {
+      const ref = fk.reference();
+      if (ref.foreignTable !== table) visit(ref.foreignTable);
+    }
+    sorted.push(table);
+  }
+
+  for (const t of tables) visit(t);
+  return sorted;
+}
+
+function emitCreateTable(table: SQLiteTable): string {
+  const cfg = getTableConfig(table);
+  const parts: string[] = [];
+
+  for (const col of cfg.columns) parts.push("  " + emitColumn(col));
+
+  for (const pk of cfg.primaryKeys) {
+    const cols = pk.columns.map((c) => `"${c.name}"`).join(", ");
+    parts.push(`  PRIMARY KEY (${cols})`);
+  }
+
+  for (const uq of cfg.uniqueConstraints) {
+    const cols = uq.columns.map((c) => `"${c.name}"`).join(", ");
+    const named = uq.name ? `CONSTRAINT "${uq.name}" ` : "";
+    parts.push(`  ${named}UNIQUE (${cols})`);
+  }
+
+  for (const fk of cfg.foreignKeys) {
+    const ref = fk.reference();
+    const local = ref.columns.map((c) => `"${c.name}"`).join(", ");
+    const foreignTableName = getTableConfig(ref.foreignTable).name;
+    const foreignCols = ref.foreignColumns.map((c) => `"${c.name}"`).join(", ");
+    parts.push(`  FOREIGN KEY (${local}) REFERENCES "${foreignTableName}"(${foreignCols})`);
+  }
+
+  return `CREATE TABLE "${cfg.name}" (\n${parts.join(",\n")}\n);`;
+}
+
+function emitColumn(col: AnySQLiteColumn): string {
+  const parts = [`"${col.name}"`, col.getSQLType()];
+  if (col.primary) parts.push("PRIMARY KEY");
+  if (col.notNull) parts.push("NOT NULL");
+  if (col.hasDefault && col.default !== undefined) {
+    parts.push(`DEFAULT ${formatDefault(col, col.default)}`);
+  }
+  return parts.join(" ");
+}
+
+function formatDefault(col: AnySQLiteColumn, value: unknown): string {
+  if (typeof value === "string") return `'${value.replace(/'/g, "''")}'`;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "1" : "0";
+  if (value === null) return "NULL";
+  throw new Error(
+    `[@pulse/db/testing] unsupported default for column "${col.name}": ${String(value)}. ` +
+      `Extend formatDefault() in pulse/db/src/testing.ts to handle this case.`,
+  );
+}
+
+interface IndexLike {
+  config: {
+    name: string;
+    columns: ReadonlyArray<{ name?: string } | unknown>;
+    unique: boolean;
+  };
+}
+
+function emitCreateIndex(idx: IndexLike, table: SQLiteTable): string {
+  const cfg = idx.config;
+  const tableName = getTableConfig(table).name;
+  const cols = cfg.columns
+    .map((c) => {
+      const colName = (c as SQLiteColumn).name;
+      if (typeof colName !== "string") {
+        throw new Error(
+          `[@pulse/db/testing] index "${cfg.name}" uses an SQL expression — ` +
+            `extend emitCreateIndex() to handle non-column index entries.`,
+        );
+      }
+      return `"${colName}"`;
+    })
+    .join(", ");
+  return `CREATE ${cfg.unique ? "UNIQUE " : ""}INDEX "${cfg.name}" ON "${tableName}" (${cols});`;
+}

--- a/pulse/db/tests/schema.test.ts
+++ b/pulse/db/tests/schema.test.ts
@@ -5,101 +5,11 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { describe, it, expect } from "vitest";
 
 import * as schema from "../src/schema";
+import { applySchema } from "../src/testing";
 
 function createTestDb() {
   const sqlite = new Database(":memory:");
-  sqlite.run(`
-    CREATE TABLE event_series (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      latitude REAL,
-      longitude REAL,
-      category TEXT,
-      image_url TEXT,
-      duration_minutes INTEGER,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      rrule TEXT NOT NULL,
-      dtstart INTEGER NOT NULL,
-      until INTEGER,
-      materialized_through INTEGER NOT NULL,
-      timezone TEXT NOT NULL DEFAULT 'UTC',
-      status TEXT NOT NULL DEFAULT 'active',
-      chat_id TEXT,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE events (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      category TEXT,
-      start_time INTEGER NOT NULL,
-      end_time INTEGER,
-      status TEXT NOT NULL DEFAULT 'upcoming',
-      image_url TEXT,
-      price_amount INTEGER,
-      price_currency TEXT,
-      latitude REAL,
-      longitude REAL,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      chat_id TEXT,
-      series_id TEXT REFERENCES event_series(id),
-      instance_override INTEGER NOT NULL DEFAULT 0,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE event_rsvps (
-      id TEXT PRIMARY KEY,
-      event_id TEXT NOT NULL REFERENCES events(id),
-      profile_id TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'going',
-      invited_by_profile_id TEXT,
-      created_at INTEGER NOT NULL,
-      UNIQUE (event_id, profile_id)
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE pulse_users (
-      profile_id TEXT PRIMARY KEY,
-      attendance_visibility TEXT NOT NULL DEFAULT 'connections',
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE event_comms (
-      id TEXT PRIMARY KEY,
-      event_id TEXT NOT NULL REFERENCES events(id),
-      channel TEXT NOT NULL,
-      body TEXT NOT NULL,
-      sent_by_profile_id TEXT NOT NULL,
-      sent_at INTEGER,
-      created_at INTEGER NOT NULL
-    )
-  `);
+  applySchema(sqlite);
   return drizzle(sqlite, { schema });
 }
 

--- a/pulse/db/tests/seed.test.ts
+++ b/pulse/db/tests/seed.test.ts
@@ -10,82 +10,11 @@ import {
   buildSeedSeries,
   buildSeedSeriesInstances,
 } from "../src/seed";
+import { applySchema } from "../src/testing";
 
 function createTestDb() {
   const sqlite = new Database(":memory:");
-  sqlite.run(`
-    CREATE TABLE event_series (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      latitude REAL,
-      longitude REAL,
-      category TEXT,
-      image_url TEXT,
-      duration_minutes INTEGER,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      rrule TEXT NOT NULL,
-      dtstart INTEGER NOT NULL,
-      until INTEGER,
-      materialized_through INTEGER NOT NULL,
-      timezone TEXT NOT NULL DEFAULT 'UTC',
-      status TEXT NOT NULL DEFAULT 'active',
-      chat_id TEXT,
-      created_by_profile_id TEXT NOT NULL,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE events (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      description TEXT,
-      location TEXT,
-      venue TEXT,
-      category TEXT,
-      start_time INTEGER NOT NULL,
-      end_time INTEGER,
-      status TEXT NOT NULL DEFAULT 'upcoming',
-      image_url TEXT,
-      price_amount INTEGER,
-      price_currency TEXT,
-      latitude REAL,
-      longitude REAL,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      guest_list_visibility TEXT NOT NULL DEFAULT 'public',
-      join_policy TEXT NOT NULL DEFAULT 'open',
-      allow_interested INTEGER NOT NULL DEFAULT 1,
-      comms_channels TEXT NOT NULL DEFAULT '["email"]',
-      chat_id TEXT,
-      series_id TEXT REFERENCES event_series(id),
-      instance_override INTEGER NOT NULL DEFAULT 0,
-      created_by_profile_id TEXT,
-      created_by_name TEXT,
-      created_by_avatar TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  sqlite.run(`
-    CREATE TABLE event_rsvps (
-      id TEXT PRIMARY KEY,
-      event_id TEXT NOT NULL REFERENCES events(id),
-      profile_id TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'going',
-      invited_by_profile_id TEXT,
-      created_at INTEGER NOT NULL,
-      UNIQUE (event_id, profile_id)
-    )
-  `);
+  applySchema(sqlite);
   return drizzle(sqlite, { schema });
 }
 

--- a/pulse/db/tests/testing.test.ts
+++ b/pulse/db/tests/testing.test.ts
@@ -1,0 +1,70 @@
+import { Database } from "bun:sqlite";
+
+import { is } from "drizzle-orm";
+import { getTableConfig, SQLiteTable } from "drizzle-orm/sqlite-core";
+import { describe, it, expect } from "vitest";
+
+import * as schema from "../src/schema";
+import { applySchema, createSchemaSql } from "../src/testing";
+
+describe("createSchemaSql", () => {
+  it("emits a CREATE TABLE for every SQLiteTable in src/schema", () => {
+    const expected = (Object.values(schema) as unknown[])
+      .filter((v): v is SQLiteTable => is(v, SQLiteTable))
+      .map((t) => getTableConfig(t).name)
+      .toSorted();
+
+    const stmts = createSchemaSql();
+
+    for (const tableName of expected) {
+      expect(
+        stmts.some((s) => s.startsWith(`CREATE TABLE "${tableName}"`)),
+        `expected createSchemaSql() to emit CREATE TABLE for "${tableName}"`,
+      ).toBe(true);
+    }
+  });
+
+  it("orders foreign-key dependencies before dependents", () => {
+    const stmts = createSchemaSql();
+    const positionOf = (table: string) =>
+      stmts.findIndex((s) => s.startsWith(`CREATE TABLE "${table}"`));
+
+    expect(positionOf("event_series")).toBeLessThan(positionOf("events"));
+    expect(positionOf("events")).toBeLessThan(positionOf("event_rsvps"));
+    expect(positionOf("events")).toBeLessThan(positionOf("event_comms"));
+  });
+});
+
+describe("applySchema", () => {
+  it("creates every table in a fresh in-memory SQLite", () => {
+    const sqlite = new Database(":memory:");
+    applySchema(sqlite);
+    const rows = sqlite
+      .query<{ name: string }, []>(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+      )
+      .all();
+    expect(rows.map((r) => r.name)).toEqual([
+      "event_comms",
+      "event_rsvps",
+      "event_series",
+      "events",
+      "pulse_users",
+    ]);
+  });
+
+  it("creates every named index declared on the schema", () => {
+    const sqlite = new Database(":memory:");
+    applySchema(sqlite);
+    const expected = (Object.values(schema) as unknown[])
+      .filter((v): v is SQLiteTable => is(v, SQLiteTable))
+      .flatMap((t) => getTableConfig(t).indexes.map((i) => i.config.name))
+      .toSorted();
+    const rows = sqlite
+      .query<{ name: string }, []>(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+      )
+      .all();
+    expect(rows.map((r) => r.name)).toEqual(expected);
+  });
+});

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -36,7 +36,7 @@ Progress tracking and deferred decisions. Completed items archived in `[[changel
 - [ ] Venue pages
 - [ ] Real SMS/email comms providers — `sendBlast` is stubbed (writes to `event_comms`); plug in actual delivery
 - [ ] Tighten Tauri CSP to allowlist `*.tile.openstreetmap.org` for Leaflet tile loads (rolls into S-L3)
-- [ ] Drizzle: extract shared `createSchemaSql()` helper so adding a column is a one-file change (currently hand-rolled in 4 places — `pulse/db/tests/schema.test.ts`, `pulse/db/tests/seed.test.ts`, `pulse/api/tests/helpers/db.ts`, `pulse/api/tests/services/zapBridge.test.ts`)
+- [x] Drizzle: extract shared `createSchemaSql()` helper so adding a column is a one-file change — shipped on `claude/drizzle-pulse-todo-cX5ps`: `@pulse/db/testing` export with `createSchemaSql()` + `applySchema()`, derived from the live Drizzle schema in FK-respecting order; replaces four hand-rolled DDL blocks across `pulse/db` and `pulse/api` tests; drift-guard regression test in `pulse/db/tests/testing.test.ts`
 - [ ] Verified-organisation tier (Phase 2): org accounts can run events over `MAX_EVENT_GUESTS` (1000) via per-event support flow
 
 ---

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -151,6 +151,7 @@ OSN's messaging app. Stack matches Pulse (Bun, Tauri+Solid, Elysia+Eden, Drizzle
 - [x] OSN Core: session schema — server-side sessions with SHA-256 hashed opaque tokens (Copenhagen Book C1)
 - [ ] Pulse: event series schema
 - [ ] Add indexes on `status` and `category` columns in pulse-db events schema
+- [ ] Mirror `@pulse/db/testing` (`createSchemaSql()` + `applySchema()`) into `@osn/db` and `@zap/db` so adding a column there is also a one-file change. Pattern: `pulse/db/src/testing.ts` derives DDL from the live Drizzle schema via `getTableConfig()` in FK-respecting topological order. `@zap/db` test fixtures (`pulse/api/tests/services/zapBridge.test.ts` zap side, plus any in `zap/api/tests/`) and `@osn/db` test fixtures should be migrated off hand-rolled `CREATE TABLE` blocks once the helpers exist.
 
 ### Crypto (`osn/crypto`)
 

--- a/wiki/changelog/completed-features.md
+++ b/wiki/changelog/completed-features.md
@@ -8,12 +8,19 @@ related:
   - "[[zap]]"
   - "[[redis]]"
   - "[[identity-model]]"
-last-reviewed: 2026-04-24
+last-reviewed: 2026-04-26
 ---
 
 # Completed Features
 
 Archived completed feature work from [[TODO]]. For open work see [[TODO]].
+
+## Pulse `@pulse/db/testing` schema helper (2026-04-26)
+
+- **`@pulse/db/testing` export.** New `createSchemaSql()` derives `CREATE TABLE` + `CREATE INDEX` statements directly from the live Drizzle schema (`drizzle-orm/sqlite-core` `getTableConfig`), in foreign-key-respecting topological order. Companion `applySchema(sqlite)` runs the statements against an in-memory SQLite handle.
+- **Replaces hand-rolled DDL in 4 places.** `pulse/db/tests/schema.test.ts`, `pulse/db/tests/seed.test.ts`, `pulse/api/tests/helpers/db.ts`, and `pulse/api/tests/services/zapBridge.test.ts` (pulse side) now call `applySchema(sqlite)` instead of duplicating column-by-column `CREATE TABLE` blocks. Adding a column is now a one-file change in `pulse/db/src/schema/`.
+- **Drift-guard regression test.** `pulse/db/tests/testing.test.ts` asserts every schema table appears in the emitted SQL, that FK dependents come after their referents, and that every declared index materialises in a fresh DB.
+- Test infrastructure only — no runtime behaviour change.
 
 ## Pulse event pricing (2026-04-24)
 


### PR DESCRIPTION
## Summary
- New `@pulse/db/testing` export with `createSchemaSql()` + `applySchema()` derived from the live Drizzle schema via `drizzle-orm/sqlite-core`'s `getTableConfig()`, in foreign-key-respecting topological order.
- Replaces ~290 lines of hand-rolled `CREATE TABLE` / `CREATE INDEX` blocks across four test files (`pulse/db/tests/schema.test.ts`, `pulse/db/tests/seed.test.ts`, `pulse/api/tests/helpers/db.ts`, `pulse/api/tests/services/zapBridge.test.ts` — pulse side only).
- Adding a column is now a one-file change in `pulse/db/src/schema/`.
- Drift-guard regression test (`pulse/db/tests/testing.test.ts`) asserts every schema table appears in the emitted SQL, FK ordering is correct, and every declared index materialises in a fresh DB.
- Test infrastructure only — no runtime behaviour change.

## Workspaces affected
- `@pulse/db` (patch) — new `./testing` subpath export, drift-guard test.
- `@pulse/api` (patch) — test helpers refactored to `applySchema()`.

## Decisions & issues

**[approach] Use `drizzle-orm/sqlite-core` `getTableConfig` rather than shelling out to drizzle-kit**
- **Issue:** Need a single source of truth for test DDL that follows the schema automatically, without forcing tests to depend on the `drizzle/` migration files.
- **Why:** Coupling tests to migrations means renaming/restructuring migrations breaks tests; hand-rolling DDL means the four copies drift from the schema (already happened — `seed.test.ts` had `created_by_profile_id TEXT` without `NOT NULL`).
- **Solution:** Iterate `Object.values(schema)` filtered by `is(value, SQLiteTable)`, topologically sort by FK references, then emit `CREATE TABLE` (with `PRIMARY KEY` / `UNIQUE` / `FOREIGN KEY` clauses) and `CREATE INDEX` directly from the column metadata via `getTableConfig()`.
- **Rationale:** Same primitives drizzle-kit uses internally; runtime cost is negligible (one DFS over ≤5 tables per test setup). The helper throws explicit "extend formatDefault/emitCreateIndex" errors on unsupported defaults / SQL-expression index columns rather than silently emitting wrong SQL.

**[scope] `@zap/db` side of `zapBridge.test.ts` left as hand-rolled**
- **Issue:** `zapBridge.test.ts` constructs two separate in-memory SQLite handles (one for `@pulse/db`, one for `@zap/db`).
- **Why:** Plan called out the Zap side as out of scope — `@zap/db` has its own schema in a different package.
- **Solution:** Migrated only the pulse handle to `applySchema(pulseSqlite)`. Zap handle still uses the existing inline `CREATE TABLE` blocks.
- **Rationale:** Mirroring the helper into `@zap/db` is a follow-up worth doing once the pattern proves out here. Doing it in this PR would expand scope and the changeset.

**[T-S1] Negative-path tests for `formatDefault` / `emitCreateIndex` guards — deferred**
- **Issue:** The two `throw new Error(…)` branches in `pulse/db/src/testing.ts` cannot be triggered by the current schema, so they have no direct assertions in `testing.test.ts`.
- **Why:** Low-impact gap — if a future schema introduces a `Date` default or an `sql\`lower(name)\`` index expression, the helper throws at suite-startup with an actionable message, and the drift-guard test would catch the missing table/index in the emitted SQL.
- **Solution:** None taken; suggestion noted for a follow-up.
- **Rationale:** Direct tests would essentially document defensive code that's unreachable from the live schema. Cheap to add later if/when a schema change actually exercises one of those branches.

**[graphBridge flake] Pre-existing `tests/services/graphBridge.test.ts > startKeyRotation > uses exponential backoff` flake**
- **Issue:** This timer-jitter test failed on the first `pulse/api test:run` of the implementation phase but passed on subsequent runs.
- **Why:** Confirmed pre-existing — fails on a clean `main` checkout with the branch's changes stashed. Unrelated to this work.
- **Solution:** None on this branch.
- **Rationale:** Out of scope; should be addressed separately.

## Reviews

- **review-tests** — build ✓, `pulse/db` 47/47, `pulse/api` 284/284. One T-S1 suggestion noted above.
- **review-performance** — no findings. Helper runs only in tests; per-setup cost is dominated by SQLite DDL execution (identical to before); introspection is O(tables + FKs + indexes) over a tiny in-memory object graph. `./testing` is a separate subpath export so production bundles are unaffected.
- **review-security** — no findings. DDL inputs are compile-time TypeScript schema constants (not user input); single quotes are doubled in string defaults; all identifiers double-quoted. Confirmed `./testing` is **not** imported from any production source under `pulse/api/src/` or `pulse/db/src/`. No new auth/crypto/HTTP/secret/console surface.

## Test plan
- [ ] `bun run --cwd pulse/db test:run` — 47 tests, all green
- [ ] `bun run --cwd pulse/api test:run` — 284 tests; the `graphBridge` flake is pre-existing and unrelated
- [ ] `bun run --cwd pulse/db check` and `bun run --cwd pulse/api check` — clean
- [ ] Spot-check: add a column to `pulse/db/src/schema/events.ts`, re-run `bun run --cwd pulse/db test:run` — drift-guard test still passes; no other test file needed touching to acknowledge the new column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ENauiFW6Lem477U7bAmZ5)_