### PR TITLE
feat(cire): consent capture for special-category dietary data (C-H2)

### DIFF
--- a/.changeset/cire-dietary-consent.md
+++ b/.changeset/cire-dietary-consent.md
@@ -1,0 +1,16 @@
+---
+"@cire/api": minor
+"@cire/db": minor
+"@cire/web": minor
+---
+
+Dietary RSVP field now captures explicit Art. 9(2)(a) consent (DPIA C-H2).
+
+The free-text `rsvps.dietary` field is special-category data, so it now
+requires an explicit, unticked-by-default opt-in and a stored consent
+record. `rsvps` gains `dietary_consent_at` + `dietary_consent_version`
+columns (migration 0011); the RSVP API rejects (422) any non-empty
+dietary submitted without consent and stamps the consent timestamp +
+version when given; the guest RSVP modal shows a consent checkbox once
+dietary text is entered, gates submit on it, and links to the `/privacy`
+notice.

--- a/cire/api/src/db/setup.ts
+++ b/cire/api/src/db/setup.ts
@@ -81,6 +81,8 @@ CREATE TABLE IF NOT EXISTS rsvps (
   event_id TEXT NOT NULL REFERENCES events(id),
   status TEXT NOT NULL CHECK(status IN ('attending', 'declined', 'maybe')),
   dietary TEXT NOT NULL DEFAULT '',
+  dietary_consent_at INTEGER,
+  dietary_consent_version TEXT,
   created_at INTEGER NOT NULL
 );
 CREATE UNIQUE INDEX IF NOT EXISTS rsvps_guest_event_uniq ON rsvps(guest_id, event_id);

--- a/cire/api/src/routes/rsvp.test.ts
+++ b/cire/api/src/routes/rsvp.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 
-import { BOOTSTRAP_WEDDING_ID, guests } from "@cire/db";
+import { BOOTSTRAP_WEDDING_ID, guests, rsvps } from "@cire/db";
 import { createRateLimiter } from "@shared/rate-limit";
+import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 
 import { createApp } from "../app";
@@ -10,6 +11,7 @@ import { DbService } from "../db";
 import type { Db } from "../db";
 import { createDb, seedDb } from "../db/setup";
 import { parseSessionToken } from "../lib/cookie";
+import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import { hostCodeService } from "../services/host-code";
 import { eff } from "../test-helpers";
 
@@ -106,6 +108,7 @@ describe("POST /api/rsvp", () => {
                 eventId: HINDU_ID,
                 status: "attending",
                 dietary: "Vegetarian",
+                dietaryConsent: true,
               },
             ],
           },
@@ -266,6 +269,87 @@ describe("POST /api/rsvp", () => {
           cookie,
         );
         expect(res.status).toBe(400);
+      }),
+    ),
+  );
+
+  it(
+    "returns 422 when dietary text is submitted without consent (C-H2)",
+    eff(
+      Effect.gen(function* () {
+        const cookie = yield* claimAndCookie("TESTONE-IVY-AA11");
+        const res = yield* post(
+          {
+            rsvps: [
+              {
+                guestId: sharmaGuestId,
+                eventId: HINDU_ID,
+                status: "attending",
+                dietary: "Vegetarian",
+                // dietaryConsent omitted → defaults false
+              },
+            ],
+          },
+          cookie,
+        );
+        expect(res.status).toBe(422);
+        const data = yield* Effect.promise(() => res.json<{ error: string }>());
+        expect(data.error).toBe("Dietary requirements need your consent to store");
+      }),
+    ),
+  );
+
+  it(
+    "returns 200 and persists a consent record when dietary is submitted WITH consent (C-H2)",
+    eff(
+      Effect.gen(function* () {
+        const cookie = yield* claimAndCookie("TESTONE-IVY-AA11");
+        const res = yield* post(
+          {
+            rsvps: [
+              {
+                guestId: sharmaGuestId,
+                eventId: HINDU_ID,
+                status: "attending",
+                dietary: "Coeliac",
+                dietaryConsent: true,
+              },
+            ],
+          },
+          cookie,
+        );
+        expect(res.status).toBe(200);
+
+        const [row] = db
+          .select({
+            dietary: rsvps.dietary,
+            at: rsvps.dietaryConsentAt,
+            version: rsvps.dietaryConsentVersion,
+          })
+          .from(rsvps)
+          .where(eq(rsvps.guestId, sharmaGuestId))
+          .all();
+        expect(row?.dietary).toBe("Coeliac");
+        expect(row?.at).toBeInstanceOf(Date);
+        expect(row?.version).toBe(DIETARY_CONSENT_VERSION);
+      }),
+    ),
+  );
+
+  it(
+    "returns 200 with no consent needed when dietary is empty (C-H2)",
+    eff(
+      Effect.gen(function* () {
+        const cookie = yield* claimAndCookie("TESTONE-IVY-AA11");
+        const res = yield* post(
+          {
+            rsvps: [
+              { guestId: sharmaGuestId, eventId: HINDU_ID, status: "attending", dietary: "" },
+            ],
+          },
+          cookie,
+        );
+        expect(res.status).toBe(200);
       }),
     ),
   );

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -102,6 +102,18 @@ export const createRsvpRoutes = (db: Db) =>
               }
             }
 
