### PR TITLE
chore: compress CLAUDE.md prose

### DIFF
--- a/.changeset/compress-claude-md.md
+++ b/.changeset/compress-claude-md.md
@@ -1,0 +1,5 @@
+---
+"osn": patch
+---
+
+Compress CLAUDE.md prose with caveman-compress to reduce AI input tokens.

--- a/.changeset/compress-claude-md.md
+++ b/.changeset/compress-claude-md.md
@@ -1,5 +1,4 @@
 ---
-"osn": patch
 ---
 
 Compress CLAUDE.md prose with caveman-compress to reduce AI input tokens.

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ data/
 
 # Obsidian (wiki vault user state)
 wiki/.obsidian/
+
+# Caveman compress backups
+*.original.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-AI coding assistant reference. For full spec see README.md. For progress/decisions see `wiki/TODO.md`.
+AI coding assistant ref. Full spec in README.md. Progress/decisions in `wiki/TODO.md`.
 
 ## Quick Context
 
@@ -19,77 +19,77 @@ Phase 1 surfaces:
 ## File Responsibilities
 
 - `README.md` → Project spec, vision, features, tech stack, contributing (human-readable)
-- `CLAUDE.md` → AI entry point: quick context, conventions, commands, and wiki navigation
+- `CLAUDE.md` → AI entry point: quick context, conventions, commands, wiki nav
 - `pulse/DESIGN.md` → Pulse visual design system: typography, color tokens, component catalog, layout patterns
 - `wiki/TODO.md` → Progress tracking, deferred decisions, task checklists
 - `wiki/` → Obsidian knowledge graph: architecture, systems, observability, runbooks
-  - Open in Obsidian for graph view; or navigate via `[[wiki links]]` from this file
-  - See `[[wiki/index]]` for the full map of content
+  - Open in Obsidian for graph view; or navigate via `[[wiki links]]`
+  - See `[[wiki/index]]` for full content map
 
 ## TODO.md Structure + Maintenance
 
-`wiki/TODO.md` is organised into these top-level sections — add new items to the right place:
+`wiki/TODO.md` organised into top-level sections — add new items to right place:
 
 | Section | What goes here |
 |---------|---------------|
-| **Up Next** | ≤8 highest-priority items across all areas. Keep it short — if everything is a priority, nothing is. Prune when items are done or promoted to a feature section. |
-| **App sections** (Pulse, OSN Core, Zap, Landing) | Feature work specific to that app. When done, move to `[[changelog/completed-features]]`. |
-| **Platform** (API, DB, Client, UI, Infra) | Shared package work and infrastructure. Same check-off rule. |
-| **Security Backlog** | Open security findings only, sorted H → M → L. When a finding is fixed, move it to `[[changelog/security-fixes]]`. |
-| **Performance Backlog** | Open perf findings only. When fixed, move to `[[changelog/performance-fixes]]`. |
-| **Compliance Backlog** | Open compliance findings only (`C-` prefix), sorted H → M → L. Each row links to `[[wiki/compliance/...]]`. When closed, move to a future `wiki/changelog/compliance-fixes.md` (created on first close). |
-| **Deferred Decisions** | Questions we're not answering yet. Add a row; remove it when the decision is made. |
-| **Future** | Phase 2/3 items. Vague is fine here — detail gets added when the phase starts. |
+| **Up Next** | ≤8 highest-priority items across all areas. Keep short — if everything priority, nothing is. Prune when done or promoted. |
+| **App sections** (Pulse, OSN Core, Zap, Landing) | Feature work per app. When done, move to `[[changelog/completed-features]]`. |
+| **Platform** (API, DB, Client, UI, Infra) | Shared package work + infra. Same check-off rule. |
+| **Security Backlog** | Open security findings only, sorted H → M → L. Fixed → move to `[[changelog/security-fixes]]`. |
+| **Performance Backlog** | Open perf findings only. Fixed → move to `[[changelog/performance-fixes]]`. |
+| **Compliance Backlog** | Open compliance findings only (`C-` prefix), sorted H → M → L. Each row links to `[[wiki/compliance/...]]`. Closed → move to `wiki/changelog/compliance-fixes.md` (created on first close). |
+| **Deferred Decisions** | Questions not answering yet. Add row; remove when decided. |
+| **Future** | Phase 2/3 items. Vague fine — detail added when phase starts. |
 
