### PR TITLE
feat: Cloudflare Turnstile bot protection (key-optional, fail-closed)

### DIFF
--- a/.changeset/cire-turnstile-guest-protection.md
+++ b/.changeset/cire-turnstile-guest-protection.md
@@ -1,0 +1,12 @@
+---
+---
+
+cire: add Cloudflare Turnstile bot protection to the public guest surfaces (claim + RSVP), key-optional and fail-closed.
+
+`cire-api` gains an optional Turnstile gate on `POST /api/claim` (the pre-auth claim-code oracle) and `POST /api/rsvp` (the spam-prone RSVP write). The verifier is built once per isolate in `src/index.ts` from `env.TURNSTILE_SECRET_KEY` via `@shared/turnstile` and threaded into `createApp`; `src/middleware/turnstile.ts` reads the body's `turnstileToken`, siteverifies it with the caller's `cf-connecting-ip`, and rejects with `403` on a missing/invalid/duplicate token. When the secret is unset the gate is a no-op (guest flow unchanged). New bounded metric `cire.turnstile.rejected{endpoint}`.
+
+`cire/web` renders the challenge on the claim form (`LoginSection`) and the RSVP modal (`RsvpModal`) via a new key-optional `TurnstileWidget` Solid island that reads `PUBLIC_TURNSTILE_SITEKEY` (build-time). `cire/organiser` passes its build-time `PUBLIC_TURNSTILE_SITEKEY` into the shared `@osn/ui` `SignIn` + `Register` forms so organiser passkey sign-in is protected too. When the sitekey is unset, no widget renders and submit proceeds without a token — a pure enhancement that ships before the widget exists.
+
+- Docs: `PUBLIC_TURNSTILE_SITEKEY` added to `cire/web` + `cire/organiser` `.env.example` and the deploy workflow (commented); `TURNSTILE_SECRET_KEY` + the dashboard widget-creation steps documented in `wiki/runbooks/production-deploy.md` §3.4.
+
+`@cire/*` packages are version-less/ignored by changesets, so this is an empty changeset.

--- a/.changeset/turnstile-bot-protection.md
+++ b/.changeset/turnstile-bot-protection.md
@@ -1,0 +1,16 @@
+---
+"@shared/turnstile": minor
+"@osn/api": minor
+"@osn/ui": minor
+"@osn/client": minor
+---
+
+Add Cloudflare Turnstile bot protection to the OSN auth surface (key-optional, fail-closed).
+
+New `@shared/turnstile` package exposes `createTurnstileVerifier(secret?)` — a key-optional, fail-closed siteverify helper. When the `TURNSTILE_SECRET_KEY` secret is **unset** the verifier is `null` and every gate is skipped (flows behave exactly as before — safe to merge before the widget exists). When **set**, it POSTs the token to Cloudflare's managed `siteverify` endpoint via `instrumentedFetch`, passing the caller's `cf-connecting-ip` as `remoteip`, and rejects on any missing / invalid / expired / duplicate (single-use) token or unreachable endpoint. The secret is never logged or returned to the client.
+
+- **`@osn/api`**: `/register/begin` and `/login/passkey/begin` are gated. The verifier is built once per isolate in `build-deps.ts` from `env.TURNSTILE_SECRET_KEY` and threaded through `createAuthRoutes`; a configured gate fails closed with `400 turnstile_failed`. New bounded metric `osn.auth.turnstile.rejected{endpoint}`.
+- **`@osn/client`**: `RegistrationClient.beginRegistration` and `LoginClient.passkeyBegin` accept an optional `turnstileToken`, sent on the begin call (omitted cleanly when absent — the no-Turnstile call shape is unchanged, and the silent conditional-UI passkey ceremony carries no token).
+- **`@osn/ui`**: new `TurnstileWidget` (Solid) renders Cloudflare's widget only when a `siteKey` prop is provided (lazy-loads `api.js`, `data-action="turnstile-spin-v1"`); `Register` + `SignIn` take an optional `turnstileSiteKey` prop and gate submit on a solved challenge. Omitted ⇒ no widget, no gate.
+
+The sitekey is public (embedded in client HTML at build time via `PUBLIC_TURNSTILE_SITEKEY`); the secret is a `wrangler secret` on osn-api. Both halves are optional and graceful, mirroring the maps-embed key and `OSN_EMAIL_OPTIONAL` precedents.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,11 +144,17 @@ jobs:
       # the build env, not at runtime. These are non-secret prod URLs.
       #   PUBLIC_GOOGLE_MAPS_EMBED_KEY is an optional referrer-restricted Embed
       #   key — wire it from a secret/var only if/when one exists.
+      #   PUBLIC_TURNSTILE_SITEKEY is the optional Cloudflare Turnstile sitekey
+      #   (public, bot protection). Uncomment once the widget exists; the build
+      #   omits it cleanly when absent (no widget, no gate — key-optional). The
+      #   matching TURNSTILE_SECRET_KEY is a `wrangler secret` on the cire-api
+      #   Worker (see wiki/runbooks/production-deploy.md).
       - name: Build cire/web
         run: bun run --cwd cire/web build
         env:
           PUBLIC_API_URL: https://api.cireweddings.com
           PUBLIC_SITE_URL: https://cireweddings.com
+          # PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Deploy cire/web to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire
@@ -192,6 +198,10 @@ jobs:
           PUBLIC_CIRE_API_URL: https://api.cireweddings.com
           PUBLIC_OSN_ISSUER_URL: https://id.cireweddings.com
           PUBLIC_CIRE_WEB_URL: https://cireweddings.com
+          # Optional Cloudflare Turnstile sitekey (public) for organiser passkey
+          # sign-in. Uncomment once the widget exists; omitted ⇒ key-optional
+          # no-op. Matching TURNSTILE_SECRET_KEY is a wrangler secret on osn-api.
+          # PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Deploy cire/organiser to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire-organiser

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@shared/observability": "workspace:*",
         "@shared/osn-auth-client": "workspace:*",
         "@shared/rate-limit": "workspace:*",
+        "@shared/turnstile": "workspace:*",
         "drizzle-orm": "^0.45.2",
         "effect": "^3.21.2",
         "elysia": "^1.4.28",
@@ -99,6 +100,7 @@
         "@shared/observability": "workspace:*",
         "@shared/rate-limit": "workspace:*",
         "@shared/redis": "workspace:*",
+        "@shared/turnstile": "workspace:*",
         "@simplewebauthn/server": "^13.3.0",
         "drizzle-orm": "^0.45.2",
         "effect": "^3.21.2",
@@ -397,6 +399,17 @@
       },
       "devDependencies": {
         "@effect/vitest": "^0.29.0",
+        "@shared/typescript-config": "workspace:*",
+        "vitest": "^4.1.8",
+      },
+    },
+    "shared/turnstile": {
+      "name": "@shared/turnstile",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/observability": "workspace:*",
+      },
+      "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "vitest": "^4.1.8",
       },
@@ -1027,6 +1040,8 @@
     "@shared/rate-limit": ["@shared/rate-limit@workspace:shared/rate-limit"],
 
     "@shared/redis": ["@shared/redis@workspace:shared/redis"],
+
+    "@shared/turnstile": ["@shared/turnstile@workspace:shared/turnstile"],
 
     "@shared/typescript-config": ["@shared/typescript-config@workspace:shared/typescript-config"],
 

--- a/cire/api/package.json
+++ b/cire/api/package.json
@@ -17,6 +17,7 @@
     "@shared/observability": "workspace:*",
     "@shared/osn-auth-client": "workspace:*",
     "@shared/rate-limit": "workspace:*",
+    "@shared/turnstile": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "effect": "^3.21.2",
     "elysia": "^1.4.28"

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -1,6 +1,7 @@
 import { cors } from "@elysiajs/cors";
 import { createRateLimiter } from "@shared/rate-limit";
 import type { RateLimiterBackend } from "@shared/rate-limit";
+import type { TurnstileVerifier } from "@shared/turnstile";
 import { Effect } from "effect";
 import { Elysia } from "elysia";
 
@@ -108,6 +109,14 @@ export interface AppOptions {
    * inject a stub.
    */
   resolveOsnProfileByHandle?: OsnHandleResolver;
+  /**
+   * Cloudflare Turnstile verifier (bot protection) for the public guest
+   * surfaces (claim + rsvp). KEY-OPTIONAL: `null`/omitted ⇒ the
+   * `TURNSTILE_SECRET_KEY` secret is unset and the gates are skipped (guest
+   * flow unchanged). A verifier ⇒ claim + rsvp require a valid Turnstile token
+   * and fail-closed. Built once per isolate in `index.ts`; tests inject a stub.
+   */
+  turnstileVerifier?: TurnstileVerifier | null;
 }
 
 export function createApp(db: Db, options: AppOptions = {}) {
@@ -128,6 +137,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
     osnTestKey,
     resolveOsnAccountId,
     resolveOsnProfileByHandle,
+    turnstileVerifier = null,
   } = options;
   const corsOrigins = allowedOrigins ?? [webOrigin];
 
