### PR TITLE
feat(cire): Security/Devices section + passkey-only step-up

### DIFF
--- a/.changeset/cire-organiser-security-devices.md
+++ b/.changeset/cire-organiser-security-devices.md
@@ -1,0 +1,17 @@
+---
+"@cire/organiser": minor
+---
+
+Organiser portal: a **Security** section for managing devices / passkeys.
+
+Signed-in organisers can now reach a top-level "Security" nav item (`#security`)
+that renders the shared `@osn/ui` `<PasskeysView>`: list passkeys, rename, remove
+(the last-passkey removal is refused server-side), and **Add passkey** to enrol a
+new device. It also explains how to get onto a brand-new device (synced passkey,
+password-manager cross-device QR, or recovery code).
+
+Step-up for the sensitive actions runs the **passkey** ceremony, never OTP —
+`passkeyOnly` is forced on because cire's osn-api runs with
+`OSN_EMAIL_OPTIONAL=true` (Cloudflare email degraded), so an emailed code would
+never arrive. The WebAuthn ceremonies are wired with `@simplewebauthn/browser`;
+`accessToken` + `activeProfileId` come from the existing `useAuth()` context.

--- a/.changeset/osn-ui-passkey-only-step-up.md
+++ b/.changeset/osn-ui-passkey-only-step-up.md
@@ -1,0 +1,21 @@
+---
+"@osn/ui": minor
+---
+
+`<PasskeysView>` / `<StepUpDialog>`: add a `passkeyOnly` mode and new-device help.
+
+- `<StepUpDialog>` gains a `passkeyOnly` prop. When set, the OTP ("email me a
+  code") factor is suppressed entirely and the passkey ceremony auto-starts on
+  mount, with a retry affordance on failure. This is for hosts where
+  transactional email is degraded (e.g. an osn-api running with
+  `OSN_EMAIL_OPTIONAL=true`) so the user is never offered a code that will never
+  arrive. Every passkey-management gate accepts a passkey step-up, so the flow
+  stays fully functional without email.
+- `<PasskeysView>` forwards `passkeyOnly` to its step-up dialog and now renders a
+  collapsible **"Signing in somewhere new?"** help disclosure that explains the
+  three real ways onto a device with no passkey yet (backed-up/synced passkey,
+  password-manager cross-device QR, recovery code) — surfacing the existing
+  cross-device path without building a new system.
+
+No server changes; the add/rename/delete passkey endpoints already accept a
+passkey step-up token.

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@astrojs/solid-js": "^6.0.1",
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
+        "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.2",
         "solid-js": "^1.9.13",

--- a/cire/organiser/package.json
+++ b/cire/organiser/package.json
@@ -13,6 +13,7 @@
     "@astrojs/solid-js": "^6.0.1",
     "@osn/client": "workspace:*",
     "@osn/ui": "workspace:*",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.2",
     "solid-js": "^1.9.13",

--- a/cire/organiser/src/components/OrganiserApp.test.tsx
+++ b/cire/organiser/src/components/OrganiserApp.test.tsx
@@ -73,6 +73,11 @@ vi.mock("./ImportPanel", () => ({
 vi.mock("./PreviewInviteButton", () => ({
   default: () => <div data-testid="preview-button" />,
 }));
+// SecurityPanel pulls in @osn/client + @osn/ui + @simplewebauthn/browser;
+// stub it so this suite stays focused on the Dashboard's view glue.
+vi.mock("./SecurityPanel", () => ({
+  default: () => <div data-testid="security-panel">passkeys</div>,
+}));
 
 import OrganiserApp from "./OrganiserApp";
 
@@ -148,5 +153,23 @@ describe("OrganiserApp Dashboard", () => {
     // The new wedding is selected (its dashboard renders) and the list now
     // carries it.
     expect(screen.getByTestId("dashboard-tabs").textContent).toBe("wed_new");
+  });
+
+  it("toggles to the Security (devices / passkeys) panel from the nav", async () => {
+    authFetchMock.mockResolvedValue(
+      listResponse([{ id: "wed_a", slug: "a", displayName: "Alice & Bob" }]),
+    );
+    render(() => <OrganiserApp />);
+    await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
+
+    // Security is reachable whenever signed in, independent of any wedding.
+    fireEvent.click(screen.getByRole("button", { name: /^Security$/ }));
+    expect(screen.getByTestId("security-panel")).toBeTruthy();
+    expect(screen.queryByTestId("wedding-list")).toBeNull();
+
+    // And back to weddings.
+    fireEvent.click(screen.getByRole("button", { name: /^Weddings$/ }));
+    expect(screen.getByTestId("wedding-list")).toBeTruthy();
+    expect(screen.queryByTestId("security-panel")).toBeNull();
   });
 });

--- a/cire/organiser/src/components/OrganiserApp.tsx
+++ b/cire/organiser/src/components/OrganiserApp.tsx
@@ -8,6 +8,7 @@ import type { WeddingSummary } from "./CreateWeddingForm";
 import DashboardTabs from "./DashboardTabs";
 import ImportPanel from "./ImportPanel";
 import PreviewInviteButton from "./PreviewInviteButton";
+import SecurityPanel from "./SecurityPanel";
 import WeddingList from "./WeddingList";
 
 type WeddingsState =
@@ -78,12 +79,35 @@ function WeddingDashboard(props: { wedding: WeddingSummary; onBack: () => void }
   );
 }
 
+type DashboardView = "weddings" | "security";
+
+const navClass = (active: boolean) =>
+  `font-body text-[0.82rem] tracking-[0.1em] uppercase underline-offset-4 transition ${
+    active ? "text-gold" : "text-text-muted hover:text-gold hover:underline"
+  }`;
+
+function initialView(): DashboardView {
+  if (typeof window === "undefined") return "weddings";
+  return window.location.hash.replace("#", "") === "security" ? "security" : "weddings";
+}
+
 function Dashboard() {
   const { authFetch, logout } = useAuth();
   // Locally-tracked weddings so a freshly-created one shows up without a
   // refetch. Seeded from the initial load.
   const [weddings, setWeddings] = createSignal<WeddingSummary[] | null>(null);
   const [selectedId, setSelectedId] = createSignal<string | null>(null);
+  // Top-level view: the wedding list/dashboard, or the account security
+  // (devices / passkeys) panel. Security is reachable whenever signed in,
+  // independent of any wedding selection.
+  const [view, setView] = createSignal<DashboardView>(initialView());
+
+  function selectView(next: DashboardView) {
+    setView(next);
+    if (typeof window !== "undefined") {
+      history.replaceState(null, "", next === "security" ? "#security" : "#");
+    }
+  }
 
   const [loaded] = createResource<WeddingsState>(async () => {
     try {
@@ -129,7 +153,25 @@ function Dashboard() {
 
   return (
     <div class="flex flex-col gap-8">
-      <div class="flex justify-end">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <nav class="flex items-center gap-5" aria-label="Portal sections">
+          <button
+            type="button"
+            onClick={() => selectView("weddings")}
+            aria-current={view() === "weddings" ? "page" : undefined}
+            class={navClass(view() === "weddings")}
+          >
+            Weddings
+          </button>
+          <button
+            type="button"
+            onClick={() => selectView("security")}
+            aria-current={view() === "security" ? "page" : undefined}
+            class={navClass(view() === "security")}
+          >
+            Security
+          </button>
+        </nav>
         <button
           type="button"
           onClick={() => void signOut()}
@@ -139,32 +181,38 @@ function Dashboard() {
         </button>
       </div>
 
-      <Show when={loaded()} fallback={<Loading label="Loading weddings…" />}>
-        <Show when={loadError()}>
-          {(message) => (
-            <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
-              {message()}
-            </p>
-          )}
-        </Show>
+      <Show when={view() === "security"}>
+        <SecurityPanel />
+      </Show>
 
-        <Show when={!loadError() && weddings()}>
-          {(list) => (
-            <Show
-              when={selected()}
-              fallback={
-                <WeddingList
-                  weddings={list()}
-                  onSelect={(w) => setSelectedId(w.id)}
-                  onCreated={handleCreated}
-                />
-              }
-            >
-              {(wedding) => (
-                <WeddingDashboard wedding={wedding()} onBack={() => setSelectedId(null)} />
-              )}
-            </Show>
-          )}
+      <Show when={view() === "weddings"}>
+        <Show when={loaded()} fallback={<Loading label="Loading weddings…" />}>
+          <Show when={loadError()}>
+            {(message) => (
+              <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
+                {message()}
+              </p>
+            )}
+          </Show>
+
+          <Show when={!loadError() && weddings()}>
+            {(list) => (
+              <Show
+                when={selected()}
+                fallback={
+                  <WeddingList
+                    weddings={list()}
+                    onSelect={(w) => setSelectedId(w.id)}
+                    onCreated={handleCreated}
+                  />
+                }
+              >
+                {(wedding) => (
+                  <WeddingDashboard wedding={wedding()} onBack={() => setSelectedId(null)} />
+                )}
+              </Show>
+            )}
+          </Show>
         </Show>
       </Show>
     </div>

--- a/cire/organiser/src/components/SecurityPanel.tsx
+++ b/cire/organiser/src/components/SecurityPanel.tsx
@@ -1,0 +1,93 @@
+import { createPasskeysClient, createStepUpClient } from "@osn/client";
+import { useAuth } from "@osn/client/solid";
+import { PasskeysView } from "@osn/ui/auth";
+import {
+  browserSupportsWebAuthn,
+  startAuthentication,
+  startRegistration,
+} from "@simplewebauthn/browser";
+import { createMemo, Show } from "solid-js";
+
+import { OSN_ISSUER_URL } from "../lib/osn";
+
+// Built once against the OSN issuer. These wrap the same osn-api endpoints the
+// rest of the portal authenticates against (id.cireweddings.com in prod).
+const passkeysClient = createPasskeysClient({ issuerUrl: OSN_ISSUER_URL });
+const stepUpClient = createStepUpClient({ issuerUrl: OSN_ISSUER_URL });
+
+/**
+ * Security → Devices panel for the organiser portal. Renders the shared
+ * `@osn/ui` `PasskeysView` so a signed-in organiser can list, rename, and
+ * remove their passkeys, and enrol a new device.
+ *
+ * passkeyOnly is forced on: cire's osn-api deployment runs with
+ * `OSN_EMAIL_OPTIONAL=true` (Cloudflare email is degraded), so the OTP
+ * step-up factor would silently never deliver. Every passkey-management
+ * gate accepts a passkey step-up, so the ceremony stays fully functional
+ * without email.
+ *
+ * The WebAuthn browser ceremonies are wired here with
+ * `@simplewebauthn/browser` so `@osn/ui` stays free of that dependency.
+ */
+export default function SecurityPanel() {
+  const { session, activeProfileId } = useAuth();
+
+  // session() is a reactive Resource; reading it inside this memo keeps the
+  // access token current as the SDK silently refreshes it.
+  const accessToken = createMemo(() => session()?.accessToken ?? null);
+  const webauthnSupported = createMemo(() => browserSupportsWebAuthn());
+
+  const runPasskeyCeremony = (options: unknown) =>
+    startAuthentication({
+      optionsJSON: options as Parameters<typeof startAuthentication>[0]["optionsJSON"],
+    });
+
+  const runPasskeyRegistration = (options: unknown) =>
+    startRegistration({
+      optionsJSON: options as Parameters<typeof startRegistration>[0]["optionsJSON"],
+    });
+
+  return (
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-1">
+        <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">Security</p>
+        <h2 class="font-display text-[1.4rem] italic">Your devices &amp; passkeys</h2>
+        <p class="font-body text-text-muted text-[0.88rem]">
+          Passkeys are how you sign in to the organiser portal. Add one for each device you use, and
+          remove any you no longer recognise.
+        </p>
+      </div>
+
+      <Show
+        when={webauthnSupported()}
+        fallback={
+          <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
+            This browser doesn&apos;t support passkeys. Open the portal in a recent browser (iOS
+            16+, Android 9+, or an up-to-date desktop browser) to manage your devices.
+          </p>
+        }
+      >
+        <Show
+          when={accessToken()}
+          fallback={
+            <p class="font-body text-text-muted animate-pulse text-[0.88rem] tracking-[0.1em] uppercase">
+              Loading…
+            </p>
+          }
+        >
+          {(token) => (
+            <PasskeysView
+              client={passkeysClient}
+              stepUpClient={stepUpClient}
+              accessToken={token()}
+              profileId={activeProfileId() ?? undefined}
+              passkeyOnly
+              runPasskeyCeremony={runPasskeyCeremony}
+              runPasskeyRegistration={runPasskeyRegistration}
+            />
+          )}
+        </Show>
+      </Show>
+    </div>
+  );
+}

--- a/osn/ui/src/auth/PasskeysView.tsx
+++ b/osn/ui/src/auth/PasskeysView.tsx
@@ -43,6 +43,15 @@ export interface PasskeysViewProps {
    * package doesn't pull in `@simplewebauthn/browser`.
    */
   runPasskeyRegistration?: (options: unknown) => Promise<unknown>;
+  /**
+   * Force the step-up ceremony to use the passkey factor only, suppressing
+   * the OTP ("email me a code") option. Set this in hosts where transactional
+   * email is degraded (the cire organiser portal runs the OSN API with
+   * `OSN_EMAIL_OPTIONAL=true`) so the user is never offered a code that won't
+   * be delivered. The delete/rename/add gates all accept a passkey step-up,
+   * so this stays fully functional.
+   */
+  passkeyOnly?: boolean;
 }
 
 function formatTs(ts: number | null): string {
@@ -250,6 +259,32 @@ export function PasskeysView(props: PasskeysViewProps) {
           </ul>
         )}
       </Show>
+      <details class="text-muted-foreground mt-2 text-sm">
+        <summary class="text-foreground cursor-pointer font-medium">
+          Signing in somewhere new?
+        </summary>
+        <div class="mt-2 flex flex-col gap-2">
+          <p>There are three ways onto a device that has no passkey yet:</p>
+          <ul class="list-inside list-disc">
+            <li>
+              <span class="text-foreground font-medium">Backed-up passkey</span> — if your passkey
+              is saved to iCloud Keychain, Google Password Manager, or a password manager, it's
+              already available on your other signed-in devices.
+            </li>
+            <li>
+              <span class="text-foreground font-medium">Cross-device sign-in</span> — on the sign-in
+              screen choose the QR / nearby-device option your password manager offers, then approve
+              it with your phone.
+            </li>
+            <li>
+              <span class="text-foreground font-medium">Recovery code</span> — if you've lost access
+              to every passkey, use a saved recovery code from the "Lost your passkey?" link on
+              sign-in, then add a fresh passkey here.
+            </li>
+          </ul>
+          <p>Once you're signed in there, use "Add passkey" above to enrol that device.</p>
+        </div>
+      </details>
       <Show when={pending()}>
         <StepUpDialog
           client={props.stepUpClient}
@@ -257,6 +292,7 @@ export function PasskeysView(props: PasskeysViewProps) {
           onToken={handleStepUp}
           onCancel={cancelStepUp}
           runPasskeyCeremony={props.runPasskeyCeremony}
+          passkeyOnly={props.passkeyOnly}
         />
       </Show>
     </div>

--- a/osn/ui/src/auth/StepUpDialog.tsx
+++ b/osn/ui/src/auth/StepUpDialog.tsx
@@ -1,5 +1,5 @@
 import type { StepUpClient, StepUpToken } from "@osn/client";
-import { createSignal, Show } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 
 import { Button } from "../components/ui/button";
 
@@ -31,15 +31,31 @@ export interface StepUpDialogProps {
    * `startAuthentication` produces).
    */
   runPasskeyCeremony?: (options: unknown) => Promise<unknown>;
+  /**
+   * Passkey-only mode: suppress the OTP ("email me a code") factor entirely
+   * and drive the passkey ceremony directly. Used where transactional email
+   * is degraded (the cire organiser portal runs with
+   * `OSN_EMAIL_OPTIONAL=true`), so offering OTP would send the user down a
+   * dead-end path that never receives a code. With this set the dialog
+   * auto-starts the passkey ceremony on mount and offers a retry on failure.
+   */
+  passkeyOnly?: boolean;
 }
 
 type Mode = "choose" | "passkey" | "otp";
 
 export function StepUpDialog(props: StepUpDialogProps) {
-  const [mode, setMode] = createSignal<Mode>("choose");
+  const [mode, setMode] = createSignal<Mode>(props.passkeyOnly ? "passkey" : "choose");
   const [code, setCode] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+
+  // Passkey-only contexts skip the factor picker — kick the ceremony off as
+  // soon as the dialog mounts so the user lands straight on the platform
+  // authenticator prompt.
+  onMount(() => {
+    if (props.passkeyOnly) void startPasskey();
+  });
 
   async function startPasskey() {
     if (!props.runPasskeyCeremony) {
@@ -103,7 +119,7 @@ export function StepUpDialog(props: StepUpDialogProps) {
         This action needs a fresh authentication. Choose a method below.
       </p>
       <Show when={error()}>{(msg) => <p class="text-destructive text-sm">{msg()}</p>}</Show>
-      <Show when={mode() === "choose"}>
+      <Show when={!props.passkeyOnly && mode() === "choose"}>
         <div class="flex flex-col gap-2">
           <Button onClick={startPasskey} disabled={busy()}>
             Use passkey
@@ -111,6 +127,21 @@ export function StepUpDialog(props: StepUpDialogProps) {
           <Button variant="outline" onClick={startOtp} disabled={busy()}>
             Email me a code
           </Button>
+          <Button variant="ghost" onClick={props.onCancel} disabled={busy()}>
+            Cancel
+          </Button>
+        </div>
+      </Show>
+      <Show when={props.passkeyOnly}>
+        <div class="flex flex-col gap-2">
+          <Show when={busy()}>
+            <p class="text-muted-foreground text-sm" aria-live="polite">
+              Waiting for your passkey…
+            </p>
+          </Show>
+          <Show when={!busy()}>
+            <Button onClick={startPasskey}>{error() ? "Try again" : "Use passkey"}</Button>
+          </Show>
           <Button variant="ghost" onClick={props.onCancel} disabled={busy()}>
             Cancel
           </Button>

--- a/osn/ui/tests/auth/PasskeysView.test.tsx
+++ b/osn/ui/tests/auth/PasskeysView.test.tsx
@@ -387,6 +387,57 @@ describe("PasskeysView", () => {
     expect(addButton.disabled).toBe(true);
   });
 
+  // passkeyOnly: in the cire organiser portal email is degraded, so the
+  // step-up dialog must not offer the OTP factor (it would never arrive).
+  // The dialog should auto-run the passkey ceremony instead.
+  it("passkeyOnly: delete uses the passkey ceremony, never OTP", async () => {
+    pk.list.mockResolvedValueOnce({ passkeys: passkeyRows });
+    pk.list.mockResolvedValueOnce({ passkeys: [passkeyRows[1]!] });
+    pk.delete.mockResolvedValue({ success: true, remaining: 1 });
+    su.passkeyBegin.mockResolvedValue({ options: { challenge: "abc" } });
+    su.passkeyComplete.mockResolvedValue(stepUpToken);
+    const runCeremony = vi.fn().mockResolvedValue({ id: "cred_su" });
+
+    render(() => (
+      <PasskeysView
+        client={asPasskeys(pk)}
+        stepUpClient={asStepUp(su)}
+        accessToken="acc"
+        passkeyOnly
+        runPasskeyCeremony={runCeremony}
+      />
+    ));
+
+    await waitFor(() => screen.getAllByRole("button", { name: /^Delete$/ }));
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete$/ })[0]!);
+
+    // No OTP affordance; passkey ceremony runs automatically.
+    await waitFor(() => expect(runCeremony).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /Email me a code/i })).toBeNull();
+    await waitFor(() =>
+      expect(pk.delete).toHaveBeenCalledWith({
+        accessToken: "acc",
+        id: "pk_aaaaaaaaaaaa",
+        stepUpToken: stepUpToken.token,
+      }),
+    );
+    expect(su.otpBegin).not.toHaveBeenCalled();
+  });
+
+  it("renders new-device help with cross-device / synced-passkey / recovery guidance", async () => {
+    pk.list.mockResolvedValue({ passkeys: passkeyRows });
+    render(() => (
+      <PasskeysView client={asPasskeys(pk)} stepUpClient={asStepUp(su)} accessToken="acc" />
+    ));
+    await waitFor(() => screen.getAllByRole("button", { name: /^Rename$/ }));
+    // The disclosure copy points users at the three real ways onto a new
+    // device. Open it first (details/summary).
+    fireEvent.click(screen.getByText(/Signing in somewhere new/i));
+    expect(screen.getByText(/Cross-device sign-in/i)).toBeTruthy();
+    expect(screen.getAllByText(/recovery code/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Backed-up passkey/i)).toBeTruthy();
+  });
+
   // S-L1: while a step-up is in flight, every Rename / Delete button on the
   // page is disabled to prevent a rapid double-click swapping the pending id.
   it("locks every Rename/Delete button while a step-up is in flight (S-L1)", async () => {

--- a/osn/ui/tests/auth/StepUpDialog.test.tsx
+++ b/osn/ui/tests/auth/StepUpDialog.test.tsx
@@ -97,4 +97,53 @@ describe("StepUpDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Confirm$/ }));
     await waitFor(() => expect(screen.getByText(/Invalid or expired code/)).toBeTruthy());
   });
+
+  // passkeyOnly: the "Email me a code" OTP factor is hidden entirely. Used by
+  // the cire organiser portal where transactional email is degraded
+  // (OSN_EMAIL_OPTIONAL=true), so an OTP step-up would dead-end the user. The
+  // passkey ceremony starts immediately on mount — no factor picker.
+  it("passkeyOnly: hides the OTP option and auto-starts the passkey ceremony", async () => {
+    stub.passkeyBegin.mockResolvedValue({ options: { challenge: "abc" } });
+    stub.passkeyComplete.mockResolvedValue({ token: "eyJpk", expiresIn: 300 });
+    const runPasskey = vi.fn(async () => ({ id: "cred", signed: true }));
+    const onToken = vi.fn();
+
+    render(() => (
+      <StepUpDialog
+        client={asClient(stub)}
+        accessToken="acc"
+        onToken={onToken}
+        onCancel={() => {}}
+        runPasskeyCeremony={runPasskey}
+        passkeyOnly
+      />
+    ));
+
+    // No OTP affordance at all.
+    expect(screen.queryByRole("button", { name: /Email me a code/i })).toBeNull();
+    // Ceremony fires without the user clicking "Use passkey".
+    await waitFor(() => expect(runPasskey).toHaveBeenCalled());
+    await waitFor(() => expect(onToken).toHaveBeenCalledWith({ token: "eyJpk", expiresIn: 300 }));
+    expect(stub.otpBegin).not.toHaveBeenCalled();
+  });
+
+  it("passkeyOnly: surfaces a retry affordance when the ceremony fails", async () => {
+    stub.passkeyBegin.mockResolvedValue({ options: { challenge: "abc" } });
+    const runPasskey = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+
+    render(() => (
+      <StepUpDialog
+        client={asClient(stub)}
+        accessToken="acc"
+        onToken={() => {}}
+        onCancel={() => {}}
+        runPasskeyCeremony={runPasskey}
+        passkeyOnly
+      />
+    ));
+
+    await waitFor(() => expect(screen.getByText(/NotAllowedError/)).toBeTruthy());
+    // A retry button is available (passkey factor, not the choose menu).
+    expect(screen.getByRole("button", { name: /Try again|Use passkey/i })).toBeTruthy();
+  });
 });

--- a/wiki/systems/passkey-primary.md
+++ b/wiki/systems/passkey-primary.md
@@ -10,7 +10,8 @@ packages:
   - "@osn/api"
   - "@osn/client"
   - "@osn/ui"
-last-reviewed: 2026-04-23
+  - "@cire/organiser"
+last-reviewed: 2026-06-18
 ---
 
 # Passkey-Primary Login
@@ -67,7 +68,45 @@ UI surface (`@osn/ui/auth`):
   gated via the same `/passkey/register/*` endpoints the registration
   flow uses). `@osn/social` mounts it behind a lazy-loaded
   `SecuritySection` so `@simplewebauthn/browser` only ships when the tab
-  is opened.
+  is opened. It also renders a collapsible **"Signing in somewhere new?"**
+  help disclosure that points users at the three real ways onto a fresh
+  device (backed-up/synced passkey, password-manager cross-device QR,
+  recovery code) — see "New-device onboarding" below.
+  - **`passkeyOnly` prop** — when set, the step-up dialog suppresses the OTP
+    ("email me a code") factor and drives the passkey ceremony directly.
+    Required wherever transactional email is degraded. The cire organiser
+    portal sets it because its osn-api runs with `OSN_EMAIL_OPTIONAL=true`
+    (Cloudflare email degraded), so an OTP step-up would dead-end on a code
+    that never arrives. Every passkey-management gate accepts a passkey
+    step-up (delete defaults to `webauthn`-only AMR; rename/register accept
+    `webauthn`), so the flow stays fully functional without email.
+
+### Surfaces that mount `<PasskeysView>`
+
+| App | Mount point | Notes |
+|---|---|---|
+| `@osn/social` | lazy `SecuritySection` (Settings → Security) | OTP factor available. |
+| `@cire/organiser` | `SecurityPanel.tsx`, reached via the top-level **Security** nav item (`#security`) in `OrganiserApp` | `passkeyOnly` forced on (degraded email). Wires the WebAuthn ceremonies with `@simplewebauthn/browser`; reads `accessToken` + `activeProfileId` from `useAuth()`. |
+
+## New-device onboarding
+
+Getting onto a brand-new device that holds no passkey yet does **not** use a
+bespoke OSN flow — it reuses what already exists, surfaced as UI copy in the
+`<PasskeysView>` help disclosure and the WebAuthn-unsupported `<SignIn>`
+screen:
+
+1. **Backed-up / synced passkey** — platform passkeys saved to iCloud
+   Keychain, Google Password Manager, or a third-party password manager are
+   already present on the user's other signed-in devices. No transfer needed.
+2. **Cross-device sign-in (CaBLE / hybrid)** — on the sign-in screen the user
+   picks the QR / nearby-device option their password manager offers and
+   approves it from their phone. The osn-api cross-device endpoints
+   (`/login/cross-device/*`, see `[[sessions]]`) exist for a future
+   first-party QR transfer, but the password-manager hybrid flow covers the
+   common case today with no extra client code.
+3. **Recovery code** — if every passkey is lost, the user signs in via the
+   "Lost your passkey?" recovery-code path, then enrols a fresh passkey from
+   the authenticated Security panel.
 
 ## Accepting security keys
 


### PR DESCRIPTION
## What & why

Existing OSN users (organisers) need a clear, in-portal way to **register new devices / additional passkeys** and **manage their passkeys** (list, rename, remove). The osn-api endpoints, the `@osn/client` passkeys/step-up wrappers, and the `@osn/ui` `PasskeysView` already existed — the missing piece was surfacing them in the cire organiser portal, plus making the flow work under the portal's degraded-email constraint and making new-device onboarding discoverable.

**Endpoints existed vs added:** all server endpoints already existed and are unchanged (`GET /passkeys`, `PATCH /passkeys/:id` rename, `DELETE /passkeys/:id`, `/passkey/register/begin|complete`, `/step-up/passkey/begin|complete`, cross-device QR). `listPasskeys` already returns `lastUsedAt`. No osn-api changes → **no osn-api redeploy needed.**

## Changes

### `@osn/ui` (minor, versioned)
- `StepUpDialog` gains a `passkeyOnly` prop: suppresses the OTP ("email me a code") factor and auto-runs the passkey ceremony on mount, with a retry on failure.
- `PasskeysView` forwards `passkeyOnly` and renders a collapsible **"Signing in somewhere new?"** help disclosure (synced passkey, cross-device QR, recovery code).

### `@cire/organiser` (minor, ignored — separate changeset)
- New `SecurityPanel.tsx` mounting `PasskeysView`, reached via a top-level **Security** nav item (`#security`) in `OrganiserApp` — reachable whenever signed in, independent of wedding selection.
- `passkeyOnly` is **forced on**: cire's osn-api runs with `OSN_EMAIL_OPTIONAL=true` (Cloudflare email degraded), so an OTP step-up would dead-end on a code that never arrives.
- WebAuthn ceremonies wired with `@simplewebauthn/browser`; `accessToken` + `activeProfileId` from `useAuth()`.

### wiki
- `wiki/systems/passkey-primary.md`: documents `passkeyOnly`, the cire mount point, and the three new-device onboarding paths.

## Step-up: passkey, not OTP
Add / rename / remove all run the **passkey** step-up ceremony in the organiser portal. The `passkeyOnly` flag only hides OTP client-side; the server still enforces step-up + AMR (delete defaults to `webauthn`-only). The **≥1-credential invariant** and last-passkey-removal refusal are enforced server-side, not just in the UI.

## New-device onboarding
No new cross-device system built — the help copy surfaces the existing options: backed-up/synced passkeys, the password-manager cross-device (CaBLE/hybrid) QR flow, and recovery codes. The osn-api `/login/cross-device/*` endpoints remain available for a future first-party QR transfer.

## Tests
- `@osn/ui`: 123 passed (added: passkeyOnly auto-ceremony + OTP-suppressed, new-device help, organiser passkey-only delete).
- `@osn/client`: 132 passed (unchanged).
- `@osn/api`: 688 passed (unchanged).
- `@cire/organiser`: 38 passed (added: Security nav toggle).
- `astro build` (organiser type gate): clean. oxlint: 0 errors.

## Security review
Ran the security-review pass over the diff — **no Critical/High/Medium findings**. `passkeyOnly` is client-side-only and doesn't weaken any server gate; enrolment is bound to the caller's own account server-side; no XSS sinks (SolidJS escapes text); no token/credential/userhandle leakage; challenges remain server-managed and single-use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)