### PR TITLE
feat(cire/web): real Google Maps Embed preview (key-optional, CSS-card fallback)

### DIFF
--- a/.changeset/cire-web-maps-embed-preview.md
+++ b/.changeset/cire-web-maps-embed-preview.md
@@ -1,0 +1,34 @@
+---
+---
+
+cire/web: render a real Google Maps Embed preview in the event-details "Where"
+section when a key is configured, with the existing CSS-drawn map card as the
+fallback.
+
+`MapPreview.tsx` now reads `PUBLIC_GOOGLE_MAPS_EMBED_KEY` (build-time, baked into
+the static Astro output). When the key is present **and** the event has a venue
+address, it renders a Google Maps Embed API `place` iframe queried by the free-text
+address (`q=`) — free, unlimited, no coordinates, no geocoding, no schema change.
+When the key is unset/blank, or the event has no address to query, it falls back to
+today's CSS-drawn cartographic card, so the page never breaks and the feature is a
+pure enhancement that ships safely before any key exists.
+
+- Security: the address is the only interpolated value and is always
+  `encodeURIComponent`-escaped via the new `resolveMapsEmbedUrl` helper in
+  `event-details.ts`; organiser text never reaches the iframe URL/DOM unescaped.
+  The key is never logged and is meant to be referrer-restricted at the Maps
+  Platform console (documented).
+- a11y/perf: the iframe has a meaningful `title` ("Map of <venue>"),
+  `loading="lazy"`, and a fixed height matching the card so it causes no layout
+  shift. The "Open in Maps" action keeps working in both modes.
+- Hardening (review S-L1/S-L2): the iframe is sandboxed
+  (`allow-scripts allow-same-origin allow-popups` — no top-navigation/forms) and
+  uses `referrerpolicy="strict-origin-when-cross-origin"`, matching the page-level
+  referrer policy so the slug-/`?code=`-bearing invite path is never leaked to
+  Google (only the origin, which the key restriction needs, is sent).
+- Docs: `PUBLIC_GOOGLE_MAPS_EMBED_KEY` added to `cire/web/.env.example` and to the
+  production-deploy runbook §3.3 (optional; human step is to create a
+  referrer-restricted, Maps-Embed-only key).
+
+`@cire/*` packages are version-less/ignored by changesets, so this is an empty
+changeset.

--- a/cire/web/.env.example
+++ b/cire/web/.env.example
@@ -2,3 +2,10 @@ PUBLIC_API_URL=http://localhost:8787
 # Wedding slug whose invite customisation this guest site renders. Matches a
 # `weddings.slug` row in cire-db (the bootstrap wedding is `cire-wedding`).
 PUBLIC_WEDDING_SLUG=cire-wedding
+# Optional. Google Maps Platform key with the *Maps Embed API* enabled. When set,
+# the event "Where" section renders a real Maps Embed iframe (free, unlimited,
+# queried by the free-text venue address — no coordinates). When unset/blank, the
+# page falls back to the CSS-drawn map card, so this is a pure enhancement.
+# This key bakes into static HTML at build time, so it MUST be referrer-restricted
+# to the guest-site origin(s) at the Maps Platform console.
+PUBLIC_GOOGLE_MAPS_EMBED_KEY=

--- a/cire/web/src/components/MapPreview.test.tsx
+++ b/cire/web/src/components/MapPreview.test.tsx
@@ -1,5 +1,5 @@
 import { render, cleanup } from "@solidjs/testing-library";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { MapPreview } from "./MapPreview";
 import type { EventSummary } from "./types";