-**When to update TODO.md:**
-- After a PR merges → move completed items to `[[changelog/]]`; add any new findings; update Up Next
-- When a security/performance review surfaces findings → add to the relevant backlog section with `[[wiki links]]` to affected system pages
-- When a new deferred decision comes up → add a row to the table
-- Keep Up Next pruned to the real next things — it should be actionable at a glance
+**When update TODO.md:**
+- After PR merge → move completed items to `[[changelog/]]`; add new findings; update Up Next
+- Security/performance review surfaces findings → add to relevant backlog with `[[wiki links]]` to affected system pages
+- New deferred decision → add row to table
+- Keep Up Next pruned to real next things — actionable at glance
 
 ## Wiki Navigation
 
-The `wiki/` directory contains detailed reference pages. Use this index to find the right page — only read the pages you need:
+`wiki/` has detailed ref pages. Use index to find right page — only read what you need:
 
 | If you need to... | Read |
 |---|---|
-| Understand the monorepo layout | `[[wiki/architecture/monorepo-structure]]` |
-| Write a new Effect service or Elysia route | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]` |
-| Understand accounts, profiles, and orgs | `[[wiki/systems/identity-model]]` |
+| Understand monorepo layout | `[[wiki/architecture/monorepo-structure]]` |
+| Write new Effect service or Elysia route | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]` |
+| Understand accounts, profiles, orgs | `[[wiki/systems/identity-model]]` |
 | Add or verify ARC S2S tokens | `[[wiki/systems/arc-tokens]]` |
-| Add rate limiting to an endpoint | `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]` |
-| Instrument logging, tracing, or metrics | `[[wiki/observability/overview]]`, then the specific page |
+| Add rate limiting to endpoint | `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]` |
+| Instrument logging, tracing, metrics | `[[wiki/observability/overview]]`, then specific page |
 | Write or review tests | `[[wiki/conventions/testing-patterns]]` |
 | Understand event visibility rules | `[[wiki/systems/event-access]]` |
-| Add or use a UI component (Button, Card, Dialog…) | `[[wiki/architecture/component-library]]` |
+| Add or use UI component (Button, Card, Dialog…) | `[[wiki/architecture/component-library]]` |
 | Understand Pulse visual design (tokens, typography, Explore layout) | `pulse/DESIGN.md` |
-| Work on the social graph | `[[wiki/systems/social-graph]]` |
+| Work on social graph | `[[wiki/systems/social-graph]]` |
 | Work on Pulse close friends | `[[wiki/systems/pulse-close-friends]]` |
-| Gate a sensitive action behind step-up auth | `[[wiki/systems/step-up]]` |
-| Understand the passkey-only login model | `[[wiki/systems/passkey-primary]]` |
-| Plan/extend the Yoti-style verified-identity layer (AU DVS / mDL / myID, SD-JWT VC) | `[[wiki/systems/verified-identity]]` |
-| Send a transactional email (OTP, security notice) | `[[wiki/systems/email]]` |
+| Gate sensitive action behind step-up auth | `[[wiki/systems/step-up]]` |
+| Understand passkey-only login model | `[[wiki/systems/passkey-primary]]` |
+| Plan/extend Yoti-style verified-identity layer (AU DVS / mDL / myID, SD-JWT VC) | `[[wiki/systems/verified-identity]]` |
+| Send transactional email (OTP, security notice) | `[[wiki/systems/email]]` |
 | Surface session list / revoke per device | `[[wiki/systems/sessions]]` |
 | Understand cross-service calls | `[[wiki/architecture/s2s-patterns]]` |
