### PR TITLE
feat(cire/web): holistic event details view — map preview, in-details calendar, full info

### DIFF
--- a/.changeset/cire-event-details-holistic-view.md
+++ b/.changeset/cire-event-details-holistic-view.md
@@ -20,3 +20,12 @@ rendering a dead link.
 
 The outer event card's button is relabelled "View Event" now that Add-to-
 Calendar lives inside the details view.
+
+The shared `AnimatedModal` (which hosts both this details view and the RSVP
+modal) is hardened for accessibility: focus is moved into the panel on open and
+restored to the trigger on close, Tab/Shift+Tab are trapped within the panel,
+Escape closes the dialog, the dialog now carries an accessible name via
+`aria-labelledby` (wired to each consumer's title), background scroll is locked
+with `overscroll-behavior: contain` on the panel, the open/close animation
+honours `prefers-reduced-motion` by snapping to the final visible state, and the
+close button gets a 44×44px hit area with a visible focus ring.

--- a/.changeset/cire-event-details-holistic-view.md
+++ b/.changeset/cire-event-details-holistic-view.md
@@ -1,0 +1,22 @@
+---
+"@cire/web": minor
+---
+
+Turn the per-event "More Details" modal into a holistic event view.
+
+The details modal is now a single, cohesive "everything about this event"
+sheet: a timezone-aware date + time range, a branded map preview of the venue
+with an "Open in Maps" action, the Add-to-Calendar control (moved here from the
+outer event card), the description, the dress code with its colour palette, and
+the Pinterest inspiration board. Each section collapses gracefully when its
+data is absent.
+
+The map preview is drawn entirely in CSS — a stylised cartographic card in the
+invite palette — so it needs no map API key, no stored coordinates, and never
+makes a network request. The "Open in Maps" link uses the organiser's `mapsUrl`
+when present and otherwise derives a Google Maps search URL from the venue
+address; if there is nothing to point at, the preview hides itself rather than
+rendering a dead link.
+
+The outer event card's button is relabelled "View Event" now that Add-to-
+Calendar lives inside the details view.

--- a/cire/web/src/components/AddToCalendar.test.tsx
+++ b/cire/web/src/components/AddToCalendar.test.tsx
@@ -148,4 +148,16 @@ describe("AddToCalendar", () => {
     unmount();
     expect(revokeObjectURL).toHaveBeenCalledWith(created);
   });
+
+  it("renders a filled primary trigger when variant is primary", () => {
+    const { getByRole } = render(() => (
+      <AddToCalendar event={baseEvent} siteUrl={SITE_URL} variant="primary" />
+    ));
+    const button = getByRole("button", { name: /add to calendar/i });
+    // The primary variant fills with the gold token; the outline variant is
+    // transparent. Asserting the class keeps the two visually distinct.
+    expect(button.className).toContain("bg-gold");
+    // Still behaves as a menu trigger regardless of variant.
+    expect(button.getAttribute("aria-haspopup")).toBe("menu");
+  });
 });

--- a/cire/web/src/components/AddToCalendar.tsx
+++ b/cire/web/src/components/AddToCalendar.tsx
@@ -7,7 +7,20 @@ import type { EventSummary } from "./types";
 interface AddToCalendarProps {
   event: EventSummary;
   siteUrl: string;
+  /**
+   * Visual weight of the trigger. `"outline"` (default) matches the secondary
+   * card buttons; `"primary"` is a filled-gold call-to-action for the details
+   * view, where Add-to-Calendar is the headline action.
+   */
+  variant?: "outline" | "primary";
 }
