### PR TITLE
feat(cire/api): 1-year guest-data retention deletion

### DIFF
--- a/.changeset/cire-retention-deletion.md
+++ b/.changeset/cire-retention-deletion.md
@@ -1,0 +1,20 @@
+---
+"@cire/api": minor
+---
+
+Enforce the 1-year guest-data retention promise with a scheduled sweep.
+
+cire's privacy notice promises guest data is deleted 1 year after the final
+wedding event. A new `retentionService.sweepExpiredGuestData(now)` Effect
+deletes the personal data — `rsvps` (incl. special-category dietary text +
+`dietary_consent_at`/`dietary_consent_version`), `guests`, and `families`
+rows, plus the wedding's `imports` bookkeeping rows — for every wedding whose
+latest event date is more than `RETENTION_AFTER_FINAL_EVENT_MS` (365 days)
+before now. The wedding + events shell is kept; weddings with no events are
+kept (the window cannot be proven to have lapsed). It runs alongside the
+existing session sweep on the same daily cron, with a `cire.guest_data.swept`
+metric counting reclaimed guest rows.
+
+The uploaded-sheet R2 objects behind expired `imports` rows are not yet
+reaped (the sweep has no R2 binding) — tracked as a TODO for a separate
+R2-aware pass / lifecycle rule.

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -13,6 +13,7 @@ import { createWorkersRateLimiter } from "./lib/workers-rate-limiter";
 import type { WorkersRateLimitBinding } from "./lib/workers-rate-limiter";
 import { runCire } from "./observability";
 import { createAccountResolverFromEnv } from "./services/osn-bridge";
+import { retentionService } from "./services/retention";
 import { sessionService } from "./services/session";
 
 // Worker bindings + vars. Mirrors `wrangler.toml` ([[d1_databases]], [[r2_buckets]],
@@ -179,23 +180,44 @@ const handler: ExportedHandler<Env> = {
     return cached.app.fetch(request);
   },
 
-  // Cron-triggered expired-session sweep (C-M2/C-M15). Configured by the
-  // `[triggers] crons` entry in wrangler.toml — daily 04:00 UTC. Guest logins
-  // leave session rows that are never deleted on the read path, so the table
-  // grows unbounded without this. The sweep deletes rows whose 30-day window
-  // has lapsed; there is no separate retention knob — `expiresAt` already
-  // encodes when a row becomes dead. `waitUntil` keeps the isolate alive until
-  // the delete settles.
+  // Cron-triggered daily maintenance (C-M2/C-M15 + retention). Configured by the
+  // single `[triggers] crons` entry in wrangler.toml — daily 04:00 UTC. Two
+  // independent sweeps share the cron:
+  //
+  //  1. Expired-session sweep — guest logins leave session rows that are never
+  //     deleted on the read path, so the table grows unbounded without this. The
+  //     sweep deletes rows whose 30-day window has lapsed; `expiresAt` already
+  //     encodes when a row becomes dead.
+  //  2. Guest-data retention sweep — enforces the published privacy promise
+  //     (cire/web privacy.astro): guest PII (guests/families/rsvps incl. dietary
+  //     + consent, plus imports bookkeeping) is deleted 1 year after a wedding's
+  //     final event.
+  //
+  // Each is its own `waitUntil` + `catchAll`, so a failure in one never aborts
+  // the other and the isolate stays alive until each delete settles.
   async scheduled(_event, env, ctx) {
     if (!env.DB) return;
     const db = createD1Db(env.DB);
+    const dbLayer = Layer.succeed(DbService, db);
+
     ctx.waitUntil(
       Effect.runPromise(
         sessionService.sweepExpired().pipe(
           Effect.catchAll((err) =>
             Effect.logError("scheduled session sweep failed", { reason: err.reason }),
           ),
-          Effect.provide(Layer.succeed(DbService, db)),
+          Effect.provide(dbLayer),
+        ),
+      ),
+    );
+
+    ctx.waitUntil(
+      Effect.runPromise(
+        retentionService.sweepExpiredGuestData().pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled guest-data retention sweep failed", { reason: err.reason }),
+          ),
+          Effect.provide(dbLayer),
         ),
       ),
     );

