### PR TITLE
fix(osn/ui): reset Turnstile after token-consuming auth call (organiser login loop)

### DIFF
--- a/.changeset/osn-ui-turnstile-single-use-reset.md
+++ b/.changeset/osn-ui-turnstile-single-use-reset.md
@@ -1,0 +1,27 @@
+---
+"@osn/ui": patch
+---
+
+Fix organiser login loop: reset the Turnstile widget after every token-consuming
+auth call so a single-use token is never replayed.
+
+Once the production Turnstile sitekey + secret went live, `@osn/ui`'s `SignIn`
+identifier-bound passkey form gated `/login/passkey/begin` on a Turnstile token.
+Cloudflare tokens are **single-use**, and the component never retired the token
+after `/begin` redeemed it — Cloudflare only auto-refreshes on the ~300s expiry,
+not on consumption. So any retry (a cancelled WebAuthn ceremony, the wrong
+passkey, a transient network error) re-submitted the already-redeemed token, the
+server rejected it `timeout-or-duplicate` → `turnstile_failed`, and the user
+bounced back to the login screen. Loop.
+
+- `TurnstileWidget` now accepts an `onReady({ reset })` callback that hands the
+  parent a bound `reset()` — it drops the stale token (`onToken(null)`) and asks
+  Cloudflare for a fresh challenge.
+- `SignIn` and `Register` call `reset()` immediately after each begin/register
+  call that redeems the token, so the next submit always carries a fresh,
+  unconsumed token. Removes the stale "the widget auto-refreshes" assumption in
+  `Register.resendCode` that had the same latent single-use bug.
+
+Regression tests: `SignIn` retries with a fresh token after a failed ceremony
+(never replays the redeemed one); `TurnstileWidget.onReady` reset drops the token
+and resets the widget instance.

--- a/osn/ui/src/auth/Register.tsx
+++ b/osn/ui/src/auth/Register.tsx
@@ -54,6 +54,10 @@ export function Register(props: RegisterProps) {
   // Turnstile token — REQUIRED only when a sitekey is provided.
   const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
   const turnstileOn = () => turnstileEnabled(props.turnstileSiteKey);
+  // Bound to the widget once it mounts; forces a fresh token after the current
+  // one is redeemed by `/register/begin` (tokens are single-use — Cloudflare
+  // only auto-refreshes on the ~300s expiry, not on consumption).
+  let resetTurnstile: (() => void) | undefined;
 
   const [handleStatus, setHandleStatus] = createSignal<
     "idle" | "checking" | "available" | "taken" | "invalid" | "error"
@@ -104,6 +108,10 @@ export function Register(props: RegisterProps) {
         displayName: displayName().trim() || undefined,
         turnstileToken: turnstileToken() ?? undefined,
       });
+      // Token redeemed by `/begin`; retire it + request a fresh one so a later
+      // resend (or a retry after a transient error) never replays a single-use
+      // token and gets rejected `timeout-or-duplicate`.
+      if (turnstileOn()) resetTurnstile?.();
       toast.success("Verification code sent");
       setStep("verify");
       startResendCooldown();
@@ -164,10 +172,11 @@ export function Register(props: RegisterProps) {
         email: email(),
         handle: handle(),
         displayName: displayName().trim() || undefined,
-        // Turnstile tokens are single-use; the widget auto-refreshes a fresh one
-        // before the 300s TTL, so the value here is the latest unconsumed token.
+        // Turnstile tokens are single-use. We reset the widget after every
+        // redeeming call, so the value here is a fresh, unconsumed token.
         turnstileToken: turnstileToken() ?? undefined,
       });
+      if (turnstileOn()) resetTurnstile?.();
       setOtp("");
       setOtpStatus("idle");
       startResendCooldown();
