### PR TITLE
chore(cire/organiser): migrate cropperjs v1→v2

### DIFF
--- a/.changeset/cropperjs-2.md
+++ b/.changeset/cropperjs-2.md
@@ -1,0 +1,49 @@
+---
+"@cire/organiser": patch
+---
+
+Migrate the image crop editor from **Cropper.js v1 → v2**.
+
+Cropper.js v2 is a ground-up rewrite. v1 was a single imperative class
+(`new Cropper(img, options)` exposing `getData` / `setData` /
+`getImageData` / `setAspectRatio` / `getCroppedCanvas` / a `ready` event /
+`destroy`); v2 ships a set of native **Web Components**
+(`<cropper-canvas>`, `<cropper-image>`, `<cropper-selection>`,
+`<cropper-handle>`, `<cropper-shade>`, `<cropper-grid>`,
+`<cropper-crosshair>`) driven by a thin `Cropper` wrapper that hides the
+source `<img>` and injects a `<cropper-canvas>` template beside it.
+
+What changed in `ImageCropModal.tsx`:
+
+- **No more `cropper.css`.** v2 styles each component inside its own Shadow
+  DOM, so the `import "cropperjs/dist/cropper.css"` line is removed (the file
+  no longer exists in the package — it was a hard build/import failure).
+- **Construction.** Still `new Cropper(imgEl, { template })`, but with an
+  explicit template wiring the canvas, image, shade, selection and resize
+  handles (mirroring v1's `viewMode`/`autoCropArea: 1`/`dragMode: "move"`
+  feel). The live elements are read back via `getCropperImage()` /
+  `getCropperSelection()` / `getCropperCanvas()`.
+- **`ready` event → `cropperImage.$ready(cb)`** — the promise/callback that
+  fires once the image has loaded; used to seed the saved box.
+- **`setData` (seed saved crop) → `selection.$change(x, y, w, h)`** in
+  canvas-pixel coordinates, projected from the stored 0..1 source fractions
+  through the displayed `<cropper-image>` bounding box.
+- **`setAspectRatio(r)` → `selection.aspectRatio = r`** (`NaN` = free /
+  unlocked) plus a `$change` + `$render` to re-snap the box.
+- **`getData(true)` + `getImageData()` (extract crop) → live geometry.** The
+  final crop is derived from the `<cropper-selection>` bounding box over the
+  `<cropper-image>` bounding box — those ratios are resolution-independent and
+  equal the same 0..1 source fractions v1 reported — and
+  `cropperImage.$image.naturalWidth/Height` supply `natW`/`natH`.
+- **`destroy()`** is unchanged in spirit (removes the canvas, restores the
+  `<img>`); still called from `onCleanup`.
+
+**Preserved, unchanged:** the component's external props/contract; the aspect
+presets (Original / 16:9 / 3:2 / 4:3 / 1:1 / 4:5 / Free); the no-stretch
+uniform-scaling render (the crop JSON still carries `natW`/`natH` so
+`image-crop.ts` renders the true pixel aspect); the crop JSON output shape; and
+legacy `{x,y,w,h}` (dims-absent) crop tolerance on re-open.
+
+The actual crop interaction cannot be exercised headlessly (the web components
+need a real browser layout engine), so the drag/zoom/aspect UX wants a human
+eyeball before relying on it in production.

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.6",
-        "cropperjs": "^1.6.2",
+        "cropperjs": "^2.1.1",
         "solid-js": "^1.9.13",
         "solid-toast": "^0.5.0",
         "tailwindcss": "^4.3.0",
@@ -94,7 +94,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@osn/db": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -253,7 +253,7 @@
     },
     "pulse/app": {
       "name": "@pulse/app",
-      "version": "0.15.9",
+      "version": "0.15.10",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -303,7 +303,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -334,7 +334,7 @@
     },
     "shared/email": {
       "name": "@shared/email",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@shared/observability": "workspace:*",
         "effect": "^3.21.2",
@@ -347,7 +347,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@effect/opentelemetry": "^0.63.0",
         "@opentelemetry/api": "^1.9.1",
@@ -371,7 +371,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.3",
@@ -409,7 +409,7 @@
     },
     "shared/turnstile": {
       "name": "@shared/turnstile",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@shared/observability": "workspace:*",
       },