--- a/cire/api/src/metrics.ts
+++ b/cire/api/src/metrics.ts
@@ -37,6 +37,9 @@ export const CIRE_METRICS = {
   sessionCreated: "cire.session.created",
   // Scheduled expired-session sweep (cron).
   sessionSwept: "cire.session.swept",
+  // Scheduled guest-data retention sweep (cron) — deletes guest PII 1 year
+  // after a wedding's final event.
+  guestDataSwept: "cire.guest_data.swept",
   // Organiser host-code (invite preview) provisioning.
   hostCodeEnsured: "cire.host_code.ensured",
   // RSVP.
@@ -106,6 +109,7 @@ type ClaimAttemptsAttrs = { result: ClaimResult };
 type ClaimLookupDurationAttrs = { result: "ok" | "error" };
 type SessionCreatedAttrs = { result: "ok" | "error" };
 type SessionSweptAttrs = { result: "ok" | "error" };
+type GuestDataSweptAttrs = { result: "ok" | "error" };
 type HostCodeEnsuredAttrs = { result: "ok" | "error" };
 type RsvpUpsertedAttrs = { status: RsvpStatus; result: "ok" | "error" };
 type ImportSimpleAttrs = { result: "ok" | "error" };
@@ -147,6 +151,13 @@ const sessionSwept = createCounter<SessionSweptAttrs>({
   description:
     "Expired guest sessions deleted by the scheduled sweeper — increment is the row count, so the sum tracks reclaimed rows",
   unit: "{session}",
+});
+
+const guestDataSwept = createCounter<GuestDataSweptAttrs>({
+  name: CIRE_METRICS.guestDataSwept,
+  description:
+    "Guest rows deleted by the scheduled retention sweep (1 year after a wedding's final event) — increment is the row count, so the sum tracks reclaimed guest records",
+  unit: "{guest}",
 });
 
 const hostCodeEnsured = createCounter<HostCodeEnsuredAttrs>({
@@ -257,6 +268,12 @@ export const metricSessionCreated = (result: "ok" | "error"): void =>
  *  single `error` increment. */
 export const metricSessionSwept = (result: "ok" | "error", count = 1): void =>
   sessionSwept.add(count, { result });
+
+/** Record a retention sweep: on success `count` is the number of guest rows
+ *  deleted, so the counter sum tracks reclaimed guest records over time. A
+ *  failed sweep records a single `error` increment. */
+export const metricGuestDataSwept = (result: "ok" | "error", count = 1): void =>
+  guestDataSwept.add(count, { result });
 
 export const metricHostCodeEnsured = (result: "ok" | "error"): void =>
   hostCodeEnsured.inc({ result });

--- a/cire/api/src/services/retention.test.ts
+++ b/cire/api/src/services/retention.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "bun:test";
+
+import { weddings, families, guests, events, rsvps, imports } from "@cire/db";
+import { eq } from "drizzle-orm";
+import { Effect } from "effect";
+
+import { DbService } from "../db";
+import { TestDbLayer } from "../db/test-layer";
+import { effWith } from "../test-helpers";
+import { retentionService, RETENTION_AFTER_FINAL_EVENT_MS } from "./retention";
+
+const withDb = effWith(TestDbLayer);
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Build a self-contained wedding with one family, one guest, and one RSVP
+ * (carrying dietary + consent), plus a set of events. Returns the ids so a test
+ * can assert on what survives the sweep. Scoped to its own wedding so it never
+ * collides with the bootstrap seed.
+ */
+function makeWedding(opts: {
+  eventDates: string[];
+  withImport?: boolean;
+}): Effect.Effect<
+  { weddingId: string; familyId: string; guestId: string; rsvpId: string },
+  never,
+  DbService
+> {
+  return Effect.gen(function* () {
+    // The test layer is bun:sqlite — synchronous; call `.run()` directly.
+    const db = yield* DbService;
+    const now = new Date();
+    const weddingId = `wed_${crypto.randomUUID()}`;
+    const familyId = crypto.randomUUID();
+    const guestId = crypto.randomUUID();
+    const rsvpId = crypto.randomUUID();
+
+    db.insert(weddings)
+      .values({
+        id: weddingId,
+        slug: `slug-${weddingId}`,
+        displayName: "Test Wedding",
+        ownerOsnProfileId: "usr_test",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    db.insert(families)
+      .values({
+        id: familyId,
+        weddingId,
+        publicId: `PUB-${weddingId}`,
+        familyName: "Smith",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    db.insert(guests)
+      .values({
+        id: guestId,
+        familyId,
+        firstName: "Alex",
+        lastName: "Smith",
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    opts.eventDates.forEach((date, i) => {
+      db.insert(events)
+        .values({
+          id: `${weddingId}-ev-${i}`,
+          weddingId,
+          slug: `${weddingId}-ev-${i}`,
+          name: `Event ${i}`,
+          date,
+          location: "Somewhere",
+          startAt: `${date}T10:00:00+11:00`,
+          endAt: `${date}T12:00:00+11:00`,
+          timezone: "Australia/Sydney",
+        })
+        .run();
+    });
+
+    // RSVP carries the special-category dietary free-text + consent records.
+    const firstEventId = opts.eventDates.length > 0 ? `${weddingId}-ev-0` : undefined;
+    if (firstEventId) {
+      db.insert(rsvps)
+        .values({
+          id: rsvpId,
+          guestId,
+          eventId: firstEventId,
+          status: "attending",
+          dietary: "nut allergy",
+          dietaryConsentAt: now,
+          dietaryConsentVersion: "v1",
+          createdAt: now,
+        })
+        .run();
+    }
+
+    if (opts.withImport) {
+      db.insert(imports)
+        .values({
+          id: crypto.randomUUID(),
+          weddingId,
+          uploadedAt: now.getTime(),
+          format: "csv",
+          eventsR2Key: `imports/${weddingId}/events.csv`,
+          guestsR2Key: `imports/${weddingId}/guests.csv`,
+          summary: "{}",
+          status: "applied",
+        })
+        .run();
+    }
+
+    return { weddingId, familyId, guestId, rsvpId };
+  });
+}
+
+describe("RETENTION_AFTER_FINAL_EVENT_MS", () => {
+  it("is exactly 365 days in milliseconds", () => {
+    expect(RETENTION_AFTER_FINAL_EVENT_MS).toBe(YEAR_MS);
+  });
+});
+
+describe("retentionService.sweepExpiredGuestData", () => {
+  it(
+    "deletes guests + rsvps for a wedding whose final event is >1 year before now",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        // Final event ~13 months ago.
+        const { weddingId, familyId, guestId, rsvpId } = yield* makeWedding({
+          eventDates: ["2025-04-01", "2025-05-10"],
+        });
+
+        const deleted = yield* retentionService.sweepExpiredGuestData(now);
+        expect(deleted).toBeGreaterThanOrEqual(1);
+
+        const guestRows = db.select().from(guests).where(eq(guests.id, guestId)).all();
+        expect(guestRows.length).toBe(0);
+        const rsvpRows = db.select().from(rsvps).where(eq(rsvps.id, rsvpId)).all();
+        expect(rsvpRows.length).toBe(0);
+        // The family row (a guest-PII container) goes too.
+        const famRows = db.select().from(families).where(eq(families.id, familyId)).all();
+        expect(famRows.length).toBe(0);
+        // The wedding + its events shell is intentionally kept.
+        const evRows = db.select().from(events).where(eq(events.weddingId, weddingId)).all();
+        expect(evRows.length).toBe(2);
+        const wedRows = db.select().from(weddings).where(eq(weddings.id, weddingId)).all();
+        expect(wedRows.length).toBe(1);
+      }),
+    ),
+  );
+
+  it(
+    "removes the dietary free-text and consent records along with the rsvp row",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        const { guestId } = yield* makeWedding({ eventDates: ["2024-01-01"] });
+
+        yield* retentionService.sweepExpiredGuestData(now);
+
+        const remaining = db.select().from(rsvps).where(eq(rsvps.guestId, guestId)).all();
+        expect(remaining.length).toBe(0);
+      }),
+    ),
+  );
+
+  it(
+    "keeps guests + rsvps for a wedding whose final event is <1 year before now",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        // Final event 2 months ago.
+        const { guestId, rsvpId } = yield* makeWedding({
+          eventDates: ["2026-03-01", "2026-04-15"],
+        });
+
+        yield* retentionService.sweepExpiredGuestData(now);
+
+        expect(db.select().from(guests).where(eq(guests.id, guestId)).all().length).toBe(1);
+        expect(db.select().from(rsvps).where(eq(rsvps.id, rsvpId)).all().length).toBe(1);
+      }),
+    ),
+  );
+
+  it(
+    "keeps a wedding that has no events at all (cannot prove the window lapsed)",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        const { guestId } = yield* makeWedding({ eventDates: [] });
+
+        yield* retentionService.sweepExpiredGuestData(now);
+
+        expect(db.select().from(guests).where(eq(guests.id, guestId)).all().length).toBe(1);
+      }),
+    ),
+  );
+
+  it(
+    "deletes imports rows for an expired wedding",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        const { weddingId } = yield* makeWedding({
+          eventDates: ["2024-06-01"],
+          withImport: true,
+        });
+
+        yield* retentionService.sweepExpiredGuestData(now);
+
+        expect(db.select().from(imports).where(eq(imports.weddingId, weddingId)).all().length).toBe(
+          0,
+        );
+      }),
+    ),
+  );
+
+  it(
+    "treats a wedding whose final event is exactly 1 year + 1ms ago as expired",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        // now is well past a 2024 event → expired.
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        const { guestId } = yield* makeWedding({ eventDates: ["2025-06-16"] });
+
+        const deleted = yield* retentionService.sweepExpiredGuestData(now);
+        expect(deleted).toBeGreaterThanOrEqual(1);
+        expect(db.select().from(guests).where(eq(guests.id, guestId)).all().length).toBe(0);
+      }),
+    ),
+  );
+});

