### PR TITLE
fix(cire/web): rounder mobile details card + maps embed tidy

### DIFF
--- a/.changeset/cire-mobile-details-card-rounding.md
+++ b/.changeset/cire-mobile-details-card-rounding.md
@@ -1,0 +1,21 @@
+---
+"@cire/web": patch
+---
+
+Round the mobile event-details bottom-sheet's top corners more so it reads as a
+card that pops up.
+
+The "more details" view is rendered by `AnimatedModal` as a bottom-anchored
+sheet on mobile (`items-end`) and a centred dialog on desktop (`md:items-center`).
+Its mobile top corners were `rounded-t-xl` (12px) — bumped to `rounded-t-[1.75rem]`
+(28px) for a pronounced rounded top so the sheet reads as a card sliding up.
+Mobile-first, so the larger top-rounding is scoped to small screens; the desktop
+`md:rounded-lg` (all four corners) override is unchanged, keeping the centred
+dialog look intact.
+
+Maps embed note: investigated removing the Google Maps Embed iframe's built-in
+"View larger map" / "Open in Google Maps" chrome (redundant with the app's own
+"Open in Maps" button). The Maps Embed API `place` mode has no officially
+documented parameter to suppress it, and hiding it with a CSS overlay would cover
+Google's attribution and violate the Maps Platform ToS — so the embed is left as
+is. The redundancy is cosmetic since the app already provides its own button.

--- a/cire/web/src/components/AnimatedModal.tsx
+++ b/cire/web/src/components/AnimatedModal.tsx
@@ -136,7 +136,7 @@ export function AnimatedModal(props: AnimatedModalProps) {
     >
       <div
         ref={panelRef}
-        class="border-border bg-surface relative max-h-[85dvh] w-full max-w-[480px] overflow-y-auto overscroll-contain rounded-t-xl border px-6 pt-8 pb-[max(2.5rem,env(safe-area-inset-bottom))] opacity-0 md:mb-8 md:max-h-[85vh] md:rounded-lg md:pb-10"
+        class="border-border bg-surface relative max-h-[85dvh] w-full max-w-[480px] overflow-y-auto overscroll-contain rounded-t-[1.75rem] border px-6 pt-8 pb-[max(2.5rem,env(safe-area-inset-bottom))] opacity-0 md:mb-8 md:max-h-[85vh] md:rounded-lg md:pb-10"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -4,8 +4,11 @@ tags: [todo, web]
 related:
   - "[[index]]"
   - "[[invite-builder]]"
-last-reviewed: 2026-06-20
+last-reviewed: 2026-06-21
 ---
+
+- [x] **Mobile details bottom-sheet — rounder top corners** (`fix/cire-invite-ui-tweaks`) — the event "more details" sheet (`AnimatedModal.tsx`, mobile bottom-anchored `items-end`) had `rounded-t-xl` (12px) top corners; bumped to `rounded-t-[1.75rem]` (28px) so it pops up reading as a card. Scoped to mobile (mobile-first); the desktop `md:rounded-lg` centred-dialog override is unchanged. **Wants a real-device eyeball** — the rounded-top card feel renders in a real browser, not happy-dom.
+- [x] **Maps embed "Open in Maps" chrome — not supportably removable** (`fix/cire-invite-ui-tweaks`) — investigated suppressing the Google Maps Embed iframe's built-in "View larger map" / "Open in Google Maps" link in `MapPreview.tsx` (it's redundant with the app's own footer "Open in Maps" button). The Maps Embed API `place` mode (`maps/embed/v1/place`) has **no officially documented parameter** to hide it, and a CSS overlay covering it would hide Google's attribution and **violate the Maps Platform ToS** — so the embed is left as-is. The redundancy is purely cosmetic (the app already ships its own "Open in Maps" affordance). Logged here so it isn't re-investigated; revisit only if Google adds a supported control.
 
 - [x] **Security headers + CSP via SSR middleware** (`feat/cire-web-csp`) — the guest site now sets a full Content-Security-Policy plus `X-Content-Type-Options` / `Referrer-Policy` / `X-Frame-Options` / `Permissions-Policy` from a new Astro `onRequest` middleware (`src/middleware.ts` → `src/lib/security-headers.ts`). This is the correct home for them on an SSR Worker: `public/_headers` only covers the static-asset layer (prerendered `/privacy` + `/terms`, `/_astro/*`), not the Worker-rendered invite routes. CSP allowlist derived from the site's real external origins (Pinterest, Google Maps embed, Google Fonts, Turnstile, first-party cire-api). See `[[security]]` for the full directive list + per-origin rationale and the real-browser smoke-test flag. `script-src` stays host-restricted but keeps `'unsafe-inline'` for Astro island hydration + the font preload `onload` handler; `style-src` keeps `'unsafe-inline'` for the invite's inline theme style attributes.
 


### PR DESCRIPTION
Two small, independent guest-invite frontend tweaks for `@cire/web`.

## Task 1 — Mobile "event more details" card: rounder top
The "more details" view (`DetailsModal` → `AnimatedModal`) renders as a bottom-anchored sheet on mobile (`items-end`) and a centred dialog on desktop (`md:items-center`). Its mobile top corners were `rounded-t-xl` (12px); bumped to **`rounded-t-[1.75rem]` (28px)** so it pops up reading as a card sliding up.

- File/classes: `cire/web/src/components/AnimatedModal.tsx`, panel container — `rounded-t-xl` → `rounded-t-[1.75rem]`.
- Mobile-first, so the larger top-rounding is scoped to small screens; the desktop `md:rounded-lg` override (all four corners) is untouched, so the centred dialog look is unchanged.

## Task 2 — Maps embed "Open in Maps" chrome: not supportably removable (no code change)
Investigated suppressing the Google Maps Embed iframe's built-in "View larger map" / "Open in Google Maps" link in `MapPreview.tsx` (it's redundant with the app's own footer "Open in Maps" button).

**Conclusion:** the Maps Embed API `place` mode (`maps/embed/v1/place`) has **no officially documented parameter** to hide that chrome, and a CSS overlay covering it would hide Google's attribution and **violate the Maps Platform ToS**. So the embed is left exactly as-is — no overlay hack. The redundancy is purely cosmetic because the app already provides its own "Open in Maps" affordance in both the iframe and CSS-card render paths. CSP/embed allowed origins are unchanged. Captured in `cire/wiki/todo/web.md` so it isn't re-investigated.

## Verification
Local (cire/web): `test` (346 pass), `check`, `build` all green. Changeset added (`@cire/web: patch`).

⚠️ **Real-device/browser eyeball still wanted:** the mobile card top-rounding and the Maps embed appearance can't be verified headlessly (happy-dom/CI) — they want a look on a real phone/browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)