### PR TITLE
fix(cire/api): resolve local-dev 429s on rate-limited routes

### DIFF
--- a/.changeset/cire-local-rate-limit-ip.md
+++ b/.changeset/cire-local-rate-limit-ip.md
@@ -1,0 +1,20 @@
+---
+"@cire/api": patch
+---
+
+Fix local dev 429s on every rate-limited route (preview-code, claim, account-link,
+invite writes).
+
+The `Bun.serve` local entry (`src/local.ts`) has no Cloudflare edge in front of
+it, so requests arrive without a `cf-connecting-ip` header. After the W5
+fail-closed IP-keying hardening, `rateLimitMiddleware` treats an unresolved IP as
+`UNRESOLVED_IP` and returns 429 before the counter is consulted — so every gated
+route 429'd on the first request locally.
+
+The local entry now injects the socket peer (`server.requestIP(...)`, falling back
+to `127.0.0.1`) as `cf-connecting-ip` so per-IP limiting resolves a real key.
+Production (`src/index.ts`, behind Cloudflare) is unaffected and keeps the
+fail-closed posture — Cloudflare sets the real header at the edge.
+
+Also corrects the stale `cire/CLAUDE.md` note that called the local dev server
+`wrangler dev` (it's the `Bun.serve` entry; wrangler is `dev:wrangler`).

--- a/cire/CLAUDE.md
+++ b/cire/CLAUDE.md
@@ -189,7 +189,7 @@ All commands run from the **OSN repo root**.
 bun run dev:cire                     # cire API + web + organiser, plus @osn/api (organiser sign-in needs the OSN issuer)
 bun run --cwd cire/web dev           # Guest site only (:4321)
 bun run --cwd cire/organiser dev     # Organiser portal only (:4322)
-bun run --cwd cire/api dev           # API only (wrangler dev, :8787)
+bun run --cwd cire/api dev           # API only (Bun.serve local entry, :8787; wrangler via dev:wrangler)
 
 # Build
 bun run build                        # Build all packages (turbo)

--- a/cire/api/src/local.ts
+++ b/cire/api/src/local.ts
@@ -47,5 +47,18 @@ const app = createApp(db, {
   osnAudience: process.env.OSN_AUDIENCE,
 });
 
-const server = Bun.serve({ port, fetch: (request: Request) => app.fetch(request) });
+const server = Bun.serve({
+  port,
+  fetch(request: Request, srv: Bun.Server) {
+    // Local dev has no Cloudflare edge, so `cf-connecting-ip` is absent and the
+    // fail-closed rate limiter (W5) 429s every gated route (claim, preview-code,
+    // account-link, invite writes). Inject the socket peer as the trusted client
+    // IP so per-IP limiting works locally. Prod (index.ts) is unaffected —
+    // Cloudflare sets the real header at the edge.
+    const ip = srv.requestIP(request)?.address ?? "127.0.0.1";
+    const headers = new Headers(request.headers);
+    if (!headers.has("cf-connecting-ip")) headers.set("cf-connecting-ip", ip);
+    return app.fetch(new Request(request, { headers }));
+  },
+});
 runCireSync(Effect.logInfo("cire-api dev server listening", { port: server.port }));


### PR DESCRIPTION
## Summary
- Local dev (`bun run --cwd cire/api dev` → `src/local.ts`, a `Bun.serve` entry) has no Cloudflare edge in front of it, so requests arrive with no `cf-connecting-ip` header.
- After the W5 fail-closed IP-keying hardening, `rateLimitMiddleware` treats an unresolved IP as `UNRESOLVED_IP` and returns **429 before the counter is consulted** — so every gated route (preview-code, claim, account-link, invite writes) 429'd on the *first* request locally. This is what broke the cire preview link.
- The local entry now injects the socket peer (`srv.requestIP(request)?.address ?? "127.0.0.1"`) as `cf-connecting-ip` when absent, so per-IP limiting resolves a real key. Production (`src/index.ts`, behind Cloudflare) is unchanged and keeps the fail-closed posture.
- Also fixes the stale `cire/CLAUDE.md` note calling the local dev server `wrangler dev` (it's the `Bun.serve` entry; wrangler is `dev:wrangler`).

## Workspaces affected
- `@cire/api` (patch) — `src/local.ts`
- Docs: `cire/CLAUDE.md`

## Decisions & issues

**[root cause]** — Fail-closed rate limiter 429s every local request
- **Issue:** `getClientIp` (trustCloudflare) returns `UNRESOLVED_IP` when `cf-connecting-ip` is missing; `rateLimitMiddleware` short-circuits to 429 before checking the counter. Local `Bun.serve` never sets that header.
- **Why:** Made all rate-limited cire routes unusable in local dev — not a request-count problem, so restarts/waiting don't help.
- **Solution:** Inject the socket peer as `cf-connecting-ip` in the local entry only, guarded by `!headers.has(...)` so an existing value is preserved.
- **Rationale:** Mirrors the existing edge-simulation convention in `test-helpers.ts:29`; keeps the prod fail-closed posture untouched (only the dev `Bun.serve` wiring changed, not the Workers `src/index.ts` handler).

**[T-S1]** — Inline injection helper has no direct unit test (dismissed)
- **Issue:** The 3-line injection lives inside the `Bun.serve` `fetch` closure and isn't reachable by the `createApp`-based bun:test suite.
- **Why:** A future refactor could silently break the `!headers.has(...)` guard or the fallback.
- **Solution:** Could extract a pure `withClientIp(request, ip)` helper into `src/lib/` and unit-test it.
- **Rationale:** Dismissed as not worth the indirection — `local.ts` is a thin dev-only wiring file uncovered by design, and the security-relevant behaviour (fail-closed + resolved-IP keying) is already thoroughly tested in `client-ip.test.ts` and `rate-limit.test.ts`.

**[S — security review]** — No concerns
- **Issue:** Could the injection weaken prod rate-limiting / IP-spoofing protection, or could the `!headers.has` guard be abused?
- **Why:** The change sits adjacent to the per-IP keying trust boundary.
- **Solution:** N/A — confirmed the production entry (`src/index.ts`) is unchanged; Cloudflare overwrites `cf-connecting-ip` at the edge regardless of client input; the shared resolver still trusts only `cf-connecting-ip` (never XFF/socket).
- **Rationale:** Direct-to-`:8787` spoofing is a pre-existing property of running a dev server with no edge; the guard neither creates nor worsens it and is irrelevant to production.

**[P-I1]** — Per-request Headers/Request clone on dev path (info, non-actionable)
- **Issue:** Each local request allocates a new `Headers` + `Request` wrapper.
- **Why:** Fixed O(1) cost on a single-developer dev path; no production or scale impact.
- **Solution:** None — cloning is the idiomatic way to mutate headers on an immutable `Request`.
- **Rationale:** Optimising would add branching for zero measurable benefit off the production path.

## Test plan
- [ ] `bun run --cwd cire/api test` → 317 pass / 0 fail
- [ ] `bun run --cwd cire/api build` → wrangler dry-run succeeds
- [ ] `bun run --cwd cire/api dev`, then exercise a rate-limited route (e.g. organiser "Preview invite") → returns 200, not 429
- [ ] Hit a route faster than its limit (>30/min for preview) → still 429s correctly (per-IP keying works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)