### PR TITLE
feat(cire/web): draft privacy notice + terms (C-H4)

### DIFF
--- a/.changeset/cire-legal-pages.md
+++ b/.changeset/cire-legal-pages.md
@@ -1,0 +1,14 @@
+---
+"@cire/web": minor
+---
+
+Add draft Privacy Notice (`/privacy`) and Terms of Use (`/terms`) pages to the
+guest site, plus a site-wide footer linking to both. The privacy notice covers
+the controller, what RSVP data is collected (guest names, RSVP status, and
+free-text dietary/access needs treated as GDPR Art.9 special-category data
+collected under explicit consent), purpose, lawful bases, retention, processors
+(Cloudflare), guest rights, and a DSAR contact route. Addresses compliance
+blocker C-H4 (privacy notice required at the point of collection on the RSVP
+form). Copy is clearly marked DRAFT / not legal advice and uses
+`{{PLACEHOLDER}}` tokens for the controller legal name, DSAR contact email,
+retention window, jurisdiction, and last-updated date.

--- a/cire/web/src/components/SiteFooter.astro
+++ b/cire/web/src/components/SiteFooter.astro
@@ -1,0 +1,41 @@
+---
+// Site-wide footer. Links to the legal pages so the privacy notice + terms are
+// reachable from every page (compliance blocker C-H4: privacy notice must be
+// published and linked at point of collection).
+---
+<footer class="site-footer">
+  <nav aria-label="Legal">
+    <a href="/privacy">Privacy Notice</a>
+    <span aria-hidden="true">&middot;</span>
+    <a href="/terms">Terms</a>
+  </nav>
+</footer>
+
+<style>
+  .site-footer {
+    padding: 2rem 1.5rem 2.5rem;
+    text-align: center;
+    font-family: var(--font-body, "Lato", system-ui, sans-serif);
+    font-size: 0.8125rem;
+    color: var(--color-text-muted, rgba(255, 255, 255, 0.5));
+  }
+
+  .site-footer nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .site-footer a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .site-footer a:hover,
+  .site-footer a:focus-visible {
+    color: var(--color-gold, oklch(74.99% 0.0854 82.08));
+    border-bottom-color: currentColor;
+  }
+</style>

--- a/cire/web/src/layouts/LegalLayout.astro
+++ b/cire/web/src/layouts/LegalLayout.astro
@@ -1,0 +1,120 @@
+---
+import '../styles/global.css'
+import SiteFooter from '../components/SiteFooter.astro'
+
+interface Props {
+  title: string
+}
+
+const { title } = Astro.props
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {/* S-L1: keep the ?code= preview credential out of cross-origin Referer headers. */}
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <title>{title}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <noscript>
+      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet" />
+    </noscript>
+  </head>
+  <body>
+    <main class="legal">
+      <slot />
+    </main>
+    <SiteFooter />
+    <style is:global>
+      .legal {
+        max-width: 46rem;
+        margin: 0 auto;
+        padding: 3.5rem 1.5rem 1rem;
+      }
+
+      .legal a {
+        color: var(--color-gold);
+      }
+
+      .legal .draft-banner {
+        border: 1px solid var(--color-gold-dim);
+        background: var(--color-surface-raised);
+        border-radius: 0.5rem;
+        padding: 0.875rem 1.125rem;
+        margin-bottom: 2.5rem;
+        font-size: 0.875rem;
+        color: var(--color-text-muted);
+      }
+
+      .legal .draft-banner strong {
+        color: var(--color-gold);
+        font-weight: 400;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .legal h1 {
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        line-height: 1.1;
+        margin: 0 0 0.5rem;
+      }
+
+      .legal h2 {
+        font-family: var(--font-display);
+        font-weight: 600;
+        font-size: 1.375rem;
+        margin: 2.25rem 0 0.625rem;
+      }
+
+      .legal h3 {
+        font-family: var(--font-body);
+        font-weight: 400;
+        font-size: 1rem;
+        letter-spacing: 0.02em;
+        margin: 1.25rem 0 0.375rem;
+        color: var(--color-gold);
+      }
+
+      .legal p,
+      .legal li {
+        color: var(--color-text);
+        font-size: 0.9375rem;
+        line-height: 1.65;
+      }
+
+      .legal .meta {
+        color: var(--color-text-muted);
+        font-size: 0.8125rem;
+        margin-top: 0;
+      }
+
+      .legal ul {
+        padding-left: 1.25rem;
+        margin: 0.5rem 0 1rem;
+      }
+
+      .legal li {
+        margin-bottom: 0.35rem;
+      }
+
+      .legal .placeholder {
+        color: var(--color-gold);
+        background: var(--color-gold-dim);
+        border-radius: 0.25rem;
+        padding: 0.05rem 0.3rem;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 0.85em;
+      }
+    </style>
+  </body>
+</html>

--- a/cire/web/src/layouts/LegalLayout.astro
+++ b/cire/web/src/layouts/LegalLayout.astro
@@ -115,6 +115,21 @@ const { title } = Astro.props
         font-family: ui-monospace, "SF Mono", Menlo, monospace;
         font-size: 0.85em;
       }