-| Work on the OSN identity / social UI | `[[wiki/apps/osn-core]]`, `[[wiki/apps/social]]` |
+| Work on OSN identity / social UI | `[[wiki/apps/osn-core]]`, `[[wiki/apps/social]]` |
 | Work on Pulse | `[[wiki/apps/pulse]]` |
 | Work on Zap | `[[wiki/apps/zap]]` |
-| Debug an auth failure | `[[wiki/runbooks/auth-failure]]` |
-| Debug an ARC verification failure | `[[wiki/runbooks/arc-token-debugging]]` |
-| Debug a rate-limit incident | `[[wiki/runbooks/rate-limit-incident]]` |
-| Debug an event-visibility leak | `[[wiki/runbooks/event-visibility-bug]]` |
-| Wire a new service into observability | `[[wiki/runbooks/observability-setup]]` |
+| Debug auth failure | `[[wiki/runbooks/auth-failure]]` |
+| Debug ARC verification failure | `[[wiki/runbooks/arc-token-debugging]]` |
+| Debug rate-limit incident | `[[wiki/runbooks/rate-limit-incident]]` |
+| Debug event-visibility leak | `[[wiki/runbooks/event-visibility-bug]]` |
+| Wire new service into observability | `[[wiki/runbooks/observability-setup]]` |
 | Check security or perf findings | `wiki/TODO.md` (Security Backlog / Performance Backlog sections) |
-| Check what compliance standards apply (GDPR, SOC 2, CCPA, DSA, COPPA, EAA, ePrivacy) | `[[wiki/compliance/index]]`, `[[wiki/compliance/scope-matrix]]` |
-| Add a personal-data field, processor, or retention rule | `[[wiki/compliance/data-map]]`, `[[wiki/compliance/subprocessors]]`, `[[wiki/compliance/retention]]` |
-| Build a DSAR / account-export / account-delete endpoint | `[[wiki/compliance/dsar]]` |
-| Respond to a security incident or breach | `[[wiki/compliance/breach-response]]` |
+| Check which compliance standards apply (GDPR, SOC 2, CCPA, DSA, COPPA, EAA, ePrivacy) | `[[wiki/compliance/index]]`, `[[wiki/compliance/scope-matrix]]` |
+| Add personal-data field, processor, or retention rule | `[[wiki/compliance/data-map]]`, `[[wiki/compliance/subprocessors]]`, `[[wiki/compliance/retention]]` |
+| Build DSAR / account-export / account-delete endpoint | `[[wiki/compliance/dsar]]` |
+| Respond to security incident or breach | `[[wiki/compliance/breach-response]]` |
 | Set up production access / quarterly access review | `[[wiki/compliance/access-control]]` |
 | Track progress and priorities | `wiki/TODO.md` |
 
 ### Searching the wiki
 
-Always check for the Obsidian CLI first (requires Obsidian app to be running):
+Check for Obsidian CLI first (requires Obsidian app running):
 
 ```bash
 # 1. Check availability
@@ -108,27 +108,27 @@ grep -r "arc token" wiki/ --include="*.md" -l          # find matching pages
 grep -r "arc token" wiki/ --include="*.md" -n          # with line numbers
 ```
 
-Note: the `obsidian` CLI communicates with the running Obsidian app — fall back to grep if Obsidian is not open.
+Note: `obsidian` CLI talks to running Obsidian app — fall back to grep if not open.
 
 ### Wiki maintenance rules
 
