### PR TITLE
fix(observability): export OTel only when endpoint set; wire from env

### DIFF
--- a/.changeset/otel-exporter-env-wiring.md
+++ b/.changeset/otel-exporter-env-wiring.md
@@ -1,0 +1,23 @@
+---
+"@shared/observability": minor
+---
+
+Wire the OTLP exporter to read its endpoint + headers from env so error/latency
+dashboards can be turned on without a code change.
+
+- `makeTracingLayer` now reads `OTEL_EXPORTER_OTLP_ENDPOINT` /
+  `OTEL_EXPORTER_OTLP_HEADERS` (via `loadConfig`, unchanged) and, crucially,
+  returns a **true** no-op (`NoopTracingLive`) when no endpoint is set —
+  previously it built the NodeSdk with an `undefined` exporter URL, which the
+  OTLP/HTTP exporter silently resolves to `http://localhost:4318` and then
+  spams failing export attempts. Setting the two env vars (plus optional
+  `OTEL_SERVICE_NAME`) is now all that's needed to start exporting.
+- New pure `otlpExporterUrl(endpoint, signal)` helper builds the per-signal
+  `<base>/v1/traces` / `<base>/v1/metrics` URL and strips a trailing slash so
+  it never emits `//v1/...`.
+- Tests pin both contracts: endpoint-from-env is honoured (real exporter layer,
+  auth header read from `OTEL_EXPORTER_OTLP_HEADERS`) and an unset endpoint
+  stays a true no-op.
+
+No behaviour change for services that already leave the endpoint unset — they
+just stop attempting (and failing) localhost exports.

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -86,3 +86,23 @@ preview_bucket_name = "cire-sheets-preview"
 binding = "ASSETS"
 bucket_name = "cire-assets"
 preview_bucket_name = "cire-assets-preview"
+
+# ── OpenTelemetry export ─────────────────────────────────────────────────────
+# Read by `@shared/observability` `loadConfig` (workerd `nodejs_compat`
+# populates `process.env` from these [vars] + secrets). With the endpoint UNSET,
+# tracing + metrics are a true no-op (zero export attempts) — so leaving this
+# commented out keeps local/dev safe. Set the base OTLP/HTTP endpoint to turn
+# export on; `@shared/observability` appends `/v1/traces` + `/v1/metrics` itself.
+#
+#   OTEL_SERVICE_NAME            non-secret, can live in [vars] (defaults to "cire-api")
+#   OTEL_EXPORTER_OTLP_ENDPOINT  non-secret base URL, e.g. Grafana Cloud OTLP gateway
+#   OTEL_EXPORTER_OTLP_HEADERS   SECRET — carries the auth token, never commit it
+#
+# Non-secret placeholders (uncomment + set the real endpoint before deploy):
+#   OTEL_SERVICE_NAME = "cire-api"
+#   OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp-gateway-<region>.grafana.net/otlp"
+#
+# The headers carry a bearer/basic auth token → provision as a Worker SECRET,
+# NOT a committed var:
+#   bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS --env production
+#     value: "authorization=Basic <base64(instanceID:apiToken)>"

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -34,3 +34,25 @@ binding = "DB"
 database_name = "osn-db-prod"
 database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
+
+# ── OpenTelemetry export ─────────────────────────────────────────────────────
+# Read by `@shared/observability` `loadConfig` at boot. With the endpoint UNSET,
+# tracing + metrics are a true no-op (zero export attempts) — safe by default.
+# Set the base OTLP/HTTP endpoint to turn export on; `@shared/observability`
+# appends `/v1/traces` + `/v1/metrics` itself. (osn-api isn't Workers-hosted yet
+# — see the note above — so today these are consumed from the process env of the
+# long-lived `bun run` host; declared here so the wiring is identical once it
+# moves to Workers.)
+#
+#   OTEL_SERVICE_NAME            non-secret (defaults to "osn-api")
+#   OTEL_EXPORTER_OTLP_ENDPOINT  non-secret base URL (Grafana Cloud OTLP gateway)
+#   OTEL_EXPORTER_OTLP_HEADERS   SECRET — carries the auth token, never commit it
+#
+# Non-secret placeholders (uncomment + set the real endpoint before deploy):
+# [env.production.vars]
+#   OTEL_SERVICE_NAME = "osn-api"
+#   OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp-gateway-<region>.grafana.net/otlp"
+#
+# The headers carry a bearer/basic auth token → provision as a Worker SECRET:
+#   bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS --env production
+#     value: "authorization=Basic <base64(instanceID:apiToken)>"