+            // Art. 9(2)(a) gate: the special-category `dietary` free-text may
+            // only be collected with the guest's explicit opt-in. Reject the
+            // whole batch (422) if any non-empty dietary lacks consent — the
+            // form blocks this, so reaching here means a tampered/legacy client.
+            // See [[wiki/compliance/dpia/cire-guest-data]] → C-H2.
+            for (const rsvp of body.rsvps) {
+              if (rsvp.dietary.length > 0 && !rsvp.dietaryConsent) {
+                set.status = 422;
+                return { error: "Dietary requirements need your consent to store" };
+              }
+            }
+
             // Ownership + invitation already validated above — service method does
             // not re-check.
             for (const rsvp of body.rsvps) {
@@ -110,6 +122,9 @@ export const createRsvpRoutes = (db: Db) =>
                 eventId: rsvp.eventId,
                 status: rsvp.status,
                 dietary: rsvp.dietary,
+                // Only stamp a consent record when there is special-category
+                // data to authorise; clearing dietary clears the record too.
+                dietaryConsent: rsvp.dietary.length > 0 && rsvp.dietaryConsent,
               });
             }
 

--- a/cire/api/src/schemas/rsvp.ts
+++ b/cire/api/src/schemas/rsvp.ts
@@ -7,26 +7,33 @@ import { Schema } from "effect";
 const MAX_DIETARY_CHARS = 500;
 const MAX_RSVP_BATCH = 200;
 
+// Privacy-notice / consent-copy version the dietary opt-in agrees to. The
+// server stamps THIS value (never a client-supplied one) into
+// `rsvps.dietary_consent_version`, so the stored Art. 9(2)(a) evidence always
+// pins the copy actually shown. Bump (date-stamped, matching the wiki
+// `last-reviewed` convention) whenever the consent wording materially changes.
+// See [[wiki/compliance/dpia/cire-guest-data]] → C-H2.
+export const DIETARY_CONSENT_VERSION = "2026-06-17";
+
 // Free-text dietary field, capped at MAX_DIETARY_CHARS.
 const DietaryText = Schema.String.pipe(Schema.maxLength(MAX_DIETARY_CHARS));
 
