### PR TITLE
feat(cire/api): scheduled expired-session sweeper (C-M2/M15)

### DIFF
--- a/.changeset/cire-session-sweeper.md
+++ b/.changeset/cire-session-sweeper.md
@@ -1,0 +1,19 @@
+---
+"@cire/api": minor
+---
+
+Add a scheduled sweeper that prunes expired guest sessions (C-M2/C-M15).
+
+Every guest login writes a `sessions` row with a 30-day TTL, but the read
+path only *reports* expiry (`validate` returns `expired`) — it never deletes
+the dead row, so the table grew unbounded.
+
+- New `sessionService.sweepExpired(now)` deletes every session whose
+  `expiresAt <= now` (inclusive boundary) and returns the deleted row count,
+  emitting the new `cire.session.swept` counter (sum tracks reclaimed rows).
+- The Worker default export gains a `scheduled(event, env, ctx)` handler that
+  runs the sweep against a per-isolate D1 Drizzle client and keeps the isolate
+  alive via `ctx.waitUntil`. The existing `fetch` handler is unchanged.
+- `wrangler.toml` adds a `[triggers] crons = ["0 4 * * *"]` daily 04:00 UTC
+  trigger. No separate retention knob — `expiresAt` already encodes when a row
+  becomes dead.

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -1,8 +1,11 @@
+import { Effect, Layer } from "effect";
+
 import { createApp } from "./app";
-import { createD1Db } from "./db";
+import { createD1Db, DbService } from "./db";
 import { createWorkersRateLimiter } from "./lib/workers-rate-limiter";
 import type { WorkersRateLimitBinding } from "./lib/workers-rate-limiter";
 import { createAccountResolverFromEnv } from "./services/osn-bridge";
+import { sessionService } from "./services/session";
 
 // Worker bindings + vars. Mirrors `wrangler.toml` ([[d1_databases]], [[r2_buckets]],
 // [vars]); regenerate the full set with `bunx wrangler types` when bindings change.
@@ -116,6 +119,28 @@ const handler: ExportedHandler<Env> = {
     }
 
     return cached.app.fetch(request);
+  },
+
+  // Cron-triggered expired-session sweep (C-M2/C-M15). Configured by the
+  // `[triggers] crons` entry in wrangler.toml — daily 04:00 UTC. Guest logins
+  // leave session rows that are never deleted on the read path, so the table
+  // grows unbounded without this. The sweep deletes rows whose 30-day window
+  // has lapsed; there is no separate retention knob — `expiresAt` already
+  // encodes when a row becomes dead. `waitUntil` keeps the isolate alive until
+  // the delete settles.
+  async scheduled(_event, env, ctx) {
+    if (!env.DB) return;
+    const db = createD1Db(env.DB);
+    ctx.waitUntil(
+      Effect.runPromise(
+        sessionService.sweepExpired().pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled session sweep failed", { reason: err.reason }),
+          ),
+          Effect.provide(Layer.succeed(DbService, db)),
+        ),
+      ),
+    );
   },
 };
 