@@ -296,7 +305,11 @@ export function Register(props: RegisterProps) {
             </div>
 
             {/* Turnstile challenge — renders only when a sitekey is provided. */}
-            <TurnstileWidget siteKey={props.turnstileSiteKey} onToken={setTurnstileToken} />
+            <TurnstileWidget
+              siteKey={props.turnstileSiteKey}
+              onToken={setTurnstileToken}
+              onReady={(c) => (resetTurnstile = c.reset)}
+            />
 
             <Button type="submit" disabled={!detailsValid() || busy()}>
               {busy() ? "Sending…" : "Send verification code"}

--- a/osn/ui/src/auth/SignIn.tsx
+++ b/osn/ui/src/auth/SignIn.tsx
@@ -57,6 +57,9 @@ export function SignIn(props: SignInProps) {
   // Turnstile token — REQUIRED only when a sitekey is provided.
   const [turnstileToken, setTurnstileToken] = createSignal<string | null>(null);
   const turnstileOn = () => turnstileEnabled(props.turnstileSiteKey);
+  // Bound to the widget once it mounts; lets us force a fresh token after the
+  // current one is redeemed by `/login/passkey/begin` (tokens are single-use).
+  let resetTurnstile: (() => void) | undefined;
 
   function reportError(e: unknown, fallback: string) {
     const msg = e instanceof Error ? e.message : fallback;
@@ -90,6 +93,13 @@ export function SignIn(props: SignInProps) {
         : client.passkeyBegin(trimmed))) as {
         options: Parameters<typeof startAuthentication>[0]["optionsJSON"];
       };
+      // The token (if any) has now been redeemed by `/begin`. Tokens are
+      // single-use, so retire it and ask the widget for a fresh one — otherwise
+      // any retry (cancelled ceremony, wrong passkey, …) replays the redeemed
+      // token, the server rejects it `timeout-or-duplicate`, and the user is
+      // trapped on the login screen. Cloudflare only auto-refreshes on the
+      // ~300s expiry, not on consumption, so we must reset explicitly.
+      if (turnstileOn()) resetTurnstile?.();
       const assertion = await startAuthentication({ optionsJSON: beginResult.options });
       const { session } = await client.passkeyComplete({ identifier: trimmed, assertion });
       await finishWithSession(session);
@@ -177,7 +187,11 @@ export function SignIn(props: SignInProps) {
             />
           </div>
           {/* Turnstile challenge — renders only when a sitekey is provided. */}
-          <TurnstileWidget siteKey={props.turnstileSiteKey} onToken={setTurnstileToken} />
+          <TurnstileWidget
+            siteKey={props.turnstileSiteKey}
+            onToken={setTurnstileToken}
+            onReady={(c) => (resetTurnstile = c.reset)}
+          />
           <Button
             type="submit"
             disabled={busy() || !identifier().trim() || (turnstileOn() && !turnstileToken())}

--- a/osn/ui/src/auth/TurnstileWidget.tsx
+++ b/osn/ui/src/auth/TurnstileWidget.tsx
@@ -81,6 +81,17 @@ export interface TurnstileWidgetProps {
   siteKey?: string;
   /** Fires with a fresh token on success, `null` on expiry/error. */
   onToken: (token: string | null) => void;
+  /**
+   * Handed a `reset()` once the widget has rendered. Turnstile tokens are
+   * SINGLE-USE: once a token has been submitted to (and redeemed by) a backend,
+   * calling `reset()` discards it and asks Cloudflare for a fresh challenge —
+   * the new token arrives via `onToken`. Without this, a form that re-submits
+   * (e.g. a failed/retried sign-in) replays the already-redeemed token and the
+   * server fails it closed (`timeout-or-duplicate`), trapping the user in a
+   * login loop. The callback is a no-op until the widget exists, so callers can
+   * invoke it unconditionally.
+   */
+  onReady?: (controls: { reset: () => void }) => void;
   theme?: "light" | "dark" | "auto";
   class?: string;
 }
@@ -122,6 +133,23 @@ export function TurnstileWidget(props: TurnstileWidgetProps) {
             props.onToken(null);
           },
         });
+        // Hand the parent a reset() bound to THIS widget instance so it can
+        // force a fresh token after the current one is redeemed (single-use).
+        props.onReady?.({
+          reset: () => {
+            const api = getTurnstile();
+            if (!api || widgetId === undefined) return;
+            // Drop the stale token immediately so the form can't replay it in
+            // the gap before Cloudflare delivers a new one via `callback`.
+            props.onToken(null);
+            try {
+              api.reset(widgetId);
+            } catch {
+              // Widget already torn down — nothing to reset.
+            }
+          },
+        });
+        return;
       })
       .catch(() => {
         setFailed(true);

--- a/osn/ui/tests/auth/SignIn.test.tsx
+++ b/osn/ui/tests/auth/SignIn.test.tsx
@@ -177,6 +177,78 @@ describe("SignIn component", () => {
     });
   });
 
