### PR TITLE
fix(osn/client): bootstrap session from refresh cookie on cold start (organiser login loop)

### DIFF
--- a/.changeset/osn-client-cold-start-session-bootstrap.md
+++ b/.changeset/osn-client-cold-start-session-bootstrap.md
@@ -1,0 +1,9 @@
+---
+"@osn/client": patch
+---
+
+Fix organiser login loop: bootstrap a session from the HttpOnly refresh cookie on cold start.
+
+After a successful passkey sign-in the organiser dashboard performed a full-page navigation, recreating a fresh `AuthProvider`. On that cold start the client had no stored account, so the session resource resolved `null` and `RequireAuth` bounced back to `/login` — even though the refresh cookie set by `/login/passkey/complete` was alive.
+
+`OsnAuthService` now exposes `loadSession()`: when no account is stored it replays the cookie against `POST /token` (`grant_type=refresh_token`, `credentials: "include"`) exactly once (single-flighted), reconstructs and persists the account from the token response, and returns the session. If no/expired cookie is present it resolves to `null` (logged out, fail-safe — never throws). The SolidJS session resource now calls `loadSession()` on mount. The authenticated 401-refresh path and its single-flight guard are unchanged.

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -79,6 +79,20 @@ export interface OsnAuthConfig {
 export interface OsnAuthService {
   readonly getSession: () => Effect.Effect<Session | null, StorageError>;
 
+  /**
+   * Session-load entry point for app mount (e.g. the SolidJS session resource).
+   *
+   * Returns the locally-cached session when an account exists. When there is
+   * NO stored account — the cold-start case after a post-login full-page
+   * navigation — it attempts to bootstrap a session from the HttpOnly refresh
+   * cookie via a single `POST /token` (grant_type=refresh_token,
+   * credentials: "include"), reconstructing and persisting the account from
+   * the token response. If no/expired cookie is present, resolves to `null`
+   * (genuinely logged out) — never throws. Single-flighted so concurrent
+   * mounts don't double-hit `/token`.
+   */
+  readonly loadSession: () => Effect.Effect<Session | null, StorageError>;
+
   readonly refreshSession: () => Effect.Effect<Session, TokenRefreshError | StorageError>;
 
   readonly logout: () => Effect.Effect<void, StorageError>;
@@ -185,6 +199,42 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
         });
 
       // -----------------------------------------------------------------------