--- a/cire/api/src/metrics.ts
+++ b/cire/api/src/metrics.ts
@@ -35,6 +35,8 @@ export const CIRE_METRICS = {
   claimLookupDuration: "cire.claim.lookup.duration",
   // Guest sessions.
   sessionCreated: "cire.session.created",
+  // Scheduled expired-session sweep (cron).
+  sessionSwept: "cire.session.swept",
   // Organiser host-code (invite preview) provisioning.
   hostCodeEnsured: "cire.host_code.ensured",
   // RSVP.
@@ -103,6 +105,7 @@ export type FamilyCodeRegenResult = "ok" | "error";
 type ClaimAttemptsAttrs = { result: ClaimResult };
 type ClaimLookupDurationAttrs = { result: "ok" | "error" };
 type SessionCreatedAttrs = { result: "ok" | "error" };
+type SessionSweptAttrs = { result: "ok" | "error" };
 type HostCodeEnsuredAttrs = { result: "ok" | "error" };
 type RsvpUpsertedAttrs = { status: RsvpStatus; result: "ok" | "error" };
 type ImportSimpleAttrs = { result: "ok" | "error" };
@@ -136,6 +139,13 @@ const claimLookupDuration = createHistogram<ClaimLookupDurationAttrs>({
 const sessionCreated = createCounter<SessionCreatedAttrs>({
   name: CIRE_METRICS.sessionCreated,
   description: "Guest session-cookie creations, by outcome",
+  unit: "{session}",
+});
+
+const sessionSwept = createCounter<SessionSweptAttrs>({
+  name: CIRE_METRICS.sessionSwept,
+  description:
+    "Expired guest sessions deleted by the scheduled sweeper — increment is the row count, so the sum tracks reclaimed rows",
   unit: "{session}",
 });
 
@@ -241,6 +251,12 @@ export const metricClaimAttempt = (result: ClaimResult): void => claimAttempts.i
 
 export const metricSessionCreated = (result: "ok" | "error"): void =>
   sessionCreated.inc({ result });
+
+/** Record a sweep: on success `count` is the number of expired rows deleted, so
+ *  the counter sum tracks reclaimed sessions over time. A failed sweep records a
+ *  single `error` increment. */
+export const metricSessionSwept = (result: "ok" | "error", count = 1): void =>
+  sessionSwept.add(count, { result });
 
 export const metricHostCodeEnsured = (result: "ok" | "error"): void =>
   hostCodeEnsured.inc({ result });

--- a/cire/api/src/services/session.test.ts
+++ b/cire/api/src/services/session.test.ts
@@ -215,3 +215,94 @@ describe("sessionService.revokeAllForFamily", () => {
     ),
   );
 });
+
+describe("sessionService.sweepExpired", () => {
+  // Insert a raw session row with an explicit expiry. Mirrors the production
+  // write shape (token stored as a 64-hex hash) but lets the test choose the
+  // expiry directly — `create()` only ever writes future-dated rows.
+  function insertSession(familyId: string, expiresAt: Date): Effect.Effect<void, never, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const hash = Array.from(
+        new Uint8Array(
+          yield* Effect.promise(() =>
+            crypto.subtle.digest("SHA-256", new TextEncoder().encode(crypto.randomUUID())),
+          ),
+        ),
+      )
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      db.insert(sessions)
+        .values({
+          id: crypto.randomUUID(),
+          familyId,
+          token: hash,
+          expiresAt,
+          createdAt: new Date(expiresAt.getTime() - 60_000),
+        })
+        .run();
+    });
+  }
+
+  function countSessions(): Effect.Effect<number, never, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      return db.select().from(sessions).all().length;
+    });
+  }
+
+  it(
+    "deletes expired rows and keeps live ones, returning the deleted count",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const familyId = db.select({ id: families.id }).from(families).all()[0]!.id;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+
+        // Two already-expired (one long dead, one just-now), one live.
+        yield* insertSession(familyId, new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000));
+        yield* insertSession(familyId, new Date(now.getTime() - 1));
+        yield* insertSession(familyId, new Date(now.getTime() + 60_000));
+
+        const deleted = yield* sessionService.sweepExpired(now);
+        expect(deleted).toBe(2);
+
+        const remaining = yield* countSessions();
+        expect(remaining).toBe(1);
+      }),
+    ),
+  );
+
+  it(
+    "treats a row expiring exactly at now as expired (boundary <=)",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const familyId = db.select({ id: families.id }).from(families).all()[0]!.id;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+
+        yield* insertSession(familyId, now);
+
+        const deleted = yield* sessionService.sweepExpired(now);
+        expect(deleted).toBe(1);
+        expect(yield* countSessions()).toBe(0);
+      }),
+    ),
+  );
+
+  it(
+    "is a no-op when every session is still live",
+    withDb(
+      Effect.gen(function* () {
+        const familyId = yield* pickFamilyId();
+        const now = new Date();
+        yield* sessionService.create(familyId, 3600);
+        yield* sessionService.create(familyId, 3600);
+
+        const deleted = yield* sessionService.sweepExpired(now);
+        expect(deleted).toBe(0);
+        expect(yield* countSessions()).toBe(2);
+      }),
+    ),
+  );
+});

--- a/cire/api/src/services/session.ts
+++ b/cire/api/src/services/session.ts
@@ -1,19 +1,29 @@
 import { sessions } from "@cire/db";
