### PR TITLE
fix(cire/api): follow pin.it → api.pinterest.com redirect hop when resolving boards

### DIFF
--- a/.changeset/cire-pinit-resolve-hop.md
+++ b/.changeset/cire-pinit-resolve-hop.md
@@ -1,0 +1,14 @@
+---
+"@cire/api": patch
+---
+
+Fix `pin.it` Pinterest board resolution failing on every short link. Pinterest
+changed `pin.it` to redirect through its first-party URL shortener
+(`pin.it/<id>` → 308 `api.pinterest.com/url_shortener/<id>/redirect/` → 302
+`www.pinterest.<tld>/<user>/<board>/`), but `resolvePinUrl`'s redirect-follow
+allowlist was `pin.it`-only, so the chain was abandoned at the middle hop and
+the short link fell back unresolved — guests only ever saw the fallback link,
+never the embedded board. Broadened the SSRF-safe redirect-follow allowlist to
+include `api.pinterest.com` + the Pinterest board hosts (still a strict
+first-party allowlist; off-allowlist redirects still stop the chain). Adds a
+regression test for the real two-hop chain.

--- a/cire/api/src/services/pinterest-resolve.test.ts
+++ b/cire/api/src/services/pinterest-resolve.test.ts
@@ -119,6 +119,45 @@ describe("resolvePinUrl", () => {
     );
   });
 