--- a/shared/observability/src/tracing/layer.ts
+++ b/shared/observability/src/tracing/layer.ts
@@ -14,17 +14,39 @@ import {
 import type { Layer } from "effect";
 
 import type { ObservabilityConfig } from "../config";
+import { NoopTracingLive } from "./noop";
+
+/**
+ * Build the per-signal OTLP HTTP endpoint URL from the base endpoint.
+ *
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` is the *base* (e.g.
+ * `https://otlp.grafana.net/otlp`); the OTLP/HTTP spec routes traces to
+ * `<base>/v1/traces` and metrics to `<base>/v1/metrics`. We build the full
+ * URL ourselves (and strip a trailing slash so we never emit `//v1/...`)
+ * rather than leaning on the exporter's own env fallback — that fallback
+ * silently defaults to `http://localhost:4318` when nothing is set, which is
+ * exactly the "blind, perpetually-failing export" we want to avoid. Returns
+ * `undefined` when no endpoint is configured so the caller can stay a no-op.
+ */
+export const otlpExporterUrl = (
+  endpoint: string | undefined,
+  signal: "traces" | "metrics",
+): string | undefined => (endpoint ? `${endpoint.replace(/\/+$/, "")}/v1/${signal}` : undefined);
 
 /**
  * Build the `@effect/opentelemetry` NodeSdk layer.
  *
- * When `config.otlpEndpoint` is unset, the OTLP exporters still initialise
- * but will fail their exports silently — this is fine for local dev and
- * tests. To make tracing a true no-op in tests, provide `NoopTracingLive`
- * from `./noop.ts` instead.
+ * The exporter endpoint + headers come from env (`OTEL_EXPORTER_OTLP_ENDPOINT`
+ * / `OTEL_EXPORTER_OTLP_HEADERS`, parsed into `config` by `loadConfig`). When
+ * `config.otlpEndpoint` is unset we return a true no-op layer
+ * (`NoopTracingLive`) — NOT the NodeSdk with an undefined URL, which would
+ * fall back to `http://localhost:4318` and spam failing export attempts.
+ * Setting the two env vars is all that's needed to turn export on.
  */
-export const makeTracingLayer = (config: ObservabilityConfig): Layer.Layer<never> =>
-  NodeSdk.layer(() => ({
+export const makeTracingLayer = (config: ObservabilityConfig): Layer.Layer<never> => {
+  if (!config.otlpEndpoint) return NoopTracingLive;
+
+  return NodeSdk.layer(() => ({
     resource: {
       serviceName: config.serviceName,
       serviceVersion: config.serviceVersion,
@@ -36,13 +58,13 @@ export const makeTracingLayer = (config: ObservabilityConfig): Layer.Layer<never
     },
     spanProcessor: new BatchSpanProcessor(
       new OTLPTraceExporter({
-        url: config.otlpEndpoint ? `${config.otlpEndpoint}/v1/traces` : undefined,
+        url: otlpExporterUrl(config.otlpEndpoint, "traces"),
         headers: config.otlpHeaders,
       }),
     ),
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
-        url: config.otlpEndpoint ? `${config.otlpEndpoint}/v1/metrics` : undefined,
+        url: otlpExporterUrl(config.otlpEndpoint, "metrics"),
         headers: config.otlpHeaders,
       }),
       // Flush metrics every 30s in prod, every 5s in dev for faster feedback.
@@ -52,3 +74,4 @@ export const makeTracingLayer = (config: ObservabilityConfig): Layer.Layer<never
       root: new TraceIdRatioBasedSampler(config.traceSampleRatio),
     }),
   }));
+};

--- a/shared/observability/tests/layer.test.ts
+++ b/shared/observability/tests/layer.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config";
 import { initObservability, makeObservabilityLayer } from "../src/index";
 import { makeLoggerLayer } from "../src/logger/layer";
