### PR TITLE
fix(cire/api): degrade gracefully on a malformed ARC bridge key

### DIFF
--- a/.changeset/cire-arc-resolver-graceful.md
+++ b/.changeset/cire-arc-resolver-graceful.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(cire/api): a malformed CIRE_API_ARC_PRIVATE_KEY now disables the OSN bridge (add-hosts / account-linking answer 503) instead of throwing out of the resolver builders. A corrupt ARC key previously made cire-api throw on every authenticated request — taking down the whole organiser dashboard — because importKeyFromJwk JSON.parse failures were unguarded. Both env-driven resolver builders now catch the import failure and degrade exactly like an absent key.

--- a/cire/api/src/services/osn-bridge.test.ts
+++ b/cire/api/src/services/osn-bridge.test.ts
@@ -111,6 +111,31 @@ describe("createAccountResolverFromEnv", () => {
     expect(resolve).not.toBeNull();
     expect(await resolve!("usr_1")).toEqual({ ok: true, accountId: "acc_env" });
   });
+
+  // A PRESENT-but-INVALID ARC key must be treated EXACTLY like an absent one:
+  // the builder returns null (⇒ feature disabled, POST answers 503) and NEVER
+  // throws. A throw here propagated out of the Worker setup path and 500'd every
+  // authenticated request (the production dashboard login-loop incident).
+  it.each([
+    ["non-JSON garbage", "{not-json"],
+    ["plain string", "garbage"],
+    ["valid JSON but not a usable JWK", '{"kty":"EC"}'],
+  ])("returns null (does NOT throw) when the ARC key is malformed: %s", async (_label, badJwk) => {
+    let resolve: unknown;
+    expect(async () => {
+      resolve = await createAccountResolverFromEnv({
+        osnApiUrl: "https://osn.example",
+        arcPrivateKeyJwk: badJwk,
+        arcKeyId: "kid-env",
+      });
+    }).not.toThrow();
+    resolve = await createAccountResolverFromEnv({
+      osnApiUrl: "https://osn.example",
+      arcPrivateKeyJwk: badJwk,
+      arcKeyId: "kid-env",
+    });
+    expect(resolve).toBeNull();
+  });
 });
 
 describe("createArcHandleResolver", () => {
@@ -217,5 +242,27 @@ describe("createHandleResolverFromEnv", () => {
     });
     expect(resolve).not.toBeNull();
     expect(await resolve!("env")).toEqual({ ok: true, profileId: "usr_env", handle: "env" });
+  });
+
+  // Sibling of the account-resolver guard: a corrupt CIRE_API_ARC_PRIVATE_KEY
+  // must disable add-co-host-by-handle (POST 503), never crash the builder.
+  it.each([
+    ["non-JSON garbage", "{not-json"],
+    ["plain string", "garbage"],
+    ["valid JSON but not a usable JWK", '{"kty":"EC"}'],
+  ])("returns null (does NOT throw) when the ARC key is malformed: %s", async (_label, badJwk) => {
+    expect(async () => {
+      await createHandleResolverFromEnv({
+        osnApiUrl: "https://osn.example",
+        arcPrivateKeyJwk: badJwk,
+        arcKeyId: "kid-env",
+      });
+    }).not.toThrow();
+    const resolve = await createHandleResolverFromEnv({
+      osnApiUrl: "https://osn.example",
+      arcPrivateKeyJwk: badJwk,
+      arcKeyId: "kid-env",
+    });
+    expect(resolve).toBeNull();
   });
 });

--- a/cire/api/src/services/osn-bridge.ts
+++ b/cire/api/src/services/osn-bridge.ts
@@ -104,7 +104,12 @@ export async function createAccountResolverFromEnv(env: {
   if (!env.osnApiUrl || !env.arcPrivateKeyJwk || !env.arcKeyId) {
     return null;
   }
-  const arcPrivateKey = await importKeyFromJwk(env.arcPrivateKeyJwk);
+  // A present-but-INVALID key (corrupt / garbled JWK) must degrade EXACTLY like
+  // an absent one — disable the feature (the POST then answers 503), never throw
+  // out of the builder. A malformed CIRE_API_ARC_PRIVATE_KEY once made cire-api
+  // throw on EVERY authed request and took down the whole organiser dashboard.
+  const arcPrivateKey = await importKeyFromJwk(env.arcPrivateKeyJwk).catch(() => null);
+  if (!arcPrivateKey) return null;
   return createArcAccountResolver({
     osnApiUrl: env.osnApiUrl,
     arcPrivateKey,
@@ -181,7 +186,11 @@ export async function createHandleResolverFromEnv(env: {
   if (!env.osnApiUrl || !env.arcPrivateKeyJwk || !env.arcKeyId) {
     return null;
   }
-  const arcPrivateKey = await importKeyFromJwk(env.arcPrivateKeyJwk);
+  // Present-but-INVALID key ⇒ degrade like absent (co-host-by-handle disabled,
+  // add-host POST answers 503) instead of throwing on every request. See the
+  // account-resolver builder above for the incident this guards against.
+  const arcPrivateKey = await importKeyFromJwk(env.arcPrivateKeyJwk).catch(() => null);
+  if (!arcPrivateKey) return null;
   return createArcHandleResolver({
     osnApiUrl: env.osnApiUrl,
     arcPrivateKey,


### PR DESCRIPTION
## Summary
A corrupt `CIRE_API_ARC_PRIVATE_KEY` made cire-api **throw on every authenticated request** (the organiser dashboard login-loop incident): `createAccountResolverFromEnv` / `createHandleResolverFromEnv` called `importKeyFromJwk` (which `JSON.parse`s the JWK) **unguarded**, so a malformed key threw out of the per-request resolver build and 500ed unrelated routes (e.g. `GET /api/organiser/weddings`).

Now a present-but-invalid key degrades **exactly like an absent one** — the OSN bridge is disabled (add-hosts / account-linking answer their existing 503), and all other routes keep working.

## Changes
- `cire/api/src/services/osn-bridge.ts` — both env-driven resolver builders `.catch(() => null)` the JWK import and return `null` on failure.
- `cire/api/src/services/osn-bridge.test.ts` — malformed-key cases (`{not-json`, `garbage`, incomplete JWK) → returns null, never throws (alongside existing absent/valid cases).

## Test plan
- `bun test cire/api/src/services/osn-bridge.test.ts` → 19 pass. A malformed key disables only add-hosts/account-linking; the dashboard is unaffected.