### PR TITLE
feat(cire/organiser): guided dashboard — getting-started checklist + clearer IA

### DIFF
--- a/.changeset/cire-organiser-ux.md
+++ b/.changeset/cire-organiser-ux.md
@@ -1,0 +1,31 @@
+---
+"@cire/organiser": minor
+---
+
+Organiser dashboard UX + structure pass — make it intuitive, well-explained, and
+fun to use, without regressing the live previews or status indicators.
+
+- **Getting-started checklist** (new `GettingStarted.tsx`): a four-step progress
+  guide — Add events → Add guests → Customise invite → Share codes — whose
+  done-state is derived from the wedding's real data (event/household counts, the
+  invite emptiness predicates, codes-sent count). It shows a progress rail + the
+  single next action for a first-timer, collapses to a calm "all set" summary
+  once complete, and each step jumps straight to the matching tab.
+- **Clearer wedding context header**: the selected wedding's name is now the page
+  `<h1>` with its slug eyebrow and an Owner/Co-host badge (was a small italic
+  line). Preview stays top-right.
+- **Workflow-ordered tabs with icons**: reordered to Events → Guests → Invite →
+  Codes → Hosts (was Guests-first), each with a small leading glyph and a
+  hover-tooltip describing it. Hash-routing is preserved and now also reacts to
+  external `hashchange` (the checklist jumps + browser back/forward).
+- **Per-tab intros + empty states** via a new shared `SectionIntro` (eyebrow +
+  serif heading + description + optional actions slot), adopted by Guests,
+  Events, Codes, and Hosts so every panel reads as one family. Guests and Events
+  gained guided empty states; the Codes copy now explains what a guest code is;
+  the Hosts copy explains owner vs co-host.
+- **Spreadsheet Import is now collapsible** so it leads a new wedding but doesn't
+  crowd an established one. The 3-step CSV format guide is unchanged.
+
+No API calls or flows changed: the theme/hero WYSIWYG previews, per-event image
+upload, RSVP CSV download, host-by-handle autocomplete, re-mint codes, and the
+security/passkey panel all behave exactly as before.

--- a/cire/organiser/src/components/DashboardTabs.test.tsx
+++ b/cire/organiser/src/components/DashboardTabs.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * DashboardTabs is the per-wedding tab bar. The leaf panels are stubbed to
+ * data-testids so this asserts only the tab glue: workflow-ordered tabs, the
+ * owner-vs-co-host tab set, hash-routing both ways (a click writes the hash; an
+ * external hashchange — e.g. the Getting-started jump — switches the panel), and
+ * that a stale `#codes` hash can't expose the owner-only panel to a co-host.
+ */
+
+vi.mock("./EventTable", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="events">{p.weddingId}</div>,
+}));
+vi.mock("./GuestTable", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="guests">{p.weddingId}</div>,
+}));
+vi.mock("./InviteBuilder", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="invite">{p.weddingId}</div>,
+}));
+vi.mock("./RemintPanel", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="codes">{p.weddingId}</div>,
+}));
+vi.mock("./HostsPanel", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="hosts">{p.weddingId}</div>,
+}));
+
+import DashboardTabs from "./DashboardTabs";
+
+function renderTabs(canManage: boolean) {
+  return render(() => (
+    <DashboardTabs
+      weddingId="wed_1"
+      weddingName="V & R"
+      weddingSlug="v-and-r"
+      canManage={canManage}
+    />
+  ));
+}
+
+describe("DashboardTabs", () => {
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+  afterEach(() => {
+    cleanup();
+    window.location.hash = "";
+  });
+
+  it("defaults to the Events tab (workflow order leads with the day)", () => {
+    renderTabs(true);
+    expect(screen.getByTestId("events")).toBeTruthy();
+    expect(screen.queryByTestId("guests")).toBeNull();
+  });
+
+  it("shows owner tabs (Codes) for an owner", () => {
+    renderTabs(true);
+    expect(screen.getByRole("tab", { name: /Codes/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Hosts/ })).toBeTruthy();
+  });
+
+  it("hides the Codes tab for a co-host", () => {
+    renderTabs(false);
+    expect(screen.queryByRole("tab", { name: /Codes/ })).toBeNull();
+    expect(screen.getByRole("tab", { name: /Hosts/ })).toBeTruthy();
+  });
+
+  it("switches panels and writes the hash when a tab is clicked", () => {
+    renderTabs(true);
+    fireEvent.click(screen.getByRole("tab", { name: /Invite/ }));
+    expect(screen.getByTestId("invite")).toBeTruthy();
+    expect(window.location.hash).toBe("#invite");
+  });
+
+  it("responds to an external hashchange (the Getting-started jump)", () => {
+    renderTabs(true);
+    window.location.hash = "guests";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+    expect(screen.getByTestId("guests")).toBeTruthy();
+    expect(screen.queryByTestId("events")).toBeNull();
+  });
+
+  it("falls a co-host's stale #codes hash back to Events", () => {
+    window.location.hash = "codes";
+    renderTabs(false);
+    expect(screen.getByTestId("events")).toBeTruthy();
+    expect(screen.queryByTestId("codes")).toBeNull();
+  });
+});

--- a/cire/organiser/src/components/DashboardTabs.tsx
+++ b/cire/organiser/src/components/DashboardTabs.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
 import EventTable from "./EventTable";
 import GuestTable from "./GuestTable";
@@ -6,7 +6,7 @@ import HostsPanel from "./HostsPanel";
 import InviteBuilder from "./InviteBuilder";
 import RemintPanel from "./RemintPanel";
 