+
+const TRIGGER_CLASS: Record<NonNullable<AddToCalendarProps["variant"]>, string> = {
+  outline:
+    "border-border font-body text-text-muted hover:border-gold hover:text-gold rounded-sm border bg-transparent px-5 py-2.5 text-[0.82rem] tracking-[0.12em] uppercase transition-colors duration-200",
+  primary:
+    "border-gold bg-gold text-bg font-body hover:bg-transparent hover:text-gold inline-flex items-center gap-2 rounded-sm border px-5 py-2.5 text-[0.82rem] tracking-[0.12em] uppercase transition-colors duration-200",
+};
 
 interface PopoverPosition {
   top: number;
@@ -175,12 +188,28 @@ export function AddToCalendar(props: AddToCalendarProps) {
       <button
         ref={buttonRef}
         type="button"
-        class="border-border font-body text-text-muted hover:border-gold hover:text-gold rounded-sm border bg-transparent px-5 py-2.5 text-[0.82rem] tracking-[0.12em] uppercase transition-colors duration-200"
+        class={TRIGGER_CLASS[props.variant ?? "outline"]}
         aria-haspopup="menu"
         aria-expanded={open()}
         aria-controls={popoverId}
         onClick={toggle}
       >
+        <Show when={props.variant === "primary"}>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <path d="M16 2v4M8 2v4M3 10h18" />
+          </svg>
+        </Show>
         Add to Calendar
       </button>
       <Show when={open()}>

--- a/cire/web/src/components/AnimatedModal.test.tsx
+++ b/cire/web/src/components/AnimatedModal.test.tsx
@@ -1,0 +1,144 @@
+import { render, cleanup, fireEvent, waitFor } from "@solidjs/testing-library";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { AnimatedModal } from "./AnimatedModal";
+
+// The open/close animation is imported dynamically; stub it so the modal's
+// imperative reveal is a no-op under the test DOM.
+vi.mock("motion", () => ({
+  animate: vi.fn(() => ({ finished: Promise.resolve() })),
+}));
+
+describe("AnimatedModal", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    // Defensive: ensure the body scroll lock is never left applied between tests.
+    document.body.style.overflow = "";
+  });
+
+  it("names the dialog via labelledBy → the referenced title element", () => {
+    const { getByRole, getByText } = render(() => (
+      <AnimatedModal onClose={() => {}} labelledBy="modal-title">
+        <h2 id="modal-title">Mehndi</h2>
+      </AnimatedModal>
+    ));
+
+    const dialog = getByRole("dialog");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("modal-title");
+    // The accessible name resolves to the referenced title's text.
+    expect(getByText("Mehndi").id).toBe("modal-title");
+    // Querying the dialog by its accessible name succeeds.
+    expect(getByRole("dialog", { name: "Mehndi" })).toBe(dialog);
+  });
+
+  it("falls back to an aria-label when no labelledBy is supplied", () => {
+    const { getByRole } = render(() => (
+      <AnimatedModal onClose={() => {}} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    const dialog = getByRole("dialog");
+    expect(dialog.getAttribute("aria-label")).toBe("Event details");
+    expect(dialog.getAttribute("aria-labelledby")).toBeNull();
+  });
+
+  it("moves focus to the close button on open", async () => {
+    const { getByLabelText } = render(() => (
+      <AnimatedModal onClose={() => {}} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(getByLabelText("Close"));
+    });
+  });
+
+  it("closes on Escape", async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <AnimatedModal onClose={onClose} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("closes via the close button", async () => {
+    const onClose = vi.fn();
+    const { getByLabelText } = render(() => (
+      <AnimatedModal onClose={onClose} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    fireEvent.click(getByLabelText("Close"));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("locks body scroll while open and restores it on close", async () => {
+    const { unmount } = render(() => (
+      <AnimatedModal onClose={() => {}} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    await waitFor(() => expect(document.body.style.overflow).toBe("hidden"));
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores focus to the trigger element when it unmounts", async () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open";
+    document.body.append(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = render(() => (
+      <AnimatedModal onClose={() => {}} label="Event details">
+        <button type="button">Inside</button>
+      </AnimatedModal>
+    ));
+
+    // Focus moves into the modal on open…
+    await waitFor(() => expect(document.activeElement).not.toBe(trigger));
+
+    // …and returns to the trigger once the modal is gone.
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it("reveals the panel to its final visible state under prefers-reduced-motion", async () => {
+    const matchMediaSpy = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    }));
+    vi.stubGlobal("matchMedia", matchMediaSpy);
+
+    const { getByRole } = render(() => (
+      <AnimatedModal onClose={() => {}} label="Event details">
+        <p>body</p>
+      </AnimatedModal>
+    ));
+
+    const dialog = getByRole("dialog");
+    // Reduced motion short-circuits to the final visible state rather than
+    // leaving the panel at its initial opacity-0 — the content must be visible.
+    await waitFor(() => expect(dialog.style.opacity).toBe("1"));
+    expect(dialog.style.transform).toBe("none");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/cire/web/src/components/AnimatedModal.tsx
+++ b/cire/web/src/components/AnimatedModal.tsx
@@ -1,22 +1,125 @@
-import { onMount, type JSX } from "solid-js";
+import { onCleanup, onMount, type JSX } from "solid-js";
 
 interface AnimatedModalProps {
   onClose: () => void;
+  /**
+   * `id` of the element that names this dialog (its title). Wired to
+   * `aria-labelledby` so the dialog announces with its heading. Consumers
+   * should point this at their existing title element.
+   */
+  labelledBy?: string;
+  /** Fallback accessible name when there is no on-screen title to reference. */
+  label?: string;
   children: JSX.Element;
+}
+
+/** Selector for the tab-order-relevant focusable descendants of the panel. */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/** Snap the backdrop + panel straight to their final visible state, no animation. */
+function showInstantly(backdrop: HTMLElement, panel: HTMLElement) {
+  backdrop.style.opacity = "1";
+  panel.style.opacity = "1";
+  panel.style.transform = "none";
 }
 
 export function AnimatedModal(props: AnimatedModalProps) {
   let backdropRef: HTMLDivElement;
   let panelRef: HTMLDivElement;
+  let closeButtonRef: HTMLButtonElement | undefined;
+
+  // The element that had focus when the modal opened, so we can restore it on
+  // close (mirrors AddToCalendar's popover focus-return pattern).
+  let previouslyFocused: HTMLElement | null = null;
+
+  function focusableElements(): HTMLElement[] {
+    if (!panelRef) return [];
+    return Array.from(panelRef.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+
+  // Trap Tab / Shift+Tab inside the panel and close on Escape.
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      void handleClose();
+      return;
+    }
+    if (e.key !== "Tab") return;
+
+    const focusables = focusableElements();
+    if (focusables.length === 0) {
+      // Nothing focusable but the panel itself — keep focus on the panel.
+      e.preventDefault();
+      panelRef?.focus();
+      return;
+    }
+
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    const active = document.activeElement as HTMLElement | null;
+
+    if (e.shiftKey) {
+      if (active === first || !panelRef?.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !panelRef?.contains(active)) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 
   onMount(async () => {
+    previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Lock background scroll while the modal is open; restore on cleanup.
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    onCleanup(() => {
+      document.body.style.overflow = previousBodyOverflow;
+    });
+
+    document.addEventListener("keydown", onKeyDown);
+    onCleanup(() => document.removeEventListener("keydown", onKeyDown));
+
+    // Move focus into the panel: the close button if present, else the panel.
+    (closeButtonRef ?? panelRef)?.focus();
+
+    if (prefersReducedMotion()) {
+      // Reduced motion: skip the imperative animation but still land on the
+      // final *visible* state — the panel ships opacity-0, so merely not
+      // animating would leave the content invisible.
+      showInstantly(backdropRef, panelRef);
+      return;
+    }
+
     const { modalEnter } = await import("./Modal.motion");
     modalEnter(backdropRef, panelRef);
   });
 
+  // Restore focus to whatever triggered the modal once it has closed.
+  onCleanup(() => previouslyFocused?.focus());
+
   async function handleClose() {
-    const { modalExit } = await import("./Modal.motion");
-    await modalExit(backdropRef, panelRef);
+    if (!prefersReducedMotion()) {
+      const { modalExit } = await import("./Modal.motion");
+      await modalExit(backdropRef, panelRef);
+    }
     props.onClose();
   }
 
@@ -28,13 +131,17 @@ export function AnimatedModal(props: AnimatedModalProps) {
     >
       <div
         ref={panelRef}
-        class="border-border bg-surface relative max-h-[85vh] w-full max-w-[480px] overflow-y-auto rounded-t-xl border px-6 pt-8 pb-10 opacity-0 md:mb-8 md:rounded-lg"
+        class="border-border bg-surface relative max-h-[85vh] w-full max-w-[480px] overflow-y-auto overscroll-contain rounded-t-xl border px-6 pt-8 pb-10 opacity-0 md:mb-8 md:rounded-lg"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={props.labelledBy}
+        aria-label={props.labelledBy ? undefined : props.label}
+        tabindex="-1"
       >
         <button
-          class="text-text-muted hover:text-text absolute top-4 right-4 cursor-pointer border-none bg-transparent p-1 text-2xl leading-none transition-colors"
+          ref={closeButtonRef}
+          class="text-text-muted hover:text-text focus-visible:ring-gold/60 absolute top-2 right-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent text-2xl leading-none transition-colors focus-visible:ring-2 focus-visible:outline-none"
           onClick={() => handleClose()}
           aria-label="Close"
         >

--- a/cire/web/src/components/DetailsModal.test.tsx
+++ b/cire/web/src/components/DetailsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, cleanup } from "@solidjs/testing-library";
+import { render, cleanup, fireEvent, screen } from "@solidjs/testing-library";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { DetailsModal } from "./DetailsModal";
@@ -7,6 +7,8 @@ import type { EventSummary } from "./types";
 vi.mock("motion", () => ({
   animate: vi.fn(() => ({ finished: Promise.resolve() })),
 }));
+
+const SITE_URL = "https://invite.example.com/abc-123";
 
 const baseEvent: EventSummary = {
   id: "9f7a2c14-1b3d-4e5f-8a01-000000000001",
@@ -17,7 +19,7 @@ const baseEvent: EventSummary = {
   startAt: "2026-09-18T16:00:00+10:00",
   endAt: "2026-09-18T22:00:00+10:00",
   timezone: "Australia/Sydney",
-  address: "12 Banksia Lane",
+  address: "12 Banksia Lane, Strathfield",
   dressCodeDescription: null,
   dressCodePalette: null,
   pinterestUrl: null,
@@ -25,101 +27,100 @@ const baseEvent: EventSummary = {
   sortOrder: 0,
 };
 
+const renderModal = (event: EventSummary) =>
+  render(() => <DetailsModal event={event} siteUrl={SITE_URL} onClose={() => {}} />);
+
 describe("DetailsModal", () => {
   afterEach(() => cleanup());
 
-  it("renders palette and description from event prop", () => {
-    const { getByText, getByLabelText } = render(() => (
-      <DetailsModal
-        event={{
-          ...baseEvent,
-          dressCodeDescription: "Bright, festive colours.",
-          dressCodePalette: [
-            { name: "Marigold", color: "oklch(76.36% 0.1533 75.16)" },
-            { name: "Fuchsia", color: "#ff00aa" },
-          ],
-        }}
-        onClose={() => {}}
-      />
-    ));
+  it("shows the event name and the timezone-aware date / time range", () => {
+    const { getByText, getByRole } = renderModal(baseEvent);
+
+    expect(getByRole("heading", { name: "Mehndi" })).toBeTruthy();
+    expect(getByText(/Friday\s+18 September 2026/)).toBeTruthy();
+    // Time range rendered in the event's own timezone (4pm–10pm Sydney).
+    expect(getByText(/4:00\s*pm\s*–\s*10:00\s*pm/i)).toBeTruthy();
+  });
+
+  it("hosts the Add to Calendar control inside the details view", () => {
+    const { getByRole } = renderModal(baseEvent);
+    const button = getByRole("button", { name: /add to calendar/i });
+    expect(button).toBeTruthy();
+
+    fireEvent.click(button);
+    // Opening it surfaces the calendar destinations (portalled to body).
+    expect(screen.getByText("Google Calendar")).toBeTruthy();
+    expect(screen.getByText("Apple / Outlook (.ics)")).toBeTruthy();
+  });
+
+  it("renders a map preview that opens the venue in maps", () => {
+    const { getByLabelText } = renderModal(baseEvent);
+    const link = getByLabelText(/open .* in maps/i) as HTMLAnchorElement;
+    expect(link.href).toContain("https://www.google.com/maps/search/");
+    expect(link.href).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+    expect(link.target).toBe("_blank");
+  });
+
+  it("renders the description in an About section", () => {
+    const { getByText } = renderModal(baseEvent);
+    expect(getByText("About")).toBeTruthy();
+    expect(getByText("An evening of henna")).toBeTruthy();
+  });
+
+  it("renders palette and dress code description when present", () => {
+    const { getByText, getByLabelText } = renderModal({
+      ...baseEvent,
+      dressCodeDescription: "Bright, festive colours.",
+      dressCodePalette: [
+        { name: "Marigold", color: "oklch(76.36% 0.1533 75.16)" },
+        { name: "Fuchsia", color: "#ff00aa" },
+      ],
+    });
 
     expect(getByText("Bright, festive colours.")).toBeTruthy();
     expect(getByLabelText("Marigold swatch")).toBeTruthy();
     expect(getByLabelText("Fuchsia swatch")).toBeTruthy();
     expect(getByText("Marigold")).toBeTruthy();
-    expect(getByText("Fuchsia")).toBeTruthy();
   });
 
-  it("renders fallback when both description and palette are null", () => {
-    const { getByText, queryByText } = render(() => (
-      <DetailsModal event={baseEvent} onClose={() => {}} />
-    ));
-
-    expect(getByText("Dress code details coming soon.")).toBeTruthy();
+  it("omits the dress code section entirely when there is no dress code", () => {
+    const { queryByText } = renderModal(baseEvent);
     expect(queryByText("Dress Code")).toBeNull();
   });
 
-  it("renders only description when palette is null", () => {
-    const { getByText, queryByLabelText } = render(() => (
-      <DetailsModal
-        event={{
-          ...baseEvent,
-          dressCodeDescription: "Wear what you love.",
-          dressCodePalette: null,
-        }}
-        onClose={() => {}}
-      />
-    ));
-
-    expect(getByText("Wear what you love.")).toBeTruthy();
-    expect(queryByLabelText(/swatch$/)).toBeNull();
+  it("omits the inspiration section when there is no pinterest board", () => {
+    const { queryByText } = renderModal(baseEvent);
+    expect(queryByText("Inspiration")).toBeNull();
   });
 
-  it("renders only palette when description is null", () => {
-    const { getByLabelText, queryByText } = render(() => (
-      <DetailsModal
-        event={{
-          ...baseEvent,
-          dressCodeDescription: null,
-          dressCodePalette: [{ name: "Sage", color: "oklch(72.88% 0.0585 128.92)" }],
-        }}
-        onClose={() => {}}
-      />
-    ));
+  it("renders only the palette when the dress code description is null", () => {
+    const { getByLabelText, queryByText } = renderModal({
+      ...baseEvent,
+      dressCodePalette: [{ name: "Sage", color: "oklch(72.88% 0.0585 128.92)" }],
+    });
 
     expect(getByLabelText("Sage swatch")).toBeTruthy();
-    expect(queryByText("Dress code details coming soon.")).toBeNull();
+    expect(queryByText("Dress Code")).toBeTruthy();
   });
 
-  it("applies the supplied colour as inline background-color", () => {
-    const { getByLabelText } = render(() => (
-      <DetailsModal
-        event={{
-          ...baseEvent,
-          dressCodePalette: [{ name: "Gold", color: "#abcdef" }],
-        }}
-        onClose={() => {}}
-      />
-    ));
+  it("applies the supplied colour as an inline background-color", () => {
+    const { getByLabelText } = renderModal({
+      ...baseEvent,
+      dressCodePalette: [{ name: "Gold", color: "#abcdef" }],
+    });
 
     const swatch = getByLabelText("Gold swatch") as HTMLElement;
-    // jsdom normalises hex to rgb()
     expect(swatch.style.backgroundColor.replace(/\s+/g, "")).toBe("rgb(171,205,239)");
   });
 
   it("does not render swatches whose colour fails validation", () => {
-    const { queryByLabelText, getByLabelText } = render(() => (
-      <DetailsModal
-        event={{
-          ...baseEvent,
-          dressCodePalette: [
-            { name: "Evil", color: "expression(alert(1))" },
-            { name: "Safe", color: "#abcdef" },
-          ],
-        }}
-        onClose={() => {}}
-      />
-    ));
+    const { queryByLabelText, getByLabelText } = renderModal({
+      ...baseEvent,
+      dressCodePalette: [
+        { name: "Evil", color: "expression(alert(1))" },
+        { name: "Safe", color: "#abcdef" },
+      ],
+    });
 
     expect(queryByLabelText("Evil swatch")).toBeNull();
     expect(getByLabelText("Safe swatch")).toBeTruthy();

--- a/cire/web/src/components/DetailsModal.tsx
+++ b/cire/web/src/components/DetailsModal.tsx
@@ -1,4 +1,4 @@
-import { For, Show, type JSX } from "solid-js";
+import { createUniqueId, For, Show, type JSX } from "solid-js";
 
 import { AddToCalendar } from "./AddToCalendar";
 import { AnimatedModal } from "./AnimatedModal";
@@ -41,12 +41,16 @@ export function DetailsModal(props: DetailsModalProps) {
   const day = () => formatEventDay(props.event);
   const timeRange = () => formatTimeRange(props.event);
   const tz = () => timezoneLabel(props.event);
+  const titleId = createUniqueId();
 
   return (
-    <AnimatedModal onClose={props.onClose}>
+    <AnimatedModal onClose={props.onClose} labelledBy={titleId}>
       <header class="mb-7">
         <p class="font-body text-gold mb-3 text-[0.72rem] tracking-[0.2em] uppercase">Details</p>
-        <h3 class="font-display text-text mb-5 text-[1.7rem] leading-tight font-light italic">
+        <h3
+          id={titleId}
+          class="font-display text-text mb-5 text-[1.7rem] leading-tight font-light italic"
+        >
           {props.event.name}
         </h3>
         <AddToCalendar event={props.event} siteUrl={props.siteUrl} variant="primary" />

--- a/cire/web/src/components/DetailsModal.tsx
+++ b/cire/web/src/components/DetailsModal.tsx
@@ -1,84 +1,129 @@
-import { For, Show } from "solid-js";
+import { For, Show, type JSX } from "solid-js";
 
+import { AddToCalendar } from "./AddToCalendar";
 import { AnimatedModal } from "./AnimatedModal";
 import { isValidColor, truncateSwatchName } from "./dress-code-render";
+import { formatEventDay, formatTimeRange, timezoneLabel } from "./event-details";
+import { MapPreview } from "./MapPreview";
 import { PinterestBoard } from "./PinterestBoard";
 import type { EventSummary } from "./types";
 
 interface DetailsModalProps {
   event: EventSummary;
+  /** Origin used to stamp the calendar invite's "Invite:" link. */
+  siteUrl: string;
   onClose: () => void;
 }
 
+/** A labelled section in the holistic event view, fronted by the gold eyebrow. */
+function Section(props: { label: string; children: JSX.Element }) {
+  return (
+    <section class="border-border/80 border-t pt-6">
+      <h4 class="font-body text-gold mb-3 text-[0.68rem] font-normal tracking-[0.22em] uppercase">
+        {props.label}
+      </h4>
+      {props.children}
+    </section>
+  );
+}
+
+/**
+ * The holistic "everything about this event" view. Opened from an EventCard, it
+ * gathers — in one cohesive sheet — when the event runs (timezone-aware), a
+ * branded map preview of the venue with an Open-in-Maps action, an Add-to-
+ * Calendar control (relocated here from the outer card), the description, the
+ * dress code with its colour palette, and the Pinterest inspiration board.
+ *
+ * Every section renders only when it has content, so a sparse event collapses
+ * gracefully to just its header and timing rather than showing empty shells.
+ */
 export function DetailsModal(props: DetailsModalProps) {
+  const day = () => formatEventDay(props.event);
+  const timeRange = () => formatTimeRange(props.event);
+  const tz = () => timezoneLabel(props.event);
+
   return (
     <AnimatedModal onClose={props.onClose}>
-      <p class="font-body text-gold mb-3 text-[0.72rem] tracking-[0.2em] uppercase">Details</p>
-      <h3 class="font-display text-text mb-6 text-[1.6rem] font-light italic">
-        {props.event.name}
-      </h3>
+      <header class="mb-7">
+        <p class="font-body text-gold mb-3 text-[0.72rem] tracking-[0.2em] uppercase">Details</p>
+        <h3 class="font-display text-text mb-5 text-[1.7rem] leading-tight font-light italic">
+          {props.event.name}
+        </h3>
+        <AddToCalendar event={props.event} siteUrl={props.siteUrl} variant="primary" />
+      </header>
 
-      <Show
-        when={props.event.dressCodeDescription || props.event.dressCodePalette}
-        fallback={
-          <p class="font-body text-text-muted text-[0.92rem] italic">
-            Dress code details coming soon.
-          </p>
-        }
-      >
-        <div class="text-center">
-          <h4 class="font-body text-gold mb-3 text-[0.72rem] font-normal tracking-[0.2em] uppercase">
-            Dress Code
-          </h4>
-
-          <Show when={props.event.dressCodeDescription}>
-            {(desc) => (
-              <p class="font-body text-text-muted mb-6 text-[0.92rem] leading-[1.65] font-light">
-                {desc()}
+      <div class="flex flex-col gap-6">
+        <Show when={day()}>
+          <Section label="When">
+            <p class="font-body text-text text-[0.98rem] font-light">{day()}</p>
+            <Show when={timeRange()}>
+              <p class="font-body text-text-muted mt-1 text-[0.9rem]">
+                {timeRange()}
+                <Show when={tz()}>
+                  <span class="text-text-muted/80"> · {tz()}</span>
+                </Show>
               </p>
-            )}
-          </Show>
-
-          <Show when={props.event.dressCodePalette}>
-            {(palette) => (
-              <div class="mb-6 flex flex-wrap justify-center gap-5">
-                <For each={palette()}>
-                  {(swatch) => (
-                    <Show when={isValidColor(swatch.color)}>
-                      <div class="flex flex-col items-center gap-2">
-                        <div
-                          class="border-border h-12 w-12 rounded-full border"
-                          style={{ "background-color": swatch.color }}
-                          aria-label={`${truncateSwatchName(swatch.name)} swatch`}
-                        />
-                        <span class="font-body text-text-muted text-[0.72rem] tracking-[0.08em] uppercase">
-                          {truncateSwatchName(swatch.name)}
-                        </span>
-                      </div>
-                    </Show>
-                  )}
-                </For>
-              </div>
-            )}
-          </Show>
-
-          <div class="border-border rounded-sm border border-dashed p-6">
-            <h4 class="font-body text-gold mb-3 text-[0.72rem] font-normal tracking-[0.2em] uppercase">
-              Inspiration
-            </h4>
-            <Show
-              when={props.event.pinterestUrl}
-              fallback={
-                <p class="font-body text-text-muted text-[0.85rem] italic">
-                  No inspiration board yet.
-                </p>
-              }
-            >
-              {(url) => <PinterestBoard url={url()} eventName={props.event.name} />}
             </Show>
-          </div>
-        </div>
-      </Show>
+          </Section>
+        </Show>
+
+        <Section label="Where">
+          <MapPreview event={props.event} />
+        </Section>
+
+        <Show when={props.event.description}>
+          {(description) => (
+            <Section label="About">
+              <p class="font-body text-text-muted text-[0.92rem] leading-[1.7] font-light whitespace-pre-line">
+                {description()}
+              </p>
+            </Section>
+          )}
+        </Show>
+
+        <Show when={props.event.dressCodeDescription || props.event.dressCodePalette}>
+          <Section label="Dress Code">
+            <Show when={props.event.dressCodeDescription}>
+              {(desc) => (
+                <p class="font-body text-text-muted mb-5 text-[0.92rem] leading-[1.65] font-light">
+                  {desc()}
+                </p>
+              )}
+            </Show>
+
+            <Show when={props.event.dressCodePalette}>
+              {(palette) => (
+                <div class="flex flex-wrap gap-5">
+                  <For each={palette()}>
+                    {(swatch) => (
+                      <Show when={isValidColor(swatch.color)}>
+                        <div class="flex flex-col items-center gap-2">
+                          <div
+                            class="border-border h-12 w-12 rounded-full border"
+                            style={{ "background-color": swatch.color }}
+                            aria-label={`${truncateSwatchName(swatch.name)} swatch`}
+                          />
+                          <span class="font-body text-text-muted text-[0.72rem] tracking-[0.08em] uppercase">
+                            {truncateSwatchName(swatch.name)}
+                          </span>
+                        </div>
+                      </Show>
+                    )}
+                  </For>
+                </div>
+              )}
+            </Show>
+          </Section>
+        </Show>
+
+        <Show when={props.event.pinterestUrl}>
+          {(url) => (
+            <Section label="Inspiration">
+              <PinterestBoard url={url()} eventName={props.event.name} />
+            </Section>
+          )}
+        </Show>
+      </div>
     </AnimatedModal>
   );
 }

--- a/cire/web/src/components/EventCard.tsx
+++ b/cire/web/src/components/EventCard.tsx
@@ -1,10 +1,8 @@
-import { AddToCalendar } from "./AddToCalendar";
 import type { EventSummary } from "./types";
 import { formatDate } from "./utils";
 
 interface EventCardProps {
   event: EventSummary;
-  siteUrl: string;
   /** Host preview session — RSVP is disabled. */
   preview?: boolean;
   onRespond: (event: EventSummary) => void;
@@ -35,9 +33,8 @@ export function EventCard(props: EventCardProps) {
           class="border-border font-body text-text-muted hover:border-gold hover:text-gold rounded-sm border bg-transparent px-5 py-2.5 text-[0.82rem] tracking-[0.12em] uppercase transition-colors duration-200"
           onClick={() => props.onDetails(props.event)}
         >
-          More Details
+          View Event
         </button>
-        <AddToCalendar event={props.event} siteUrl={props.siteUrl} />
       </div>
     </article>
   );

--- a/cire/web/src/components/InvitePage.tsx
+++ b/cire/web/src/components/InvitePage.tsx
@@ -64,7 +64,6 @@ export default function InvitePage(props: InvitePageProps) {
                     <div data-event-card>
                       <EventCard
                         event={event}
-                        siteUrl={siteUrl()}
                         preview={data().preview}
                         onRespond={setRsvpEvent}
                         onDetails={setDetailsEvent}
@@ -96,7 +95,9 @@ export default function InvitePage(props: InvitePageProps) {
       </Show>
 
       <Show when={detailsEvent()}>
-        {(event) => <DetailsModal event={event()} onClose={() => setDetailsEvent(null)} />}
+        {(event) => (
+          <DetailsModal event={event()} siteUrl={siteUrl()} onClose={() => setDetailsEvent(null)} />
+        )}
       </Show>
     </>
   );

--- a/cire/web/src/components/MapPreview.test.tsx
+++ b/cire/web/src/components/MapPreview.test.tsx
@@ -61,4 +61,28 @@ describe("MapPreview", () => {
     // No venue text to show — falls back to a neutral "View on map" label.
     expect(getByText("View on map")).toBeTruthy();
   });
+
+  // T-S1: when there's no venue text to name the link, the accessible name
+  // falls back to the generic "Open the venue in maps".
+  it("uses an accessible-name fallback when there is no venue but a mapsUrl is present", () => {
+    const url = "https://maps.google.com/?q=somewhere";
+    const { getByLabelText } = render(() => (
+      <MapPreview event={{ ...baseEvent, address: null, location: "", mapsUrl: url }} />
+    ));
+    expect(getByLabelText(/open the venue in maps/i)).toBeTruthy();
+  });
+
+  // T-S2: a dangerous organiser-supplied mapsUrl (e.g. javascript:) must never
+  // reach the anchor href — the component routes through resolveMapsUrl, which
+  // rejects non-http(s) schemes and falls back to the safe Google Maps search
+  // URL derived from the address.
+  it("never renders a javascript: mapsUrl, falling back to the safe maps search", () => {
+    const { getByRole } = render(() => (
+      <MapPreview event={{ ...baseEvent, mapsUrl: "javascript:alert(1)" }} />
+    ));
+    const link = getByRole("link") as HTMLAnchorElement;
+    expect(link.href.startsWith("https://www.google.com/maps/search/")).toBe(true);
+    expect(link.href).not.toContain("javascript:");
+    expect(link.href).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+  });
 });

--- a/cire/web/src/components/MapPreview.test.tsx
+++ b/cire/web/src/components/MapPreview.test.tsx
@@ -1,0 +1,64 @@
+import { render, cleanup } from "@solidjs/testing-library";
+import { describe, it, expect, afterEach } from "vitest";
+
+import { MapPreview } from "./MapPreview";
+import type { EventSummary } from "./types";
+
+const baseEvent: EventSummary = {
+  id: "9f7a2c14-1b3d-4e5f-8a01-000000000001",
+  name: "Mehndi",
+  date: "2026-09-18",
+  location: "The Sharma Residence",
+  description: "An evening of henna",
+  startAt: "2026-09-18T16:00:00+10:00",
+  endAt: "2026-09-18T22:00:00+10:00",
+  timezone: "Australia/Sydney",
+  address: "12 Banksia Lane, Strathfield",
+  dressCodeDescription: null,
+  dressCodePalette: null,
+  pinterestUrl: null,
+  mapsUrl: null,
+  sortOrder: 0,
+};
+
+describe("MapPreview", () => {
+  afterEach(() => cleanup());
+
+  it("links to a derived Google Maps search when only an address is present", () => {
+    const { getByRole } = render(() => <MapPreview event={baseEvent} />);
+    const link = getByRole("link") as HTMLAnchorElement;
+    expect(link.href).toContain("https://www.google.com/maps/search/?api=1&query=");
+    expect(link.href).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+    expect(link.target).toBe("_blank");
+    expect(link.rel).toBe("noopener noreferrer");
+  });
+
+  it("prefers an organiser-supplied mapsUrl", () => {
+    const url = "https://maps.apple.com/?address=12+Banksia+Lane";
+    const { getByRole } = render(() => <MapPreview event={{ ...baseEvent, mapsUrl: url }} />);
+    expect((getByRole("link") as HTMLAnchorElement).href).toBe(url);
+  });
+
+  it("shows the venue line on the card", () => {
+    const { getByText } = render(() => <MapPreview event={baseEvent} />);
+    expect(getByText("12 Banksia Lane, Strathfield")).toBeTruthy();
+    expect(getByText(/open in maps/i)).toBeTruthy();
+  });
+
+  it("renders nothing when there is no address, location, or mapsUrl", () => {
+    const { container } = render(() => (
+      <MapPreview event={{ ...baseEvent, address: null, location: "", mapsUrl: null }} />
+    ));
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("still renders when the address is absent but a mapsUrl is supplied", () => {
+    const url = "https://maps.google.com/?q=somewhere";
+    const { getByRole, getByText } = render(() => (
+      <MapPreview event={{ ...baseEvent, address: null, location: "", mapsUrl: url }} />
+    ));
+    expect((getByRole("link") as HTMLAnchorElement).href).toBe(url);
+    // No venue text to show — falls back to a neutral "View on map" label.
+    expect(getByText("View on map")).toBeTruthy();
+  });
+});

--- a/cire/web/src/components/MapPreview.tsx
+++ b/cire/web/src/components/MapPreview.tsx
@@ -1,0 +1,117 @@
+import { Show } from "solid-js";
+
+import { resolveMapsUrl, venueLine } from "./event-details";
+import type { EventSummary } from "./types";
+
+interface MapPreviewProps {
+  event: EventSummary;
+}
+
+/**
+ * A branded, self-contained map-style preview for a wedding event.
+ *
+ * Cire stores only a venue `address` + an optional `mapsUrl` — no lat/lng
+ * coordinates — and assumes NO map API key. So rather than a real (keyed,
+ * networked) tile that would break the page when the key or coordinates are
+ * absent, this renders a CSS-drawn "cartographic" card in the invite palette:
+ * stylised gold contour rings and a street grid behind a marker pin, with the
+ * address overlaid. It reads as a map without pretending to be satellite
+ * imagery, needs zero secrets, and never makes a network request.
+ *
+ * The whole card is an outbound link to maps: it uses the organiser's `mapsUrl`
+ * when present, otherwise derives a Google Maps search URL from the address
+ * (see `resolveMapsUrl`). If there is nothing to point at, the component renders
+ * nothing — no dead button, no broken tile.
+ */
+export function MapPreview(props: MapPreviewProps) {
+  const venue = () => venueLine(props.event);
+  const mapsHref = () => resolveMapsUrl(props.event);
+
+  return (
+    <Show when={mapsHref()}>
+      {(href) => (
+        <a
+          href={href()}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group border-border bg-bg focus-visible:ring-gold/60 relative block overflow-hidden rounded-md border focus:outline-none focus-visible:ring-2"
+          aria-label={`Open ${venue() ?? "the venue"} in maps`}
+        >
+          {/* Decorative cartographic backdrop — contour rings + street grid,
+              drawn entirely in CSS so it ships no image and needs no key. */}
+          <div
+            aria-hidden="true"
+            class="relative h-36 w-full motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]"
+            style={{
+              "background-color": "var(--color-surface)",
+              "background-image": [
+                // concentric "contour" glow around the pin
+                "radial-gradient(circle at 50% 58%, oklch(74.99% 0.0854 82.08 / 0.16) 0%, transparent 42%)",
+                // diagonal "roads"
+                "repeating-linear-gradient(38deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 26px)",
+                "repeating-linear-gradient(-52deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 34px)",
+                // faint base grid
+                "repeating-linear-gradient(0deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
+                "repeating-linear-gradient(90deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
+              ].join(", "),
+            }}
+          >
+            {/* Marker pin, centred over the contour glow. */}
+            <div class="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-[60%] flex-col items-center">
+              <svg
+                width="26"
+                height="26"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="text-gold drop-shadow-[0_2px_6px_oklch(0%_0_0/0.45)]"
+                aria-hidden="true"
+              >
+                <path d="M12 21s7-6.3 7-11a7 7 0 1 0-14 0c0 4.7 7 11 7 11Z" />
+                <circle cx="12" cy="10" r="2.4" />
+              </svg>
+              {/* pin shadow ellipse on the "ground" */}
+              <span class="bg-gold/30 mt-0.5 h-1 w-3 rounded-full blur-[1px]" />
+            </div>
+          </div>
+
+          {/* Address + action row. */}
+          <div class="border-border/70 bg-surface-raised flex items-center justify-between gap-3 border-t px-4 py-3">
+            <Show
+              when={venue()}
+              fallback={
+                <span class="font-body text-text-muted text-[0.8rem] italic">View on map</span>
+              }
+            >
+              {(line) => (
+                <span class="font-body text-text-muted min-w-0 flex-1 truncate text-left text-[0.82rem]">
+                  {line()}
+                </span>
+              )}
+            </Show>
+            <span class="border-gold font-body text-gold group-hover:bg-gold group-hover:text-bg inline-flex shrink-0 items-center gap-1.5 rounded-sm border px-3.5 py-1.5 text-[0.72rem] tracking-[0.12em] uppercase transition-colors duration-200">
+              Open in Maps
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M7 17 17 7" />
+                <path d="M8 7h9v9" />
+              </svg>
+            </span>
+          </div>
+        </a>
+      )}
+    </Show>
+  );
+}

--- a/cire/web/src/components/RsvpModal.tsx
+++ b/cire/web/src/components/RsvpModal.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, onCleanup, Show, For } from "solid-js";
+import { createMemo, createSignal, createUniqueId, onCleanup, Show, For } from "solid-js";
 
 import { AnimatedModal } from "./AnimatedModal";
 import type { EventSummary, FamilyMember, RsvpSummary } from "./types";
@@ -56,6 +56,7 @@ export function RsvpModal(props: RsvpModalProps) {
   const [responses, setResponses] = createSignal<Record<string, MemberState>>(initialResponses());
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
+  const titleId = createUniqueId();
 
   // Abort the in-flight submit if the modal unmounts mid-request — keeps the
   // setError / setLoading writes from landing on a disposed instance.
@@ -167,9 +168,9 @@ export function RsvpModal(props: RsvpModalProps) {
   }
 
   return (
-    <AnimatedModal onClose={props.onClose}>
+    <AnimatedModal onClose={props.onClose} labelledBy={titleId}>
       <p class="font-body text-gold mb-3 text-[0.72rem] tracking-[0.2em] uppercase">Respond</p>
-      <h3 class="font-display text-text mb-6 text-[1.6rem] font-light italic">
+      <h3 id={titleId} class="font-display text-text mb-6 text-[1.6rem] font-light italic">
         {props.event.name}
       </h3>
 

--- a/cire/web/src/components/event-details.test.ts
+++ b/cire/web/src/components/event-details.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  formatEventDay,
+  formatTimeRange,
+  resolveMapsUrl,
+  timezoneLabel,
+  venueLine,
+} from "./event-details";
+import type { EventSummary } from "./types";
+
+const base: EventSummary = {
+  id: "9f7a2c14-1b3d-4e5f-8a01-000000000001",
+  name: "Mehndi",
+  date: "2026-09-18",
+  location: "The Sharma Residence",
+  description: "An evening of henna",
+  startAt: "2026-09-18T16:00:00+10:00",
+  endAt: "2026-09-18T22:00:00+10:00",
+  timezone: "Australia/Sydney",
+  address: "12 Banksia Lane, Strathfield",
+  dressCodeDescription: null,
+  dressCodePalette: null,
+  pinterestUrl: null,
+  mapsUrl: null,
+  sortOrder: 0,
+};
+
+describe("venueLine", () => {
+  it("prefers the canonical address", () => {
+    expect(venueLine(base)).toBe("12 Banksia Lane, Strathfield");
+  });
+
+  it("falls back to the deprecated location when address is null", () => {
+    expect(venueLine({ ...base, address: null })).toBe("The Sharma Residence");
+  });
+
+  it("returns null when neither is present", () => {
+    expect(venueLine({ address: null, location: "" })).toBeNull();
+    expect(venueLine({ address: "   ", location: "" })).toBeNull();
+  });
+});
+
+describe("formatEventDay", () => {
+  it("formats the wall-clock day in the event timezone", () => {
+    const out = formatEventDay(base);
+    expect(out).toContain("Friday");
+    expect(out).toContain("18 September 2026");
+  });
+
+  it("does not roll back across the UTC date boundary", () => {
+    // 11pm Sydney on the 18th is still the 18th locally even though it is the
+    // 18th 13:00 UTC — guard the off-by-one a naive UTC formatter would hit.
+    const late = { ...base, startAt: "2026-09-18T23:00:00+10:00" };
+    expect(formatEventDay(late)).toContain("18 September 2026");
+  });
+
+  it("returns an empty string for an unparseable instant", () => {
+    expect(formatEventDay({ ...base, startAt: "not-a-date" })).toBe("");
+  });
+});
+
+describe("formatTimeRange", () => {
+  it("renders a start–end range in the event timezone", () => {
+    const out = formatTimeRange(base);
+    expect(out).toMatch(/4:00\s*pm/i);
+    expect(out).toMatch(/10:00\s*pm/i);
+    expect(out).toContain("–");
+  });
+
+  it("collapses to a single time when start and end coincide", () => {
+    const point = { ...base, endAt: base.startAt };
+    const out = formatTimeRange(point);
+    expect(out).toMatch(/4:00\s*pm/i);
+    expect(out).not.toContain("–");
+  });
+});
+
+describe("timezoneLabel", () => {
+  it("returns a short zone label for the instant", () => {
+    expect(timezoneLabel(base)).toMatch(/GMT\+10|AE[SD]T/);
+  });
+});
+
+describe("resolveMapsUrl", () => {
+  it("uses a valid organiser-supplied mapsUrl verbatim", () => {
+    const url = "https://maps.apple.com/?address=12+Banksia+Lane";
+    expect(resolveMapsUrl({ ...base, mapsUrl: url })).toBe(url);
+  });
+
+  it("ignores a non-http mapsUrl and derives from the address", () => {
+    const out = resolveMapsUrl({ ...base, mapsUrl: "javascript:alert(1)" });
+    expect(out).toContain("https://www.google.com/maps/search/");
+    expect(out).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+  });
+
+  it("derives a search URL from the address when mapsUrl is null", () => {
+    const out = resolveMapsUrl(base);
+    expect(out).toContain("https://www.google.com/maps/search/?api=1&query=");
+    expect(out).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+  });
+
+  it("falls back to the deprecated location when address is null", () => {
+    const out = resolveMapsUrl({ ...base, address: null });
+    expect(out).toContain(encodeURIComponent("The Sharma Residence"));
+  });
+
+  it("returns null when there is nothing to point at", () => {
+    expect(resolveMapsUrl({ mapsUrl: null, address: null, location: "" })).toBeNull();
+  });
+});

--- a/cire/web/src/components/event-details.ts
+++ b/cire/web/src/components/event-details.ts
@@ -1,0 +1,102 @@
+import type { EventSummary } from "./types";
+
+/**
+ * Helpers for the holistic event-details view. Pure, framework-free, and
+ * timezone-aware — the modal stays declarative and these stay unit-testable.
+ *
+ * Cire stores `startAt` / `endAt` as ISO strings (with offset) plus an IANA
+ * `timezone`, and a venue `address` + an optional `mapsUrl`. There are NO
+ * stored lat/lng coordinates, so every "where" affordance below is derived
+ * from `address` / `mapsUrl` alone — no map API key, no network call.
+ */
+
+/** Resolve the canonical venue string, preferring `address` over the deprecated `location`. */
+export function venueLine(event: Pick<EventSummary, "address" | "location">): string | null {
+  const address = event.address?.trim();
+  if (address) return address;
+  const location = event.location?.trim();
+  return location && location.length > 0 ? location : null;
+}
+
+/**
+ * Format the event's calendar day in its own timezone, e.g. "Friday, 18 September 2026".
+ * Reads the wall-clock day in `timezone` so a late-evening event in a +10 zone
+ * never rolls back to the previous UTC day.
+ */
+export function formatEventDay(event: Pick<EventSummary, "startAt" | "timezone">): string {
+  const date = new Date(event.startAt);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("en-AU", {
+    timeZone: event.timezone,
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+/** Format a single instant as a wall-clock time in `timezone`, e.g. "4:00 pm". */
+function formatClock(iso: string, timeZone: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("en-AU", {
+    timeZone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(date);
+}
+
+/** Short timezone label for the event instant, e.g. "AEST" / "GMT+10". */
+export function timezoneLabel(event: Pick<EventSummary, "startAt" | "timezone">): string {
+  const date = new Date(event.startAt);
+  if (Number.isNaN(date.getTime())) return "";
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: event.timezone,
+    timeZoneName: "short",
+  }).formatToParts(date);
+  return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+}
+
+/**
+ * Format the start–end time range in the event's timezone, e.g.
+ * "4:00 pm – 10:00 pm". Falls back to just the start when the two clock labels
+ * collapse to the same value (a zero-length or mis-entered window).
+ */
+export function formatTimeRange(
+  event: Pick<EventSummary, "startAt" | "endAt" | "timezone">,
+): string {
+  const start = formatClock(event.startAt, event.timezone);
+  const end = formatClock(event.endAt, event.timezone);
+  if (!start) return "";
+  if (!end || end === start) return start;
+  return `${start} – ${end}`;
+}
+
+/**
+ * Resolve a safe, always-working "open in maps" URL.
+ *
+ * Prefers the organiser-supplied `mapsUrl` when it is a valid http(s) link;
+ * otherwise derives a Google Maps *search* URL from the venue `address`. Returns
+ * null only when neither a usable link nor an address is available, so the
+ * caller can hide the affordance rather than render a dead button.
+ */
+export function resolveMapsUrl(
+  event: Pick<EventSummary, "mapsUrl" | "address" | "location">,
+): string | null {
+  const direct = event.mapsUrl?.trim();
+  if (direct && isHttpUrl(direct)) return direct;
+
+  const venue = venueLine(event);
+  if (!venue) return null;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(venue)}`;
+}
+
+function isHttpUrl(s: string): boolean {
+  try {
+    const u = new URL(s);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- A **holistic event view** for the cire wedding guest site (modeled on Pulse's event detail) — replacing the old "more details" with a single, cohesive "everything about this event" sheet: a **map preview + Open in Maps**, the **Add to Calendar moved into the details**, and all general details (timezone-aware date/time, venue, dress code + palette, description, Pinterest inspiration) — sections collapse gracefully when empty. Plus accessibility hardening of the shared modal.

## Workspaces affected
- `@cire/web` (minor)

## Decisions & issues

**[design]** Brand-consistent holistic layout (forest-green + gold, Cormorant/Lato) with labelled When/Where/About/Dress Code/Inspiration sections. Verified visually at desktop + mobile widths.

**[map preview — no dependency, nothing to provision]** Cire stores only `address` + optional `mapsUrl` (no coordinates, no map key). Built a **dependency-free CSS-drawn map card** — zero network/API key — that links out via the organiser's `mapsUrl` when it's a valid http(s) link, else a derived `https://www.google.com/maps/search/?api=1&query=<encoded address>`; hides itself when there's nothing to point at.

**[add to calendar]** Moved from the outer `EventCard` into the details view as the primary action (new `variant="primary"`); ICS / Google Calendar generation (`calendar.ts`) unchanged; `siteUrl` re-threaded via `InvitePage → DetailsModal`.

**[security ✓ — reviewed]** Outbound links are **http(s)-only validated**, the address is **`encodeURIComponent`-encoded**, every external anchor has **`rel="noopener noreferrer"` + `target="_blank"`**; no `innerHTML`/CSS-injection sink; dress-swatch colors are `isValidColor`-gated; ICS text escaping intact. No findings. A `javascript:`-`href` regression test guards the top safety property.

**[accessibility ✓ — fixed in the shared `AnimatedModal`]** A web-interface-guidelines review found the new components solid but the shared modal lacked: focus trap + return-focus, `Escape`-to-close, an accessible name, background scroll-lock/`overscroll-contain`, and `prefers-reduced-motion` handling (the panel ships `opacity-0` relying on JS — reduced-motion now short-circuits to the **final visible** state, never hiding content). All fixed + the close target bumped to 44×44px; wired into **both** `DetailsModal` and `RsvpModal`. Contrast **measured** from the oklch tokens — gold-on-surface ≈7.54:1, the pill ≈6.46:1 — both clear WCAG AA.

**[optional, needs you later]** A real per-event `mapsUrl`/coordinates backfill would let "Open in Maps" deep-link to an exact pin instead of an address search — works fine without it.

## Test plan
- `cire/web` **201 pass** (+34: map preview incl. the `javascript:`-href safety test, relocated AddToCalendar, timezone helpers, and 9 `AnimatedModal` a11y tests — accessible name, Escape, focus move/restore, scroll lock, reduced-motion reveal) · `bun run --cwd cire/web build` clean · oxlint clean. PinterestBoard consent gate + InviteHeader responsive images untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