+
+      .legal .owner-note {
+        border-left: 2px solid var(--color-gold-dim);
+        background: var(--color-surface-raised);
+        border-radius: 0.25rem;
+        padding: 0.625rem 0.875rem;
+        margin: 0.75rem 0 1rem;
+        font-size: 0.8125rem;
+        color: var(--color-text-muted);
+      }
+
+      .legal .owner-note strong {
+        color: var(--color-gold);
+        font-weight: 400;
+      }
     </style>
   </body>
 </html>

--- a/cire/web/src/pages/index.astro
+++ b/cire/web/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css'
 import InviteHeader, { type InviteCustomisation } from '../components/InviteHeader'
 import InvitePage from '../components/InvitePage'
+import SiteFooter from '../components/SiteFooter.astro'
 
 const apiUrl = import.meta.env.PUBLIC_API_URL ?? 'http://localhost:8787'
 const weddingSlug = import.meta.env.PUBLIC_WEDDING_SLUG ?? 'cire-wedding'
@@ -49,5 +50,6 @@ const preloadHero = initialInvite?.hero.imageUrl
       apiUrl={apiUrl}
       siteUrl={import.meta.env.PUBLIC_SITE_URL}
     />
+    <SiteFooter />
   </body>
 </html>

--- a/cire/web/src/pages/privacy.astro
+++ b/cire/web/src/pages/privacy.astro
@@ -9,7 +9,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   </div>
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: <span class="placeholder">{'{{LAST_UPDATED}}'}</span></p>
+  <p class="meta">Last updated: 2026-06-17</p>
 
   <p>
     This is a private wedding invitation website. We only collect the small amount
@@ -18,13 +18,23 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     over your information.
   </p>
 
+  <p>
+    We run this site as individuals planning a personal celebration, not as a
+    business. A private wedding organised by individuals for a personal,
+    family or household event is likely to sit outside the strict reach of the
+    <em>Privacy Act 1988</em> (Cth) and the Australian Privacy Principles (APPs)
+    — which generally apply to “APP entities” such as businesses and agencies.
+    We are nonetheless providing this notice as a matter of good-practice
+    transparency, and we aim to follow the spirit of the APPs. It should not be
+    read as a claim that any particular legal regime strictly applies to us.
+  </p>
+
   <h2>Who is responsible for your information</h2>
   <p>
-    The person responsible for the information collected through this website
-    (the “data controller” under the UK GDPR / EU GDPR) is
-    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span>. You can reach us
-    about anything in this notice at
-    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
+    The people responsible for the information collected through this website are
+    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span> (the couple). You
+    can reach us about anything in this notice at
+    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
   </p>
 
   <h2>What we collect</h2>
@@ -46,27 +56,27 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h3>A note on dietary information</h3>
   <p>