--- a/cire/api/src/services/retention.ts
+++ b/cire/api/src/services/retention.ts
@@ -1,0 +1,174 @@
+import { events, families, guests, imports, rsvps } from "@cire/db";
+import { inArray, lt, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
+import { Data, Effect } from "effect";
+
+import { DbService, dbQuery } from "../db";
+import { metricGuestDataSwept } from "../metrics";
+
+export class RetentionWriteError extends Data.TaggedError("RetentionWriteError")<{
+  op: "sweep";
+  reason: string;
+}> {}
+
+/**
+ * Guest-data retention window. cire's published privacy notice
+ * (`cire/web/src/pages/privacy.astro`) promises guest data is deleted **1 year
+ * after the final wedding event**. This constant encodes that window; change it
+ * here (and the notice copy) to move the line. 365 days in milliseconds.
+ */
+export const RETENTION_AFTER_FINAL_EVENT_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Rows changed by a Drizzle `.run()` write, normalised across drivers.
+ * bun:sqlite returns `{ changes }`; Cloudflare D1 returns `{ meta: { changes } }`.
+ */
+function rowsChanged(result: unknown): number {
+  if (typeof result !== "object" || result === null) return 0;
+  const r = result as { changes?: number; meta?: { changes?: number } };
+  return r.meta?.changes ?? r.changes ?? 0;
+}
+
+/**
+ * `events.date` is a zero-padded `YYYY-MM-DD` string, so lexical order equals
+ * chronological order — a string comparison against the cutoff date is exact and
+ * needs no parsing. Returns the `YYYY-MM-DD` for `now - RETENTION_AFTER_FINAL_EVENT_MS`.
+ */
+function cutoffDateString(now: Date): string {
+  const cutoff = new Date(now.getTime() - RETENTION_AFTER_FINAL_EVENT_MS);
+  return cutoff.toISOString().slice(0, 10);
+}
+
+export const retentionService = {
+  /**
+   * Enforce the 1-year guest-data retention promise (C-H2 / privacy notice).
+   *
+   * For every wedding whose **latest event date** is more than
+   * `RETENTION_AFTER_FINAL_EVENT_MS` before `now`, delete the personal data:
+   * the wedding's `rsvps` (names + RSVP status + special-category dietary text +
+   * the Art. 9(2)(a) `dietaryConsentAt`/`dietaryConsentVersion` records),
+   * `guests`, and `families` rows, plus its `imports` bookkeeping rows. The
+   * wedding/events shell is intentionally **kept** — it carries no guest PII and
+   * deleting it would orphan the published invite + slug.
+   *
+   * Selection: `events.date` is a zero-padded `YYYY-MM-DD` string, so the latest
+   * event is `MAX(date)` and "final event > 1 year ago" is `MAX(date) < cutoff`
+   * (strict — a wedding whose final event is *exactly* at the cutoff is kept one
+   * more day). A wedding with **no events** is never selected (the inner join
+   * drops it) — we cannot prove its window has lapsed, so the safe default is to
+   * keep it; this is also the in-progress-setup case.
+   *
+   * R2 note: the `imports` rows reference R2 objects (`eventsR2Key`/`guestsR2Key`,
+   * the uploaded sheets which contain guest PII). This sweep deletes the DB rows
+   * but does NOT delete the R2 objects — the sweep is a pure-Drizzle Effect with
+   * no R2 binding in scope. See the TODO below; the objects must be reaped by a
+   * separate R2-aware pass (or an R2 lifecycle rule keyed on the `imports/` prefix).
+   *
+   * Run from the Worker's `scheduled` cron handler. Returns the number of guest
+   * rows deleted (the metric/log subject).
+   */
+  // TODO(retention-r2): delete the R2 objects behind expired weddings' `imports`
+  // rows (`eventsR2Key`/`guestsR2Key` in the SHEETS bucket). Needs an R2 binding
+  // threaded into this service; until then the uploaded sheets outlive the DB
+  // rows. Tracked in cire/wiki/todo/api.md.
+  sweepExpiredGuestData(
+    now: Date = new Date(),
+  ): Effect.Effect<number, RetentionWriteError, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const cutoff = cutoffDateString(now);
+
+      // Weddings whose latest event date is strictly before the cutoff.
+      const expired = yield* dbQuery(() =>
+        db
+          .select({ weddingId: events.weddingId })
+          .from(events)
+          .groupBy(events.weddingId)
+          .having(lt(sql`max(${events.date})`, cutoff))
+          .all(),
+      );
+      const weddingIds = expired.map((r) => r.weddingId);
+
+      if (weddingIds.length === 0) {
+        yield* Effect.sync(() => metricGuestDataSwept("ok", 0));
+        yield* Effect.logInfo("guest-data retention sweep complete", { weddings: 0, deleted: 0 });
+        return 0;
+      }
+
+      // Family ids in scope — `guests` is keyed by `family_id`, not `wedding_id`,
+      // so we delete guests via their families. `rsvps` is keyed by `guest_id`;
+      // ON DELETE CASCADE from families → guests → rsvps would handle the
+      // children, but we issue explicit deletes (parent-last) so the sweep does
+      // not depend on FK cascade being enabled on every driver, and so the guest
+      // delete result gives us an exact reclaimed-row count for the metric.
+      const familyRows = yield* dbQuery(() =>
+        db
+          .select({ id: families.id })
+          .from(families)
+          .where(inArray(families.weddingId, weddingIds))
+          .all(),
+      );
+      const familyIds = familyRows.map((r) => r.id);
+
+      const result = yield* Effect.tryPromise({
+        try: () => {
+          const stmts: BatchItem<"sqlite">[] = [];
+          if (familyIds.length > 0) {
+            // rsvps → guests (children) before families (parent).
+            stmts.push(
+              db
+                .delete(rsvps)
+                .where(
+                  inArray(
+                    rsvps.guestId,
+                    db
+                      .select({ id: guests.id })
+                      .from(guests)
+                      .where(inArray(guests.familyId, familyIds)),
+                  ),
+                ),
+            );
+            stmts.push(db.delete(guests).where(inArray(guests.familyId, familyIds)));
+            stmts.push(db.delete(families).where(inArray(families.id, familyIds)));
+          }
+          // imports bookkeeping (the uploaded-sheet PII references). R2 objects
+          // are NOT reaped here — see the service-level TODO.
+          stmts.push(db.delete(imports).where(inArray(imports.weddingId, weddingIds)));
+
+          const batchable = db as {
+            batch?: (s: [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]]) => Promise<unknown[]>;
+          };
+          if (typeof batchable.batch === "function" && stmts.length > 0) {
+            return batchable.batch(stmts as [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]]);
+          }
+          // bun:sqlite (tests/local): no .batch(); run sequentially, children first.
+          return (async () => {
+            const out: unknown[] = [];
+            for (const stmt of stmts) out.push(await stmt);
+            return out;
+          })();
+        },
+        catch: (e) => new RetentionWriteError({ op: "sweep", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("guest-data retention sweep failed", { reason: err.reason }),
+        ),
+      );
+
+      // The guests delete is the (familyIds>0 ? second : absent) statement; sum
+      // every result's changed-rows but report the guest count as the subject.
+      const guestsDeleted =
+        familyIds.length > 0 && Array.isArray(result) ? rowsChanged(result[1]) : 0;
+
+      yield* Effect.sync(() => metricGuestDataSwept("ok", guestsDeleted));
+      yield* Effect.logInfo("guest-data retention sweep complete", {
+        weddings: weddingIds.length,
+        deleted: guestsDeleted,
+      });
+      return guestsDeleted;
+    }).pipe(
+      Effect.tapError(() => Effect.sync(() => metricGuestDataSwept("error"))),
+      Effect.withSpan("cire.retention.sweepExpiredGuestData"),
+    );
+  },
+};

