### PR TITLE
feat(cire): create a new OSN account from the organiser login page

### DIFF
--- a/.changeset/cire-organiser-create-account.md
+++ b/.changeset/cire-organiser-create-account.md
@@ -1,0 +1,11 @@
+---
+"@cire/organiser": minor
+"@osn/ui": minor
+---
+
+Organisers can now create a new OSN account directly from the cire login
+page, not just sign in. `SignInPanel` toggles between the `SignIn` and
+`Register` flows from `@osn/ui/auth`; a freshly-created account is signed
+in immediately and lands on the dashboard. `Register` gains an optional
+`onSuccess` callback (fired once the account exists and its first passkey
+is enrolled) so standalone login pages can own the post-signup redirect.

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,12 @@
       },
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
+        "@solidjs/testing-library": "^0.8.10",
+        "@testing-library/jest-dom": "^6.9.1",
+        "happy-dom": "^20.9.0",
+        "vite": "^8.0.13",
+        "vite-plugin-solid": "^2.11.12",
+        "vitest": "^4.1.6",
       },
     },
     "cire/web": {
@@ -1414,7 +1420,7 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -2072,7 +2078,7 @@
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
@@ -2210,7 +2216,7 @@
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
@@ -2260,6 +2266,8 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
+    "@astrojs/language-server/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -2294,6 +2302,8 @@
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -2312,11 +2322,11 @@
 
     "@vitest/coverage-istanbul/vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
     "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "astro/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
@@ -2324,9 +2334,9 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
-    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "happy-dom/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -2339,6 +2349,8 @@
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "jsdom/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
@@ -2354,7 +2366,7 @@
 
     "unstorage/lru-cache": ["lru-cache@11.3.0", "", {}, "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ=="],
 
-    "vite/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "vitest/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2380,8 +2392,6 @@
 
     "@effect/vitest/vitest/@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
 
-    "@effect/vitest/vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
-
     "@opentelemetry/sdk-trace-web/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@opentelemetry/sdk-trace-web/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA=="],
@@ -2398,6 +2408,8 @@
 
     "@osn/landing/astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "@osn/landing/astro/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "@vitest/coverage-istanbul/vitest/@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
     "@vitest/coverage-istanbul/vitest/@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
@@ -2412,6 +2424,8 @@
 
     "@vitest/coverage-istanbul/vitest/@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
+    "@vitest/coverage-istanbul/vitest/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
@@ -2424,10 +2438,6 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "@effect/vitest/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
     "@osn/landing/astro/@astrojs/markdown-remark/@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
-
-    "@vitest/coverage-istanbul/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
   }
 }

--- a/cire/CLAUDE.md
+++ b/cire/CLAUDE.md
@@ -200,6 +200,7 @@ bun run --cwd cire/api build
 bun run test                         # All packages (turbo)
 bun run --cwd cire/api test
 bun run --cwd cire/web test
+bun run --cwd cire/organiser test    # SolidJS islands (vitest + happy-dom)
 
 # Lint + Format (root config)
 bun run lint                         # oxlint

--- a/cire/organiser/package.json
+++ b/cire/organiser/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev --port 4322",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "echo 'No tests yet'"
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
   },
   "dependencies": {
     "@astrojs/solid-js": "^6.0.1",
@@ -19,6 +20,12 @@
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
-    "@shared/typescript-config": "workspace:*"
+    "@shared/typescript-config": "workspace:*",
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^6.9.1",
+    "happy-dom": "^20.9.0",
+    "vite": "^8.0.13",
+    "vite-plugin-solid": "^2.11.12",
+    "vitest": "^4.1.6"
   }
 }

