### PR TITLE
feat(cire): Cloudflare Images transformations via R2 for invite assets

### DIFF
--- a/.changeset/cire-cloudflare-images.md
+++ b/.changeset/cire-cloudflare-images.md
@@ -13,14 +13,30 @@ collapses to `card`) and negotiates a modern output format from the request
 `env.IMAGES.input(...).transform({ width }).output({ format })` and served with
 `Vary: Accept` plus the existing immutable long-max-age cache headers.
 
+Worker Cache API short-circuit: because the Images binding bills per call with
+no per-unique dedupe, the serve route now checks `caches.default` before
+invoking `env.IMAGES`. The cache key is a canonical GET `Request` keyed on
+slug + slot + resolved variant + negotiated output format (+ the existing `?v=`
+content version) — the format is baked into the key because it is `Accept`-
+negotiated and therefore absent from the request URL, so AVIF/WebP/JPEG are
+cached as separate entries and a WebP-only client can never be served an AVIF.
+A hit serves the transformed bytes without touching the binding (or the DB); a
+miss runs the transform and writes the result back to the cache via
+`ctx.waitUntil` (bridged into the Elysia handler per-request, since Elysia's
+`fetch` does not forward the Workers execution context), falling back to an
+inline `await` when no execution context is bound. When `caches` is undefined
+(unit tests / non-Workers runtimes) the route still serves correctly, just
+without caching. Cache hits are observable on the bounded `cire.image.transform`
+counter via the new `result: cache_hit` value.
+
 Graceful fallback is the core behaviour: when the `IMAGES` binding is absent
 (local `wrangler dev` / miniflare / unit tests, or an account without the Images
 product) **or** a transform fails, the route serves the raw R2 original — the
 pre-existing behaviour — and never 500s on a transform miss. The fallback is
 logged (`Effect.logWarning`) and recorded on a bounded `cire.image.transform`
-counter (`result: transformed | original`, plus the `variant` + `format`
-literal unions — no slug or per-wedding value). The transform is traced with
-`Effect.withSpan("cire.invite_assets.transform")`.
+counter (`result: cache_hit | transformed | original`, plus the `variant` +
+`format` literal unions — no slug or per-wedding value). The transform is traced
+with `Effect.withSpan("cire.invite_assets.transform")`.
 
 The guest site (`cire/web`) emits a responsive `srcset`/`sizes` against the
 variant widths for the hero + story images (with the hero `<link rel=preload>`

--- a/.changeset/cire-cloudflare-images.md
+++ b/.changeset/cire-cloudflare-images.md
@@ -1,0 +1,33 @@
+---
+"@cire/api": minor
+"@cire/web": minor
+---
+
+Serve responsive, optimised invite images via the Cloudflare Workers Images
+binding, transformed on the fly from the R2 originals.
+
+`GET /api/invite/:slug/image/:slot` now resolves a bounded, allowlisted variant
+from `?variant=` (`thumb`/`card`/`hero` → 320/800/1600px; missing/unknown
+collapses to `card`) and negotiates a modern output format from the request
+`Accept` header (AVIF → WebP → JPEG). The original R2 bytes are streamed through
+`env.IMAGES.input(...).transform({ width }).output({ format })` and served with
+`Vary: Accept` plus the existing immutable long-max-age cache headers.
+
+Graceful fallback is the core behaviour: when the `IMAGES` binding is absent
+(local `wrangler dev` / miniflare / unit tests, or an account without the Images
+product) **or** a transform fails, the route serves the raw R2 original — the
+pre-existing behaviour — and never 500s on a transform miss. The fallback is
+logged (`Effect.logWarning`) and recorded on a bounded `cire.image.transform`
+counter (`result: transformed | original`, plus the `variant` + `format`
+literal unions — no slug or per-wedding value). The transform is traced with
+`Effect.withSpan("cire.invite_assets.transform")`.
+
+The guest site (`cire/web`) emits a responsive `srcset`/`sizes` against the
+variant widths for the hero + story images (with the hero `<link rel=preload>`
+upgraded to `imagesrcset`/`imagesizes`), keeping a plain `src` as a progressive
+fallback.
+
+Deploy note: the Cloudflare **Images** product must be enabled on the account
+before deploy (transformations are billed per unique transformation). The
+`[images]` binding is declared at top-level **and** mirrored under
+`[env.production]` (named environments do not inherit top-level bindings).

--- a/.changeset/cire-cloudflare-images.md
+++ b/.changeset/cire-cloudflare-images.md
@@ -16,12 +16,25 @@ collapses to `card`) and negotiates a modern output format from the request
 Worker Cache API short-circuit: because the Images binding bills per call with
 no per-unique dedupe, the serve route now checks `caches.default` before
 invoking `env.IMAGES`. The cache key is a canonical GET `Request` keyed on
-slug + slot + resolved variant + negotiated output format (+ the existing `?v=`
-content version) — the format is baked into the key because it is `Accept`-
-negotiated and therefore absent from the request URL, so AVIF/WebP/JPEG are
-cached as separate entries and a WebP-only client can never be served an AVIF.
-A hit serves the transformed bytes without touching the binding (or the DB); a
-miss runs the transform and writes the result back to the cache via
+slug + slot + resolved variant + negotiated output format + a content version
+**derived server-side from the wedding row's `updatedAt`** (S-M1) — the format
+is baked into the key because it is `Accept`-negotiated and therefore absent
+from the request URL, so AVIF/WebP/JPEG are cached as separate entries and a
+WebP-only client can never be served an AVIF.
+
+S-M1 (cost/abuse): the cache-key version is the server-side `updatedAt`, **not**
+the client `?v=` query param. Slugs are public, so keying on the unbounded,
+unvalidated `?v=` let an attacker loop `?v=1,2,3,…` on a valid slug to force
+unlimited cache-missing, per-call-billed transforms. The serve route now does
+the slug→wedding lookup FIRST (a cheap indexed D1 read — required on every
+request to authorise the slug and read the authoritative version; the expensive
+R2 read + binding call are still cache-skipped), 404s when the image is unset,
+then keys the cache on `updatedAt.getTime()`. The frontend may still send `?v=`
+for browser-cache busting (it equals `updatedAt`); it no longer influences the
+Worker cache key or triggers a transform, collapsing the live transform count
+per (slug, slot, variant, format) back to exactly 1. A hit serves the
+transformed bytes without re-running the binding; a miss runs the transform and
+writes the result back to the cache via
 `ctx.waitUntil` (bridged into the Elysia handler per-request, since Elysia's
 `fetch` does not forward the Workers execution context), falling back to an
 inline `await` when no execution context is bound. When `caches` is undefined

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -17,6 +17,7 @@ import {
 } from "./routes/organiser-weddings";
 import { createRsvpRoutes } from "./routes/rsvp";
 import type { AssetsBucket } from "./services/invite-assets";
+import type { ImagesBindingLike } from "./services/invite-image-transform";
 import type { OsnAccountResolver } from "./services/osn-bridge";
 import type { R2Bucket } from "./services/r2-imports";
 
@@ -59,6 +60,11 @@ export interface AppOptions {
   r2?: R2Bucket;
   /** R2 bucket binding for invite-builder images (separate from `r2`). */
   assets?: AssetsBucket;
+  /**
+   * Cloudflare Images binding for on-the-fly transforms of the invite-image
+   * originals. Absent ⇒ the public serve route falls back to the raw R2 bytes.
+   */
+  images?: ImagesBindingLike;
   /** JWKS endpoint of the OSN issuer that signs organiser access tokens. */
   osnJwksUrl?: string;
   /** Expected `aud` claim on organiser access tokens. */
@@ -84,6 +90,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
     previewLimiter = defaultPreviewLimiter,
     r2,
     assets,
+    images,
     osnJwksUrl = "http://localhost:4000/.well-known/jwks.json",
     osnAudience = "osn-access",
     osnTestKey,
@@ -143,7 +150,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
       .use(createOrganiserImportRoutes(db, r2, osnAuthOptions))
       // Invite builder. Public reads (guest site) + organiser writes split into
       // sibling instances so the guest GET isn't behind osnAuth.
-      .use(createInvitePublicRoutes(db, assets))
+      .use(createInvitePublicRoutes(db, assets, images))
       .use(createInviteOrganiserRoutes(db, assets, osnAuthOptions, inviteLimiter))
       // Account linking. Two sibling instances on the same prefix: GET/DELETE
       // need only the guest session; the POST link additionally requires an OSN

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -9,6 +9,7 @@ import {
   isDeployedEnv,
   resolveBootstrapOwnerProfileId,
 } from "./db/bootstrap-owner";
+import { setExecutionCtx } from "./lib/execution-ctx";
 import { createWorkersRateLimiter } from "./lib/workers-rate-limiter";
 import type { WorkersRateLimitBinding } from "./lib/workers-rate-limiter";
 import { runCire } from "./observability";
@@ -106,7 +107,7 @@ const misconfigured = (detail: string) =>
   });
 
 const handler: ExportedHandler<Env> = {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     // Fail closed at the edge if any required binding/var is missing, rather
     // than letting createApp fall back to its localhost dev defaults for the
     // OSN issuer/audience in a misconfigured production deployment (S-M1).
@@ -183,6 +184,12 @@ const handler: ExportedHandler<Env> = {
       };
     }
 