+      // Shared /token grant.
+      //
+      // POST {issuer}/token with grant_type=refresh_token and
+      // credentials: "include". The session (refresh) token lives only in the
+      // HttpOnly cookie (Copenhagen Book C3), so this single request both
+      // drives the authenticated 401-refresh path and the cold-start bootstrap
+      // below — the only difference is whether a local account already exists.
+      // -----------------------------------------------------------------------
+      const fetchTokenGrant = () =>
+        Effect.gen(function* () {
+          const raw = yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.issuerUrl}/token`, {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                credentials: "include",
+                body: new URLSearchParams({
+                  grant_type: "refresh_token",
+                }).toString(),
+              }).then((r) => {
+                // A non-2xx (e.g. 401 invalid_grant — cookie gone/expired) is a
+                // genuine "no session", not a transport error. Surface it as a
+                // typed failure so the cold-start path can fail-safe to null.
+                if (!r.ok) throw new Error(`Token grant failed: ${r.status}`);
+                return r.json() as Promise<unknown>;
+              }),
+            catch: (cause) => new TokenRefreshError({ cause }),
+          });
+
+          return yield* Effect.try({
+            try: () => parseTokenResponse(raw),
+            catch: (cause) => new TokenRefreshError({ cause }),
+          });
+        });
+
+      // -----------------------------------------------------------------------
       // Single-flight refresh (S-H1 / P-W1).
       //
       // Multiple concurrent authFetch calls that all 401 must NOT each fire
@@ -210,23 +260,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
           }
 
           // C3: session token is in the HttpOnly cookie; send credentials: include.
-          const raw = yield* Effect.tryPromise({
-            try: () =>
-              fetch(`${config.issuerUrl}/token`, {
-                method: "POST",
-                headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                credentials: "include",
-                body: new URLSearchParams({
-                  grant_type: "refresh_token",
-                }).toString(),
-              }).then((r) => r.json() as Promise<unknown>),
-            catch: (cause) => new TokenRefreshError({ cause }),
-          });
-
-          const next = yield* Effect.try({
-            try: () => parseTokenResponse(raw),
-            catch: (cause) => new TokenRefreshError({ cause }),
-          });
+          const next = yield* fetchTokenGrant();
 
           const profileId = extractJwtSub(next.accessToken) ?? account.activeProfileId;
           account.profileTokens[profileId] = {
@@ -266,6 +300,83 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
             return yield* Effect.fail(result.left);
           }
           return result.right;
+        });
+
+      // -----------------------------------------------------------------------
+      // Cold-start bootstrap (production login-loop fix).
+      //
+      // After a full-page navigation following a successful passkey sign-in,
+      // a fresh AuthProvider has NO stored account, yet the HttpOnly refresh
+      // cookie that /login/passkey/complete just set is alive. Treating "no
+      // local account" as logged-out makes RequireAuth bounce back to /login —
+      // the loop. Instead, replay the cookie against /token once and rebuild
+      // the account from the token response.
+      //
+      // Single-flighted on its own promise (concurrent fresh-mount loaders must
+      // not double-hit /token — replaying a rotated cookie trips C2 reuse
+      // detection). On any failure (no/expired cookie → non-2xx, or network),
+      // resolve to null: genuinely logged out, fail-safe, no throw.
+      // -----------------------------------------------------------------------
+      let inFlightBootstrap: Promise<RefreshEither> | null = null;
+
+      const doBootstrap = () =>
+        Effect.gen(function* () {
+          const next = yield* fetchTokenGrant();
+
+          // The access token's `sub` is the active profile id.
+          const profileId = extractJwtSub(next.accessToken) ?? "default";
+          const account: AccountSession = {
+            hasSession: true,
+            activeProfileId: profileId,
+            profileTokens: {
+              [profileId]: {
+                accessToken: next.accessToken,
+                expiresAt: next.expiresAt,
+              },
+            },
+            scopes: next.scopes,
+            idToken: next.idToken,
+          };
+          yield* saveAccountSession(account);
+          return next;
+        });
+
+      const bootstrapFromCookie = () =>
+        Effect.gen(function* () {
+          if (!inFlightBootstrap) {
+            const promise = Effect.runPromise(
+              Effect.either(doBootstrap()),
+            ) as Promise<RefreshEither>;
+            inFlightBootstrap = promise;
+            void promise.finally(() => {
+              if (inFlightBootstrap === promise) inFlightBootstrap = null;
+            });
+          }
+
+          // The shared promise is Either-wrapped so it never rejects; any
+          // failure (bad cookie, network, storage) arrives as a Left and maps
+          // to null — a failed bootstrap means "logged out", never a throw.
+          // A defensive orElse covers the should-never-happen rejection too.
+          const result = yield* Effect.tryPromise({
+            try: () => inFlightBootstrap!,
+            catch: (cause) => new TokenRefreshError({ cause }),
+          }).pipe(
+            Effect.map((r): Session | null => (r._tag === "Left" ? null : r.right)),
+            Effect.orElseSucceed((): Session | null => null),
+          );
+
+          return result;
+        });
+
+      // loadSession — the session-load entry point the SolidJS resource calls
+      // on mount. Returns the local session when an account exists; otherwise
+      // attempts a cold-start bootstrap from the HttpOnly cookie before
+      // concluding the user is logged out.
+      const loadSession = () =>
+        Effect.gen(function* () {
+          const account = yield* getAccountSession();
+          if (account) return toSession(account);
+          return yield* bootstrapFromCookie();
         });
 
       const logout = () =>
@@ -527,6 +638,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
 
       return {
         getSession,
+        loadSession,
         refreshSession,
         logout,
         setSession,

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -50,8 +50,12 @@ export function AuthProvider(props: AuthProviderProps) {
       Effect.provide(eff, layer).pipe(Effect.orDie) as Effect.Effect<A, never, never>,
     );
 
+  // On mount this calls loadSession (not getSession): when there is no stored
+  // account it bootstraps from the HttpOnly refresh cookie via /token before
+  // concluding "logged out", so a post-login full-page navigation re-establishes
+  // the session instead of bouncing RequireAuth back to /login.
   const [session, { refetch: refetchSession }] = createResource<Session | null>(() =>
-    run(Effect.flatMap(OsnAuth, (auth) => auth.getSession())),
+    run(Effect.flatMap(OsnAuth, (auth) => auth.loadSession())),
   );
 
   // P-W2: Gate profiles on session — only fetch when a session exists.

--- a/osn/client/tests/cold-start-bootstrap.test.ts
+++ b/osn/client/tests/cold-start-bootstrap.test.ts
@@ -1,0 +1,191 @@
+import { it, expect } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { vi } from "vitest";
+
+import { OsnAuth, createOsnAuthLive } from "../src/service";
+import { createMemoryStorage } from "../src/storage";
+
+const config = { issuerUrl: "https://osn.example.com" };
+
+function createTestLayer() {
+  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+}
+
+/** Build a fake JWT whose payload contains the given `sub` claim. */
+function fakeJwt(sub: string): string {
+  const header = btoa(JSON.stringify({ alg: "ES256", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ sub, iat: Date.now() }));
+  return `${header}.${payload}.fake_signature`;
+}
+
+function mockResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cold-start bootstrap (the production login-loop regression test).
+//
+// After a full-page navigation post-login, a fresh AuthProvider has NO stored
+// account but the HttpOnly refresh cookie that /login/passkey/complete set is
+// still alive. loadSession() must replay that cookie against /token and
+// reconstruct a session, instead of treating "no local account" as logged-out.
+// ---------------------------------------------------------------------------
+
+it.effect(
+  "loadSession bootstraps a session from the /token cookie when there is no stored account",
+  () =>
+    Effect.gen(function* () {
+      const profileId = "usr_coldstart01";
+      let tokenCallInit: RequestInit | undefined;
+      const fetchMock = vi
+        .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+        .mockImplementation((input, init) => {
+          const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+          if (url.endsWith("/token")) {
+            tokenCallInit = init;
+            return Promise.resolve(
+              mockResponse(200, {
+                access_token: fakeJwt(profileId),
+                token_type: "Bearer",
+                expires_in: 300,
+                scope: "openid profile",
+              }),
+            );
+          }
+          return Promise.resolve(mockResponse(404));
+        });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const auth = yield* OsnAuth;
+
+      // No setSession — simulates a cold page load with only the cookie present.
+      const session = yield* auth.loadSession();
+
+      expect(session).not.toBeNull();
+      expect(session?.scopes).toEqual(["openid", "profile"]);
+
+      // A /token POST with credentials: include was made (replays the cookie).
+      const tokenCall = fetchMock.mock.calls.find(([input]) => {
+        const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+        return url.endsWith("/token");
+      });
+      expect(tokenCall).toBeDefined();
+      expect(tokenCallInit?.credentials).toBe("include");
+      expect(tokenCallInit?.method).toBe("POST");
+
+      // The reconstructed account is persisted: a subsequent getSession sees it.
+      const persisted = yield* auth.getSession();
+      expect(persisted).not.toBeNull();
+      expect(persisted?.accessToken).toBe(session?.accessToken);
+
+      // The active profile is the access token's `sub`.
+      const active = yield* auth.getActiveProfile();
+      expect(active).toBe(profileId);
+
+      vi.unstubAllGlobals();
+    }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect(
+  "loadSession resolves to null when there is no account and the cookie is gone/expired",
+  () =>
+    Effect.gen(function* () {
+      const fetchMock = vi
+        .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+        .mockImplementation((input) => {
+          const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+          if (url.endsWith("/token")) {
+            return Promise.resolve(mockResponse(401, { error: "invalid_grant" }));
+          }
+          return Promise.resolve(mockResponse(404));
+        });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const auth = yield* OsnAuth;
+
+      // No account, cookie rejected → genuinely logged out. Must resolve null,
+      // not throw (a throw would bubble through Effect.orDie and crash the page).
+      const session = yield* auth.loadSession();
+      expect(session).toBeNull();
+
+      vi.unstubAllGlobals();
+    }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect(
+  "loadSession returns the existing session without hitting /token when an account is present",
+  () =>
+    Effect.gen(function* () {
+      const fetchMock = vi
+        .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+        .mockResolvedValue(mockResponse(200, {}));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const auth = yield* OsnAuth;
+      yield* auth.setSession({
+        accessToken: fakeJwt("usr_existing0001"),
+        idToken: null,
+        expiresAt: Date.now() + 60_000,
+        scopes: ["openid", "profile"],
+      });
+
+      const session = yield* auth.loadSession();
+      expect(session).not.toBeNull();
+
+      // No /token call: we already have a valid local account.
+      const tokenCalls = fetchMock.mock.calls.filter(([input]) => {
+        const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+        return url.endsWith("/token");
+      });
+      expect(tokenCalls).toHaveLength(0);
+
+      vi.unstubAllGlobals();
+    }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("loadSession single-flights — concurrent cold-start loads fire ONE /token", () =>
+  Effect.gen(function* () {
+    let tokenCalls = 0;
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockImplementation((input) => {
+        const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+        if (url.endsWith("/token")) {
+          tokenCalls += 1;
+          // Widen the race window so concurrent callers overlap.
+          return new Promise((resolve) =>
+            setTimeout(() => {
+              resolve(
+                mockResponse(200, {
+                  access_token: fakeJwt("usr_concurrent01"),
+                  token_type: "Bearer",
+                  expires_in: 300,
+                  scope: "openid profile",
+                }),
+              );
+            }, 10),
+          );
+        }
+        return Promise.resolve(mockResponse(404));
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = yield* OsnAuth;
+
+    const [s1, s2, s3] = yield* Effect.all(
+      [auth.loadSession(), auth.loadSession(), auth.loadSession()],
+      { concurrency: "unbounded" },
+    );
+
+    expect(s1).not.toBeNull();
+    expect(s2).not.toBeNull();
+    expect(s3).not.toBeNull();
+    // Replaying a rotated cookie a second time trips reuse detection — only ONE.
+    expect(tokenCalls).toBe(1);
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);


### PR DESCRIPTION
## Root cause (one line)
After a successful organiser passkey sign-in, the post-login full-page navigation recreates a fresh `AuthProvider` with no stored account; the client treated "no local account" as logged-out and never replayed the live HttpOnly refresh cookie against `/token`, so `RequireAuth` bounced back to `/login` — the loop.

## The bug (live-confirmed)
`wrangler tail` of osn-api during a real attempt: `POST /login/passkey/begin` 200 → `POST /login/passkey/complete` 200 → `GET /profiles/list` ×3 200, then **no `/token` call**, then bounce. Login + session establishment succeed server-side; the client fails to restore the session after the full-page reload.

Code path:
- `@osn/ui` `SignIn.finishWithSession` → consumer `onSuccess` is a full-page `window.location.href = "/"` (`SignInPanel.tsx`) → fresh `AuthProvider`.
- The session resource called `getSession()`, which returns `null` with no in-memory/stored account; `doRefresh()` also failed fast with `"No session available"`. Neither hit `/token`.
- But the HttpOnly refresh cookie `/login/passkey/complete` set was alive — it can re-establish a session with no client-side account.

## The fix
`@osn/client` now **bootstraps a session from the `/token` cookie on cold start**:
- New `OsnAuthService.loadSession()`: returns the local session when an account exists; otherwise replays the cookie against `POST {issuerUrl}/token` (`grant_type=refresh_token`, `credentials: "include"`) **once**, reconstructs the account from the token response (access token `sub` → `activeProfileId`, `profileTokens[sub]`, `hasSession`, `scopes`, `idToken`), persists it, and returns the `Session`. No/expired cookie → resolves to `null` (logged out), never throws.
- The `/token` fetch+parse is factored into a shared `fetchTokenGrant()` used by both the authenticated 401-refresh path (`doRefresh`) and the new cold-start `doBootstrap`.
- Bootstrap is **single-flighted** on its own in-flight promise so concurrent fresh-mount loaders don't double-hit `/token` (replaying a rotated cookie trips C2 reuse-detection). The existing authenticated-refresh single-flight is untouched.
- The SolidJS session resource (`solid/context.tsx`) now calls `loadSession()` on mount.

## Tests (TDD — written first, watched fail, then fixed)
New `osn/client/tests/cold-start-bootstrap.test.ts`:
- **Cold start with a live cookie** → returns a Session, persists the account, asserts a `/token` POST with `credentials:"include"` was made (regression test for the loop).
- **Cold start with no/expired cookie** (`/token` 401) → resolves to `null`, no throw.
- **Account present** → returns local session, no `/token` call.
- **Single-flight** → 3 concurrent `loadSession()` fire exactly ONE `/token`.

All green: `@osn/client` 136 tests, `@osn/ui` 123, `cire/organiser` 54 + build, `tsc --noEmit` clean across all three. Lint clean on changed files.

## Security disposition
The bootstrap only trusts the server `/token` response + the HttpOnly cookie (never client-controlled input). Single-flight preserved (no rotated-cookie replay → no reuse-detection family revocation). No token logged. A failed bootstrap = logged-out (fail-safe). `activeProfileId` derived from the server-issued access token's `sub`. Authenticated 401-refresh path unchanged.

## Deploy note
Ships in the organiser Pages bundle via `@osn/client` (consumed as source). A **Pages rebuild deploys it — no osn-api change required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)