--- a/cire/organiser/src/components/SignInPanel.test.tsx
+++ b/cire/organiser/src/components/SignInPanel.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * SignInPanel owns the only new logic in the organiser portal's login
+ * surface: a signin/register mode toggle that lets an organiser without an
+ * OSN account create one without leaving the page. The OSN ceremonies
+ * themselves are exhaustively covered in @osn/ui (SignIn/Register tests),
+ * so this test stubs those components and @osn/client and asserts only the
+ * wiring it introduces — which view shows, and that the toggle/cancel
+ * controls flip between them.
+ */
+
+vi.mock("@osn/client", () => ({
+  createLoginClient: () => ({}),
+  createRecoveryClient: () => ({}),
+  createRegistrationClient: () => ({}),
+}));
+
+vi.mock("@osn/client/solid", () => ({
+  // Pass children straight through; the real provider only supplies context
+  // the stubbed SignIn/Register don't read.
+  AuthProvider: (props: { children: unknown }) => props.children,
+}));
+
+vi.mock("@osn/ui/auth", () => ({
+  SignIn: () => <div data-testid="signin-view">sign in</div>,
+  Register: (props: { onCancel: () => void }) => (
+    <div data-testid="register-view">
+      <button onClick={() => props.onCancel()}>register-cancel</button>
+    </div>
+  ),
+}));
+
+vi.mock("solid-toast", () => ({
+  Toaster: () => null,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import SignInPanel from "./SignInPanel";
+
+describe("SignInPanel", () => {
+  afterEach(() => cleanup());
+
+  it("shows the sign-in view by default, with a create-account toggle", () => {
+    render(() => <SignInPanel />);
+    expect(screen.getByTestId("signin-view")).toBeTruthy();
+    expect(screen.queryByTestId("register-view")).toBeNull();
+    expect(screen.getByRole("button", { name: /Create an account/i })).toBeTruthy();
+  });
+
+  it("switches to the register view when 'Create an account' is clicked", () => {
+    render(() => <SignInPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Create an account/i }));
+    expect(screen.getByTestId("register-view")).toBeTruthy();
+    expect(screen.queryByTestId("signin-view")).toBeNull();
+  });
+
+  it("returns to the sign-in view when Register cancels", () => {
+    render(() => <SignInPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Create an account/i }));
+    fireEvent.click(screen.getByRole("button", { name: /register-cancel/i }));
+    expect(screen.getByTestId("signin-view")).toBeTruthy();
+    expect(screen.queryByTestId("register-view")).toBeNull();
+  });
+});

--- a/cire/organiser/src/components/SignInPanel.tsx
+++ b/cire/organiser/src/components/SignInPanel.tsx
@@ -1,27 +1,57 @@
-import { createLoginClient, createRecoveryClient } from "@osn/client";
+import { createLoginClient, createRecoveryClient, createRegistrationClient } from "@osn/client";
 import { AuthProvider } from "@osn/client/solid";
-import { SignIn } from "@osn/ui/auth";
+import { Register, SignIn } from "@osn/ui/auth";
+import { createSignal, Show } from "solid-js";
 import { Toaster } from "solid-toast";
 
 import { OSN_ISSUER_URL } from "../lib/osn";
 
 const loginClient = createLoginClient({ issuerUrl: OSN_ISSUER_URL });
 const recoveryClient = createRecoveryClient({ issuerUrl: OSN_ISSUER_URL });