+  it("follows the real pin.it → api.pinterest.com url_shortener → board chain", async () => {
+    // Reproduces the live redirect shape that broke resolution: pin.it now
+    // 308s through Pinterest's first-party url_shortener (api.pinterest.com)
+    // before landing on the regional board host. The middle hop must be
+    // followed, not abandoned.
+    const fetched: string[] = [];
+    const fetchImpl = ((input: string) => {
+      fetched.push(input);
+      if (input === "https://pin.it/116q3t3HW") {
+        return Promise.resolve(
+          new Response(null, {
+            status: 308,
+            headers: { location: "https://api.pinterest.com/url_shortener/116q3t3HW/redirect/" },
+          }),
+        );
+      }
+      if (input === "https://api.pinterest.com/url_shortener/116q3t3HW/redirect/") {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: {
+              location:
+                "https://www.pinterest.com.au/pcvmpasupati/catholic-wedding-guest-moodboard/?invite_code=abc&sender=123",
+            },
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch: ${input}`);
+    }) as unknown as typeof fetch;
+    expect(await resolvePinUrl("https://pin.it/116q3t3HW", { fetchImpl })).toBe(
+      "https://www.pinterest.com.au/pcvmpasupati/catholic-wedding-guest-moodboard/",
+    );
+    // Both first-party hops were followed; tracking query params are stripped.
+    expect(fetched).toEqual([
+      "https://pin.it/116q3t3HW",
+      "https://api.pinterest.com/url_shortener/116q3t3HW/redirect/",
+    ]);
+  });
+
   it("keeps the original pin.it URL when the final location is a single pin", async () => {
     const fetchImpl = (() =>
       Promise.resolve(

--- a/cire/api/src/services/pinterest-resolve.ts
+++ b/cire/api/src/services/pinterest-resolve.ts
@@ -36,10 +36,34 @@ const PINTEREST_BOARD_HOSTS = new Set<string>([
   "pinterest.ie",
 ]);
 
-// The two short-link hosts we are willing to make an outbound fetch to. This is
-// the SSRF allowlist — we NEVER fetch an arbitrary user-supplied URL, only a
-// first-party Pinterest short link.
+// The two short-link hosts we are willing to make the FIRST outbound fetch to.
+// This is the SSRF entry gate — we NEVER start resolving an arbitrary
+// user-supplied URL, only a first-party Pinterest short link.
 const PIN_IT_HOSTS = new Set<string>(["pin.it", "www.pin.it"]);
+
+// Hosts we will FOLLOW a redirect *through* while chasing a short link to its
+// board. Broader than PIN_IT_HOSTS because `pin.it` no longer redirects
+// straight to the board — it bounces through Pinterest's first-party URL
+// shortener: `pin.it/<id>` → 308 `api.pinterest.com/url_shortener/<id>/redirect/`
+// → 302 `www.pinterest.<tld>/<user>/<board>/`. Without `api.pinterest.com` here
+// the chain was abandoned at the middle hop and every short link fell back
+// unresolved. The board hosts are included too, so a locale hop (e.g.
+// `www.pinterest.com` → `www.pinterest.com.au`) that doesn't immediately
+// canonicalise is still followed. Every entry is first-party Pinterest
+// infrastructure; any host OFF this allowlist stops the chain and we fall back
+// to the original url, so a redirect can never bounce the Worker to an
+// internal / attacker host (SSRF).
+const REDIRECT_FOLLOW_HOSTS = new Set<string>([
+  ...PIN_IT_HOSTS,
+  "api.pinterest.com",
+  ...PINTEREST_BOARD_HOSTS,
+  ...[...PINTEREST_BOARD_HOSTS].map((h) => `www.${h}`),
+]);
+
+/** Is `host` one we'll follow a redirect through (first-party Pinterest only)? */
+export function isFollowableRedirectHost(host: string): boolean {
+  return REDIRECT_FOLLOW_HOSTS.has(host.toLowerCase());
+}
 
 // A board path is `/<user>/<board>` with an optional single section sub-segment
 // (`/<user>/<board>/<section>`). Segments use the URL-safe characters real
@@ -188,13 +212,14 @@ export async function resolvePinUrl(
         const canonical = canonicalizePinterestBoardUrl(next.toString());
         if (canonical) return canonical;
         // SSRF guard — re-validate EVERY hop before issuing the next fetch. We
-        // only keep following while the chain stays on the first-party pin.it
-        // allowlist over https. The instant a redirect points anywhere else and
-        // it isn't a board (handled above), we STOP and fall back to the
-        // original url — we never fetch an off-allowlist host. Without this a
-        // pin.it link could 30x-redirect the Worker to an internal/attacker
-        // host (cloud metadata, private IPs, …).
-        if (next.protocol !== "https:" || !isPinItHost(next.hostname)) {
+        // only keep following while the chain stays on the first-party Pinterest
+        // redirect allowlist over https (pin.it → api.pinterest.com →
+        // pinterest.<tld>). The instant a redirect points anywhere else and it
+        // isn't a board (handled above), we STOP and fall back to the original
+        // url — we never fetch an off-allowlist host. Without this a pin.it link
+        // could 30x-redirect the Worker to an internal/attacker host (cloud
+        // metadata, private IPs, …).
+        if (next.protocol !== "https:" || !isFollowableRedirectHost(next.hostname)) {
           return url;
         }
         current = next.toString();


### PR DESCRIPTION
## Why the Pinterest embed stopped working

Investigating "still not seeing the Pinterest embed" on the live wedding site. Two compounding causes:

1. **Stale data:** the 4 live events store raw `pin.it` short links (imported before #190's import-time resolution). `isEmbeddablePinterestBoardUrl()` correctly rejects short links → only the fallback link renders. *(Fixed by a one-time prod backfill, separate.)*
2. **The resolver itself is now broken** (this PR). Pinterest changed `pin.it` to redirect through its first-party URL shortener:
   ```
   pin.it/<id>  →308→  api.pinterest.com/url_shortener/<id>/redirect/  →302→  www.pinterest.<tld>/<user>/<board>/
   ```
   `resolvePinUrl`'s redirect-follow allowlist was `pin.it`-only, so it bailed at the `api.pinterest.com` middle hop and returned every short link **unresolved**. So even re-importing wouldn't fix the boards.

## Fix

Broaden the redirect-follow allowlist to first-party Pinterest redirect hosts (`pin.it` + `api.pinterest.com` + the `pinterest.<tld>` board hosts). 

**SSRF guarantee unchanged:** the *initial* fetch gate stays `pin.it`-only (we never start resolving an arbitrary URL), and any redirect to an off-allowlist host still stops the chain and falls back to the original. Verified against the 4 real live short links — all now resolve to canonical embeddable board URLs, e.g.:
`pin.it/116q3t3HW` → `https://www.pinterest.com.au/pcvmpasupati/catholic-wedding-guest-moodboard/`

Adds a regression test for the real two-hop chain (incl. tracking-param stripping + that both first-party hops are followed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)