-type Tab = "guests" | "events" | "invite" | "codes" | "hosts";
+type Tab = "events" | "guests" | "invite" | "codes" | "hosts";
 
 interface DashboardTabsProps {
   weddingId: string;
@@ -21,16 +21,34 @@ interface DashboardTabsProps {
   canManage: boolean;
 }
 
-const BASE_TABS: { id: Tab; label: string }[] = [
-  { id: "guests", label: "Guests" },
-  { id: "events", label: "Events" },
-  { id: "invite", label: "Invite" },
+/** A tab's nav entry. The glyph is a small leading mark that makes the row
+ *  scannable; `hint` is its native-tooltip one-liner. Order follows the real
+ *  workflow: build the day (Events) → invite the people (Guests) → dress it up
+ *  (Invite) → housekeeping (Codes, Hosts). */
+interface TabDef {
+  id: Tab;
+  label: string;
+  glyph: string;
+  hint: string;
+}
+
+const BASE_TABS: TabDef[] = [
+  { id: "events", label: "Events", glyph: "◇", hint: "Your ceremony, reception, and more" },
+  { id: "guests", label: "Guests", glyph: "✎", hint: "Households, invites, and RSVPs" },
+  { id: "invite", label: "Invite", glyph: "✦", hint: "Photos, story, colours, and fonts" },
 ];
 
 // `Codes` (the destructive re-mint) is owner-only; `Hosts` stays visible to
 // co-hosts (read-only — the panel itself gates the add/remove actions).
-const OWNER_TABS: { id: Tab; label: string }[] = [{ id: "codes", label: "Codes" }];
-const HOSTS_TAB: { id: Tab; label: string } = { id: "hosts", label: "Hosts" };
+const OWNER_TABS: TabDef[] = [
+  { id: "codes", label: "Codes", glyph: "⌗", hint: "Change the guest code style" },
+];
+const HOSTS_TAB: TabDef = {
+  id: "hosts",
+  label: "Hosts",
+  glyph: "♔",
+  hint: "Share editing with a co-host",
+};
 
 function isTab(value: string): value is Tab {
   return (
@@ -42,17 +60,30 @@ function isTab(value: string): value is Tab {
   );
 }
 
-function initialTab(canManage: boolean): Tab {
-  if (typeof window === "undefined") return "guests";
-  const hash = window.location.hash.replace("#", "");
-  if (!isTab(hash)) return "guests";
+function resolveHash(hash: string, canManage: boolean): Tab {
+  if (!isTab(hash)) return "events";
   // The owner-only Codes tab isn't selectable for co-hosts even via a stale hash.
-  if (!canManage && hash === "codes") return "guests";
+  if (!canManage && hash === "codes") return "events";
   return hash;
+}
+
+function initialTab(canManage: boolean): Tab {
+  if (typeof window === "undefined") return "events";
+  return resolveHash(window.location.hash.replace("#", ""), canManage);
 }
 
 export default function DashboardTabs(props: DashboardTabsProps) {
   const [active, setActive] = createSignal<Tab>(initialTab(props.canManage));
+
+  // React to external hash changes — the Getting-started checklist jumps tabs by
+  // setting the hash, and the browser back/forward buttons move through them too.
+  function onHashChange() {
+    setActive(resolveHash(window.location.hash.replace("#", ""), props.canManage));
+  }
+  onMount(() => window.addEventListener("hashchange", onHashChange));
+  onCleanup(() => {
+    if (typeof window !== "undefined") window.removeEventListener("hashchange", onHashChange);
+  });
 
   const tabs = () =>
     props.canManage ? [...BASE_TABS, ...OWNER_TABS, HOSTS_TAB] : [...BASE_TABS, HOSTS_TAB];
@@ -66,35 +97,39 @@ export default function DashboardTabs(props: DashboardTabsProps) {
 
   return (
     <div class="flex flex-col gap-6">
-      <nav class="border-border flex gap-1 border-b" role="tablist">
+      <nav class="border-border flex flex-wrap gap-1 border-b" role="tablist">
         <For each={tabs()}>
           {(tab) => (
             <button
               type="button"
               role="tab"
               aria-selected={active() === tab.id}
+              title={tab.hint}
               onClick={() => select(tab.id)}
-              class={`font-body relative -mb-px px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition ${
+              class={`font-body relative -mb-px flex items-center gap-2 px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition ${
                 active() === tab.id
                   ? "border-gold text-gold border-b-2"
                   : "text-text-muted hover:text-text border-b-2 border-transparent"
               }`}
             >
+              <span aria-hidden class="text-[0.9em] opacity-80">
+                {tab.glyph}
+              </span>
               {tab.label}
             </button>
           )}
         </For>
       </nav>
 
+      <Show when={active() === "events"}>
+        <EventTable weddingId={props.weddingId} />
+      </Show>
       <Show when={active() === "guests"}>
         <GuestTable
           weddingId={props.weddingId}
           weddingName={props.weddingName}
           weddingSlug={props.weddingSlug}
         />
-      </Show>
-      <Show when={active() === "events"}>
-        <EventTable weddingId={props.weddingId} />
       </Show>
       <Show when={active() === "invite"}>
         <InviteBuilder weddingId={props.weddingId} />

--- a/cire/organiser/src/components/EventTable.test.tsx
+++ b/cire/organiser/src/components/EventTable.test.tsx
@@ -71,7 +71,7 @@ describe("EventTable per-event image", () => {
 
     await waitFor(() => screen.getByText("Reception"));
     expect(screen.getByLabelText("Event image")).toBeTruthy();
-    expect(screen.getByText(/uploading replaces the current one/i)).toBeTruthy();
+    expect(screen.getByText(/replaces the current one/i)).toBeTruthy();
   });
 
   it("POSTs the chosen file to the per-event image endpoint and shows the preview", async () => {

--- a/cire/organiser/src/components/EventTable.tsx
+++ b/cire/organiser/src/components/EventTable.tsx
@@ -3,6 +3,7 @@ import { createSignal, onMount, Show, For } from "solid-js";
 import { toast } from "solid-toast";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import SectionIntro from "./SectionIntro";
 
 interface DressSwatch {
   name: string;
@@ -123,8 +124,16 @@ export default function EventTable(props: EventTableProps) {
     }
   }
 
+  const hasEvents = () => events().length > 0;
+
   return (
     <div class="flex flex-col gap-6">
+      <SectionIntro
+        eyebrow="Events"
+        title="The day, hour by hour"
+        description="Every event your guests can be invited to — the details come from your spreadsheet import. Add one photo per event here to bring each card to life."
+      />
+
       <Show when={loading()}>
         <div class="flex flex-col gap-3">
           <For each={[1, 2, 3, 4]}>
@@ -139,14 +148,21 @@ export default function EventTable(props: EventTableProps) {
         </p>
       </Show>
 
-      <Show when={!loading() && !error()}>
-        <div class="flex flex-col gap-1">
-          <p class="font-body text-text-muted text-[0.82rem]">{events().length} events</p>
-          <p class="font-body text-text-muted text-[0.72rem] italic">
-            Event details come from your spreadsheet import. You can add one image per event below —
-            uploading replaces the current one.
+      <Show when={!loading() && !error() && !hasEvents()}>
+        <div class="border-border bg-surface/30 flex flex-col items-start gap-2 rounded-sm border border-dashed p-8 text-center">
+          <p class="font-display text-gold-dim w-full text-[1.2rem] italic">No events yet</p>
+          <p class="font-body text-text-muted w-full text-[0.85rem] leading-relaxed">
+            Import your events sheet from the Spreadsheet Import above. Add the events first —
+            guests are matched to events that already exist.
           </p>
         </div>
+      </Show>
+
+      <Show when={!loading() && !error() && hasEvents()}>
+        <p class="font-body text-text-muted text-[0.82rem]">
+          {events().length} {events().length === 1 ? "event" : "events"} · uploading a photo
+          replaces the current one
+        </p>
 
         <ul class="flex flex-col gap-4">
           <For each={events()}>

--- a/cire/organiser/src/components/GettingStarted.test.tsx
+++ b/cire/organiser/src/components/GettingStarted.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * GettingStarted fetches a one-off snapshot (events, guests, invite) and derives
+ * a four-step checklist whose `done` state reflects the wedding's real data. It
+ * jumps to a tab when a step is clicked. The OSN auth + api helpers are stubbed;
+ * this asserts the derivation (counts → complete/incomplete) and the jump.
+ */
+
+const authFetchMock = vi.fn();
+const redirectSpy = vi.fn();
+
+vi.mock("@osn/client/solid", () => ({
+  useAuth: () => ({ authFetch: authFetchMock }),
+}));
+
+vi.mock("../lib/api", () => ({
+  apiUrl: (path: string) => `https://api.test${path}`,
+  isAuthExpired: (err: unknown) => String(err).includes("AuthExpiredError"),
+  redirectToLogin: () => redirectSpy(),
+}));
+
+import GettingStarted from "./GettingStarted";
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Route the three snapshot fetches by URL so order doesn't matter. */
+function mockSnapshot(opts: { events: unknown[]; guests: unknown[]; invite: unknown }) {
+  authFetchMock.mockImplementation((url: string) => {
+    if (url.endsWith("/events")) return Promise.resolve(json(opts.events));
+    if (url.endsWith("/guests")) return Promise.resolve(json(opts.guests));
+    if (url.endsWith("/invite")) return Promise.resolve(json(opts.invite));
+    return Promise.resolve(json({}, 404));
+  });
+}
+
+const EMPTY_INVITE = {
+  hero: { title: null, subtitle: null, imageUrl: null },
+  story: { heading: null, body: null, imageUrl: null },
+};
+
+describe("GettingStarted", () => {
+  afterEach(() => {
+    cleanup();
+    authFetchMock.mockReset();
+    redirectSpy.mockReset();
+  });
+
+  it("shows 0/4 and all steps incomplete for a brand-new wedding", async () => {
+    mockSnapshot({ events: [], guests: [], invite: EMPTY_INVITE });
+    render(() => <GettingStarted weddingId="wed_1" onJump={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
+    // Every step button is pending (data-complete=false).
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.every((b) => b.getAttribute("data-complete") === "false")).toBe(true);
+  });
+
+  it("marks events + guests complete once they exist", async () => {
+    mockSnapshot({
+      events: [{ id: "e1" }],
+      // Two members of one household, only one sent.
+      guests: [
+        { familyId: "f1", codeSharedAt: 123 },
+        { familyId: "f1", codeSharedAt: null },
+      ],
+      invite: EMPTY_INVITE,
+    });
+    render(() => <GettingStarted weddingId="wed_1" onJump={() => {}} />);
+
+    // events ✓, guests ✓, invite ✗ (empty), share ✓ (the one family is sent) ⇒ 3/4.
+    await waitFor(() => expect(screen.getByText("3 / 4 done")).toBeTruthy());
+  });
+
+  it("counts the invite as customised when a hero title is set", async () => {
+    mockSnapshot({
+      events: [{ id: "e1" }],
+      guests: [{ familyId: "f1", codeSharedAt: 1 }],
+      invite: {
+        hero: { title: "V & R", subtitle: null, imageUrl: null },
+        story: { heading: null, body: null, imageUrl: null },
+      },
+    });
+    render(() => <GettingStarted weddingId="wed_1" onJump={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText("4 / 4 done")).toBeTruthy());
+    expect(screen.getByText(/Everything's ready/i)).toBeTruthy();
+  });
+
+  it("jumps to the matching tab when a step is clicked", async () => {
+    mockSnapshot({ events: [], guests: [], invite: EMPTY_INVITE });
+    const onJump = vi.fn();
+    render(() => <GettingStarted weddingId="wed_1" onJump={onJump} />);
+
+    await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
+    fireEvent.click(screen.getByText("Add your events"));
+    expect(onJump).toHaveBeenCalledWith("events");
+  });
+});

--- a/cire/organiser/src/components/GettingStarted.tsx
+++ b/cire/organiser/src/components/GettingStarted.tsx
@@ -1,0 +1,241 @@
+import { useAuth } from "@osn/client/solid";
+import { createMemo, createResource, For, Show } from "solid-js";
+
+import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import { isHeroEmpty, isStoryEmpty } from "../lib/invite-emptiness";
+
+/**
+ * The dashboard's "what do I do next" guide — a four-step checklist that reflects
+ * the wedding's REAL state (events imported, guests imported, invite customised,
+ * codes shared), so a first-time organiser is led through the flow in order and
+ * an established one sees a quiet "all set" summary instead.
+ *
+ * Each step's `done` is derived from data the dashboard already serves; the panel
+ * fetches its own snapshot once so it stays decoupled from the tab components.
+ * Clicking a step jumps to the matching tab via the same hash-routing the tabs
+ * use (`#events`, `#guests`, `#invite`) — no new navigation model.
+ */
+
+interface EventRow {
+  id: string;
+}
+
+interface GuestRow {
+  familyId: string;
+  codeSharedAt: number | null;
+}
+
+interface InviteCustomisation {
+  hero: { title: string | null; subtitle: string | null; imageUrl: string | null };
+  story: { heading: string | null; body: string | null; imageUrl: string | null };
+}
+
+interface Snapshot {
+  eventCount: number;
+  familyCount: number;
+  sharedFamilyCount: number;
+  inviteCustomised: boolean;
+}
+
+interface Step {
+  key: string;
+  /** The tab hash this step links to. */
+  tab: "events" | "guests" | "invite";
+  label: string;
+  /** What the step achieves, in plain terms — shown when not yet done. */
+  todo: string;
+  /** A reassuring one-liner once the step is complete. */
+  done: string;
+  complete: boolean;
+}
+
+export default function GettingStarted(props: {
+  weddingId: string;
+  onJump: (tab: string) => void;
+}) {
+  const { authFetch } = useAuth();
+
+  const [snapshot] = createResource<Snapshot>(async () => {
+    try {
+      const base = `/api/organiser/weddings/${props.weddingId}`;
+      const [eventsRes, guestsRes, inviteRes] = await Promise.all([
+        authFetch(apiUrl(`${base}/events`)),
+        authFetch(apiUrl(`${base}/guests`)),
+        authFetch(apiUrl(`${base}/invite`)),
+      ]);
+      if (eventsRes.status === 401 || guestsRes.status === 401 || inviteRes.status === 401) {
+        redirectToLogin();
+        return { eventCount: 0, familyCount: 0, sharedFamilyCount: 0, inviteCustomised: false };
+      }
+      const events = eventsRes.ok ? ((await eventsRes.json()) as EventRow[]) : [];
+      const guests = guestsRes.ok ? ((await guestsRes.json()) as GuestRow[]) : [];
+      const invite = inviteRes.ok ? ((await inviteRes.json()) as InviteCustomisation) : null;
+
+      // Guest rows repeat per family member — dedupe to families, and a family
+      // counts as "sent" if any of its rows carries a codeSharedAt.
+      const sharedByFamily = new Map<string, boolean>();
+      for (const g of guests) {
+        sharedByFamily.set(g.familyId, sharedByFamily.get(g.familyId) || g.codeSharedAt !== null);
+      }
+
+      // The invite counts as "customised" once either the hero or the Our Story
+      // section would actually render for a guest (mirrors the builder's badges).
+      const inviteCustomised = invite
+        ? !isHeroEmpty(invite.hero) || !isStoryEmpty(invite.story)
+        : false;
+
+      return {
+        eventCount: events.length,
+        familyCount: sharedByFamily.size,
+        sharedFamilyCount: Array.from(sharedByFamily.values()).filter(Boolean).length,
+        inviteCustomised,
+      };
+    } catch (err) {
+      if (isAuthExpired(err)) redirectToLogin();
+      // Fail soft: a failed snapshot just hides the guide rather than blocking
+      // the dashboard. The tabs below are still fully usable.
+      return null as unknown as Snapshot;
+    }
+  });
+
+  const steps = createMemo<Step[]>(() => {
+    const s = snapshot();
+    if (!s) return [];
+    return [
+      {
+        key: "events",
+        tab: "events",
+        label: "Add your events",
+        todo: "Import the events sheet so guests can see the ceremony, reception, and more.",
+        done: `${s.eventCount} ${s.eventCount === 1 ? "event" : "events"} added.`,
+        complete: s.eventCount > 0,
+      },
+      {
+        key: "guests",
+        tab: "guests",
+        label: "Add your guests",
+        todo: "Import the guests sheet to group households and assign who's invited to what.",
+        done: `${s.familyCount} ${s.familyCount === 1 ? "household" : "households"} on the list.`,
+        complete: s.familyCount > 0,
+      },
+      {
+        key: "invite",
+        tab: "invite",
+        label: "Customise the invite",
+        todo: "Add a hero photo, your story, and your colours — or keep the elegant default.",
+        done: "Your personal touches are live.",
+        complete: s.inviteCustomised,
+      },
+      {
+        key: "share",
+        tab: "guests",
+        label: "Share the codes",
+        todo: "Copy each household's invite message and send it however you like.",
+        done: `${s.sharedFamilyCount} of ${s.familyCount} ${s.familyCount === 1 ? "household" : "households"} sent.`,
+        complete: s.familyCount > 0 && s.sharedFamilyCount === s.familyCount,
+      },
+    ];
+  });
+
+  const completed = createMemo(() => steps().filter((s) => s.complete).length);
+  const total = createMemo(() => steps().length);
+  const allDone = createMemo(() => total() > 0 && completed() === total());
+  // The first step that still needs doing — the one "next action" we nudge toward.
+  const nextStep = createMemo(() => steps().find((s) => !s.complete));
+
+  return (
+    <Show when={snapshot()}>
+      <section
+        aria-label="Getting started"
+        class="border-gold/25 from-surface/50 to-surface/20 flex flex-col gap-5 rounded-sm border bg-gradient-to-br p-6"
+      >
+        <div class="flex flex-wrap items-end justify-between gap-x-6 gap-y-2">
+          <div class="flex flex-col gap-1">
+            <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
+              {allDone() ? "You're all set" : "Getting started"}
+            </p>
+            <h2 class="font-display text-text text-[1.4rem] font-light italic">
+              {allDone() ? "Everything's ready for your guests" : "Four steps to your invite"}
+            </h2>
+            <Show when={!allDone() && nextStep()}>
+              {(step) => (
+                <p class="font-body text-text-muted text-[0.82rem] leading-relaxed">
+                  Next: <span class="text-text">{step().todo}</span>
+                </p>
+              )}
+            </Show>
+          </div>
+          <span
+            class="font-body text-gold-dim shrink-0 text-[0.78rem] tracking-[0.12em] uppercase tabular-nums"
+            aria-hidden
+          >
+            {completed()} / {total()} done
+          </span>
+        </div>
+
+        {/* A thin progress rail — a single calm indicator of how far along the
+            couple are. Pure CSS width transition, no library. */}
+        <div
+          class="bg-bg/60 h-1 w-full overflow-hidden rounded-full"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={total()}
+          aria-valuenow={completed()}
+          aria-label="Setup progress"
+        >
+          <div
+            class="bg-gold h-full rounded-full transition-[width] duration-500 ease-out"
+            style={{ width: `${total() > 0 ? (completed() / total()) * 100 : 0}%` }}
+          />
+        </div>
+
+        <ol class="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+          <For each={steps()}>
+            {(step, i) => (
+              <li>
+                <button
+                  type="button"
+                  onClick={() => props.onJump(step.tab)}
+                  data-complete={step.complete ? "true" : "false"}
+                  class="group border-border bg-bg/30 hover:border-gold/60 flex w-full items-start gap-3 rounded-sm border p-3 text-left transition-colors"
+                >
+                  <StepMarker n={i() + 1} complete={step.complete} />
+                  <span class="flex flex-col gap-0.5">
+                    <span
+                      class="font-body text-[0.9rem]"
+                      classList={{ "text-text": !step.complete, "text-text-muted": step.complete }}
+                    >
+                      {step.label}
+                    </span>
+                    <span class="font-body text-text-muted text-[0.76rem] leading-snug">
+                      {step.complete ? step.done : step.todo}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            )}
+          </For>
+        </ol>
+      </section>
+    </Show>
+  );
+}
+
+/**
+ * The numbered/checked marker leading each step. A gold check when done, a
+ * hollow numbered ring while pending — so progress is legible at a glance.
+ */
+function StepMarker(props: { n: number; complete: boolean }) {
+  return (
+    <span
+      aria-hidden
+      class="font-body mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[0.78rem] transition-colors"
+      classList={{
+        "border-gold bg-gold text-bg": props.complete,
+        "border-gold/40 text-gold-dim group-hover:border-gold/70": !props.complete,
+      }}
+    >
+      {props.complete ? "✓" : props.n}
+    </span>
+  );
+}

--- a/cire/organiser/src/components/GuestTable.tsx
+++ b/cire/organiser/src/components/GuestTable.tsx
@@ -5,6 +5,7 @@ import { toast } from "solid-toast";
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { downloadBlob } from "../lib/download";
 import { buildInviteMessage, copyToClipboard } from "../lib/invite-message";
+import SectionIntro from "./SectionIntro";
 
 interface OrganiserGuestRow {
   familyId: string;
@@ -146,8 +147,28 @@ export default function GuestTable(props: GuestTableProps) {
     }
   }
 
+  const hasGuests = () => families().length > 0;
+
   return (
     <div class="flex flex-col gap-8">
+      <SectionIntro
+        eyebrow="Guest list"
+        title="Households, invites & RSVPs"
+        description="Everyone you're inviting, grouped into households. Copy a household's invite message to send their link and code, and download replies any time."
+        actions={
+          <Show when={!loading() && !error() && hasGuests()}>
+            <button
+              type="button"
+              onClick={() => void exportRsvps()}
+              disabled={exporting()}
+              class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-3 py-1.5 text-[0.72rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
+            >
+              {exporting() ? "Exporting…" : "Download RSVPs (CSV)"}
+            </button>
+          </Show>
+        }
+      />
+
       <Show when={loading()}>
         <div class="flex flex-col gap-3">
           <For each={[1, 2, 3, 4, 5]}>
@@ -162,20 +183,21 @@ export default function GuestTable(props: GuestTableProps) {
         </p>
       </Show>
 
-      <Show when={!loading() && !error()}>
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <p class="font-body text-text-muted text-[0.82rem]">
-            {guests().length} guests across {families().length} families
+      <Show when={!loading() && !error() && !hasGuests()}>
+        <div class="border-border bg-surface/30 flex flex-col items-start gap-2 rounded-sm border border-dashed p-8 text-center">
+          <p class="font-display text-gold-dim w-full text-[1.2rem] italic">No guests yet</p>
+          <p class="font-body text-text-muted w-full text-[0.85rem] leading-relaxed">
+            Import your guests sheet from the Spreadsheet Import above to build the list. Each
+            household gets its own code and invite message to share.
           </p>
-          <button
-            type="button"
-            onClick={() => void exportRsvps()}
-            disabled={exporting()}
-            class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-3 py-1.5 text-[0.72rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
-          >
-            {exporting() ? "Exporting…" : "Download RSVPs (CSV)"}
-          </button>
         </div>
+      </Show>
+
+      <Show when={!loading() && !error() && hasGuests()}>
+        <p class="font-body text-text-muted text-[0.82rem]">
+          {guests().length} {guests().length === 1 ? "guest" : "guests"} across {families().length}{" "}
+          {families().length === 1 ? "household" : "households"}
+        </p>
 
         <div class="overflow-x-auto">
           <table class="font-body w-full border-collapse text-[0.88rem]">

--- a/cire/organiser/src/components/HostsPanel.tsx
+++ b/cire/organiser/src/components/HostsPanel.tsx
@@ -3,6 +3,7 @@ import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import SectionIntro from "./SectionIntro";
 
 interface HostRow {
   osnProfileId: string;
@@ -243,17 +244,15 @@ export default function HostsPanel(props: HostsPanelProps) {
 
   return (
     <div class="flex flex-col gap-8">
-      <div class="flex flex-col gap-1">
-        <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">Co-hosts</p>
-        <h2 class="font-display text-text text-[1.4rem] font-light italic">
-          Share this wedding's dashboard
-        </h2>
-        <p class="font-body text-text-muted text-[0.82rem]">
-          {props.canManage
-            ? "Add another organiser by their OSN handle. Co-hosts can view and edit this wedding, but only you can manage who hosts it."
-            : "These organisers can view and edit this wedding."}
-        </p>
-      </div>
+      <SectionIntro
+        eyebrow="Co-hosts"
+        title="Share this wedding's dashboard"
+        description={
+          props.canManage
+            ? "Invite a partner or planner to help. Add them by their OSN handle — co-hosts can view and edit everything here, but only you, the owner, can manage who hosts it."
+            : "These organisers can view and edit this wedding. The owner manages who's on this list."
+        }
+      />
 
       <Show when={props.canManage}>
         <form class="flex flex-col gap-3" onSubmit={add}>

--- a/cire/organiser/src/components/ImportPanel.tsx
+++ b/cire/organiser/src/components/ImportPanel.tsx
@@ -141,137 +141,149 @@ export default function ImportPanel(props: { weddingId: string }) {
   }
 
   return (
-    <section class="border-border bg-surface/30 flex flex-col gap-6 rounded-sm border p-6">
-      <header class="flex flex-col gap-1">
-        <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
-          Spreadsheet Import
-        </p>
-        <h2 class="font-display text-text text-[1.4rem] font-light italic">
+    <details open class="border-border bg-surface/30 group/import rounded-sm border open:pb-6">
+      <summary class="flex cursor-pointer flex-col gap-1 p-6 select-none [&::-webkit-details-marker]:hidden">
+        <span class="flex items-center justify-between gap-3">
+          <span class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
+            Spreadsheet Import
+          </span>
+          <span
+            class="font-body text-text-muted group-open/import:text-gold flex items-center gap-1.5 text-[0.72rem] tracking-[0.1em] uppercase transition"
+            aria-hidden
+          >
+            <span class="group-open/import:hidden">Open</span>
+            <span class="hidden group-open/import:inline">Close</span>
+            <span class="inline-block transition-transform group-open/import:rotate-90">›</span>
+          </span>
+        </span>
+        <span class="font-display text-text text-[1.4rem] font-light italic">
           Upload events &amp; guests CSV
-        </h2>
-        <p class="font-body text-text-muted text-[0.82rem]">
+        </span>
+        <span class="font-body text-text-muted text-[0.82rem]">
           Import your two sheets as CSV — events first, then guests. Start from a template below, or
           read the format guide if you're building your own.
-        </p>
-      </header>
+        </span>
+      </summary>
 
-      <div class="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          onClick={() => downloadCsv("cire-events-template.csv", buildEventsTemplateCsv())}
-          class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition"
-        >
-          Download events template
-        </button>
-        <button
-          type="button"
-          onClick={() => downloadCsv("cire-guests-template.csv", buildGuestsTemplateCsv())}
-          class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition"
-        >
-          Download guests template
-        </button>
-      </div>
-
-      <CsvFormatHelp />
-
-      <form class="flex flex-col gap-4" onSubmit={handlePreview}>
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <label class="flex flex-col gap-1.5">
-            <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
-              events.csv
-            </span>
-            <input
-              type="file"
-              accept=".csv,text/csv"
-              onChange={(e) => setEventsFile(e.currentTarget.files?.[0] ?? null)}
-              class="font-body text-text file:border-border file:bg-bg file:font-body file:text-text hover:file:border-gold text-[0.82rem] file:mr-3 file:rounded-sm file:border file:px-3 file:py-1.5 file:text-[0.82rem]"
-            />
-            <Show when={eventsFile()}>
-              <span class="text-text-muted font-mono text-[0.72rem]">{eventsFile()?.name}</span>
-            </Show>
-          </label>
-
-          <label class="flex flex-col gap-1.5">
-            <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
-              guests.csv
-            </span>
-            <input
-              type="file"
-              accept=".csv,text/csv"
-              onChange={(e) => setGuestsFile(e.currentTarget.files?.[0] ?? null)}
-              class="font-body text-text file:border-border file:bg-bg file:font-body file:text-text hover:file:border-gold text-[0.82rem] file:mr-3 file:rounded-sm file:border file:px-3 file:py-1.5 file:text-[0.82rem]"
-            />
-            <Show when={guestsFile()}>
-              <span class="text-text-muted font-mono text-[0.72rem]">{guestsFile()?.name}</span>
-            </Show>
-          </label>
-        </div>
-
+      <div class="flex flex-col gap-6 px-6">
         <div class="flex flex-wrap items-center gap-3">
           <button
-            type="submit"
-            disabled={busy()}
-            class="border-gold bg-gold/10 font-body text-gold hover:bg-gold/20 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
+            type="button"
+            onClick={() => downloadCsv("cire-events-template.csv", buildEventsTemplateCsv())}
+            class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition"
           >
-            {busy() ? "Working…" : "Preview"}
+            Download events template
           </button>
-          <Show when={preview() || applied() || error()}>
-            <button
-              type="button"
-              onClick={reset}
-              disabled={busy()}
-              class="font-body text-text-muted text-[0.82rem] underline-offset-4 hover:underline disabled:opacity-40"
-            >
-              Reset
-            </button>
-          </Show>
+          <button
+            type="button"
+            onClick={() => downloadCsv("cire-guests-template.csv", buildGuestsTemplateCsv())}
+            class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition"
+          >
+            Download guests template
+          </button>
         </div>
-      </form>
 
-      <Show when={error()}>
-        <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
-          {error()}
-        </p>
-      </Show>
+        <CsvFormatHelp />
 
-      <Show when={preview()}>
-        {(p) => (
-          <div class="border-border bg-bg/40 flex flex-col gap-4 rounded-sm border p-4">
-            <h3 class="font-display text-gold-dim text-[1.1rem] italic">Diff preview</h3>
-            <PlanCounts plan={p().plan} />
-            <Show when={p().plan.warnings.length > 0}>
-              <ul class="text-text-muted flex flex-col gap-1 text-[0.82rem]">
-                <For each={p().plan.warnings}>
-                  {(w) => <li class="before:mr-2 before:content-['•']">{w}</li>}
-                </For>
-              </ul>
-            </Show>
+        <form class="flex flex-col gap-4" onSubmit={handlePreview}>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label class="flex flex-col gap-1.5">
+              <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
+                events.csv
+              </span>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => setEventsFile(e.currentTarget.files?.[0] ?? null)}
+                class="font-body text-text file:border-border file:bg-bg file:font-body file:text-text hover:file:border-gold text-[0.82rem] file:mr-3 file:rounded-sm file:border file:px-3 file:py-1.5 file:text-[0.82rem]"
+              />
+              <Show when={eventsFile()}>
+                <span class="text-text-muted font-mono text-[0.72rem]">{eventsFile()?.name}</span>
+              </Show>
+            </label>
+
+            <label class="flex flex-col gap-1.5">
+              <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
+                guests.csv
+              </span>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => setGuestsFile(e.currentTarget.files?.[0] ?? null)}
+                class="font-body text-text file:border-border file:bg-bg file:font-body file:text-text hover:file:border-gold text-[0.82rem] file:mr-3 file:rounded-sm file:border file:px-3 file:py-1.5 file:text-[0.82rem]"
+              />
+              <Show when={guestsFile()}>
+                <span class="text-text-muted font-mono text-[0.72rem]">{guestsFile()?.name}</span>
+              </Show>
+            </label>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-3">
             <button
-              type="button"
-              onClick={handleApply}
+              type="submit"
               disabled={busy()}
-              class="border-gold bg-gold font-body text-bg hover:bg-gold-dim self-start rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
+              class="border-gold bg-gold/10 font-body text-gold hover:bg-gold/20 rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
             >
-              {busy() ? "Applying…" : "Apply import"}
+              {busy() ? "Working…" : "Preview"}
             </button>
+            <Show when={preview() || applied() || error()}>
+              <button
+                type="button"
+                onClick={reset}
+                disabled={busy()}
+                class="font-body text-text-muted text-[0.82rem] underline-offset-4 hover:underline disabled:opacity-40"
+              >
+                Reset
+              </button>
+            </Show>
           </div>
-        )}
-      </Show>
+        </form>
 
-      <Show when={applied()}>
-        {(s) => (
-          <div class="border-gold/30 bg-gold/5 text-text flex flex-col gap-2 rounded-sm border p-4 text-[0.88rem]">
-            <p class="font-display text-gold-dim text-[1.1rem] italic">Applied</p>
-            <p class="text-text-muted font-mono text-[0.72rem]">{s().importId}</p>
-            <p>
-              events: +{s().eventsCreated} / ~{s().eventsUpdated} / -{s().eventsRemoved} · families:
-              +{s().familiesCreated} / -{s().familiesRemoved} · guests: +{s().guestsCreated} / ~
-              {s().guestsUpdated} / -{s().guestsRemoved}
-            </p>
-          </div>
-        )}
-      </Show>
-    </section>
+        <Show when={error()}>
+          <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
+            {error()}
+          </p>
+        </Show>
+
+        <Show when={preview()}>
+          {(p) => (
+            <div class="border-border bg-bg/40 flex flex-col gap-4 rounded-sm border p-4">
+              <h3 class="font-display text-gold-dim text-[1.1rem] italic">Diff preview</h3>
+              <PlanCounts plan={p().plan} />
+              <Show when={p().plan.warnings.length > 0}>
+                <ul class="text-text-muted flex flex-col gap-1 text-[0.82rem]">
+                  <For each={p().plan.warnings}>
+                    {(w) => <li class="before:mr-2 before:content-['•']">{w}</li>}
+                  </For>
+                </ul>
+              </Show>
+              <button
+                type="button"
+                onClick={handleApply}
+                disabled={busy()}
+                class="border-gold bg-gold font-body text-bg hover:bg-gold-dim self-start rounded-sm border px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition disabled:opacity-40"
+              >
+                {busy() ? "Applying…" : "Apply import"}
+              </button>
+            </div>
+          )}
+        </Show>
+
+        <Show when={applied()}>
+          {(s) => (
+            <div class="border-gold/30 bg-gold/5 text-text flex flex-col gap-2 rounded-sm border p-4 text-[0.88rem]">
+              <p class="font-display text-gold-dim text-[1.1rem] italic">Applied</p>
+              <p class="text-text-muted font-mono text-[0.72rem]">{s().importId}</p>
+              <p>
+                events: +{s().eventsCreated} / ~{s().eventsUpdated} / -{s().eventsRemoved} ·
+                families: +{s().familiesCreated} / -{s().familiesRemoved} · guests: +
+                {s().guestsCreated} / ~{s().guestsUpdated} / -{s().guestsRemoved}
+              </p>
+            </div>
+          )}
+        </Show>
+      </div>
+    </details>
   );
 }
 

--- a/cire/organiser/src/components/OrganiserApp.test.tsx
+++ b/cire/organiser/src/components/OrganiserApp.test.tsx
@@ -70,6 +70,13 @@ vi.mock("./ImportPanel", () => ({
     <div data-testid="import-panel">{props.weddingId}</div>
   ),
 }));
+// GettingStarted fetches its own events/guests/invite snapshot — stub it so this
+// suite stays on the Dashboard's view glue rather than the checklist's fetches.
+vi.mock("./GettingStarted", () => ({
+  default: (props: { weddingId: string }) => (
+    <div data-testid="getting-started">{props.weddingId}</div>
+  ),
+}));
 vi.mock("./PreviewInviteButton", () => ({
   default: () => <div data-testid="preview-button" />,
 }));

--- a/cire/organiser/src/components/OrganiserApp.tsx
+++ b/cire/organiser/src/components/OrganiserApp.tsx
@@ -6,6 +6,7 @@ import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { OSN_ISSUER_URL } from "../lib/osn";
 import type { WeddingSummary } from "./CreateWeddingForm";
 import DashboardTabs from "./DashboardTabs";
+import GettingStarted from "./GettingStarted";
 import ImportPanel from "./ImportPanel";
 import PreviewInviteButton from "./PreviewInviteButton";
 import SecurityPanel from "./SecurityPanel";
@@ -41,17 +42,31 @@ function RequireAuth(props: ParentProps) {
   );
 }
 
-/** The chosen wedding's dashboard — the existing tabbed guests/events/invite
- *  view, now scoped to whichever wedding the organiser opened. Co-hosts are
- *  trusted co-organisers: they get the full read/edit dashboard, including the
- *  spreadsheet import (the API gates it with weddingMember). Only the
- *  owner-only management actions (managing co-hosts, re-minting codes) stay
- *  gated on `isOwner` — passed down via `canManage`. */
+/** Move the tabs to `tab` — the tabs listen for `hashchange`, so updating the
+ *  hash (and dispatching the event for same-value jumps) switches the panel and
+ *  scrolls it into view. Used by the Getting-started checklist's step buttons. */
+function jumpToTab(tab: string) {
+  if (typeof window === "undefined") return;
+  window.location.hash = tab;
+  window.dispatchEvent(new HashChangeEvent("hashchange"));
+  document.getElementById("wedding-tabs")?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+/** The chosen wedding's dashboard — the context header, the Getting-started
+ *  checklist, the spreadsheet import, and the tabbed events/guests/invite view,
+ *  scoped to whichever wedding the organiser opened. Co-hosts are trusted
+ *  co-organisers: they get the full read/edit dashboard, including the
+ *  spreadsheet import (the API gates it with weddingMember). Only the owner-only
+ *  management actions (managing co-hosts, re-minting codes) stay gated on
+ *  `isOwner` — passed down via `canManage`. */
 function WeddingDashboard(props: { wedding: WeddingSummary; onBack: () => void }) {
   const isOwner = () => props.wedding.role === "owner";
+
   return (
-    <div class="flex flex-col gap-12">
-      <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-10">
+      {/* ── Wedding context header — "which wedding am I editing" + the two
+          things every organiser wants up top: preview it, share it. ───────── */}
+      <header class="flex flex-col gap-4">
         <button
           type="button"
           onClick={() => props.onBack()}
@@ -59,29 +74,49 @@ function WeddingDashboard(props: { wedding: WeddingSummary; onBack: () => void }
         >
           ← All weddings
         </button>
-        <div class="flex flex-wrap items-center justify-between gap-4">
-          <div class="flex items-center gap-3">
-            <p class="font-display text-gold-dim text-[1.2rem] italic">
-              {props.wedding.displayName}
-            </p>
-            <Show when={!isOwner()}>
-              <span class="border-gold/40 text-gold font-body rounded-sm border px-2 py-0.5 text-[0.62rem] tracking-[0.16em] uppercase">
-                Co-host
+        <div class="flex flex-wrap items-end justify-between gap-4">
+          <div class="flex flex-col gap-1">
+            <span class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
+              {props.wedding.slug}
+            </span>
+            <div class="flex flex-wrap items-center gap-3">
+              <h1 class="font-display text-text text-[1.8rem] leading-none font-light italic">
+                {props.wedding.displayName}
+              </h1>
+              <span
+                class="border-gold/40 text-gold font-body rounded-sm border px-2 py-0.5 text-[0.62rem] tracking-[0.16em] uppercase"
+                title={
+                  isOwner()
+                    ? "You created this wedding and manage who hosts it"
+                    : "You can view and edit this wedding"
+                }
+              >
+                {isOwner() ? "Owner" : "Co-host"}
               </span>
-            </Show>
+            </div>
           </div>
           <PreviewInviteButton weddingId={props.wedding.id} />
         </div>
-      </div>
+      </header>
+
+      {/* The progress checklist — the dashboard's "what next". Reflects real
+          state and links straight to the relevant tab. */}
+      <GettingStarted weddingId={props.wedding.id} onJump={jumpToTab} />
+
       {/* Import is available to every member (owner or co-host) — the API
-          authorises it with weddingMember(). */}
+          authorises it with weddingMember(). Tucked in a collapsible so it's
+          front-and-centre for a new wedding (open it from a checklist nudge) but
+          doesn't crowd the dashboard once the list is populated. */}
       <ImportPanel weddingId={props.wedding.id} />
-      <DashboardTabs
-        weddingId={props.wedding.id}
-        weddingName={props.wedding.displayName}
-        weddingSlug={props.wedding.slug}
-        canManage={isOwner()}
-      />
+
+      <div id="wedding-tabs" class="scroll-mt-6">
+        <DashboardTabs
+          weddingId={props.wedding.id}
+          weddingName={props.wedding.displayName}
+          weddingSlug={props.wedding.slug}
+          canManage={isOwner()}
+        />
+      </div>
     </div>
   );
 }

--- a/cire/organiser/src/components/RemintPanel.tsx
+++ b/cire/organiser/src/components/RemintPanel.tsx
@@ -4,6 +4,7 @@ import { toast } from "solid-toast";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import type { CodeStyle } from "./CreateWeddingForm";
+import SectionIntro from "./SectionIntro";
 
 interface RemintPanelProps {
   weddingId: string;
@@ -96,16 +97,11 @@ export default function RemintPanel(props: RemintPanelProps) {
 
   return (
     <div class="border-border bg-surface/30 flex flex-col gap-5 rounded-sm border p-6">
-      <div class="flex flex-col gap-1">
-        <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">Guest codes</p>
-        <h2 class="font-display text-text text-[1.4rem] font-light italic">
-          Change the code style
-        </h2>
-        <p class="font-body text-text-muted mt-1 text-[0.85rem] leading-relaxed">
-          Re-mints every family&apos;s code in the chosen style. This replaces all current codes —
-          any code you&apos;ve already shared will stop working.
-        </p>
-      </div>
+      <SectionIntro
+        eyebrow="Guest codes"
+        title="Change the code style"
+        description="Each household has a private code they enter to open your invite and RSVP. If you'd rather they were shorter and friendlier — or longer and harder to guess — switch the style here. Re-minting replaces every code, so any code you've already shared will stop working."
+      />
 
       <fieldset class="m-0 flex flex-col gap-1.5 border-0 p-0">
         <legend class="font-body text-text-muted mb-1.5 text-[0.72rem] tracking-[0.1em] uppercase">

--- a/cire/organiser/src/components/SectionIntro.test.tsx
+++ b/cire/organiser/src/components/SectionIntro.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+
+import SectionIntro from "./SectionIntro";
+
+/**
+ * SectionIntro is the shared header used at the top of every tab panel — an
+ * eyebrow, a serif heading, an optional description, and an optional actions
+ * slot. These assert it renders each part and omits the optional ones cleanly.
+ */
+describe("SectionIntro", () => {
+  afterEach(cleanup);
+
+  it("renders the eyebrow and title", () => {
+    render(() => <SectionIntro eyebrow="Guest list" title="Households" />);
+    expect(screen.getByText("Guest list")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Households" })).toBeTruthy();
+  });
+
+  it("renders the description when given", () => {
+    render(() => <SectionIntro eyebrow="E" title="T" description="A helpful line." />);
+    expect(screen.getByText("A helpful line.")).toBeTruthy();
+  });
+
+  it("omits the description when not given", () => {
+    render(() => <SectionIntro eyebrow="E" title="T" />);
+    // Only the eyebrow + heading text are present; no stray paragraph.
+    expect(screen.queryByText("A helpful line.")).toBeNull();
+  });
+
+  it("renders the actions slot", () => {
+    render(() => (
+      <SectionIntro eyebrow="E" title="T" actions={<button type="button">Export</button>} />
+    ));
+    expect(screen.getByRole("button", { name: "Export" })).toBeTruthy();
+  });
+});

--- a/cire/organiser/src/components/SectionIntro.tsx
+++ b/cire/organiser/src/components/SectionIntro.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from "solid-js";
+import { Show } from "solid-js";
+
+/**
+ * The shared header for a dashboard section or tab panel — an uppercase gold
+ * eyebrow, a serif italic heading, and an optional one-line description. Every
+ * tab leads with one of these so the panels read as one consistent family
+ * (Invite / Import already used this shape inline; this is that pattern extracted
+ * so Guests / Events / Codes / Hosts match it exactly). `actions` slots a control
+ * (e.g. an export button) to the right of the heading on wider screens.
+ */
+export default function SectionIntro(props: {
+  eyebrow: string;
+  title: string;
+  description?: string;
+  /** Right-aligned controls (a button, a count) that belong with this header. */
+  actions?: JSX.Element;
+}) {
+  return (
+    <div class="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+      <div class="flex flex-col gap-1">
+        <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">{props.eyebrow}</p>
+        <h2 class="font-display text-text text-[1.4rem] font-light italic">{props.title}</h2>
+        <Show when={props.description}>
+          <p class="font-body text-text-muted max-w-prose text-[0.82rem] leading-relaxed">
+            {props.description}
+          </p>
+        </Show>
+      </div>
+      <Show when={props.actions}>
+        <div class="flex shrink-0 items-center gap-3">{props.actions}</div>
+      </Show>
+    </div>
+  );
+}

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -7,6 +7,37 @@ related:
 last-reviewed: 2026-06-19
 ---
 
+> [!note] Organiser dashboard UX + structure pass (`feat/cire-organiser-ux`)
+> A polish + restructure pass over `cire/organiser` (NOT the guest invite) to make
+> the dashboard intuitive and guided for a non-technical couple. The live theme/hero
+> previews, status badges, per-event image upload, RSVP CSV, host autocomplete,
+> codes, and security panel are all preserved.
+> - **`GettingStarted.tsx`** (new) — a four-step checklist (Events → Guests →
+>   Invite → Share codes) whose done-state is derived from the wedding's REAL data:
+>   it fetches a one-off snapshot of `/events`, `/guests`, `/invite`, dedupes guest
+>   rows to households, reuses `lib/invite-emptiness` to tell whether the invite is
+>   customised, and counts codes-sent. Shows a progress rail + the single next
+>   action; collapses to an "all set" summary when complete; each step jumps to its
+>   tab. Fails soft (hidden) if the snapshot fetch errors.
+> - **`SectionIntro.tsx`** (new shared) — eyebrow + serif heading + description +
+>   optional actions slot. Adopted by Guests / Events / Codes / Hosts so every tab
+>   panel leads with the same header shape the Invite/Import sections already used.
+> - **`DashboardTabs.tsx`** — reordered to workflow order (Events first, was Guests),
+>   each tab gets a leading glyph + a `title` tooltip, and the panel now reacts to
+>   external `hashchange` so the checklist's jumps + browser back/forward work.
+>   Default tab is now `events`.
+> - **`OrganiserApp.tsx`** — wedding context header promoted: name is the page
+>   `<h1>` with a slug eyebrow + Owner/Co-host badge. Import panel + tabs reflowed
+>   under the checklist; `#wedding-tabs` anchor for smooth-scroll jumps.
+> - **`ImportPanel.tsx`** — wrapped in a `<details open>` so it leads a new wedding
+>   but can be collapsed once the list is populated (3-step CSV guide unchanged).
+> - Guests + Events gained guided empty states; Codes copy now explains what a guest
+>   code is; Hosts copy explains owner vs co-host.
+> - Tests: +`SectionIntro.test.tsx`, +`GettingStarted.test.tsx`, +`DashboardTabs.test.tsx`
+>   (the tab bar had none before). 96 organiser tests green.
+> ⚠️ Real-device check still wanted: the checklist + header rhythm at 320/375/390/768px,
+> and the tab-bar wrapping at the narrowest widths.
+
 > [!note] Per-event image — alternating two-column EventCard (`feat/cire-event-images`)
 > Each event can carry **one** optional image. `EventCard.tsx` gains an
 > `orientation` prop (`norm`/`alt`) + consumes the event's `imageUrl` (added to


### PR DESCRIPTION
## What & why

A polish + restructure pass over the **cire organiser dashboard** (`cire/organiser`) to make it intuitive, well-explained, and fun to use for a non-technical couple managing their own wedding. This is **not a rewrite** — every existing flow and the live previews/status indicators are preserved; the changes are additive structure, guidance, and rhythm.

## Evaluation — top friction points (before)

1. **No onboarding path / "what next" was implicit.** A fresh wedding landed on an empty Guests tab with the import panel above it, but nothing told the couple the order of operations (events → guests → customise → share).
2. **Import panel was always heavy and always on top** — vital for a new wedding, pure noise for an established one, but the same weight either way.
3. **Tab order was presentation-led, not workflow-led** (Guests, Events, Invite, Codes, Hosts). The natural sequence starts with Events (guests are matched to events that already exist).
4. **Weak tab scanability** — five identical uppercase text labels, no icons, no hints.
5. **Thin wedding-context header** — a small italic name; easy to lose track of which wedding you're editing.
6. **Explanation gaps** — the Codes tab never said what a guest code *is*; Guests/Events panels had no intro and a different visual tier from Invite/Import.

## Changes

| Area | Change |
|---|---|
| **Getting started** (new `GettingStarted.tsx`) | Four-step checklist — Events → Guests → Invite → Share codes — whose done-state is **derived from the wedding's real data** (event/household counts, `lib/invite-emptiness` for "is the invite customised", codes-sent count). Progress rail + the single next action up top; collapses to an "all set" summary when complete; each step jumps to its tab. Fetches a one-off snapshot and **fails soft** (hides itself) on error. |
| **Shared `SectionIntro.tsx`** (new) | Eyebrow + serif heading + description + optional actions slot. Adopted by Guests / Events / Codes / Hosts so every panel leads with the same header shape Invite/Import already used. |
| **`DashboardTabs.tsx`** | Reordered to workflow order (**Events first**), each tab gets a leading glyph + a `title` tooltip, and the bar now reacts to **external `hashchange`** so the checklist jumps + browser back/forward work. Hash-routing preserved; default tab is now `events`. |
| **`OrganiserApp.tsx`** | Wedding context header promoted — name is the page `<h1>` with a slug eyebrow + **Owner/Co-host** badge (with explanatory tooltip). Checklist → import → tabs; `#wedding-tabs` anchor for smooth-scroll jumps. |
| **`ImportPanel.tsx`** | Wrapped in a `<details open>` so it leads a new wedding but can be **collapsed** once the list is populated. The 3-step CSV format guide is unchanged. |
| **Guests / Events / Codes / Hosts** | Guided **empty states** for Guests + Events; Codes copy now explains what a guest code is and where guests use it; Hosts copy explains owner vs co-host. |

## Before → after IA

```
BEFORE                              AFTER
─ All weddings                      ─ All weddings
Name (small italic)  [Preview]      SLUG · Name (h1)  [Owner]   [Preview]
[Import panel — always open]        ┌ Getting started ─────────────┐
Tabs: Guests Events Invite          │ ▓▓░░ 1/4 · Next: add guests   │
      Codes Hosts                   │ ✓ Events  2 Guests            │
                                    │ 3 Invite  4 Share codes       │
                                    └───────────────────────────────┘
                                    [Import — collapsible]
                                    Tabs: ◇Events ✎Guests ✦Invite
                                          ⌗Codes ♔Hosts
```

## Deliberately left untouched

- The InviteBuilder's theme/hero **WYSIWYG live previews**, hero-display sliders, and per-section "Shown / Hidden — empty" status badges — these are the bits the product owner called out as loved; they're fully preserved.
- Per-event image upload, RSVP CSV download, host-by-handle autocomplete, re-mint codes, the security/passkey panel, and the CSV import preview/apply flow — no API calls or behaviour changed.
- The guest-facing invite (`cire/web`) — out of scope.

## Verification

- `cire/organiser` tests: **96 passed** (was 82; +14 across the new `SectionIntro`, `GettingStarted`, and `DashboardTabs` suites — the tab bar had no test before). Updated one EventTable copy assertion I intentionally reworded.
- `bun run --cwd cire/organiser build` ✓ · typecheck (tsc) ✓ · `bun run lint` 0 errors ✓ · oxfmt clean ✓ (lefthook lint+format + pre-push typecheck both passed).
- Accessibility: tabs keep `role="tab"`/`aria-selected`; the checklist has `role="progressbar"` with aria values + an `aria-label`ed section; step buttons are real `<button>`s; the Owner/Co-host badge and tab glyphs carry tooltips / `aria-hidden`. Contrast uses the existing gold/text tokens.

## Screenshots needed / real-device callouts

- A render from the built CSS is attached in the chat (fonts approximate). **Real-device check still wanted** at 320 / 375 / 390 / 768px for: the checklist + header rhythm, and the tab-bar wrapping at the narrowest widths (it now `flex-wrap`s with glyphs).
- Subjective for the product owner to eyeball: the four tab **glyphs** (◇ ✎ ✦ ⌗ ♔) — tasteful but swappable; and the checklist copy tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)