-- **When you add a new system or pattern**, create a wiki page and link it from the table above and from `[[wiki/index]]`.
-- **When you modify an existing pattern**, update the corresponding wiki page in the same PR.
-- **Every wiki page must have YAML frontmatter** with at least `title`, `tags`, `related`, and `last-reviewed` fields.
-- **Use `[[wiki links]]`** to connect pages inside `wiki/`; never use relative markdown links between wiki pages.
-- **Security/performance findings** in `wiki/TODO.md` should include `[[wiki links]]` to the affected system pages (e.g., `[[rate-limiting]]`, `[[arc-tokens]]`).
+- **New system or pattern** → create wiki page, link from table above and `[[wiki/index]]`.
+- **Modify existing pattern** → update wiki page in same PR.
+- **Every wiki page must have YAML frontmatter** with `title`, `tags`, `related`, `last-reviewed`.
+- **Use `[[wiki links]]`** between wiki pages; never relative markdown links.
+- **Security/performance findings** in `wiki/TODO.md` include `[[wiki links]]` to affected system pages (e.g., `[[rate-limiting]]`, `[[arc-tokens]]`).
 - **Update `last-reviewed`** in frontmatter of any wiki page you touch.
 
 ## Current State (summary)
 
-Monorepo organised by domain. Four directories, four prefixes — see `[[wiki/architecture/monorepo-structure]]` for the full tree.
+Monorepo by domain. Four dirs, four prefixes — see `[[wiki/architecture/monorepo-structure]]` for full tree.
 
 | Dir | Prefix | What lives here |
 |-----|--------|-----------------|
-| `osn/` | `@osn/*` | Identity stack (auth, graph, organisations, recommendations, SDK, landing, social app) — crypto moved to `@shared/crypto` |
+| `osn/` | `@osn/*` | Identity stack (auth, graph, orgs, recommendations, SDK, landing, social app) — crypto moved to `@shared/crypto` |
 | `pulse/` | `@pulse/*` | Events stack (app, API, DB) |
 | `zap/` | `@zap/*` | Messaging stack (API on port 3002, DB) |
-| `shared/` | `@shared/*` | Cross-cutting utilities (`@shared/crypto` for ARC tokens, `@shared/email` for transactional mail, `@shared/observability`, `@shared/rate-limit`) |
+| `shared/` | `@shared/*` | Cross-cutting utils (`@shared/crypto` for ARC tokens, `@shared/email` for transactional mail, `@shared/observability`, `@shared/rate-limit`) |
 
 ## Tech (one-liner)
 
@@ -136,27 +136,27 @@ Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+RES
 
 ## Key Patterns
 
-One-line summaries — open the wiki page for the full contract, current API surface, finding history, and observability.
+One-line summaries — open wiki page for full contract, API surface, finding history, observability.
 
 | Pattern | Purpose | Wiki page |
 |---|---|---|
 | ARC Tokens | S2S auth via self-issued ES256 JWTs (kid + scope + audience). Lives in `@shared/crypto`. | `[[wiki/systems/arc-tokens]]` |
