### PR TITLE
refactor(osn/api): workerd-safe logger-only observability (Workers migration P4)

### DIFF
--- a/.changeset/osn-workers-logger-observability.md
+++ b/.changeset/osn-workers-logger-observability.md
@@ -1,0 +1,21 @@
+---
+"@osn/api": patch
+---
+
+Add a workerd-safe, logger-only observability layer to `@osn/api` so the
+eventual Cloudflare Workers entry never imports `@effect/opentelemetry/NodeSdk`
+(Node-only, won't run on workerd).
+
+- New `osn/api/src/observability.ts` mirrors `cire/api`'s: exports
+  `osnLoggerLayer` (built via `makeLoggerLayer(loadConfig({ serviceName: "osn-api" }))`,
+  importing only the effect-only `@shared/observability/config` + `/logger`
+  subpaths) plus `runOsn` / `runOsnSync` helpers. It deliberately never calls
+  `initObservability` / `makeTracingLayer`, which pull the Node OTel SDK. Typed
+  `Layer.Layer<never>`, so it is interchangeable with the full layer in the app
+  runtime / route signatures.
+- `createApp` (`app.ts`) gains an `includeObservabilityPlugin: boolean` deps
+  flag. The Elysia `observabilityPlugin` calls `process.hrtime.bigint()` on the
+  per-request hot path (start timestamp + duration), which is not available on
+  workerd without `nodejs_compat`; the flag lets the Workers path omit it while
+  keeping `healthRoutes` + the redacting logger. The Bun path passes `true` —
+  no behaviour change.

--- a/osn/api/src/app.ts
+++ b/osn/api/src/app.ts
@@ -37,6 +37,19 @@ import type { AuthConfig } from "./services/auth";
 export interface AppDeps {
   /** Service name threaded through observability + health routes. */
   serviceName: string;
+  /**
+   * Whether to mount the Elysia `observabilityPlugin` (per-request server span
+   * + RED metrics + in-flight gauge). True on the Bun path. The future Workers
+   * entry passes `false`: the plugin calls `process.hrtime.bigint()` directly
+   * on every request (start timestamp + duration), which is not available on
+   * workerd without `nodejs_compat`, and even then it is a polyfill we'd rather
+   * not depend on for request hot-path timing. Its transitive imports are
+   * otherwise workerd-safe (only `@opentelemetry/api`'s no-op tracer/meter +
+   * the effect-only `redact`), so omitting it loses only the auto-emitted
+   * server span/metrics — the redacting logger (the load-bearing PII guard) and
+   * `healthRoutes` stay on both paths.
+   */
+  includeObservabilityPlugin: boolean;
   /** Auth config (rp id/name, origins, issuer, JWT key material, TTLs, pepper). */
   authConfig: AuthConfig;
   /** Cookie session config — drives Secure flag + `__Host-` prefix. */
@@ -91,6 +104,7 @@ export interface AppDeps {
 export function createApp(deps: AppDeps) {
   const {
     serviceName,
+    includeObservabilityPlugin,
     authConfig,
     cookieConfig,
     corsOrigins,
@@ -112,10 +126,19 @@ export function createApp(deps: AppDeps) {
     clientIpConfig,
   } = deps;
 
-  return new Elysia()
+  const base = new Elysia()
     .use(cors({ origin: corsOrigins, credentials: true }))
-    .onBeforeHandle(originGuard)
-    .use(observabilityPlugin({ serviceName }))
+    .onBeforeHandle(originGuard);
+
+  // The per-request observability plugin is gated behind a deps flag: the Bun
+  // path mounts it; the future Workers path omits it (see `includeObservabilityPlugin`
+  // in AppDeps for why — `process.hrtime` on the request hot path). `healthRoutes`
+  // and the redacting logger remain on both paths regardless.
+  const withObservability = includeObservabilityPlugin
+    ? base.use(observabilityPlugin({ serviceName }))
+    : base;
+
+  return withObservability
     .use(healthRoutes({ serviceName }))
     .get("/", () => ({ status: "ok", service: "osn-auth" }))
     .use(

--- a/osn/api/src/local.ts
+++ b/osn/api/src/local.ts
@@ -300,6 +300,9 @@ export async function buildAppDeps(): Promise<BuiltDeps> {
 
   const deps: AppDeps = {
     serviceName: SERVICE_NAME,
+    // Bun path keeps the full per-request observability plugin (server span +
+    // RED metrics). The Workers entry will pass `false` — see AppDeps.
+    includeObservabilityPlugin: true,
     authConfig,
     cookieConfig,
     corsOrigins,

--- a/osn/api/src/observability.ts
+++ b/osn/api/src/observability.ts
@@ -1,0 +1,51 @@
+import { loadConfig } from "@shared/observability/config";
+import { makeLoggerLayer } from "@shared/observability/logger";
+import { Effect } from "effect";
+
+/**
+ * Redacting structured-logger layer for osn/api — the workerd-safe sibling of
+ * the full `initObservability()` layer used on the Bun path (`local.ts`).
+ *
+ * Replaces Effect's default logger with the shared OSN redacting logger (json
+ * in prod / pretty in dev) so every `Effect.log*` message + annotation is run
+ * through the secret/PII deny-list (`@shared/observability/logger`'s `redact`)
+ * before serialization. Without this layer osn's log calls fall through to
+ * Effect's *default* logger and annotated PII — `email`, `token`, `sessionId`,
+ * `passwordHash`, … — is NOT scrubbed.
+ *
+ * Built once at module load from env (`OSN_ENV` / `OSN_LOG_LEVEL`, parsed by
+ * `loadConfig`). On workerd `nodejs_compat` populates `process.env` from
+ * wrangler `[vars]` + secrets; in bun:sqlite tests and the local dev server
+ * `process.env` is native.
+ *
+ * Workerd-safe: the `/logger` and `/config` subpaths import only `effect` (no
+ * `@opentelemetry/*` SDK, no `@effect/opentelemetry/NodeSdk`), so adopting this
+ * does not drag the Node OTel SDK into the Worker bundle. This is what the
+ * eventual Phase-6 Workers entry will hand to `createApp` as its
+ * `observabilityLayer`; the Bun entry keeps providing the FULL logger + OTLP
+ * tracing layer via `initObservability()`. Metric/trace EXPORT on workerd
+ * remains deferred — the recording call-sites are correct and type-checked
+ * today, but are no-ops until an exporter is attached.
+ *
+ * Typed as `Layer.Layer<never>` (the return type of `makeLoggerLayer`) so it is
+ * interchangeable with the full observability layer in the app runtime / every
+ * route-factory signature — no signature changes required.
+ */
+export const osnLoggerLayer = makeLoggerLayer(loadConfig({ serviceName: "osn-api" }));
+
+/**
+ * Run a fully-resolved osn effect to a Promise with the redacting logger
+ * installed. The effect must already have its services (`DbService`,
+ * `EmailService`, …) provided and its typed errors handled — this only swaps in
+ * the logger. Use on the Workers path instead of bare `Effect.runPromise` so no
+ * log line escapes redaction.
+ */
+export const runOsn = <A, E>(effect: Effect.Effect<A, E, never>): Promise<A> =>
+  Effect.runPromise(Effect.provide(effect, osnLoggerLayer));
+
+/**
+ * Synchronous counterpart for framework error boundaries and startup banners,
+ * where there is no Promise to await.
+ */
+export const runOsnSync = <A, E>(effect: Effect.Effect<A, E, never>): A =>
+  Effect.runSync(Effect.provide(effect, osnLoggerLayer));

--- a/osn/api/tests/observability.test.ts
+++ b/osn/api/tests/observability.test.ts
@@ -1,0 +1,93 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { osnLoggerLayer, runOsn, runOsnSync } from "../src/observability";
+
+/**
+ * The load-bearing contract of `runOsn` / `runOsnSync` is that they install
+ * `osnLoggerLayer` — the workerd-safe, logger-only observability layer — so
+ * every log line is routed through the shared redaction deny-list. The deny-
+ * list *logic* is owned + tested upstream (`@shared/observability`
+ * redact.test.ts); these tests pin that osn's logger layer actually *applies*
+ * it: a PII-bearing context object passed to an osn log call comes out
+ * `[REDACTED]` end-to-end, and a refactor that drops the layer (or swaps
+ * `runOsn` back to a bare `Effect.runPromise`) fails loudly.
+ *
+ * Note on shape: PII is passed as the log MESSAGE object
+ * (`Effect.logInfo("msg", { email })`) — not via `Effect.annotateLogs`. The
+ * redacting logger walks the message object and scrubs by key, which is the
+ * path exercised here. (A denied annotation KEY carrying a primitive value is
+ * not redacted — a pre-existing shared-logger limitation, see cire's
+ * observability.test.ts note — so it would be the wrong thing to assert.)
+ */
+
+/**
+ * Capture everything Effect's logger writes for one run. Effect's default
+ * loggers emit through `globalThis.console`, so we temporarily swap those
+ * methods for a sink. (`globalThis.console` is used rather than the bare
+ * `console` global so the no-console lint rule — which targets production code
+ * — isn't tripped by this test-only interception.)
+ */
+async function captureLogs(run: () => unknown | Promise<unknown>): Promise<string> {
+  const lines: string[] = [];
+  const sink = (...args: unknown[]): void => {
+    lines.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+  const c = globalThis.console;
+  const original = { log: c.log, info: c.info, warn: c.warn, error: c.error, debug: c.debug };
+  Object.assign(c, { log: sink, info: sink, warn: sink, error: sink, debug: sink });
+  try {
+    await run();
+  } finally {
+    Object.assign(c, original);
+  }
+  return lines.join("\n");
+}
+
+describe("osn observability logger layer", () => {
+  it("builds a logger-only layer without pulling the Node OTel SDK", () => {
+    // If the layer (or its import graph) referenced @effect/opentelemetry's
+    // NodeSdk, importing this module on a non-Node runtime would blow up at
+    // load. Building it as a value here proves the layer is constructable from
+    // the effect-only `/logger` + `/config` subpaths.
+    expect(osnLoggerLayer).toBeDefined();
+  });
+
+  it("scrubs PII keys in an osn log message object (runOsn)", async () => {
+    const out = await captureLogs(() =>
+      runOsn(
+        Effect.logInfo("session issued", {
+          email: "ivy@example.com",
+          accessToken: "tok_raw_secret_value",
+          osn_session: "ses_raw_secret_value",
+          profileId: "prof_loggable",
+        }),
+      ),
+    );
+
+    // Sensitive values must never reach the log output.
+    expect(out).not.toContain("ivy@example.com");
+    expect(out).not.toContain("tok_raw_secret_value");
+    expect(out).not.toContain("ses_raw_secret_value");
+    // The deny-list placeholder proves redaction actually ran.
+    expect(out).toContain("[REDACTED]");
+    // Non-PII operational context still passes through (negative control).
+    // policy: profileId is loggable (see redact.ts PII note).
+    expect(out).toContain("prof_loggable");
+  });
+
+  it("applies the same redaction on the synchronous path (runOsnSync)", async () => {
+    const out = await captureLogs(() =>
+      runOsnSync(
+        Effect.logError("unhandled request error", {
+          accountId: "acc_secret_principal",
+          profileId: "prof_sync",
+        }),
+      ),
+    );
+
+    expect(out).not.toContain("acc_secret_principal");
+    expect(out).toContain("[REDACTED]");
+    expect(out).toContain("prof_sync");
+  });
+});


### PR DESCRIPTION
## Summary
- **Migration Phase 4:** give osn-api a workerd-safe **logger-only** observability layer so the future Workers entry never imports `@effect/opentelemetry/NodeSdk` (Node-only). New `osn/api/src/observability.ts` (`osnLoggerLayer` + `runOsn`/`runOsnSync`), mirroring cire's approach. **Bun/local path unchanged.** No Workers entry yet (P6).

## Workspaces affected
- `@osn/api` (patch)

## Decisions & issues

**[observabilityPlugin is NOT workerd-safe → made optional]**
- **Issue:** The shared `observabilityPlugin` calls `process.hrtime.bigint()` on the per-request hot path (`plugin.ts`), unavailable/polyfilled on workerd.
- **Why:** It would break (or silently degrade) on the Workers path; cire's worker `createApp` uses neither the plugin nor `healthRoutes` for this reason.
- **Solution:** Added an `includeObservabilityPlugin` flag to `AppDeps`; `createApp` gates the `.use(observabilityPlugin(...))` behind it. Bun (`local.ts`) passes `true` (unchanged); the future Workers path passes `false`, losing only the server-span/RED telemetry.
- **Rationale:** Its import graph is clean of NodeSdk, but the runtime `hrtime` call isn't safe — gating is the minimal, behavior-preserving fix.

**[redaction preserved — security verdict]** PII redaction lives in `makeLoggerLayer` (deny-list scrubbing), which BOTH paths keep (`initObservability` = logger+tracing; `osnLoggerLayer` = logger only). Dropping the plugin loses no security control (redaction, health, auth/origin guard all retained). Independently reviewed — **no security findings**.

**[T-L1 → P6]** No test yet exercises the `includeObservabilityPlugin: false` app wiring (health mounted + redaction) — add alongside the Phase-6 Workers entry. **[S-H3 → P6 reminder]** if the Workers entry echoes a request-id, re-apply the plugin's `x-request-id` sanitization.

## Test plan
- `osn/api` 617 pass (+3 new redaction tests, async + sync) · `tsc --noEmit` clean · oxlint clean.
- Confirm `observability.ts` import graph never reaches `@effect/opentelemetry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