+const registrationClient = createRegistrationClient({ issuerUrl: OSN_ISSUER_URL });
+
+type Mode = "signin" | "register";
+
+const toDashboard = () => {
+  window.location.href = "/";
+};
 
 /**
- * Login page island. SignIn must render inside AuthProvider — it adopts
- * the session via useAuth().adoptSession on ceremony success.
+ * Login page island. SignIn / Register must render inside AuthProvider —
+ * they adopt the session via useAuth().adoptSession on ceremony success.
+ * Organisers who don't yet have an OSN account switch to the registration
+ * flow; a freshly-created account is signed in immediately, so both paths
+ * land on the dashboard.
  */
 export default function SignInPanel() {
+  const [mode, setMode] = createSignal<Mode>("signin");
+
   return (
     <AuthProvider config={{ issuerUrl: OSN_ISSUER_URL }}>
-      <SignIn
-        client={loginClient}
-        recoveryClient={recoveryClient}
-        onSuccess={() => {
-          window.location.href = "/";
-        }}
-      />
+      <Show
+        when={mode() === "register"}
+        fallback={
+          <div class="flex flex-col gap-4">
+            <SignIn client={loginClient} recoveryClient={recoveryClient} onSuccess={toDashboard} />
+            <p class="text-muted-foreground text-center text-sm">
+              New to OSN?{" "}
+              <button
+                type="button"
+                class="text-primary font-medium hover:underline"
+                onClick={() => setMode("register")}
+              >
+                Create an account
+              </button>
+            </p>
+          </div>
+        }
+      >
+        <Register
+          client={registrationClient}
+          onCancel={() => setMode("signin")}
+          onSuccess={toDashboard}
+        />
+      </Show>
       <Toaster position="bottom-right" />
     </AuthProvider>
   );

--- a/cire/organiser/vitest.config.ts
+++ b/cire/organiser/vitest.config.ts
@@ -1,0 +1,10 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [solid()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/cire/wiki/todo/status.md
+++ b/cire/wiki/todo/status.md
@@ -3,7 +3,7 @@ title: "Cire TODO — status + up next"
 tags: [todo, status]
 related:
   - "[[index]]"
-last-reviewed: 2026-06-11
+last-reviewed: 2026-06-15
 ---
 
 # Status + Up Next
@@ -28,6 +28,7 @@ Monorepo built and functional. `cire/db` models families with a shareable `publi
 - [x] `POST /api/organiser/import/{preview,apply,revert,list}` endpoints (PR-C; now gated behind `osnAuth()` + `ownedWedding()` since the OSN merge)
 - [x] Wire organiser portal upload UI to `/api/organiser/import/*` — inline import panel on the dashboard (preview diff → apply); history/revert UI still deferred (see [[spreadsheet-import]])
 - [x] Migrate from `X-Organiser-Token` shared secret to organiser passkey auth — done in the OSN merge; token path deleted
+- [x] Inline OSN account creation on the organiser login page — `SignInPanel` toggles `<SignIn>` ⇄ `<Register>` (from `@osn/ui`, via `@osn/client`'s registration client) so organisers without an OSN account can register without leaving cire; first vitest harness for `@cire/organiser`. See `[[wiki/systems/cire-auth]]`
 - [ ] **Substitute `usr_REPLACE_BEFORE_PROD`** (bootstrap `wed_bootstrap` owner in migration `0006_multi_tenant.sql`) with the real OSN profile id **before applying migrations to remote/production D1**
 - [x] Migrate runtime DB layer in `cire/api/src/index.ts` from 503 stub to real D1 — `index.ts` is now a Workers `fetch` handler building a per-request Drizzle-D1 client from `env.DB`; `Db` broadened over `"sync" | "async"` so the same service code runs on bun:sqlite (local/tests) and D1 (prod) via a `dbQuery` bridge. Pure JWK helpers split into DB-free `@shared/crypto/jwk` so the `osnAuth` verify path no longer drags `bun:sqlite` into the Worker bundle (build is green). Still pending before remote push: `usr_REPLACE_BEFORE_PROD` substitution + real `database_id`.
 - [x] Per-person per-event RSVP with dietary requirements

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -17,6 +17,13 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 interface RegisterProps {
   client: RegistrationClient;
   onCancel: () => void;
+  /**
+   * Fired once the account exists and its first passkey is enrolled — i.e.
+   * the session is fully usable. Consumers that own navigation (e.g. a
+   * standalone login page) redirect here; consumers that react to
+   * `session()` directly can omit it.
+   */
+  onSuccess?: () => void;
 }
 
 export function Register(props: RegisterProps) {
@@ -173,6 +180,7 @@ export function Register(props: RegisterProps) {
       });
       toast.success(`Welcome, @${handle()}`);
       setStep("done");
+      props.onSuccess?.();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Passkey setup failed";
       setPasskeyError(msg);

--- a/osn/ui/tests/auth/Register.test.tsx
+++ b/osn/ui/tests/auth/Register.test.tsx
@@ -288,7 +288,7 @@ describe("Register component", () => {
       }
     }
 
-    async function reachPasskey() {
+    async function reachPasskey(extra?: { onSuccess?: () => void }) {
       stub.checkHandle.mockResolvedValue({ available: true });
       stub.beginRegistration.mockResolvedValue({ sent: true });
       stub.completeRegistration.mockResolvedValue({
@@ -298,7 +298,9 @@ describe("Register component", () => {
         session: sampleSession,
       });
       hoisted.adoptSession.mockResolvedValue(undefined);
-      render(() => <Register client={asClient(stub)} onCancel={() => {}} />);
+      render(() => (
+        <Register client={asClient(stub)} onCancel={() => {}} onSuccess={extra?.onSuccess} />
+      ));
       fillEmail("alice@example.com");
       fillHandle("alice");
       await vi.advanceTimersByTimeAsync(350);
@@ -341,6 +343,59 @@ describe("Register component", () => {
     it("there is no 'Skip' button — enrollment is required to finish the flow", async () => {
       await reachPasskey();
       expect(screen.queryByRole("button", { name: /Skip/i })).toBeNull();
+    });
+
+    // T-U1: onSuccess is the contract this prop exists for — consumers that
+    // own navigation (cire's standalone login page) redirect from it. Pin
+    // that it fires exactly once on the enrollment success path.
+    it("fires onSuccess after a successful enrollment", async () => {
+      const onSuccess = vi.fn();
+      await reachPasskey({ onSuccess });
+      stub.passkeyRegisterBegin.mockResolvedValue({ challenge: "ch" });
+      hoisted.startRegistration.mockResolvedValue({ id: "cred", rawId: "raw" });
+      stub.passkeyRegisterComplete.mockResolvedValue({ passkeyId: "pk_1" });
+
+      fireEvent.click(screen.getByRole("button", { name: /Enroll credential/i }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+      });
+      // It must follow a real enrollment, never precede it.
+      expect(stub.passkeyRegisterComplete).toHaveBeenCalled();
+    });
+
+    // T-E1: the "every account has ≥1 passkey" invariant rests on onSuccess
+    // (and the redirect it drives) NOT firing until enrollment truly
+    // succeeds. A failed ceremony must keep the user on the passkey step.
+    it("does not fire onSuccess and surfaces an error when enrollment fails", async () => {
+      const onSuccess = vi.fn();
+      await reachPasskey({ onSuccess });
+      stub.passkeyRegisterBegin.mockResolvedValue({ challenge: "ch" });
+      hoisted.startRegistration.mockRejectedValue(new Error("ceremony cancelled"));
+
+      fireEvent.click(screen.getByRole("button", { name: /Enroll credential/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/ceremony cancelled/)).toBeTruthy();
+      });
+      expect(onSuccess).not.toHaveBeenCalled();
+      // Still on the passkey step — enrollment remains required.
+      expect(screen.getByRole("button", { name: /Enroll credential/i })).toBeTruthy();
+    });
+
+    // T-S1: onSuccess is optional — consumers that react to session()
+    // directly (osn/social) omit it. Omission must not break completion.
+    it("completes to the done step when onSuccess is omitted", async () => {
+      await reachPasskey();
+      stub.passkeyRegisterBegin.mockResolvedValue({ challenge: "ch" });
+      hoisted.startRegistration.mockResolvedValue({ id: "cred", rawId: "raw" });
+      stub.passkeyRegisterComplete.mockResolvedValue({ passkeyId: "pk_1" });
+
+      fireEvent.click(screen.getByRole("button", { name: /Enroll credential/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/You.re all set/)).toBeTruthy();
+      });
     });
   });
 

--- a/wiki/apps/cire.md
+++ b/wiki/apps/cire.md
@@ -14,7 +14,7 @@ related:
   - "[[passkey-primary]]"
   - "[[data-map]]"
   - "[[dpia/cire-guest-data]]"
-last-reviewed: 2026-06-12
+last-reviewed: 2026-06-15
 ---
 
 # Cire
@@ -26,7 +26,7 @@ Cire is a bespoke digital wedding invite — a tactile, animated guest-facing si
 | Package | Dir | Port (dev) | Purpose |
 |---|---|---|---|
 | `@cire/web` | `cire/web` | 4321 | Guest-facing Astro + SolidJS site (claim code → events → RSVP) |
-| `@cire/organiser` | `cire/organiser` | 4322 | Organiser portal (Astro + SolidJS) — guest/event tables, spreadsheet import, OSN passkey sign-in |
+| `@cire/organiser` | `cire/organiser` | 4322 | Organiser portal (Astro + SolidJS) — guest/event tables, spreadsheet import, OSN passkey sign-in + inline account creation |
 | `@cire/api` | `cire/api` | 8787 | Elysia on Cloudflare Workers + Effect services + Drizzle on D1 |
 | `@cire/db` | `cire/db` | — | Drizzle schema + D1 SQL migrations |
 
@@ -37,7 +37,7 @@ Note: `@cire/api` runs Elysia with `aot: false` — Elysia's ahead-of-time compi
 Two deliberately separate systems — full contract in [[cire-auth]]:
 
 - **Guests** never become OSN account holders. A family claim code (`families.public_id`, e.g. `SHARMA-IVY-QM42`) is exchanged at `POST /api/claim` for a 256-bit session token (SHA-256-hashed at rest), carried in a 30-day HttpOnly `cire_session` cookie. `sessionAuth()` gates `/api/rsvp`.
-- **Organisers** sign in with their OSN passkey (via `@osn/client` + `@osn/ui` on the portal). `cire/api` verifies the resulting ES256 access JWT (`aud: "osn-access"`) against the OSN issuer's JWKS using `osnAuth()` from `@shared/osn-auth-client`; wedding ownership is enforced by `weddingOwner()` / `ownedWedding()` middleware against `weddings.owner_osn_profile_id`.
+- **Organisers** sign in with their OSN passkey (via `@osn/client` + `@osn/ui` on the portal), or create a new OSN account inline — the portal's `SignInPanel` toggles between the `<SignIn>` and `<Register>` flows, so an organiser without an account never has to leave to register (the account is still created on OSN, not cire). `cire/api` verifies the resulting ES256 access JWT (`aud: "osn-access"`) against the OSN issuer's JWKS using `osnAuth()` from `@shared/osn-auth-client`; wedding ownership is enforced by `weddingOwner()` / `ownedWedding()` middleware against `weddings.owner_osn_profile_id`.
 - **Optional guest account linking** (backend shipped; frontend deferred) — an invitee may attach their seat to an OSN/Pulse account. `POST /api/account/link` is the one dual-credential route (guest cookie + OSN token); it resolves the profile to an account id over ARC and writes `guest_account_links`. Full contract + the 401/dual-credential nuances in [[cire-auth]].
 
 ## Data model

--- a/wiki/systems/cire-auth.md
+++ b/wiki/systems/cire-auth.md
@@ -9,7 +9,7 @@ related:
   - "[[data-map]]"
   - "[[access-control]]"
   - "[[arc-tokens]]"
-last-reviewed: 2026-06-12
+last-reviewed: 2026-06-15
 ---
 
 # Cire two-system auth
@@ -38,6 +38,8 @@ Cire runs **two deliberately separate auth systems** that never overlap. Guests 
 ## Organiser path: OSN passkey → access JWT → wedding ownership
 
 Organisers sign in on the organiser portal (`@cire/organiser`, :4322) using the standard OSN `<SignIn>` component from `@osn/ui` driven by `@osn/client` — a normal OSN passkey ceremony against the OSN issuer (`@osn/api`, :4000). Cire adds no login surface of its own.
+
+Organisers who don't yet have an OSN account can create one from the same page: `SignInPanel` toggles between `<SignIn>` and the `<Register>` component (also from `@osn/ui`, driven by `@osn/client`'s registration client), so the email-OTP + first-passkey ceremony runs against the OSN issuer just like sign-in. The account is created on OSN, not cire — cire still owns no identity store. A freshly-registered account is signed in immediately (the `<Register>` `onSuccess` callback redirects to the dashboard), so it flows into the same access-JWT verification chain below.
 
 ### Verification chain (request → claims)
 


### PR DESCRIPTION
## Summary
- The cire organiser portal only offered "sign in with OSN", stranding organisers who don't yet have an account. `SignInPanel` now toggles between the `<SignIn>` and `<Register>` flows from `@osn/ui/auth` (driven by `@osn/client`'s registration client), so an organiser can create an OSN account inline and land on the dashboard — without leaving cire.
- The account is still created on OSN (`@osn/api`), not cire — cire owns no identity store. Registration is a browser↔OSN-API ceremony; `cire/api` is untouched. A freshly-created account flows into the existing `osnAuth()` access-JWT verification + wedding-ownership chain unchanged.
- `@osn/ui`'s `Register` gains an optional `onSuccess?: () => void` callback (fired once the account exists and its first passkey is enrolled) so standalone login pages can own the post-signup redirect. `osn/social` doesn't pass it and reacts to `session()` directly, so it's unaffected.
- Stood up the first vitest + happy-dom test harness for `@cire/organiser` and added `onSuccess` coverage to the shared `Register` suite.

## Workspaces affected
- `@cire/organiser` (minor) — login-page mode toggle + new test harness
- `@osn/ui` (minor) — optional `onSuccess` prop on `Register` + new tests

Docs updated: `wiki/systems/cire-auth.md`, `wiki/apps/cire.md`, `cire/wiki/todo/status.md`, `cire/CLAUDE.md`.

## Decisions & issues

**[approach] — Reuse `<Register>` instead of building a cire-specific signup**
- **Issue:** Cire needed an account-creation surface but has no identity store and must not duplicate the OSN registration ceremony.
- **Why:** A bespoke flow would re-implement (and risk diverging from) the email-OTP + mandatory-passkey enrollment ceremony, the WebAuthn-support gate, and the "every account has ≥1 passkey" invariant.
- **Solution:** Mount the existing shared `@osn/ui` `<Register>` component against the same OSN issuer already used for sign-in, toggled from `SignInPanel`.
- **Rationale:** Single source of truth for the registration ceremony; cire stays a pure client of OSN identity, matching how `osn/social` already consumes the same component.

**[approach] — Add `onSuccess` to `Register` rather than watch `session()` in cire**
- **Issue:** `Register` adopts the session itself and previously had no success hook; the cire login page needs to redirect to the dashboard on completion.
- **Why:** A session watcher at the panel level would also fire for an already-restored session on mount, subtly changing the existing sign-in-only behaviour; it's also less explicit than `SignIn`'s existing `onSuccess`.
- **Solution:** Optional `onSuccess?: () => void`, fired inside `enrollPasskey` only after `passkeyRegisterComplete` resolves (i.e. after the first passkey is enrolled). cire passes a hardcoded same-origin redirect.
- **Rationale:** Mirrors `SignIn`'s existing prop, is backward-compatible (optional → `osn/social` unaffected), and keeps the redirect tied to genuine enrollment success.

**[T-U1 / T-E1 / T-S1] — `Register.onSuccess` was unasserted**
- **Issue:** The new callback — the whole point of the PR — had no test on either the success or failure path.
- **Why:** A regression dropping/misordering `onSuccess?.()` (e.g. firing on the error path or before enrollment) would pass all existing tests while breaking the redirect or, worse, redirecting a user whose passkey ceremony failed (violating the ≥1-passkey invariant).
- **Solution:** Added three tests in `osn/ui/tests/auth/Register.test.tsx` — fires once on success (T-U1), does not fire and surfaces the error on enrollment failure (T-E1), and completes when omitted (T-S1).
- **Rationale:** Pins the callback contract (fires once, only after real enrollment) and covers the previously-untested enrollment error branch.

**[T-S2] — `@cire/organiser` had no test runner**
- **Issue:** The new `SignInPanel` mode-toggle logic was uncovered; the workspace's `test` script was `echo 'No tests yet'`.
- **Why:** The toggle is the user-visible surface of this PR; a regression in the mode switch or cancel wiring would ship undetected.
- **Solution:** Added `vitest.config.ts` (vite-plugin-solid + happy-dom, mirroring `osn/ui`), test devDeps, and `SignInPanel.test.tsx` asserting the signin⇄register toggle and Register-cancel return. OSN ceremonies are stubbed — the test only pins cire's wiring.
- **Rationale:** Establishes the first harness for the workspace and covers exactly the new branch; the ceremonies themselves are already exhaustively tested in `@osn/ui`.

**[harness] — `vite-plugin-solid` requires `@testing-library/jest-dom` installed**
- **Issue:** The new vitest harness failed with `Cannot find module '@testing-library/jest-dom/vitest'` despite my config declaring no `setupFiles`.
- **Why:** `vite-plugin-solid` auto-injects `@testing-library/jest-dom/vitest` into `setupFiles` in non-browser mode, so the package must be installed (as it already is for `cire/web` and `osn/ui`).
- **Solution:** Added `@testing-library/jest-dom` to `@cire/organiser` devDeps.
- **Rationale:** Matches the established pattern across the monorepo's SolidJS test setups; no test code depends on its matchers (assertions use `toBeTruthy()`).

**[security] — No findings (open-redirect, CORS, abuse, passkey invariant all dismissed)**
- **Issue:** Exposing account creation from the cire origin could in principle introduce open-redirect, cross-origin, or account-abuse risk.
- **Why:** New auth surfaces warrant an explicit threat model.
- **Solution:** Reviewed and dismissed each: `onSuccess` is a hardcoded same-origin `/` (no URL-controlled input); the cire origin is already CORS-trusted for sign-in; registration endpoints' server-side rate limits are unchanged (not touched by this branch); `onSuccess` fires only after enrollment so the ≥1-passkey invariant holds.
- **Rationale:** No new endpoints, server changes, data collection, or trust-boundary widening — only client-side UI wiring over an already-shipped, already-rate-limited ceremony.

**[performance] — No material concerns (P-I1/P-I2/P-I3 info-only)**
- **Issue:** Module-scope client construction, the `Show`-based toggle, and the full-page redirect on success were reviewed.
- **Why:** Confirm no re-render, dual-mount, or allocation regression.
- **Solution:** None needed — `Show` mounts one subtree at a time, clients are cheap module-scope singletons (pre-existing pattern), and the one-shot redirect matches existing `SignIn` behaviour.
- **Rationale:** Frontend-only change with no backend/DB/hot-path impact.

## Test plan
- [ ] `bun run --cwd osn/ui test:run` — 116 pass (incl. 3 new `onSuccess` cases)
- [ ] `bun run --cwd cire/organiser test:run` — 3 pass (new SignInPanel toggle harness)
- [ ] `bun run --cwd cire/organiser build` — clean
- [ ] Manual: `bun run dev:cire`, open the organiser portal `/login`, click "Create an account", complete the OTP + passkey ceremony, confirm redirect to the dashboard; click "Cancel" returns to sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3dTF7ghH3NobwKrwfZjga)_