-import { eq } from "drizzle-orm";
+import { eq, lte } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { Effect, Data } from "effect";
 
 import { DbService, dbQuery } from "../db";
-import { metricSessionCreated } from "../metrics";
+import { metricSessionCreated, metricSessionSwept } from "../metrics";
 
 export class SessionInvalid extends Data.TaggedError("SessionInvalid")<{
   reason: "missing" | "expired";
 }> {}
 
 export class SessionWriteError extends Data.TaggedError("SessionWriteError")<{
-  op: "insert" | "delete" | "deleteAllForFamily";
+  op: "insert" | "delete" | "deleteAllForFamily" | "sweep";
   reason: string;
 }> {}
+
+/**
+ * Rows changed by a Drizzle `.run()` write, normalised across drivers.
+ * bun:sqlite returns `{ changes }`; Cloudflare D1 returns `{ meta: { changes } }`.
+ */
+function rowsChanged(result: unknown): number {
+  if (typeof result !== "object" || result === null) return 0;
+  const r = result as { changes?: number; meta?: { changes?: number } };
+  return r.meta?.changes ?? r.changes ?? 0;
+}
 
 const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60;
 
@@ -200,5 +210,32 @@ export const sessionService = {
         ),
       );
     }).pipe(Effect.withSpan("cire.session.revokeAllForFamily"));
+  },
+
+  /**
+   * Prune every session whose `expiresAt` has passed (`<= now`). A guest login
+   * leaves a row that is dead the moment its 30-day window lapses but is never
+   * deleted on the read path (`validate` only *reports* expiry); without this
+   * the table grows unbounded (C-M2/C-M15). Run from the Worker's `scheduled`
+   * cron handler. Boundary is inclusive so a row expiring exactly at `now` is
+   * swept. Returns the number of rows deleted.
+   */
+  sweepExpired(now: Date = new Date()): Effect.Effect<number, SessionWriteError, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const result = yield* Effect.tryPromise({
+        try: () => Promise.resolve(db.delete(sessions).where(lte(sessions.expiresAt, now)).run()),
+        catch: (e) => new SessionWriteError({ op: "sweep", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) => Effect.logError("session sweep failed", { reason: err.reason })),
+      );
+      const deleted = rowsChanged(result);
+      yield* Effect.sync(() => metricSessionSwept("ok", deleted));
+      yield* Effect.logInfo("session sweep complete", { deleted });
+      return deleted;
+    }).pipe(
+      Effect.tapError(() => Effect.sync(() => metricSessionSwept("error"))),
+      Effect.withSpan("cire.session.sweepExpired"),
+    );
   },
 };

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -3,6 +3,12 @@ main = "src/index.ts"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Scheduled expired-session sweep (C-M2/C-M15). Daily 04:00 UTC — off-peak for
+# the AU/EU guest audience, low contention with normal traffic. Sessions carry
+# a 30-day TTL so once-a-day pruning bounds the dead-row backlog to <1 day.
+[triggers]
+crons = ["0 4 * * *"]
+
 [vars]
 WEB_ORIGIN = "http://localhost:4321"
 OSN_JWKS_URL = "http://localhost:4000/.well-known/jwks.json"


### PR DESCRIPTION
## What
Scheduled sweeper for Cire's unbounded `sessions` table (C-M2 / C-M15 — every guest login left a dead row; the read path only reports expiry, never deletes).

- `sweepExpired(now)` (testable Effect) deletes rows where `expiresAt <= now` (the table already carries a 30-day sliding TTL, so `expiresAt` is the sole predicate — no extra retention window).
- `scheduled(event, env, ctx)` added to the Worker default export (existing `fetch` untouched); runs the sweep in `ctx.waitUntil`.
- Cron `0 4 * * *` (daily 04:00 UTC) in `[triggers]`. New metric `cire.session.swept`. Driver-portable row-count helper (bun:sqlite vs D1).

## Tests
`bun test` → **252 pass / 0 fail**; oxlint clean; worker build green.

## Notes
- Touches `cire/api/wrangler.toml` (`[triggers]` only) and `src/index.ts` (`scheduled`) — conflicts with #prod-config / #otel (toml) and #bootstrap-owner (index.ts); keep all additions when resolving.
- Confirm the same cron cadence is wanted across dev/staging/prod.
