### PR TITLE
feat(cire/organiser): deep-linkable dashboard routes + survive refresh, dismissable checklist

### DIFF
--- a/.changeset/cire-dashboard-routing.md
+++ b/.changeset/cire-dashboard-routing.md
@@ -1,0 +1,48 @@
+---
+"@cire/organiser": minor
+---
+
+Deep-linkable organiser dashboard routes + refresh persistence, and a
+dismissable Getting-started checklist.
+
+- **Hash-route scheme** (new `cire/organiser/src/lib/dashboard-route.ts`) — the
+  full navigable state is encoded in the URL hash so a hard refresh restores it
+  and a shared link reopens it:
+  - `#/weddings` → the wedding list
+  - `#/weddings/<weddingId>` → that wedding, default tab (events)
+  - `#/weddings/<weddingId>/<tab>` → that wedding + a specific tab
+    (`events`/`guests`/`invite`/`codes`/`hosts`)
+  - `#/security` → the account-security view
+
+  `parseRoute`/`serializeRoute` are small, dependency-free, total + defensive:
+  unknown shapes fall back to the list, an unknown tab falls back to the default
+  tab (keeping the wedding), and ids are percent-encoded so they round-trip. The
+  default tab is left implicit so a wedding link stays short and canonical.
+- **`OrganiserApp.tsx`** now owns a single `route` signal that is the source of
+  truth for render and is mirrored into the hash. Opening a wedding / going back
+  to the list / switching the top-level view `pushState`s (so Back/Forward walks
+  them); switching tabs `replaceState`s (so they don't pile up history). A
+  `hashchange` listener re-syncs on browser Back/Forward and manual edits, and a
+  legacy/shorthand hash (`#security`, `#guests`, "") is normalised to the
+  canonical `#/…` form on mount. **Not-authorised fallback:** once the wedding
+  list loads, a hash naming a wedding the organiser can't load (not owner/host,
+  or gone) drops back to the list rather than hanging.
+- **`DashboardTabs.tsx`** is now a controlled component: it takes the active
+  `tab` + an `onTab` callback from the parent instead of self-managing the hash.
+  Owner-only `codes` stays gated — a co-host deep-linking `#/weddings/<id>/codes`
+  resolves to a visible tab.
+- **`GettingStarted.tsx`** gains an accessible **X / dismiss** button (label
+  "Dismiss getting started"); dismissal is persisted per wedding in
+  `localStorage` (`cire:getting-started-dismissed:<weddingId>`) so it stays
+  hidden across reloads, with a small "Show getting started" affordance to bring
+  it back. The data-derived done-state logic is unchanged.
+
+Deeper sub-state (open modals, a selected guest row) is intentionally not
+deep-linked yet — view + wedding + tab is the requirement. Tests: new
+`dashboard-route.test.ts` (parse/serialize + round-trip + fallbacks), updated
+`DashboardTabs.test.tsx` for the controlled component, and new `OrganiserApp`
+coverage for restoring a wedding+tab from a hash on load, the not-authorised
+fallback, hash updates on navigation, and `hashchange` re-sync; plus
+GettingStarted dismiss/restore + per-wedding persistence. 130 organiser tests
+green. ⚠️ Wants a real-browser eyeball on Back/Forward + a hard refresh on a
+wedding tab (happy-dom can't fully exercise the history stack).

--- a/cire/organiser/src/components/DashboardTabs.test.tsx
+++ b/cire/organiser/src/components/DashboardTabs.test.tsx
@@ -1,13 +1,18 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardTab } from "../lib/dashboard-route";
 
 /**
- * DashboardTabs is the per-wedding tab bar. The leaf panels are stubbed to
+ * DashboardTabs is the per-wedding tab bar, now a CONTROLLED component: the
+ * active tab comes in as a prop (the parent, OrganiserApp, owns the URL hash)
+ * and a click reports up via `onTab`. The leaf panels are stubbed to
  * data-testids so this asserts only the tab glue: workflow-ordered tabs, the
- * owner-vs-co-host tab set, hash-routing both ways (a click writes the hash; an
- * external hashchange — e.g. the Getting-started jump — switches the panel), and
- * that a stale `#codes` hash can't expose the owner-only panel to a co-host.
+ * owner-vs-co-host tab set, the controlled active panel + change callback, and
+ * that a deep-linked owner-only `codes` tab can't expose the owner panel to a
+ * co-host (it falls back to a visible tab).
  */
 
 vi.mock("./EventTable", () => ({
@@ -28,28 +33,29 @@ vi.mock("./HostsPanel", () => ({
 
 import DashboardTabs from "./DashboardTabs";
 
-function renderTabs(canManage: boolean) {
-  return render(() => (
+/** Render with a controllable `tab` signal so a test can drive the parent's
+ *  "active tab" the way OrganiserApp would on a hash change. */
+function renderTabs(canManage: boolean, initial: DashboardTab = "events") {
+  const [tab, setTab] = createSignal<DashboardTab>(initial);
+  const onTab = vi.fn((t: DashboardTab) => setTab(t));
+  const utils = render(() => (
     <DashboardTabs
       weddingId="wed_1"
       weddingName="V & R"
       weddingSlug="v-and-r"
       canManage={canManage}
+      tab={tab()}
+      onTab={onTab}
     />
   ));
+  return { ...utils, onTab, setTab };
 }
 
 describe("DashboardTabs", () => {
-  beforeEach(() => {
-    window.location.hash = "";
-  });
-  afterEach(() => {
-    cleanup();
-    window.location.hash = "";
-  });
+  afterEach(() => cleanup());
 
-  it("defaults to the Events tab (workflow order leads with the day)", () => {
-    renderTabs(true);
+  it("renders the controlled tab's panel (events by default)", () => {
+    renderTabs(true, "events");
     expect(screen.getByTestId("events")).toBeTruthy();
     expect(screen.queryByTestId("guests")).toBeNull();
   });
@@ -66,24 +72,25 @@ describe("DashboardTabs", () => {
     expect(screen.getByRole("tab", { name: /Hosts/ })).toBeTruthy();
   });
 
-  it("switches panels and writes the hash when a tab is clicked", () => {
-    renderTabs(true);
+  it("reports a tab switch up via onTab when a tab is clicked", () => {
+    const { onTab } = renderTabs(true);
     fireEvent.click(screen.getByRole("tab", { name: /Invite/ }));
+    expect(onTab).toHaveBeenCalledWith("invite");
+    // The controlled signal followed the click, so the panel switched.
     expect(screen.getByTestId("invite")).toBeTruthy();
-    expect(window.location.hash).toBe("#invite");
   });
 
-  it("responds to an external hashchange (the Getting-started jump)", () => {
-    renderTabs(true);
-    window.location.hash = "guests";
-    window.dispatchEvent(new HashChangeEvent("hashchange"));
+  it("follows the controlled tab prop (the parent's hash-driven change)", () => {
+    const { setTab } = renderTabs(true, "events");
+    setTab("guests");
     expect(screen.getByTestId("guests")).toBeTruthy();
     expect(screen.queryByTestId("events")).toBeNull();
   });
 
-  it("falls a co-host's stale #codes hash back to Events", () => {
-    window.location.hash = "codes";
-    renderTabs(false);
+  it("falls a co-host's deep-linked #codes tab back to a visible panel", () => {
+    // A co-host opening `#/weddings/<id>/codes` must not see the owner-only
+    // Codes panel — it resolves to the default Events tab instead.
+    renderTabs(false, "codes");
     expect(screen.getByTestId("events")).toBeTruthy();
     expect(screen.queryByTestId("codes")).toBeNull();
   });

--- a/cire/organiser/src/components/DashboardTabs.tsx
+++ b/cire/organiser/src/components/DashboardTabs.tsx
@@ -1,12 +1,13 @@
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { For, Show } from "solid-js";
 
+import { type DashboardTab, DEFAULT_TAB } from "../lib/dashboard-route";
 import EventTable from "./EventTable";
 import GuestTable from "./GuestTable";
 import HostsPanel from "./HostsPanel";
 import InviteBuilder from "./InviteBuilder";
 import RemintPanel from "./RemintPanel";
 
-type Tab = "events" | "guests" | "invite" | "codes" | "hosts";
+type Tab = DashboardTab;
 
 interface DashboardTabsProps {
   weddingId: string;
@@ -19,6 +20,11 @@ interface DashboardTabsProps {
   /** Owner of this wedding? Owners can manage co-hosts + re-mint codes; co-hosts
    *  see the list read-only and don't get the destructive Codes tab. */
   canManage: boolean;
+  /** Active tab — controlled by the parent, which owns the URL hash so a deep
+   *  link / hard refresh restores the exact tab. */
+  tab: Tab;
+  /** Report a tab switch up to the parent so it can update the hash. */
+  onTab: (tab: Tab) => void;
 }
 
 /** A tab's nav entry. The glyph is a small leading mark that makes the row
@@ -50,50 +56,22 @@ const HOSTS_TAB: TabDef = {
   hint: "Share editing with a co-host",
 };
 
-function isTab(value: string): value is Tab {
-  return (
-    value === "guests" ||
-    value === "events" ||
-    value === "invite" ||
-    value === "codes" ||
-    value === "hosts"
-  );
-}
-
-function resolveHash(hash: string, canManage: boolean): Tab {
-  if (!isTab(hash)) return "events";
-  // The owner-only Codes tab isn't selectable for co-hosts even via a stale hash.
-  if (!canManage && hash === "codes") return "events";
-  return hash;
-}
-
-function initialTab(canManage: boolean): Tab {
-  if (typeof window === "undefined") return "events";
-  return resolveHash(window.location.hash.replace("#", ""), canManage);
+/**
+ * Resolve the visible tab from the controlled `tab` prop. The owner-only Codes
+ * tab isn't selectable for co-hosts even via a deep link / stale hash — it falls
+ * back to the default tab so a `#/weddings/<id>/codes` link opens to a visible
+ * panel rather than a blank one.
+ */
+function visibleTab(tab: Tab, canManage: boolean): Tab {
+  if (!canManage && tab === "codes") return DEFAULT_TAB;
+  return tab;
 }
 
 export default function DashboardTabs(props: DashboardTabsProps) {
-  const [active, setActive] = createSignal<Tab>(initialTab(props.canManage));
-
-  // React to external hash changes — the Getting-started checklist jumps tabs by
-  // setting the hash, and the browser back/forward buttons move through them too.
-  function onHashChange() {
-    setActive(resolveHash(window.location.hash.replace("#", ""), props.canManage));
-  }
-  onMount(() => window.addEventListener("hashchange", onHashChange));
-  onCleanup(() => {
-    if (typeof window !== "undefined") window.removeEventListener("hashchange", onHashChange);
-  });
+  const active = () => visibleTab(props.tab, props.canManage);
 
   const tabs = () =>
     props.canManage ? [...BASE_TABS, ...OWNER_TABS, HOSTS_TAB] : [...BASE_TABS, HOSTS_TAB];
-
-  function select(tab: Tab) {
-    setActive(tab);
-    if (typeof window !== "undefined") {
-      history.replaceState(null, "", `#${tab}`);
-    }
-  }
 
   return (
     <div class="flex flex-col gap-6">
@@ -105,7 +83,7 @@ export default function DashboardTabs(props: DashboardTabsProps) {
               role="tab"
               aria-selected={active() === tab.id}
               title={tab.hint}
-              onClick={() => select(tab.id)}
+              onClick={() => props.onTab(tab.id)}
               class={`font-body relative -mb-px flex items-center gap-2 px-4 py-2 text-[0.82rem] tracking-[0.1em] uppercase transition ${
                 active() === tab.id
                   ? "border-gold text-gold border-b-2"

--- a/cire/organiser/src/components/GettingStarted.test.tsx
+++ b/cire/organiser/src/components/GettingStarted.test.tsx
@@ -5,8 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 /**
  * GettingStarted fetches a one-off snapshot (events, guests, invite) and derives
  * a four-step checklist whose `done` state reflects the wedding's real data. It
- * jumps to a tab when a step is clicked. The OSN auth + api helpers are stubbed;
- * this asserts the derivation (counts → complete/incomplete) and the jump.
+ * jumps to a tab when a step is clicked, and can be dismissed (persisted per
+ * wedding in localStorage) and brought back. The OSN auth + api helpers are
+ * stubbed; this asserts the derivation (counts → complete/incomplete), the jump,
+ * and the dismiss/restore + persistence.
  */
 
 const authFetchMock = vi.fn();
@@ -46,11 +48,20 @@ const EMPTY_INVITE = {
   story: { heading: null, body: null, imageUrl: null },
 };
 
+/** The checklist's step buttons carry data-complete; the dismiss X doesn't —
+ *  filter to the steps so chrome buttons aren't counted. */
+function stepButtons() {
+  return screen.getAllByRole("button").filter((b) => b.hasAttribute("data-complete"));
+}
+
 describe("GettingStarted", () => {
   afterEach(() => {
     cleanup();
     authFetchMock.mockReset();
     redirectSpy.mockReset();
+    // Dismissal persists to localStorage per wedding — reset between tests so
+    // one test's dismiss doesn't hide the checklist in the next.
+    localStorage.clear();
   });
 
   it("shows 0/4 and all steps incomplete for a brand-new wedding", async () => {
@@ -59,8 +70,9 @@ describe("GettingStarted", () => {
 
     await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
     // Every step button is pending (data-complete=false).
-    const buttons = screen.getAllByRole("button");
-    expect(buttons.every((b) => b.getAttribute("data-complete") === "false")).toBe(true);
+    const steps = stepButtons();
+    expect(steps).toHaveLength(4);
+    expect(steps.every((b) => b.getAttribute("data-complete") === "false")).toBe(true);
   });
 
   it("marks events + guests complete once they exist", async () => {
@@ -102,5 +114,49 @@ describe("GettingStarted", () => {
     await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
     fireEvent.click(screen.getByText("Add your events"));
     expect(onJump).toHaveBeenCalledWith("events");
+  });
+
+  it("dismisses to a 'Show getting started' affordance and restores", async () => {
+    mockSnapshot({ events: [], guests: [], invite: EMPTY_INVITE });
+    render(() => <GettingStarted weddingId="wed_1" onJump={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
+
+    // Dismiss via the X — the checklist collapses to the "Show" link, and the
+    // dismissal is persisted for this wedding.
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss getting started/i }));
+    expect(screen.queryByText("0 / 4 done")).toBeNull();
+    expect(screen.getByRole("button", { name: /Show getting started/i })).toBeTruthy();
+    expect(localStorage.getItem("cire:getting-started-dismissed:wed_1")).toBe("1");
+
+    // Bring it back — the checklist returns and the persisted flag is cleared.
+    fireEvent.click(screen.getByRole("button", { name: /Show getting started/i }));
+    expect(screen.getByText("0 / 4 done")).toBeTruthy();
+    expect(localStorage.getItem("cire:getting-started-dismissed:wed_1")).toBeNull();
+  });
+
+  it("stays dismissed across a reload when localStorage already has the flag", async () => {
+    // Simulate a prior dismissal persisted for this wedding.
+    localStorage.setItem("cire:getting-started-dismissed:wed_9", "1");
+    mockSnapshot({ events: [], guests: [], invite: EMPTY_INVITE });
+    render(() => <GettingStarted weddingId="wed_9" onJump={() => {}} />);
+
+    // The checklist never paints; only the restore affordance does (once the
+    // snapshot resolves).
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Show getting started/i })).toBeTruthy(),
+    );
+    expect(screen.queryByText("0 / 4 done")).toBeNull();
+  });
+
+  it("keeps dismissal per-wedding (dismissing one leaves another visible)", async () => {
+    // wed_a dismissed, wed_b not.
+    localStorage.setItem("cire:getting-started-dismissed:wed_a", "1");
+    mockSnapshot({ events: [], guests: [], invite: EMPTY_INVITE });
+    render(() => <GettingStarted weddingId="wed_b" onJump={() => {}} />);
+
+    // wed_b's checklist shows because its own key isn't set.
+    await waitFor(() => expect(screen.getByText("0 / 4 done")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /Show getting started/i })).toBeNull();
   });
 });

--- a/cire/organiser/src/components/GettingStarted.tsx
+++ b/cire/organiser/src/components/GettingStarted.tsx
@@ -1,8 +1,36 @@
 import { useAuth } from "@osn/client/solid";
-import { createMemo, createResource, For, Show } from "solid-js";
+import { createMemo, createResource, createSignal, For, Show } from "solid-js";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { isHeroEmpty, isStoryEmpty } from "../lib/invite-emptiness";
+
+/** localStorage key for "this organiser dismissed the getting-started checklist
+ *  for this wedding". Per-wedding so dismissing one wedding's guide leaves the
+ *  others intact. */
+function dismissKey(weddingId: string): string {
+  return `cire:getting-started-dismissed:${weddingId}`;
+}
+
+function readDismissed(weddingId: string): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(dismissKey(weddingId)) === "1";
+  } catch {
+    // Private-mode / disabled storage — treat as not dismissed (fail visible).
+    return false;
+  }
+}
+
+function writeDismissed(weddingId: string, dismissed: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    if (dismissed) localStorage.setItem(dismissKey(weddingId), "1");
+    else localStorage.removeItem(dismissKey(weddingId));
+  } catch {
+    // No-op if storage is unavailable; the in-memory signal still drives the UI
+    // for this session.
+  }
+}
 
 /**
  * The dashboard's "what do I do next" guide — a four-step checklist that reflects
@@ -12,8 +40,13 @@ import { isHeroEmpty, isStoryEmpty } from "../lib/invite-emptiness";
  *
  * Each step's `done` is derived from data the dashboard already serves; the panel
  * fetches its own snapshot once so it stays decoupled from the tab components.
- * Clicking a step jumps to the matching tab via the same hash-routing the tabs
- * use (`#events`, `#guests`, `#invite`) — no new navigation model.
+ * Clicking a step jumps to the matching tab via the parent's `onJump` (which
+ * updates the URL hash through the shared dashboard-route scheme) — no new
+ * navigation model.
+ *
+ * The checklist can be dismissed (an X, top-right); the choice is persisted per
+ * wedding in localStorage and a small "Show getting started" affordance brings
+ * it back. The data-derived done-state logic is unchanged by dismissal.
  */
 
 interface EventRow {
@@ -54,6 +87,21 @@ export default function GettingStarted(props: {
   onJump: (tab: string) => void;
 }) {
   const { authFetch } = useAuth();
+
+  // Dismissal is per-wedding and persisted in localStorage, so an organiser who
+  // doesn't want the checklist can hide it and have it stay hidden across
+  // reloads — with a small "Show getting started" affordance to bring it back.
+  // Seeded from storage so a hard refresh respects a prior dismissal.
+  const [dismissed, setDismissed] = createSignal(readDismissed(props.weddingId));
+
+  function dismiss() {
+    setDismissed(true);
+    writeDismissed(props.weddingId, true);
+  }
+  function restore() {
+    setDismissed(false);
+    writeDismissed(props.weddingId, false);
+  }
 
   const [snapshot] = createResource<Snapshot>(async () => {
     try {
@@ -145,78 +193,109 @@ export default function GettingStarted(props: {
 
   return (
     <Show when={snapshot()}>
-      <section
-        aria-label="Getting started"
-        class="border-gold/25 from-surface/50 to-surface/20 flex flex-col gap-5 rounded-sm border bg-gradient-to-br p-6"
-      >
-        <div class="flex flex-wrap items-end justify-between gap-x-6 gap-y-2">
-          <div class="flex flex-col gap-1">
-            <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
-              {allDone() ? "You're all set" : "Getting started"}
-            </p>
-            <h2 class="font-display text-text text-[1.4rem] font-light italic">
-              {allDone() ? "Everything's ready for your guests" : "Four steps to your invite"}
-            </h2>
-            <Show when={!allDone() && nextStep()}>
-              {(step) => (
-                <p class="font-body text-text-muted text-[0.82rem] leading-relaxed">
-                  Next: <span class="text-text">{step().todo}</span>
-                </p>
-              )}
-            </Show>
-          </div>
-          <span
-            class="font-body text-gold-dim shrink-0 text-[0.78rem] tracking-[0.12em] uppercase tabular-nums"
-            aria-hidden
+      {/* Dismissed ⇒ collapse to a quiet "Show getting started" affordance the
+          organiser can use to bring the checklist back. */}
+      <Show when={dismissed()}>
+        <div class="flex justify-end">
+          <button
+            type="button"
+            onClick={restore}
+            class="font-body text-text-muted hover:text-gold text-[0.74rem] tracking-[0.12em] uppercase underline-offset-4 transition hover:underline"
           >
-            {completed()} / {total()} done
-          </span>
+            Show getting started
+          </button>
         </div>
+      </Show>
 
-        {/* A thin progress rail — a single calm indicator of how far along the
-            couple are. Pure CSS width transition, no library. */}
-        <div
-          class="bg-bg/60 h-1 w-full overflow-hidden rounded-full"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={total()}
-          aria-valuenow={completed()}
-          aria-label="Setup progress"
+      <Show when={!dismissed()}>
+        <section
+          aria-label="Getting started"
+          class="border-gold/25 from-surface/50 to-surface/20 relative flex flex-col gap-5 rounded-sm border bg-gradient-to-br p-6"
         >
-          <div
-            class="bg-gold h-full rounded-full transition-[width] duration-500 ease-out"
-            style={{ width: `${total() > 0 ? (completed() / total()) * 100 : 0}%` }}
-          />
-        </div>
+          {/* Dismiss (X) — top-right, so an organiser who doesn't want the guide
+            can hide it; the choice persists per wedding in localStorage. */}
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Dismiss getting started"
+            title="Dismiss getting started"
+            class="text-text-muted hover:text-gold hover:border-gold/50 border-border absolute top-3 right-3 flex h-7 w-7 items-center justify-center rounded-sm border border-transparent text-[0.9rem] leading-none transition-colors"
+          >
+            <span aria-hidden>✕</span>
+          </button>
 
-        <ol class="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-          <For each={steps()}>
-            {(step, i) => (
-              <li>
-                <button
-                  type="button"
-                  onClick={() => props.onJump(step.tab)}
-                  data-complete={step.complete ? "true" : "false"}
-                  class="group border-border bg-bg/30 hover:border-gold/60 flex w-full items-start gap-3 rounded-sm border p-3 text-left transition-colors"
-                >
-                  <StepMarker n={i() + 1} complete={step.complete} />
-                  <span class="flex flex-col gap-0.5">
-                    <span
-                      class="font-body text-[0.9rem]"
-                      classList={{ "text-text": !step.complete, "text-text-muted": step.complete }}
-                    >
-                      {step.label}
+          <div class="flex flex-wrap items-end justify-between gap-x-6 gap-y-2 pr-8">
+            <div class="flex flex-col gap-1">
+              <p class="font-body text-gold text-[0.72rem] tracking-[0.2em] uppercase">
+                {allDone() ? "You're all set" : "Getting started"}
+              </p>
+              <h2 class="font-display text-text text-[1.4rem] font-light italic">
+                {allDone() ? "Everything's ready for your guests" : "Four steps to your invite"}
+              </h2>
+              <Show when={!allDone() && nextStep()}>
+                {(step) => (
+                  <p class="font-body text-text-muted text-[0.82rem] leading-relaxed">
+                    Next: <span class="text-text">{step().todo}</span>
+                  </p>
+                )}
+              </Show>
+            </div>
+            <span
+              class="font-body text-gold-dim shrink-0 text-[0.78rem] tracking-[0.12em] uppercase tabular-nums"
+              aria-hidden
+            >
+              {completed()} / {total()} done
+            </span>
+          </div>
+
+          {/* A thin progress rail — a single calm indicator of how far along the
+            couple are. Pure CSS width transition, no library. */}
+          <div
+            class="bg-bg/60 h-1 w-full overflow-hidden rounded-full"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={total()}
+            aria-valuenow={completed()}
+            aria-label="Setup progress"
+          >
+            <div
+              class="bg-gold h-full rounded-full transition-[width] duration-500 ease-out"
+              style={{ width: `${total() > 0 ? (completed() / total()) * 100 : 0}%` }}
+            />
+          </div>
+
+          <ol class="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+            <For each={steps()}>
+              {(step, i) => (
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => props.onJump(step.tab)}
+                    data-complete={step.complete ? "true" : "false"}
+                    class="group border-border bg-bg/30 hover:border-gold/60 flex w-full items-start gap-3 rounded-sm border p-3 text-left transition-colors"
+                  >
+                    <StepMarker n={i() + 1} complete={step.complete} />
+                    <span class="flex flex-col gap-0.5">
+                      <span
+                        class="font-body text-[0.9rem]"
+                        classList={{
+                          "text-text": !step.complete,
+                          "text-text-muted": step.complete,
+                        }}
+                      >
+                        {step.label}
+                      </span>
+                      <span class="font-body text-text-muted text-[0.76rem] leading-snug">
+                        {step.complete ? step.done : step.todo}
+                      </span>
                     </span>
-                    <span class="font-body text-text-muted text-[0.76rem] leading-snug">
-                      {step.complete ? step.done : step.todo}
-                    </span>
-                  </span>
-                </button>
-              </li>
-            )}
-          </For>
-        </ol>
-      </section>
+                  </button>
+                </li>
+              )}
+            </For>
+          </ol>
+        </section>
+      </Show>
     </Show>
   );
 }

--- a/cire/organiser/src/components/OrganiserApp.test.tsx
+++ b/cire/organiser/src/components/OrganiserApp.test.tsx
@@ -58,10 +58,23 @@ vi.mock("./WeddingList", () => ({
   ),
 }));
 
+// The tab bar is controlled now: it gets the active `tab` + an `onTab` callback.
+// Surface both so the suite can assert the hash-driven tab and exercise a tab
+// switch (which the parent mirrors into the URL hash).
 vi.mock("./DashboardTabs", () => ({
-  default: (props: { weddingId: string; canManage: boolean }) => (
-    <div data-testid="dashboard-tabs" data-can-manage={String(props.canManage)}>
+  default: (props: {
+    weddingId: string;
+    canManage: boolean;
+    tab: string;
+    onTab: (t: string) => void;
+  }) => (
+    <div
+      data-testid="dashboard-tabs"
+      data-can-manage={String(props.canManage)}
+      data-tab={props.tab}
+    >
       {props.weddingId}
+      <button onClick={() => props.onTab("guests")}>go-guests</button>
     </div>
   ),
 }));
@@ -105,6 +118,9 @@ describe("OrganiserApp Dashboard", () => {
     cleanup();
     authFetchMock.mockReset();
     redirectSpy.mockReset();
+    // The dashboard mirrors its state into the URL hash — reset it so one test's
+    // deep link doesn't seed the next.
+    history.replaceState(null, "", window.location.pathname + window.location.search);
   });
 
   it("renders the wedding list once the fetch resolves", async () => {
@@ -131,7 +147,7 @@ describe("OrganiserApp Dashboard", () => {
     await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
 
     fireEvent.click(screen.getByText("select-first"));
-    expect(screen.getByTestId("dashboard-tabs").textContent).toBe("wed_a");
+    expect(screen.getByTestId("dashboard-tabs").textContent).toContain("wed_a");
     // Owner ⇒ management enabled + the import panel rendered.
     expect(screen.getByTestId("dashboard-tabs").getAttribute("data-can-manage")).toBe("true");
     expect(screen.getByTestId("import-panel").textContent).toBe("wed_a");
@@ -145,7 +161,7 @@ describe("OrganiserApp Dashboard", () => {
     await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
 
     fireEvent.click(screen.getByText("select-first"));
-    expect(screen.getByTestId("dashboard-tabs").textContent).toBe("wed_c");
+    expect(screen.getByTestId("dashboard-tabs").textContent).toContain("wed_c");
     // Co-host ⇒ owner-only management disabled (threaded into the Hosts/Codes
     // tabs), but the spreadsheet import is available — co-hosts are trusted
     // co-organisers (gated server-side by weddingMember).
@@ -161,7 +177,7 @@ describe("OrganiserApp Dashboard", () => {
     fireEvent.click(screen.getByText("create"));
     // The new wedding is selected (its dashboard renders) and the list now
     // carries it.
-    expect(screen.getByTestId("dashboard-tabs").textContent).toBe("wed_new");
+    expect(screen.getByTestId("dashboard-tabs").textContent).toContain("wed_new");
   });
 
   it("toggles to the Security (devices / passkeys) panel from the nav", async () => {
@@ -180,5 +196,73 @@ describe("OrganiserApp Dashboard", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Weddings$/ }));
     expect(screen.getByTestId("wedding-list")).toBeTruthy();
     expect(screen.queryByTestId("security-panel")).toBeNull();
+  });
+
+  // ── Deep-linking + refresh persistence (the headline ask) ───────────────────
+
+  it("restores a wedding + tab from the URL hash on load (survives a hard refresh)", async () => {
+    // Simulate landing with a deep link / a hard refresh on a wedding tab.
+    history.replaceState(null, "", "#/weddings/wed_a/guests");
+    authFetchMock.mockResolvedValue(
+      listResponse([{ id: "wed_a", slug: "a", displayName: "Alice & Bob" }]),
+    );
+    render(() => <OrganiserApp />);
+
+    // It opens straight to the wedding's dashboard on the deep-linked tab — no
+    // bounce back to the list.
+    await waitFor(() => expect(screen.getByTestId("dashboard-tabs")).toBeTruthy());
+    expect(screen.queryByTestId("wedding-list")).toBeNull();
+    expect(screen.getByTestId("dashboard-tabs").getAttribute("data-tab")).toBe("guests");
+  });
+
+  it("falls back to the list for a hash naming a wedding the organiser can't load", async () => {
+    // Deep link to a wedding that isn't in the loaded list (not owner/host, or
+    // gone) — it must not hang; it drops to the list.
+    history.replaceState(null, "", "#/weddings/wed_missing/invite");
+    authFetchMock.mockResolvedValue(
+      listResponse([{ id: "wed_a", slug: "a", displayName: "Alice & Bob" }]),
+    );
+    render(() => <OrganiserApp />);
+
+    await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
+    expect(screen.queryByTestId("dashboard-tabs")).toBeNull();
+    // And the hash was corrected to the canonical list route.
+    expect(window.location.hash).toBe("#/weddings");
+  });
+
+  it("writes the wedding to the hash when one is opened, and clears it on back", async () => {
+    authFetchMock.mockResolvedValue(
+      listResponse([{ id: "wed_a", slug: "a", displayName: "Alice & Bob" }]),
+    );
+    render(() => <OrganiserApp />);
+    await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("select-first"));
+    expect(window.location.hash).toBe("#/weddings/wed_a");
+
+    // Switching tabs reflects in the hash (shareable / refresh-safe).
+    fireEvent.click(screen.getByText("go-guests"));
+    expect(window.location.hash).toBe("#/weddings/wed_a/guests");
+    expect(screen.getByTestId("dashboard-tabs").getAttribute("data-tab")).toBe("guests");
+
+    // Back to all weddings clears the wedding from the hash.
+    fireEvent.click(screen.getByRole("button", { name: /All weddings/i }));
+    expect(screen.getByTestId("wedding-list")).toBeTruthy();
+    expect(window.location.hash).toBe("#/weddings");
+  });
+
+  it("re-syncs on a browser Back/Forward style hashchange", async () => {
+    authFetchMock.mockResolvedValue(
+      listResponse([{ id: "wed_a", slug: "a", displayName: "Alice & Bob" }]),
+    );
+    render(() => <OrganiserApp />);
+    await waitFor(() => expect(screen.getByTestId("wedding-list")).toBeTruthy());
+
+    // Simulate the browser navigating the hash (Back/Forward, or a manual edit).
+    window.location.hash = "#/weddings/wed_a/invite";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    await waitFor(() => expect(screen.getByTestId("dashboard-tabs")).toBeTruthy());
+    expect(screen.getByTestId("dashboard-tabs").getAttribute("data-tab")).toBe("invite");
   });
 });

--- a/cire/organiser/src/components/OrganiserApp.tsx
+++ b/cire/organiser/src/components/OrganiserApp.tsx
@@ -1,8 +1,24 @@
 import { AuthProvider, useAuth } from "@osn/client/solid";
-import { createEffect, createResource, createSignal, Show, type ParentProps } from "solid-js";
+import {
+  createEffect,
+  createResource,
+  createSignal,
+  onCleanup,
+  onMount,
+  type ParentProps,
+  Show,
+} from "solid-js";
 import { Toaster } from "solid-toast";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import {
+  type DashboardRoute,
+  type DashboardTab,
+  isDashboardTab,
+  LIST_ROUTE,
+  parseRoute,
+  serializeRoute,
+} from "../lib/dashboard-route";
 import { OSN_ISSUER_URL } from "../lib/osn";
 import type { WeddingSummary } from "./CreateWeddingForm";
 import DashboardTabs from "./DashboardTabs";
@@ -42,25 +58,38 @@ function RequireAuth(props: ParentProps) {
   );
 }
 
-/** Move the tabs to `tab` — the tabs listen for `hashchange`, so updating the
- *  hash (and dispatching the event for same-value jumps) switches the panel and
- *  scrolls it into view. Used by the Getting-started checklist's step buttons. */
-function jumpToTab(tab: string) {
-  if (typeof window === "undefined") return;
-  window.location.hash = tab;
-  window.dispatchEvent(new HashChangeEvent("hashchange"));
-  document.getElementById("wedding-tabs")?.scrollIntoView({ behavior: "smooth", block: "start" });
-}
-
 /** The chosen wedding's dashboard — the context header, the Getting-started
  *  checklist, the spreadsheet import, and the tabbed events/guests/invite view,
  *  scoped to whichever wedding the organiser opened. Co-hosts are trusted
  *  co-organisers: they get the full read/edit dashboard, including the
  *  spreadsheet import (the API gates it with weddingMember). Only the owner-only
  *  management actions (managing co-hosts, re-minting codes) stay gated on
- *  `isOwner` — passed down via `canManage`. */
-function WeddingDashboard(props: { wedding: WeddingSummary; onBack: () => void }) {
+ *  `isOwner` — passed down via `canManage`.
+ *
+ *  The active tab is fully controlled by the parent (URL-hash driven) so a deep
+ *  link / hard refresh restores the exact tab; the dashboard reports tab changes
+ *  back up via `onTab`, and offers a checklist jump that switches tab + scrolls. */
+function WeddingDashboard(props: {
+  wedding: WeddingSummary;
+  /** Active tab as an accessor so it stays reactive across hash changes even
+   *  while the same wedding object stays selected. */
+  tab: () => DashboardTab;
+  onTab: (tab: DashboardTab) => void;
+  onBack: () => void;
+}) {
   const isOwner = () => props.wedding.role === "owner";
+
+  /** Move to a tab from the Getting-started checklist: switch the panel (via the
+   *  parent's hash update) and scroll the tab strip into view. */
+  function jumpToTab(tab: string) {
+    if (!isDashboardTab(tab)) return;
+    props.onTab(tab);
+    if (typeof document !== "undefined") {
+      document
+        .getElementById("wedding-tabs")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
 
   return (
     <div class="flex flex-col gap-10">
@@ -115,22 +144,22 @@ function WeddingDashboard(props: { wedding: WeddingSummary; onBack: () => void }
           weddingName={props.wedding.displayName}
           weddingSlug={props.wedding.slug}
           canManage={isOwner()}
+          tab={props.tab()}
+          onTab={props.onTab}
         />
       </div>
     </div>
   );
 }
 
-type DashboardView = "weddings" | "security";
-
 const navClass = (active: boolean) =>
   `font-body text-[0.82rem] tracking-[0.1em] uppercase underline-offset-4 transition ${
     active ? "text-gold" : "text-text-muted hover:text-gold hover:underline"
   }`;
 
-function initialView(): DashboardView {
-  if (typeof window === "undefined") return "weddings";
-  return window.location.hash.replace("#", "") === "security" ? "security" : "weddings";
+function initialRoute(): DashboardRoute {
+  if (typeof window === "undefined") return LIST_ROUTE;
+  return parseRoute(window.location.hash);
 }
 
 function Dashboard() {
@@ -138,17 +167,69 @@ function Dashboard() {
   // Locally-tracked weddings so a freshly-created one shows up without a
   // refetch. Seeded from the initial load.
   const [weddings, setWeddings] = createSignal<WeddingSummary[] | null>(null);
-  const [selectedId, setSelectedId] = createSignal<string | null>(null);
-  // Top-level view: the wedding list/dashboard, or the account security
-  // (devices / passkeys) panel. Security is reachable whenever signed in,
-  // independent of any wedding selection.
-  const [view, setView] = createSignal<DashboardView>(initialView());
 
-  function selectView(next: DashboardView) {
-    setView(next);
-    if (typeof window !== "undefined") {
-      history.replaceState(null, "", next === "security" ? "#security" : "#");
+  // The single source of navigable state: top-level view + selected wedding +
+  // active tab, mirrored into the URL hash so a hard refresh restores it and a
+  // shared link reopens it. Seeded from the hash on first paint.
+  const [route, setRouteSignal] = createSignal<DashboardRoute>(initialRoute());
+
+  // Write the hash with replaceState by default (tab switches) so they don't
+  // pile up history entries; explicit navigations (open a wedding, go back to
+  // the list, switch view) push so Back/Forward walks them. Either way the URL
+  // stays the source of truth and a manual edit or browser Back/Forward
+  // re-syncs via the hashchange listener below.
+  function setRoute(next: DashboardRoute, mode: "push" | "replace" = "replace") {
+    setRouteSignal(next);
+    if (typeof window === "undefined") return;
+    const hash = serializeRoute(next);
+    if (window.location.hash === hash) return;
+    const url = `${window.location.pathname}${window.location.search}${hash}`;
+    if (mode === "push") history.pushState(null, "", url);
+    else history.replaceState(null, "", url);
+  }
+
+  // Re-sync from the hash on browser Back/Forward and manual edits. The signal
+  // is the source of truth for render; the listener just mirrors external hash
+  // changes back into it (it never writes the hash, so no feedback loop).
+  function onHashChange() {
+    setRouteSignal(parseRoute(window.location.hash));
+  }
+  onMount(() => {
+    window.addEventListener("hashchange", onHashChange);
+    // Normalise a legacy / shorthand hash (e.g. `#security`, `#guests`, or "")
+    // into the canonical `#/…` form without adding a history entry.
+    const canonical = serializeRoute(parseRoute(window.location.hash));
+    if (window.location.hash !== canonical) {
+      history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}${canonical}`,
+      );
     }
+  });
+  onCleanup(() => {
+    if (typeof window !== "undefined") window.removeEventListener("hashchange", onHashChange);
+  });
+
+  const view = () => route().view;
+
+  function selectView(next: "weddings" | "security") {
+    if (next === "security") setRoute({ view: "security", weddingId: null, tab: "events" }, "push");
+    else setRoute(LIST_ROUTE, "push");
+  }
+
+  function selectWedding(wedding: WeddingSummary) {
+    setRoute({ view: "weddings", weddingId: wedding.id, tab: "events" }, "push");
+  }
+
+  function backToList() {
+    setRoute(LIST_ROUTE, "push");
+  }
+
+  function selectTab(tab: DashboardTab) {
+    const r = route();
+    if (r.view !== "weddings" || r.weddingId === null) return;
+    setRoute({ view: "weddings", weddingId: r.weddingId, tab }, "replace");
   }
 
   const [loaded] = createResource<WeddingsState>(async () => {
@@ -176,16 +257,31 @@ function Dashboard() {
     return state?.kind === "error" ? state.message : null;
   };
 
+  // The wedding named by the route, once the list has loaded. A deep link to a
+  // wedding the organiser can't load (not owner/host, or gone) resolves to null;
+  // the effect below then falls the route back to the list rather than hanging.
   const selected = () => {
-    const id = selectedId();
-    return weddings()?.find((w) => w.id === id) ?? null;
+    const r = route();
+    if (r.view !== "weddings" || r.weddingId === null) return null;
+    return weddings()?.find((w) => w.id === r.weddingId) ?? null;
   };
+
+  // Graceful fallback: once the list is loaded, if the route names a wedding
+  // that isn't in it, drop back to the list (replace — a dead link shouldn't
+  // leave a Back-able entry).
+  createEffect(() => {
+    const r = route();
+    if (r.view !== "weddings" || r.weddingId === null) return;
+    const list = weddings();
+    if (!list) return; // still loading — don't judge yet
+    if (!list.some((w) => w.id === r.weddingId)) setRoute(LIST_ROUTE, "replace");
+  });
 
   function handleCreated(wedding: WeddingSummary) {
     setWeddings((prev) => [...(prev ?? []), wedding]);
     // Open the new wedding straight away — the organiser just made it to fill
     // it in.
-    setSelectedId(wedding.id);
+    selectWedding(wedding);
   }
 
   async function signOut() {
@@ -244,13 +340,21 @@ function Dashboard() {
                 fallback={
                   <WeddingList
                     weddings={list()}
-                    onSelect={(w) => setSelectedId(w.id)}
+                    onSelect={(w) => selectWedding(w)}
                     onCreated={handleCreated}
                   />
                 }
               >
                 {(wedding) => (
-                  <WeddingDashboard wedding={wedding()} onBack={() => setSelectedId(null)} />
+                  <WeddingDashboard
+                    wedding={wedding()}
+                    tab={() => {
+                      const r = route();
+                      return r.view === "weddings" ? r.tab : "events";
+                    }}
+                    onTab={selectTab}
+                    onBack={backToList}
+                  />
                 )}
               </Show>
             )}

--- a/cire/organiser/src/lib/dashboard-route.test.ts
+++ b/cire/organiser/src/lib/dashboard-route.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type DashboardRoute,
+  DEFAULT_TAB,
+  isDashboardTab,
+  LIST_ROUTE,
+  parseRoute,
+  serializeRoute,
+} from "./dashboard-route";
+
+/**
+ * The hash-route helper is the contract the dashboard's deep-linking + refresh-
+ * persistence rests on: it must parse every shape the app produces (and fall
+ * unknown shapes back to the list), and round-trip its own serialisations.
+ */
+describe("dashboard-route", () => {
+  describe("parseRoute", () => {
+    it("parses the wedding list", () => {
+      expect(parseRoute("#/weddings")).toEqual(LIST_ROUTE);
+    });
+
+    it("parses a wedding with the default tab", () => {
+      expect(parseRoute("#/weddings/wed_1")).toEqual({
+        view: "weddings",
+        weddingId: "wed_1",
+        tab: DEFAULT_TAB,
+      });
+    });
+
+    it("parses a wedding + a specific tab", () => {
+      expect(parseRoute("#/weddings/wed_1/guests")).toEqual({
+        view: "weddings",
+        weddingId: "wed_1",
+        tab: "guests",
+      });
+    });
+
+    it("parses every known tab", () => {
+      for (const tab of ["events", "guests", "invite", "codes", "hosts"] as const) {
+        expect(parseRoute(`#/weddings/wed_1/${tab}`).tab).toBe(tab);
+      }
+    });
+
+    it("parses the security view", () => {
+      expect(parseRoute("#/security")).toEqual({
+        view: "security",
+        weddingId: null,
+        tab: DEFAULT_TAB,
+      });
+    });
+
+    it("decodes a wedding id with reserved characters", () => {
+      expect(parseRoute("#/weddings/wed%2F1/invite")).toEqual({
+        view: "weddings",
+        weddingId: "wed/1",
+        tab: "invite",
+      });
+    });
+
+    it("falls back to the list for an empty / bare hash", () => {
+      expect(parseRoute("")).toEqual(LIST_ROUTE);
+      expect(parseRoute("#")).toEqual(LIST_ROUTE);
+      expect(parseRoute("#/")).toEqual(LIST_ROUTE);
+    });
+
+    it("falls back to the list for an unknown top segment", () => {
+      expect(parseRoute("#/nonsense/x/y")).toEqual(LIST_ROUTE);
+    });
+
+    it("falls back to the list when a wedding id is missing", () => {
+      expect(parseRoute("#/weddings/")).toEqual(LIST_ROUTE);
+    });
+
+    it("falls an unknown tab back to the default tab (keeps the wedding)", () => {
+      expect(parseRoute("#/weddings/wed_1/bogus")).toEqual({
+        view: "weddings",
+        weddingId: "wed_1",
+        tab: DEFAULT_TAB,
+      });
+    });
+
+    it("tolerates legacy bare hashes", () => {
+      // The legacy top-level `#security` hash still resolves to the security
+      // view (the segment matches), so a pre-scheme bookmark keeps working.
+      expect(parseRoute("#security")).toEqual({
+        view: "security",
+        weddingId: null,
+        tab: DEFAULT_TAB,
+      });
+      // A legacy bare tab hash (`#guests`) is not a recognised top segment, so
+      // it degrades to the list rather than erroring. (OrganiserApp normalises
+      // the canonical `#/…` form on mount.)
+      expect(parseRoute("#guests")).toEqual(LIST_ROUTE);
+    });
+  });
+
+  describe("serializeRoute", () => {
+    it("serialises the list", () => {
+      expect(serializeRoute(LIST_ROUTE)).toBe("#/weddings");
+    });
+
+    it("omits the default tab for a short, canonical wedding link", () => {
+      expect(serializeRoute({ view: "weddings", weddingId: "wed_1", tab: DEFAULT_TAB })).toBe(
+        "#/weddings/wed_1",
+      );
+    });
+
+    it("appends a non-default tab", () => {
+      expect(serializeRoute({ view: "weddings", weddingId: "wed_1", tab: "codes" })).toBe(
+        "#/weddings/wed_1/codes",
+      );
+    });
+
+    it("serialises security", () => {
+      expect(serializeRoute({ view: "security", weddingId: null, tab: DEFAULT_TAB })).toBe(
+        "#/security",
+      );
+    });
+
+    it("encodes a wedding id with reserved characters", () => {
+      expect(serializeRoute({ view: "weddings", weddingId: "wed/1", tab: "invite" })).toBe(
+        "#/weddings/wed%2F1/invite",
+      );
+    });
+  });
+
+  describe("round-trip", () => {
+    const routes: DashboardRoute[] = [
+      LIST_ROUTE,
+      { view: "weddings", weddingId: "wed_1", tab: "events" },
+      { view: "weddings", weddingId: "wed_1", tab: "guests" },
+      { view: "weddings", weddingId: "wed_1", tab: "invite" },
+      { view: "weddings", weddingId: "wed_1", tab: "codes" },
+      { view: "weddings", weddingId: "wed_1", tab: "hosts" },
+      { view: "weddings", weddingId: "wed/with spaces", tab: "guests" },
+      { view: "security", weddingId: null, tab: DEFAULT_TAB },
+    ];
+
+    it("parse(serialize(route)) === route for every producible route", () => {
+      for (const route of routes) {
+        expect(parseRoute(serializeRoute(route))).toEqual(route);
+      }
+    });
+  });
+
+  describe("isDashboardTab", () => {
+    it("accepts the five tabs and rejects everything else", () => {
+      for (const tab of ["events", "guests", "invite", "codes", "hosts"]) {
+        expect(isDashboardTab(tab)).toBe(true);
+      }
+      expect(isDashboardTab("weddings")).toBe(false);
+      expect(isDashboardTab("")).toBe(false);
+      expect(isDashboardTab("EVENTS")).toBe(false);
+    });
+  });
+});

--- a/cire/organiser/src/lib/dashboard-route.ts
+++ b/cire/organiser/src/lib/dashboard-route.ts
@@ -1,0 +1,98 @@
+/**
+ * The organiser dashboard's navigable state, encoded in the URL hash so a hard
+ * refresh restores exactly where you were and a shared link opens to (almost)
+ * the same place the sender was in.
+ *
+ * Scheme (everything after the `#`):
+ *   #/weddings                         → the wedding list
+ *   #/weddings/<weddingId>             → that wedding, default tab (events)
+ *   #/weddings/<weddingId>/<tab>       → that wedding + a specific tab
+ *   #/security                         → the account-security view
+ *
+ * `<tab>` is one of events | guests | invite | codes | hosts. The list view and
+ * the security view carry no further state here; deeper sub-state (open modals,
+ * a selected guest row) is intentionally NOT deep-linked yet — see the wiki.
+ *
+ * Anything unrecognised parses to the wedding list, so a stale or hand-edited
+ * hash degrades gracefully rather than erroring.
+ */
+
+export const DASHBOARD_TABS = ["events", "guests", "invite", "codes", "hosts"] as const;
+
+export type DashboardTab = (typeof DASHBOARD_TABS)[number];
+
+export const DEFAULT_TAB: DashboardTab = "events";
+
+export function isDashboardTab(value: string): value is DashboardTab {
+  return (DASHBOARD_TABS as readonly string[]).includes(value);
+}
+
+/**
+ * The full parsed route. A discriminated union so callers branch on `view`:
+ * - `weddings` with no `weddingId` ⇒ the list
+ * - `weddings` with a `weddingId` ⇒ that wedding's dashboard on `tab`
+ * - `security` ⇒ the security panel
+ */
+export type DashboardRoute =
+  | { view: "weddings"; weddingId: null; tab: DashboardTab }
+  | { view: "weddings"; weddingId: string; tab: DashboardTab }
+  | { view: "security"; weddingId: null; tab: DashboardTab };
+
+export const LIST_ROUTE: DashboardRoute = {
+  view: "weddings",
+  weddingId: null,
+  tab: DEFAULT_TAB,
+};
+
+/** Strip a single leading `#` and any leading/trailing slashes, then split into
+ *  path segments. `decodeURIComponent` each so an id with reserved chars round-
+ *  trips. Empty/garbage ⇒ `[]`. */
+function segments(hash: string): string[] {
+  const raw = hash.replace(/^#/, "").replace(/^\/+|\/+$/g, "");
+  if (raw === "") return [];
+  return raw.split("/").map((s) => {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      // A malformed %-escape shouldn't throw — keep the raw segment.
+      return s;
+    }
+  });
+}
+
+/**
+ * Parse a location hash into a {@link DashboardRoute}. Total + defensive:
+ * unknown shapes fall back to the wedding list. An owner-only tab on a deep link
+ * is NOT gated here (the parser doesn't know the caller's role) — the dashboard
+ * resolves the visible tab when it renders.
+ */
+export function parseRoute(hash: string): DashboardRoute {
+  const parts = segments(hash);
+  if (parts.length === 0) return LIST_ROUTE;
+
+  if (parts[0] === "security") {
+    return { view: "security", weddingId: null, tab: DEFAULT_TAB };
+  }
+
+  if (parts[0] === "weddings") {
+    const weddingId = parts[1];
+    if (!weddingId) return LIST_ROUTE;
+    const rawTab = parts[2];
+    const tab = rawTab && isDashboardTab(rawTab) ? rawTab : DEFAULT_TAB;
+    return { view: "weddings", weddingId, tab };
+  }
+
+  return LIST_ROUTE;
+}
+
+/** Serialize a route back to a hash string (always leading `#/`). The inverse of
+ *  {@link parseRoute} for every route it can produce. */
+export function serializeRoute(route: DashboardRoute): string {
+  if (route.view === "security") return "#/security";
+  if (route.weddingId === null) return "#/weddings";
+  const id = encodeURIComponent(route.weddingId);
+  // The default tab is left implicit so a wedding link stays short + canonical;
+  // an explicit non-default tab is appended.
+  if (route.tab === DEFAULT_TAB) return `#/weddings/${id}`;
+  return `#/weddings/${id}/${route.tab}`;
+}

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -7,6 +7,44 @@ related:
 last-reviewed: 2026-06-19
 ---
 
+> [!note] Deep-linkable dashboard routes + refresh persistence + dismissable checklist (`feat/cire-dashboard-routing`)
+> The organiser dashboard's full navigable state now lives in the URL hash, so a
+> hard refresh restores where you were and a shared link reopens it. New
+> dependency-free helper `cire/organiser/src/lib/dashboard-route.ts`
+> (`parseRoute`/`serializeRoute`, a `DashboardRoute` discriminated union).
+> - **Hash-route scheme:**
+>   - `#/weddings` → the wedding list
+>   - `#/weddings/<weddingId>` → that wedding, default tab (`events`, left implicit)
+>   - `#/weddings/<weddingId>/<tab>` → that wedding + a specific tab (`events`/`guests`/`invite`/`codes`/`hosts`)
+>   - `#/security` → the account-security view
+> - **Source of truth:** `OrganiserApp.tsx` owns one `route` signal, mirrored into
+>   the hash. Opening a wedding / back-to-list / switching the top-level view
+>   `pushState`s (Back/Forward walks them); tab switches `replaceState` (no history
+>   pile-up). A `hashchange` listener re-syncs on browser Back/Forward + manual
+>   edits, and a legacy/shorthand hash (`#security`, `#guests`, "") is normalised
+>   to the canonical `#/…` form on mount.
+> - **Not-authorised fallback:** once the wedding list loads, a hash naming a
+>   wedding the organiser can't load (not owner/host, or gone) drops back to the
+>   list (replace — no Back-able dead entry) rather than hanging.
+> - **`DashboardTabs.tsx` is now controlled** — it takes `tab` + `onTab` from the
+>   parent instead of self-managing the hash. Owner-only `codes` stays gated: a
+>   co-host deep-linking `#/weddings/<id>/codes` resolves to a visible tab.
+> - **`GettingStarted.tsx` dismiss** — an accessible X (label "Dismiss getting
+>   started"), persisted per wedding in `localStorage`
+>   (`cire:getting-started-dismissed:<weddingId>`) so it stays hidden across
+>   reloads, with a "Show getting started" affordance to restore it. Data-derived
+>   done-state logic unchanged.
+> - **Scope:** deeper sub-state (open modals, a selected guest row) is intentionally
+>   NOT deep-linked yet — view + wedding + tab is the requirement; deeper
+>   sub-state deep-linking is a future follow-up.
+> - Tests: new `dashboard-route.test.ts` (parse/serialize + round-trip + fallbacks),
+>   `DashboardTabs.test.tsx` rewritten for the controlled component, new
+>   `OrganiserApp` coverage (restore wedding+tab from hash on load, not-authorised
+>   fallback, hash updates on nav, `hashchange` re-sync), GettingStarted
+>   dismiss/restore + per-wedding persistence. 130 organiser tests green.
+> ⚠️ Real-browser eyeball still wanted: Back/Forward + a hard refresh on a wedding
+> tab (happy-dom can't fully exercise the history stack).
+
 > [!note] GuestTable "Opened" status (`feat/cire-invite-opened-status`)
 > The organiser Guests tab (`GuestTable.tsx`) now shows a reliable **"Opened"**
 > badge per household, driven by the server's `firstOpenedAt` (a real guest
@@ -120,6 +158,7 @@ last-reviewed: 2026-06-19
 
 Frontend feature work. Tick items as PRs land; add new entries when scope is discovered. Don't edit `wiki/todo/status.md` for area-specific items.
 
+- [x] **Deep-linkable dashboard routes + survive hard refresh, and a dismissable Getting-started checklist** (`feat/cire-dashboard-routing`) — the organiser dashboard's full navigable state (top-level view + selected wedding + active tab) is now encoded in the URL hash, so a hard refresh restores the current wedding/tab instead of dropping back to the list, and a shared link reopens to almost exactly the sender's state. Dependency-free scheme in new `cire/organiser/src/lib/dashboard-route.ts`: `#/weddings`, `#/weddings/<id>`, `#/weddings/<id>/<tab>` (`events`/`guests`/`invite`/`codes`/`hosts`), `#/security`. `OrganiserApp.tsx` owns one `route` signal as the source of truth, mirrored into the hash (push on wedding-open/back/view-switch so Back/Forward walks them; replace on tab switch); a `hashchange` listener re-syncs on Back/Forward + manual edits; a legacy/shorthand hash is normalised on mount. A hash naming a wedding the organiser can't load (not owner/host, or gone) falls back to the list rather than hanging. `DashboardTabs.tsx` became a controlled component (`tab` + `onTab` props) — owner-only `codes` stays gated, a co-host deep link to it resolves to a visible tab. `GettingStarted.tsx` gained an accessible X dismiss (label "Dismiss getting started") persisted per wedding in `localStorage` with a "Show getting started" restore affordance. Deeper sub-state (modals, selected rows) deferred as a future follow-up. See the note block above. **Wants a real-browser eyeball** on Back/Forward + a hard refresh on a wedding tab.
 - [x] **Accessible popover colour picker with obvious hex input** (`feat/cire-color-picker`) — replaced the bare native `<input type="color">` in the invite builder's theme section (Hero / Our Story / Event Details accent + background) with a proper Kobalte colour picker, after a product-owner note that hex entry was hidden ("nice, but I didn't realise at first how to input hex codes"). New `cire/organiser/src/components/ColorPicker.tsx` (extracted from the in-file `ColorPicker` sub-component) built on **Kobalte 0.13.x colour primitives** (`@kobalte/core/color-area`, `/color-slider`, `/color-field`, `/color-swatch`, `/popover`, plus `parseColor`/`Color` from `/colors`): a `ColorSwatch` **trigger button** showing the current colour + its `#RRGGBB` value (or "Default"), opening a `Popover` with a saturation/brightness `ColorArea` + a `hue` `ColorSlider` for visual picking AND a clearly-labelled **"Hex" `ColorField`** front-and-centre for typing/pasting a hex code. The area, hue slider, and hex field share one HSB `Color` signal so they stay in sync; partial/invalid hex never escapes upstream. The "Use default" reset (→ `onChange(null)`) is preserved. The **`onChange(string | null)` hex contract is unchanged** — still emits a `#rrggbb` string (or `null`) — so the live `ThemePreview` and the `cire/api` `isThemeColor` allow-list (`#[0-9a-fA-F]{3,8}` / rgb / hsl / oklch) keep working untouched. Added `@kobalte/core` as a direct `@cire/organiser` dep (already transitive via `@osn/ui`); `@internationalized/color` not needed (Kobalte bundles `parseColor`). Styled with the existing organiser theme tokens (`--color-border`/`-surface-raised`/`-text`/`-text-muted`/`-gold`, `font-body`, uppercase micro-labels); keyboard-navigable via Kobalte popover focus handling. Tests: new `ColorPicker.test.tsx` (renders labelled swatch trigger, hex field emits on a full hex, partial hex does NOT emit, "Use default" emits null, external value reflected) + the two InviteBuilder theme tests that drove the old native input updated to open the popover and type into the "Hex" field. **Wants a real-device/visual eyeball** — the `ColorArea`/`ColorSlider` gradient backgrounds + thumb positioning render in a real browser, not happy-dom.
 - [x] **Our Story — two-column desktop / mobile image-hidden layout** (`feat/cire-story-two-column`) — restyled the "Our Story" section (`InviteHeader.tsx`) from the old centred image-above-text stack into a balanced two-column editorial layout. On laptop/desktop (`md`+) the story photo is on the LEFT and the eyebrow/heading/body block on the RIGHT, vertically centred (`items-center`) with a comfortable gap and left-aligned copy; the section widens to `max-w-[960px]` to give the columns room. On mobile (below `md`) the image wrapper is `hidden md:block`, so the photo is **not even laid out** — guests see only the full-width centred text. When there is **no** story image the grid collapses to a single full-width centred column at every breakpoint, driven by a `data-has-image` attribute on the grid (`data-[has-image=true]:md:grid-cols-2` / `…:md:text-left` / `…:md:max-w-[960px]`, plus a `group-data-[has-image=true]/story:md:mx-0` on the body wrapper), so nothing ever leaves an empty half-column. The `buildSrcSet(url, ["thumb","card"])` variant usage, the `--invite-*` theme vars, and the `Show when={showStory()}` emptiness gating are all unchanged (the image `sizes` hint was nudged to `(min-width: 768px) 480px, 100vw` to match the new `md` breakpoint). **Wants a real-device check** of both breakpoints (image-present 2-col desktop vs text-only mobile, and the image-less single-column fallback).
 - [x] **Conditional invite segments — empty sections hidden** (`feat/invite-conditional-segments`) — a section with **no content at all** is no longer rendered on the guest invite (no empty full-screen hero, no empty "Our Story" surface). New shared predicates `cire/web/src/components/invite-emptiness.ts` (`hasText`, `isHeroEmpty`, `isStoryEmpty`, `hasPinterest`, `hasDressCode`) — "absent" = null / empty / **whitespace-only**. `InviteHeader.tsx` wraps the hero in `Show when={showHero()}` (renders only when it has an image OR title OR subtitle — image-only / title-only valid) and the story in `Show when={showStory()}` (heading OR body OR image; the eyebrow label alone does not keep it alive). `DetailsModal.tsx` already hid Inspiration/Dress Code; tightened both to the shared predicates so a whitespace-only `pinterestUrl` or dress-code description now counts as absent. Theme vars, the no-store SSR revalidation, and the Pinterest desktop-embed/mobile-link split are all preserved. The organiser builder mirrors the same logic with Shown/Hidden badges (see `[[invite-builder]]` + `[[api]]`). New vitest: hero hidden when fully empty / shown image-only + title-only, story hidden when all-empty / shown with a body, Inspiration + Dress Code hidden for whitespace-only values, + a unit suite for the predicate module.


### PR DESCRIPTION
## What & why

Two product-owner asks for the organiser dashboard:

**A. Deep-linkable routes + survive hard refresh (headline).** Previously the selected wedding was in-memory only, so a hard refresh on a wedding dashboard dropped back to the wedding list and a shared link couldn't target a specific wedding/tab. Now the full navigable state (top-level view + selected wedding + active tab) is encoded in the URL hash, so a refresh restores the current wedding/tab and a link reopens to almost exactly the sender's state.

**B. Dismiss the Getting-started checklist.** An accessible X to hide it, persisted per wedding, with a way to bring it back.

## Hash-route scheme

New dependency-free helper `cire/organiser/src/lib/dashboard-route.ts` (`parseRoute` / `serializeRoute`, a `DashboardRoute` discriminated union):

| Hash | State |
|---|---|
| `#/weddings` | the wedding list |
| `#/weddings/<weddingId>` | that wedding, default tab (`events`, left implicit) |
| `#/weddings/<weddingId>/<tab>` | that wedding + a specific tab (`events`/`guests`/`invite`/`codes`/`hosts`) |
| `#/security` | the account-security view |

Examples: `#/weddings/wed_abc/guests`, `#/weddings/wed_abc/codes`, `#/security`.

The parser is total + defensive: unknown shapes fall back to the list, an unknown tab falls back to the default tab (keeping the wedding), and ids are percent-encoded so they round-trip. The default tab is left implicit so a wedding link stays short and canonical.

## How refresh / deep-link / Back-Forward are handled

`OrganiserApp.tsx` owns a single `route` signal that is the source of truth for render and is mirrored into the hash:

- **On load / hard refresh / deep link** — seeds the signal from `window.location.hash` via `parseRoute`, so it opens straight to the wedding+tab. A legacy/shorthand hash (`#security`, `#guests`, "") is normalised to the canonical `#/…` form on mount (replace, no history entry).
- **Navigation** — opening a wedding, going back to the list, and switching the top-level view `pushState` (so Back/Forward walks them); tab switches `replaceState` (so they don't pile up history entries). One consistent mechanism throughout.
- **Back/Forward + manual hash edits** — a `hashchange` listener re-syncs the signal from the hash. It never writes the hash, so there's no feedback loop.
- **Not-authorised / gone fallback** — once the wedding list loads, a hash naming a wedding the organiser can't load (not owner/host, or gone) drops back to the list (replace — no Back-able dead entry) rather than hanging or erroring.

`DashboardTabs.tsx` is now a **controlled** component (`tab` + `onTab` props) instead of self-managing the hash, folding its old per-tab hash behaviour into the new scheme. Owner-only `codes` stays gated: a co-host deep-linking `#/weddings/<id>/codes` resolves to a visible tab.

## GettingStarted dismiss / restore

`GettingStarted.tsx` gains an accessible **X / dismiss** button (top-right, label "Dismiss getting started"). Dismissal persists per wedding in `localStorage` (`cire:getting-started-dismissed:<weddingId>`) so it stays hidden across reloads, with a small "Show getting started" affordance to bring it back. The data-derived done-state logic is unchanged; storage access is wrapped so private-mode failures fail visible.

## Scope

Deeper sub-state (open modals, a selected guest row) is intentionally **not** deep-linked yet — view + wedding + tab is the requirement; deeper sub-state deep-linking is noted as a future follow-up.

## Verification

- `bun run --cwd cire/organiser test` — **130 passed** (18 files). New `dashboard-route.test.ts` (parse/serialize + round-trip + fallbacks); `DashboardTabs.test.tsx` rewritten for the controlled component; new `OrganiserApp` coverage (restore wedding+tab from hash on load, not-authorised fallback, hash updates on nav, `hashchange` re-sync); GettingStarted dismiss/restore + per-wedding persistence.
- `bun run --cwd cire/organiser build` — succeeds.
- oxlint + oxfmt clean on the changed files; pre-commit + pre-push (typecheck) hooks passed.

⚠️ **Wants a real-browser eyeball:** Back/Forward + a hard refresh on a wedding tab (happy-dom can't fully exercise the history stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