-import { makeTracingLayer } from "../src/tracing/layer";
+import { makeTracingLayer, otlpExporterUrl } from "../src/tracing/layer";
+import { NoopTracingLive } from "../src/tracing/noop";
 
 /**
  * Layer-construction smoke tests. These don't spin up a real OTel
@@ -79,30 +80,70 @@ describe("makeLoggerLayer", () => {
   });
 });
 
-describe("makeTracingLayer", () => {
-  it("builds without throwing when no OTLP endpoint is configured", () => {
-    const config = loadConfig({ serviceName: "test", env: "dev" });
-    expect(config.otlpEndpoint).toBeUndefined();
-    expect(() => makeTracingLayer(config)).not.toThrow();
+describe("otlpExporterUrl", () => {
+  it("suffixes the per-signal path onto the base endpoint", () => {
+    expect(otlpExporterUrl("https://otlp.grafana.net/otlp", "traces")).toBe(
+      "https://otlp.grafana.net/otlp/v1/traces",
+    );
+    expect(otlpExporterUrl("https://otlp.grafana.net/otlp", "metrics")).toBe(
+      "https://otlp.grafana.net/otlp/v1/metrics",
+    );
   });
 
-  it("builds without throwing when an OTLP endpoint is configured", () => {
+  it("collapses a trailing slash so it never emits //v1", () => {
+    expect(otlpExporterUrl("http://localhost:4318/", "traces")).toBe(
+      "http://localhost:4318/v1/traces",
+    );
+  });
+
+  it("returns undefined when no endpoint is configured", () => {
+    expect(otlpExporterUrl(undefined, "traces")).toBeUndefined();
+  });
+});
+
+describe("makeTracingLayer", () => {
+  it("is a true no-op (NoopTracingLive) when no OTLP endpoint is configured", () => {
+    const config = loadConfig({ serviceName: "test", env: "dev" });
+    expect(config.otlpEndpoint).toBeUndefined();
+    // An unset endpoint must NOT spin up the NodeSdk pointed at
+    // localhost:4318 — it must return the empty no-op layer so there are
+    // zero export attempts. Identity check pins exactly that.
+    expect(makeTracingLayer(config)).toBe(NoopTracingLive);
+  });
+
+  it("honours the endpoint from env and builds a real exporter layer", () => {
     const prev = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318";
+    const prevHeaders = process.env.OTEL_EXPORTER_OTLP_HEADERS;
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.grafana.net/otlp";
+    process.env.OTEL_EXPORTER_OTLP_HEADERS = "authorization=Bearer test-token";
     try {
       const config = loadConfig({ serviceName: "test", env: "dev" });
-      expect(config.otlpEndpoint).toBe("http://localhost:4318");
+      // The endpoint + auth header are read straight from env.
+      expect(config.otlpEndpoint).toBe("https://otlp.grafana.net/otlp");
+      expect(config.otlpHeaders).toEqual({ authorization: "Bearer test-token" });
+      // With an endpoint set we get the real NodeSdk layer, not the no-op.
+      const layer = makeTracingLayer(config);
+      expect(layer).not.toBe(NoopTracingLive);
+      expect(layer).toBeDefined();
+    } finally {
+      if (prev === undefined) delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+      else process.env.OTEL_EXPORTER_OTLP_ENDPOINT = prev;
+      if (prevHeaders === undefined) delete process.env.OTEL_EXPORTER_OTLP_HEADERS;
+      else process.env.OTEL_EXPORTER_OTLP_HEADERS = prevHeaders;
+    }
+  });
+
+  it("builds without throwing in production mode with tight sampling", () => {
+    const prev = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.grafana.net/otlp";
+    try {
+      const config = loadConfig({ serviceName: "test", env: "production" });
+      expect(config.traceSampleRatio).toBe(0.1);
       expect(() => makeTracingLayer(config)).not.toThrow();
     } finally {
       if (prev === undefined) delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
       else process.env.OTEL_EXPORTER_OTLP_ENDPOINT = prev;
     }
-  });
-
-  it("builds without throwing in production mode with tight sampling", () => {
-    const config = loadConfig({ serviceName: "test", env: "production" });
-    expect(config.traceSampleRatio).toBe(0.1);
-    expect(() => makeTracingLayer(config)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## What
Make OTel actually export (it was wired to read env but built blind).

- Root cause: `makeTracingLayer` (`@shared/observability`) built the `NodeSdk` with `url: undefined` even when no endpoint was set — OTLP/HTTP silently defaults to `localhost:4318` and retries failing exports forever (a non-no-op masquerading as one).
- Now returns a genuine `NoopTracingLive` when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, and the real exporter (endpoint + headers from env) when set. New `otlpExporterUrl()` helper builds `/v1/traces` + `/v1/metrics` and strips trailing slashes.
- Commented `OTEL_*` placeholders added to cire + osn wrangler configs (headers = prod **secret**).

## Tests
`shared/observability` → **90 pass**; `tsc --noEmit` clean; cire dry-run deploy parses.

## Values still needed
- `OTEL_EXPORTER_OTLP_ENDPOINT` (e.g. Grafana Cloud `.../otlp`) — non-secret.
- `OTEL_EXPORTER_OTLP_HEADERS` (auth) — **secret**, `wrangler secret put`.
- osn + cire **share** one endpoint + token; differ only by `service.name`.

## Note
Touches `cire/api/wrangler.toml` (`[env.production.vars]` block) — minor conflict with #prod-config / #sweeper.