-    Some dietary or access details can count as “special category” data under
-    Article 9 of the GDPR (for example information that reveals your health or
-    your religious beliefs). This field is optional. We only collect what you
-    choose to enter, and we ask for your explicit consent before you submit it.
-    Please don’t include any health or other sensitive detail you’d rather not
-    share — a simple note such as “vegetarian” or “no nuts” is all we need.
+    Some dietary or access details count as “sensitive information” under the
+    <em>Privacy Act 1988</em> (Cth) — for example information about your health,
+    or your religious beliefs. Under the Australian Privacy Principles (APP 3.3),
+    sensitive information should only be collected with your consent. This field
+    is therefore optional: we only collect what you choose to enter, and we ask
+    for your explicit consent before you submit it. Please don’t include any
+    health or other sensitive detail you’d rather not share — a simple note such
+    as “vegetarian” or “no nuts” is all we need.
   </p>
 
-  <h2>Why we use it and our lawful basis</h2>
+  <h2>Why we use it</h2>
   <ul>
     <li>
       <strong>Guest names &amp; RSVP status</strong> — to manage invitations,
-      confirm numbers, and organise seating and logistics. Our lawful basis is
-      our <strong>legitimate interest</strong> in planning our wedding (and,
-      where relevant, performing our arrangements with you as an invited guest).
+      confirm numbers, and organise seating and logistics for our wedding.
     </li>
     <li>
       <strong>Dietary requirements / access needs</strong> — to cater safely and
-      accommodate your needs on the day. Because this can include special
-      category data, our lawful basis is your <strong>explicit consent</strong>,
-      which you give when you choose to fill in that field and submit your RSVP.
+      accommodate your needs on the day. Because this can include sensitive
+      information, we rely on your <strong>consent</strong>, which you give when
+      you choose to fill in that field and submit your RSVP.
     </li>
   </ul>
 
@@ -78,47 +88,58 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   </p>
   <p>
     The site and its data are hosted on <strong>Cloudflare</strong>, which
-    provides our website hosting, database, and security on our behalf as a data
-    processor. Cloudflare may process and store data in the course of providing
-    that service. We don’t transfer your information to anyone else except where
-    we’re required to by law.
+    provides our website hosting, database, and security on our behalf. Cloudflare
+    may process and store data in the course of providing that service. We don’t
+    transfer your information to anyone else except where we’re required to by law.
   </p>
 
   <h2>How long we keep it</h2>
   <p>
     We keep your RSVP information only as long as we need it to plan the wedding.
-    We delete it after the event, and in any case no later than
-    <span class="placeholder">{'{{RETENTION_WINDOW}}'}</span> after the final
-    event date. After that it is permanently removed from our systems.
+    By default we delete it <strong>90 days after the final wedding event</strong>,
+    after which guest data is removed. After that it is permanently deleted from
+    our systems.
+  </p>
+  <p class="owner-note">
+    <strong>Note for the site owner:</strong> this 90-day default retention window
+    is a sensible starting point — you can change it to whatever suits your plans
+    (e.g. a shorter or longer period). Update both this wording and the actual
+    deletion schedule together so they stay consistent.
   </p>
 
   <h2>Your rights</h2>
-  <p>You have the right to:</p>
+  <p>You can ask us to:</p>
   <ul>
     <li><strong>Access</strong> the information we hold about you;</li>
     <li><strong>Correct</strong> anything that is wrong or out of date;</li>
-    <li><strong>Ask us to delete</strong> your information;</li>
+    <li><strong>Delete</strong> your information;</li>
     <li>
       <strong>Withdraw your consent</strong> to the dietary/access information at
-      any time — this won’t affect anything we did before you withdrew it;
-    </li>
-    <li>
-      <strong>Object to or restrict</strong> how we use information we hold on the
-      basis of legitimate interests.
+      any time — this won’t affect anything we did before you withdrew it.
     </li>
   </ul>
   <p>
     To exercise any of these, just email us at
-    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
-    We’ll respond within one month.
+    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
+    We’ll respond as soon as we reasonably can.
+  </p>
+
+  <h3>If you’re in the EU or UK</h3>
+  <p>
+    If any of our guests are in the EU or UK, we’ll also honour the rights you
+    have under the GDPR / UK GDPR — including the right to erasure and to withdraw
+    consent. Please use the same contact,
+    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>, and we’ll take
+    care of it.
   </p>
 
   <h2>Complaints</h2>
   <p>