+  describe("Turnstile single-use token (login-loop regression)", () => {
+    // A minimal stand-in for Cloudflare's `window.turnstile`. `render` issues
+    // a fresh token synchronously; `reset` issues another and re-fires the
+    // callback — exactly Cloudflare's contract. This lets us prove the form
+    // never replays a redeemed (single-use) token, which is what trapped
+    // organisers on the login screen once the prod sitekey went live (#160).
+    function installTurnstileStub() {
+      let n = 0;
+      let cb: ((token: string) => void) | undefined;
+      const reset = vi.fn(() => {
+        n += 1;
+        cb?.(`tok-${n}`);
+      });
+      const stub = {
+        render: vi.fn((_el: HTMLElement, opts: { callback?: (t: string) => void }) => {
+          cb = opts.callback;
+          n += 1;
+          cb?.(`tok-${n}`);
+          return "widget-1";
+        }),
+        reset,
+        remove: vi.fn(),
+      };
+      (globalThis as unknown as { turnstile?: unknown }).turnstile = stub;
+      return { stub, reset };
+    }
+
+    afterEach(() => {
+      delete (globalThis as unknown as { turnstile?: unknown }).turnstile;
+    });
+
+    it("retries with a FRESH token after a failed ceremony — never replays the redeemed one", async () => {
+      const { reset } = installTurnstileStub();
+
+      login.passkeyBegin.mockResolvedValue({ options: { challenge: "ch" } });
+      // First ceremony fails (user cancels / wrong passkey); second succeeds.
+      hoisted.startAuthentication
+        .mockRejectedValueOnce(new Error("ceremony cancelled"))
+        .mockResolvedValueOnce({ id: "cred", rawId: "raw" });
+      login.passkeyComplete.mockResolvedValue({ session: sampleSession, user: sampleUser });
+      hoisted.adoptSession.mockResolvedValue(undefined);
+
+      render(() => (
+        <SignIn
+          client={asLogin(login)}
+          recoveryClient={asRecovery(recovery)}
+          turnstileSiteKey="0x4AAAAAADnA2piUnbgG_kVw"
+        />
+      ));
+
+      fillIdentifier("alice");
+      // Wait for the widget to deliver its first token + enable the button.
+      const button = () => screen.getByRole("button", { name: /^Continue$/ }) as HTMLButtonElement;
+      await waitFor(() => expect(button().disabled).toBe(false));
+
+      // Attempt 1 — begin consumes tok-1, then the ceremony fails.
+      fireEvent.click(button());
+      await waitFor(() => expect(login.passkeyBegin).toHaveBeenCalledTimes(1));
+      expect(login.passkeyBegin).toHaveBeenLastCalledWith("alice", "tok-1");
+      // The widget must have been reset so a retry gets a fresh token.
+      await waitFor(() => expect(reset).toHaveBeenCalled());
+
+      // Attempt 2 — must carry a DIFFERENT (fresh) token, not the redeemed tok-1.
+      await waitFor(() => expect(button().disabled).toBe(false));
+      fireEvent.click(button());
+      await waitFor(() => expect(login.passkeyBegin).toHaveBeenCalledTimes(2));
+      const secondToken = login.passkeyBegin.mock.calls[1]![1] as string;
+      expect(secondToken).not.toBe("tok-1");
+      await waitFor(() => expect(hoisted.adoptSession).toHaveBeenCalledWith(sampleSession));
+    });
+  });
+
   describe("WebAuthn-unsupported fallback", () => {
     it("shows the informational screen and routes to recovery on click", async () => {
       hoisted.webauthnSupported = false;

--- a/osn/ui/tests/auth/TurnstileWidget.test.tsx
+++ b/osn/ui/tests/auth/TurnstileWidget.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { render, cleanup, screen } from "@solidjs/testing-library";
+import { render, cleanup, screen, waitFor } from "@solidjs/testing-library";
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { TurnstileWidget, turnstileEnabled } from "../../src/auth/TurnstileWidget";
@@ -38,5 +38,40 @@ describe("TurnstileWidget — unconfigured renders nothing", () => {
     render(() => <TurnstileWidget siteKey="0x4AAAtest" onToken={onToken} />);
     // The accessible label is always present in the configured branch.
     expect(screen.getByText("Human verification challenge")).toBeTruthy();
+  });
+});
+
+describe("TurnstileWidget — single-use reset (onReady)", () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { turnstile?: unknown }).turnstile;
+  });
+
+  it("hands the parent a reset() that drops the stale token then resets the widget", async () => {
+    let cb: ((token: string) => void) | undefined;
+    const reset = vi.fn();
+    (globalThis as unknown as { turnstile?: unknown }).turnstile = {
+      render: vi.fn((_el: HTMLElement, opts: { callback?: (t: string) => void }) => {
+        cb = opts.callback;
+        cb?.("first-token");
+        return "wid-1";
+      }),
+      reset,
+      remove: vi.fn(),
+    };
+
+    const onToken = vi.fn();
+    let controls: { reset: () => void } | undefined;
+    render(() => (
+      <TurnstileWidget siteKey="0x4AAAtest" onToken={onToken} onReady={(c) => (controls = c)} />
+    ));
+
+    await waitFor(() => expect(controls).toBeDefined());
+    await waitFor(() => expect(onToken).toHaveBeenCalledWith("first-token"));
+
+    controls!.reset();
+    // The stale token is dropped synchronously (null) so the form can't replay it,
+    expect(onToken).toHaveBeenCalledWith(null);
+    // and the underlying Cloudflare widget is reset to mint a fresh challenge.
+    expect(reset).toHaveBeenCalledWith("wid-1");
   });
 });