@@ -22,7 +22,10 @@ const baseEvent: EventSummary = {
 };
 
 describe("MapPreview", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+  });
 
   it("links to a derived Google Maps search when only an address is present", () => {
     const { getByRole } = render(() => <MapPreview event={baseEvent} />);
@@ -84,5 +87,68 @@ describe("MapPreview", () => {
     expect(link.href.startsWith("https://www.google.com/maps/search/")).toBe(true);
     expect(link.href).not.toContain("javascript:");
     expect(link.href).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+  });
+
+  describe("with PUBLIC_GOOGLE_MAPS_EMBED_KEY configured", () => {
+    const KEY = "test-embed-key";
+
+    it("renders a Google Maps Embed iframe keyed on the encoded address", () => {
+      vi.stubEnv("PUBLIC_GOOGLE_MAPS_EMBED_KEY", KEY);
+      const { container } = render(() => <MapPreview event={baseEvent} />);
+
+      const iframe = container.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      const src = iframe!.getAttribute("src") ?? "";
+      expect(src).toContain("https://www.google.com/maps/embed/v1/place?");
+      expect(src).toContain(`key=${encodeURIComponent(KEY)}`);
+      expect(src).toContain(`q=${encodeURIComponent("12 Banksia Lane, Strathfield")}`);
+    });
+
+    it("gives the iframe an accessible title, lazy loading, and a safe referrerpolicy", () => {
+      vi.stubEnv("PUBLIC_GOOGLE_MAPS_EMBED_KEY", KEY);
+      const { container } = render(() => <MapPreview event={baseEvent} />);
+
+      const iframe = container.querySelector("iframe")!;
+      expect(iframe.getAttribute("title")).toBe("Map of 12 Banksia Lane, Strathfield");
+      expect(iframe.getAttribute("loading")).toBe("lazy");
+      // S-L2: matches the page-level referrer policy so the slug-bearing path
+      // is not leaked to Google; only the origin (which the key restriction
+      // needs) is sent cross-origin.
+      expect(iframe.getAttribute("referrerpolicy")).toBe("strict-origin-when-cross-origin");
+      // S-L1: least-privilege sandbox — no top-navigation / forms.
+      const sandbox = iframe.getAttribute("sandbox") ?? "";
+      expect(sandbox).toContain("allow-scripts");
+      expect(sandbox).toContain("allow-same-origin");
+      expect(sandbox).not.toContain("allow-top-navigation");
+    });
+
+    it("keeps the 'Open in Maps' link working alongside the iframe", () => {
+      vi.stubEnv("PUBLIC_GOOGLE_MAPS_EMBED_KEY", KEY);
+      const { getByRole } = render(() => <MapPreview event={baseEvent} />);
+
+      const link = getByRole("link") as HTMLAnchorElement;
+      expect(link.href).toContain("https://www.google.com/maps/search/?api=1&query=");
+      expect(link.href).toContain(encodeURIComponent("12 Banksia Lane, Strathfield"));
+      expect(link.target).toBe("_blank");
+      expect(link.rel).toBe("noopener noreferrer");
+    });
+
+    it("falls back to the CSS card (no iframe) when there is no address to query", () => {
+      vi.stubEnv("PUBLIC_GOOGLE_MAPS_EMBED_KEY", KEY);
+      // mapsUrl present so the component still renders, but no address/location
+      // means there is nothing to feed the Embed API `q` — so no iframe.
+      const { container, getByRole } = render(() => (
+        <MapPreview
+          event={{
+            ...baseEvent,
+            address: null,
+            location: "",
+            mapsUrl: "https://maps.google.com/?q=somewhere",
+          }}
+        />
+      ));
+      expect(container.querySelector("iframe")).toBeNull();
+      expect(getByRole("link")).toBeTruthy();
+    });
   });
 });

--- a/cire/web/src/components/MapPreview.tsx
+++ b/cire/web/src/components/MapPreview.tsx
@@ -1,6 +1,6 @@
 import { Show } from "solid-js";
 