-| Passkey-Primary Login | The only primary login factor. OTP / magic-link primary surfaces removed; OTP survives only as a step-up factor. Account-level invariant: ≥1 WebAuthn credential at all times. | `[[wiki/systems/passkey-primary]]` |
-| User Access Tokens | ES256 JWTs, **5-min TTL**, `aud: "osn-access"`. Public key at `/.well-known/jwks.json`; downstream services verify via JWKS fetch (no shared secret). Client `authFetch` silent-refreshes on 401 from the HttpOnly session cookie. | `[[wiki/systems/identity-model]]` |
-| Server-side Sessions | Opaque `ses_*` refresh tokens, SHA-256 hashed at rest, 30-day sliding window. Rotated on every `/token` grant; reuse → family revocation via `RotatedSessionStore`. Refresh token lives **only** in an HttpOnly cookie (S-M1). | `[[wiki/systems/sessions]]` |
-| Step-up (sudo) tokens | Short-lived `aud: "osn-step-up"` JWTs minted by a fresh passkey/OTP ceremony. Required by `/recovery/generate`, `/account/email/complete`, security-event ack, passkey rename/delete. Single-use via `StepUpJtiStore`. | `[[wiki/systems/step-up]]` |
-| Recovery Codes | Copenhagen Book M2 — 10 × 64-bit single-use codes, hashed at rest. Generate / consume both inserted into `security_events` and surfaced via the in-app banner. | `[[wiki/systems/recovery-codes]]` |
+| Passkey-Primary Login | Only primary login factor. OTP/magic-link primary removed; OTP survives only as step-up. Account invariant: ≥1 WebAuthn credential always. | `[[wiki/systems/passkey-primary]]` |
+| User Access Tokens | ES256 JWTs, **5-min TTL**, `aud: "osn-access"`. Public key at `/.well-known/jwks.json`; downstream verifies via JWKS fetch (no shared secret). Client `authFetch` silent-refreshes on 401 from HttpOnly session cookie. | `[[wiki/systems/identity-model]]` |
+| Server-side Sessions | Opaque `ses_*` refresh tokens, SHA-256 hashed at rest, 30-day sliding window. Rotated every `/token` grant; reuse → family revocation via `RotatedSessionStore`. Refresh token **only** in HttpOnly cookie (S-M1). | `[[wiki/systems/sessions]]` |
+| Step-up (sudo) tokens | Short-lived `aud: "osn-step-up"` JWTs from fresh passkey/OTP ceremony. Required by `/recovery/generate`, `/account/email/complete`, security-event ack, passkey rename/delete. Single-use via `StepUpJtiStore`. | `[[wiki/systems/step-up]]` |
+| Recovery Codes | Copenhagen Book M2 — 10 × 64-bit single-use codes, hashed at rest. Generate/consume both in `security_events` and surfaced via in-app banner. | `[[wiki/systems/recovery-codes]]` |
 | Session Introspection | `GET/DELETE /sessions[/:id]`, `POST /sessions/revoke-all-other`. Coarse UA labels + HMAC-peppered IP hashes. | `[[wiki/systems/sessions]]` |
-| Cross-Device Login | QR-code mediated session transfer. Device B begins + polls; device A scans QR and approves. 256-bit secret, SHA-256 hashed at rest, one-time consumption, 5-min TTL. In-memory store (Redis Phase 4). | `[[wiki/systems/sessions]]` |
-| Email Change | Step-up gated; OTP to the NEW address; atomically swaps email and revokes other sessions. Cap 2 changes / 7 days. | `[[wiki/systems/identity-model]]` |
-| Email Transport | Transactional-only (OTPs + security notices). `EmailService` Effect Tag in `@shared/email`; `CloudflareEmailLive` POSTs directly to Cloudflare Email Service REST API (bearer-authed); `LogEmailLive` captures in-memory for dev + tests. | `[[wiki/systems/email]]` |
-| Origin Guard (M1) | Origin header validation on POST/PUT/PATCH/DELETE. ARC-protected internal routes are exempt. | `osn/api/src/lib/origin-guard.ts` |
+| Cross-Device Login | QR-code mediated session transfer. Device B begins + polls; device A scans QR, approves. 256-bit secret, SHA-256 hashed at rest, one-time consumption, 5-min TTL. In-memory store (Redis Phase 4). | `[[wiki/systems/sessions]]` |
+| Email Change | Step-up gated; OTP to NEW address; atomically swaps email + revokes other sessions. Cap 2 changes / 7 days. | `[[wiki/systems/identity-model]]` |
+| Email Transport | Transactional-only (OTPs + security notices). `EmailService` Effect Tag in `@shared/email`; `CloudflareEmailLive` POSTs to Cloudflare Email Service REST API (bearer-authed); `LogEmailLive` captures in-memory for dev + tests. | `[[wiki/systems/email]]` |
+| Origin Guard (M1) | Origin header validation on POST/PUT/PATCH/DELETE. ARC-protected internal routes exempt. | `osn/api/src/lib/origin-guard.ts` |
 | Rate Limiting | Per-IP on auth endpoints; per-user on graph/org writes and `/recommendations/connections`. Redis-backed when `REDIS_URL` set, in-memory fallback for local dev. Fail-closed. | `[[wiki/systems/rate-limiting]]`, `[[wiki/systems/redis]]` |
 | Observability | OpenTelemetry → Grafana Cloud. Three rules: no `console.*`, no raw OTel constructors, no unbounded metric attributes. | `[[wiki/observability/overview]]` |
 | Testing | `it.effect` + `createTestLayer()` for service tests; `createXxxRoutes(createTestLayer())` for route tests. In-memory SQLite. | `[[wiki/conventions/testing-patterns]]` |
 | Schema Layers | Elysia TypeBox at HTTP boundary, Effect Schema in services. Never mix. | `[[wiki/architecture/schema-layers]]` |
 | Review Finding IDs | S-C/H/M/L (security), P-C/W/I (perf), T-M/U/E/R/S (tests). Four-field format (Issue / Why / Solution / Rationale). | `[[wiki/conventions/review-findings]]` |