--- a/wiki/systems/turnstile.md
+++ b/wiki/systems/turnstile.md
@@ -16,7 +16,7 @@ packages:
   - "@cire/web"
   - "@cire/organiser"
 finding-ids: []
-last-reviewed: 2026-06-18
+last-reviewed: 2026-06-19
 ---
 
 # Turnstile bot protection
@@ -84,6 +84,38 @@ limiter keys on — see [[rate-limiting]].
 **Same widget for both backends.** One sitekey + one secret; the widget's
 domains cover `cireweddings.com` (guest) and `app.cireweddings.com` (organiser),
 and osn-api lives on `id.cireweddings.com`.
+
+> **Widget allowed-hostnames must include every form origin.** Turnstile only
+> issues a token on a hostname listed in the widget's **Domains** (Cloudflare
+> dashboard → Turnstile → widget). If `app.cireweddings.com` is missing, the
+> organiser widget fires `error-callback` (Cloudflare error `110200`), never
+> calls back with a token, and the gated form's submit stays disabled — the
+> `@osn/ui` widget surfaces this as "Couldn't load the verification challenge",
+> not a silent hang. Add **`cireweddings.com`, `app.cireweddings.com`,
+> `id.cireweddings.com`** to the widget's domain list.
+
+## Client widget: single-use tokens must be reset after each submit
+
+A Turnstile token is **single-use**: once a backend has siteverified it, the
+same value is rejected `timeout-or-duplicate` forever. Cloudflare only
+auto-refreshes a token on its **~300s expiry**, *not* when it is consumed by a
+form submit. So a frontend that re-submits a form (a retried sign-in, a "resend
+code") **must explicitly reset the widget** to mint a fresh token — otherwise it
+replays the redeemed token and the server fail-closes it.
+
+`@osn/ui`'s `TurnstileWidget` exposes this via `onReady({ reset })`: `reset()`
+drops the stale token (`onToken(null)`) and calls Cloudflare's `turnstile.reset()`
+on the live widget instance (no re-render, no new iframe), and the fresh token
+arrives on the existing `onToken` callback. `SignIn` and `Register` call it
+immediately after each token-consuming `/begin` call.
+
+**Login-loop regression (fixed):** before this wiring, once the prod sitekey +
+secret went live (**#160**), the organiser `SignIn` form replayed its redeemed
+token on every retry → `/login/passkey/begin` returned `turnstile_failed` → the
+user bounced back to the login screen. Any new client form that gates a backend
+call on a Turnstile token MUST reset the widget after the call. The silent
+conditional-UI (autofill) passkey ceremony is exempt — it carries no token and
+osn-api does not gate it (#163 Bug C).
 
 ## Activation (the rollout order matters)
 


### PR DESCRIPTION
## Summary
- Fixes the **organiser login loop** at `app.cireweddings.com`: after a passkey sign-in attempt the user bounced back to the login screen.
- Root cause: Cloudflare Turnstile tokens are **single-use**, but `@osn/ui`'s `SignIn` form gated `/login/passkey/begin` on a token and never retired it after `/begin` redeemed it. Cloudflare only auto-refreshes a token on its ~300s expiry, *not* on consumption — so any retry (cancelled WebAuthn ceremony, wrong passkey, transient error) replayed the redeemed token, the server rejected it `timeout-or-duplicate` → `turnstile_failed`, and the user was thrown back to login. The loop went live the moment **#160** activated the prod sitekey + secret.
- Fix: `TurnstileWidget` now exposes `onReady({ reset })`; `SignIn` and `Register` call `reset()` immediately after each token-consuming begin call so the next submit always carries a fresh token. Also kills the same latent single-use replay bug in `Register.resendCode`.

## Workspaces affected
- `@osn/ui` (patch) — the only changed workspace. Consumed by cire/organiser SignInPanel; the new prop is optional, so non-breaking.

## Decisions & issues

**[root-cause / which PR]** — Turnstile single-use token replay
- **Issue:** `SignIn.submitPasskey` consumed the Turnstile token on `/login/passkey/begin` but left `turnstileToken()` set; the widget does not auto-mint a fresh token on consumption (only on the ~300s expiry). Retries replayed the redeemed token.
- **Why:** Server `@shared/turnstile` verifier fail-closes on `timeout-or-duplicate` (already-redeemed). Live-verified: `POST id.cireweddings.com/login/passkey/begin` with `{identifier}` + a token now returns `turnstile_failed`; the no-identifier autofill path is exempt and returns 200. The interactive form was the broken path.
- **Solution:** Added `TurnstileWidget.onReady({ reset })` (drops the stale token, calls `turnstile.reset()` on the existing widget instance — no re-render/new iframe); `SignIn` + `Register` invoke it after each redeeming begin. The no-Turnstile call shape (`passkeyBegin(identifier)`) is preserved.
- **Rationale:** Mints a fresh, legitimately-solved token per attempt. The bot-protection guarantee is unchanged — enforcement is entirely server-side and fail-closed; reset cannot self-issue or skip a token, only obtain a new challenge.

**[which recent PR introduced it]** — #160 activated the gate; #154 shipped the gap
- **Issue:** #154 added the client Turnstile gate to `SignIn`/`Register` without a post-consume reset. #160 then activated `PUBLIC_TURNSTILE_SITEKEY` (prod sitekey `0x4AAAAAADnA2piUnbgG_kVw`, confirmed baked into the live `SignInPanel` bundle) + the matching `TURNSTILE_SECRET_KEY`, flipping `turnstileOn()` true in prod and exposing the latent bug.
- **Why:** Before #160 the sitekey was unset → `turnstileOn()` false → no gate → no loop. The loop is therefore "caused in the last few PRs" exactly as reported.
- **Solution:** Fix lands in `@osn/ui` where the single-use handling belongs.
- **Rationale:** Ruled out #163 (only touched passkey-ENROLL principal + the correct login-begin autofill exemption — not login complete/session), #155/#156 (cire authz; the post-login `/api/organiser/weddings` 401 redirect is a secondary path that requires an already-established session) and CORS/cookie config (verified correct live).

**[S-L1/S-L2, P-I1–P-I3]** — review findings, accepted as-is
- **Issue:** Security review: reset drops token to `null` before the fresh one arrives (S-L1); reset runs before the WebAuthn ceremony, widening the challenge window slightly (S-L2). Perf review: one extra reactive cycle per submit from the double `onToken` write (P-I1).
- **Why:** Reviewed for bypass / leak / leaked-widget-instance risk.
- **Solution:** No change. The null-first ordering is the deliberate fail-safe (the exact replay window being closed); both submit guards fail-closed on null so a submit in the gap is blocked, not sent token-less; reset reuses the existing `widgetId` (no leaked iframe). No Critical/High/Medium findings from either review.
- **Rationale:** Client fail-closed mirrors the server's fail-closed siteverify; the cost is a momentarily disabled button on a cold (submit) path.

## ⚠️ User-side config to verify (not code)
The fix repairs the **single-use replay** loop. Separately, confirm the Turnstile widget's **Domains** list (Cloudflare dashboard → Turnstile → widget) includes **`cireweddings.com`, `app.cireweddings.com`, `id.cireweddings.com`**. If `app.cireweddings.com` is absent, the organiser widget fires `error-callback` (CF error `110200`), never issues a token, and the interactive form's submit stays disabled — `@osn/ui` now surfaces this as "Couldn't load the verification challenge" instead of a silent block. (Autofill sign-in is unaffected — it carries no token.)

## Test plan
- [x] `bun run --cwd osn/ui test:run` — 125 pass (incl. new regression tests).
- [x] Regression test proven: removing the `reset()` call makes the new SignIn test fail (1 failed) → restoring it passes. TDD-verified.
- [x] `bun run --cwd osn/ui check` (tsc) clean; `bun run --cwd cire/organiser test:run` — 54 pass (consumer).
- [ ] After deploy: interactive organiser sign-in, cancel the passkey prompt once, retry — should succeed (no `turnstile_failed`), not loop.
- [ ] Verify widget Domains include `app.cireweddings.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)