### PR TITLE
ops: require email (drop OSN_EMAIL_OPTIONAL) + activate Turnstile sitekey

### DIFF
--- a/.changeset/finalize-email-turnstile.md
+++ b/.changeset/finalize-email-turnstile.md
@@ -1,0 +1,5 @@
+---
+"@osn/api": patch
+---
+
+ops: email is now required in prod (Resend delivery confirmed from hello@cireweddings.com) — removed the `OSN_EMAIL_OPTIONAL` degraded opt-in from osn-api's production vars, so osn-api fails closed at startup if `RESEND_API_KEY` is ever absent rather than silently dropping OTP/security mail. Also activated the Cloudflare Turnstile sitekey in the cire/web + cire/organiser Pages builds (`deploy.yml`), reading the `PUBLIC_TURNSTILE_SITEKEY` repo Variable; the matching `TURNSTILE_SECRET_KEY` is set on the osn-api + cire-api Workers (sitekey-first rollout so the gate never blocks before the widget is live).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           PUBLIC_API_URL: https://api.cireweddings.com
           PUBLIC_SITE_URL: https://cireweddings.com
-          # PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
+          PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Deploy cire/web to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire
@@ -201,7 +201,7 @@ jobs:
           # Optional Cloudflare Turnstile sitekey (public) for organiser passkey
           # sign-in. Uncomment once the widget exists; omitted ⇒ key-optional
           # no-op. Matching TURNSTILE_SECRET_KEY is a wrangler secret on osn-api.
-          # PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
+          PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Deploy cire/organiser to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire-organiser

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -216,15 +216,11 @@ OSN_ORIGIN = "https://app.cireweddings.com"
 OSN_ISSUER_URL = "https://id.cireweddings.com"
 OSN_CORS_ORIGIN = "https://app.cireweddings.com"
 OSN_EMAIL_FROM = "hello@cireweddings.com"
-# Degraded-email opt-in. We are launching WITHOUT Cloudflare email (it needs a
-# paid Workers plan + ~1 week sender-domain onboarding, §1.1). With this set
-# truthy AND the CLOUDFLARE_* email secrets absent, osn-api boots with a NO-OP
-# email transport (transactional mail DISCARDED, loud startup warning) instead
-# of throwing at startup. Passkey login is primary and unaffected; OTP step-up,
-# email-change OTPs, and security-notice emails will NOT be delivered while this
-# is set. Re-enable email: provision the CLOUDFLARE_* secrets, then REMOVE this
-# line (creds win, but unset the opt-in so a creds outage fails closed again).
-OSN_EMAIL_OPTIONAL = "true"
+# Email is sent via Resend (RESEND_API_KEY secret, §1.1) — confirmed delivering
+# from hello@cireweddings.com on 2026-06-18. Email is REQUIRED in prod: if
+# RESEND_API_KEY is ever absent osn-api fails closed at startup rather than
+# silently dropping OTP/security mail. (The former OSN_EMAIL_OPTIONAL degraded
+# opt-in was removed once Resend delivery was verified.)
 
 # Custom-domain route: serves osn-api on id.cireweddings.com. `custom_domain =
 # true` auto-provisions DNS + edge cert because the cireweddings.com zone is in
@@ -285,15 +281,11 @@ crons = ["0 */6 * * *"]
 #   OSN_SESSION_IP_PEPPER      ≥32-byte HMAC key           — REQUIRED non-local
 #   UPSTASH_REDIS_REST_URL     Upstash REST URL            — REQUIRED non-local (S-L1; region TBD C-M18)
 #   UPSTASH_REDIS_REST_TOKEN   Upstash REST token          — REQUIRED non-local (S-L1; region TBD C-M18)
-#   CLOUDFLARE_ACCOUNT_ID      for the Email Service REST API — REQUIRED non-local
-#                              UNLESS OSN_EMAIL_OPTIONAL is set (degraded mode)
-#   CLOUDFLARE_EMAIL_API_TOKEN bearer token for email send  — REQUIRED non-local
-#                              UNLESS OSN_EMAIL_OPTIONAL is set (degraded mode)
+#   RESEND_API_KEY             Resend bearer key — REQUIRED non-local (preferred
+#                              email transport; selected over CLOUDFLARE_* creds)
+#   CLOUDFLARE_ACCOUNT_ID      legacy Cloudflare Email Service — optional fallback
+#   CLOUDFLARE_EMAIL_API_TOKEN legacy Cloudflare Email Service — optional fallback
 #   OSN_EMAIL_FROM             verified sender (also settable as a [vars])
-#   OSN_EMAIL_OPTIONAL         non-secret [vars] boolean. Truthy = boot WITHOUT
-#                              email (no-op transport) when the CLOUDFLARE_*
-#                              creds are absent in a non-local env, instead of
-#                              throwing. Unset = fail-closed. Creds always win.
 #   INTERNAL_SERVICE_SECRET    S2S registration shared secret (optional)
 #   PULSE_API_URL / ZAP_API_URL deletion fan-out targets (optional; also [vars])
 #   TRUSTED_PROXY_COUNT        legacy XFF proxy-hop count. IGNORED in deployed


### PR DESCRIPTION
## Summary
Email via Resend is **confirmed delivering** (test landed in inbox from `hello@cireweddings.com`), so:
- **Drop `OSN_EMAIL_OPTIONAL`** from osn-api `[env.production.vars]` → email is now **required/fail-closed** (osn-api throws at startup if `RESEND_API_KEY` is absent, instead of silently dropping OTP/security mail). `RESEND_API_KEY` is set + validated; `OSN_EMAIL_FROM=hello@cireweddings.com`.
- **Activate the Turnstile sitekey** in the cire/web + cire/organiser Pages builds (`deploy.yml`) via the `PUBLIC_TURNSTILE_SITEKEY` repo Variable (already set; secret validated against siteverify).

## Rollout (sitekey-first — the gate is fail-closed when the secret is set)
1. Merge → CI rebuilds both Pages with the widget live but **unenforced** (no `TURNSTILE_SECRET_KEY` on the Workers yet).
2. I redeploy osn-api (picks up the `OSN_EMAIL_OPTIONAL` removal).
3. Verify the widget renders.
4. `wrangler secret put TURNSTILE_SECRET_KEY` on osn-api + cire-api → enforcement on (widgets already producing tokens).
5. Manual confirm: a real login + RSVP completes the challenge.

## Test plan
- Email: live test send already confirmed (inbox, clean). After redeploy, OTP/step-up email delivers via Resend.
- Turnstile: widget renders post-Pages-rebuild; real login/RSVP passes once the secret is set.