--- a/cire/wiki/todo/api.md
+++ b/cire/wiki/todo/api.md
@@ -4,7 +4,7 @@ tags: [todo, api]
 related:
   - "[[index]]"
   - "[[invite-builder]]"
-last-reviewed: 2026-06-15
+last-reviewed: 2026-06-17
 ---
 
 # cire/api
@@ -29,4 +29,6 @@ Backend feature work. The Elysia + Effect + Drizzle layer in `cire/api`.
 - [x] ~~Auth middleware — validate passkey session or magic link token~~ — **Obsolete**: superseded by the two-system model (guest `sessionAuth` cookie + organiser `osnAuth` JWT); no cire-local passkey/magic-link layer
 - [x] ~~Passkey (WebAuthn) registration + authentication endpoints~~ — **Obsolete**: organisers reuse OSN's passkey infra (`@osn/api` issuer); cire ships no WebAuthn endpoints of its own
 - [x] ~~Magic link email dispatch (Resend)~~ — **Obsolete**: no magic-link factor in the two-system model
+- [x] **1-year guest-data retention deletion** — `retentionService.sweepExpiredGuestData(now)` (Effect, `services/retention.ts`) deletes guest PII (`rsvps` incl. dietary + Art. 9(2)(a) consent, `guests`, `families`, plus `imports` rows) for every wedding whose latest `events.date` is > `RETENTION_AFTER_FINAL_EVENT_MS` (365 days) before now. Window enforced from the published privacy notice. Wedding+events shell kept; no-events weddings kept. Wired into the existing daily-cron `scheduled` handler alongside the session sweep; `cire.guest_data.swept` metric.
+- [ ] **Retention R2 follow-up** — the retention sweep deletes expired weddings' `imports` DB rows but NOT the R2 objects they reference (`eventsR2Key`/`guestsR2Key` — uploaded sheets carry guest PII). Reap them via a separate R2-aware pass or an R2 lifecycle rule on the `imports/` prefix. (TODO `retention-r2` in `services/retention.ts`.)
 - [ ] Admin endpoints — view RSVPs, regenerate passwords, deactivate families