@@ -424,7 +424,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -626,6 +626,28 @@
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260606.1", "", {}, "sha512-0FFUsixapowVJcAjRlXLb6UEZG1caUlSuUX1KHhKgWgjKxq20dY5XeCS5lKPqgc80XJ9puwffJ2H1U6Fwr5N1g=="],
 
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
+
+    "@cropper/element": ["@cropper/element@2.1.1", "", { "dependencies": { "@cropper/utils": "^2.1.1" } }, "sha512-pthgIQq3PFAFRGUts96yrMgmMY/4rS/zKEq/Vvw7L0Ur09MgzrUg15z4k96K53bJ8XvNeXdQ0qIDw90gh4Xcug=="],
+
+    "@cropper/element-canvas": ["@cropper/element-canvas@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-QHiHnPHsykkc4salOiCLOIKWPK3sLQ1SzpJYFE/yQPvqTPu6ERZNcxVwB1x7WhNN+SdP0S0CEHPYIkgIfUo7VA=="],
+
+    "@cropper/element-crosshair": ["@cropper/element-crosshair@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-DtZnOiY2RZSizDZzMUvya3wZ55YnWclf3hmIrLW6jdcFlQkYEbX6bkOyOJzQmEX0yIbmwMkXfFcMkEZ9dE1rJQ=="],
+
+    "@cropper/element-grid": ["@cropper/element-grid@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-MZdPBh5QMU10T78nqG+5cK+gq4DHoWZvdOo+/wZ9/z3VH0u21sROeHOCnf0QAdxguPHSSFsPjzARK+ffS4Loog=="],
+
+    "@cropper/element-handle": ["@cropper/element-handle@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-TmSSphyMr2NEA0DqUTf9PCN8kcpzM0BxreOMyzbfuq1NUUePV1LxYgSOUT7dftMjZnTcu8cHQeFYa69U2BZnBA=="],
+
+    "@cropper/element-image": ["@cropper/element-image@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/element-canvas": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-cldzN3hVJo0Luui+FDSIkmbQtwIjxWiTcTMLCMSi3hqIq6lc7YOBz+rC5R8AYnYV7YvsWonE6PrJZS+iZpBkdQ=="],
+
+    "@cropper/element-selection": ["@cropper/element-selection@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/element-canvas": "^2.1.1", "@cropper/element-image": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-QtMYhcuR+8JG3QEv8iSRCfQEVYljor61vLPrnGCFIkDJhvcyEWDx4H/Kfn6Jrdo90PyXf2VbpTG7TgH8i/EZFg=="],
+
+    "@cropper/element-shade": ["@cropper/element-shade@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/element-canvas": "^2.1.1", "@cropper/element-selection": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-MhJVc3jC87TjQu4EfBnNFddL3LxvA+Wzjy1Qhyi0wNdeTAzs97uYJ3KwGVtvzPYP/4JaSU4JDpw+BfIdUqR0bg=="],
+
+    "@cropper/element-viewer": ["@cropper/element-viewer@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/element-canvas": "^2.1.1", "@cropper/element-image": "^2.1.1", "@cropper/element-selection": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-RpXTGW/rTtJVNd3/R3imdCBJzyZRhA/OeWNo7RID4qW7UYEiL6Lwh7Six3QhFIci/IaUAyL9NAAN10av2YWqog=="],
+
+    "@cropper/elements": ["@cropper/elements@2.1.1", "", { "dependencies": { "@cropper/element": "^2.1.1", "@cropper/element-canvas": "^2.1.1", "@cropper/element-crosshair": "^2.1.1", "@cropper/element-grid": "^2.1.1", "@cropper/element-handle": "^2.1.1", "@cropper/element-image": "^2.1.1", "@cropper/element-selection": "^2.1.1", "@cropper/element-shade": "^2.1.1", "@cropper/element-viewer": "^2.1.1" } }, "sha512-cHShk4l6iExM4S6B1xx7+09gtDs+kdxWqe7Yv6DEbAyWhxVIVJyJAPpKlzLfA5MYnlSnkvCvY66hLLQPwooRMQ=="],
+
+    "@cropper/utils": ["@cropper/utils@2.1.1", "", {}, "sha512-0eQs08WyQUNFMfU3ieE091dEQkrW0YdgZ3n6Thnk1EUQv45ypfiL+MevHwr7UzNnUlqUYR2FNSCgE6qBxK0sFw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -1381,7 +1403,7 @@
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
-    "cropperjs": ["cropperjs@1.6.2", "", {}, "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="],
+    "cropperjs": ["cropperjs@2.1.1", "", { "dependencies": { "@cropper/elements": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-FDJMarkY+/SepYarPZsvkG2LmI2PElecciMFnvBiBIoKnFYua/scprC5qejCLLyuX2jEqJRS2njbAsHxfjtIXA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/cire/organiser/package.json
+++ b/cire/organiser/package.json
@@ -17,7 +17,7 @@
     "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.6",
-    "cropperjs": "^1.6.2",
+    "cropperjs": "^2.1.1",
     "solid-js": "^1.9.13",
     "solid-toast": "^0.5.0",
     "tailwindcss": "^4.3.0"

--- a/cire/organiser/src/components/ImageCropModal.tsx
+++ b/cire/organiser/src/components/ImageCropModal.tsx
@@ -1,7 +1,7 @@
 import Cropper from "cropperjs";
+import type { CropperImage, CropperSelection } from "cropperjs";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
-import "cropperjs/dist/cropper.css";
 import {
   ASPECT_PRESETS,
   type AspectPresetId,
@@ -16,17 +16,31 @@ import {
  * battle-tested vanilla Cropper.js (per the repo's "prefer existing libraries"
  * rule — we never hand-roll the crop interaction).
  *
- * The organiser picks an aspect ratio from a small set of presets (Original /
- * 16:9 / 3:2 / 4:3 / 1:1 / 4:5 / Free); selecting one re-locks the Cropper box to
- * that ratio. On save we capture the image's NATURAL pixel dimensions alongside
- * the normalised `{x,y,w,h}` rectangle, so the guest site can render the crop at
- * its true pixel aspect — UNIFORMLY scaled, never stretched (the distortion fix).
+ * Cropper.js v2 is a ground-up rewrite: instead of v1's single `new Cropper(img)`
+ * imperative class it ships native Web Components (`<cropper-canvas>`,
+ * `<cropper-image>`, `<cropper-selection>`, `<cropper-handle>`…). The default
+ * `Cropper` wrapper class still takes the `<img>` element, but it now hides that
+ * `<img>` and injects a `<cropper-canvas>` template beside it; we read the live
+ * elements back via `getCropperImage()` / `getCropperSelection()`. There is no
+ * separate `cropper.css` in v2 — every component styles itself inside its own
+ * Shadow DOM — so the old `import "cropperjs/dist/cropper.css"` is gone.
  *
- * Lifecycle: on mount we attach Cropper to the `<img>` ref, opening on the saved
- * crop's preset (or the slot default); when ready we seed the saved box.
- * Save reads `getData(true)` (the crop in source pixels) + `naturalWidth/Height`
- * and normalises to 0..1 fractions + `natW`/`natH`; Reset clears back to the
- * full-frame default (`crop: null`). Both delegate the network call to the parent.
+ * The organiser picks an aspect ratio from a small set of presets (Original /
+ * 16:9 / 3:2 / 4:3 / 1:1 / 4:5 / Free); selecting one re-locks the crop selection
+ * to that ratio. On save we capture the image's NATURAL pixel dimensions
+ * alongside the normalised `{x,y,w,h}` rectangle, so the guest site can render the
+ * crop at its true pixel aspect — UNIFORMLY scaled, never stretched (the
+ * distortion fix).
+ *
+ * Lifecycle: on mount we attach Cropper to the `<img>` ref; once the image is
+ * ready we seed the saved crop's box (and its preset). Save derives the crop
+ * rectangle from the live geometry — the displayed `<cropper-image>` bounding box
+ * vs the `<cropper-selection>` bounding box give the same 0..1 source fractions
+ * v1's `getData(true)` produced (selection-over-image fractions are
+ * resolution-independent), and `naturalWidth/Height` give `natW`/`natH`. Reset
+ * clears back to the full-frame default (`crop: null`). Both delegate the network
+ * call to the parent. On cleanup we `destroy()` the cropper (removes the canvas,
+ * restores the `<img>`).
  */
 export interface ImageCropModalProps {
   /** Absolute image URL to crop (already API-origin-prefixed). */
@@ -41,7 +55,7 @@ export interface ImageCropModalProps {
   onClose: () => void;
 }
 
-/** Clamp a fraction into [0,1] — Cropper can report a hair outside on edge drags. */
+/** Clamp a fraction into [0,1] — geometry can report a hair outside on edge drags. */
 function clamp01(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.min(1, Math.max(0, n));
@@ -59,36 +73,93 @@ export default function ImageCropModal(props: ImageCropModalProps) {
     presetForCrop(props.initialCrop, props.slot),
   );
 
+  /** The live `<cropper-selection>`, or undefined before the cropper is built. */
+  function selection(): CropperSelection | undefined {
+    return cropper?.getCropperSelection() ?? undefined;
+  }
+
+  /** The live `<cropper-image>`, or undefined before the cropper is built. */
+  function cropperImage(): CropperImage | undefined {
+    return cropper?.getCropperImage() ?? undefined;
+  }
+
+  /**
+   * Lock the selection to the given aspect ratio. v2's `<cropper-selection>` takes
+   * `aspectRatio` as a property (NaN ⇒ unlocked / free). Re-rendering re-fits the
+   * current box to the new ratio.
+   */
+  function applyAspectRatio(ratio: number) {
+    const sel = selection();
+    if (!sel) return;
+    sel.aspectRatio = ratio;
+    // Re-snap the existing box to the new ratio, keeping its top-left corner.
+    if (Number.isFinite(ratio) && sel.width > 0) {
+      sel.$change(sel.x, sel.y, sel.width, sel.width / ratio, ratio);
+    }
+    sel.$render();
+  }
+
   onMount(() => {
     const el = imgEl;
     if (!el) return;
     cropper = new Cropper(el, {
-      aspectRatio: presetAspectRatio(preset(), props.slot),
-      viewMode: 1, // crop box stays within the image bounds
-      autoCropArea: 1, // default selection covers the whole image
-      dragMode: "move", // drag the image to pan; the box resizes for zoom
-      background: false,
-      responsive: true,
-      checkOrientation: false,
-      ready() {
-        const c = props.initialCrop;
-        if (!c || !cropper) return;
-        // Seed the saved box. Cropper works in source-image coordinates, so map
-        // the stored fractions back to pixels against the natural dimensions.
-        const data = cropper.getImageData();
-        const naturalW = data.naturalWidth || 0;
-        const naturalH = data.naturalHeight || 0;
-        if (naturalW > 0 && naturalH > 0) {
-          cropper.setData({
-            x: c.x * naturalW,
-            y: c.y * naturalH,
-            width: c.w * naturalW,
-            height: c.h * naturalH,
-          });
-        }
-      },
+      // A custom template mirroring the v1 editor: the image pans/zooms inside the
+      // canvas, a shaded overlay dims the un-selected area, and the selection box
+      // is movable + resizable with corner/edge handles. `initial-coverage="1"`
+      // opens the box over the whole image (v1's `autoCropArea: 1`).
+      template: `<cropper-canvas background style="width:100%;height:100%">
+        <cropper-image rotatable scalable translatable></cropper-image>
+        <cropper-shade hidden></cropper-shade>
+        <cropper-handle action="select" plain></cropper-handle>
+        <cropper-selection initial-coverage="1" movable resizable outlined>
+          <cropper-grid role="grid" covered></cropper-grid>
+          <cropper-crosshair centered></cropper-crosshair>
+          <cropper-handle action="move" theme-color="rgba(255,255,255,0.35)"></cropper-handle>
+          <cropper-handle action="n-resize"></cropper-handle>
+          <cropper-handle action="e-resize"></cropper-handle>
+          <cropper-handle action="s-resize"></cropper-handle>
+          <cropper-handle action="w-resize"></cropper-handle>
+          <cropper-handle action="ne-resize"></cropper-handle>
+          <cropper-handle action="nw-resize"></cropper-handle>
+          <cropper-handle action="se-resize"></cropper-handle>
+          <cropper-handle action="sw-resize"></cropper-handle>
+        </cropper-selection>
+      </cropper-canvas>`,
     });
+
+    const sel = selection();
+    const img = cropperImage();
+    if (sel) {
+      sel.aspectRatio = presetAspectRatio(preset(), props.slot);
+    }
+    // Seed the saved box once the image has loaded (we need its real geometry to
+    // map the stored fractions onto the displayed image).
+    img?.$ready(() => seedInitialCrop());
   });
+
+  /**
+   * Map the saved `{x,y,w,h}` source fractions onto the live selection. v2's
+   * selection geometry is in `<cropper-canvas>` pixel space, so we project the
+   * fractions through the displayed `<cropper-image>` bounding box (which already
+   * reflects the image's scale + position inside the canvas).
+   */
+  function seedInitialCrop() {
+    const c = props.initialCrop;
+    const sel = selection();
+    const img = cropperImage();
+    const canvas = cropper?.getCropperCanvas();
+    if (!c || !sel || !img || !canvas) return;
+    const imgRect = img.getBoundingClientRect();
+    const canvasRect = canvas.getBoundingClientRect();
+    if (imgRect.width <= 0 || imgRect.height <= 0) return;
+    // Canvas-local coordinates of the saved crop region.
+    const x = imgRect.left - canvasRect.left + c.x * imgRect.width;
+    const y = imgRect.top - canvasRect.top + c.y * imgRect.height;
+    const width = c.w * imgRect.width;
+    const height = c.h * imgRect.height;
+    sel.$change(x, y, width, height, sel.aspectRatio || Number.NaN, true);
+    sel.$render();
+  }
 
   onCleanup(() => {
     cropper?.destroy();
@@ -98,27 +169,35 @@ export default function ImageCropModal(props: ImageCropModalProps) {
   /** Switch the locked aspect ratio of the crop box (Free ⇒ NaN ⇒ unlocked). */
   function choosePreset(id: AspectPresetId) {
     setPreset(id);
-    cropper?.setAspectRatio(presetAspectRatio(id, props.slot));
+    applyAspectRatio(presetAspectRatio(id, props.slot));
   }
 
   async function handleSave() {
-    if (!cropper) return;
+    const sel = selection();
+    const img = cropperImage();
+    const canvas = cropper?.getCropperCanvas();
+    if (!sel || !img || !canvas) return;
     setError(null);
-    const img = cropper.getImageData();
-    const naturalW = img.naturalWidth || 0;
-    const naturalH = img.naturalHeight || 0;
+    const naturalW = img.$image.naturalWidth || 0;
+    const naturalH = img.$image.naturalHeight || 0;
     if (naturalW <= 0 || naturalH <= 0) {
       setError("Could not read the image size — try re-uploading.");
       return;
     }
-    // `getData(true)` rounds to whole source pixels; normalise to fractions and
-    // capture the natural dims so the guest render honours the chosen aspect.
-    const d = cropper.getData(true);
+    // Derive 0..1 source fractions from the live geometry: the selection box over
+    // the displayed image box. These fractions are resolution-independent, so they
+    // equal the same fractions v1's `getData(true)` produced in source pixels.
+    const imgRect = img.getBoundingClientRect();
+    const selRect = sel.getBoundingClientRect();
+    if (imgRect.width <= 0 || imgRect.height <= 0) {
+      setError("Could not read the image size — try re-uploading.");
+      return;
+    }
     const crop: ImageCrop = {
-      x: clamp01(d.x / naturalW),
-      y: clamp01(d.y / naturalH),
-      w: clamp01(d.width / naturalW),
-      h: clamp01(d.height / naturalH),
+      x: clamp01((selRect.left - imgRect.left) / imgRect.width),
+      y: clamp01((selRect.top - imgRect.top) / imgRect.height),
+      w: clamp01(selRect.width / imgRect.width),
+      h: clamp01(selRect.height / imgRect.height),
       natW: naturalW,
       natH: naturalH,
     };
@@ -206,9 +285,9 @@ export default function ImageCropModal(props: ImageCropModalProps) {
           </div>
         </div>
 
-        {/* Bounded height so the cropper canvas fits the modal; Cropper.js sizes
-            the image to this box. */}
-        <div class="bg-surface max-h-[55vh] overflow-hidden rounded-sm">
+        {/* Bounded height so the cropper canvas fits the modal; Cropper.js v2 hides
+            this `<img>` and injects a `<cropper-canvas>` sibling that fills the box. */}
+        <div class="bg-surface h-[55vh] overflow-hidden rounded-sm">
           <img
             ref={imgEl}
             src={props.imageUrl}


### PR DESCRIPTION
## What

Upgrades `cropperjs` `^1.6.2` → `^2.1.1` in `@cire/organiser` and migrates the crop editor (`ImageCropModal.tsx`) to the v2 API.

Cropper.js v2 is a ground-up rewrite: v1 was a single imperative class (`new Cropper(img, options)`); v2 ships native **Web Components** (`<cropper-canvas>`, `<cropper-image>`, `<cropper-selection>`, `<cropper-handle>`, `<cropper-shade>`, `<cropper-grid>`, `<cropper-crosshair>`) behind a thin `Cropper` wrapper that hides the source `<img>` and injects a `<cropper-canvas>` template beside it.

## v1 → v2 API mapping

| v1 | v2 |
|----|----|
| `import "cropperjs/dist/cropper.css"` | **removed** — no CSS file in v2; each component styles itself in its Shadow DOM (the stale import was a hard build failure) |
| `new Cropper(img, opts)` | `new Cropper(img, { template })` + `getCropperImage()` / `getCropperSelection()` / `getCropperCanvas()` |
| `ready` event | `cropperImage.$ready(cb)` |
| `setData({x,y,w,h})` (seed) | `selection.$change(x, y, w, h)` in canvas-pixel coords, projected from stored 0..1 source fractions via the `<cropper-image>` bounding box |
| `setAspectRatio(r)` | `selection.aspectRatio = r` (`NaN` = free) + `$change`/`$render` to re-snap |
| `getData(true)` + `getImageData()` (extract) | live geometry: `<cropper-selection>` bbox over `<cropper-image>` bbox (resolution-independent → same 0..1 source fractions) + `cropperImage.$image.naturalWidth/Height` for `natW`/`natH` |
| `destroy()` | `destroy()` (unchanged — removes canvas, restores `<img>`); still called in `onCleanup` |

## Preserved (unchanged contract)

- Component external props / callers (`EventTable.tsx`, `InviteBuilder.tsx`) untouched
- Aspect presets: Original / 16:9 / 3:2 / 4:3 / 1:1 / 4:5 / Free
- No-stretch **uniform-scaling** render — crop JSON still carries `natW`/`natH`, `image-crop.ts` renders true pixel aspect
- Crop JSON output shape `{x,y,w,h,natW?,natH?}`
- Legacy `{x,y,w,h}` (dims-absent) crop tolerance on re-open

## Verification

- `bun run --cwd cire/organiser test:run` — 19 files / 147 tests pass (the `EventTable`/`InviteBuilder` suites that import the modal now resolve again; pre-migration they failed on the missing CSS import)
- `tsc --noEmit` on `@cire/organiser` — clean; pre-push type check across all 19 packages — clean
- `turbo build --filter=@cire/organiser` (`astro build`) — succeeds; Astro island / SSR setup resolves the v2 web-components import with no CSS error
- oxlint + oxfmt — clean

> ⚠️ The actual crop interaction (drag / zoom / aspect-ratio handles) **cannot be exercised headlessly** — the web components need a real browser layout engine for `getBoundingClientRect()` geometry. **This wants a human browser eyeball before relying on it on the live site.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)