-    We hope to resolve any concern directly, but you have the right to complain to
-    your local data protection authority — in the UK, the Information
-    Commissioner’s Office (ICO) at
-    <a href="https://ico.org.uk/make-a-complaint/" rel="noreferrer">ico.org.uk</a>.
+    We hope to resolve any concern directly. If you’re in Australia and you’re not
+    satisfied, you can contact the Office of the Australian Information Commissioner
+    (OAIC) at <a href="https://www.oaic.gov.au/" rel="noreferrer">oaic.gov.au</a>.
+    Guests in the EU or UK may instead contact their local data protection
+    authority.
   </p>
 
   <h2>Changes to this notice</h2>

--- a/cire/web/src/pages/privacy.astro
+++ b/cire/web/src/pages/privacy.astro
@@ -96,12 +96,12 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>How long we keep it</h2>
   <p>
     We keep your RSVP information only as long as we need it to plan the wedding.
-    By default we delete it <strong>90 days after the final wedding event</strong>,
+    By default we delete it <strong>1 year after the final wedding event</strong>,
     after which guest data is removed. After that it is permanently deleted from
     our systems.
   </p>
   <p class="owner-note">
-    <strong>Note for the site owner:</strong> this 90-day default retention window
+    <strong>Note for the site owner:</strong> this 1-year default retention window
     is a sensible starting point — you can change it to whatever suits your plans
     (e.g. a shorter or longer period). Update both this wording and the actual
     deletion schedule together so they stay consistent.

--- a/cire/web/src/pages/privacy.astro
+++ b/cire/web/src/pages/privacy.astro
@@ -32,7 +32,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>Who is responsible for your information</h2>
   <p>
     The people responsible for the information collected through this website are
-    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span> (the couple). You
+    <span class="placeholder">{'Aniket Chavan'}</span> (the couple). You
     can reach us about anything in this notice at
     <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
   </p>