+    // Bridge the Workers execution context to the in-flight request so route
+    // handlers can reach `ctx.waitUntil` (Elysia's `fetch` doesn't forward it).
+    // The public image serve route uses it to populate the Cache API in the
+    // background after a transform. Keyed by this exact Request instance, which
+    // Elysia passes straight through to the handler.
+    setExecutionCtx(request, ctx);
     return cached.app.fetch(request);
   },
 

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -29,6 +29,11 @@ export interface Env {
   // lifecycle: binary, served publicly). Absent ⇒ image upload/serve fail at
   // use, text customisation still works.
   ASSETS?: R2Bucket;
+  // Cloudflare Workers Images binding — transforms the R2 originals into
+  // responsive, modern-format variants on the public serve path. Absent (local
+  // `wrangler dev` / miniflare / unit tests, or an account without the Images
+  // product) ⇒ the serve route falls back to the raw R2 bytes, never 500s.
+  IMAGES?: ImagesBinding;
   WEB_ORIGIN: string;
   OSN_JWKS_URL: string;
   OSN_AUDIENCE: string;
@@ -170,6 +175,7 @@ const handler: ExportedHandler<Env> = {
           inviteLimiter: edgeLimiter,
           r2: env.SHEETS,
           assets: env.ASSETS,
+          images: env.IMAGES,
           osnJwksUrl: env.OSN_JWKS_URL,
           osnAudience: env.OSN_AUDIENCE,
           resolveOsnAccountId,

--- a/cire/api/src/lib/execution-ctx.ts
+++ b/cire/api/src/lib/execution-ctx.ts
@@ -1,0 +1,40 @@
+/**
+ * Bridge the Cloudflare Workers `ExecutionContext` into Elysia route handlers.
+ *
+ * Elysia's `app.fetch(request)` signature only takes the `Request` — it does not
+ * forward the Workers `fetch(request, env, ctx)` third argument — so a handler
+ * has no first-class way to reach `ctx.waitUntil`. We bridge it per-request: the
+ * top-level Worker `fetch` calls {@link setExecutionCtx} before dispatching into
+ * Elysia, keyed by the exact `Request` instance Elysia hands back to the handler
+ * (Elysia does not clone the request). The handler then calls {@link getWaitUntil}
+ * to schedule background work (e.g. a Cache API write) without blocking the
+ * response.
+ *
+ * The map is a `WeakMap`, so an entry is collected as soon as the request object
+ * is — no manual cleanup, no leak. In unit tests / non-Workers contexts the Worker
+ * `fetch` never runs, so `getWaitUntil` returns `undefined` and callers fall back
+ * to awaiting the work inline.
+ */
+
+/** The slice of the Workers `ExecutionContext` we depend on. */
+export interface WaitUntilCtx {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+const ctxByRequest = new WeakMap<Request, WaitUntilCtx>();
+
+/** Associate a Workers execution context with the in-flight request. Called by
+ *  the top-level Worker `fetch` before dispatching into Elysia. */
+export function setExecutionCtx(request: Request, ctx: WaitUntilCtx): void {
+  ctxByRequest.set(request, ctx);
+}
+
+/**
+ * Return a `waitUntil` bound to the request's execution context, or `undefined`
+ * when none was registered (unit tests / non-Workers runtimes). Callers that get
+ * `undefined` must do the background work inline (e.g. `await`) instead.
+ */
+export function getWaitUntil(request: Request): ((promise: Promise<unknown>) => void) | undefined {
+  const ctx = ctxByRequest.get(request);
+  return ctx ? (promise) => ctx.waitUntil(promise) : undefined;
+}

--- a/cire/api/src/metrics.ts
+++ b/cire/api/src/metrics.ts
@@ -28,6 +28,8 @@ import {
 import type { Result } from "@shared/observability/metrics";
 import { Effect } from "effect";
 
+import type { ImageVariant, OutputFormat } from "./services/invite-image-transform";
+
 /** Canonical metric name consts — grep-able, refactor-safe. */
 export const CIRE_METRICS = {
   // Guest claim (pre-auth credential exchange surface).
@@ -54,6 +56,8 @@ export const CIRE_METRICS = {
   inviteSaved: "cire.invite.saved",
   inviteAssetUploaded: "cire.invite.asset.uploaded",
   inviteAssetSize: "cire.invite.asset.size",
+  // On-the-fly image transform on the public serve path (Cloudflare Images).
+  imageTransform: "cire.image.transform",
   // Guest account-linking (OSN bridge).
   accountLinkRequests: "cire.account_link.requests",
   accountLinkUnlinks: "cire.account_link.unlinks",
@@ -116,6 +120,20 @@ type ImportSimpleAttrs = { result: "ok" | "error" };
 type ImportRowsAttrs = { entity: ImportEntity };
 type ImportParseRejectedAttrs = { reason: ParseRejectReason };
 type InviteSimpleAttrs = { result: "ok" | "error" };
+
+/**
+ * Outcome of a public image serve:
+ *  - `transformed` — the Images binding produced the requested variant.
+ *  - `original`    — fell back to the raw R2 bytes because the binding was
+ *                    absent (local/dev/tests) or the transform failed.
+ * `variant` + `format` are the bounded unions from the transform module — never
+ * the slug or any per-wedding value.
+ */
+type ImageTransformAttrs = {
+  result: "transformed" | "original";
+  variant: ImageVariant;
+  format: OutputFormat;
+};
 type AccountLinkRequestsAttrs = { result: AccountLinkResult };
 type AccountLinkUnlinksAttrs = { result: "ok" | "error" };
 type AccountLinkResolveDurationAttrs = { result: ResolveResult };
@@ -223,6 +241,13 @@ const inviteAssetSize = createHistogram<Record<never, never>>({
   boundaries: BYTE_BUCKETS,
 });
 
+const imageTransform = createCounter<ImageTransformAttrs>({
+  name: CIRE_METRICS.imageTransform,
+  description:
+    "Public invite-image serves, by whether the Cloudflare Images binding produced a variant or we fell back to the R2 original, plus the resolved variant + output format",
+  unit: "{serve}",
+});
+
 const accountLinkRequests = createCounter<AccountLinkRequestsAttrs>({
   name: CIRE_METRICS.accountLinkRequests,
   description: "Guest account-link POST attempts, by outcome",
@@ -323,6 +348,14 @@ export const metricInviteAssetUploaded = (result: "ok" | "error", byteLength?: n
   inviteAssetUploaded.inc({ result });
   if (result === "ok" && byteLength !== undefined) inviteAssetSize.record(byteLength, {});
 };
+
+/** Record a public image serve: `transformed` when the Images binding produced
+ *  the variant, `original` when we fell back to the raw R2 bytes. */
+export const metricImageTransform = (
+  result: "transformed" | "original",
+  variant: ImageVariant,
+  format: OutputFormat,
+): void => imageTransform.inc({ result, variant, format });
 
 export const metricAccountLinkRequest = (result: AccountLinkResult): void =>
   accountLinkRequests.inc({ result });

--- a/cire/api/src/metrics.ts
+++ b/cire/api/src/metrics.ts
@@ -123,14 +123,17 @@ type InviteSimpleAttrs = { result: "ok" | "error" };
 
 /**
  * Outcome of a public image serve:
- *  - `transformed` — the Images binding produced the requested variant.
+ *  - `cache_hit`   — served from the Worker Cache API; the (billed) Images
+ *                    binding was NOT invoked. The cost win we instrument for.
+ *  - `transformed` — cache miss; the Images binding produced the requested
+ *                    variant (and the result was written back to the cache).
  *  - `original`    — fell back to the raw R2 bytes because the binding was
  *                    absent (local/dev/tests) or the transform failed.
  * `variant` + `format` are the bounded unions from the transform module — never
  * the slug or any per-wedding value.
  */
 type ImageTransformAttrs = {
-  result: "transformed" | "original";
+  result: "cache_hit" | "transformed" | "original";
   variant: ImageVariant;
   format: OutputFormat;
 };
@@ -244,7 +247,7 @@ const inviteAssetSize = createHistogram<Record<never, never>>({
 const imageTransform = createCounter<ImageTransformAttrs>({
   name: CIRE_METRICS.imageTransform,
   description:
-    "Public invite-image serves, by whether the Cloudflare Images binding produced a variant or we fell back to the R2 original, plus the resolved variant + output format",
+    "Public invite-image serves, by whether the response came from the Worker Cache API (cache_hit), the Cloudflare Images binding produced a variant (transformed), or we fell back to the R2 original (original), plus the resolved variant + output format",
   unit: "{serve}",
 });
 
@@ -349,10 +352,11 @@ export const metricInviteAssetUploaded = (result: "ok" | "error", byteLength?: n
   if (result === "ok" && byteLength !== undefined) inviteAssetSize.record(byteLength, {});
 };
 
-/** Record a public image serve: `transformed` when the Images binding produced
- *  the variant, `original` when we fell back to the raw R2 bytes. */
+/** Record a public image serve: `cache_hit` when served from the Worker Cache
+ *  API (binding not invoked), `transformed` when the Images binding produced the
+ *  variant, `original` when we fell back to the raw R2 bytes. */
 export const metricImageTransform = (
-  result: "transformed" | "original",
+  result: "cache_hit" | "transformed" | "original",
   variant: ImageVariant,
   format: OutputFormat,
 ): void => imageTransform.inc({ result, variant, format });

--- a/cire/api/src/routes/invite.test.ts
+++ b/cire/api/src/routes/invite.test.ts
@@ -299,6 +299,136 @@ describe("invite image transforms (Cloudflare Images)", () => {
   });
 });
 
+// ── Cache API short-circuit (Worker edge cache) ──────────────────────────────
+
+/** Map-backed `caches.default` stub. Records put/match calls so a test can assert
+ *  the binding only ran on a miss. Matches by the cache key's URL (what the real
+ *  Cache API keys on). */
+function createCacheStub() {
+  const store = new Map<string, Response>();
+  const calls = { match: 0, put: 0 };
+  const def = {
+    async match(req: Request | string): Promise<Response | undefined> {
+      calls.match += 1;
+      const url = typeof req === "string" ? req : req.url;
+      const hit = store.get(url);
+      return hit ? hit.clone() : undefined;
+    },
+    async put(req: Request | string, res: Response): Promise<void> {
+      calls.put += 1;
+      const url = typeof req === "string" ? req : req.url;
+      store.set(url, res);
+    },
+  };
+  return { calls, store, caches: { default: def } as unknown as CacheStorage };
+}
+
+/** Install a stub `globalThis.caches` for the duration of `fn`, restoring after. */
+async function withCaches<T>(stub: CacheStorage, fn: () => Promise<T>): Promise<T> {
+  const original = (globalThis as { caches?: CacheStorage }).caches;
+  (globalThis as { caches?: CacheStorage }).caches = stub;
+  try {
+    return await fn();
+  } finally {
+    (globalThis as { caches?: CacheStorage }).caches = original;
+  }
+}
+
+describe("invite image transforms — Cache API short-circuit", () => {
+  it("caches the first transform, then serves the second request from cache without re-invoking the binding", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const app = buildApp({ images }).app;
+      await uploadHero(app);
+
+      const accept = { accept: "image/avif,image/webp,*/*" };
+
+      // First request → miss → binding runs once + result cached.
+      const first = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(first.status).toBe(200);
+      expect(first.headers.get("content-type")).toBe("image/avif");
+      expect(new Uint8Array(await first.arrayBuffer())).toEqual(TRANSFORMED);
+      expect(images.widths).toEqual([1600]); // binding called once
+      expect(cache.calls.put).toBe(1); // cached on miss
+
+      // Second identical request → hit → served from cache, binding NOT called again.
+      const second = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(second.status).toBe(200);
+      expect(second.headers.get("content-type")).toBe("image/avif");
+      expect(new Uint8Array(await second.arrayBuffer())).toEqual(TRANSFORMED);
+      expect(images.widths).toEqual([1600]); // still one call — no re-invocation
+      expect(cache.calls.put).toBe(1); // no second write
+    });
+  });
+
+  it("keys a different variant separately (binding called again, new cache entry)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const app = buildApp({ images }).app;
+      await uploadHero(app);
+
+      await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`);
+      await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=thumb`);
+
+      // Two distinct variants ⇒ two binding invocations + two cache entries.
+      expect(images.widths).toEqual([1600, 320]);
+      expect(cache.store.size).toBe(2);
+    });
+  });
+
+  it("keys a different negotiated format separately (AVIF vs WebP cached apart)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const app = buildApp({ images }).app;
+      await uploadHero(app);
+
+      const avif = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=card`, {
+        headers: { accept: "image/avif,*/*" },
+      });
+      const webp = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=card`, {
+        headers: { accept: "image/webp,*/*" },
+      });
+
+      expect(avif.headers.get("content-type")).toBe("image/avif");
+      expect(webp.headers.get("content-type")).toBe("image/webp");
+      // Same variant, different format ⇒ two binding calls + two cache entries.
+      expect(images.widths.length).toBe(2);
+      expect(cache.store.size).toBe(2);
+
+      // A WebP-only client must NOT get the AVIF entry: repeat WebP hits cache,
+      // binding count unchanged.
+      const webp2 = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=card`, {
+        headers: { accept: "image/webp,*/*" },
+      });
+      expect(webp2.headers.get("content-type")).toBe("image/webp");
+      expect(images.widths.length).toBe(2);
+    });
+  });
+
+  it("serves correctly via the binding when the Cache API is absent (no caches global)", async () => {
+    // No stub installed ⇒ `caches` is undefined in this runtime; the route must
+    // still serve the transform (just without caching).
+    const images = createImagesStub();
+    const app = buildApp({ images }).app;
+    await uploadHero(app);
+
+    const img = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+      headers: { accept: "image/avif,*/*" },
+    });
+    expect(img.status).toBe(200);
+    expect(img.headers.get("content-type")).toBe("image/avif");
+    expect(new Uint8Array(await img.arrayBuffer())).toEqual(TRANSFORMED);
+    expect(images.widths).toEqual([1600]);
+  });
+});
+
 describe("invite write rate limiting (IB-S-L1)", () => {
   it("429s once the per-IP limit is exceeded", async () => {
     const { app } = buildApp({

--- a/cire/api/src/routes/invite.test.ts
+++ b/cire/api/src/routes/invite.test.ts
@@ -7,6 +7,11 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { createApp } from "../app";
 import { createDb, seedDb } from "../db/setup";
 import { createAssetsStub } from "../services/invite-assets";
+import type {
+  ImagesBindingLike,
+  ImageTransformHandle,
+  OutputFormat,
+} from "../services/invite-image-transform";
 import { appRequest } from "../test-helpers";
 import { makeOsnTestAuth } from "../test-helpers/osn-token";
 import type { OsnTestAuth } from "../test-helpers/osn-token";
@@ -24,19 +29,60 @@ beforeAll(async () => {
   auth = await makeOsnTestAuth();
 });
 
-function buildApp(opts?: { inviteLimiter?: RateLimiterBackend }) {
+function buildApp(opts?: { inviteLimiter?: RateLimiterBackend; images?: ImagesBindingLike }) {
   const db = createDb(":memory:");
   seedDb(db);
   const assets = createAssetsStub();
   const app = createApp(db, {
     osnTestKey: auth.key,
     assets,
+    images: opts?.images,
     // Generous per-test limiter so the shared module default can't bleed across
     // tests; the rate-limit test below injects a tight one.
     inviteLimiter:
       opts?.inviteLimiter ?? createRateLimiter({ maxRequests: 1000, windowMs: 60_000 }),
   });
   return { db, app, assets };
+}
+
+// Distinct bytes from the uploaded PNG so a test can tell a transformed serve
+// apart from the raw-original fallback.
+const TRANSFORMED = new Uint8Array([0xaa, 0xbb, 0xcc]);
+
+/** Stub Images binding. Echoes the requested format as content-type, records the
+ *  transform widths, and can be made to throw to exercise the fallback path. */
+function createImagesStub(opts?: { fail?: boolean }): ImagesBindingLike & {
+  widths: (number | undefined)[];
+} {
+  const widths: (number | undefined)[] = [];
+  return {
+    widths,
+    input() {
+      const handle: ImageTransformHandle = {
+        transform(t) {
+          widths.push(t.width);
+          return handle;
+        },
+        output(o: { format: OutputFormat }) {
+          if (opts?.fail) return Promise.reject(new Error("transform boom"));
+          return Promise.resolve({
+            response: () => new Response(TRANSFORMED, { headers: { "Content-Type": o.format } }),
+            contentType: () => o.format,
+          });
+        },
+      };
+      return handle;
+    },
+  };
+}
+
+async function uploadHero(app: ReturnType<typeof buildApp>["app"]): Promise<void> {
+  const up = await appRequest(app, `${orgBase}/image/hero`, {
+    method: "POST",
+    headers: await authHeaders(BOOTSTRAP_OWNER),
+    body: PNG,
+  });
+  expect(up.status).toBe(200);
 }
 
 const emptyText = JSON.stringify({
@@ -192,6 +238,64 @@ describe("invite image upload + serve + remove", () => {
     const { app } = buildApp();
     const res = await appRequest(app, `/api/invite/${SLUG}/image/story`);
     expect(res.status).toBe(404);
+  });
+});
+
+describe("invite image transforms (Cloudflare Images)", () => {
+  it("falls back to the original bytes when no IMAGES binding is present", async () => {
+    // No `images` ⇒ the serve route serves the raw R2 original (today's
+    // behaviour), unchanged — the critical local-dev / test path.
+    const app = buildApp().app;
+    await uploadHero(app);
+    const img = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`);
+    expect(img.status).toBe(200);
+    expect(img.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await img.arrayBuffer())).toEqual(PNG);
+  });
+
+  it("serves a transformed variant when the IMAGES binding is present", async () => {
+    const images = createImagesStub();
+    const app = buildApp({ images }).app;
+    await uploadHero(app);
+
+    const img = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+      headers: { accept: "image/avif,image/webp,*/*" },
+    });
+    expect(img.status).toBe(200);
+    // AVIF negotiated from Accept; transformed bytes (not the original PNG).
+    expect(img.headers.get("content-type")).toBe("image/avif");
+    expect(img.headers.get("vary")).toBe("Accept");
+    expect(new Uint8Array(await img.arrayBuffer())).toEqual(TRANSFORMED);
+    // `hero` variant ⇒ 1600px render width.
+    expect(images.widths).toEqual([1600]);
+  });
+
+  it("negotiates WebP when AVIF is not advertised", async () => {
+    const images = createImagesStub();
+    const app = buildApp({ images }).app;
+    await uploadHero(app);
+
+    const img = await appRequest(app, `/api/invite/${SLUG}/image/hero`, {
+      headers: { accept: "image/webp,*/*" },
+    });
+    expect(img.status).toBe(200);
+    expect(img.headers.get("content-type")).toBe("image/webp");
+    // No ?variant ⇒ default `card` (800px).
+    expect(images.widths).toEqual([800]);
+  });
+
+  it("falls back to the original (never 500s) when a transform fails", async () => {
+    const images = createImagesStub({ fail: true });
+    const app = buildApp({ images }).app;
+    await uploadHero(app);
+
+    const img = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=card`, {
+      headers: { accept: "image/avif,*/*" },
+    });
+    expect(img.status).toBe(200);
+    // Transform threw ⇒ raw R2 original, with its stored content-type.
+    expect(img.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await img.arrayBuffer())).toEqual(PNG);
   });
 });
 

--- a/cire/api/src/routes/invite.test.ts
+++ b/cire/api/src/routes/invite.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 
-import { BOOTSTRAP_WEDDING_ID } from "@cire/db";
+import { BOOTSTRAP_WEDDING_ID, weddingInviteCustomisations } from "@cire/db";
 import { createRateLimiter } from "@shared/rate-limit";
 import type { RateLimiterBackend } from "@shared/rate-limit";
+import { eq } from "drizzle-orm";
 
 import { createApp } from "../app";
 import { createDb, seedDb } from "../db/setup";
@@ -409,6 +410,85 @@ describe("invite image transforms — Cache API short-circuit", () => {
       });
       expect(webp2.headers.get("content-type")).toBe("image/webp");
       expect(images.widths.length).toBe(2);
+    });
+  });
+
+  it("a re-upload (bumped updatedAt) creates a second cache entry and re-runs the binding (T-S1)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const built = buildApp({ images });
+      const app = built.app;
+      await uploadHero(app);
+
+      const accept = { accept: "image/avif,image/webp,*/*" };
+
+      // First request → miss → binding runs once, one cache entry written under
+      // the current server `updatedAt`.
+      const first = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(first.status).toBe(200);
+      expect(images.widths).toEqual([1600]); // binding ran once
+      expect(cache.store.size).toBe(1);
+
+      // Simulate a re-upload by advancing the wedding's stored `updatedAt`. After
+      // the S-M1 fix the cache version is derived from this DB value (NOT the
+      // client ?v=), so a bump must mint a fresh key — the new image can't be
+      // served the stale cached transform.
+      built.db
+        .update(weddingInviteCustomisations)
+        .set({ updatedAt: new Date(Date.now() + 60_000) })
+        .where(eq(weddingInviteCustomisations.weddingId, BOOTSTRAP_WEDDING_ID))
+        .run();
+
+      // Same request URL (same ?variant, same Accept) → because the server
+      // version changed, this is a MISS against a new key → binding re-runs and a
+      // SECOND cache entry is created.
+      const second = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(second.status).toBe(200);
+      expect(second.headers.get("content-type")).toBe("image/avif");
+      expect(new Uint8Array(await second.arrayBuffer())).toEqual(TRANSFORMED);
+      expect(images.widths).toEqual([1600, 1600]); // binding ran a second time
+      expect(cache.store.size).toBe(2); // new version ⇒ distinct cache entry
+    });
+  });
+
+  it("ignores the client ?v= for cache keying — looping ?v= does NOT re-bill transforms (S-M1)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const app = buildApp({ images }).app;
+      await uploadHero(app);
+
+      const accept = { accept: "image/avif,image/webp,*/*" };
+
+      // First request primes the cache (server-derived version).
+      const first = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero&v=1`, {
+        headers: accept,
+      });
+      expect(first.status).toBe(200);
+      expect(images.widths).toEqual([1600]);
+      expect(cache.store.size).toBe(1);
+
+      // An attacker loops distinct ?v= values on the same valid slug. The cache
+      // is already primed (above), so each MUST hit the SAME server-derived entry
+      // — the binding never re-runs and no new entries are minted, so the
+      // per-(slug,slot,variant,format) live transform count stays at exactly 1.
+      const responses = await Promise.all(
+        [2, 3, 4, 5].map((v) =>
+          appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero&v=${v}`, {
+            headers: accept,
+          }),
+        ),
+      );
+      const bodies = await Promise.all(responses.map((r) => r.arrayBuffer()));
+      for (const res of responses) expect(res.status).toBe(200);
+      for (const body of bodies) expect(new Uint8Array(body)).toEqual(TRANSFORMED);
+      expect(images.widths).toEqual([1600]); // still exactly one transform
+      expect(cache.store.size).toBe(1); // no extra cache entries
     });
   });
 

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 
 import { DbService } from "../db";
 import type { Db } from "../db";
+import { getWaitUntil } from "../lib/execution-ctx";
 import { metricImageTransform } from "../metrics";
 import { osnAuth } from "../middleware/osn-auth";
 import type { OsnAuthOptions } from "../middleware/osn-auth";
@@ -20,6 +21,7 @@ import {
 } from "../services/invite-assets";
 import type { AssetsBucket, StoredAsset } from "../services/invite-assets";
 import {
+  buildTransformCacheKey,
   negotiateFormat,
   resolveVariant,
   transformAsset,
@@ -80,10 +82,32 @@ export const createInvitePublicRoutes = (
       // cardinality per slot is capped (3 variants × 3 formats) — keeps the edge
       // cache hot and denies an attacker unbounded distinct transform URLs.
       // (`?v=` is the separate, pre-existing content-version cache-buster.)
-      const variant = resolveVariant((query as Record<string, string | undefined>).variant);
+      const q = query as Record<string, string | undefined>;
+      const variant = resolveVariant(q.variant);
       const format = negotiateFormat(request.headers.get("accept"));
       return runCire(
         Effect.gen(function* () {
+          // Cache API short-circuit. The Images binding bills per call with no
+          // per-unique dedupe, so a fresh guest/device would otherwise re-bill
+          // the same transform on every request. We key on slug+slot+variant+
+          // format (+ the ?v= content version) — the format is baked into the
+          // key because it's Accept-negotiated, not in the request URL — so each
+          // negotiated output is a distinct entry. A hit serves the transformed
+          // bytes WITHOUT touching the binding (or even the DB). `caches` is
+          // undefined in unit tests / non-Workers runtimes, so guard it.
+          const cache =
+            typeof caches !== "undefined" && caches.default ? caches.default : undefined;
+          const cacheKey = cache
+            ? buildTransformCacheKey({ slug: params.slug, slot, variant, format, version: q.v })
+            : undefined;
+          if (cache && cacheKey) {
+            const hit = yield* Effect.promise(() => cache.match(cacheKey));
+            if (hit) {
+              metricImageTransform("cache_hit", variant, format);
+              return hit;
+            }
+          }
+
           const key = yield* inviteService.imageKeyForSlug(params.slug, slot);
           if (!key) {
             set.status = 404;
@@ -117,7 +141,7 @@ export const createInvitePublicRoutes = (
             metricImageTransform("original", variant, format);
           }
 
-          return new Response(served.bytes, {
+          const response = new Response(served.bytes, {
             headers: {
               "Content-Type": served.contentType,
               // Bytes are magic-byte sniffed + allowlisted to JPEG/PNG/WebP on
@@ -128,10 +152,30 @@ export const createInvitePublicRoutes = (
               "Cache-Control": "public, max-age=31536000, immutable",
               // The chosen output format depends on the request Accept header, so
               // a shared cache must key on it — otherwise an AVIF response could
-              // be served to a JPEG-only client (or vice versa).
+              // be served to a JPEG-only client (or vice versa). The Cache API
+              // key bakes the format in too, but keep Vary for any intermediary
+              // (and browser) cache that keys on the raw URL.
               Vary: "Accept",
             },
           });
+
+          // Populate the edge cache on a miss so the next identical request skips
+          // the binding. Prefer `ctx.waitUntil` (Elysia doesn't forward it, so we
+          // bridge it per-request via setExecutionCtx in the Worker fetch); fall
+          // back to awaiting the write inline when no execution context is bound
+          // (non-Workers runtimes). Cache the clone so the live `response` body
+          // stays readable.
+          if (cache && cacheKey) {
+            const put = cache.put(cacheKey, response.clone());
+            const waitUntil = getWaitUntil(request);
+            if (waitUntil) {
+              waitUntil(put);
+            } else {
+              yield* Effect.promise(() => put);
+            }
+          }
+
+          return response;
         }).pipe(
           Effect.provideService(DbService, db),
           Effect.provideService(AssetsR2Service, assets as AssetsBucket),

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -81,24 +81,46 @@ export const createInvitePublicRoutes = (
       // format. Both collapse to a fixed value, so the transform-URL/format
       // cardinality per slot is capped (3 variants × 3 formats) — keeps the edge
       // cache hot and denies an attacker unbounded distinct transform URLs.
-      // (`?v=` is the separate, pre-existing content-version cache-buster.)
-      const q = query as Record<string, string | undefined>;
-      const variant = resolveVariant(q.variant);
+      // (The client's `?v=` is intentionally NOT read here — the cache version is
+      // derived server-side from the wedding row's `updatedAt` below, S-M1.)
+      const variant = resolveVariant((query as Record<string, string | undefined>).variant);
       const format = negotiateFormat(request.headers.get("accept"));
       return runCire(
         Effect.gen(function* () {
+          // Resolve the slug → image key + authoritative content version FIRST.
+          // This is a cheap, indexed D1 read and it's required before we can key
+          // the cache: the cache-key version is derived SERVER-SIDE from the
+          // row's `updatedAt` (NOT the client `?v=`). Slugs are public, so if we
+          // keyed on the raw `?v=` an attacker could loop ?v=1,2,3… on a valid
+          // slug to force unbounded cache-missing, per-call-billed transforms,
+          // defeating the bounded-cardinality cost guarantee (S-M1). The client
+          // may still SEND `?v=` (the frontend uses it for browser-cache busting
+          // and it equals `updatedAt` anyway) but it MUST NOT influence this key.
+          // By design this DB read now runs on EVERY request — it's cheap and is
+          // the source of the authoritative version; the expensive work (R2 read
+          // + Images binding call) is still skipped on a cache hit below.
+          const { key, updatedAt } = yield* inviteService.imageKeyForSlug(params.slug, slot);
+          if (!key) {
+            set.status = 404;
+            return { error: "Not found" };
+          }
+          // Server-derived version: the row's `updatedAt` epoch ms. A re-upload
+          // bumps `updatedAt`, which mints a new cache key (fresh entry) so the
+          // new image is never served stale from the old entry.
+          const version = updatedAt ? String(updatedAt.getTime()) : undefined;
+
           // Cache API short-circuit. The Images binding bills per call with no
           // per-unique dedupe, so a fresh guest/device would otherwise re-bill
           // the same transform on every request. We key on slug+slot+variant+
-          // format (+ the ?v= content version) — the format is baked into the
+          // format (+ the server content version) — the format is baked into the
           // key because it's Accept-negotiated, not in the request URL — so each
           // negotiated output is a distinct entry. A hit serves the transformed
-          // bytes WITHOUT touching the binding (or even the DB). `caches` is
-          // undefined in unit tests / non-Workers runtimes, so guard it.
+          // bytes WITHOUT touching the binding (R2 read + transform skipped).
+          // `caches` is undefined in unit tests / non-Workers runtimes, so guard.
           const cache =
             typeof caches !== "undefined" && caches.default ? caches.default : undefined;
           const cacheKey = cache
-            ? buildTransformCacheKey({ slug: params.slug, slot, variant, format, version: q.v })
+            ? buildTransformCacheKey({ slug: params.slug, slot, variant, format, version })
             : undefined;
           if (cache && cacheKey) {
             const hit = yield* Effect.promise(() => cache.match(cacheKey));
@@ -108,11 +130,6 @@ export const createInvitePublicRoutes = (
             }
           }
 
-          const key = yield* inviteService.imageKeyForSlug(params.slug, slot);
-          if (!key) {
-            set.status = 404;
-            return { error: "Not found" };
-          }
           const original = yield* fetchAsset(key);
 
           // Transform through the Images binding when present; on any failure

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 
 import { DbService } from "../db";
 import type { Db } from "../db";
+import { metricImageTransform } from "../metrics";
 import { osnAuth } from "../middleware/osn-auth";
 import type { OsnAuthOptions } from "../middleware/osn-auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
@@ -17,7 +18,13 @@ import {
   fetchAsset,
   MAX_IMAGE_BYTES,
 } from "../services/invite-assets";
-import type { AssetsBucket } from "../services/invite-assets";
+import type { AssetsBucket, StoredAsset } from "../services/invite-assets";
+import {
+  negotiateFormat,
+  resolveVariant,
+  transformAsset,
+} from "../services/invite-image-transform";
+import type { ImagesBindingLike } from "../services/invite-image-transform";
 
 // Sentinel parse hook: stop Elysia consuming the body so handlers parse it by
 // hand (JSON for text, raw bytes for images) — matches the import route.
@@ -29,9 +36,19 @@ const manualParse = { parse: () => ({}) };
  * — same split as /api/rsvp and the account-link reads.
  *
  *   GET /api/invite/:slug              → text + image URLs for the guest site
- *   GET /api/invite/:slug/image/:slot  → image bytes (served from R2)
+ *   GET /api/invite/:slug/image/:slot  → optimised image bytes (R2 + Images)
+ *
+ * `images` is the Cloudflare Images binding. When present the serve route
+ * transforms the R2 original into the requested responsive variant + a
+ * negotiated modern format; when absent (local/dev/tests, or an account without
+ * the Images product) — or when a transform fails — it serves the raw R2 bytes
+ * (the original behaviour), so the route never 500s on a transform miss.
  */
-export const createInvitePublicRoutes = (db: Db, assets: AssetsBucket | undefined) =>
+export const createInvitePublicRoutes = (
+  db: Db,
+  assets: AssetsBucket | undefined,
+  images?: ImagesBindingLike,
+) =>
   new Elysia({ prefix: "/api/invite" })
     .get("/:slug", ({ params, set }) =>
       runCire(
@@ -52,12 +69,19 @@ export const createInvitePublicRoutes = (db: Db, assets: AssetsBucket | undefine
         ),
       ),
     )
-    .get("/:slug/image/:slot", ({ params, set }) => {
+    .get("/:slug/image/:slot", ({ params, query, request, set }) => {
       if (!isInviteImageSlot(params.slot)) {
         set.status = 404;
         return { error: "Not found" };
       }
       const slot = params.slot;
+      // Bounded, allowlisted variant (?variant=) + Accept-negotiated output
+      // format. Both collapse to a fixed value, so the transform-URL/format
+      // cardinality per slot is capped (3 variants × 3 formats) — keeps the edge
+      // cache hot and denies an attacker unbounded distinct transform URLs.
+      // (`?v=` is the separate, pre-existing content-version cache-buster.)
+      const variant = resolveVariant((query as Record<string, string | undefined>).variant);
+      const format = negotiateFormat(request.headers.get("accept"));
       return runCire(
         Effect.gen(function* () {
           const key = yield* inviteService.imageKeyForSlug(params.slug, slot);
@@ -65,16 +89,47 @@ export const createInvitePublicRoutes = (db: Db, assets: AssetsBucket | undefine
             set.status = 404;
             return { error: "Not found" };
           }
-          const asset = yield* fetchAsset(key);
-          return new Response(asset.bytes, {
+          const original = yield* fetchAsset(key);
+
+          // Transform through the Images binding when present; on any failure
+          // (or when the binding is absent) fall back to the raw R2 original —
+          // never 500 on a transform miss. The metric records which path ran.
+          let served: StoredAsset = original;
+          if (images) {
+            served = yield* transformAsset(images, original, variant, format).pipe(
+              Effect.tap(() =>
+                Effect.sync(() => metricImageTransform("transformed", variant, format)),
+              ),
+              Effect.catchTag("ImageTransformError", (err) =>
+                Effect.gen(function* () {
+                  yield* Effect.logWarning("invite image transform failed; serving original", {
+                    slot,
+                    variant,
+                    format,
+                    reason: err.reason,
+                  });
+                  metricImageTransform("original", variant, format);
+                  return original;
+                }),
+              ),
+            );
+          } else {
+            metricImageTransform("original", variant, format);
+          }
+
+          return new Response(served.bytes, {
             headers: {
-              "Content-Type": asset.contentType,
+              "Content-Type": served.contentType,
               // Bytes are magic-byte sniffed + allowlisted to JPEG/PNG/WebP on
               // upload, but pin the declared type so a browser can't be coaxed
               // into interpreting the response as anything else (IB-S-M1).
               "X-Content-Type-Options": "nosniff",
               // URL is cache-busted by ?v=<updatedAt>, so a hit is safe to pin.
               "Cache-Control": "public, max-age=31536000, immutable",
+              // The chosen output format depends on the request Accept header, so
+              // a shared cache must key on it — otherwise an AVIF response could
+              // be served to a JPEG-only client (or vice versa).
+              Vary: "Accept",
             },
           });
         }).pipe(

--- a/cire/api/src/services/invite-image-transform.test.ts
+++ b/cire/api/src/services/invite-image-transform.test.ts
@@ -87,6 +87,18 @@ describe("buildTransformCacheKey", () => {
     expect(new Set([avif, webp, jpeg]).size).toBe(3);
   });
 
+  it("differs by version so a re-upload (bumped updatedAt) mints a fresh entry (T-S1)", () => {
+    // After the S-M1 fix the version is the server-side row `updatedAt` epoch ms,
+    // not the client `?v=`. Two different versions must yield different keys so a
+    // re-uploaded image isn't served the stale cached transform.
+    const base = { slug: "s", slot: "hero", variant: "card", format: "image/jpeg" } as const;
+    const v1 = buildTransformCacheKey({ ...base, version: "1718000000000" });
+    const v2 = buildTransformCacheKey({ ...base, version: "1718999999999" });
+    expect(v1.url).not.toBe(v2.url);
+    expect(new URL(v1.url).searchParams.get("v")).toBe("1718000000000");
+    expect(new URL(v2.url).searchParams.get("v")).toBe("1718999999999");
+  });
+
   it("differs by variant and includes the ?v= content version when present", () => {
     const card = buildTransformCacheKey({
       slug: "s",

--- a/cire/api/src/services/invite-image-transform.test.ts
+++ b/cire/api/src/services/invite-image-transform.test.ts
@@ -4,6 +4,7 @@ import { Effect, Exit } from "effect";
 
 import type { StoredAsset } from "./invite-assets";
 import {
+  buildTransformCacheKey,
   DEFAULT_VARIANT,
   IMAGE_VARIANTS,
   negotiateFormat,
@@ -41,6 +42,74 @@ describe("negotiateFormat", () => {
     expect(negotiateFormat(null)).toBe("image/jpeg");
     expect(negotiateFormat(undefined)).toBe("image/jpeg");
     expect(negotiateFormat("")).toBe("image/jpeg");
+  });
+});
+
+describe("buildTransformCacheKey", () => {
+  const keyUrl = (args: Parameters<typeof buildTransformCacheKey>[0]) =>
+    new URL(buildTransformCacheKey(args).url);
+
+  it("bakes slug, slot, variant and format into a stable GET key", () => {
+    const req = buildTransformCacheKey({
+      slug: "cire-wedding",
+      slot: "hero",
+      variant: "hero",
+      format: "image/avif",
+    });
+    expect(req.method).toBe("GET");
+    const url = new URL(req.url);
+    expect(url.pathname).toBe("/cire-wedding/hero");
+    expect(url.searchParams.get("variant")).toBe("hero");
+    expect(url.searchParams.get("format")).toBe("avif");
+  });
+
+  it("is identical for identical inputs (cache hits land)", () => {
+    const a = buildTransformCacheKey({
+      slug: "s",
+      slot: "hero",
+      variant: "card",
+      format: "image/webp",
+    });
+    const b = buildTransformCacheKey({
+      slug: "s",
+      slot: "hero",
+      variant: "card",
+      format: "image/webp",
+    });
+    expect(a.url).toBe(b.url);
+  });
+
+  it("differs by format so AVIF/WebP/JPEG are cached apart", () => {
+    const base = { slug: "s", slot: "hero", variant: "card" } as const;
+    const avif = keyUrl({ ...base, format: "image/avif" }).searchParams.get("format");
+    const webp = keyUrl({ ...base, format: "image/webp" }).searchParams.get("format");
+    const jpeg = keyUrl({ ...base, format: "image/jpeg" }).searchParams.get("format");
+    expect(new Set([avif, webp, jpeg]).size).toBe(3);
+  });
+
+  it("differs by variant and includes the ?v= content version when present", () => {
+    const card = buildTransformCacheKey({
+      slug: "s",
+      slot: "hero",
+      variant: "card",
+      format: "image/jpeg",
+    });
+    const hero = buildTransformCacheKey({
+      slug: "s",
+      slot: "hero",
+      variant: "hero",
+      format: "image/jpeg",
+    });
+    expect(card.url).not.toBe(hero.url);
+
+    const versioned = keyUrl({
+      slug: "s",
+      slot: "hero",
+      variant: "card",
+      format: "image/jpeg",
+      version: "1718000000",
+    });
+    expect(versioned.searchParams.get("v")).toBe("1718000000");
   });
 });
 

--- a/cire/api/src/services/invite-image-transform.test.ts
+++ b/cire/api/src/services/invite-image-transform.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "bun:test";
+
+import { Effect, Exit } from "effect";
+
+import type { StoredAsset } from "./invite-assets";
+import {
+  DEFAULT_VARIANT,
+  IMAGE_VARIANTS,
+  negotiateFormat,
+  resolveVariant,
+  transformAsset,
+  type ImagesBindingLike,
+  type ImageTransformHandle,
+  type OutputFormat,
+} from "./invite-image-transform";
+
+describe("resolveVariant", () => {
+  it("returns a known variant verbatim", () => {
+    expect(resolveVariant("thumb")).toBe("thumb");
+    expect(resolveVariant("card")).toBe("card");
+    expect(resolveVariant("hero")).toBe("hero");
+  });
+
+  it("collapses missing/unknown values to the default (bounds cardinality)", () => {
+    expect(resolveVariant(null)).toBe(DEFAULT_VARIANT);
+    expect(resolveVariant(undefined)).toBe(DEFAULT_VARIANT);
+    expect(resolveVariant("")).toBe(DEFAULT_VARIANT);
+    expect(resolveVariant("999")).toBe(DEFAULT_VARIANT);
+    expect(resolveVariant("../../etc/passwd")).toBe(DEFAULT_VARIANT);
+  });
+});
+
+describe("negotiateFormat", () => {
+  it("prefers AVIF, then WebP, then JPEG by Accept", () => {
+    expect(negotiateFormat("image/avif,image/webp,*/*")).toBe("image/avif");
+    expect(negotiateFormat("image/webp,*/*")).toBe("image/webp");
+    expect(negotiateFormat("image/png,*/*")).toBe("image/jpeg");
+  });
+
+  it("falls back to JPEG when Accept is missing", () => {
+    expect(negotiateFormat(null)).toBe("image/jpeg");
+    expect(negotiateFormat(undefined)).toBe("image/jpeg");
+    expect(negotiateFormat("")).toBe("image/jpeg");
+  });
+});
+
+const ORIGINAL: StoredAsset = {
+  bytes: new Uint8Array([1, 2, 3, 4]).buffer,
+  contentType: "image/png",
+};
+
+/** Stub binding that records the transform args and returns canned bytes. */
+function createImagesStub(opts?: { throwOn?: "input" | "output" }): ImagesBindingLike & {
+  calls: { width?: number; format?: OutputFormat }[];
+} {
+  const calls: { width?: number; format?: OutputFormat }[] = [];
+  return {
+    calls,
+    input(_stream) {
+      if (opts?.throwOn === "input") throw new Error("input boom");
+      const handle: ImageTransformHandle = {
+        transform(t) {
+          calls.push({ width: t.width });
+          return handle;
+        },
+        output(o) {
+          if (opts?.throwOn === "output") return Promise.reject(new Error("output boom"));
+          if (calls.length > 0) calls[calls.length - 1]!.format = o.format;
+          return Promise.resolve({
+            response: () =>
+              new Response(new Uint8Array([9, 9, 9]), { headers: { "Content-Type": o.format } }),
+            contentType: () => o.format,
+          });
+        },
+      };
+      return handle;
+    },
+  };
+}
+
+describe("transformAsset", () => {
+  it("runs the original through the binding at the variant width + format", async () => {
+    const images = createImagesStub();
+    const out = await Effect.runPromise(transformAsset(images, ORIGINAL, "hero", "image/avif"));
+    expect(images.calls).toEqual([{ width: IMAGE_VARIANTS.hero, format: "image/avif" }]);
+    expect(out.contentType).toBe("image/avif");
+    expect(new Uint8Array(out.bytes)).toEqual(new Uint8Array([9, 9, 9]));
+  });
+
+  it("fails with ImageTransformError when the binding throws at input", async () => {
+    const images = createImagesStub({ throwOn: "input" });
+    const exit = await Effect.runPromiseExit(
+      transformAsset(images, ORIGINAL, "card", "image/webp"),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("fails with ImageTransformError when output rejects", async () => {
+    const images = createImagesStub({ throwOn: "output" });
+    const exit = await Effect.runPromiseExit(
+      transformAsset(images, ORIGINAL, "card", "image/webp"),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/cire/api/src/services/invite-image-transform.ts
+++ b/cire/api/src/services/invite-image-transform.ts
@@ -81,8 +81,10 @@ export function negotiateFormat(accept: string | null | undefined): OutputFormat
  *    is NOT in the request URL (it comes from the `Accept` header), so baking it
  *    into the key is what keeps AVIF/WebP/JPEG as separate entries — otherwise a
  *    WebP-only client could be served an AVIF cached for an AVIF-capable one.
- *  - `v` — the existing `?v=<updatedAt>` content-version cache-buster, passed
- *    through so a re-upload invalidates the cached transform.
+ *  - `v` — the content version, derived SERVER-SIDE from the wedding row's
+ *    `updatedAt` (NOT the client `?v=`, which is ignored for keying — S-M1), so a
+ *    re-upload bumps `updatedAt` → a new key → the new image isn't served stale,
+ *    while an attacker can't loop arbitrary `?v=` values to mint fresh transforms.
  *
  * The format slug strips the `image/` prefix to keep the key tidy. We use a
  * synthetic host so the key never collides with a real inbound request URL and

--- a/cire/api/src/services/invite-image-transform.ts
+++ b/cire/api/src/services/invite-image-transform.ts
@@ -1,0 +1,135 @@
+import { Data, Effect } from "effect";
+
+import type { StoredAsset } from "./invite-assets";
+
+/**
+ * On-the-fly responsive/optimised image transforms for invite assets, run
+ * through the Cloudflare Workers Images binding (`env.IMAGES`) against the R2
+ * original. The binding is undefined locally (`wrangler dev` / miniflare) and in
+ * unit tests, and a transform can fail at the edge — both paths fall back to
+ * serving the original bytes (today's behaviour), so this module never 500s on a
+ * transform miss. The actual fallback wiring lives in the serve route; here we
+ * keep the pure, testable pieces (variant resolution, format negotiation) plus
+ * the thin Effect wrapper around the binding.
+ */
+
+// ── Variant scheme ────────────────────────────────────────────────────────────
+
+/**
+ * Bounded, allowlisted set of named variants → fixed render widths. Named (not
+ * an arbitrary `?w=`) on purpose: cardinality is exactly three per slot, which
+ * keeps the edge cache hot and denies an attacker the ability to mint unbounded
+ * distinct transform URLs (a cache-poisoning / cost amplifier). `card` is the
+ * default when no/unknown variant is requested — the common in-page size. This
+ * union is the single source of truth: it bounds the `?v=` query param, the
+ * `srcset` widths the frontend emits, and the bounded metric/span attribute.
+ */
+export const IMAGE_VARIANTS = {
+  thumb: 320,
+  card: 800,
+  hero: 1600,
+} as const;
+
+export type ImageVariant = keyof typeof IMAGE_VARIANTS;
+
+export const DEFAULT_VARIANT: ImageVariant = "card";
+
+/** Ordered widest→narrowest, for emitting a `srcset` on the frontend. */
+export const VARIANT_NAMES = ["thumb", "card", "hero"] as const;
+
+/**
+ * Resolve a requested `?v=` value to a known variant. Anything missing or
+ * outside the allowlist collapses to {@link DEFAULT_VARIANT} rather than 400 —
+ * an unknown variant is a benign "serve the default size", not a client error,
+ * and refusing to mint URLs outside the set is what bounds cardinality.
+ */
+export function resolveVariant(raw: string | null | undefined): ImageVariant {
+  if (raw && raw in IMAGE_VARIANTS) return raw as ImageVariant;
+  return DEFAULT_VARIANT;
+}
+
+// ── Output-format negotiation ─────────────────────────────────────────────────
+
+/** Modern formats we are willing to emit, best→worst, gated on `Accept`. */
+export type OutputFormat = "image/avif" | "image/webp" | "image/jpeg";
+
+/**
+ * Pick the best output format the client advertises in its `Accept` header,
+ * preferring AVIF, then WebP, falling back to JPEG (universally supported). We
+ * negotiate ourselves rather than relying on a magic `format: "auto"` so the
+ * chosen format is an explicit, bounded value we can put on the metric + span.
+ */
+export function negotiateFormat(accept: string | null | undefined): OutputFormat {
+  const header = accept ?? "";
+  if (header.includes("image/avif")) return "image/avif";
+  if (header.includes("image/webp")) return "image/webp";
+  return "image/jpeg";
+}
+
+// ── Binding wrapper ───────────────────────────────────────────────────────────
+
+/**
+ * Minimal structural shape of the Workers Images binding we depend on — narrow
+ * by design (mirrors the `AssetsBucket` Tag style) so a test stub implements
+ * just `input().transform().output()`. The real `ImagesBinding` from
+ * `@cloudflare/workers-types` satisfies this structurally.
+ */
+export interface ImageTransformer {
+  width?: number;
+}
+
+export interface ImageOutput {
+  /** The transformed image as a Response (carries the right content-type). */
+  response(): Response;
+  contentType(): string;
+}
+
+export interface ImageTransformHandle {
+  transform(t: { width?: number }): ImageTransformHandle;
+  output(o: { format: OutputFormat; quality?: number }): Promise<ImageOutput>;
+}
+
+export interface ImagesBindingLike {
+  input(stream: ReadableStream<Uint8Array>): ImageTransformHandle;
+}
+
+export class ImageTransformError extends Data.TaggedError("ImageTransformError")<{
+  readonly reason: string;
+  readonly variant: ImageVariant;
+  readonly format: OutputFormat;
+  readonly cause?: unknown;
+}> {}
+
+/** JPEG quality for the lossy outputs — a sane visual/size tradeoff for photos. */
+const OUTPUT_QUALITY = 82;
+
+/**
+ * Run the original bytes through the Images binding for the given variant +
+ * negotiated format, returning the transformed bytes + their content-type.
+ * Fails with {@link ImageTransformError} when the binding throws — the caller
+ * catches and falls back to the original. A successful transform's content-type
+ * comes from the binding (it knows what it actually produced).
+ */
+export function transformAsset(
+  images: ImagesBindingLike,
+  original: StoredAsset,
+  variant: ImageVariant,
+  format: OutputFormat,
+): Effect.Effect<StoredAsset, ImageTransformError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const stream = new Response(original.bytes).body;
+      if (!stream) {
+        throw new Error("original asset had no readable body");
+      }
+      const out = await images
+        .input(stream)
+        .transform({ width: IMAGE_VARIANTS[variant] })
+        .output({ format, quality: OUTPUT_QUALITY });
+      const bytes = await out.response().arrayBuffer();
+      return { bytes, contentType: out.contentType() };
+    },
+    catch: (cause) =>
+      new ImageTransformError({ reason: "transform failed", variant, format, cause }),
+  }).pipe(Effect.withSpan("cire.invite_assets.transform", { attributes: { variant, format } }));
+}

--- a/cire/api/src/services/invite-image-transform.ts
+++ b/cire/api/src/services/invite-image-transform.ts
@@ -66,6 +66,47 @@ export function negotiateFormat(accept: string | null | undefined): OutputFormat
   return "image/jpeg";
 }
 
+// ── Cache key ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build the canonical Cache API key URL for a transformed serve. The Workers
+ * Images binding bills per call with no per-unique dedupe, so we short-circuit
+ * with `caches.default` and only invoke the binding on a miss. A Cache API key is
+ * a `Request`, matched by its URL — so every field that changes the transformed
+ * bytes MUST be in the URL:
+ *
+ *  - `slug` + `slot` — which asset.
+ *  - `variant` — the resolved render width (bounded to the 3-variant allowlist).
+ *  - `format` — the Accept-negotiated output format. Critical: the chosen format
+ *    is NOT in the request URL (it comes from the `Accept` header), so baking it
+ *    into the key is what keeps AVIF/WebP/JPEG as separate entries — otherwise a
+ *    WebP-only client could be served an AVIF cached for an AVIF-capable one.
+ *  - `v` — the existing `?v=<updatedAt>` content-version cache-buster, passed
+ *    through so a re-upload invalidates the cached transform.
+ *
+ * The format slug strips the `image/` prefix to keep the key tidy. We use a
+ * synthetic host so the key never collides with a real inbound request URL and
+ * is independent of the request's own host/scheme.
+ */
+export function buildTransformCacheKey(args: {
+  slug: string;
+  slot: string;
+  variant: ImageVariant;
+  format: OutputFormat;
+  version?: string | null;
+}): Request {
+  const formatSlug = args.format.replace("image/", "");
+  const params = new URLSearchParams({
+    variant: args.variant,
+    format: formatSlug,
+  });
+  if (args.version) params.set("v", args.version);
+  const url = `https://cire-image-cache.internal/${encodeURIComponent(args.slug)}/${encodeURIComponent(
+    args.slot,
+  )}?${params.toString()}`;
+  return new Request(url, { method: "GET" });
+}
+
 // ── Binding wrapper ───────────────────────────────────────────────────────────
 
 /**

--- a/cire/api/src/services/invite.ts
+++ b/cire/api/src/services/invite.ts
@@ -154,11 +154,19 @@ export const inviteService = {
     }).pipe(Effect.withSpan("cire.invite.getForSlug"));
   },
 
-  /** Resolve the R2 key backing a slug's image slot (for serving). */
+  /**
+   * Resolve the R2 key backing a slug's image slot (for serving) PLUS the row's
+   * `updatedAt` — the authoritative content version. The serve route derives its
+   * edge-cache key from this server-side `updatedAt` (not the client `?v=`), so
+   * an attacker can't loop distinct `?v=` values to force unbounded, per-call-
+   * billed transforms (S-M1). `updatedAt` is null when the wedding exists but has
+   * no customisation row yet (LEFT JOIN miss) — the slot key is then null too, so
+   * the route 404s before it ever builds a cache key.
+   */
   imageKeyForSlug(
     slug: string,
     slot: InviteImageSlot,
-  ): Effect.Effect<string | null, WeddingNotFound, DbService> {
+  ): Effect.Effect<{ key: string | null; updatedAt: Date | null }, WeddingNotFound, DbService> {
     return Effect.gen(function* () {
       const db = yield* DbService;
       // Single LEFT JOIN keyed on the slug: a missing weddings row is a 404; a
@@ -170,6 +178,7 @@ export const inviteService = {
             weddingId: weddings.id,
             heroImageKey: weddingInviteCustomisations.heroImageKey,
             storyImageKey: weddingInviteCustomisations.storyImageKey,
+            updatedAt: weddingInviteCustomisations.updatedAt,
           })
           .from(weddings)
           .leftJoin(
@@ -180,7 +189,8 @@ export const inviteService = {
           .all(),
       );
       if (!row) return yield* Effect.fail(new WeddingNotFound({ slug }));
-      return slot === "hero" ? row.heroImageKey : row.storyImageKey;
+      const key = slot === "hero" ? row.heroImageKey : row.storyImageKey;
+      return { key, updatedAt: row.updatedAt };
     }).pipe(Effect.withSpan("cire.invite.imageKeyForSlug"));
   },
 

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -53,6 +53,16 @@ binding = "ASSETS"
 bucket_name = "cire-assets"
 preview_bucket_name = "cire-assets-preview"
 
+# Cloudflare Images binding — transforms the R2 invite-image originals into
+# responsive, modern-format (WebP/AVIF) variants on the public serve path
+# (GET /api/invite/:slug/image/:slot). The serve route falls back to the raw R2
+# bytes when this binding is absent (local `wrangler dev` / miniflare / tests) or
+# a transform fails, so it never 500s on a transform miss. The Images product
+# must be enabled on the Cloudflare account before deploy (transformations are
+# billed per unique transformation — see the human note in the PR).
+[images]
+binding = "IMAGES"
+
 [env.production.vars]
 # Comma-separated allowlist (index.ts splits on "," and trims). Entry 0 is the
 # guest site; the organiser portal origin MUST also be present or organiser
@@ -99,6 +109,13 @@ preview_bucket_name = "cire-sheets-preview"
 binding = "ASSETS"
 bucket_name = "cire-assets"
 preview_bucket_name = "cire-assets-preview"
+
+# Mirror of the top-level [images] binding — named environments do NOT inherit
+# top-level bindings (see the binding-inheritance note above), so the Images
+# binding must be redeclared here or `wrangler deploy --env production` ships
+# without it and every serve falls back to the un-transformed R2 original.
+[env.production.images]
+binding = "IMAGES"
 
 # ── OpenTelemetry export ─────────────────────────────────────────────────────
 # Read by `@shared/observability` `loadConfig` (workerd `nodejs_compat`

--- a/cire/web/src/components/InviteHeader.test.tsx
+++ b/cire/web/src/components/InviteHeader.test.tsx
@@ -1,0 +1,63 @@
+import { render, cleanup, waitFor } from "@solidjs/testing-library";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import InviteHeader, { buildSrcSet } from "./InviteHeader";
+import type { InviteCustomisation } from "./InviteHeader";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("buildSrcSet (T-M1)", () => {
+  it("appends &variant=…<width>w for each variant when the base URL already has a query", () => {
+    // Base ends with the ?v= content-version cache-buster, so the separator for
+    // the appended &variant= must be `&` (not a second `?`).
+    const srcset = buildSrcSet("/api/invite/s/image/hero?v=123", ["thumb", "card", "hero"]);
+    expect(srcset).toBe(
+      "/api/invite/s/image/hero?v=123&variant=thumb 320w, " +
+        "/api/invite/s/image/hero?v=123&variant=card 800w, " +
+        "/api/invite/s/image/hero?v=123&variant=hero 1600w",
+    );
+  });
+
+  it("uses ? as the first separator when the base URL has no query", () => {
+    const srcset = buildSrcSet("/img", ["thumb", "card"]);
+    expect(srcset).toBe("/img?variant=thumb 320w, /img?variant=card 800w");
+  });
+
+  it("emits the correct width descriptor for each named variant", () => {
+    expect(buildSrcSet("/x?v=1", ["hero"])).toBe("/x?v=1&variant=hero 1600w");
+  });
+});
+
+describe("InviteHeader render", () => {
+  it("renders the hero <img> with a responsive srcset + sizes from the initial data", async () => {
+    const initial: InviteCustomisation = {
+      hero: { title: null, subtitle: null, imageUrl: "/api/invite/s/image/hero?v=123" },
+      story: { eyebrow: null, heading: null, body: null, imageUrl: null },
+    };
+    // Keep the build-time data: a failed revalidation must not wipe the hero.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline"))),
+    );
+
+    const { container } = render(() => (
+      <InviteHeader apiUrl="https://api.test" slug="s" initial={initial} />
+    ));
+
+    await waitFor(() => {
+      const img = container.querySelector("section img");
+      expect(img).not.toBeNull();
+    });
+    const img = container.querySelector("section img") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe("https://api.test/api/invite/s/image/hero?v=123");
+    expect(img.getAttribute("sizes")).toBe("100vw");
+    expect(img.getAttribute("srcset")).toBe(
+      "https://api.test/api/invite/s/image/hero?v=123&variant=thumb 320w, " +
+        "https://api.test/api/invite/s/image/hero?v=123&variant=card 800w, " +
+        "https://api.test/api/invite/s/image/hero?v=123&variant=hero 1600w",
+    );
+  });
+});

--- a/cire/web/src/components/InviteHeader.tsx
+++ b/cire/web/src/components/InviteHeader.tsx
@@ -1,5 +1,26 @@
 import { createResource, createSignal, Show } from "solid-js";
 
+/**
+ * Responsive variant widths the API can transform an invite image to. Mirrors
+ * the bounded `IMAGE_VARIANTS` allowlist in `cire/api` — the API resolves an
+ * unknown/absent `?variant=` (and any environment without the Cloudflare Images
+ * binding) to the original bytes, so the plain `src` below always works as a
+ * progressive fallback even when `srcset` is ignored or transforms are off.
+ */
+const VARIANT_WIDTHS = { thumb: 320, card: 800, hero: 1600 } as const;
+type VariantName = keyof typeof VARIANT_WIDTHS;
+
+/**
+ * Build a `srcset` from a base image URL (which already carries the `?v=`
+ * content-version cache-buster) by appending the bounded `&variant=` for each
+ * width in `variants`. The browser picks the entry matching the rendered size +
+ * DPR; the API negotiates WebP/AVIF per request via Accept.
+ */
+function buildSrcSet(baseUrl: string, variants: readonly VariantName[]): string {
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  return variants.map((v) => `${baseUrl}${sep}variant=${v} ${VARIANT_WIDTHS[v]}w`).join(", ");
+}
+
 export interface InviteCustomisation {
   hero: { title: string | null; subtitle: string | null; imageUrl: string | null };
   story: {
@@ -73,6 +94,9 @@ export default function InviteHeader(props: InviteHeaderProps) {
           {(url) => (
             <img
               src={url()}
+              srcset={buildSrcSet(url(), ["thumb", "card", "hero"])}
+              // Hero spans the full viewport width at every breakpoint.
+              sizes="100vw"
               alt=""
               onLoad={() => setHeroLoaded(true)}
               class="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
@@ -119,6 +143,9 @@ export default function InviteHeader(props: InviteHeaderProps) {
             {(url) => (
               <img
                 src={url()}
+                // Story photo renders at most 480px wide — thumb/card cover it.
+                srcset={buildSrcSet(url(), ["thumb", "card"])}
+                sizes="(min-width: 480px) 480px, 100vw"
                 alt=""
                 class="border-border mx-auto mb-8 max-h-80 w-full max-w-[480px] rounded-sm border object-cover"
               />

--- a/cire/web/src/components/InviteHeader.tsx
+++ b/cire/web/src/components/InviteHeader.tsx
@@ -16,7 +16,7 @@ type VariantName = keyof typeof VARIANT_WIDTHS;
  * width in `variants`. The browser picks the entry matching the rendered size +
  * DPR; the API negotiates WebP/AVIF per request via Accept.
  */
-function buildSrcSet(baseUrl: string, variants: readonly VariantName[]): string {
+export function buildSrcSet(baseUrl: string, variants: readonly VariantName[]): string {
   const sep = baseUrl.includes("?") ? "&" : "?";
   return variants.map((v) => `${baseUrl}${sep}variant=${v} ${VARIANT_WIDTHS[v]}w`).join(", ");
 }

--- a/cire/web/src/pages/index.astro
+++ b/cire/web/src/pages/index.astro
@@ -18,8 +18,14 @@ try {
 } catch {
   initialInvite = null
 }
-const preloadHero = initialInvite?.hero.imageUrl
-  ? `${apiUrl}${initialInvite.hero.imageUrl}`
+// Preload the hero (the LCP element). It now renders responsively via srcset,
+// so preload the same candidate set + sizes — the browser preloads exactly the
+// variant it will pick, instead of the un-transformed original. Mirrors the
+// bounded variant allowlist in cire/api (thumb/card/hero → 320/800/1600w).
+const heroBase = initialInvite?.hero.imageUrl ? `${apiUrl}${initialInvite.hero.imageUrl}` : null
+const heroSep = heroBase?.includes('?') ? '&' : '?'
+const preloadHeroSrcset = heroBase
+  ? `${heroBase}${heroSep}variant=thumb 320w, ${heroBase}${heroSep}variant=card 800w, ${heroBase}${heroSep}variant=hero 1600w`
   : null
 ---
 <!DOCTYPE html>
@@ -41,7 +47,15 @@ const preloadHero = initialInvite?.hero.imageUrl
     <noscript>
       <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet" />
     </noscript>
-    {preloadHero && <link rel="preload" as="image" href={preloadHero} />}
+    {heroBase && (
+      <link
+        rel="preload"
+        as="image"
+        href={heroBase}
+        imagesrcset={preloadHeroSrcset}
+        imagesizes="100vw"
+      />
+    )}
   </head>
   <body>
     <InviteHeader client:load apiUrl={apiUrl} slug={weddingSlug} initial={initialInvite} />


### PR DESCRIPTION
## Summary
- **Cloudflare Images transformations via R2 for cire invite images.** Serve responsive, optimized variants of the `cire-assets` R2 originals through the Workers `env.IMAGES` binding, with a **Worker Cache API short-circuit** so the per-call-billed binding only fires on a cache miss. Frontend gets responsive `srcset`/`sizes`.

## Workspaces affected
- `@cire/api` (minor), `@cire/web` (minor)

## Decisions & issues

**[design]** Workers Images binding transforming R2 originals — cire is on `*.pages.dev`/`*.workers.dev` (no zone for `/cdn-cgi/image/` URL transforms), and the binding works without a custom domain. **Named variants** `thumb`/`card`/`hero` (320/800/1600), Accept-negotiated format (AVIF>WebP>JPEG). **Graceful fallback** to the raw R2 original when `env.IMAGES` is absent (local/tests/no-Images-product) or a transform fails — never 500s.

**[cost — the headline]** Transformations-via-R2 is **cheaper than the Images store**: Free plan includes **5,000 unique transformations/mo free**; reuses cire's existing R2 (no double storage, zero egress). The Images store has no free tier + per-delivery billing. The Cache API short-circuit + server-derived version keep usage to bounded unique transforms → **free at wedding scale**.

**[S-M1 fixed — cost/abuse]** The cache key originally trusted the client's unbounded `?v=` with no rate limit on the public route — an attacker could loop `?v=` on a public slug to mint unlimited billable transforms. **Fixed:** version is now derived **server-side** from the wedding row's `updatedAt` (the slug lookup moved before the cache check — a cheap indexed D1 read; the expensive R2 read + binding are still skipped on a hit); client `?v=` no longer influences the key. Regression-tested.

**[security ✓]** `:slot` is enum-gated (`hero`/`story`), `:slug` is DB-validated and only the *stored* R2 key is read (no path traversal / cross-wedding enumeration); the cache key bakes in the negotiated format (an AVIF can't be served to a WebP-only client); the `executionCtx` WeakMap bridge is keyed per-Request (no cross-request confusion). No Critical/High.

**[perf ✓]** Cache hit skips the R2 read + binding call; `ctx.waitUntil(cache.put)` doesn't block the response; `srcset` widths match the variants. **Deferred follow-ups:** P-W1 (the R2 original is buffered then re-wrapped as a stream — miss-path-only ~2× memory) and P-I1 (dedupe the `srcset` separator helper across `InviteHeader` + `index.astro`).

**[observability]** span `cire.invite_assets.transform`; bounded counter `cire.image.transform` (`result: cache_hit|transformed|original`, variant, format — no slug); warn-on-fallback. No `console.*`.

**[needs you at deploy]** Enable the **Cloudflare Images** product on the account (transformations billed; first 5k/mo free). Until then every request safely serves the un-transformed R2 original.

## Test plan
- `cire/api` **339 pass** · `cire/web` **167 pass** · oxlint clean · `wrangler deploy --dry-run` clean with `IMAGES` in both default + production envs.
- Covers: variant resolution + allowlist, format negotiation, fallback (no-binding + transform-throws), cache hit/miss, distinct entries per variant/format, **re-upload freshness**, the **`?v=` loop no-rebill regression**, and the `InviteHeader` srcset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