-export const RsvpBody = Schema.Struct({
+// Per-RSVP shape shared by the single + bulk bodies. `dietaryConsent` is the
+// guest's explicit opt-in for the special-category dietary field; the route
+// rejects (422) any non-empty `dietary` submitted without it.
+const RsvpItem = Schema.Struct({
   guestId: Schema.NonEmptyString,
   eventId: Schema.NonEmptyString,
   status: Schema.Literal("attending", "declined", "maybe"),
   dietary: Schema.optionalWith(DietaryText, { default: () => "" }),
+  dietaryConsent: Schema.optionalWith(Schema.Boolean, { default: () => false }),
 });
+
+export const RsvpBody = RsvpItem;
 export type RsvpBody = Schema.Schema.Type<typeof RsvpBody>;
 
 export const BulkRsvpBody = Schema.Struct({
-  rsvps: Schema.Array(
-    Schema.Struct({
-      guestId: Schema.NonEmptyString,
-      eventId: Schema.NonEmptyString,
-      status: Schema.Literal("attending", "declined", "maybe"),
-      dietary: Schema.optionalWith(DietaryText, { default: () => "" }),
-    }),
-  ).pipe(Schema.maxItems(MAX_RSVP_BATCH)),
+  rsvps: Schema.Array(RsvpItem).pipe(Schema.maxItems(MAX_RSVP_BATCH)),
 });
 export type BulkRsvpBody = Schema.Schema.Type<typeof BulkRsvpBody>;
 

--- a/cire/api/src/services/rsvp.test.ts
+++ b/cire/api/src/services/rsvp.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from "bun:test";
 
-import { guests } from "@cire/db";
-import { eq } from "drizzle-orm";
+import { guests, rsvps as rsvpsTable } from "@cire/db";
+import { and, eq } from "drizzle-orm";
 import { Effect } from "effect";
 
 import eventsData from "../data/events.json";
 import { DbService } from "../db";
 import { TestDbLayer } from "../db/test-layer";
+import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import { effWith } from "../test-helpers";
 import { rsvpService } from "./rsvp";
 
@@ -44,6 +45,7 @@ describe("rsvpService.submitRsvp", () => {
           eventId: HINDU_ID,
           status: "attending",
           dietary: "",
+          dietaryConsent: false,
         });
 
         const rsvps = yield* rsvpService.getRsvpsForFamily(priya.familyId);
@@ -65,12 +67,14 @@ describe("rsvpService.submitRsvp", () => {
           eventId: HINDU_ID,
           status: "attending",
           dietary: "",
+          dietaryConsent: false,
         });
         yield* rsvpService.submitRsvp({
           guestId: priya.id,
           eventId: HINDU_ID,
           status: "declined",
           dietary: "",
+          dietaryConsent: false,
         });
 
         const rsvps = yield* rsvpService.getRsvpsForFamily(priya.familyId);
@@ -91,11 +95,92 @@ describe("rsvpService.submitRsvp", () => {
           eventId: RECEPTION_ID,
           status: "attending",
           dietary: "Vegetarian, no nuts",
+          dietaryConsent: true,
         });
 
         const rsvps = yield* rsvpService.getRsvpsForFamily(priya.familyId);
         const receptionRsvp = rsvps.find((r) => r.eventId === RECEPTION_ID);
         expect(receptionRsvp?.dietary).toBe("Vegetarian, no nuts");
+      }),
+    ),
+  );
+
+  it(
+    "stamps a consent record (timestamp + version) when dietaryConsent is true",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const priya = yield* lookupGuest("Ada");
+        // Drizzle `timestamp` mode persists epoch *seconds*, so the round-trip
+        // truncates sub-second precision — floor the lower bound to the second.
+        const before = Math.floor(Date.now() / 1000) * 1000;
+        yield* rsvpService.submitRsvp({
+          guestId: priya.id,
+          eventId: RECEPTION_ID,
+          status: "attending",
+          dietary: "Coeliac",
+          dietaryConsent: true,
+        });
+
+        const [row] = db
+          .select({
+            at: rsvpsTable.dietaryConsentAt,
+            version: rsvpsTable.dietaryConsentVersion,
+          })
+          .from(rsvpsTable)
+          .where(and(eq(rsvpsTable.guestId, priya.id), eq(rsvpsTable.eventId, RECEPTION_ID)))
+          .all();
+        expect(row?.version).toBe(DIETARY_CONSENT_VERSION);
+        expect(row?.at).toBeInstanceOf(Date);
+        expect(row!.at!.getTime()).toBeGreaterThanOrEqual(before);
+      }),
+    ),
+  );
+
+  it(
+    "leaves the consent record null when dietaryConsent is false, and clears it on re-submit",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const priya = yield* lookupGuest("Ada");
+
+        // No consent → null record.
+        yield* rsvpService.submitRsvp({
+          guestId: priya.id,
+          eventId: RECEPTION_ID,
+          status: "declined",
+          dietary: "",
+          dietaryConsent: false,
+        });
+        const read = () =>
+          db
+            .select({ at: rsvpsTable.dietaryConsentAt, version: rsvpsTable.dietaryConsentVersion })
+            .from(rsvpsTable)
+            .where(and(eq(rsvpsTable.guestId, priya.id), eq(rsvpsTable.eventId, RECEPTION_ID)))
+            .all()[0];
+        expect(read()?.at).toBeNull();
+        expect(read()?.version).toBeNull();
+
+        // Consent given on re-submit → record stamped.
+        yield* rsvpService.submitRsvp({
+          guestId: priya.id,
+          eventId: RECEPTION_ID,
+          status: "attending",
+          dietary: "Halal",
+          dietaryConsent: true,
+        });
+        expect(read()?.version).toBe(DIETARY_CONSENT_VERSION);
+
+        // Dietary removed → consent record cleared (no special-category data left).
+        yield* rsvpService.submitRsvp({
+          guestId: priya.id,
+          eventId: RECEPTION_ID,
+          status: "attending",
+          dietary: "",
+          dietaryConsent: false,
+        });
+        expect(read()?.at).toBeNull();
+        expect(read()?.version).toBeNull();
       }),
     ),
   );
