### PR TITLE
ci: activate Google Maps Embed preview (cire/web)

### DIFF
--- a/.changeset/activate-maps-embed.md
+++ b/.changeset/activate-maps-embed.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: wire PUBLIC_GOOGLE_MAPS_EMBED_KEY (referrer-restricted, repo Variable) into the cire/web Pages build so the guest invite renders the real Google Maps Embed iframe (replacing the CSS-card fallback). Key-optional — absent ⇒ fallback.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,6 +155,9 @@ jobs:
           PUBLIC_API_URL: https://api.cireweddings.com
           PUBLIC_SITE_URL: https://cireweddings.com
           PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
+          # Google Maps Embed API key (public, referrer-restricted to *.cireweddings.com).
+          # Present ⇒ real Embed iframe; absent ⇒ CSS-card fallback (key-optional).
+          PUBLIC_GOOGLE_MAPS_EMBED_KEY: ${{ vars.PUBLIC_GOOGLE_MAPS_EMBED_KEY }}
 
       - name: Deploy cire/web to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire


### PR DESCRIPTION
## Summary
Wire the `PUBLIC_GOOGLE_MAPS_EMBED_KEY` repo Variable (referrer-restricted to `*.cireweddings.com`, set from your key) into the cire/web Pages build, so the guest invite now renders the **real Google Maps Embed iframe** instead of the CSS-card fallback (#146, key-optional).

## Test plan
- Merge → CI rebuilds cire/web Pages with the key baked in → the event-details map preview shows a live map. Absent key ⇒ CSS-card fallback (unchanged contract).