--- a/cire/web/src/pages/privacy.astro
+++ b/cire/web/src/pages/privacy.astro
@@ -1,0 +1,129 @@
+---
+import LegalLayout from '../layouts/LegalLayout.astro'
+---
+<LegalLayout title="Privacy Notice">
+  <div class="draft-banner">
+    <strong>Draft</strong> — This is a working draft for review, not legal advice.
+    Please have it checked before publishing and replace every highlighted
+    <span class="placeholder">{'{{PLACEHOLDER}}'}</span> value.
+  </div>
+
+  <h1>Privacy Notice</h1>
+  <p class="meta">Last updated: <span class="placeholder">{'{{LAST_UPDATED}}'}</span></p>
+
+  <p>
+    This is a private wedding invitation website. We only collect the small amount
+    of information we need to plan the day and cater for our guests. This notice
+    explains what we collect, why, how long we keep it, and the rights you have
+    over your information.
+  </p>
+
+  <h2>Who is responsible for your information</h2>
+  <p>
+    The person responsible for the information collected through this website
+    (the “data controller” under the UK GDPR / EU GDPR) is
+    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span>. You can reach us
+    about anything in this notice at
+    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
+  </p>
+
+  <h2>What we collect</h2>
+  <ul>
+    <li><strong>Guest names</strong> — the names on your household invitation.</li>
+    <li><strong>RSVP status</strong> — whether each named guest is attending each event.</li>
+    <li>
+      <strong>Dietary requirements and access needs</strong> — anything you choose
+      to type into the free-text field (for example allergies, intolerances, or
+      requirements that may reveal health information, or religious or
+      belief-based dietary needs).
+    </li>
+  </ul>
+  <p>
+    We do <strong>not</strong> ask for or knowingly collect any other personal
+    information through this site. You only ever fill in details for the members
+    of your own household.
+  </p>
+
+  <h3>A note on dietary information</h3>
+  <p>
+    Some dietary or access details can count as “special category” data under
+    Article 9 of the GDPR (for example information that reveals your health or
+    your religious beliefs). This field is optional. We only collect what you
+    choose to enter, and we ask for your explicit consent before you submit it.
+    Please don’t include any health or other sensitive detail you’d rather not
+    share — a simple note such as “vegetarian” or “no nuts” is all we need.
+  </p>
+
+  <h2>Why we use it and our lawful basis</h2>
+  <ul>
+    <li>
+      <strong>Guest names &amp; RSVP status</strong> — to manage invitations,
+      confirm numbers, and organise seating and logistics. Our lawful basis is
+      our <strong>legitimate interest</strong> in planning our wedding (and,
+      where relevant, performing our arrangements with you as an invited guest).
+    </li>
+    <li>
+      <strong>Dietary requirements / access needs</strong> — to cater safely and
+      accommodate your needs on the day. Because this can include special
+      category data, our lawful basis is your <strong>explicit consent</strong>,
+      which you give when you choose to fill in that field and submit your RSVP.
+    </li>
+  </ul>
+
+  <h2>Who can see it</h2>
+  <p>
+    Your information is seen by us (the couple) and the small number of people
+    helping us organise the day, such as our caterer and venue, strictly so they
+    can do their job. We do not sell your information or use it for marketing.
+  </p>
+  <p>
+    The site and its data are hosted on <strong>Cloudflare</strong>, which
+    provides our website hosting, database, and security on our behalf as a data
+    processor. Cloudflare may process and store data in the course of providing
+    that service. We don’t transfer your information to anyone else except where
+    we’re required to by law.
+  </p>
+
+  <h2>How long we keep it</h2>
+  <p>
+    We keep your RSVP information only as long as we need it to plan the wedding.
+    We delete it after the event, and in any case no later than
+    <span class="placeholder">{'{{RETENTION_WINDOW}}'}</span> after the final
+    event date. After that it is permanently removed from our systems.
+  </p>
+
+  <h2>Your rights</h2>
+  <p>You have the right to:</p>
+  <ul>
+    <li><strong>Access</strong> the information we hold about you;</li>
+    <li><strong>Correct</strong> anything that is wrong or out of date;</li>
+    <li><strong>Ask us to delete</strong> your information;</li>
+    <li>
+      <strong>Withdraw your consent</strong> to the dietary/access information at
+      any time — this won’t affect anything we did before you withdrew it;
+    </li>
+    <li>
+      <strong>Object to or restrict</strong> how we use information we hold on the
+      basis of legitimate interests.
+    </li>
+  </ul>
+  <p>
+    To exercise any of these, just email us at
+    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
+    We’ll respond within one month.
+  </p>
+
+  <h2>Complaints</h2>
+  <p>
+    We hope to resolve any concern directly, but you have the right to complain to
+    your local data protection authority — in the UK, the Information
+    Commissioner’s Office (ICO) at
+    <a href="https://ico.org.uk/make-a-complaint/" rel="noreferrer">ico.org.uk</a>.
+  </p>
+
+  <h2>Changes to this notice</h2>
+  <p>
+    If we change how we handle your information, we’ll update this page and revise
+    the “last updated” date above.
+  </p>
+</LegalLayout>

--- a/cire/web/src/pages/terms.astro
+++ b/cire/web/src/pages/terms.astro
@@ -13,7 +13,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <p>
     This is a private website for invited guests of the wedding of
-    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span>. By using it you
+    <span class="placeholder">{'Aniket Chavan'}</span>. By using it you
     agree to these short terms. If you don’t agree, please don’t use the site.
   </p>
 