@@ -176,8 +186,8 @@ export function createApp(db: Db, options: AppOptions = {}) {
       // same allowlist CORS echoes. Mounted before the route factories so it
       // gates the whole app. Empty allowlist (dev) disables it.
       .use(originGuard(corsOrigins))
-      .use(createClaimRoutes(db, { webOrigin, limiter: claimLimiter }))
-      .use(createRsvpRoutes(db))
+      .use(createClaimRoutes(db, { webOrigin, limiter: claimLimiter, turnstileVerifier }))
+      .use(createRsvpRoutes(db, { turnstileVerifier }))
       .use(createOrganiserWeddingsRoutes(db, osnAuthOptions))
       .use(createOrganiserWeddingCreateRoute(db, osnAuthOptions, weddingCreateLimiter))
       .use(createOrganiserPreviewRoutes(db, osnAuthOptions, previewLimiter))

--- a/cire/api/src/db/d1-integration.test.ts
+++ b/cire/api/src/db/d1-integration.test.ts
@@ -40,6 +40,19 @@ const GUEST_2 = "g2";
 let mf: Miniflare;
 let db: Db;
 
+// Booting workerd (which backs Miniflare's D1) is a cold-start the first time a
+// CI runner touches it: spawning the runtime + opening the loopback socket can
+// take several seconds on a fresh, network-constrained GitHub Actions box. bun's
+// DEFAULT per-hook timeout is 5_000ms, so a slow boot makes the `beforeAll`
+// (or a `beforeEach` issuing the first real D1 round-trip) blow past it — bun
+// then fails the hook AND tears the suite down, at which point the still-pending
+// workerd D1 call lands on a now-disposed ("poisoned") stub and surfaces as
+// "Unhandled error between tests", failing the whole `bun test` run. Locally the
+// runtime is warm so the hooks finish in ~400ms and never trip the limit; this
+// is the CI-only flake. Give every Miniflare-backed hook a generous budget so a
+// cold boot can never race the default timeout.
+const MF_HOOK_TIMEOUT_MS = 30_000;
+
 const run = <A, E>(eff: Effect.Effect<A, E, DbService>): Promise<A> =>
   Effect.runPromise(eff.pipe(Effect.provideService(DbService, db)));
 
@@ -131,11 +144,15 @@ beforeAll(async () => {
     await d1.prepare(stmt).run();
   }
   db = createD1Db(d1);
-});
+}, MF_HOOK_TIMEOUT_MS);
 
 afterAll(async () => {
+  // `dispose()` poisons every D1 stub this instance handed out — only call it
+  // once the suite is fully done so no in-flight query can resolve against a
+  // dead stub. (All hooks/tests above `await` their D1 ops, so nothing is
+  // pending here; this stays defensive in case that ever changes.)
   await mf?.dispose();
-});
+}, MF_HOOK_TIMEOUT_MS);
 
 beforeEach(async () => {
   // FK-safe truncate, then reseed — keeps each test isolated on the shared D1.
@@ -143,7 +160,7 @@ beforeEach(async () => {
     await db.delete(table);
   }
   await seed();
-});
+}, MF_HOOK_TIMEOUT_MS);
 
 describe("cire/api over real D1 (Miniflare)", () => {
   it("claim.lookup resolves a seeded family across async D1 reads", async () => {

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -1,6 +1,7 @@
 import { BOOTSTRAP_WEDDING_ID, weddings } from "@cire/db";
 import { createWorkersRateLimiter } from "@shared/rate-limit";
 import type { WorkersRateLimitBinding } from "@shared/rate-limit";
+import { createTurnstileVerifier } from "@shared/turnstile";
 import { and, eq } from "drizzle-orm";
 import { Effect, Layer } from "effect";
 
@@ -49,6 +50,10 @@ export interface Env {
   // limiter is the global, atomic edge limiter; absent (local `wrangler dev`
   // without the binding, or non-Workers runtimes) ⇒ the in-memory fallback.
   CLAIM_RATE_LIMITER?: WorkersRateLimitBinding;
+  // Turnstile bot-protection secret (KEY-OPTIONAL). When set, the guest claim +
+  // RSVP endpoints require a valid Turnstile token (fail-closed); unset ⇒ those
+  // gates are skipped. `wrangler secret put TURNSTILE_SECRET_KEY`.
+  TURNSTILE_SECRET_KEY?: string;
 }
 
 // P-W1: the Elysia app graph (root + cors + route factories + auth plugins) is
@@ -174,6 +179,10 @@ const handler: ExportedHandler<Env> = {
       const edgeLimiter = env.CLAIM_RATE_LIMITER
         ? createWorkersRateLimiter(env.CLAIM_RATE_LIMITER)
         : undefined;
+      // Turnstile bot protection (KEY-OPTIONAL). Unset secret ⇒ null ⇒ the
+      // claim + rsvp gates are skipped. The secret is read here and never
+      // logged or placed anywhere but Cloudflare's siteverify endpoint.
+      const turnstileVerifier = createTurnstileVerifier(env.TURNSTILE_SECRET_KEY);
       cached = {
         dbBinding: env.DB,
         app: createApp(db, {
@@ -189,6 +198,7 @@ const handler: ExportedHandler<Env> = {
           osnAudience: env.OSN_AUDIENCE,
           resolveOsnAccountId,
           resolveOsnProfileByHandle,
+          turnstileVerifier,
         }),
       };
     }

--- a/cire/api/src/metrics.ts
+++ b/cire/api/src/metrics.ts
@@ -34,6 +34,9 @@ import type { ImageVariant, OutputFormat } from "./services/invite-image-transfo
 export const CIRE_METRICS = {
   // Guest claim (pre-auth credential exchange surface).
   claimAttempts: "cire.claim.attempts",
+  // Turnstile bot-protection rejections (fail-closed) on the gated guest
+  // surfaces (claim + rsvp). Only emitted when Turnstile is configured.
+  turnstileRejected: "cire.turnstile.rejected",
   claimLookupDuration: "cire.claim.lookup.duration",
   // Guest sessions.
   sessionCreated: "cire.session.created",
@@ -82,6 +85,9 @@ export const CIRE_METRICS = {
 /** Outcome of a guest claim attempt. `rate_limited` is gated upstream by the
  *  per-IP limiter (429 before the handler) and reserved for that call-site. */
 export type ClaimResult = "ok" | "invalid_credentials" | "rate_limited" | "error";
+
+/** Turnstile-gated guest surface. Bounded literal union — never a raw path. */
+export type TurnstileEndpoint = "claim" | "rsvp";
 
 /** Terminal RSVP status after an upsert — matches the cire `rsvps.status` enum. */
 export type RsvpStatus = "attending" | "declined" | "maybe";
@@ -339,6 +345,16 @@ const hostResolveDuration = createHistogram<HostResolveDurationAttrs>({
 // ---------------------------------------------------------------------------
 
 export const metricClaimAttempt = (result: ClaimResult): void => claimAttempts.inc({ result });
+
+const turnstileRejected = createCounter<{ endpoint: TurnstileEndpoint }>({
+  name: CIRE_METRICS.turnstileRejected,
+  description: "Guest requests rejected by Turnstile siteverify (fail-closed), by surface",
+  unit: "{rejection}",
+});
+
+/** Records a fail-closed Turnstile rejection on a configured guest gate. */
+export const metricTurnstileRejected = (endpoint: TurnstileEndpoint): void =>
+  turnstileRejected.inc({ endpoint });
 
 export const metricSessionCreated = (result: "ok" | "error"): void =>
   sessionCreated.inc({ result });

--- a/cire/api/src/middleware/turnstile.ts
+++ b/cire/api/src/middleware/turnstile.ts
@@ -1,0 +1,48 @@
+import type { TurnstileVerifier } from "@shared/turnstile";
+
+import { metricTurnstileRejected, type TurnstileEndpoint } from "../metrics";
+
+/**
+ * Turnstile bot-protection gate for the public guest surfaces (claim + rsvp).
+ *
+ * KEY-OPTIONAL + fail-closed, matching the project's other graceful-degradation
+ * integrations (maps-embed key, account-link ARC). The verifier is built once
+ * per isolate in `index.ts` from the `TURNSTILE_SECRET_KEY` wrangler secret and
+ * passed into `createApp`:
+ *
+ *  - `verifier === null` (secret unset) ⇒ {@link turnstileGate} resolves to
+ *    `null` immediately — the gate is a no-op and the guest flow runs exactly as
+ *    it did before Turnstile existed. Safe to ship before the widget is created.
+ *  - configured ⇒ the body's `turnstileToken` is siteverified with the caller's
+ *    `cf-connecting-ip` as `remoteip`. A missing/invalid/duplicate token (or an
+ *    unreachable siteverify) fails CLOSED → returns `{ status, error }` for the
+ *    caller to short-circuit on. The secret is never logged or echoed.
+ *
+ * Returns `null` to proceed, or a `{ status, error }` rejection the route turns
+ * into a response.
+ */
+export async function turnstileGate(
+  verifier: TurnstileVerifier | null,
+  endpoint: TurnstileEndpoint,
+  rawBody: unknown,
+  headers: Headers,
+): Promise<{ status: number; error: string } | null> {
+  if (!verifier) return null;
+
+  // The widget token rides in the JSON body alongside the form fields. Read it
+  // defensively — a non-object / missing field fails closed via the verifier's
+  // own missing-token branch.
+  const token =
+    rawBody && typeof rawBody === "object" && "turnstileToken" in rawBody
+      ? (rawBody as { turnstileToken?: unknown }).turnstileToken
+      : undefined;
+  const tokenStr = typeof token === "string" ? token : undefined;
+
+  const remoteip = headers.get("cf-connecting-ip");
+  const result = await verifier.verify(tokenStr, remoteip);
+  if (!result.ok) {
+    metricTurnstileRejected(endpoint);
+    return { status: 403, error: "Verification failed. Please try again." };
+  }
+  return null;
+}

--- a/cire/api/src/routes/claim.ts
+++ b/cire/api/src/routes/claim.ts
@@ -1,4 +1,5 @@
 import type { RateLimiterBackend } from "@shared/rate-limit";
+import type { TurnstileVerifier } from "@shared/turnstile";
 import { Effect, Schema } from "effect";
 import { Elysia } from "elysia";
 
@@ -6,6 +7,7 @@ import { DbService } from "../db";
 import type { Db } from "../db";
 import { buildSessionCookie } from "../lib/cookie";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { turnstileGate } from "../middleware/turnstile";
 import { runCire } from "../observability";
 import { ClaimBody } from "../schemas/claim";
 import { claimService } from "../services/claim";
@@ -18,13 +20,30 @@ export interface ClaimRouteOptions {
   webOrigin: string;
   /** Per-IP rate limiter (brute-force protection — S-C2). */
   limiter: RateLimiterBackend;
+  /**
+   * Turnstile verifier (KEY-OPTIONAL). `null` ⇒ gate skipped; configured ⇒
+   * a missing/invalid token fails closed (403) before the credential lookup.
+   */
+  turnstileVerifier?: TurnstileVerifier | null;
 }
 
-export const createClaimRoutes = (db: Db, { webOrigin, limiter }: ClaimRouteOptions) =>
+export const createClaimRoutes = (
+  db: Db,
+  { webOrigin, limiter, turnstileVerifier = null }: ClaimRouteOptions,
+) =>
   new Elysia({ prefix: "/api/claim" }).use(rateLimitMiddleware(limiter)).post(
     "/",
     async ({ request, set }) => {
       const raw: unknown = await request.json().catch(() => null);
+
+      // Turnstile bot gate (key-optional; no-op when unconfigured). Runs after
+      // the per-IP limiter, before the credential lookup — a bot that can't pass
+      // the challenge never reaches the claim-code oracle.
+      const tsErr = await turnstileGate(turnstileVerifier, "claim", raw, request.headers);
+      if (tsErr) {
+        set.status = tsErr.status;
+        return { error: tsErr.error };
+      }
 
       return runCire(
         Effect.gen(function* () {

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -1,4 +1,5 @@
 import { families, guests, guestEvents } from "@cire/db";
+import type { TurnstileVerifier } from "@shared/turnstile";
 import { eq, inArray } from "drizzle-orm";
 import { Effect, Schema } from "effect";
 import { Elysia } from "elysia";
@@ -7,6 +8,7 @@ import { DbService, dbQuery } from "../db";
 import type { Db } from "../db";
 import { metricRsvpBatchSize } from "../metrics";
 import { sessionAuth } from "../middleware/auth";
+import { turnstileGate } from "../middleware/turnstile";
 import { runCire } from "../observability";
 import { BulkRsvpBody } from "../schemas/rsvp";
 import { rsvpService } from "../services/rsvp";
@@ -17,7 +19,15 @@ import { rsvpService } from "../services/rsvp";
 // this is a cheap upfront guard against a CDN that strips/lies notwithstanding.
 const MAX_RSVP_BYTES = 256 * 1024;
 
-export const createRsvpRoutes = (db: Db) =>
+export interface RsvpRouteOptions {
+  /**
+   * Turnstile verifier (KEY-OPTIONAL). `null` ⇒ gate skipped; configured ⇒ a
+   * missing/invalid token fails closed (403) after auth, before any write.
+   */
+  turnstileVerifier?: TurnstileVerifier | null;
+}
+
+export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRouteOptions = {}) =>
   new Elysia({ prefix: "/api/rsvp" })
     // Gate every method under /api/rsvp behind a valid session cookie.
     .use(sessionAuth(db))
@@ -41,6 +51,15 @@ export const createRsvpRoutes = (db: Db) =>
         }
 
         const raw: unknown = await request.json().catch(() => null);
+
+        // Turnstile bot gate (key-optional; no-op when unconfigured). The
+        // session cookie already authenticated the household above; this is the
+        // anti-automation layer on the spam-prone RSVP write surface.
+        const tsErr = await turnstileGate(turnstileVerifier, "rsvp", raw, request.headers);
+        if (tsErr) {
+          set.status = tsErr.status;
+          return { error: tsErr.error };
+        }
 
         return runCire(
           Effect.gen(function* () {

--- a/cire/api/src/routes/turnstile.test.ts
+++ b/cire/api/src/routes/turnstile.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+
+import { createRateLimiter } from "@shared/rate-limit";
+import type { TurnstileVerifier } from "@shared/turnstile";
+
+import { createApp } from "../app";
+import { createDb, seedDb } from "../db/setup";
+
+/**
+ * Turnstile bot-protection gate on the guest surfaces (`/api/claim`,
+ * `/api/rsvp`). Exercises the key-optional contract end-to-end through the
+ * full app (CORS + origin guard + rate limit + the gate).
+ *
+ * Every request carries `cf-connecting-ip` (the fail-closed limiter denies a
+ * request without a resolvable IP) and a same-origin `Origin` (the origin guard
+ * gates state-changing methods).
+ */
+
+const db = createDb(":memory:");
+beforeAll(() => seedDb(db));
+
+/** Stub verifier with inspectable verdict + captured args. */
+function stubVerifier(ok: boolean): TurnstileVerifier & {
+  calls: Array<{ token: string | null | undefined; remoteip?: string | null }>;
+} {
+  const calls: Array<{ token: string | null | undefined; remoteip?: string | null }> = [];
+  return {
+    calls,
+    async verify(token, remoteip) {
+      calls.push({ token, remoteip });
+      if (!token || token.trim() === "")
+        return { ok: false, errorCodes: ["missing-input-response"] };
+      return { ok, errorCodes: ok ? [] : ["invalid-input-response"] };
+    },
+  };
+}
+
+const headers = (extra: Record<string, string> = {}) => ({
+  "Content-Type": "application/json",
+  "cf-connecting-ip": "203.0.113.7",
+  Origin: "http://localhost:4321",
+  ...extra,
+});
+
+function appWith(verifier: TurnstileVerifier | null) {
+  return createApp(db, {
+    claimLimiter: createRateLimiter({ maxRequests: 10_000, windowMs: 60_000 }),
+    turnstileVerifier: verifier,
+  });
+}
+
+describe("Turnstile gate — UNCONFIGURED is a clean no-op", () => {
+  it("/api/claim succeeds with no token when Turnstile is unconfigured", async () => {
+    const app = appWith(null);
+    const res = await app.fetch(
+      new Request("http://localhost/api/claim", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ publicId: "TESTONE-IVY-AA11" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("Turnstile gate on /api/claim — CONFIGURED (fail-closed)", () => {
+  it("passes a valid token through to the credential lookup", async () => {
+    const verifier = stubVerifier(true);
+    const app = appWith(verifier);
+    const res = await app.fetch(
+      new Request("http://localhost/api/claim", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ publicId: "TESTONE-IVY-AA11", turnstileToken: "good" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(verifier.calls).toHaveLength(1);
+    expect(verifier.calls[0]!.token).toBe("good");
+    expect(verifier.calls[0]!.remoteip).toBe("203.0.113.7");
+  });
+
+  it("rejects (403) a missing token BEFORE the credential lookup", async () => {
+    const verifier = stubVerifier(true);
+    const app = appWith(verifier);
+    const res = await app.fetch(
+      new Request("http://localhost/api/claim", {
+        method: "POST",
+        headers: headers(),
+        // A VALID code, but no token — must still be rejected by the gate, and
+        // the claim lookup must never run (no session minted).
+        body: JSON.stringify({ publicId: "TESTONE-IVY-AA11" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  it("rejects (403) an invalid token", async () => {
+    const app = appWith(stubVerifier(false));
+    const res = await app.fetch(
+      new Request("http://localhost/api/claim", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ publicId: "TESTONE-IVY-AA11", turnstileToken: "bad" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("Turnstile gate on /api/rsvp — CONFIGURED (fail-closed)", () => {
+  /** Claim first (with a passing gate) to obtain a session cookie. */
+  async function claimSession(verifier: TurnstileVerifier): Promise<string> {
+    const app = appWith(verifier);
+    const res = await app.fetch(
+      new Request("http://localhost/api/claim", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ publicId: "TESTONE-IVY-AA11", turnstileToken: "good" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const cookie = res.headers.get("Set-Cookie");
+    expect(cookie).not.toBeNull();
+    return cookie!.split(";")[0]!;
+  }
+
+  it("rejects (403) an RSVP with a missing token even with a valid session", async () => {
+    const verifier = stubVerifier(true);
+    const sessionCookie = await claimSession(verifier);
+    const app = appWith(verifier);
+    const res = await app.fetch(
+      new Request("http://localhost/api/rsvp", {
+        method: "POST",
+        headers: headers({ Cookie: sessionCookie }),
+        body: JSON.stringify({ rsvps: [] }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("passes a valid token + session through to the RSVP handler", async () => {
+    const verifier = stubVerifier(true);
+    const sessionCookie = await claimSession(verifier);
+    const app = appWith(verifier);
+    const res = await app.fetch(
+      new Request("http://localhost/api/rsvp", {
+        method: "POST",
+        headers: headers({ Cookie: sessionCookie }),
+        // Empty batch is a valid no-op RSVP — reaches the handler (200), proving
+        // the gate let it through.
+        body: JSON.stringify({ rsvps: [], turnstileToken: "good" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/cire/organiser/.env.example
+++ b/cire/organiser/.env.example
@@ -11,3 +11,9 @@ PUBLIC_OSN_ISSUER_URL=http://localhost:4000
 # with the wedding's host preview code pre-filled. Production:
 # https://cireweddings.com.
 PUBLIC_CIRE_WEB_URL=http://localhost:4321
+# Optional. Cloudflare Turnstile sitekey (PUBLIC) for organiser passkey sign-in +
+# registration. When set, the SignIn / Register forms render the Turnstile
+# challenge and gate on it, and osn-api enforces siteverify (set TURNSTILE_SECRET_KEY
+# on the osn-api Worker). Unset/blank ⇒ key-optional no-op. Bakes in at build time.
+# Use the same widget as the guest site (domains include app.cireweddings.com).
+PUBLIC_TURNSTILE_SITEKEY=

--- a/cire/organiser/src/components/SignInPanel.tsx
+++ b/cire/organiser/src/components/SignInPanel.tsx
@@ -10,6 +10,10 @@ const loginClient = createLoginClient({ issuerUrl: OSN_ISSUER_URL });
 const recoveryClient = createRecoveryClient({ issuerUrl: OSN_ISSUER_URL });
 const registrationClient = createRegistrationClient({ issuerUrl: OSN_ISSUER_URL });
 
+// Public Turnstile sitekey, baked in at build time. Undefined ⇒ key-optional
+// (no widget rendered; osn-api also skips siteverify). See deploy runbook.
+const TURNSTILE_SITEKEY = import.meta.env.PUBLIC_TURNSTILE_SITEKEY;
+
 type Mode = "signin" | "register";
 
 const toDashboard = () => {
@@ -32,7 +36,12 @@ export default function SignInPanel() {
         when={mode() === "register"}
         fallback={
           <div class="flex flex-col gap-4">
-            <SignIn client={loginClient} recoveryClient={recoveryClient} onSuccess={toDashboard} />
+            <SignIn
+              client={loginClient}
+              recoveryClient={recoveryClient}
+              onSuccess={toDashboard}
+              turnstileSiteKey={TURNSTILE_SITEKEY}
+            />
             <p class="text-muted-foreground text-center text-sm">
               New to OSN?{" "}
               <button
@@ -50,6 +59,7 @@ export default function SignInPanel() {
           client={registrationClient}
           onCancel={() => setMode("signin")}
           onSuccess={toDashboard}
+          turnstileSiteKey={TURNSTILE_SITEKEY}
         />
       </Show>
       <Toaster position="bottom-right" />

--- a/cire/organiser/src/env.d.ts
+++ b/cire/organiser/src/env.d.ts
@@ -7,6 +7,13 @@ interface ImportMetaEnv {
   readonly PUBLIC_CIRE_API_URL?: string;
   /** Legacy name for the cire/api origin; still honoured as a fallback. */
   readonly PUBLIC_API_URL?: string;
+  /**
+   * Cloudflare Turnstile sitekey (public, build-time) for organiser passkey
+   * sign-in + registration. When set, the SignIn / Register forms render the
+   * Turnstile challenge and gate on it; osn-api enforces siteverify. Unset ⇒
+   * key-optional no-op.
+   */
+  readonly PUBLIC_TURNSTILE_SITEKEY?: string;
 }
 
 interface ImportMeta {

--- a/cire/web/.env.example
+++ b/cire/web/.env.example
@@ -15,3 +15,11 @@ PUBLIC_WEDDING_SLUG=cire-wedding
 # This key bakes into static HTML at build time, so it MUST be referrer-restricted
 # to the guest-site origin(s) at the Maps Platform console.
 PUBLIC_GOOGLE_MAPS_EMBED_KEY=
+# Optional. Cloudflare Turnstile sitekey (PUBLIC — safe to embed in client HTML).
+# When set, the guest claim + RSVP forms render the Turnstile bot-challenge and
+# gate submit on it, and the cire-api Worker enforces siteverify (set the matching
+# TURNSTILE_SECRET_KEY there via `wrangler secret put`). When unset/blank, no
+# widget renders and no siteverify runs — key-optional, so this is a pure
+# enhancement. Bakes into static HTML at build time. Create the widget at
+# Cloudflare dash → Turnstile (domains: cireweddings.com + app.cireweddings.com).
+PUBLIC_TURNSTILE_SITEKEY=

--- a/cire/web/env.d.ts
+++ b/cire/web/env.d.ts
@@ -3,6 +3,13 @@
 interface ImportMetaEnv {
   readonly PUBLIC_API_URL: string;
   readonly PUBLIC_SITE_URL?: string;
+  /**
+   * Cloudflare Turnstile sitekey (public — safe to embed in client HTML). When
+   * set, the guest claim + RSVP forms render the Turnstile challenge and gate
+   * submit on it; the cire-api Worker enforces siteverify. Unset/blank ⇒ no
+   * widget, no gate (key-optional). Baked in at build time by Vite.
+   */
+  readonly PUBLIC_TURNSTILE_SITEKEY?: string;
 }
 
 interface ImportMeta {

--- a/cire/web/src/components/LoginSection.tsx
+++ b/cire/web/src/components/LoginSection.tsx
@@ -1,5 +1,6 @@
 import { createSignal, onMount, Show, For } from "solid-js";
 
+import { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";
 import type { ClaimResult } from "./types";
 import { isValidClaimResponse } from "./utils";
 
@@ -15,10 +16,20 @@ export function LoginSection(props: LoginSectionProps) {
   const [code, setCode] = createSignal("");
   const [loading, setLoading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+  // Turnstile token. `null` until the widget solves; only REQUIRED when a
+  // sitekey is configured (`turnstileEnabled()`). When Turnstile is off, this
+  // stays null and submit proceeds without it.
+  const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
 
   async function submitCode(rawCode: string) {
     const publicId = rawCode.trim().toUpperCase();
     if (!publicId) return;
+    // Block submit until the challenge is solved when Turnstile is configured.
+    const token = turnstileToken();
+    if (turnstileEnabled() && !token) {
+      setError("Please complete the verification challenge below.");
+      return;
+    }
     setError(null);
     setLoading(true);
 
@@ -29,7 +40,9 @@ export function LoginSection(props: LoginSectionProps) {
         // Include cookies so the API's Set-Cookie response sticks for follow-up
         // calls (e.g. /api/rsvp). Requires CORS `credentials: true` server-side.
         credentials: "include",
-        body: JSON.stringify({ publicId }),
+        // `turnstileToken` is included only when present; the server treats a
+        // missing token as a hard fail ONLY when it has a secret configured.
+        body: JSON.stringify(token ? { publicId, turnstileToken: token } : { publicId }),
       });
 
       if (res.status === 401) {
@@ -112,10 +125,13 @@ export function LoginSection(props: LoginSectionProps) {
                 {error()}
               </p>
             </Show>
+            {/* Turnstile challenge — renders only when a sitekey is configured;
+                otherwise this is nothing and the form is unchanged. */}
+            <TurnstileWidget onToken={setTurnstileToken} class="flex justify-center" />
             <button
               type="submit"
               class="border-gold font-body text-gold hover:bg-gold hover:text-bg disabled:hover:text-gold rounded-sm border bg-transparent px-6 py-3.5 text-[0.88rem] tracking-[0.12em] uppercase transition-colors duration-200 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
-              disabled={loading() || !code().trim()}
+              disabled={loading() || !code().trim() || (turnstileEnabled() && !turnstileToken())}
             >
               {loading() ? "Checking\u2026" : "Open Invitation"}
             </button>

--- a/cire/web/src/components/RsvpModal.tsx
+++ b/cire/web/src/components/RsvpModal.tsx
@@ -1,6 +1,7 @@
 import { createMemo, createSignal, createUniqueId, onCleanup, Show, For } from "solid-js";
 
 import { AnimatedModal } from "./AnimatedModal";
+import { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";
 import type { EventSummary, FamilyMember, RsvpSummary } from "./types";
 
 interface RsvpModalProps {
@@ -56,6 +57,8 @@ export function RsvpModal(props: RsvpModalProps) {
   const [responses, setResponses] = createSignal<Record<string, MemberState>>(initialResponses());
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
+  // Turnstile token — REQUIRED only when a sitekey is configured.
+  const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
   const titleId = createUniqueId();
 
   // Abort the in-flight submit if the modal unmounts mid-request — keeps the
@@ -111,9 +114,17 @@ export function RsvpModal(props: RsvpModalProps) {
       return;
     }
 
+    // Block submit until the challenge is solved when Turnstile is configured.
+    const token = turnstileToken();
+    if (turnstileEnabled() && !token) {
+      setError("Please complete the verification challenge below.");
+      return;
+    }
+
     setLoading(true);
 
     const body = {
+      ...(token ? { turnstileToken: token } : {}),
       rsvps: visible.map((m) => {
         const state = current[m.guestId]!;
         const attending = state.attending === "attending";
@@ -270,6 +281,9 @@ export function RsvpModal(props: RsvpModalProps) {
           </p>
         </Show>
 
+        {/* Turnstile challenge — renders only when a sitekey is configured. */}
+        <TurnstileWidget onToken={setTurnstileToken} class="flex justify-center" />
+
         <div class="border-border bg-surface sticky bottom-0 -mx-6 -mb-10 flex gap-3 border-t px-6 py-4">
           <button
             type="button"
@@ -282,7 +296,7 @@ export function RsvpModal(props: RsvpModalProps) {
           <button
             type="submit"
             class="border-gold font-body text-gold hover:bg-gold hover:text-bg disabled:hover:text-gold flex-1 cursor-pointer rounded-sm border bg-transparent px-4 py-3 text-[0.82rem] tracking-[0.1em] uppercase transition-colors duration-200 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
-            disabled={loading()}
+            disabled={loading() || (turnstileEnabled() && !turnstileToken())}
           >
             {loading() ? "Saving…" : "Save"}
           </button>

--- a/cire/web/src/components/TurnstileWidget.test.tsx
+++ b/cire/web/src/components/TurnstileWidget.test.tsx
@@ -1,0 +1,49 @@
+import { render, cleanup } from "@solidjs/testing-library";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { TurnstileWidget, turnstileEnabled, turnstileSiteKey } from "./TurnstileWidget";
+
+/**
+ * Key-optional render contract for the guest-site Turnstile widget. The sitekey
+ * is read from `import.meta.env.PUBLIC_TURNSTILE_SITEKEY` (stubbed here). When
+ * unset, the widget renders nothing and never injects the Cloudflare script, so
+ * the claim + RSVP forms behave exactly as before Turnstile existed.
+ */
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+  document.getElementById("cf-turnstile-script")?.remove();
+});
+
+describe("turnstileEnabled / turnstileSiteKey", () => {
+  it("is disabled when the env var is unset", () => {
+    vi.stubEnv("PUBLIC_TURNSTILE_SITEKEY", "");
+    expect(turnstileSiteKey()).toBeUndefined();
+    expect(turnstileEnabled()).toBe(false);
+  });
+
+  it("is enabled when a sitekey is configured", () => {
+    vi.stubEnv("PUBLIC_TURNSTILE_SITEKEY", "0x4AAAtest");
+    expect(turnstileSiteKey()).toBe("0x4AAAtest");
+    expect(turnstileEnabled()).toBe(true);
+  });
+});
+
+describe("TurnstileWidget render", () => {
+  it("renders nothing + injects no script when unconfigured", () => {
+    vi.stubEnv("PUBLIC_TURNSTILE_SITEKEY", "");
+    const onToken = vi.fn();
+    const { container } = render(() => <TurnstileWidget onToken={onToken} />);
+    expect(container.querySelector("div")).toBeNull();
+    expect(document.getElementById("cf-turnstile-script")).toBeNull();
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it("renders the challenge wrapper when configured", () => {
+    vi.stubEnv("PUBLIC_TURNSTILE_SITEKEY", "0x4AAAtest");
+    const onToken = vi.fn();
+    const { container } = render(() => <TurnstileWidget onToken={onToken} />);
+    expect(container.querySelector("div")).not.toBeNull();
+  });
+});

--- a/cire/web/src/components/TurnstileWidget.tsx
+++ b/cire/web/src/components/TurnstileWidget.tsx
@@ -1,0 +1,180 @@
+import { createSignal, createUniqueId, onCleanup, onMount, Show } from "solid-js";
+
+/**
+ * Cloudflare Turnstile widget — KEY-OPTIONAL Solid island for the guest site.
+ *
+ * Mirrors the maps-embed key-optional pattern (`MapPreview`): the sitekey is
+ * read from `import.meta.env.PUBLIC_TURNSTILE_SITEKEY`, statically inlined by
+ * Vite at build time. When it is absent (no key configured yet), the component
+ * renders NOTHING and the form behaves exactly as before — so this ships safely
+ * before the widget exists. When present, it lazily injects Cloudflare's small
+ * `api.js` script (only on first use, never unconditionally), renders the
+ * widget explicitly, and reports the token via `onToken`.
+ *
+ * The sitekey is public by design (it is embedded in client HTML); the secret
+ * lives only on the Worker. The `data-action` carries the Spin telemetry marker.
+ *
+ * Contract for the parent form:
+ *  - Read `PUBLIC_TURNSTILE_SITEKEY` (via {@link turnstileEnabled}) to decide
+ *    whether a token is REQUIRED before submit. When the key is unset, submit
+ *    proceeds with no token (server skips siteverify too).
+ *  - When the key is set, gate submit on a non-null token from `onToken`.
+ */
+
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+const SCRIPT_ID = "cf-turnstile-script";
+
+/** The build-time sitekey, or undefined when Turnstile is not configured. */
+export function turnstileSiteKey(): string | undefined {
+  const key = import.meta.env.PUBLIC_TURNSTILE_SITEKEY;
+  return key && key.trim() !== "" ? key : undefined;
+}
+
+/** True when a sitekey is configured (the widget will render + gate submit). */
+export function turnstileEnabled(): boolean {
+  return turnstileSiteKey() !== undefined;
+}
+
+/** Minimal shape of the global `turnstile` object we call. */
+interface TurnstileApi {
+  render(
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      action?: string;
+      callback?: (token: string) => void;
+      "expired-callback"?: () => void;
+      "error-callback"?: () => void;
+      "timeout-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+    },
+  ): string;
+  remove(widgetId: string): void;
+  reset(widgetId?: string): void;
+}
+
+function getTurnstile(): TurnstileApi | undefined {
+  return (globalThis as { turnstile?: TurnstileApi }).turnstile;
+}
+
+/** Inject Cloudflare's api.js once; resolve when `window.turnstile` is ready. */
+let scriptPromise: Promise<void> | null = null;
+function loadTurnstileScript(): Promise<void> {
+  if (getTurnstile()) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    const onReady = () => {
+      // api.js may set `window.turnstile` slightly after `load`; poll briefly.
+      const start = Date.now();
+      const tick = () => {
+        if (getTurnstile()) return resolve();
+        if (Date.now() - start > 10_000) return reject(new Error("turnstile load timeout"));
+        setTimeout(tick, 50);
+      };
+      tick();
+    };
+    if (existing) {
+      if (getTurnstile()) resolve();
+      else existing.addEventListener("load", onReady, { once: true });
+      return;
+    }
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", onReady, { once: true });
+    script.addEventListener("error", () => reject(new Error("turnstile script error")), {
+      once: true,
+    });
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+interface TurnstileWidgetProps {
+  /**
+   * Fires with a fresh token on success, and with `null` when the token expires
+   * / errors so the parent can re-disable submit. No-op when Turnstile is off.
+   */
+  onToken: (token: string | null) => void;
+  /** Widget theme. Defaults to "auto". */
+  theme?: "light" | "dark" | "auto";
+  /** Optional extra classes on the wrapper. */
+  class?: string;
+}
+
+/**
+ * Renders the Turnstile challenge when a sitekey is configured; renders nothing
+ * otherwise. Cleans up the widget instance on unmount.
+ */
+export function TurnstileWidget(props: TurnstileWidgetProps) {
+  const siteKey = turnstileSiteKey();
+  const [failed, setFailed] = createSignal(false);
+  const labelId = createUniqueId();
+  let container: HTMLDivElement | undefined;
+  let widgetId: string | undefined;
+
+  onMount(() => {
+    if (!siteKey || !container) return;
+    loadTurnstileScript()
+      .then(() => {
+        const ts = getTurnstile();
+        if (!ts || !container) {
+          setFailed(true);
+          return;
+        }
+        widgetId = ts.render(container, {
+          sitekey: siteKey,
+          // Spin telemetry marker (account-level aggregate; carries no PII).
+          action: "turnstile-spin-v1",
+          theme: props.theme ?? "auto",
+          callback: (token) => {
+            setFailed(false);
+            props.onToken(token);
+          },
+          "expired-callback": () => props.onToken(null),
+          "timeout-callback": () => props.onToken(null),
+          "error-callback": () => {
+            setFailed(true);
+            props.onToken(null);
+          },
+        });
+      })
+      .catch(() => {
+        // Network failure loading api.js. Surface a hint; the parent keeps
+        // submit disabled because no token ever arrives (fail-closed on the UX
+        // side too — the server enforces the real gate).
+        setFailed(true);
+        props.onToken(null);
+      });
+  });
+
+  onCleanup(() => {
+    const ts = getTurnstile();
+    if (ts && widgetId) {
+      try {
+        ts.remove(widgetId);
+      } catch {
+        // Widget already torn down — ignore.
+      }
+    }
+  });
+
+  return (
+    <Show when={siteKey}>
+      <div class={props.class}>
+        <div ref={container} aria-labelledby={labelId} />
+        <span id={labelId} class="sr-only">
+          Human verification challenge
+        </span>
+        <Show when={failed()}>
+          <p class="font-body text-error mt-2 text-[0.78rem]" role="alert">
+            Couldn&apos;t load the verification challenge. Refresh and try again.
+          </p>
+        </Show>
+      </div>
+    </Show>
+  );
+}

--- a/osn/api/.env.example
+++ b/osn/api/.env.example
@@ -58,3 +58,13 @@ OSN_REFRESH_TOKEN_TTL=2592000
 # Must match INTERNAL_SERVICE_SECRET in each client service's environment.
 # Leave unset to disable the registration endpoint (returns 501).
 INTERNAL_SERVICE_SECRET=change-me-to-a-shared-random-secret
+
+# Cloudflare Turnstile secret key (bot protection). KEY-OPTIONAL: when set,
+# /register/begin and /login/passkey/begin REQUIRE a valid Turnstile token and
+# fail-closed (reject on missing/invalid/duplicate). When unset (the default,
+# both locally and in any tier), those gates are skipped and the flows behave
+# exactly as before — safe to leave unset until the widget exists. This is the
+# server half of the public PUBLIC_TURNSTILE_SITEKEY embedded in the organiser
+# portal / osn-social builds. NEVER commit the value — in deployed tiers set it
+# with `wrangler secret put TURNSTILE_SECRET_KEY` (see production-deploy runbook).
+# TURNSTILE_SECRET_KEY=

--- a/osn/api/package.json
+++ b/osn/api/package.json
@@ -24,6 +24,7 @@
     "@shared/observability": "workspace:*",
     "@shared/rate-limit": "workspace:*",
     "@shared/redis": "workspace:*",
+    "@shared/turnstile": "workspace:*",
     "@simplewebauthn/server": "^13.3.0",
     "drizzle-orm": "^0.45.2",
     "effect": "^3.21.2",

--- a/osn/api/src/app.ts
+++ b/osn/api/src/app.ts
@@ -2,6 +2,7 @@ import { cors } from "@elysiajs/cors";
 import { DbLive } from "@osn/db/service";
 import { healthRoutes, observabilityPlugin } from "@shared/observability";
 import type { ClientIpOptions } from "@shared/rate-limit";
+import type { TurnstileVerifier } from "@shared/turnstile";
 import { Elysia } from "elysia";
 
 import type { CookieSessionConfig } from "./lib/cookie-session";
@@ -101,6 +102,14 @@ export interface AppDeps {
    */
   internalServiceSecret: string | undefined;
   /**
+   * Cloudflare Turnstile verifier (bot protection). KEY-OPTIONAL: `null` when
+   * the `TURNSTILE_SECRET_KEY` secret is unset ⇒ the register / passkey-login
+   * gates are skipped. A verifier ⇒ those gates enforce siteverify, fail-closed.
+   * Built once per isolate in the composition root and threaded into
+   * `createAuthRoutes`.
+   */
+  turnstileVerifier: TurnstileVerifier | null;
+  /**
    * Elysia ahead-of-time handler compilation. AOT uses `new Function(...)`,
    * which workerd forbids ("Code generation from strings disallowed"). The Bun
    * path leaves this `true` (default, faster); the Workers entry passes `false`.
@@ -138,6 +147,7 @@ export function createApp(deps: AppDeps) {
     emailChangeBeginCap,
     clientIpConfig,
     internalServiceSecret,
+    turnstileVerifier,
     aot,
   } = deps;
 
@@ -180,6 +190,7 @@ export function createApp(deps: AppDeps) {
         cookieConfig,
         clientIpConfig,
         appRuntime,
+        turnstileVerifier,
       ),
     )
     .use(createGraphRoutes(authConfig, DbLive, observabilityLayer, graphRateLimiter, appRuntime))

--- a/osn/api/src/build-deps.ts
+++ b/osn/api/src/build-deps.ts
@@ -3,6 +3,7 @@ import { generateArcKeyPair, importKeyFromJwk, thumbprintKid } from "@shared/cry
 import type { EmailService } from "@shared/email";
 import type { RedisClient } from "@shared/redis";
 import { sanitizeCause } from "@shared/redis";
+import { createTurnstileVerifier } from "@shared/turnstile";
 import { Effect, Layer, ManagedRuntime } from "effect";
 
 import type { AppDeps } from "./app";
@@ -324,6 +325,12 @@ export async function buildAppDeps(env: EnvRecord, parts: BuildParts): Promise<B
     // Gates the S2S service-registration endpoints. On workerd this is a
     // wrangler secret, surfaced via the `env` binding; on Bun it's process.env.
     internalServiceSecret: env.INTERNAL_SERVICE_SECRET,
+    // Turnstile bot protection (KEY-OPTIONAL). `TURNSTILE_SECRET_KEY` is a
+    // wrangler secret (`env` on workerd, process.env on Bun). Unset ⇒ `null` ⇒
+    // the register / passkey-login gates are skipped (flow unchanged). Set ⇒ a
+    // fail-closed verifier enforces siteverify on those endpoints. The secret is
+    // read here and never logged or placed in any other dep.
+    turnstileVerifier: createTurnstileVerifier(env.TURNSTILE_SECRET_KEY),
     // AOT and the observability plugin co-vary by runtime: both ON for Bun,
     // both OFF for workerd (AOT's `new Function` is forbidden there). The
     // `includeObservabilityPlugin` flag is the single Bun-vs-Workers

--- a/osn/api/src/index.ts
+++ b/osn/api/src/index.ts
@@ -70,6 +70,10 @@ export interface Env {
   CLOUDFLARE_ACCOUNT_ID?: string;
   CLOUDFLARE_EMAIL_API_TOKEN?: string;
   INTERNAL_SERVICE_SECRET?: string;
+  // Turnstile bot-protection secret (KEY-OPTIONAL). When set, `/register/begin`
+  // and `/login/passkey/begin` require a valid Turnstile token (fail-closed).
+  // Unset ⇒ those gates are skipped. `wrangler secret put TURNSTILE_SECRET_KEY`.
+  TURNSTILE_SECRET_KEY?: string;
 }
 
 const isNonLocal = (env: Env): boolean => !!env.OSN_ENV && env.OSN_ENV !== "local";

--- a/osn/api/src/metrics.ts
+++ b/osn/api/src/metrics.ts
@@ -64,6 +64,7 @@ export const OSN_METRICS = {
   authHandleCheck: "osn.auth.handle.check",
   authOtpSent: "osn.auth.otp.sent",
   authRateLimited: "osn.auth.rate_limited",
+  authTurnstileRejected: "osn.auth.turnstile.rejected",
   authSessionRotations: "osn.auth.session.rotations",
   authSessionReuseDetected: "osn.auth.session.reuse_detected",
   authSessionFamilyRevoked: "osn.auth.session.family_revoked",
@@ -118,6 +119,9 @@ type TokenRefreshAttrs = { result: Result };
 type HandleCheckAttrs = { result: "available" | "taken" | "invalid" };
 type OtpSentAttrs = { purpose: "registration" | "step_up" | "email_change" };
 type AuthRateLimitAttrs = { endpoint: AuthRateLimitedEndpoint };
+/** Turnstile-gated endpoints. Bounded literal union — never a raw path. */
+type AuthTurnstileEndpoint = "register_begin" | "passkey_login_begin";
+type AuthTurnstileRejectedAttrs = { endpoint: AuthTurnstileEndpoint };
 type GraphConnectionAttrs = { action: GraphConnectionAction; result: Result };
 type GraphBlockAttrs = { action: GraphBlockAction; result: Result };
 type OrgAttrs = { action: OrgAction; result: Result };
@@ -448,6 +452,16 @@ export const withProfileCrud =
 
 export const metricAuthRateLimited = (endpoint: AuthRateLimitedEndpoint): void =>
   authRateLimited.inc({ endpoint });
+
+const authTurnstileRejected = createCounter<AuthTurnstileRejectedAttrs>({
+  name: OSN_METRICS.authTurnstileRejected,
+  description: "Auth requests rejected by Turnstile siteverify (fail-closed)",
+  unit: "{rejection}",
+});
+
+/** Records a fail-closed Turnstile rejection on a configured gate. */
+export const metricAuthTurnstileRejected = (endpoint: AuthTurnstileEndpoint): void =>
+  authTurnstileRejected.inc({ endpoint });
 
 // ---------------------------------------------------------------------------
 // Session rotation (Copenhagen Book C2)

--- a/osn/api/src/routes/auth.ts
+++ b/osn/api/src/routes/auth.ts
@@ -8,6 +8,7 @@ import {
   type ClientIpOptions,
   type RateLimiterBackend,
 } from "@shared/rate-limit";
+import type { TurnstileVerifier } from "@shared/turnstile";
 import { Effect, Layer } from "effect";
 import { Elysia, t } from "elysia";
 
@@ -21,7 +22,11 @@ import {
 import { publicError } from "../lib/public-error";
 import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { deriveUaLabel } from "../lib/ua-label";
-import { metricAuthJwksServed, metricAuthRateLimited } from "../metrics";
+import {
+  metricAuthJwksServed,
+  metricAuthRateLimited,
+  metricAuthTurnstileRejected,
+} from "../metrics";
 import { createAuthService, type AuthConfig } from "../services/auth";
 
 /**
@@ -202,6 +207,20 @@ export function createAuthRoutes(
    * (tests), a runtime is built once from `dbLayer` + `loggerLayer`.
    */
   runtime?: AppRuntime,
+  /**
+   * Cloudflare Turnstile verifier (bot protection). KEY-OPTIONAL:
+   *
+   *  - `null` / omitted ⇒ Turnstile is NOT configured (the `TURNSTILE_SECRET_KEY`
+   *    secret is unset). The credential-abuse gates below are skipped entirely
+   *    and the register / passkey-login flows behave exactly as before — this is
+   *    what makes the feature safe to ship before the widget is created.
+   *  - a verifier ⇒ Turnstile IS configured. `/register/begin` and
+   *    `/login/passkey/begin` REQUIRE a valid `turnstileToken` in the body and
+   *    fail CLOSED (400 `turnstile_failed`) on a missing/invalid/duplicate
+   *    token. Tokens are single-use (Cloudflare enforces); the secret never
+   *    leaves the server.
+   */
+  turnstileVerifier: TurnstileVerifier | null = null,
 ) {
   // Fail-fast: validate every limiter slot at construction time (S-L2) so a
   // partially-valid object surfaces immediately instead of on the first
@@ -312,6 +331,34 @@ export function createAuthRoutes(
   }
 
   /**
+   * Turnstile bot-protection gate (KEY-OPTIONAL, fail-closed). Returns `null`
+   * to proceed, or an error sentinel the caller turns into a 400.
+   *
+   *  - `turnstileVerifier === null` (secret unset) ⇒ ALWAYS returns `null`: the
+   *    gate is a no-op, the flow runs as it did before Turnstile existed.
+   *  - configured ⇒ the body's `turnstileToken` is siteverified with the
+   *    caller's `cf-connecting-ip` as `remoteip`. A missing/invalid/duplicate
+   *    token (or an unreachable siteverify) fails CLOSED → `{ error }`. The
+   *    secret is never logged; only the bounded outcome metric is emitted.
+   */
+  async function turnstileGate(
+    endpoint: "register_begin" | "passkey_login_begin",
+    token: string | undefined,
+    headers: Record<string, string | undefined>,
+  ): Promise<{ error: string } | null> {
+    if (!turnstileVerifier) return null;
+    // Prefer Cloudflare's attributed client IP for siteverify's risk scoring.
+    // Absent (local dev / non-CF), Cloudflare simply scores without it.
+    const remoteip = headers["cf-connecting-ip"] ?? null;
+    const result = await turnstileVerifier.verify(token, remoteip);
+    if (!result.ok) {
+      metricAuthTurnstileRejected(endpoint);
+      return { error: "turnstile_failed" };
+    }
+    return null;
+  }
+
+  /**
    * Resolves the authenticated principal for /passkey/register/* calls.
    * The caller must present a Bearer access token whose `sub` matches the
    * body `profileId`; we resolve `accountId` via a DB lookup. New users
@@ -381,6 +428,12 @@ export function createAuthRoutes(
             set.status = 429;
             return rlErr;
           }
+          // Turnstile bot gate (key-optional; no-op when the secret is unset).
+          const tsErr = await turnstileGate("register_begin", body.turnstileToken, headers);
+          if (tsErr) {
+            set.status = 400;
+            return tsErr;
+          }
           try {
             return await run(auth.beginRegistration(body.email, body.handle, body.displayName));
           } catch (e) {
@@ -394,6 +447,10 @@ export function createAuthRoutes(
             email: t.String(),
             handle: t.String(),
             displayName: t.Optional(t.String()),
+            // Turnstile widget token. Optional at the schema level so the
+            // endpoint still accepts requests when Turnstile is unconfigured;
+            // when configured, `turnstileGate` rejects a missing/invalid value.
+            turnstileToken: t.Optional(t.String()),
           }),
         },
       )
@@ -612,6 +669,12 @@ export function createAuthRoutes(
             set.status = 429;
             return rlErr;
           }
+          // Turnstile bot gate (key-optional; no-op when the secret is unset).
+          const tsErr = await turnstileGate("passkey_login_begin", body.turnstileToken, headers);
+          if (tsErr) {
+            set.status = 400;
+            return tsErr;
+          }
           try {
             // M-PK: identifier is optional. Omitting it kicks off the
             // discoverable-credential / conditional-UI flow and the
@@ -625,7 +688,12 @@ export function createAuthRoutes(
           }
         },
         {
-          body: t.Object({ identifier: t.Optional(t.String()) }),
+          body: t.Object({
+            identifier: t.Optional(t.String()),
+            // Turnstile widget token (see /register/begin). Optional in the
+            // schema; enforced by `turnstileGate` only when configured.
+            turnstileToken: t.Optional(t.String()),
+          }),
         },
       )
       .post(

--- a/osn/api/tests/routes/auth-turnstile.test.ts
+++ b/osn/api/tests/routes/auth-turnstile.test.ts
@@ -1,0 +1,180 @@
+import type { TurnstileVerifier } from "@shared/turnstile";
+import { Layer } from "effect";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { createAuthRoutes } from "../../src/routes/auth";
+import { makeTestAuthConfig } from "../helpers/auth-config";
+import { createTestLayer } from "../helpers/db";
+
+/**
+ * Turnstile bot-protection gate on `/register/begin` + `/login/passkey/begin`.
+ *
+ * These tests drive the RAW `createAuthRoutes` factory (not the XFF test
+ * wrapper) so they can inject the 8th `turnstileVerifier` argument directly.
+ * Per-IP keying isn't under test here, so each request carries an
+ * `x-forwarded-for`; the routes run in direct mode (no `clientIpConfig`), which
+ * trusts the socket peer — absent a Bun server that resolves to UNRESOLVED and
+ * the rate-limit gate denies BEFORE the Turnstile gate. To exercise the
+ * Turnstile branch we pass `{ trustedProxyCount: 1 }` so XFF keys the limiter.
+ */
+
+let config: Awaited<ReturnType<typeof makeTestAuthConfig>>;
+beforeAll(async () => {
+  config = await makeTestAuthConfig();
+});
+
+/** A stub verifier whose verdict + last-seen args are inspectable. */
+function stubVerifier(ok: boolean): TurnstileVerifier & {
+  calls: Array<{ token: string | null | undefined; remoteip?: string | null }>;
+} {
+  const calls: Array<{ token: string | null | undefined; remoteip?: string | null }> = [];
+  return {
+    calls,
+    async verify(token, remoteip) {
+      calls.push({ token, remoteip });
+      // Mirror the real fail-closed behaviour for a blank token.
+      if (!token || token.trim() === "")
+        return { ok: false, errorCodes: ["missing-input-response"] };
+      return { ok, errorCodes: ok ? [] : ["invalid-input-response"] };
+    },
+  };
+}
+
+function buildApp(verifier: TurnstileVerifier | null) {
+  const layer = createTestLayer();
+  return createAuthRoutes(
+    config,
+    layer,
+    Layer.empty,
+    undefined,
+    { secure: false },
+    { trustedProxyCount: 1 },
+    undefined,
+    verifier,
+  );
+}
+
+const headers = { "Content-Type": "application/json", "x-forwarded-for": "203.0.113.9" };
+
+describe("Turnstile gate — UNCONFIGURED (verifier null) is a clean no-op", () => {
+  it("/register/begin proceeds with no token when Turnstile is unconfigured", async () => {
+    const app = buildApp(null);
+    const res = await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ email: "a@example.com", handle: "noturnstile" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { sent: boolean }).sent).toBe(true);
+  });
+
+  it("/login/passkey/begin proceeds with no token when Turnstile is unconfigured", async () => {
+    const app = buildApp(null);
+    const res = await app.handle(
+      new Request("http://localhost/login/passkey/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ identifier: "ghost@example.com" }),
+      }),
+    );
+    // 200 (challenge issued) — never 400 from a Turnstile gate that's off.
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("Turnstile gate — CONFIGURED enforces siteverify (fail-closed)", () => {
+  let verifier: ReturnType<typeof stubVerifier>;
+  beforeEach(() => {
+    verifier = stubVerifier(true);
+  });
+
+  it("/register/begin passes when the token verifies", async () => {
+    const app = buildApp(verifier);
+    const res = await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          email: "ok@example.com",
+          handle: "okhandle",
+          turnstileToken: "good",
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(verifier.calls).toHaveLength(1);
+    expect(verifier.calls[0]!.token).toBe("good");
+    // remoteip is sourced from cf-connecting-ip; absent here ⇒ null.
+    expect(verifier.calls[0]!.remoteip).toBeNull();
+  });
+
+  it("/register/begin rejects (400 turnstile_failed) when the token is missing", async () => {
+    const app = buildApp(verifier);
+    const res = await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ email: "x@example.com", handle: "missingtok" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("turnstile_failed");
+  });
+
+  it("/register/begin rejects when the token is invalid", async () => {
+    const app = buildApp(stubVerifier(false));
+    const res = await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ email: "y@example.com", handle: "badtok", turnstileToken: "nope" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("turnstile_failed");
+  });
+
+  it("passes cf-connecting-ip to siteverify as remoteip", async () => {
+    const app = buildApp(verifier);
+    await app.handle(
+      new Request("http://localhost/register/begin", {
+        method: "POST",
+        headers: { ...headers, "cf-connecting-ip": "198.51.100.4" },
+        body: JSON.stringify({
+          email: "ip@example.com",
+          handle: "iphandle",
+          turnstileToken: "good",
+        }),
+      }),
+    );
+    expect(verifier.calls[0]!.remoteip).toBe("198.51.100.4");
+  });
+
+  it("/login/passkey/begin rejects when the token is missing", async () => {
+    const app = buildApp(verifier);
+    const res = await app.handle(
+      new Request("http://localhost/login/passkey/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ identifier: "user@example.com" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("turnstile_failed");
+  });
+
+  it("/login/passkey/begin passes when the token verifies", async () => {
+    const app = buildApp(verifier);
+    const res = await app.handle(
+      new Request("http://localhost/login/passkey/begin", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ identifier: "user@example.com", turnstileToken: "good" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(verifier.calls).toHaveLength(1);
+  });
+});

--- a/osn/client/src/login.ts
+++ b/osn/client/src/login.ts
@@ -59,8 +59,17 @@ export interface LoginClient {
    * flow, or omit to kick off the discoverable-credential (conditional-UI)
    * flow — the response then carries a `challengeId` the caller must pass
    * to `passkeyComplete`.
+   *
+   * `turnstileToken` is sent to `/login/passkey/begin` when the UI rendered the
+   * Turnstile widget. Optional: osn-api only requires it when its
+   * `TURNSTILE_SECRET_KEY` is configured (fail-closed there); unset ⇒ ignored.
+   * The conditional-UI flow (no identifier) omits it — that ceremony runs
+   * silently in the background before the user interacts with the widget.
    */
-  passkeyBegin(identifier?: string): Promise<{ options: unknown; challengeId?: string }>;
+  passkeyBegin(
+    identifier?: string,
+    turnstileToken?: string,
+  ): Promise<{ options: unknown; challengeId?: string }>;
   /** Complete WebAuthn login — exchange a signed assertion for a session. */
   passkeyComplete(
     input: { identifier: string; assertion: unknown } | { challengeId: string; assertion: unknown },
@@ -76,11 +85,11 @@ export function createLoginClient(config: LoginClientConfig): LoginClient {
   });
 
   return {
-    passkeyBegin: (identifier) =>
-      postJson<{ options: unknown; challengeId?: string }>(
-        `${base}/login/passkey/begin`,
-        identifier === undefined ? {} : { identifier },
-      ),
+    passkeyBegin: (identifier, turnstileToken) =>
+      postJson<{ options: unknown; challengeId?: string }>(`${base}/login/passkey/begin`, {
+        ...(identifier === undefined ? {} : { identifier }),
+        ...(turnstileToken ? { turnstileToken } : {}),
+      }),
 
     passkeyComplete: async (input) => {
       const raw = await postJson<{ session: unknown; profile: LoginProfile }>(

--- a/osn/client/src/register.ts
+++ b/osn/client/src/register.ts
@@ -83,6 +83,12 @@ export interface RegistrationClient {
     email: string;
     handle: string;
     displayName?: string;
+    /**
+     * Cloudflare Turnstile token. Sent to `/register/begin` when the UI rendered
+     * the widget. Optional: osn-api only requires it when its
+     * `TURNSTILE_SECRET_KEY` is configured (fail-closed there); unset ⇒ ignored.
+     */
+    turnstileToken?: string;
   }): Promise<{ sent: boolean }>;
   completeRegistration(input: { email: string; code: string }): Promise<CompleteRegistrationResult>;
   /** WebAuthn options for the first-passkey enrollment. `accessToken` is the one returned by `completeRegistration`. */
@@ -115,8 +121,12 @@ export function createRegistrationClient(config: RegistrationClientConfig): Regi
     return { available: json.available };
   };
 
-  const beginRegistration = (input: { email: string; handle: string; displayName?: string }) =>
-    postJson<{ sent: boolean }>(`${base}/register/begin`, input);
+  const beginRegistration = (input: {
+    email: string;
+    handle: string;
+    displayName?: string;
+    turnstileToken?: string;
+  }) => postJson<{ sent: boolean }>(`${base}/register/begin`, input);
 
   const completeRegistration = async (input: {
     email: string;

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -8,6 +8,7 @@ import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { OtpInput, type OtpStatus } from "../components/ui/otp-input";
+import { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";
 
 type Step = "details" | "verify" | "passkey" | "done";
 
@@ -24,6 +25,13 @@ interface RegisterProps {
    * `session()` directly can omit it.
    */
   onSuccess?: () => void;
+  /**
+   * Cloudflare Turnstile sitekey (public, build-time). When provided, the
+   * "details" step renders the Turnstile challenge and gates "Send verification
+   * code" on it (the token rides on `/register/begin`). Omitted/blank ⇒ no
+   * widget, no gate (key-optional — matches osn-api skipping siteverify).
+   */
+  turnstileSiteKey?: string;
 }
 
 export function Register(props: RegisterProps) {
@@ -43,6 +51,9 @@ export function Register(props: RegisterProps) {
   const [profileId, setProfileId] = createSignal<string | null>(null);
   const [accessToken, setAccessToken] = createSignal<string | null>(null);
   const [passkeyError, setPasskeyError] = createSignal<string | null>(null);
+  // Turnstile token — REQUIRED only when a sitekey is provided.
+  const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
+  const turnstileOn = () => turnstileEnabled(props.turnstileSiteKey);
 
   const [handleStatus, setHandleStatus] = createSignal<
     "idle" | "checking" | "available" | "taken" | "invalid" | "error"
@@ -77,7 +88,10 @@ export function Register(props: RegisterProps) {
     }, 300);
   }
 
-  const detailsValid = () => EMAIL_RE.test(email()) && handleStatus() === "available";
+  const detailsValid = () =>
+    EMAIL_RE.test(email()) &&
+    handleStatus() === "available" &&
+    (!turnstileOn() || turnstileToken() !== null);
 
   async function submitDetails(e: Event) {
     e.preventDefault();
@@ -88,6 +102,7 @@ export function Register(props: RegisterProps) {
         email: email(),
         handle: handle(),
         displayName: displayName().trim() || undefined,
+        turnstileToken: turnstileToken() ?? undefined,
       });
       toast.success("Verification code sent");
       setStep("verify");
@@ -149,6 +164,9 @@ export function Register(props: RegisterProps) {
         email: email(),
         handle: handle(),
         displayName: displayName().trim() || undefined,
+        // Turnstile tokens are single-use; the widget auto-refreshes a fresh one
+        // before the 300s TTL, so the value here is the latest unconsumed token.
+        turnstileToken: turnstileToken() ?? undefined,
       });
       setOtp("");
       setOtpStatus("idle");
@@ -276,6 +294,9 @@ export function Register(props: RegisterProps) {
                 onInput={(e) => setDisplayName(e.currentTarget.value)}
               />
             </div>
+
+            {/* Turnstile challenge — renders only when a sitekey is provided. */}
+            <TurnstileWidget siteKey={props.turnstileSiteKey} onToken={setTurnstileToken} />
 
             <Button type="submit" disabled={!detailsValid() || busy()}>
               {busy() ? "Sending…" : "Send verification code"}

--- a/osn/ui/src/auth/SignIn.tsx
+++ b/osn/ui/src/auth/SignIn.tsx
@@ -8,6 +8,7 @@ import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { RecoveryLoginForm } from "./RecoveryLoginForm";
+import { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";
 
 /**
  * Shared sign-in component. WebAuthn (passkey or security key) is the only
@@ -28,6 +29,15 @@ export interface SignInProps {
   recoveryClient: RecoveryClient;
   onSuccess?: () => void;
   onCancel?: () => void;
+  /**
+   * Cloudflare Turnstile sitekey (public, build-time). When provided, the
+   * identifier-bound passkey form renders the Turnstile challenge and gates
+   * "Continue" on it (the token rides on `/login/passkey/begin`). The silent
+   * conditional-UI (autofill) ceremony does NOT carry a token — it runs in the
+   * background before the user touches the widget, and osn-api only enforces the
+   * gate on the explicit begin call. Omitted/blank ⇒ no widget, no gate.
+   */
+  turnstileSiteKey?: string;
 }
 
 export function SignIn(props: SignInProps) {
@@ -44,6 +54,9 @@ export function SignIn(props: SignInProps) {
   const [busy, setBusy] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [signedIn, setSignedIn] = createSignal(false);
+  // Turnstile token — REQUIRED only when a sitekey is provided.
+  const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
+  const turnstileOn = () => turnstileEnabled(props.turnstileSiteKey);
 
   function reportError(e: unknown, fallback: string) {
     const msg = e instanceof Error ? e.message : fallback;
@@ -61,11 +74,20 @@ export function SignIn(props: SignInProps) {
   async function submitPasskey(e: Event) {
     e.preventDefault();
     if (busy() || !identifier().trim()) return;
+    if (turnstileOn() && !turnstileToken()) {
+      setError("Please complete the verification challenge below.");
+      return;
+    }
     setBusy(true);
     setError(null);
     try {
       const trimmed = identifier().trim();
-      const beginResult = (await client.passkeyBegin(trimmed)) as {
+      const token = turnstileToken() ?? undefined;
+      // Pass the token only when present so the no-Turnstile call shape is
+      // unchanged (single-arg `passkeyBegin(identifier)`).
+      const beginResult = (await (token
+        ? client.passkeyBegin(trimmed, token)
+        : client.passkeyBegin(trimmed))) as {
         options: Parameters<typeof startAuthentication>[0]["optionsJSON"];
       };
       const assertion = await startAuthentication({ optionsJSON: beginResult.options });
@@ -154,7 +176,12 @@ export function SignIn(props: SignInProps) {
               onInput={(e) => setIdentifier(e.currentTarget.value)}
             />
           </div>
-          <Button type="submit" disabled={busy() || !identifier().trim()}>
+          {/* Turnstile challenge — renders only when a sitekey is provided. */}
+          <TurnstileWidget siteKey={props.turnstileSiteKey} onToken={setTurnstileToken} />
+          <Button
+            type="submit"
+            disabled={busy() || !identifier().trim() || (turnstileOn() && !turnstileToken())}
+          >
             {busy() ? "Verifying…" : "Continue"}
           </Button>
           <button

--- a/osn/ui/src/auth/TurnstileWidget.tsx
+++ b/osn/ui/src/auth/TurnstileWidget.tsx
@@ -1,0 +1,158 @@
+import { createSignal, createUniqueId, onCleanup, onMount, Show } from "solid-js";
+
+/**
+ * Cloudflare Turnstile widget — KEY-OPTIONAL Solid island for the OSN auth
+ * surface (Register + SignIn).
+ *
+ * `@osn/ui` is a shared library consumed by multiple apps (the organiser portal,
+ * osn-social), so — unlike the guest-site widget — the sitekey is passed in as a
+ * PROP rather than read from `import.meta.env`. The consuming app reads its own
+ * build-time `PUBLIC_TURNSTILE_SITEKEY` and threads it down.
+ *
+ * Contract: when `siteKey` is undefined/blank, this renders NOTHING and the
+ * parent form behaves exactly as before (Turnstile not configured). When set, it
+ * lazily injects Cloudflare's `api.js`, renders the widget, and reports the
+ * token via `onToken`. The sitekey is public; the secret lives only on osn-api.
+ */
+
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+const SCRIPT_ID = "cf-turnstile-script";
+
+interface TurnstileApi {
+  render(
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      action?: string;
+      callback?: (token: string) => void;
+      "expired-callback"?: () => void;
+      "error-callback"?: () => void;
+      "timeout-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+    },
+  ): string;
+  remove(widgetId: string): void;
+  reset(widgetId?: string): void;
+}
+
+function getTurnstile(): TurnstileApi | undefined {
+  return (globalThis as { turnstile?: TurnstileApi }).turnstile;
+}
+
+let scriptPromise: Promise<void> | null = null;
+function loadTurnstileScript(): Promise<void> {
+  if (getTurnstile()) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    const onReady = () => {
+      const start = Date.now();
+      const tick = () => {
+        if (getTurnstile()) return resolve();
+        if (Date.now() - start > 10_000) return reject(new Error("turnstile load timeout"));
+        setTimeout(tick, 50);
+      };
+      tick();
+    };
+    if (existing) {
+      if (getTurnstile()) resolve();
+      else existing.addEventListener("load", onReady, { once: true });
+      return;
+    }
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", onReady, { once: true });
+    script.addEventListener("error", () => reject(new Error("turnstile script error")), {
+      once: true,
+    });
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+export interface TurnstileWidgetProps {
+  /**
+   * The build-time `PUBLIC_TURNSTILE_SITEKEY` from the consuming app. Undefined
+   * / blank ⇒ Turnstile not configured ⇒ renders nothing.
+   */
+  siteKey?: string;
+  /** Fires with a fresh token on success, `null` on expiry/error. */
+  onToken: (token: string | null) => void;
+  theme?: "light" | "dark" | "auto";
+  class?: string;
+}
+
+/** True when a usable sitekey is provided. */
+export function turnstileEnabled(siteKey: string | undefined): boolean {
+  return !!siteKey && siteKey.trim() !== "";
+}
+
+export function TurnstileWidget(props: TurnstileWidgetProps) {
+  const siteKey = () => (props.siteKey && props.siteKey.trim() !== "" ? props.siteKey : undefined);
+  const [failed, setFailed] = createSignal(false);
+  const labelId = createUniqueId();
+  let container: HTMLDivElement | undefined;
+  let widgetId: string | undefined;
+
+  onMount(() => {
+    const key = siteKey();
+    if (!key || !container) return;
+    loadTurnstileScript()
+      .then(() => {
+        const ts = getTurnstile();
+        if (!ts || !container) {
+          setFailed(true);
+          return;
+        }
+        widgetId = ts.render(container, {
+          sitekey: key,
+          action: "turnstile-spin-v1",
+          theme: props.theme ?? "auto",
+          callback: (token) => {
+            setFailed(false);
+            props.onToken(token);
+          },
+          "expired-callback": () => props.onToken(null),
+          "timeout-callback": () => props.onToken(null),
+          "error-callback": () => {
+            setFailed(true);
+            props.onToken(null);
+          },
+        });
+      })
+      .catch(() => {
+        setFailed(true);
+        props.onToken(null);
+      });
+  });
+
+  onCleanup(() => {
+    const ts = getTurnstile();
+    if (ts && widgetId) {
+      try {
+        ts.remove(widgetId);
+      } catch {
+        // Already torn down.
+      }
+    }
+  });
+
+  return (
+    <Show when={siteKey()}>
+      <div class={props.class}>
+        <div ref={container} aria-labelledby={labelId} />
+        <span id={labelId} class="sr-only">
+          Human verification challenge
+        </span>
+        <Show when={failed()}>
+          <p class="text-destructive mt-2 text-xs" role="alert">
+            Couldn&apos;t load the verification challenge. Refresh and try again.
+          </p>
+        </Show>
+      </div>
+    </Show>
+  );
+}

--- a/osn/ui/src/auth/index.ts
+++ b/osn/ui/src/auth/index.ts
@@ -10,3 +10,4 @@ export { SecurityEventsBanner } from "./SecurityEventsBanner";
 export { SessionsView } from "./SessionsView";
 export { SignIn } from "./SignIn";
 export { StepUpDialog } from "./StepUpDialog";
+export { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";

--- a/osn/ui/tests/auth/TurnstileWidget.test.tsx
+++ b/osn/ui/tests/auth/TurnstileWidget.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { render, cleanup, screen } from "@solidjs/testing-library";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { TurnstileWidget, turnstileEnabled } from "../../src/auth/TurnstileWidget";
+
+/**
+ * Key-optional render contract for the OSN auth Turnstile widget. When no
+ * sitekey is provided it must render NOTHING (and never inject the Cloudflare
+ * script tag) so the surrounding auth forms behave exactly as before Turnstile.
+ */
+
+afterEach(() => {
+  cleanup();
+  document.getElementById("cf-turnstile-script")?.remove();
+});
+
+describe("turnstileEnabled", () => {
+  it("is false for undefined / blank, true for a real key", () => {
+    expect(turnstileEnabled(undefined)).toBe(false);
+    expect(turnstileEnabled("")).toBe(false);
+    expect(turnstileEnabled("   ")).toBe(false);
+    expect(turnstileEnabled("0x4AAA")).toBe(true);
+  });
+});
+
+describe("TurnstileWidget — unconfigured renders nothing", () => {
+  it("renders no container and injects no script when siteKey is undefined", () => {
+    const onToken = vi.fn();
+    const { container } = render(() => <TurnstileWidget siteKey={undefined} onToken={onToken} />);
+    expect(container.querySelector("div")).toBeNull();
+    expect(document.getElementById("cf-turnstile-script")).toBeNull();
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it("renders the challenge wrapper + a11y label when a sitekey is present", () => {
+    const onToken = vi.fn();
+    render(() => <TurnstileWidget siteKey="0x4AAAtest" onToken={onToken} />);
+    // The accessible label is always present in the configured branch.
+    expect(screen.getByText("Human verification challenge")).toBeTruthy();
+  });
+});

--- a/shared/turnstile/package.json
+++ b/shared/turnstile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@shared/turnstile",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
+  },
+  "dependencies": {
+    "@shared/observability": "workspace:*"
+  },
+  "devDependencies": {
+    "@shared/typescript-config": "workspace:*",
+    "vitest": "^4.1.8"
+  }
+}

--- a/shared/turnstile/src/index.ts
+++ b/shared/turnstile/src/index.ts
@@ -1,0 +1,148 @@
+/**
+ * Cloudflare Turnstile server-side siteverify helper — key-optional, fail-closed.
+ *
+ * Shared by every backend that gates a form behind a Turnstile widget
+ * (`@osn/api` register + passkey login, `@cire/api` guest claim + RSVP). The
+ * design mirrors the project's other key-optional integrations (the maps-embed
+ * key and `OSN_EMAIL_OPTIONAL`):
+ *
+ *  - **Secret UNSET** → `createTurnstileVerifier(undefined)` returns `null`. The
+ *    caller treats a `null` verifier as "Turnstile not configured": no token is
+ *    expected, no siteverify call is made, the flow proceeds exactly as it did
+ *    before Turnstile existed. This keeps the PR safe to merge BEFORE the widget
+ *    is created.
+ *  - **Secret SET** → returns a verifier whose `verify(token, remoteip)` calls
+ *    Cloudflare's siteverify endpoint and **fails closed**: a missing, empty,
+ *    invalid, expired, already-redeemed (single-use), or unreachable token all
+ *    resolve to `{ ok: false }`. The caller MUST reject the request on `ok:
+ *    false` — there is no path where a configured secret silently lets a
+ *    request through without a valid token.
+ *
+ * The secret is never logged, never returned to the caller, and never sent
+ * anywhere except Cloudflare's siteverify endpoint over POST. Outbound goes
+ * through `instrumentedFetch` so the call shows up on the trace tree (the token
+ * + secret are NOT annotated onto the span — only the boolean outcome + error
+ * codes, which carry no PII).
+ */
+
+import { instrumentedFetch } from "@shared/observability/fetch";
+
+/** Cloudflare's managed siteverify endpoint. */
+export const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Minimal fetch shape this module needs. Both the global `fetch` and
+ * `@shared/observability`'s `instrumentedFetch` satisfy it; using a structural
+ * type (rather than `typeof fetch`) avoids coupling to lib-dom's `preconnect`
+ * member, which the instrumented wrapper doesn't expose.
+ */
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/** Result of a single siteverify attempt. `ok` is the only field a gate needs. */
+export interface TurnstileVerifyResult {
+  /** True only when Cloudflare confirmed the token is valid + unredeemed. */
+  ok: boolean;
+  /**
+   * Cloudflare's machine-readable error codes (e.g. `invalid-input-response`,
+   * `timeout-or-duplicate`, `missing-input-response`). Safe to log — they carry
+   * no token, no secret, no PII. Empty on success.
+   */
+  errorCodes: readonly string[];
+}
+
+export interface TurnstileVerifier {
+  /**
+   * Verify a client-supplied Turnstile token. Fail-closed: a missing/blank
+   * token short-circuits to `{ ok: false }` without a network call; a network
+   * or parse error also resolves to `{ ok: false }` (never throws).
+   *
+   * @param token    the `cf-turnstile-response` value from the widget
+   * @param remoteip the caller's IP (`cf-connecting-ip`), optional. Passed to
+   *                 siteverify when present for Cloudflare's own risk scoring.
+   */
+  verify(
+    token: string | undefined | null,
+    remoteip?: string | null,
+  ): Promise<TurnstileVerifyResult>;
+}
+
+/** Shape of Cloudflare's siteverify JSON response (subset we read). */
+interface SiteverifyResponse {
+  success?: boolean;
+  "error-codes"?: string[];
+}
+
+/**
+ * Raw siteverify call. Exported for tests + advanced callers; most code should
+ * use {@link createTurnstileVerifier} so the key-optional branch is handled.
+ *
+ * `fetchImpl` is injectable purely for unit tests — production always uses the
+ * instrumented fetch. Never throws: any failure maps to `{ ok: false }`.
+ */
+export async function siteverify(
+  secret: string,
+  token: string,
+  remoteip: string | null | undefined,
+  fetchImpl: FetchLike = instrumentedFetch,
+): Promise<TurnstileVerifyResult> {
+  const form = new URLSearchParams();
+  form.set("secret", secret);
+  form.set("response", token);
+  // remoteip is optional per Cloudflare; only send a real value.
+  if (remoteip) form.set("remoteip", remoteip);
+
+  try {
+    const res = await fetchImpl(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString(),
+      // S-L2: bound the call so a hung siteverify can't tie up the isolate. An
+      // abort lands in the catch below → fail-closed `{ ok: false }`, so a slow
+      // Cloudflare degrades to "reject" rather than "hang then reject".
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) {
+      // A non-2xx from siteverify is an infrastructure failure, not a verdict —
+      // fail closed.
+      return { ok: false, errorCodes: [`http-${res.status}`] };
+    }
+    const data = (await res.json()) as SiteverifyResponse;
+    return {
+      ok: data.success === true,
+      errorCodes: data["error-codes"] ?? [],
+    };
+  } catch {
+    // Network error, abort, malformed JSON — fail closed. We deliberately do
+    // NOT surface the thrown value (it could embed the request body, which
+    // contains the secret) to logs here; the caller logs the boolean outcome.
+    return { ok: false, errorCodes: ["siteverify-unreachable"] };
+  }
+}
+
+/**
+ * Build a verifier from an optional secret.
+ *
+ *  - `secret` unset / empty / whitespace ⇒ returns `null` (Turnstile not
+ *    configured — caller skips the gate entirely).
+ *  - `secret` present ⇒ returns a fail-closed {@link TurnstileVerifier}.
+ *
+ * @param secret   the `TURNSTILE_SECRET_KEY` wrangler secret, or undefined.
+ * @param fetchImpl test seam; defaults to the instrumented fetch.
+ */
+export function createTurnstileVerifier(
+  secret: string | undefined | null,
+  fetchImpl: FetchLike = instrumentedFetch,
+): TurnstileVerifier | null {
+  const trimmed = secret?.trim();
+  if (!trimmed) return null;
+
+  return {
+    async verify(token, remoteip) {
+      // Fail-closed on a missing token without spending a network round-trip.
+      if (!token || token.trim() === "") {
+        return { ok: false, errorCodes: ["missing-input-response"] };
+      }
+      return siteverify(trimmed, token, remoteip ?? null, fetchImpl);
+    },
+  };
+}

--- a/shared/turnstile/tests/turnstile.test.ts
+++ b/shared/turnstile/tests/turnstile.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createTurnstileVerifier, siteverify, SITEVERIFY_URL, type FetchLike } from "../src/index";
+
+/** Build a stub `fetch` that records its call and returns a canned response. */
+function stubFetch(
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {},
+): { fetch: FetchLike; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl: FetchLike = async (url, reqInit) => {
+    calls.push({ url: String(url), init: reqInit });
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+    } as Response;
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+describe("createTurnstileVerifier — key-optional branch", () => {
+  it("returns null when the secret is undefined (unconfigured → skip)", () => {
+    expect(createTurnstileVerifier(undefined)).toBeNull();
+  });
+
+  it("returns null when the secret is empty or whitespace", () => {
+    expect(createTurnstileVerifier("")).toBeNull();
+    expect(createTurnstileVerifier("   ")).toBeNull();
+  });
+
+  it("returns a verifier when a real secret is present", () => {
+    expect(createTurnstileVerifier("0xSECRET")).not.toBeNull();
+  });
+});
+
+describe("verifier.verify — fail-closed semantics (configured)", () => {
+  it("passes on a Cloudflare success:true response", async () => {
+    const { fetch, calls } = stubFetch({ success: true });
+    const verifier = createTurnstileVerifier("0xSECRET", fetch)!;
+    const result = await verifier.verify("good-token", "203.0.113.7");
+    expect(result.ok).toBe(true);
+    expect(result.errorCodes).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(SITEVERIFY_URL);
+  });
+
+  it("rejects on success:false (invalid token)", async () => {
+    const { fetch } = stubFetch({ success: false, "error-codes": ["invalid-input-response"] });
+    const verifier = createTurnstileVerifier("0xSECRET", fetch)!;
+    const result = await verifier.verify("bad-token");
+    expect(result.ok).toBe(false);
+    expect(result.errorCodes).toEqual(["invalid-input-response"]);
+  });
+
+  it("rejects a duplicate (already-redeemed, single-use) token", async () => {
+    const { fetch } = stubFetch({ success: false, "error-codes": ["timeout-or-duplicate"] });
+    const verifier = createTurnstileVerifier("0xSECRET", fetch)!;
+    const result = await verifier.verify("reused-token");
+    expect(result.ok).toBe(false);
+    expect(result.errorCodes).toContain("timeout-or-duplicate");
+  });
+
+  it("rejects a missing/blank token WITHOUT a network call", async () => {
+    const { fetch, calls } = stubFetch({ success: true });
+    const verifier = createTurnstileVerifier("0xSECRET", fetch)!;
+    expect((await verifier.verify(undefined)).ok).toBe(false);
+    expect((await verifier.verify("")).ok).toBe(false);
+    expect((await verifier.verify("   ")).ok).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("fails closed when siteverify returns a non-2xx", async () => {
+    const { fetch } = stubFetch({}, { ok: false, status: 502 });
+    const verifier = createTurnstileVerifier("0xSECRET", fetch)!;
+    const result = await verifier.verify("token");
+    expect(result.ok).toBe(false);
+    expect(result.errorCodes).toEqual(["http-502"]);
+  });
+
+  it("fails closed (never throws) when fetch rejects", async () => {
+    const fetchImpl: FetchLike = async () => {
+      throw new Error("network down");
+    };
+    const verifier = createTurnstileVerifier("0xSECRET", fetchImpl)!;
+    const result = await verifier.verify("token");
+    expect(result.ok).toBe(false);
+    expect(result.errorCodes).toEqual(["siteverify-unreachable"]);
+  });
+});
+
+describe("siteverify — wire format", () => {
+  it("POSTs secret + response + remoteip as urlencoded form", async () => {
+    const { fetch, calls } = stubFetch({ success: true });
+    await siteverify("0xSECRET", "the-token", "203.0.113.7", fetch);
+    const body = String(calls[0]!.init!.body);
+    const params = new URLSearchParams(body);
+    expect(params.get("secret")).toBe("0xSECRET");
+    expect(params.get("response")).toBe("the-token");
+    expect(params.get("remoteip")).toBe("203.0.113.7");
+    expect(calls[0]!.init!.method).toBe("POST");
+  });
+
+  it("omits remoteip when not provided", async () => {
+    const { fetch, calls } = stubFetch({ success: true });
+    await siteverify("0xSECRET", "the-token", null, fetch);
+    const params = new URLSearchParams(String(calls[0]!.init!.body));
+    expect(params.has("remoteip")).toBe(false);
+  });
+
+  it("never embeds the secret in the URL (only the POST body)", async () => {
+    const { fetch, calls } = stubFetch({ success: true });
+    await siteverify("0xSECRET", "tok", "1.2.3.4", fetch);
+    expect(calls[0]!.url).not.toContain("0xSECRET");
+  });
+});

--- a/shared/turnstile/tsconfig.json
+++ b/shared/turnstile/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/node.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/shared/turnstile/vitest.config.ts
+++ b/shared/turnstile/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
+  },
+});

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -275,6 +275,8 @@ bunx wrangler secret put CLOUDFLARE_ACCOUNT_ID      --env <dev|staging|productio
 bunx wrangler secret put CLOUDFLARE_EMAIL_API_TOKEN --env <dev|staging|production>
 # OPTIONAL — only for the cire→osn account-linking ARC bridge (§6.2):
 bunx wrangler secret put INTERNAL_SERVICE_SECRET    --env <dev|staging|production>
+# Turnstile bot protection (OPTIONAL — only after the widget exists, §3.4):
+bunx wrangler secret put TURNSTILE_SECRET_KEY        --env <dev|staging|production>
 # Observability (deferred export on workerd; header is a secret):
 bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|production>
 ```
@@ -298,6 +300,7 @@ bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|producti
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `[env.<env>.vars]` | Recommended | Grafana OTLP gateway. Metric/trace **export is deferred on workerd** — the redacting logger is active, recording call-sites are no-ops until an exporter is attached. [[observability-setup]] |
 | `OTEL_EXPORTER_OTLP_HEADERS` | `wrangler secret put` | Recommended | `Authorization=Basic <base64(instance:token)>`. [[observability-setup]] |
 | `INTERNAL_SERVICE_SECRET` | `wrangler secret put` | **Conditional** | Bearer secret guarding `POST /graph/internal/register-service` (`routes/graph-internal.ts`). Needed **only** to register cire-api's ARC public key (§6.2). Endpoint returns 501 when unset. |
+| `TURNSTILE_SECRET_KEY` | `wrangler secret put` | **Optional (key-optional)** | Cloudflare Turnstile secret. When set, `/register/begin` + `/login/passkey/begin` **require** a valid Turnstile token and **fail-closed** (reject on missing/invalid/duplicate; single-use enforced by Cloudflare). When unset, those gates are skipped and the flows behave as before — safe to leave unset until the widget exists. Server half of the public `PUBLIC_TURNSTILE_SITEKEY` baked into the organiser-portal build. Create the widget in §3.4. (`build-deps.ts` → `createTurnstileVerifier`). |
 | `TRUSTED_PROXY_COUNT` | `[env.<env>.vars]` | Optional | On Workers, Cloudflare sets `cf-connecting-ip`, so this is usually unneeded. Set only if a proxy sits in front and XFF must be trusted N hops. |
 | `OSN_RP_NAME` | `[env.<env>.vars]` | Optional | Display name in passkey prompts (default `OSN`). |
 | `OSN_ACCESS_TOKEN_TTL` / `OSN_REFRESH_TOKEN_TTL` | `[env.<env>.vars]` | Optional | Defaults 300s / 2592000s. |
@@ -316,6 +319,7 @@ bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|producti
 | `CIRE_API_ARC_KEY_ID` | `wrangler secret put CIRE_API_ARC_KEY_ID` | **Conditional** | `kid` matching the public key registered in osn-api `service_accounts` for serviceId `cire-api`. §6.2 |
 | `OSN_API_URL` | `wrangler secret put OSN_API_URL` (or var) | **Conditional** | osn-api base URL the ARC bridge calls. §6.2 |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` | `wrangler secret put` | Recommended | Worker observability. [[observability-setup]] |
+| `TURNSTILE_SECRET_KEY` | `wrangler secret put TURNSTILE_SECRET_KEY` | **Optional (key-optional)** | Cloudflare Turnstile secret. When set, the guest **`/api/claim`** + **`/api/rsvp`** endpoints require a valid Turnstile token and **fail-closed** (403 on missing/invalid/duplicate). Unset ⇒ those gates are skipped (guest flow unchanged). Same widget/secret as osn-api — the widget's domains cover both `cireweddings.com` and `app.cireweddings.com`. Create the widget in §3.4. (`src/index.ts` → `createTurnstileVerifier`). |
 
 > ⚠️ **cire `wrangler.toml` env nuance:** the D1 + R2 bindings are at the **top level**
 > (not under `[env.production]`), while the prod URLs live under `[env.production.vars]`.
@@ -339,6 +343,44 @@ build outside CI, export these before `bun run --cwd <site> build`.
 | `PUBLIC_CIRE_API_URL` | cire/organiser | **Yes** | `https://api.cireweddings.com` | cire-api prod origin (`cire/organiser/src/lib/osn.ts`; `PUBLIC_API_URL` honoured as legacy fallback). |
 | `PUBLIC_OSN_ISSUER_URL` | cire/organiser | **Yes** | `https://id.cireweddings.com` | osn-api prod origin for organiser passkey sign-in (`osn.ts`, dev default `http://localhost:4000`). Must equal osn-api's `OSN_ISSUER_URL`. |
 | `PUBLIC_CIRE_WEB_URL` | cire/organiser | Recommended | `https://cireweddings.com` | Guest site URL used in organiser preview links (`osn.ts`). |
+| `PUBLIC_TURNSTILE_SITEKEY` | cire/web **and** cire/organiser | Optional (key-optional) | _(unset)_ | Cloudflare Turnstile **sitekey** (public — safe to embed in client HTML). When set, the guest claim + RSVP forms (cire/web) and the organiser SignIn + Register forms (cire/organiser, via `@osn/ui`) render the Turnstile challenge and gate submit on it; when unset/blank no widget renders and no token is sent (a pure enhancement). Wired (commented) in the `deploy-cire-web` / `deploy-cire-organiser` build steps as `${{ vars.PUBLIC_TURNSTILE_SITEKEY }}` — set the repo **Variable** + uncomment once the widget exists (§3.4). The matching `TURNSTILE_SECRET_KEY` secret must be set on **both** the cire-api Worker (claim/rsvp) and the osn-api Worker (register/login). |
+
+### 3.4 Create the Cloudflare Turnstile widget (one-time, gates Turnstile on) 🔑
+
+Turnstile is **key-optional** — every flow ships and works with NO widget. Do this
+step only when you want bot protection ON. The same widget (one sitekey + one secret)
+covers **both** the guest site and the organiser portal.
+
+The `wrangler` OAuth token in use (`chavaniket@duck.com`) lacks the `Account.Turnstile:Edit`
+scope, so the widget **could not be created programmatically** during this work —
+create it in the dashboard (or with a custom API token that has the scope):
+
+1. **Dashboard → Turnstile → Add widget** (account `fad09b83d3590eaeb803eca52d5bf1b7`).
+   - **Name:** `cire-weddings`
+   - **Domains:** `cireweddings.com`, `app.cireweddings.com` (apex covers the guest
+     site; `app.` covers the organiser portal — osn-api's passkey origin). Add
+     `localhost` if you want to exercise it locally.
+   - **Widget mode:** **Managed** (no pre-clearance — siteverify is the gate).
+2. Copy the **Sitekey** (public, `0x…`) and the **Secret key** (private).
+3. **Sitekey** → set as the repo **Variable** `PUBLIC_TURNSTILE_SITEKEY` and **uncomment**
+   the two `PUBLIC_TURNSTILE_SITEKEY:` lines in `.github/workflows/deploy.yml`
+   (`deploy-cire-web` + `deploy-cire-organiser` build steps). Static Astro bakes it
+   in at build time, so a **rebuild + redeploy** of both Pages projects is required to
+   activate the widget.
+4. **Secret key** → set on **both** Workers (never commit it):
+   ```bash
+   # from osn/api (gates /register/begin + /login/passkey/begin)
+   cd osn/api && echo "<secret>" | bunx wrangler secret put TURNSTILE_SECRET_KEY --env production
+   # from cire/api (gates /api/claim + /api/rsvp)
+   cd cire/api && echo "<secret>" | bunx wrangler secret put TURNSTILE_SECRET_KEY --env production
+   ```
+   Then `wrangler deploy` both Workers so the new isolate picks up the secret.
+5. **Order matters (fail-closed):** set the **secret on the Workers FIRST**, then ship
+   the **sitekey** in the Pages build. If you ship the sitekey while the secret is
+   absent the widget renders but the server skips verify (harmless); if you set the
+   secret while the sitekey is absent the server requires a token the UI never sends
+   and legitimate requests 400/403. The safe rollout is secret-first, sitekey-second
+   (or both together via a coordinated deploy).
 
 ---
 


### PR DESCRIPTION
## What

Adds Cloudflare Turnstile bot protection to the highest-value abuse targets, **key-optional + graceful** (same philosophy as the maps-embed key and `OSN_EMAIL_OPTIONAL`). When the sitekey/secret are **unset**, every flow works exactly as today (no widget, siteverify skipped) — so this is **safe to merge before the widget is created**. When **set**, server-side siteverify is **mandatory and fail-closed**.

### Protected surfaces
| Surface | Where siteverify runs |
|---|---|
| osn-api `/register/begin` + `/login/passkey/begin` (organiser sign-in on `app.cireweddings.com`) | `osn/api/src/routes/auth.ts` → `turnstileGate` |
| cire guest `/api/claim` + `/api/rsvp` (public guest site) | `cire/api/src/routes/{claim,rsvp}.ts` → `cire/api/src/middleware/turnstile.ts` |

### Shared verifier — `@shared/turnstile`
`createTurnstileVerifier(secret?)` → `null` when the secret is unset (gate skipped), else a fail-closed verifier. Rejects on missing / empty / invalid / expired / **duplicate (single-use)** token, non-2xx, or unreachable endpoint. POSTs to Cloudflare's managed siteverify via `instrumentedFetch` with `remoteip = cf-connecting-ip`, a 5s timeout, and the secret **never logged / never in a response / never in a metric attribute / never in a URL**.

### Frontend (render only when a sitekey is configured)
- `@osn/ui` `TurnstileWidget` (sitekey via prop) wired into `Register` + `SignIn`; `cire/web` `TurnstileWidget` (sitekey via `import.meta.env.PUBLIC_TURNSTILE_SITEKEY`) wired into `LoginSection` + `RsvpModal`. `cire/organiser` threads its build-time sitekey into the shared `@osn/ui` forms.
- Widget lazy-loads `api.js` only when a key exists, carries `data-action="turnstile-spin-v1"`, gates submit on a solved token, and is a pure no-op otherwise.
- Token threaded through `@osn/client` `beginRegistration` / `passkeyBegin` (omitted cleanly when absent; conditional-UI passkey ceremony carries none).

## Widget creation — NEEDS A DASHBOARD STEP

The available `wrangler` OAuth token (`chavaniket@duck.com`) lacks the `Account.Turnstile:Edit` scope, so the widget **could not be created programmatically**. The integration ships key-optional regardless. To turn Turnstile **on**, create the widget in the dashboard (account `fad09b83d3590eaeb803eca52d5bf1b7`):
- **Name** `cire-weddings`, **mode** Managed, **domains** `cireweddings.com` + `app.cireweddings.com` (+ `localhost` for local testing).
- Set the **sitekey** as the repo Variable `PUBLIC_TURNSTILE_SITEKEY` and uncomment the two lines in `.github/workflows/deploy.yml`; set the **secret** via `wrangler secret put TURNSTILE_SECRET_KEY` on **both** the osn-api and cire-api Workers. Secret-first, then sitekey. Full steps in `wiki/runbooks/production-deploy.md` §3.4.

## Tests
- `@shared/turnstile`: 12 (key-optional branch + fail-closed semantics + wire format + secret-not-in-URL)
- `@osn/api`: 688 (incl. new `auth-turnstile.test.ts` — unconfigured no-op, valid passes, missing/invalid reject 400, `cf-connecting-ip`→remoteip, both endpoints)
- `@cire/api`: 426 (incl. new `turnstile.test.ts` — unconfigured no-op, claim + rsvp configured fail-closed, no session minted on reject)
- `@osn/ui` 119, `@osn/client` 132, `@cire/web` 228, `@cire/organiser` 37 — all green. Workspace `tsc` clean; both Worker bundles build.

## Security review
Verdict **SHIP** — no Critical/High/Medium. Confirmed: siteverify is server-side + mandatory-when-configured (no bypass path), fails **closed** on outage, single-use delegated to Cloudflare, `remoteip` is the non-spoofable `cf-connecting-ip`, secret hygiene holds (swallowed in the catch so the body+secret never logs), the null-vs-configured decision is server-only (client can't force the unconfigured path once keys are set), and the gate runs after rate-limit but before any side effect (credential lookup / OTP / session write). Applied the one actionable Low (**S-L2**: 5s siteverify timeout). The other Low is a pre-existing workerd metric-export gap (already tracked), not a regression.

## Changesets
Split per the contract — versioned (`@shared/turnstile` minor + `@osn/api`/`@osn/ui`/`@osn/client` minor) and ignored (`@cire/*` empty); never mixed.

## Deploy wiring
- Build-time `PUBLIC_TURNSTILE_SITEKEY` → `.env.example`s (cire/web, cire/organiser, documented in osn/api too) + commented in `deploy.yml` Pages build steps + runbook §3.3/§3.4.
- `TURNSTILE_SECRET_KEY` wrangler secret on **both** osn-api and cire-api — `wrangler secret put` documented (value never committed).

> Note: `osn/social`'s Register/SignIn (the social app, not on `app.cireweddings.com`) is intentionally left unwired — the optional props mean it's an unaffected no-op; can be wired later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)