-| Component Library | Zaidan-style (shadcn for SolidJS) on Kobalte. Three class utilities: `bx()` defaults, `clsx()` conditional joins, `cn()` only for arbitrary conflicts. | `[[wiki/architecture/component-library]]` |
+| Component Library | Zaidan-style (shadcn for SolidJS) on Kobalte. Three class utils: `bx()` defaults, `clsx()` conditional joins, `cn()` only for arbitrary conflicts. | `[[wiki/architecture/component-library]]` |
 
 ## Conventions
 
@@ -164,7 +164,7 @@ One-line summaries — open the wiki page for the full contract, current API sur
 |---|---|
 | Apps | Tauri apps created via CLI (`bunx create-tauri-app`), not manually |
 | Functional core | Effect.ts trial in OSN/Pulse first, decision tracked in `wiki/TODO.md` Deferred Decisions |
-| Messaging | `@zap/api` is a shared backend — Pulse consumes it for event chats; users don't need a Zap install |
+| Messaging | `@zap/api` shared backend — Pulse consumes for event chats; users don't need Zap install |
 | Privacy | E2E encryption everywhere; all personalisation data user-accessible + resettable |
 | Platform priority | iOS > Web > Android (Android deferred) |
 | Pre-commit | lefthook runs oxlint + oxfmt (auto-fix + re-stage) on staged files |
@@ -172,9 +172,9 @@ One-line summaries — open the wiki page for the full contract, current API sur
 | oxlint | `oxlintrc.json` — plugins: typescript, unicorn, oxc, import, promise, vitest, node, jsx-a11y (React plugin disabled — SolidJS) |
 | oxfmt | `.oxfmtrc.json` — import sorting + Tailwind class sorting |
 | Runtime | Use `bunx --bun` for all tooling |
-| Branching | PRs required to merge to main; always work on a feature branch |
-| Changesets | Every PR includes a changeset (`bun run changeset`) — CI fails without one. Package names must match the workspace `name` field exactly (e.g. `"@pulse/app"`, not `"pulse"`); Changeset Check enforces this |
-| Versioning | Automatic — changesets consumed and committed by CI on merge to main |
+| Branching | PRs required to merge to main; always work on feature branch |
+| Changesets | Every PR includes changeset (`bun run changeset`) — CI fails without. Package names must match workspace `name` field exactly (e.g. `"@pulse/app"`, not `"pulse"`); Changeset Check enforces |
+| Versioning | Automatic — changesets consumed + committed by CI on merge to main |
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Ran caveman-compress on CLAUDE.md to reduce AI input tokens (~5% byte reduction)
- Added `*.original.md` to `.gitignore` to keep compress backups out of git
- All code blocks, paths, commands, and technical terms preserved exactly

## Test plan
- [x] Type check passes (`bun run check` — 17/17)
- [ ] Verify CLAUDE.md still readable and all links/tables intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)