-import { resolveMapsUrl, venueLine } from "./event-details";
+import { resolveMapsEmbedUrl, resolveMapsUrl, venueLine } from "./event-details";
 import type { EventSummary } from "./types";
 
 interface MapPreviewProps {
@@ -8,110 +8,200 @@ interface MapPreviewProps {
 }
 
 /**
- * A branded, self-contained map-style preview for a wedding event.
+ * Map preview for a wedding event's "Where" section.
  *
- * Cire stores only a venue `address` + an optional `mapsUrl` — no lat/lng
- * coordinates — and assumes NO map API key. So rather than a real (keyed,
- * networked) tile that would break the page when the key or coordinates are
- * absent, this renders a CSS-drawn "cartographic" card in the invite palette:
- * stylised gold contour rings and a street grid behind a marker pin, with the
- * address overlaid. It reads as a map without pretending to be satellite
- * imagery, needs zero secrets, and never makes a network request.
+ * Two render paths share one footer (venue line + "Open in Maps" action):
  *
- * The whole card is an outbound link to maps: it uses the organiser's `mapsUrl`
- * when present, otherwise derives a Google Maps search URL from the address
- * (see `resolveMapsUrl`). If there is nothing to point at, the component renders
- * nothing — no dead button, no broken tile.
+ *  - **Real map** — when `PUBLIC_GOOGLE_MAPS_EMBED_KEY` is configured at build
+ *    time AND the event has a venue address, the top of the card is a Google
+ *    Maps Embed API `place` iframe keyed on the free-text address (no lat/lng,
+ *    no geocoding, no schema change). The key is referrer-restricted at the
+ *    Maps Platform console, which is what makes baking it into static HTML safe.
+ *    The iframe is sandboxed and uses a strict referrer policy so the
+ *    slug-bearing invite path is never leaked to Google (see S-L1 / S-L2).
+ *
+ *  - **CSS card (fallback)** — when no key is configured, or there is no address
+ *    to query, the top is a self-contained CSS-drawn "cartographic" card (gold
+ *    contour rings + street grid + marker pin) that ships no image, needs no
+ *    secret, and makes no network request. This keeps the page working before
+ *    any key exists, so shipping the key is a pure enhancement.
+ *
+ * The whole component renders nothing when there is no usable maps target at all
+ * (no `mapsUrl` and no address) — no dead button, no broken tile.
+ *
+ * Security: the address is the only interpolated value and is always
+ * `encodeURIComponent`-escaped (in `resolveMapsEmbedUrl`); organiser text never
+ * reaches the iframe URL or the DOM unescaped, and the key is never logged.
  */
 export function MapPreview(props: MapPreviewProps) {
   const venue = () => venueLine(props.event);
   const mapsHref = () => resolveMapsUrl(props.event);
+  // Vite statically replaces `import.meta.env.PUBLIC_*` at build time for the
+  // island bundle, so the key bakes in (or is absent) just like the API URL.
+  const embedSrc = () =>
+    resolveMapsEmbedUrl(props.event, import.meta.env.PUBLIC_GOOGLE_MAPS_EMBED_KEY);
 
   return (
     <Show when={mapsHref()}>
       {(href) => (
-        <a
-          href={href()}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group border-border bg-bg focus-visible:ring-gold/60 relative block overflow-hidden rounded-md border focus:outline-none focus-visible:ring-2"
-          aria-label={`Open ${venue() ?? "the venue"} in maps`}
-        >
-          {/* Decorative cartographic backdrop — contour rings + street grid,
-              drawn entirely in CSS so it ships no image and needs no key. */}
-          <div
-            aria-hidden="true"
-            class="relative h-36 w-full motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]"
-            style={{
-              "background-color": "var(--color-surface)",
-              "background-image": [
-                // concentric "contour" glow around the pin
-                "radial-gradient(circle at 50% 58%, oklch(74.99% 0.0854 82.08 / 0.16) 0%, transparent 42%)",
-                // diagonal "roads"
-                "repeating-linear-gradient(38deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 26px)",
-                "repeating-linear-gradient(-52deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 34px)",
-                // faint base grid
-                "repeating-linear-gradient(0deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
-                "repeating-linear-gradient(90deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
-              ].join(", "),
-            }}
-          >
-            {/* Marker pin, centred over the contour glow. */}
-            <div class="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-[60%] flex-col items-center">
-              <svg
-                width="26"
-                height="26"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="text-gold drop-shadow-[0_2px_6px_oklch(0%_0_0/0.45)]"
-                aria-hidden="true"
-              >
-                <path d="M12 21s7-6.3 7-11a7 7 0 1 0-14 0c0 4.7 7 11 7 11Z" />
-                <circle cx="12" cy="10" r="2.4" />
-              </svg>
-              {/* pin shadow ellipse on the "ground" */}
-              <span class="bg-gold/30 mt-0.5 h-1 w-3 rounded-full blur-[1px]" />
-            </div>
-          </div>
-
-          {/* Address + action row. */}
-          <div class="border-border/70 bg-surface-raised flex items-center justify-between gap-3 border-t px-4 py-3">
-            <Show
-              when={venue()}
-              fallback={
-                <span class="font-body text-text-muted text-[0.8rem] italic">View on map</span>
-              }
-            >
-              {(line) => (
-                <span class="font-body text-text-muted min-w-0 flex-1 truncate text-left text-[0.82rem]">
-                  {line()}
-                </span>
-              )}
-            </Show>
-            <span class="border-gold font-body text-gold group-hover:bg-gold group-hover:text-bg inline-flex shrink-0 items-center gap-1.5 rounded-sm border px-3.5 py-1.5 text-[0.72rem] tracking-[0.12em] uppercase transition-colors duration-200">
-              Open in Maps
-              <svg
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.4"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M7 17 17 7" />
-                <path d="M8 7h9v9" />
-              </svg>
-            </span>
-          </div>
-        </a>
+        <Show when={embedSrc()} fallback={<MapCard href={href()} venue={venue()} />}>
+          {(src) => <MapEmbed href={href()} venue={venue()} src={src()} />}
+        </Show>
       )}
     </Show>
+  );
+}
+
+/**
+ * The real Google Maps Embed iframe + the shared footer. The iframe captures
+ * pointer events, so (unlike the CSS card) the actionable "open in maps" link
+ * lives in the footer rather than wrapping the whole card.
+ */
+function MapEmbed(props: { href: string; venue: string | null; src: string }) {
+  const title = () => `Map of ${props.venue ?? "the venue"}`;
+
+  return (
+    <div class="border-border bg-bg overflow-hidden rounded-md border">
+      <iframe
+        src={props.src}
+        title={title()}
+        loading="lazy"
+        // S-L2: strict-origin matches the page-level referrer policy
+        // (`index.astro` sets `strict-origin-when-cross-origin` to keep the
+        // slug-/`?code=`-bearing path out of cross-origin Referer headers).
+        // Google's referrer key-restriction only needs the origin, which this
+        // still sends, so the embed and the key restriction keep working.
+        referrerpolicy="strict-origin-when-cross-origin"
+        // S-L1: least-privilege sandbox. The Maps Embed needs scripts +
+        // same-origin (to google.com) + popups (the "View larger map" link);
+        // withholding allow-top-navigation/allow-forms removes the frame's
+        // ability to navigate the guest page or submit forms.
+        sandbox="allow-scripts allow-same-origin allow-popups"
+        // Fully constrained box (h-36 = 9rem tall, full-width) matching the
+        // CSS-card path, so the iframe reserves its space up front and never
+        // shifts layout as the embed loads.
+        class="block h-36 w-full border-0"
+      />
+      <FooterRow href={props.href} venue={props.venue} />
+    </div>
+  );
+}
+
+/** The CSS-drawn cartographic fallback card; the whole card is the maps link. */
+function MapCard(props: { href: string; venue: string | null }) {
+  return (
+    <a
+      href={props.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="group border-border bg-bg focus-visible:ring-gold/60 relative block overflow-hidden rounded-md border focus:outline-none focus-visible:ring-2"
+      aria-label={`Open ${props.venue ?? "the venue"} in maps`}
+    >
+      {/* Decorative cartographic backdrop — contour rings + street grid,
+          drawn entirely in CSS so it ships no image and needs no key. */}
+      <div
+        aria-hidden="true"
+        class="relative h-36 w-full motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]"
+        style={{
+          "background-color": "var(--color-surface)",
+          "background-image": [
+            // concentric "contour" glow around the pin
+            "radial-gradient(circle at 50% 58%, oklch(74.99% 0.0854 82.08 / 0.16) 0%, transparent 42%)",
+            // diagonal "roads"
+            "repeating-linear-gradient(38deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 26px)",
+            "repeating-linear-gradient(-52deg, oklch(85.51% 0.069 144.94 / 0.07) 0 1px, transparent 1px 34px)",
+            // faint base grid
+            "repeating-linear-gradient(0deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
+            "repeating-linear-gradient(90deg, oklch(85.51% 0.069 144.94 / 0.04) 0 1px, transparent 1px 22px)",
+          ].join(", "),
+        }}
+      >
+        {/* Marker pin, centred over the contour glow. */}
+        <div class="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-[60%] flex-col items-center">
+          <svg
+            width="26"
+            height="26"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="text-gold drop-shadow-[0_2px_6px_oklch(0%_0_0/0.45)]"
+            aria-hidden="true"
+          >
+            <path d="M12 21s7-6.3 7-11a7 7 0 1 0-14 0c0 4.7 7 11 7 11Z" />
+            <circle cx="12" cy="10" r="2.4" />
+          </svg>
+          {/* pin shadow ellipse on the "ground" */}
+          <span class="bg-gold/30 mt-0.5 h-1 w-3 rounded-full blur-[1px]" />
+        </div>
+      </div>
+
+      <FooterRow href={props.href} venue={props.venue} interactive={false} />
+    </a>
+  );
+}
+
+/**
+ * Shared footer: venue line + the "Open in Maps" affordance. In the CSS-card
+ * path the enclosing `<a>` is the link, so the action is a non-interactive
+ * `<span>` (`interactive={false}`); in the iframe path it is itself the link.
+ */
+function FooterRow(props: { href: string; venue: string | null; interactive?: boolean }) {
+  const isLink = () => props.interactive !== false;
+
+  return (
+    <div class="border-border/70 bg-surface-raised flex items-center justify-between gap-3 border-t px-4 py-3">
+      <Show
+        when={props.venue}
+        fallback={<span class="font-body text-text-muted text-[0.8rem] italic">View on map</span>}
+      >
+        {(line) => (
+          <span class="font-body text-text-muted min-w-0 flex-1 truncate text-left text-[0.82rem]">
+            {line()}
+          </span>
+        )}
+      </Show>
+      <Show
+        when={isLink()}
+        fallback={
+          <span class="border-gold font-body text-gold group-hover:bg-gold group-hover:text-bg inline-flex shrink-0 items-center gap-1.5 rounded-sm border px-3.5 py-1.5 text-[0.72rem] tracking-[0.12em] uppercase transition-colors duration-200">
+            Open in Maps
+            <OpenIcon />
+          </span>
+        }
+      >
+        <a
+          href={props.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Open ${props.venue ?? "the venue"} in maps`}
+          class="border-gold font-body text-gold hover:bg-gold hover:text-bg focus-visible:ring-gold/60 inline-flex shrink-0 items-center gap-1.5 rounded-sm border px-3.5 py-1.5 text-[0.72rem] tracking-[0.12em] uppercase transition-colors duration-200 focus:outline-none focus-visible:ring-2"
+        >
+          Open in Maps
+          <OpenIcon />
+        </a>
+      </Show>
+    </div>
+  );
+}
+
+function OpenIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M7 17 17 7" />
+      <path d="M8 7h9v9" />
+    </svg>
   );
 }

--- a/cire/web/src/components/event-details.test.ts
+++ b/cire/web/src/components/event-details.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   formatEventDay,
   formatTimeRange,
+  resolveMapsEmbedUrl,
   resolveMapsUrl,
   timezoneLabel,
   venueLine,
@@ -107,5 +108,38 @@ describe("resolveMapsUrl", () => {
 
   it("returns null when there is nothing to point at", () => {
     expect(resolveMapsUrl({ mapsUrl: null, address: null, location: "" })).toBeNull();
+  });
+});
+
+describe("resolveMapsEmbedUrl", () => {
+  const KEY = "test-embed-key";
+
+  it("builds a Maps Embed place URL with an encoded address query", () => {
+    const out = resolveMapsEmbedUrl(base, KEY);
+    expect(out).toContain("https://www.google.com/maps/embed/v1/place?");
+    expect(out).toContain(`key=${encodeURIComponent(KEY)}`);
+    expect(out).toContain(`q=${encodeURIComponent("12 Banksia Lane, Strathfield")}`);
+  });
+
+  it("falls back to the deprecated location when address is null", () => {
+    const out = resolveMapsEmbedUrl({ ...base, address: null }, KEY);
+    expect(out).toContain(`q=${encodeURIComponent("The Sharma Residence")}`);
+  });
+
+  it("returns null when no key is configured", () => {
+    expect(resolveMapsEmbedUrl(base, undefined)).toBeNull();
+    expect(resolveMapsEmbedUrl(base, "")).toBeNull();
+    expect(resolveMapsEmbedUrl(base, "   ")).toBeNull();
+  });
+
+  it("returns null when there is no venue address to query", () => {
+    expect(resolveMapsEmbedUrl({ ...base, address: null, location: "" }, KEY)).toBeNull();
+  });
+
+  it("encodes special characters in the address so they cannot break the query", () => {
+    const out = resolveMapsEmbedUrl({ ...base, address: "Café & Co, 1 A&B St #2" }, KEY);
+    expect(out).toContain(`q=${encodeURIComponent("Café & Co, 1 A&B St #2")}`);
+    // The raw ampersand must not appear unescaped in the query segment.
+    expect(out?.split("&q=")[1]).not.toContain("&");
   });
 });

--- a/cire/web/src/components/event-details.ts
+++ b/cire/web/src/components/event-details.ts
@@ -100,3 +100,34 @@ function isHttpUrl(s: string): boolean {
     return false;
   }
 }
+
+/**
+ * Resolve a Google Maps Embed API `place` URL for the event's venue, or null.
+ *
+ * The Embed API takes a free-text address as its `q` query — no coordinates and
+ * no geocoding — so it slots straight onto the `address` cire already stores
+ * (see `venueLine`). The result is meant for an `<iframe>` `src`.
+ *
+ * Returns null (so the caller renders the CSS-card fallback) when:
+ *  - no `key` is configured (the var is unset/blank at build time), or
+ *  - there is no venue address to query.
+ *
+ * The address is the only interpolated value and is always `encodeURIComponent`-
+ * escaped, so organiser-supplied text can never break out of the query string.
+ * The key is referrer-restricted at the Google Maps Platform console, which is
+ * what makes baking it into static HTML safe; it must never be logged.
+ */
+export function resolveMapsEmbedUrl(
+  event: Pick<EventSummary, "address" | "location">,
+  key: string | undefined,
+): string | null {
+  const trimmedKey = key?.trim();
+  if (!trimmedKey) return null;
+
+  const venue = venueLine(event);
+  if (!venue) return null;
+
+  return `https://www.google.com/maps/embed/v1/place?key=${encodeURIComponent(
+    trimmedKey,
+  )}&q=${encodeURIComponent(venue)}`;
+}

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -4,7 +4,7 @@ tags: [todo, web]
 related:
   - "[[index]]"
   - "[[invite-builder]]"
-last-reviewed: 2026-06-17
+last-reviewed: 2026-06-18
 ---
 
 # cire/web
@@ -25,6 +25,7 @@ Frontend feature work. Tick items as PRs land; add new entries when scope is dis
 - [x] Wire RSVP modal to API using surfaced `guestId` per member (PR-F)
 - [x] **Dietary-consent checkbox in `RsvpModal`** (C-H2 (cire dietary), PR #123) — once a guest enters dietary free-text (special-category Art. 9(2)(a)), the modal shows an explicit, **unticked-by-default** consent checkbox and gates submit on it, linking the `/privacy` notice. The server 422s a non-empty dietary without consent and stamps the consent record. See `[[api]]` + `[[dpia/cire-guest-data]]` (root compliance).
 - [ ] "Open in Maps" button on event cards driven by `event.mapsUrl`
+- [x] **Real Google Maps Embed preview in the event-details "Where" section** (key-optional) — `MapPreview.tsx` renders a Google Maps Embed API `place` iframe (free, unlimited, queried by the free-text venue `address` — no lat/lng, no geocoding, no schema change) when `PUBLIC_GOOGLE_MAPS_EMBED_KEY` is configured at build time; when the key is unset/blank, or the event has no address to query, it falls back to the existing CSS-drawn map card, so it is a pure enhancement and ships safely before any key exists. Address-only interpolation, always `encodeURIComponent`-escaped; iframe has a meaningful `title`, `loading="lazy"`, `referrerpolicy="no-referrer-when-downgrade"`, and a fixed height matching the card (no layout shift). The "Open in Maps" affordance keeps working in both modes (in the iframe path it moves to the footer, since the iframe captures pointer events). New env var documented in `cire/web/.env.example` + production-deploy runbook §3.3; human step is to create a referrer-restricted Maps-Embed-only key. `resolveMapsEmbedUrl` helper in `event-details.ts`.
 - [x] Add-to-calendar links (Google Calendar, Apple Calendar, .ics) sourced from `event.startAt` / `endAt` / `timezone` (PR-G)
 - [x] ~~Passkey registration + login UI~~ — **Obsolete**: guests use claim codes (no accounts); organiser sign-in reuses OSN's `<SignIn>` from `@osn/ui` on the portal (OSN merge)
 - [x] ~~Magic link email fallback UI~~ — **Obsolete**: no magic-link factor in the two-system auth model

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -306,6 +306,7 @@ time** — set them in the build environment, not at runtime.
 |---|---|---|---|
 | `PUBLIC_API_URL` | cire/web | **Yes** | cire-api prod origin (`cire/web/src/pages/index.astro:6`, default `http://localhost:8787`). |
 | `PUBLIC_SITE_URL` | cire/web | Recommended | Guest site canonical URL (`index.astro:50`). |
+| `PUBLIC_GOOGLE_MAPS_EMBED_KEY` | cire/web | Optional | Google Maps Platform key with the **Maps Embed API** enabled. When set, the event "Where" section renders a real Maps Embed iframe (queried by the free-text venue address — no coordinates, no geocoding); when unset/blank it falls back to the CSS-drawn map card, so it is a pure enhancement (`cire/web/src/components/MapPreview.tsx`). **Human step:** create the key, **enable only the Maps Embed API**, and **restrict it by HTTP referrer** to the guest-site origin(s) — the key bakes into static HTML, and a referrer-restricted Embed-only key is safe to ship. |
 | `PUBLIC_CIRE_API_URL` | cire/organiser | **Yes** | cire-api prod origin (`cire/organiser/src/lib/osn.ts:8-9`; `PUBLIC_API_URL` honoured as legacy fallback). |
 | `PUBLIC_OSN_ISSUER_URL` | cire/organiser | **Yes** | osn-api prod origin for organiser passkey sign-in (`osn.ts:3`, default `http://localhost:4000`). |
 | `PUBLIC_CIRE_WEB_URL` | cire/organiser | Recommended | Guest site URL used in organiser links (`osn.ts:14`). |


### PR DESCRIPTION
## Summary
- The cire guest-site event-details "Where" section now renders a **real Google Maps Embed API `place` iframe** when `PUBLIC_GOOGLE_MAPS_EMBED_KEY` is configured at build time, querying the **free-text venue address** (`q=`) — free, unlimited, no coordinates, no geocoding, **no schema change**.
- When the key is **unset/blank**, or the event has **no address** to query, it falls back to today's CSS-drawn cartographic map card. The page never breaks, so this is a **pure enhancement that is safe to merge before any key exists**.
- The "Open in Maps" action keeps working in both modes (in the iframe path it moves to the footer, since the iframe captures pointer events).
- New pure helper `resolveMapsEmbedUrl(event, key)` in `event-details.ts`; the address is the only interpolated value and is always `encodeURIComponent`-escaped.

## Workspaces affected
- `@cire/web` (static Astro guest site) — version-less/ignored by changesets, so an **empty changeset** is used.
- Docs only: `wiki/runbooks/production-deploy.md` (§3.3), `cire/wiki/todo/web.md`.

## Decisions & issues

**[approach] Maps Embed API iframe over a keyed tile / geocoding**
- **Issue:** The old preview was a CSS-drawn placeholder; we wanted a real map without storing coordinates.
- **Why:** cire stores only a free-text `address` (+ optional `mapsUrl`), no lat/lng/placeId. A tile/JS-API map would need geocoding and/or a schema change.
- **Solution:** The Maps Embed API `place` mode accepts the address as a free-text `q` query, so it slots onto existing data with zero schema change and is free + unlimited.
- **Rationale:** Lowest-cost path to a real map; keeps the data model untouched.

**[approach] Key as a build-time `PUBLIC_*` var with CSS-card fallback**
- **Issue:** cire/web is a static Astro build (`output: "static"`) and no map key exists anywhere today.
- **Why:** Shipping must not break the page before a key is provisioned.
- **Solution:** Read `import.meta.env.PUBLIC_GOOGLE_MAPS_EMBED_KEY` (baked in at build); absent/blank → CSS card; present + address → iframe.
- **Rationale:** Decouples the code change from the human key-provisioning step; the PR is safe to merge immediately.

**[S-L2] Referrer policy leaked the slug-bearing invite path to Google** *(fixed)*
- **Issue:** Initial iframe used `referrerpolicy="no-referrer-when-downgrade"`, which would send the full guest-site URL (path + `?code=`/slug) as `Referer` to google.com.
- **Why:** The wedding slug / preview `?code=` are soft capability identifiers; `index.astro` deliberately sets a page-level `strict-origin-when-cross-origin` policy to keep them out of cross-origin Referer headers, and the iframe was overriding that intent.
- **Solution:** Switched the iframe to `referrerpolicy="strict-origin-when-cross-origin"`.
- **Rationale:** Google's referrer key-restriction only needs the **origin** (still sent), so the embed and the key restriction keep working while the slug-bearing path is no longer leaked.

**[S-L1] iframe had no `sandbox` attribute** *(fixed)*
- **Issue:** The embed iframe ran with full iframe privileges.
- **Why:** Defense-in-depth against a compromised embed origin (top-navigation, forms).
- **Solution:** Added least-privilege `sandbox="allow-scripts allow-same-origin allow-popups"` (scripts + same-origin + the "View larger map" popup; no top-nav/forms). Verified the build still succeeds and tests pass.
- **Rationale:** Removes top-navigation/form vectors at zero functional cost; the map still renders.

**[perf] No CLS / off the critical path** *(no action — verified)*
- **Issue:** Could a Maps iframe hurt Core Web Vitals?
- **Why:** Iframes can cause layout shift and compete for the connection budget.
- **Solution:** The iframe only mounts when a guest opens the details modal (off initial load); it uses a fully-constrained box (`h-36 w-full`) so space is reserved up front (no CLS) plus `loading="lazy"`. No static preconnect to google.com (intentional — keeps the maps origin off the initial-load budget).
- **Rationale:** Perf review returned 3 Info notes, all already handled correctly.

## Test plan
- `bun run --cwd cire/web test` → **210 passed** (incl. new `resolveMapsEmbedUrl` helper tests and `MapPreview` iframe-path tests: key present → iframe with correctly-encoded `q` + title/lazy/referrerpolicy/sandbox; key absent → CSS-card fallback; no-address → fallback/no iframe; "Open in Maps" still works).
- `bun run --cwd cire/web build` → static build succeeds.
- oxlint + oxfmt clean on changed files.
- **Human follow-up before/at deploy (optional):** create a Google Maps Platform key, enable **only the Maps Embed API**, **restrict it by HTTP referrer** to the guest-site origin(s), then set `PUBLIC_GOOGLE_MAPS_EMBED_KEY` in the cire/web build environment (see production-deploy runbook §3.3). Until then the CSS card renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)