### PR TITLE
fix(cire/web): Add-to-Calendar popover hidden behind the details modal

### DIFF
--- a/.changeset/cire-add-to-calendar-zindex.md
+++ b/.changeset/cire-add-to-calendar-zindex.md
@@ -1,0 +1,12 @@
+---
+"@cire/web": patch
+---
+
+Fix the "Add to Calendar" button doing nothing.
+
+`AddToCalendar` is only ever opened from inside the event details modal
+(`AnimatedModal`, `z-100`), but its portalled popover menu was `z-90` — below
+the modal — so the Google Calendar / `.ics` menu rendered behind the modal
+backdrop and was invisible and unclickable. Raised the popover to `z-110` so it
+paints above the modal it's launched from. Added a regression test asserting the
+menu sits above the modal layer.

--- a/cire/web/src/components/AddToCalendar.test.tsx
+++ b/cire/web/src/components/AddToCalendar.test.tsx
@@ -107,6 +107,18 @@ describe("AddToCalendar", () => {
     expect(document.body.contains(menu)).toBe(true);
   });
 
+  it("paints the popover above the details modal layer (z-110 > modal z-100)", () => {
+    // Regression: AddToCalendar is opened from inside the details modal
+    // (AnimatedModal, z-100). At z-90 the portalled menu rendered behind the
+    // modal backdrop and was invisible/unclickable ("Add to Calendar doesn't
+    // work"). It must sit above the modal.
+    const { getByRole } = render(() => <AddToCalendar event={baseEvent} siteUrl={SITE_URL} />);
+    fireEvent.click(getByRole("button", { name: /add to calendar/i }));
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("z-110");
+    expect(menu.className).not.toContain("z-90");
+  });
+
   it("closes when Escape is pressed", () => {
     const { getByRole } = render(() => <AddToCalendar event={baseEvent} siteUrl={SITE_URL} />);
     const button = getByRole("button", { name: /add to calendar/i });

--- a/cire/web/src/components/AddToCalendar.tsx
+++ b/cire/web/src/components/AddToCalendar.tsx
@@ -226,11 +226,13 @@ export function AddToCalendar(props: AddToCalendarProps) {
             id={popoverId}
             role="menu"
             aria-label="Add to calendar options"
-            // z-90 sits below AnimatedModal (z-100) — modals always win — and
-            // above every event card / page-level content. The popover is
-            // portalled to <body>, so this z-index isn't trapped inside the
-            // EventCard's stacking context.
-            class="border-border bg-surface-raised fixed z-90 flex max-w-[calc(100vw-1rem)] min-w-[14rem] flex-col gap-1 rounded-sm border p-2 shadow-lg"
+            // z-110 sits ABOVE AnimatedModal (z-100). Add-to-Calendar is
+            // triggered from inside the details modal, so its popover must paint
+            // on top of that modal — at z-90 it rendered *behind* the modal
+            // backdrop, leaving the menu invisible and unclickable ("Add to
+            // Calendar doesn't work"). The popover is portalled to <body>, so
+            // this z-index isn't trapped inside the modal's stacking context.
+            class="border-border bg-surface-raised fixed z-110 flex max-w-[calc(100vw-1rem)] min-w-[14rem] flex-col gap-1 rounded-sm border p-2 shadow-lg"
             style={{ top: `${position().top}px`, left: `${position().left}px` }}
           >
             <a

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -7,6 +7,8 @@ related:
 last-reviewed: 2026-06-20
 ---
 
+- [x] **"Add to Calendar" button fixed** (`fix/cire-add-to-calendar-zindex`) — the button is only ever opened from inside the event details modal (`AnimatedModal`, `z-100`), but its portalled popover (`AddToCalendar.tsx`, Google Calendar / `.ics` menu) was `z-90` — below the modal — so the menu painted behind the modal backdrop and was invisible/unclickable ("doesn't work"). Raised the popover to `z-110` (above the modal it launches from). Regression test asserts the menu sits above the modal layer. The `calendar.ts` URL/ICS builders were already correct.
+
 > [!note] Deep-linkable dashboard routes + refresh persistence + dismissable checklist (`feat/cire-dashboard-routing`)
 > The organiser dashboard's full navigable state now lives in the URL hash, so a
 > hard refresh restores where you were and a shared link reopens it. New


### PR DESCRIPTION
## Problem
The **"Add to Calendar"** button "doesn't seem to work."

## Root cause
`AddToCalendar` is used **only inside** the event details modal (`DetailsModal` → `AnimatedModal`, which is `z-100`). Its menu is portalled to `<body>` with `position: fixed` at **`z-90`** — *below* the modal. So clicking the button does open the popover, but it renders **behind the modal backdrop**: invisible and unclickable. The button appears dead.

The `calendar.ts` Google Calendar URL + `.ics` blob builders were already correct — this was purely a stacking-order bug.

## Fix
Raise the popover to **`z-110`** (above the `z-100` modal it launches from). One-line z-index change + comment correction. Added a regression test asserting the portalled menu carries a z-index above the modal layer.

## Verify
- New regression test in `AddToCalendar.test.tsx` (menu className includes `z-110`, not `z-90`).
- `z-110` is a valid Tailwind v4 dynamic z-index utility (same family as the existing `z-90`/`z-100`).
- Local `cire/web` build is currently blocked by an unrelated stale-`node_modules` state in the main worktree (`@astrojs/cloudflare` unresolved); CI runs a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)