### PR TITLE
fix(osn/api): register outbound ARC key on Workers scheduled path (erasure fan-out)

### DIFF
--- a/.changeset/osn-workers-arc-registration.md
+++ b/.changeset/osn-workers-arc-registration.md
@@ -1,0 +1,22 @@
+---
+"@osn/api": patch
+---
+
+Fix: register osn's outbound ARC public key with Pulse/Zap on the Cloudflare
+Workers path before the account-erasure deletion fan-out.
+
+Pulse + Zap verify osn's inbound ARC tokens against a **pre-registered** public
+key (kid → registered key; no JWKS-by-kid pull). The Bun server registers that
+key at boot via `startOutboundKeyRotation` (`local.ts`), but the workerd
+`scheduled` handler — which runs the deletion fan-out and mints `account:erase`
+ARC tokens — never did. The first `/internal/account-deleted` POST would be
+401'd by the downstream and the GDPR Art. 17 erasure would stall (P6 finding).
+
+The `scheduled` handler now calls a new `registerOutboundKeysOnce` (reusing the
+existing `registerWithDownstream` logic) **before** the fan-out sweeps,
+registering once per isolate (a module latch suppresses re-POSTing on later cron
+ticks; the downstream upsert is idempotent regardless). A registration failure
+is logged via `Effect.logError` and swallowed so a transient downstream outage
+never aborts the cron — the latch only flips on full success, so the next tick
+retries. The misleading "lazily inits on first outbound use" comment in
+`src/index.ts` is corrected. No change to the Bun path.

--- a/osn/api/src/index.ts
+++ b/osn/api/src/index.ts
@@ -5,6 +5,7 @@ import { Effect, Layer } from "effect";
 
 import { createApp, type App } from "./app";
 import { buildAppDeps, type EnvRecord } from "./build-deps";
+import { registerOutboundKeysOnce } from "./lib/outbound-arc";
 import { osnLoggerLayer } from "./observability";
 import { initRedisClientFromEnv } from "./redis";
 import * as accountErasure from "./services/account-erasure";
