### PR TITLE
perf(cire/api): batch RSVP upserts, pipeline claim reads, stream served images

### DIFF
--- a/.changeset/cire-hotpath-perf.md
+++ b/.changeset/cire-hotpath-perf.md
@@ -1,0 +1,39 @@
+---
+"@cire/api": patch
+---
+
+Cut round-trips on the cire guest hot paths (RSVP submit + invite claim) and
+stop buffering served original images in Worker memory.
+
+- **P-W1 — batch the RSVP upserts.** `rsvpService.submitRsvp` issued one
+  awaited `INSERT … ON CONFLICT` per guest×event pair, so a family RSVPing to N
+  pairs cost N sequential D1 round-trips. New `rsvpService.submitRsvps([...])`
+  builds one upsert statement per pair and commits them as a single
+  `db.batch([...])` via `commitBatch` — atomic, one Workers↔D1 round-trip on
+  D1; sequential in-process on bun:sqlite (no `.batch()`), mirroring
+  `applyImport`. `submitRsvp` is now a thin single-element wrapper, so the
+  per-pair upsert + Art. 9(2)(a) dietary-consent stamping + per-pair
+  `metricRsvpUpserted` are unchanged. `POST /api/rsvp`'s submit loop is one
+  `submitRsvps` call.
+
+- **P-W2 — pipeline `claim.lookup`'s independent reads.** After the required
+  family-by-publicId read, the three reads keyed only off `family` (wedding
+  slug, guests + event-memberships, this family's rsvps) now issue together via
+  `Effect.all({...}, { concurrency: "unbounded" })` instead of serially — ~1
+  fewer serial round-trip on the hot path (no-op concurrency on bun:sqlite).
+  The events read stays sequential after — it depends on the event ids derived
+  from the guest rows. Response shape is byte-identical.
+
+- **IB-P-I2 — stream the served original image.** The no-transform serve path
+  (no Images binding, or an account without the product) now uses
+  `fetchAssetStream` to pipe R2's `obj.body` `ReadableStream` straight into the
+  `Response` instead of holding the whole (≤5 MB) image via
+  `obj.arrayBuffer()`. `response.clone()` tees the stream so the Cache-API
+  `put` and the returned body each get a copy. The Images transform path is
+  unchanged — the binding needs the bytes buffered, and its failure fallback
+  serves those same buffered bytes.
+
+Hot-path correctness rests on the sync/async DB bridge: every batch/read works
+on both bun:sqlite (tests/local, sync) and D1 (prod, async). Covered by the
+existing claim + invite serve suites plus new batch-upsert and
+`fetchAssetStream` tests.

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -23,6 +23,7 @@ import {
   AssetsR2Service,
   detectImageType,
   fetchAsset,
+  fetchAssetStream,
   MAX_IMAGE_BYTES,
 } from "../services/invite-assets";
 import type { AssetR2Error, AssetsBucket, StoredAsset } from "../services/invite-assets";
@@ -41,6 +42,17 @@ import type {
 // Sentinel parse hook: stop Elysia consuming the body so handlers parse it by
 // hand (JSON for text, raw bytes for images) — matches the import route.
 const manualParse = { parse: () => ({}) };
+
+/** Shared immutable-image response headers for both the transformed + streamed-
+ * original serve paths (the bytes are version-busted via the cache key / URL). */
+function imageResponseHeaders(contentType: string): Record<string, string> {
+  return {
+    "Content-Type": contentType,
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "public, max-age=31536000, immutable",
+    Vary: "Accept",
+  };
+}
 
 /**
  * Serve a transformed image given an already-resolved R2 key + server-derived
@@ -92,11 +104,19 @@ function serveTransformedImage(args: {
       }
     }
 
-    const original = yield* fetchAsset(key);
-
-    let served: StoredAsset = original;
+    let response: Response;
     if (images) {
-      served = yield* transformAsset(images, original, variant, format, blurOverride).pipe(
+      // Transform path: the Images binding needs the original BUFFERED (it feeds
+      // the bytes through `input()`), so we keep `fetchAsset`. A transform failure
+      // falls back to serving those same already-buffered original bytes.
+      const original = yield* fetchAsset(key);
+      const served: StoredAsset = yield* transformAsset(
+        images,
+        original,
+        variant,
+        format,
+        blurOverride,
+      ).pipe(
         Effect.tap(() => Effect.sync(() => metricImageTransform("transformed", variant, format))),
         Effect.catchTag("ImageTransformError", (err) =>
           Effect.gen(function* () {
@@ -111,18 +131,19 @@ function serveTransformedImage(args: {
           }),
         ),
       );
+      response = new Response(served.bytes, { headers: imageResponseHeaders(served.contentType) });
     } else {
+      // Original-serve path (no Images binding — local/dev/tests, or an account
+      // without the Images product): STREAM R2's body straight into the Response
+      // instead of buffering the whole (≤5 MB) image in Worker memory (IB-P-I2).
+      // `response.clone()` below tees the stream, so the Cache API `put` and the
+      // returned body each get an independent copy.
+      const streamed = yield* fetchAssetStream(key);
       metricImageTransform("original", variant, format);
+      response = new Response(streamed.body, {
+        headers: imageResponseHeaders(streamed.contentType),
+      });
     }
-
-    const response = new Response(served.bytes, {
-      headers: {
-        "Content-Type": served.contentType,
-        "X-Content-Type-Options": "nosniff",
-        "Cache-Control": "public, max-age=31536000, immutable",
-        Vary: "Accept",
-      },
-    });
 
     if (cache && cacheKey) {
       const put = cache.put(cacheKey, response.clone());

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -134,9 +134,10 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
             }
 
             // Ownership + invitation already validated above — service method does
-            // not re-check.
-            for (const rsvp of body.rsvps) {
-              yield* rsvpService.submitRsvp({
+            // not re-check. Upsert the whole batch in ONE D1 round-trip (P-W1)
+            // instead of N sequential ones on the guest hot path.
+            yield* rsvpService.submitRsvps(
+              body.rsvps.map((rsvp) => ({
                 guestId: rsvp.guestId,
                 eventId: rsvp.eventId,
                 status: rsvp.status,
@@ -144,8 +145,8 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
                 // Only stamp a consent record when there is special-category
                 // data to authorise; clearing dietary clears the record too.
                 dietaryConsent: rsvp.dietary.length > 0 && rsvp.dietaryConsent,
-              });
-            }
+              })),
+            );
 
             yield* Effect.sync(() => metricRsvpBatchSize(body.rsvps.length));
 

--- a/cire/api/src/services/claim.ts
+++ b/cire/api/src/services/claim.ts
@@ -121,39 +121,65 @@ export const claimService = {
         );
       }
 
-      // The wedding slug scopes the first-party event-image paths below. A family
-      // always belongs to a wedding (FK), so the row is present; default to the
-      // family's weddingId if a slug is somehow absent (image URLs would 404, but
-      // the rest of the claim is unaffected — never fail the whole lookup on it).
-      const [wedding] = yield* dbQuery(() =>
-        db
-          .select({ slug: weddings.slug })
-          .from(weddings)
-          .where(eq(weddings.id, family.weddingId))
-          .all(),
+      // Three genuinely INDEPENDENT reads, each keyed only off the already-resolved
+      // `family` row, so they're pipelined together with `Effect.all` (P-W2): on D1
+      // their three round-trips overlap (~1 fewer serial RTT on the hot path), and
+      // on bun:sqlite (tests/local) they resolve in-process so concurrency is a
+      // harmless no-op. The events read can't join this group — it depends on the
+      // event ids derived from `guestRows` below — so it stays sequential after.
+      //  (a) the wedding slug — scopes the first-party event-image paths. A family
+      //      always belongs to a wedding (FK), so the row is present; default to the
+      //      family's weddingId if a slug is somehow absent (image URLs would 404,
+      //      but the rest of the claim is unaffected — never fail the lookup on it).
+      //  (b) guests + their event-id memberships. Kept narrow (no events join) to
+      //      avoid the cartesian explosion of duplicating every event row — incl.
+      //      its JSON palette blob — once per invited guest.
+      //  (c) this family's RSVPs.
+      const {
+        wedding: [wedding],
+        guestRows,
+        rsvpRows,
+      } = yield* Effect.all(
+        {
+          wedding: dbQuery(() =>
+            db
+              .select({ slug: weddings.slug })
+              .from(weddings)
+              .where(eq(weddings.id, family.weddingId))
+              .all(),
+          ),
+          guestRows: dbQuery(() =>
+            db
+              .select({
+                guestId: guests.id,
+                firstName: guests.firstName,
+                lastName: guests.lastName,
+                sortOrder: guests.sortOrder,
+                eventId: guestEvents.eventId,
+              })
+              .from(guests)
+              .leftJoin(guestEvents, eq(guestEvents.guestId, guests.id))
+              .where(eq(guests.familyId, family.id))
+              .orderBy(asc(guests.sortOrder))
+              .all(),
+          ),
+          rsvpRows: dbQuery(() =>
+            db
+              .select({
+                guestId: rsvps.guestId,
+                eventId: rsvps.eventId,
+                status: rsvps.status,
+                dietary: rsvps.dietary,
+              })
+              .from(rsvps)
+              .innerJoin(guests, eq(rsvps.guestId, guests.id))
+              .where(eq(guests.familyId, family.id))
+              .all(),
+          ),
+        },
+        { concurrency: "unbounded" },
       );
       const slug = wedding?.slug ?? family.weddingId;
-
-      // Two queries kept narrow to avoid the cartesian explosion of joining
-      // events into the per-guest rows (every event row was previously
-      // duplicated once per invited guest, including the JSON palette blob).
-      // (a) guests + their event-id memberships, (b) the unique events.
-      // Run independently; each shape is small.
-      const guestRows = yield* dbQuery(() =>
-        db
-          .select({
-            guestId: guests.id,
-            firstName: guests.firstName,
-            lastName: guests.lastName,
-            sortOrder: guests.sortOrder,
-            eventId: guestEvents.eventId,
-          })
-          .from(guests)
-          .leftJoin(guestEvents, eq(guestEvents.guestId, guests.id))
-          .where(eq(guests.familyId, family.id))
-          .orderBy(asc(guests.sortOrder))
-          .all(),
-      );
 
       const memberMap = new Map<
         string,
@@ -214,20 +240,6 @@ export const claimService = {
         });
       }
       eventList.sort((a, b) => a.sortOrder - b.sortOrder);
-
-      const rsvpRows = yield* dbQuery(() =>
-        db
-          .select({
-            guestId: rsvps.guestId,
-            eventId: rsvps.eventId,
-            status: rsvps.status,
-            dietary: rsvps.dietary,
-          })
-          .from(rsvps)
-          .innerJoin(guests, eq(rsvps.guestId, guests.id))
-          .where(eq(guests.familyId, family.id))
-          .all(),
-      );
 
       return {
         familyId: family.id,

--- a/cire/api/src/services/invite-assets.test.ts
+++ b/cire/api/src/services/invite-assets.test.ts
@@ -8,6 +8,7 @@ import {
   deleteAsset,
   detectImageType,
   fetchAsset,
+  fetchAssetStream,
   storeAsset,
 } from "./invite-assets";
 
@@ -58,6 +59,52 @@ describe("invite-assets R2 round-trip", () => {
     const stub = createAssetsStub();
     const exit = await Effect.runPromiseExit(
       fetchAsset("assets/missing").pipe(Effect.provideService(AssetsR2Service, stub)),
+    );
+    expect(exit._tag).toBe("Failure");
+  });
+});
+
+describe("fetchAssetStream (IB-P-I2 — original-serve streaming)", () => {
+  it("streams the stored bytes (via Response body) preserving content type", async () => {
+    const stub = createAssetsStub();
+    const { contentType, bytes } = await Effect.runPromise(
+      Effect.gen(function* () {
+        const key = yield* storeAsset("wed_y", "story", buf(JPEG), "image/jpeg");
+        const streamed = yield* fetchAssetStream(key);
+        // Drain the stream the way the serve route hands it to `new Response(body)`.
+        const collected = yield* Effect.promise(() => new Response(streamed.body).arrayBuffer());
+        return { contentType: streamed.contentType, bytes: collected };
+      }).pipe(Effect.provideService(AssetsR2Service, stub)),
+    );
+    expect(contentType).toBe("image/jpeg");
+    expect(new Uint8Array(bytes)).toEqual(JPEG);
+  });
+
+  it("falls back to buffering when the object exposes no streaming body", async () => {
+    // A minimal backend that only implements `arrayBuffer()` — no `.body`.
+    const bufferOnly = {
+      put: () => Promise.resolve(),
+      get: (_key: string) => ({
+        arrayBuffer: () => Promise.resolve(buf(PNG)),
+        httpMetadata: { contentType: "image/png" },
+      }),
+      delete: () => Promise.resolve(),
+    };
+    const out = await Effect.runPromise(
+      Effect.gen(function* () {
+        const streamed = yield* fetchAssetStream("assets/whatever");
+        const collected = yield* Effect.promise(() => new Response(streamed.body).arrayBuffer());
+        return { contentType: streamed.contentType, bytes: collected };
+      }).pipe(Effect.provideService(AssetsR2Service, bufferOnly)),
+    );
+    expect(out.contentType).toBe("image/png");
+    expect(new Uint8Array(out.bytes)).toEqual(PNG);
+  });
+
+  it("fails fetchAssetStream for a missing key", async () => {
+    const stub = createAssetsStub();
+    const exit = await Effect.runPromiseExit(
+      fetchAssetStream("assets/missing").pipe(Effect.provideService(AssetsR2Service, stub)),
     );
     expect(exit._tag).toBe("Failure");
   });

--- a/cire/api/src/services/invite-assets.ts
+++ b/cire/api/src/services/invite-assets.ts
@@ -19,6 +19,13 @@ export type AssetSlotLabel = InviteImageSlot | "event";
 // implements just these methods.
 export interface AssetObjectBody {
   arrayBuffer(): Promise<ArrayBuffer>;
+  // R2's `R2ObjectBody` exposes the unread object as a `ReadableStream` — the
+  // serve path that returns the ORIGINAL bytes (no Images transform) streams this
+  // straight into the `Response` rather than buffering the whole image in Worker
+  // memory (IB-P-I2). Optional so a minimal stub (or a non-R2 backend) that only
+  // implements `arrayBuffer()` still satisfies the interface — the streaming
+  // fetch falls back to buffering when it's absent.
+  readonly body?: ReadableStream<Uint8Array> | null;
   readonly httpMetadata?: { contentType?: string };
 }
 
@@ -87,6 +94,51 @@ export function fetchAsset(key: string): Effect.Effect<StoredAsset, AssetR2Error
         if (!obj) return null;
         const bytes = await obj.arrayBuffer();
         return { bytes, contentType: obj.httpMetadata?.contentType ?? "application/octet-stream" };
+      },
+      catch: (cause) => new AssetR2Error({ reason: "fetch failed", key, cause }),
+    });
+    if (result === null) {
+      return yield* Effect.fail(new AssetR2Error({ reason: "key not found", key }));
+    }
+    return result;
+  }).pipe(Effect.withSpan("cire.invite.fetchAsset"));
+}
+
+/**
+ * A served image as a STREAM rather than a buffered `ArrayBuffer`. `body` is fed
+ * straight into a `Response`, so the (≤5 MB) image is never fully materialised in
+ * Worker memory — used by the original-serve path (no Images transform). The
+ * transform path still needs the bytes buffered (it feeds them through the Images
+ * binding + sniffs nothing here), so it keeps {@link fetchAsset}.
+ */
+export interface StreamedAsset {
+  body: ReadableStream<Uint8Array>;
+  contentType: string;
+}
+
+/**
+ * Fetch an image as a STREAM for the original-serve path (IB-P-I2). Returns R2's
+ * `obj.body` `ReadableStream` directly so the bytes flow object→Response without a
+ * full-image buffer in Worker memory. When the underlying object exposes no `body`
+ * (a minimal test stub, or a non-R2 backend), it falls back to buffering via
+ * `arrayBuffer()` and wrapping the bytes in a one-shot stream — same observable
+ * result, just without the streaming win. Fails when the key is absent.
+ */
+export function fetchAssetStream(
+  key: string,
+): Effect.Effect<StreamedAsset, AssetR2Error, AssetsR2Service> {
+  return Effect.gen(function* () {
+    const bucket = yield* AssetsR2Service;
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const obj = await Promise.resolve(bucket.get(key));
+        if (!obj) return null;
+        const contentType = obj.httpMetadata?.contentType ?? "application/octet-stream";
+        // Prefer R2's streaming body; fall back to a buffered one-shot stream when
+        // the backend/stub doesn't expose one.
+        const body = obj.body ?? new Response(await obj.arrayBuffer()).body;
+        if (!body) throw new Error("asset object exposed no readable body");
+        return { body, contentType };
       },
       catch: (cause) => new AssetR2Error({ reason: "fetch failed", key, cause }),
     });
@@ -195,6 +247,12 @@ export function createAssetsStub(): AssetsBucket & {
       if (!v) return null;
       return {
         arrayBuffer: () => Promise.resolve(v.bytes),
+        // Mirror R2's streaming `body` so the original-serve path (IB-P-I2) is
+        // exercised against the stub exactly as it is against R2 — each `get`
+        // mints a fresh one-shot stream over the stored bytes.
+        get body() {
+          return new Response(v.bytes).body;
+        },
         httpMetadata: { contentType: v.contentType },
       };
     },

--- a/cire/api/src/services/rsvp.test.ts
+++ b/cire/api/src/services/rsvp.test.ts
@@ -186,6 +186,146 @@ describe("rsvpService.submitRsvp", () => {
   );
 });
 
+describe("rsvpService.submitRsvps (P-W1 — batched upserts)", () => {
+  it(
+    "upserts multiple guests × events in one batch, preserving status + dietary",
+    withDb(
+      Effect.gen(function* () {
+        const bo = yield* lookupGuest("Bo");
+        const cleo = yield* lookupGuest("Cleo");
+
+        yield* rsvpService.submitRsvps([
+          {
+            guestId: bo.id,
+            eventId: HINDU_ID,
+            status: "attending",
+            dietary: "",
+            dietaryConsent: false,
+          },
+          {
+            guestId: bo.id,
+            eventId: RECEPTION_ID,
+            status: "declined",
+            dietary: "",
+            dietaryConsent: false,
+          },
+          {
+            guestId: cleo.id,
+            eventId: HINDU_ID,
+            status: "maybe",
+            dietary: "Vegan, no shellfish",
+            dietaryConsent: true,
+          },
+        ]);
+
+        const rsvps = yield* rsvpService.getRsvpsForFamily(bo.familyId);
+        expect(rsvps).toHaveLength(3);
+
+        const byPair = new Map(rsvps.map((r) => [`${r.guestId}::${r.eventId}`, r]));
+        expect(byPair.get(`${bo.id}::${HINDU_ID}`)?.status).toBe("attending");
+        expect(byPair.get(`${bo.id}::${RECEPTION_ID}`)?.status).toBe("declined");
+        const cleoHindu = byPair.get(`${cleo.id}::${HINDU_ID}`);
+        expect(cleoHindu?.status).toBe("maybe");
+        expect(cleoHindu?.dietary).toBe("Vegan, no shellfish");
+      }),
+    ),
+  );
+
+  it(
+    "is upsert-correct within a batch — a (guest,event) pair already present is updated in place, not duplicated",
+    withDb(
+      Effect.gen(function* () {
+        const ada = yield* lookupGuest("Ada");
+
+        // Seed an attending RSVP, then re-submit the SAME pair in a batch as
+        // declined alongside a fresh pair.
+        yield* rsvpService.submitRsvps([
+          {
+            guestId: ada.id,
+            eventId: HINDU_ID,
+            status: "attending",
+            dietary: "",
+            dietaryConsent: false,
+          },
+        ]);
+        yield* rsvpService.submitRsvps([
+          {
+            guestId: ada.id,
+            eventId: HINDU_ID,
+            status: "declined",
+            dietary: "",
+            dietaryConsent: false,
+          },
+          {
+            guestId: ada.id,
+            eventId: RECEPTION_ID,
+            status: "attending",
+            dietary: "",
+            dietaryConsent: false,
+          },
+        ]);
+
+        const rsvps = yield* rsvpService.getRsvpsForFamily(ada.familyId);
+        const hindu = rsvps.filter((r) => r.eventId === HINDU_ID);
+        expect(hindu).toHaveLength(1);
+        expect(hindu[0]!.status).toBe("declined");
+        expect(rsvps).toHaveLength(2);
+      }),
+    ),
+  );
+
+  it(
+    "stamps the consent record per-pair within a batch (set for the consented pair, null for the rest)",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const ada = yield* lookupGuest("Ada");
+
+        yield* rsvpService.submitRsvps([
+          {
+            guestId: ada.id,
+            eventId: HINDU_ID,
+            status: "attending",
+            dietary: "Coeliac",
+            dietaryConsent: true,
+          },
+          {
+            guestId: ada.id,
+            eventId: RECEPTION_ID,
+            status: "attending",
+            dietary: "",
+            dietaryConsent: false,
+          },
+        ]);
+
+        const consentFor = (eventId: string) =>
+          db
+            .select({ at: rsvpsTable.dietaryConsentAt, version: rsvpsTable.dietaryConsentVersion })
+            .from(rsvpsTable)
+            .where(and(eq(rsvpsTable.guestId, ada.id), eq(rsvpsTable.eventId, eventId)))
+            .all()[0];
+
+        expect(consentFor(HINDU_ID)?.version).toBe(DIETARY_CONSENT_VERSION);
+        expect(consentFor(HINDU_ID)?.at).toBeInstanceOf(Date);
+        expect(consentFor(RECEPTION_ID)?.at).toBeNull();
+        expect(consentFor(RECEPTION_ID)?.version).toBeNull();
+      }),
+    ),
+  );
+
+  it(
+    "an empty batch is a no-op",
+    withDb(
+      Effect.gen(function* () {
+        const ada = yield* lookupGuest("Ada");
+        yield* rsvpService.submitRsvps([]);
+        const rsvps = yield* rsvpService.getRsvpsForFamily(ada.familyId);
+        expect(rsvps).toHaveLength(0);
+      }),
+    ),
+  );
+});
+
 describe("rsvpService.getRsvpsForFamily", () => {
   it(
     "returns all RSVPs across family members",

--- a/cire/api/src/services/rsvp.ts
+++ b/cire/api/src/services/rsvp.ts
@@ -1,11 +1,24 @@
 import { rsvps, guests } from "@cire/db";
 import { eq } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import { Effect } from "effect";
 
-import { DbService, dbQuery } from "../db";
+import { DbService, dbQuery, commitBatch } from "../db";
 import { metricRsvpUpserted } from "../metrics";
 import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import type { RsvpRecord } from "../schemas/rsvp";
+
+/** One guest×event RSVP to upsert. */
+export interface RsvpInput {
+  guestId: string;
+  eventId: string;
+  status: "attending" | "declined" | "maybe";
+  dietary: string;
+  // True only when the guest opted in AND there is dietary text to authorise
+  // (the route already collapses both conditions). Stamps an Art. 9(2)(a)
+  // consent record; false clears any prior record (e.g. dietary removed).
+  dietaryConsent: boolean;
+}
 
 export const rsvpService = {
   /**
@@ -13,25 +26,44 @@ export const rsvpService = {
    * family before invoking — this method does not re-check ownership. The
    * route handler builds the family-guest set once and validates the whole
    * batch up front, so a per-call SELECT here would be redundant.
+   *
+   * Thin wrapper over {@link submitRsvps} (a single-element batch) so the
+   * one-pair and bulk paths share one implementation and stay semantically
+   * identical.
    */
-  submitRsvp(input: {
-    guestId: string;
-    eventId: string;
-    status: "attending" | "declined" | "maybe";
-    dietary: string;
-    // True only when the guest opted in AND there is dietary text to authorise
-    // (the route already collapses both conditions). Stamps an Art. 9(2)(a)
-    // consent record; false clears any prior record (e.g. dietary removed).
-    dietaryConsent: boolean;
-  }): Effect.Effect<void, never, DbService> {
+  submitRsvp(input: RsvpInput): Effect.Effect<void, never, DbService> {
+    return rsvpService.submitRsvps([input]);
+  },
+
+  /**
+   * Upsert a batch of RSVPs (one per guest×event pair) in a SINGLE D1 round-trip
+   * (P-W1). Caller MUST have validated every `guestId` belongs to the claimed
+   * family AND every (guestId, eventId) is a real invitation before invoking —
+   * this method does not re-check (the route validates the whole batch up front).
+   *
+   * Each pair becomes its own `INSERT … ON CONFLICT DO UPDATE`, collected into one
+   * `db.batch([...])` via {@link commitBatch} — mirroring `applyImport`'s write set
+   * and respecting the sync/async bridge:
+   *  - D1 (production): one atomic Workers↔D1 round-trip for the whole batch
+   *    (was N sequential round-trips on the guest hot path).
+   *  - bun:sqlite (tests/local, no `.batch()`): `commitBatch` awaits the statements
+   *    sequentially in-process — same per-pair upserts, no network cost.
+   * Either way the per-pair upsert semantics + dietary-consent stamping are
+   * unchanged. An empty batch is a no-op (no statements, no metrics). Per-pair
+   * `metricRsvpUpserted` is preserved so the observability shape is identical to
+   * N single submits. The whole batch shares one `now` (a single submit always
+   * did too); a re-submit that clears dietary still nulls the consent record.
+   */
+  submitRsvps(inputs: readonly RsvpInput[]): Effect.Effect<void, never, DbService> {
     return Effect.gen(function* () {
       const db = yield* DbService;
+      if (inputs.length === 0) return;
 
       const now = new Date();
-      const dietaryConsentAt = input.dietaryConsent ? now : null;
-      const dietaryConsentVersion = input.dietaryConsent ? DIETARY_CONSENT_VERSION : null;
-      yield* dbQuery(() =>
-        db
+      const statements: BatchItem<"sqlite">[] = inputs.map((input) => {
+        const dietaryConsentAt = input.dietaryConsent ? now : null;
+        const dietaryConsentVersion = input.dietaryConsent ? DIETARY_CONSENT_VERSION : null;
+        return db
           .insert(rsvps)
           .values({
             id: crypto.randomUUID(),
@@ -51,10 +83,13 @@ export const rsvpService = {
               dietaryConsentAt,
               dietaryConsentVersion,
             },
-          })
-          .run(),
-      );
-      yield* Effect.sync(() => metricRsvpUpserted(input.status, "ok"));
+          });
+      });
+
+      yield* dbQuery(() => commitBatch(db, statements));
+      for (const input of inputs) {
+        yield* Effect.sync(() => metricRsvpUpserted(input.status, "ok"));
+      }
     }).pipe(Effect.withSpan("cire.rsvp.submit"));
   },
 

--- a/cire/wiki/todo/perf.md
+++ b/cire/wiki/todo/perf.md
@@ -4,7 +4,7 @@ tags: [todo, performance]
 related:
   - "[[index]]"
   - "[[review-findings]]"
-last-reviewed: 2026-06-16
+last-reviewed: 2026-06-20
 ---
 
 # Performance Backlog
@@ -25,7 +25,7 @@ Branch-scoped IDs (distinct from the numbered items below).
 - [x] **IB-P-W2** (fixed PR #112) — Custom hero image was invisible to the preload scanner. Fixed: `index.astro` emits `<link rel="preload" as="image">` for the build-resolved hero image (immutably cached).
 - [x] **IB-P-W3** (fixed PR #112) — `getForWeddingId` now does one `weddings LEFT JOIN wedding_invite_customisations` query (was slug-lookup + customisation-lookup); `upsertText` / `removeImage` re-call it after the write (now write + 1 join).
 - [x] **IB-P-I1** (fixed PR #112) — `imageKeyForSlug` now uses a single `LEFT JOIN` keyed on `weddings.slug`: a missing weddings row is the 404, a null-joined customisation is "no image yet" — one round-trip.
-- [ ] **IB-P-I2** — `fetchAsset` (`cire/api/src/services/invite-assets.ts`) materialises the full image via `obj.arrayBuffer()` (≤5 MB held in Worker memory) rather than streaming R2's `obj.body` into the `Response`. Bounded by the cap + CDN caching, hence Info. Fix on serve path only (upload buffering is needed for the magic-byte sniff).
+- [x] **IB-P-I2** — Stream the served ORIGINAL image instead of buffering. The no-transform serve path (no Images binding, or an account without the product) now uses `fetchAssetStream` to pipe R2's `obj.body` `ReadableStream` straight into the `Response`, so a ≤5 MB image is never fully materialised in Worker memory; `response.clone()` tees the stream so the Cache-API `put` and the returned body each get a copy. The Images **transform** path is deliberately unchanged — the binding needs the bytes buffered (`fetchAsset` → `input(stream-over-bytes)`), and a transform-failure fallback serves those same already-buffered bytes. `AssetObjectBody.body` is optional, so a non-R2 backend that only implements `arrayBuffer()` falls back to a buffered one-shot stream (same result, no streaming win). Existing serve-route tests (assert served bytes == original) + new `fetchAssetStream` unit tests cover it. (cire-hotpath-perf branch)
 
 ### Account linking (guest → OSN/Pulse) — review notes (Info, no action)
 
@@ -44,10 +44,10 @@ Branch-scoped IDs (distinct from the numbered items below).
 - [ ] PBKDF2 100k iterations + dummy-hash-on-miss is ~20-40ms per request on Workers. Pairs with rate limiting (above) before public launch — once that's in place, consider lowering iterations to 25-50k for a wedding-scale threat model.
 - [ ] `getAllGuests` paginate / cursor once organiser UI is built — current single-join is fine at 100 guests, problematic past a few thousand
 - [x] **P-C1** — `applyImport` commits its write set as a single atomic `db.batch([...])` on D1 (one round-trip, all-or-nothing) instead of N sequential awaited statements; bun:sqlite (no `.batch()`) keeps the sequential path. Driver-branched in `commitWriteSet` (`services/import.ts`). Also closes the non-atomic partial-apply gap (S-L1). D1-batch atomicity covered by `src/db/d1-integration.test.ts`. (D1 runtime wiring branch)
-- [ ] **P-W1** — Batch `rsvpService.submitRsvp` upserts via a single multi-row `INSERT … ON CONFLICT` / `db.batch([...])` (currently N round-trips on the guest hot path). Deferred follow-up to the D1 wiring branch
-- [ ] **P-W2** — Pipeline `claim.lookup`'s independent D1 reads (guests+links, rsvps) via `Effect.all`; today sequential, ~1 extra round-trip on the hot path. Deferred follow-up to the D1 wiring branch
+- [x] **P-W1** — Batch `rsvpService.submitRsvp` upserts (was N sequential D1 round-trips on the guest hot path). New `rsvpService.submitRsvps([...])` builds one `INSERT … ON CONFLICT DO UPDATE` per pair and commits them as a single `db.batch([...])` via `commitBatch` — atomic, one Workers↔D1 round-trip on D1; sequential in-process on bun:sqlite (no `.batch()`), mirroring `applyImport`. `submitRsvp` is now a thin single-element wrapper, so semantics (per-pair upsert + Art. 9(2)(a) dietary-consent stamping) + per-pair `metricRsvpUpserted` are identical. The `POST /api/rsvp` loop is replaced by one `submitRsvps` call. Savings: a family RSVPing to N (guest×event) pairs drops from N D1 round-trips to 1. New batch tests (multi guest×event, in-place upsert, per-pair consent, empty no-op). (cire-hotpath-perf branch)
+- [x] **P-W2** — Pipeline `claim.lookup`'s independent D1 reads via `Effect.all({...}, { concurrency: "unbounded" })`. After the required family-by-publicId read, the three reads keyed only off `family` (wedding slug, guests+event-memberships, this family's rsvps) now issue together instead of serially — ~1 fewer serial round-trip on the guest hot path (no-op concurrency on bun:sqlite, in-process). The events read stays sequential after — it depends on the event ids derived from the guest rows. Response shape is byte-identical (existing claim.lookup tests pass unchanged). (cire-hotpath-perf branch)
 - [ ] Landing page animations must not block LCP — defer Motion One until after first paint
-- [ ] Hero photo must be optimised (WebP/AVIF, responsive srcset)
+- [x] Hero photo must be optimised (WebP/AVIF, responsive srcset) — CONFIRMED already done. The image serve route negotiates a modern output format per request via `negotiateFormat` (`Accept`-driven AVIF → WebP → JPEG fallback, on the metric/span as a bounded value) and the Cloudflare Images binding emits it; the frontend renders responsively via `buildSrcSet` (the `thumb`/`card`/`hero` width variants) — `InviteHeader.tsx` (hero + event images) + `EventCard.tsx` — and the hero LCP element is preloaded with `imagesrcset`/`imagesizes` in `InviteDocument.astro`. Nothing missing.
 - [x] Add-to-calendar data should not require a round-trip if event data is already hydrated in the page (PR-G — `googleCalendarUrl` + `icsBlob` are pure client-side helpers consuming the existing claim payload)
 - [x] .ics generation can be client-side to avoid unnecessary Worker invocation (PR-G — `cire/web/src/components/calendar.ts` builds the VCALENDAR in the browser; no Worker route added)
 - [ ] Organiser `ImportPanel` re-fetches events on every tab switch — cache the events response (or lift it to the dashboard shell) so switching Guests ↔ Events doesn't refire the request. Minor; noticed during the OSN-merge E2E pass.


### PR DESCRIPTION
Deferred perf items from `cire/wiki/todo/perf.md` on the cire guest hot paths. All three landed; one image item attempted and **done** (not deferred).

## P-W1 — batch the RSVP upserts
`rsvpService.submitRsvp` issued one awaited `INSERT … ON CONFLICT DO UPDATE` per guest×event pair, so a family RSVPing to N pairs cost **N sequential D1 round-trips** on the guest hot path.

New `rsvpService.submitRsvps([...])` builds one upsert statement per pair and commits them as a single `db.batch([...])` via `commitBatch` — mirroring `applyImport`'s write set. `submitRsvp` is now a thin single-element wrapper, so both paths share one implementation.
- **Savings:** N D1 round-trips → **1** (atomic batch).
- Semantics preserved exactly: per-pair upsert (conflict target `(guestId, eventId)`), Art. 9(2)(a) dietary-consent stamping (set when consented, nulled when dietary cleared), and per-pair `metricRsvpUpserted`. The route's validation (each guestId belongs to the session family + each pair is a real invitation) is unchanged and still runs up front. `POST /api/rsvp`'s submit loop is replaced by one `submitRsvps` call.

## P-W2 — pipeline claim.lookup's independent reads
After the required family-by-publicId read, `claim.lookup` did several **independent** reads sequentially. The three keyed only off the resolved `family` row — wedding slug, guests + event-memberships, this family's rsvps — now issue together via `Effect.all({...}, { concurrency: "unbounded" })`.
- **Savings:** ~1 fewer serial round-trip on the hot path.
- Only genuinely independent reads were grouped: the **events** read stays sequential after, because it depends on the event ids derived from the guest rows. The first-open best-effort `UPDATE` is untouched.
- Response shape is **byte-identical** — verified by the existing `claim.lookup` suite (passes unchanged).

## IB-P-I2 — stream the served image (ATTEMPTED → **DONE**, not deferred)
The no-transform serve path (no Images binding — local/dev/tests, or an account without the product) now uses `fetchAssetStream` to pipe R2's `obj.body` `ReadableStream` straight into the `Response`, instead of holding the whole (≤5 MB) image via `obj.arrayBuffer()` in Worker memory.
- `response.clone()` tees the stream, so the Cache-API `put(response.clone())` and the returned body each get an independent copy — caching still works.
- The Cloudflare **Images transform path is unchanged**: the binding needs the bytes buffered (`fetchAsset` → `input(stream-over-bytes)`), and its failure fallback serves those same already-buffered original bytes. Only the genuine original-serve fallback streams.
- `AssetObjectBody.body` is **optional**: a backend that only implements `arrayBuffer()` falls back to a buffered one-shot stream (same result, no streaming win) — keeps the test stub and any non-R2 backend valid. The stub now also exposes a `body` getter so the streaming path is exercised in tests.

This was done cleanly without risking transform/cache correctness, so it is **not** deferred and the wiki item is ticked.

## Hero photo WebP/AVIF + responsive — confirmed already done
Confirmed in code and ticked with a note: the image serve route negotiates a modern output format per request (`negotiateFormat`: `Accept`-driven AVIF → WebP → JPEG fallback) and the Images binding emits it; the frontend renders responsively via `buildSrcSet` (`thumb`/`card`/`hero` widths) in `InviteHeader.tsx` + `EventCard.tsx`, and the hero LCP element is preloaded with `imagesrcset`/`imagesizes` in `InviteDocument.astro`. Nothing missing — scope not expanded.

## Sync/async-bridge correctness
Every batch + read runs over both DB backends: **bun:sqlite** (tests/local, synchronous) and **Cloudflare D1** (prod, asynchronous). `commitBatch` feature-detects `.batch()` (D1 → one atomic batch; bun:sqlite → sequential in-process), and `Effect.all`'s concurrency is a real pipeline on D1 and a harmless no-op on the synchronous backend. The D1-batch atomicity path is covered by `src/db/d1-integration.test.ts`.

## Verification
- `bun test` (cire/api): **620 pass / 0 fail** (was 613 — +7 new tests: 4 batch-upsert + 3 `fetchAssetStream`).
- `bun run lint`: 0 errors (14 pre-existing warnings, none in changed files).
- `bun run fmt:check`: clean.
- `bunx --bun wrangler deploy --dry-run` (cire/api): passes.
- No DB migration.

New tests prove the batched RSVP path upserts correctly (multiple guests×events, in-place upsert not duplicated, dietary + per-pair consent preserved, empty no-op) and the streamed serve path returns the original bytes; the parallelised `claim.lookup` keeps its identical response shape under the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)