--- a/cire/web/src/pages/terms.astro
+++ b/cire/web/src/pages/terms.astro
@@ -1,0 +1,60 @@
+---
+import LegalLayout from '../layouts/LegalLayout.astro'
+---
+<LegalLayout title="Terms of Use">
+  <div class="draft-banner">
+    <strong>Draft</strong> — This is a working draft for review, not legal advice.
+    Please have it checked before publishing and replace every highlighted
+    <span class="placeholder">{'{{PLACEHOLDER}}'}</span> value.
+  </div>
+
+  <h1>Terms of Use</h1>
+  <p class="meta">Last updated: <span class="placeholder">{'{{LAST_UPDATED}}'}</span></p>
+
+  <p>
+    This is a private website for invited guests of the wedding of
+    <span class="placeholder">{'{{CONTROLLER_LEGAL_NAME}}'}</span>. By using it you
+    agree to these short terms. If you don’t agree, please don’t use the site.
+  </p>
+
+  <h2>Invited guests only</h2>
+  <p>
+    Access is by personal invitation code. Please don’t share your code or attempt
+    to access invitations or details that aren’t meant for your household. The
+    information on this site is private and shared with you in confidence.
+  </p>
+
+  <h2>Using the site</h2>
+  <ul>
+    <li>Please keep the information you give us (such as your RSVP and guest names) accurate and up to date.</li>
+    <li>Please don’t submit anything unlawful, abusive, or that isn’t yours to share.</li>
+    <li>Please don’t try to disrupt, probe, or gain unauthorised access to the site or its data.</li>
+  </ul>
+
+  <h2>Your information</h2>
+  <p>
+    How we handle the information you provide is explained in our
+    <a href="/privacy">Privacy Notice</a>. By submitting an RSVP you confirm the
+    details you enter are correct to the best of your knowledge.
+  </p>
+
+  <h2>Availability</h2>
+  <p>
+    We provide this site as-is for the convenience of our guests. We can’t promise
+    it will always be available or error-free, and we may update or take it down at
+    any time — for example after the wedding.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions about these terms? Email us at
+    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
+  </p>
+
+  <h2>Governing law</h2>
+  <p>
+    These terms are governed by the laws of
+    <span class="placeholder">{'{{JURISDICTION}}'}</span>, and any disputes will be
+    subject to the courts of that jurisdiction.
+  </p>
+</LegalLayout>

--- a/cire/web/src/pages/terms.astro
+++ b/cire/web/src/pages/terms.astro
@@ -9,7 +9,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   </div>
 
   <h1>Terms of Use</h1>
-  <p class="meta">Last updated: <span class="placeholder">{'{{LAST_UPDATED}}'}</span></p>
+  <p class="meta">Last updated: 2026-06-17</p>
 
   <p>
     This is a private website for invited guests of the wedding of
@@ -48,13 +48,12 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>Contact</h2>
   <p>
     Questions about these terms? Email us at
-    <a href="mailto:{{DSAR_CONTACT_EMAIL}}"><span class="placeholder">{'{{DSAR_CONTACT_EMAIL}}'}</span></a>.
+    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
   </p>
 
   <h2>Governing law</h2>
   <p>
-    These terms are governed by the laws of
-    <span class="placeholder">{'{{JURISDICTION}}'}</span>, and any disputes will be
-    subject to the courts of that jurisdiction.
+    These terms are governed by the laws of <strong>Australia</strong>, and any
+    disputes will be subject to the courts of that jurisdiction.
   </p>
 </LegalLayout>


### PR DESCRIPTION
## What
Draft privacy notice + terms at point of collection (compliance blocker **C-H4**).

- `cire/web/src/pages/privacy.astro` — draft Privacy Notice: controller, data collected (names, RSVP, dietary = Art. 9 special-category, consent-gated), purposes + lawful bases, retention, processors (Cloudflare), guest rights, DSAR route, ICO complaints route.
- `cire/web/src/pages/terms.astro` — short wedding-appropriate ToS.
- `LegalLayout.astro` + `SiteFooter.astro` (no layout/footer existed) — site-wide footer links to both; rendered on `index.astro`.
- Both clearly marked **DRAFT — not legal advice**.

## Build
`bun run --cwd cire/web build` exits 0; `/privacy`, `/terms`, footer links emitted.

## Values still needed (placeholder tokens)
`{{CONTROLLER_LEGAL_NAME}}`, `{{DSAR_CONTACT_EMAIL}}`, `{{RETENTION_WINDOW}}`, `{{JURISDICTION}}` (swap ICO if non-UK), `{{LAST_UPDATED}}`.