@@ -212,13 +213,39 @@ export const handler: {
   // its own `waitUntil` + `catchAll` so a failure in one never aborts the other
   // and the isolate stays alive until each settles.
   //
-  // ARC outbound-key rotation is NOT scheduled here: it lazily inits on first
-  // outbound use (`outbound-arc.ts`), so on Workers we rely on cron-triggered
-  // fan-out + that lazy init rather than the Bun `setTimeout` self-reschedule.
+  // ARC outbound-key registration on the Workers path. Pulse + Zap verify
+  // inbound ARC tokens against a PRE-REGISTERED public key (Pulse:
+  // `arc-middleware.ts` looks the kid up in an in-memory registry seeded by
+  // `POST /internal/register-service`; osn's own register-service stores keys
+  // in `service_account_keys` — there is NO JWKS-by-kid pull). The Bun server
+  // registers osn's outbound key at boot via `startOutboundKeyRotation` in
+  // `local.ts`. A workerd isolate has no boot hook, so we register here, once
+  // per isolate, BEFORE the fan-out sweeps run — otherwise the very first
+  // `/internal/account-deleted` POST would be 401'd by the downstream and the
+  // GDPR Art. 17 erasure would stall. `outbound-arc.ts`'s lazy init only mints
+  // the keypair; it does NOT publish the public key downstream. Registration is
+  // an idempotent upsert; the once-per-isolate latch keeps every later cron
+  // tick from re-POSTing. A failure here is logged and swallowed so a transient
+  // downstream outage never aborts the sweeps (the next tick retries).
   async scheduled(_event, env, ctx) {
     if (!env.DB) return;
     const dbLayer = makeDbD1Live(env.DB);
     const fanoutUrls = { pulseApiUrl: env.PULSE_API_URL, zapApiUrl: env.ZAP_API_URL };
+
+    ctx.waitUntil(
+      registerOutboundKeysOnce({
+        pulseApiUrl: env.PULSE_API_URL,
+        zapApiUrl: env.ZAP_API_URL,
+        internalServiceSecret: env.INTERNAL_SERVICE_SECRET,
+        osnEnv: env.OSN_ENV,
+      }).catch((err) =>
+        Effect.runPromise(
+          Effect.logError("scheduled outbound ARC key registration failed", {
+            reason: String(err),
+          }).pipe(Effect.provide(osnLoggerLayer)),
+        ),
+      ),
+    );
 
     ctx.waitUntil(
       Effect.runPromise(

--- a/osn/api/src/index.ts
+++ b/osn/api/src/index.ts
@@ -232,31 +232,35 @@ export const handler: {
     const dbLayer = makeDbD1Live(env.DB);
     const fanoutUrls = { pulseApiUrl: env.PULSE_API_URL, zapApiUrl: env.ZAP_API_URL };
 
+    // Register the outbound ARC key, THEN run the fan-out retry sweep — awaited in
+    // sequence within the tick so the first `/internal/account-deleted` POST on a
+    // fresh isolate isn't 401'd before the key is published downstream. A
+    // registration failure is logged and does not block the sweep (the POST then
+    // 401s and is retried on the next tick, per the fail-and-retry posture below).
     ctx.waitUntil(
-      registerOutboundKeysOnce({
-        pulseApiUrl: env.PULSE_API_URL,
-        zapApiUrl: env.ZAP_API_URL,
-        internalServiceSecret: env.INTERNAL_SERVICE_SECRET,
-        osnEnv: env.OSN_ENV,
-      }).catch((err) =>
-        Effect.runPromise(
-          Effect.logError("scheduled outbound ARC key registration failed", {
-            reason: String(err),
-          }).pipe(Effect.provide(osnLoggerLayer)),
-        ),
-      ),
-    );
-
-    ctx.waitUntil(
-      Effect.runPromise(
-        accountErasure.runFanOutRetrySweep(fanoutUrls).pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled fan-out retry sweep failed", { reason: String(err) }),
+      (async () => {
+        await registerOutboundKeysOnce({
+          pulseApiUrl: env.PULSE_API_URL,
+          zapApiUrl: env.ZAP_API_URL,
+          internalServiceSecret: env.INTERNAL_SERVICE_SECRET,
+          osnEnv: env.OSN_ENV,
+        }).catch((err) =>
+          Effect.runPromise(
+            Effect.logError("scheduled outbound ARC key registration failed", {
+              reason: String(err),
+            }).pipe(Effect.provide(osnLoggerLayer)),
           ),
-          Effect.provide(dbLayer),
-          Effect.provide(osnLoggerLayer),
-        ),
-      ),
+        );
+        await Effect.runPromise(
+          accountErasure.runFanOutRetrySweep(fanoutUrls).pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled fan-out retry sweep failed", { reason: String(err) }),
+            ),
+            Effect.provide(dbLayer),
+            Effect.provide(osnLoggerLayer),
+          ),
+        );
+      })(),
     );
 
     ctx.waitUntil(

--- a/osn/api/src/lib/outbound-arc.ts
+++ b/osn/api/src/lib/outbound-arc.ts
@@ -201,9 +201,70 @@ export async function startOutboundKeyRotation(opts: {
 }
 
 /**
+ * Once-per-isolate registration guard for the Workers `scheduled` path.
+ *
+ * The Bun server self-reschedules rotation via `startOutboundKeyRotation`'s
+ * `setTimeout`, but a workerd isolate has no long-lived timer — every cron
+ * tick re-enters `scheduled`. `registerWithDownstream` is an idempotent
+ * upsert, so repeating it is harmless, but POSTing osn's public key to every
+ * downstream on *every* tick is wasteful. This flag is flipped on the first
+ * successful registration pass so subsequent ticks within the same isolate
+ * skip the network round-trips. A fresh isolate starts unregistered and
+ * registers again on its first tick (and rotation resets it — see below).
+ */
+let _downstreamRegistered = false;
+
+/**
+ * Registers osn's outbound ARC public key with each configured downstream
+ * (Pulse + Zap) exactly once per isolate. Intended for the Workers
+ * `scheduled` handler, which has no boot hook to run `startOutboundKeyRotation`
+ * (the Bun path does that in `local.ts`).
+ *
+ * Reuses `registerWithDownstream` (no duplicated POST logic). Idempotent at
+ * two levels: the module flag skips the network calls after the first success
+ * this isolate, and `registerWithDownstream` itself is a PUT/upsert downstream.
+ *
+ * Resolves to `true` once registration has been attempted+succeeded (or was
+ * already done this isolate), `false` when there is nothing to register (no
+ * downstream URLs configured) so the caller can tell a no-op apart. Any
+ * registration failure rejects — the caller is expected to log + swallow so a
+ * transient downstream outage never aborts the cron sweeps.
+ */
+export async function registerOutboundKeysOnce(opts: {
+  pulseApiUrl?: string;
+  zapApiUrl?: string;
+  internalServiceSecret?: string;
+  osnEnv?: string;
+}): Promise<boolean> {
+  if (_downstreamRegistered) return true;
+
+  const osnEnv = opts.osnEnv ?? process.env.OSN_ENV;
+  const internalServiceSecret = opts.internalServiceSecret ?? process.env.INTERNAL_SERVICE_SECRET;
+  const services = [
+    { url: opts.pulseApiUrl, selfId: "osn-api" as const, scopes: "account:erase" },
+    { url: opts.zapApiUrl, selfId: "osn-api" as const, scopes: "account:erase" },
+  ].filter((s): s is { url: string; selfId: "osn-api"; scopes: string } => Boolean(s.url));
+
+  if (services.length === 0) return false;
+
+  for (const s of services) {
+    // eslint-disable-next-line no-await-in-loop -- sequential so a configured-stack failure short-circuits before the next downstream (mirrors startOutboundKeyRotation)
+    await registerWithDownstream(s.url, s.selfId, s.scopes, { internalServiceSecret, osnEnv });
+  }
+
+  // Only latch once every configured downstream accepted the key — a partial
+  // failure throws above, leaving the flag false so the next tick retries.
+  _downstreamRegistered = true;
+  return true;
+}
+
+/**
  * Reset hook for tests — clears the in-memory keypair singleton so each
- * test that exercises outbound ARC starts with a fresh key.
+ * test that exercises outbound ARC starts with a fresh key. Also clears the
+ * once-per-isolate downstream-registration latch so registration can be
+ * re-exercised.
  */
 export function _resetOutboundKeyForTests(): void {
   _keyInitPromise = null;
+  _downstreamRegistered = false;
 }

--- a/osn/api/src/lib/outbound-arc.ts
+++ b/osn/api/src/lib/outbound-arc.ts
@@ -210,7 +210,11 @@ export async function startOutboundKeyRotation(opts: {
  * downstream on *every* tick is wasteful. This flag is flipped on the first
  * successful registration pass so subsequent ticks within the same isolate
  * skip the network round-trips. A fresh isolate starts unregistered and
- * registers again on its first tick (and rotation resets it — see below).
+ * registers again on its first tick. Note: workerd has no rotation timer, so
+ * the latch is never reset within an isolate's life; the downstream
+ * registration TTL (~24h) only bites an isolate that outlives it — in practice
+ * isolates are short-lived, and a lapsed registration just 401s the fan-out,
+ * which is retried next tick (fail-and-retry, never a silent erasure drop).
  */
 let _downstreamRegistered = false;
 

--- a/osn/api/tests/index-fetch.test.ts
+++ b/osn/api/tests/index-fetch.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import type { ExecutionContext, ScheduledController } from "@cloudflare/workers-types";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 
 import { handler, type Env } from "../src/index";
+import { _resetOutboundKeyForTests } from "../src/lib/outbound-arc";
 
 /**
  * T-R1 — Workers `fetch` handler fail-closed paths.
@@ -66,5 +68,92 @@ describe("handler.fetch — fail-closed (T-R1)", () => {
     expect(error).not.toContain("OSN_ISSUER_URL");
     expect(error).not.toContain("OSN_CORS_ORIGIN");
     expect(error).not.toContain("OSN_RP_ID");
+  });
+});
+
+/**
+ * T-R2 — the cron `scheduled` handler registers osn's outbound ARC public key
+ * with each downstream BEFORE the fan-out sweeps. Pulse/Zap verify osn's ARC
+ * tokens against a pre-registered key, so without this the very first
+ * `/internal/account-deleted` POST is 401'd and GDPR Art. 17 erasure stalls.
+ *
+ * Drives the real exported `handler.scheduled(event, env, ctx)` with a fake
+ * env + a `waitUntil` collector. The DB-backed sweeps run against a stub D1
+ * binding and fail internally — they're wrapped in `Effect.catchAll`/`logError`
+ * so they never throw out of `scheduled`; this test only asserts the
+ * registration POSTs fired and are once-per-isolate.
+ */
+describe("handler.scheduled — outbound ARC key registration (T-R2)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  const collectWaitUntil = (): { ctx: ExecutionContext; settled: () => Promise<void> } => {
+    const promises: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => promises.push(p.catch(() => undefined)),
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext;
+    return { ctx, settled: async () => void (await Promise.all(promises)) };
+  };
+
+  const registerCalls = (): number =>
+    fetchSpy.mock.calls.filter((c: Parameters<typeof fetch>) => {
+      const input = c[0];
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      return url.includes("/internal/register-service");
+    }).length;
+
+  const env: Env = {
+    DB: {} as Env["DB"],
+    OSN_ENV: "production",
+    PULSE_API_URL: "https://pulse.test",
+    ZAP_API_URL: "https://zap.test",
+    INTERNAL_SERVICE_SECRET: "s3cr3t",
+  };
+
+  const scheduledEvent = {
+    scheduledTime: Date.now(),
+    cron: "0 */6 * * *",
+    noRetry: () => {},
+  } as unknown as ScheduledController;
+
+  beforeEach(() => {
+    _resetOutboundKeyForTests();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    _resetOutboundKeyForTests();
+  });
+
+  it("POSTs register-service to each downstream on the first cron tick", async () => {
+    const { ctx, settled } = collectWaitUntil();
+    await handler.scheduled(scheduledEvent, env, ctx);
+    await settled();
+    // One register-service POST per downstream (pulse + zap).
+    expect(registerCalls()).toBe(2);
+  });
+
+  it("does NOT re-register on a second tick within the same isolate", async () => {
+    const first = collectWaitUntil();
+    await handler.scheduled(scheduledEvent, env, first.ctx);
+    await first.settled();
+    expect(registerCalls()).toBe(2);
+
+    const second = collectWaitUntil();
+    await handler.scheduled(scheduledEvent, env, second.ctx);
+    await second.settled();
+    // Still 2 — the once-per-isolate latch suppressed the second pass.
+    expect(registerCalls()).toBe(2);
+  });
+
+  it("does not throw when env.DB is absent (early return)", async () => {
+    const { ctx } = collectWaitUntil();
+    await expect(handler.scheduled(scheduledEvent, {} as Env, ctx)).resolves.toBeUndefined();
+    expect(registerCalls()).toBe(0);
   });
 });

--- a/osn/api/tests/lib/outbound-arc.test.ts
+++ b/osn/api/tests/lib/outbound-arc.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _resetOutboundKeyForTests, registerOutboundKeysOnce } from "../../src/lib/outbound-arc";
+
+/**
+ * T-R2 — Workers `scheduled`-path outbound ARC key registration.
+ *
+ * Pulse + Zap verify osn's inbound ARC tokens against a PRE-REGISTERED public
+ * key (kid → registered key), so the Workers deletion fan-out MUST publish
+ * osn's outbound key to each downstream's `/internal/register-service` before
+ * it POSTs `/internal/account-deleted`. The Bun path does this at boot via
+ * `startOutboundKeyRotation`; on workerd `registerOutboundKeysOnce` does it,
+ * once per isolate, from the cron `scheduled` handler.
+ *
+ * These tests assert: a successful pass POSTs to every configured downstream
+ * and is then a no-op on later ticks (once-per-isolate), the upsert is
+ * idempotent downstream, a partial failure does NOT latch (so the next tick
+ * retries), and a no-downstream config is a clean no-op.
+ */
+
+const OK = (): Response => new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+const registerUrls = (res: string[]): string[] =>
+  res
+    .map((u) => new URL(u))
+    .filter((u) => u.pathname === "/internal/register-service")
+    .map((u) => `${u.protocol}//${u.host}`);
+
+describe("registerOutboundKeysOnce (Workers scheduled path) — T-R2", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  const calledUrls = (): string[] =>
+    registerUrls(
+      fetchSpy.mock.calls.map((c: Parameters<typeof fetch>) => {
+        const input = c[0];
+        return typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      }),
+    );
+
+  const baseOpts = {
+    pulseApiUrl: "https://pulse.test",
+    zapApiUrl: "https://zap.test",
+    internalServiceSecret: "s3cr3t",
+    osnEnv: "production",
+  };
+
+  beforeEach(() => {
+    _resetOutboundKeyForTests();
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(OK());
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    _resetOutboundKeyForTests();
+  });
+
+  it("registers osn's outbound key with every configured downstream on the first pass", async () => {
+    const result = await registerOutboundKeysOnce(baseOpts);
+
+    expect(result).toBe(true);
+    const urls = calledUrls();
+    expect(urls).toContain("https://pulse.test");
+    expect(urls).toContain("https://zap.test");
+    expect(urls).toHaveLength(2);
+
+    // The registration POST carries the shared INTERNAL_SERVICE_SECRET as a
+    // Bearer token (NOT an ARC token) — that is how the downstream gates the
+    // register-service endpoint.
+    const firstInit = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(firstInit.headers);
+    expect(headers.get("authorization")).toBe("Bearer s3cr3t");
+    expect(firstInit.method).toBe("POST");
+  });
+
+  it("is a once-per-isolate no-op on subsequent ticks (idempotent + no re-POST)", async () => {
+    await registerOutboundKeysOnce(baseOpts);
+    expect(calledUrls()).toHaveLength(2);
+
+    // Two more cron ticks within the same isolate — must NOT re-POST.
+    const second = await registerOutboundKeysOnce(baseOpts);
+    const third = await registerOutboundKeysOnce(baseOpts);
+
+    expect(second).toBe(true);
+    expect(third).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // still just the first pass
+  });
+
+  it("does NOT latch on a partial failure, so the next tick retries", async () => {
+    // First downstream (pulse) rejects; `registerWithDownstream` throws on a
+    // non-2xx, which propagates out of `registerOutboundKeysOnce`.
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+
+    await expect(registerOutboundKeysOnce(baseOpts)).rejects.toThrow();
+
+    // Latch stayed false → a later tick re-attempts and can succeed.
+    fetchSpy.mockResolvedValue(OK());
+    const retry = await registerOutboundKeysOnce(baseOpts);
+    expect(retry).toBe(true);
+    expect(calledUrls()).toContain("https://pulse.test");
+    expect(calledUrls()).toContain("https://zap.test");
+  });
+
+  it("is a clean no-op (returns false, no fetch) when no downstream URLs are configured", async () => {
+    const result = await registerOutboundKeysOnce({
+      internalServiceSecret: "s3cr3t",
+      osnEnv: "production",
+    });
+
+    expect(result).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/wiki/systems/arc-tokens.md
+++ b/wiki/systems/arc-tokens.md
@@ -22,7 +22,7 @@ packages:
   - "@shared/crypto"
   - "@osn/api"
   - "@pulse/api"
-last-reviewed: 2026-06-16
+last-reviewed: 2026-06-18
 security-fixes:
   - S-H100
   - S-H101
@@ -213,6 +213,31 @@ Env vars: `INTERNAL_SERVICE_SECRET`, `KEY_TTL_HOURS` (default 24), `KEY_ROTATION
 # Both env files need:
 INTERNAL_SERVICE_SECRET=<shared-random-string>
 ```
+
+### osn-api as issuer — outbound key registration (deletion fan-out)
+
+The flow above has `pulse-api` / `zap-api` registering **with** osn-api. The
+reverse also holds: when osn-api fans out a full-account erasure it acts as the
+ARC **issuer**, POSTing `/internal/account-deleted` to Pulse + Zap with
+`scope: account:erase`. Because those downstreams verify against a
+**pre-registered** key (Pulse's `arc-middleware.ts` looks the `kid` up in an
+in-memory registry seeded by `POST /internal/register-service`; there is **no**
+JWKS-by-kid pull), osn-api must first publish *its own* outbound ARC public key
+to each downstream — otherwise the first `/internal/account-deleted` POST is
+401'd and the GDPR Art. 17 erasure stalls.
+
+- **Bun path** (`local.ts`): `startOutboundKeyRotation()` in
+  `osn/api/src/lib/outbound-arc.ts` registers with Pulse + Zap at boot and
+  self-reschedules rotation via an unref'd `setTimeout`.
+- **Workers path** (`osn/api/src/index.ts` `scheduled`): a workerd isolate has
+  no boot hook, so `registerOutboundKeysOnce()` runs inside the cron
+  `scheduled` handler, **before** the fan-out sweeps, registering once per
+  isolate (a module-level latch suppresses re-POSTing on later ticks; the
+  downstream upsert makes a repeat harmless anyway). A registration failure is
+  logged via `Effect.logError` and swallowed so a transient downstream outage
+  never aborts the sweeps — the next tick retries (the latch only flips on full
+  success). The lazy key init in `outbound-arc.ts` only *mints* the keypair; it
+  does **not** publish the public key, so this explicit registration is required.
 
 ### Key revocation
 


### PR DESCRIPTION
## Summary
- **Closes follow-up #16.** Register osn's outbound ARC public key with downstreams (Pulse/Zap) on the Cloudflare Workers `scheduled` path. The Workers cron mints ARC tokens for the account-erasure fan-out but never published the key (the Bun server did, at boot via `local.ts`) — so on Workers the fan-out would 401 and downstream **GDPR Art. 17 erasure would stall**.

## Workspaces affected
- `@osn/api` (patch) + `wiki/systems/arc-tokens.md`

## Decisions & issues

**[verification model = pre-registration]** Investigated first: Pulse verifies inbound ARC by a key it stored at registration (`arc-middleware.ts` `keyRegistry.get(kid)` populated only by `/internal/register-service`; osn's `resolvePublicKey` reads `service_account_keys` by kid) — **no JWKS-by-kid pull**. So registration is genuinely required on Workers (Model A).

**[fix]** New `registerOutboundKeysOnce` reuses the existing `registerWithDownstream`, guarded by a module-level once-per-isolate latch that **flips only on full success** (partial failure retries next tick). Called from `scheduled`, secrets threaded from `env`, failure logged + swallowed so the cron never crashes.

**[S-L1 ✓ fixed]** Sequenced registration **before** the fan-out retry sweep within the tick (single awaited `waitUntil`, was three concurrent) — a fresh isolate's first POST is no longer 401'd before the key is published. Hard-delete sweep stays independent.

**[S-L2 ✓ fixed]** Corrected the docstring that overclaimed "rotation resets" the latch — workerd has no rotation timer; documented the 24h registration-TTL edge (mitigated by short-lived isolates + fail-and-retry).

**[security ✓]** Independently reviewed: `INTERNAL_SERVICE_SECRET` from `env`, never logged; latch correct; the registered key is the same kid the fan-out signs with; a registration/POST failure leaves `*_done_at` NULL so the account is **not** hard-deleted and retries — fail-and-retry, never a silent erasure drop. No Critical/High/Medium.

## Test plan
- `osn/api` **648 pass** (+7: registration once-per-isolate, idempotent, partial-failure-retries, no-downstream no-op, `scheduled` POSTs each downstream) · tsc clean · oxlint clean · `wrangler deploy --dry-run` clean workerd bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