### PR DESCRIPTION
## What

Enforce cire's published guest-data retention promise. The privacy notice (`cire/web/src/pages/privacy.astro`) states guest data is deleted **1 year after the final wedding event** — nothing enforced it. This adds an automated retention-deletion sweep, mirroring the existing session sweeper (#127).

## How

- **`retentionService.sweepExpiredGuestData(now)`** (`cire/api/src/services/retention.ts`) — a testable Effect that, for every wedding whose **latest event date** is more than `RETENTION_AFTER_FINAL_EVENT_MS` (365 days) before `now`, deletes the personal data:
  - `rsvps` (names + RSVP status + **special-category dietary** free-text + the Art. 9(2)(a) `dietary_consent_at` / `dietary_consent_version` records)
  - `guests`
  - `families`
  - the wedding's `imports` bookkeeping rows
- **Deletion predicate:** `events.date` is a zero-padded `YYYY-MM-DD` string, so the final event is `MAX(date)` and "> 1 year ago" is `MAX(date) < cutoff` (strict). Issued parent-last in a `db.batch` on D1, sequentially on bun:sqlite.
- **Kept on purpose:** the wedding + events shell (carries no guest PII; deleting would orphan the published invite/slug). A wedding with **no events** is also kept — its window can't be proven lapsed (also the in-setup case).
- **Constant + metric:** `RETENTION_AFTER_FINAL_EVENT_MS` is a named const; new `cire.guest_data.swept` counter mirrors `cire.session.swept` (increment = reclaimed guest rows).
- **Wiring:** added to the existing daily-cron `scheduled` handler in `index.ts` alongside the session sweep — same `0 4 * * *` cron, each sweep in its own `waitUntil` + `catchAll`/`Effect.logError`.

## Imports / R2

`imports` **DB rows** are deleted. The **R2 objects** they reference (`eventsR2Key`/`guestsR2Key` — uploaded sheets that carry guest PII) are **not** reaped: the sweep is a pure-Drizzle Effect with no R2 binding in scope. Left as a clear `TODO(retention-r2)` in the service + a tracked item in `cire/wiki/todo/api.md` (separate R2-aware pass or an R2 lifecycle rule on the `imports/` prefix).

## Tests (TDD — written first)

`cire/api/src/services/retention.test.ts` — 7 tests: final event >1yr ago → guests+rsvps deleted; <1yr ago → kept; no events → kept; dietary+consent removed with the rsvp; imports rows deleted; cutoff boundary. `bun test cire/api/src` → **317 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)