@@ -114,12 +199,14 @@ describe("rsvpService.getRsvpsForFamily", () => {
           eventId: HINDU_ID,
           status: "attending",
           dietary: "",
+          dietaryConsent: false,
         });
         yield* rsvpService.submitRsvp({
           guestId: emma.id,
           eventId: HINDU_ID,
           status: "maybe",
           dietary: "Gluten-free",
+          dietaryConsent: true,
         });
 
         const rsvps = yield* rsvpService.getRsvpsForFamily(james.familyId);

--- a/cire/api/src/services/rsvp.ts
+++ b/cire/api/src/services/rsvp.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 
 import { DbService, dbQuery } from "../db";
 import { metricRsvpUpserted } from "../metrics";
+import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import type { RsvpRecord } from "../schemas/rsvp";
 
 export const rsvpService = {
@@ -18,11 +19,17 @@ export const rsvpService = {
     eventId: string;
     status: "attending" | "declined" | "maybe";
     dietary: string;
+    // True only when the guest opted in AND there is dietary text to authorise
+    // (the route already collapses both conditions). Stamps an Art. 9(2)(a)
+    // consent record; false clears any prior record (e.g. dietary removed).
+    dietaryConsent: boolean;
   }): Effect.Effect<void, never, DbService> {
     return Effect.gen(function* () {
       const db = yield* DbService;
 
       const now = new Date();
+      const dietaryConsentAt = input.dietaryConsent ? now : null;
+      const dietaryConsentVersion = input.dietaryConsent ? DIETARY_CONSENT_VERSION : null;
       yield* dbQuery(() =>
         db
           .insert(rsvps)
@@ -32,6 +39,8 @@ export const rsvpService = {
             eventId: input.eventId,
             status: input.status,
             dietary: input.dietary,
+            dietaryConsentAt,
+            dietaryConsentVersion,
             createdAt: now,
           })
           .onConflictDoUpdate({
@@ -39,6 +48,8 @@ export const rsvpService = {
             set: {
               status: input.status,
               dietary: input.dietary,
+              dietaryConsentAt,
+              dietaryConsentVersion,
             },
           })
           .run(),

--- a/cire/db/migrations/0011_dietary_consent.sql
+++ b/cire/db/migrations/0011_dietary_consent.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `rsvps` ADD `dietary_consent_at` integer;--> statement-breakpoint
+ALTER TABLE `rsvps` ADD `dietary_consent_version` text;

--- a/cire/db/src/schema.ts
+++ b/cire/db/src/schema.ts
@@ -158,6 +158,16 @@ export const rsvps = sqliteTable(
       enum: ["attending", "declined", "maybe"],
     }).notNull(),
     dietary: text("dietary").notNull().default(""),
+    // Explicit Art. 9(2)(a) consent record for the special-category `dietary`
+    // free-text (see [[wiki/compliance/dpia/cire-guest-data]] → C-H2). Captured
+    // here, 1:1 with the RSVP, because consent authorises exactly this row's
+    // dietary data and the `(guest_id, event_id)` upsert already keys it — a
+    // separate table would duplicate that key and add a join for no gain. Both
+    // columns are null unless the guest ticked the opt-in for non-empty dietary
+    // text; `dietary_consent_at` is when they consented, `dietary_consent_version`
+    // pins which privacy-notice/copy version they agreed to.
+    dietaryConsentAt: integer("dietary_consent_at", { mode: "timestamp" }),
+    dietaryConsentVersion: text("dietary_consent_version"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   },
   (t) => [uniqueIndex("rsvps_guest_event_uniq").on(t.guestId, t.eventId)],

--- a/cire/web/src/components/RsvpModal.test.tsx
+++ b/cire/web/src/components/RsvpModal.test.tsx
@@ -153,11 +153,12 @@ describe("RsvpModal", () => {
       />
     ));
 
-    // Priya: attending + dietary
+    // Priya: attending + dietary (+ consent box ticked, required for dietary)
     const priyaFs = fieldsetFor("Priya");
     fireEvent.click(within(priyaFs).getByText("Attending"));
     const dietary = within(priyaFs).getByPlaceholderText(/Vegetarian/) as HTMLInputElement;
     fireEvent.input(dietary, { target: { value: "Vegetarian" } });
+    fireEvent.click(within(priyaFs).getByRole("checkbox"));
 
     // Raj: declined
     fireEvent.click(within(fieldsetFor("Raj")).getByText("Not attending"));
@@ -176,8 +177,20 @@ describe("RsvpModal", () => {
     expect(parsed).not.toHaveProperty("familyPublicId");
     expect(parsed).toEqual({
       rsvps: [
-        { guestId: "guest-priya", eventId: "event-1", status: "attending", dietary: "Vegetarian" },
-        { guestId: "guest-raj", eventId: "event-1", status: "declined", dietary: "" },
+        {
+          guestId: "guest-priya",
+          eventId: "event-1",
+          status: "attending",
+          dietary: "Vegetarian",
+          dietaryConsent: true,
+        },
+        {
+          guestId: "guest-raj",
+          eventId: "event-1",
+          status: "declined",
+          dietary: "",
+          dietaryConsent: false,
+        },
       ],
     });
 
@@ -323,6 +336,98 @@ describe("RsvpModal", () => {
     expect(within(fs).getByText("Not attending").getAttribute("aria-pressed")).toBe("false");
   });
 
+  it("hides the consent checkbox until dietary text is entered (C-H2)", () => {
+    render(() => (
+      <RsvpModal event={event} members={[priya]} apiUrl="https://api.test" onClose={() => {}} />
+    ));
+
+    const fs = fieldsetFor("Priya");
+    // Attending, no dietary text yet → no checkbox.
+    fireEvent.click(within(fs).getByText("Attending"));
+    expect(within(fs).queryByRole("checkbox")).toBeNull();
+
+    // Enter dietary text → consent checkbox appears, unticked, linking /privacy.
+    fireEvent.input(within(fs).getByPlaceholderText(/Vegetarian/), {
+      target: { value: "Vegan" },
+    });
+    const checkbox = within(fs).getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    const privacyLink = within(fs)
+      .getByText(/privacy notice/i)
+      .closest("a") as HTMLAnchorElement;
+    expect(privacyLink.getAttribute("href")).toBe("/privacy");
+  });
+
+  it("blocks submit and shows an error when dietary is entered without consent (C-H2)", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { getByText } = render(() => (
+      <RsvpModal event={event} members={[priya]} apiUrl="https://api.test" onClose={() => {}} />
+    ));
+
+    const fs = fieldsetFor("Priya");
+    fireEvent.click(within(fs).getByText("Attending"));
+    fireEvent.input(within(fs).getByPlaceholderText(/Vegetarian/), {
+      target: { value: "Vegan" },
+    });
+    // Leave the consent box unticked.
+    fireEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(
+        getByText("Please tick the box to let us store your dietary requirements."),
+      ).toBeTruthy();
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows submit with empty dietary and no consent needed (C-H2)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ rsvps: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { getByText } = render(() => (
+      <RsvpModal event={event} members={[priya]} apiUrl="https://api.test" onClose={() => {}} />
+    ));
+
+    // Attending, no dietary text → no consent gate.
+    fireEvent.click(within(fieldsetFor("Priya")).getByText("Attending"));
+    fireEvent.click(getByText("Save"));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const parsed = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(parsed.rsvps[0]).toEqual({
+      guestId: "guest-priya",
+      eventId: "event-1",
+      status: "attending",
+      dietary: "",
+      dietaryConsent: false,
+    });
+  });
+
+  it("prefills the consent box as ticked when an existing RSVP carries dietary (C-H2)", () => {
+    const existing: RsvpSummary[] = [
+      { guestId: "guest-priya", eventId: "event-1", status: "attending", dietary: "Vegan" },
+    ];
+    render(() => (
+      <RsvpModal
+        event={event}
+        members={[priya]}
+        existingRsvps={existing}
+        apiUrl="https://api.test"
+        onClose={() => {}}
+      />
+    ));
+
+    const checkbox = within(fieldsetFor("Priya")).getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
   it("does not log dietary input to console (frontend redaction sanity)", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -347,6 +452,7 @@ describe("RsvpModal", () => {
     fireEvent.input(within(fs).getByPlaceholderText(/Vegetarian/), {
       target: { value: "peanut allergy" },
     });
+    fireEvent.click(within(fs).getByRole("checkbox"));
     fireEvent.click(getByText("Save"));
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());

--- a/cire/web/src/components/RsvpModal.tsx
+++ b/cire/web/src/components/RsvpModal.tsx
@@ -17,6 +17,11 @@ type Attending = "attending" | "declined" | null;
 interface MemberState {
   attending: Attending;
   dietary: string;
+  // Explicit Art. 9(2)(a) opt-in for the special-category dietary free-text.
+  // Unticked by default; gates submit when `dietary` is non-empty. Prefilled
+  // true when an existing RSVP already carries dietary text (consent was
+  // captured at the prior submit). See cire-guest-data DPIA → C-H2.
+  dietaryConsent: boolean;
 }
 
 export function RsvpModal(props: RsvpModalProps) {
@@ -35,9 +40,14 @@ export function RsvpModal(props: RsvpModalProps) {
         else if (existing.status === "declined") attending = "declined";
         // "maybe" → null (UX is binary now)
       }
+      const dietary = existing?.dietary ?? "";
       map[m.guestId] = {
         attending,
-        dietary: existing?.dietary ?? "",
+        dietary,
+        // Existing dietary text was only stored because consent was given, so
+        // a prefilled value implies prior consent — keep the box ticked so an
+        // unchanged response re-submits cleanly.
+        dietaryConsent: dietary.length > 0,
       };
     }
     return map;
@@ -66,6 +76,13 @@ export function RsvpModal(props: RsvpModalProps) {
     }));
   }
 
+  function setDietaryConsent(guestId: string, dietaryConsent: boolean) {
+    setResponses((prev) => ({
+      ...prev,
+      [guestId]: { ...prev[guestId]!, dietaryConsent },
+    }));
+  }
+
   async function handleSubmit(e: SubmitEvent) {
     e.preventDefault();
     setError(null);
@@ -78,16 +95,34 @@ export function RsvpModal(props: RsvpModalProps) {
       return;
     }
 
+    // Art. 9(2)(a) gate: dietary free-text is special-category data and may only
+    // be sent with the guest's explicit opt-in. Block submit if anyone entered
+    // dietary text but left the consent box unticked. (The server also enforces
+    // this with a 422 — see cire-guest-data DPIA → C-H2.)
+    const missingConsent = visible.some((m) => {
+      const state = current[m.guestId]!;
+      return (
+        state.attending === "attending" && state.dietary.trim().length > 0 && !state.dietaryConsent
+      );
+    });
+    if (missingConsent) {
+      setError("Please tick the box to let us store your dietary requirements.");
+      return;
+    }
+
     setLoading(true);
 
     const body = {
       rsvps: visible.map((m) => {
         const state = current[m.guestId]!;
+        const attending = state.attending === "attending";
+        const dietary = attending ? state.dietary : "";
         return {
           guestId: m.guestId,
           eventId: props.event.id,
           status: state.attending!,
-          dietary: state.attending === "attending" ? state.dietary : "",
+          dietary,
+          dietaryConsent: dietary.trim().length > 0 && state.dietaryConsent,
         };
       }),
     };
@@ -194,6 +229,34 @@ export function RsvpModal(props: RsvpModalProps) {
                       disabled={loading()}
                     />
                   </label>
+
+                  {/* Explicit, unticked-by-default consent — only shown once the
+                      guest has actually entered dietary text (special-category
+                      data). See cire-guest-data DPIA → C-H2. */}
+                  <Show when={(responses()[guestId]?.dietary.trim().length ?? 0) > 0}>
+                    <label class="font-body text-text-muted mt-3 flex items-start gap-2.5 text-[0.78rem] leading-relaxed normal-case">
+                      <input
+                        type="checkbox"
+                        class="accent-gold mt-0.5 h-4 w-4 shrink-0 cursor-pointer"
+                        checked={responses()[guestId]?.dietaryConsent ?? false}
+                        onChange={(e) => setDietaryConsent(guestId, e.currentTarget.checked)}
+                        disabled={loading()}
+                      />
+                      <span>
+                        I agree to my dietary requirements above being stored and shared with the
+                        caterers for this wedding. See our{" "}
+                        <a
+                          href="/privacy"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-gold underline underline-offset-2"
+                        >
+                          privacy notice
+                        </a>
+                        .
+                      </span>
+                    </label>
+                  </Show>
                 </Show>
               </fieldset>
             );


### PR DESCRIPTION
## What
Explicit opt-in consent + stored consent record for the special-category `rsvps.dietary` field (GDPR Art. 9 / DPIA finding **C-H2** — collecting it without consent was flagged unlawful).

- DB: migration `0011` adds `dietaryConsentAt` (ts) + `dietaryConsentVersion` (text) on `rsvps` (1:1 with the RSVP row; null = no consent).
- API: `routes/rsvp.ts` rejects **422** if any non-empty `dietary` lacks consent; `services/rsvp.ts` stamps consent (now + version) only when there's dietary text, and **nulls both when dietary is cleared** so the record never outlives the data.
- Web: `RsvpModal.tsx` adds an unticked-by-default consent checkbox (shown once dietary text entered, gates submit) + a `/privacy` link. Server-authoritative `DIETARY_CONSENT_VERSION = "2026-06-17"`.

## Tests
API `bun test` → **254 pass**; web vitest → **161 pass**; lint clean. Verified locally.

## Copy (for legal review)
> "I agree to my dietary requirements above being stored and shared with the caterers for this wedding. See our [privacy notice]."

## Values still needed
- Confirm consent-version scheme (date-stamped vs semver vs tied to /privacy version).
- DPIA C-H2 sign-off + TODO update (left to humans).
- `/privacy` page lands via the legal-pages PR.
