### PR TITLE
feat(cire/organiser): import history + one-click revert UI

### DIFF
--- a/.changeset/cire-import-history-ui.md
+++ b/.changeset/cire-import-history-ui.md
@@ -1,0 +1,5 @@
+---
+"@cire/organiser": patch
+---
+
+Add an import history + one-click revert UI to the organiser portal. `ImportPanel` now renders an `ImportHistory` disclosure that lazy-loads past CSV imports (date, a human diff summary, and status), with a confirm-gated Revert on applied entries that calls the existing `import/revert` endpoint and refreshes events + guests. Co-host accessible, matching the `weddingMember()`-gated backend routes.

--- a/cire/organiser/src/components/ImportHistory.test.tsx
+++ b/cire/organiser/src/components/ImportHistory.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ImportHistory fetches the import list when its disclosure is opened, renders a
+ * human summary + status per entry, and offers a confirm-gated Revert on applied
+ * entries that POSTs to the revert endpoint and refreshes. These tests drive that
+ * behaviour against a mocked authFetch.
+ */
+
+const authFetchMock = vi.fn();
+
+vi.mock("@osn/client/solid", () => ({
+  useAuth: () => ({ authFetch: authFetchMock }),
+}));
+
+vi.mock("../lib/api", () => ({
+  apiUrl: (path: string) => `https://api.test${path}`,
+  isAuthExpired: (err: unknown) => String(err).includes("AuthExpiredError"),
+  redirectToLogin: vi.fn(),
+}));
+
+const invalidateEventsMock = vi.fn();
+vi.mock("../lib/events-store", () => ({
+  invalidateEvents: (id: string) => invalidateEventsMock(id),
+}));
+
+import ImportHistory from "./ImportHistory";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const APPLIED_ENTRY = {
+  id: "imp_applied",
+  uploadedAt: 1_700_000_000_000,
+  format: "csv",
+  status: "applied" as const,
+  appliedAt: 1_700_000_000_500,
+  revertedAt: null,
+  summary: { guestCreates: 12, guestRemoves: 2, eventUpdates: 3 },
+};
+
+const REVERTED_ENTRY = {
+  id: "imp_reverted",
+  uploadedAt: 1_699_000_000_000,
+  format: "csv",
+  status: "reverted" as const,
+  appliedAt: 1_699_000_000_500,
+  revertedAt: 1_699_000_001_000,
+  summary: { guestCreates: 4 },
+};
+
+let confirmMock: ReturnType<typeof vi.fn>;
+let reloadMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  // happy-dom doesn't implement window.confirm; define it as a mock (default: OK).
+  confirmMock = vi.fn().mockReturnValue(true);
+  Object.defineProperty(window, "confirm", { configurable: true, value: confirmMock });
+  reloadMock = vi.fn();
+  // happy-dom's location.reload is read-only; redefine it for the assertion.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, reload: reloadMock },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  authFetchMock.mockReset();
+  invalidateEventsMock.mockReset();
+});
+
+function openHistory() {
+  const summary = [...document.querySelectorAll("details > summary")].find((s) =>
+    /import history/i.test(s.textContent ?? ""),
+  );
+  expect(summary).toBeTruthy();
+  // Opening the <details> is what the component listens for (onToggle); set the
+  // open attribute then fire the toggle event the same way the browser would.
+  const details = summary!.closest("details") as HTMLDetailsElement;
+  details.open = true;
+  fireEvent(details, new Event("toggle"));
+}
+
+describe("ImportHistory", () => {
+  it("fetches and renders entries with a human summary + status when opened", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ imports: [APPLIED_ENTRY, REVERTED_ENTRY], nextCursor: null }),
+    );
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    await waitFor(() => expect(document.body.textContent).toContain("+12 guests"));
+    expect(authFetchMock.mock.calls[0]![0]).toContain("/api/organiser/weddings/wed_a/import/list");
+
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("−2 guests");
+    expect(body).toContain("3 events updated");
+    expect(body).toContain("Applied");
+    expect(body).toContain("Reverted");
+  });
+
+  it("offers Revert only on applied entries", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ imports: [APPLIED_ENTRY, REVERTED_ENTRY], nextCursor: null }),
+    );
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /revert/i }).length).toBe(1));
+  });
+
+  it("reverts: confirms, POSTs the import id, invalidates events, reloads + refreshes list", async () => {
+    authFetchMock
+      .mockResolvedValueOnce(jsonResponse({ imports: [APPLIED_ENTRY], nextCursor: null }))
+      .mockResolvedValueOnce(jsonResponse({ summary: { importId: "imp_applied" } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          imports: [{ ...APPLIED_ENTRY, status: "reverted", revertedAt: Date.now() }],
+          nextCursor: null,
+        }),
+      );
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    const revertBtn = await screen.findByRole("button", { name: /revert/i });
+    fireEvent.click(revertBtn);
+
+    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    // Calls: list (open) → revert (POST) → list (refresh).
+    expect(authFetchMock).toHaveBeenCalledTimes(3);
+    const revertCall = authFetchMock.mock.calls[1]!;
+    expect(revertCall[0]).toContain("/api/organiser/weddings/wed_a/import/revert");
+    expect(revertCall[1]).toMatchObject({ method: "POST" });
+    expect(JSON.parse((revertCall[1] as { body: string }).body)).toEqual({
+      importId: "imp_applied",
+    });
+    expect(invalidateEventsMock).toHaveBeenCalledWith("wed_a");
+  });
+
+  it("does not POST when the user cancels the confirm", async () => {
+    confirmMock.mockReturnValue(false);
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ imports: [APPLIED_ENTRY], nextCursor: null }),
+    );
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    const revertBtn = await screen.findByRole("button", { name: /revert/i });
+    fireEvent.click(revertBtn);
+
+    expect(confirmMock).toHaveBeenCalled();
+    // Only the initial list fetch ran — no revert POST.
+    expect(authFetchMock).toHaveBeenCalledTimes(1);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an API error from revert inline", async () => {
+    authFetchMock
+      .mockResolvedValueOnce(jsonResponse({ imports: [APPLIED_ENTRY], nextCursor: null }))
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "No prior applied import to revert to" }, false, 409),
+      );
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    const revertBtn = await screen.findByRole("button", { name: /revert/i });
+    fireEvent.click(revertBtn);
+
+    await waitFor(() =>
+      expect(document.body.textContent).toContain("No prior applied import to revert to"),
+    );
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error when the list fetch fails", async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse({ error: "boom" }, false, 500));
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    await waitFor(() => expect(document.body.textContent).toContain("boom"));
+  });
+
+  it("renders an empty state when there are no imports", async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse({ imports: [], nextCursor: null }));
+
+    render(() => <ImportHistory weddingId="wed_a" />);
+    openHistory();
+
+    await waitFor(() => expect(document.body.textContent).toContain("No imports yet."));
+  });
+});

--- a/cire/organiser/src/components/ImportHistory.tsx
+++ b/cire/organiser/src/components/ImportHistory.tsx
@@ -1,0 +1,243 @@
+import { useAuth } from "@osn/client/solid";
+import { createSignal, For, Show } from "solid-js";
+
+import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import { invalidateEvents } from "../lib/events-store";
+
+/**
+ * One row of the import list as returned by
+ * `GET /api/organiser/weddings/:weddingId/import/list`. `summary` mirrors the
+ * counts the API stores at preview time (see organiser-import.ts `/preview`);
+ * an older row whose summary failed to parse comes back as `{}`, so every field
+ * is optional and defaulted to 0 when we render.
+ */
+interface ImportSummaryCounts {
+  eventCreates?: number;
+  eventUpdates?: number;
+  eventRemoves?: number;
+  familyCreates?: number;
+  familyRemoves?: number;
+  guestCreates?: number;
+  guestUpdates?: number;
+  guestRemoves?: number;
+}
+
+type ImportStatus = "preview" | "applied" | "reverted";
+
+interface ImportEntry {
+  id: string;
+  uploadedAt: number;
+  format: string;
+  status: ImportStatus;
+  appliedAt: number | null;
+  revertedAt: number | null;
+  summary: ImportSummaryCounts;
+}
+
+interface ListResponse {
+  imports: ImportEntry[];
+  nextCursor: number | null;
+}
+
+const STATUS_LABEL: Record<ImportStatus, string> = {
+  preview: "Preview only",
+  applied: "Applied",
+  reverted: "Reverted",
+};
+
+function formatDate(ms: number): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(ms));
+  } catch {
+    return new Date(ms).toISOString();
+  }
+}
+
+/**
+ * A compact human summary of a diff, e.g. "+12 guests, −2, 3 events updated".
+ * Only non-zero buckets are mentioned; an empty diff reads "No changes".
+ */
+function summarise(s: ImportSummaryCounts): string {
+  const parts: string[] = [];
+  const guestAdds = s.guestCreates ?? 0;
+  const guestRemoves = s.guestRemoves ?? 0;
+  const guestUpdates = s.guestUpdates ?? 0;
+  const eventAdds = s.eventCreates ?? 0;
+  const eventUpdates = s.eventUpdates ?? 0;
+  const eventRemoves = s.eventRemoves ?? 0;
+  const familyAdds = s.familyCreates ?? 0;
+  const familyRemoves = s.familyRemoves ?? 0;
+
+  if (guestAdds) parts.push(`+${guestAdds} guests`);
+  if (guestRemoves) parts.push(`−${guestRemoves} guests`);
+  if (guestUpdates) parts.push(`${guestUpdates} guests updated`);
+  if (familyAdds) parts.push(`+${familyAdds} families`);
+  if (familyRemoves) parts.push(`−${familyRemoves} families`);
+  if (eventAdds) parts.push(`+${eventAdds} events`);
+  if (eventUpdates) parts.push(`${eventUpdates} events updated`);
+  if (eventRemoves) parts.push(`−${eventRemoves} events`);
+
+  return parts.length > 0 ? parts.join(", ") : "No changes";
+}
+
+/**
+ * The past-imports list with a per-entry one-click revert. Lives behind a native
+ * <details> that lazy-loads the list the first time it's opened (and on demand
+ * after a revert). Revert is offered only for `applied` entries; a successful
+ * revert re-applies the predecessor import server-side, so we mirror Apply's
+ * post-mutation refresh — drop the events cache + full reload — and re-fetch the
+ * list so the row flips to "Reverted".
+ *
+ * Authorised exactly like the rest of the import surface (OSN access JWT +
+ * wedding membership) — co-hosts get history + revert too, matching the
+ * weddingMember()-gated backend routes.
+ */
+export default function ImportHistory(props: { weddingId: string }) {
+  const { authFetch } = useAuth();
+  const listUrl = () => apiUrl(`/api/organiser/weddings/${props.weddingId}/import/list`);
+  const revertUrl = () => apiUrl(`/api/organiser/weddings/${props.weddingId}/import/revert`);
+
+  const [entries, setEntries] = createSignal<ImportEntry[] | null>(null);
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [revertingId, setRevertingId] = createSignal<string | null>(null);
+  const [loaded, setLoaded] = createSignal(false);
+
+  async function loadList() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await authFetch(listUrl());
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Could not load import history (${res.status})`);
+      }
+      const data = (await res.json()) as ListResponse;
+      setEntries(data.imports);
+      setLoaded(true);
+    } catch (err) {
+      if (isAuthExpired(err)) return redirectToLogin();
+      setError(err instanceof Error ? err.message : "Could not load import history.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function onToggle(e: Event) {
+    // Lazy-load the first time the disclosure is opened.
+    if ((e.currentTarget as HTMLDetailsElement).open && !loaded() && !loading()) {
+      void loadList();
+    }
+  }
+
+  async function handleRevert(entry: ImportEntry) {
+    if (entry.status !== "applied") return;
+    const ok = window.confirm(
+      "Revert this import? This re-applies the previous import — guests, families and events will be rolled back to that state.",
+    );
+    if (!ok) return;
+
+    setRevertingId(entry.id);
+    setError(null);
+    try {
+      const res = await authFetch(revertUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ importId: entry.id }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Revert failed (${res.status})`);
+      }
+      // Revert re-applies the predecessor import, so this wedding's events list
+      // is now stale — drop the cache (mirrors Apply) so the Events tab refetches
+      // …and a full reload re-pulls the (uncached) guest table too. We refresh
+      // the list first so, if the reload is ever a no-op, the row still flips to
+      // "Reverted".
+      invalidateEvents(props.weddingId);
+      await loadList();
+      window.location.reload();
+    } catch (err) {
+      if (isAuthExpired(err)) return redirectToLogin();
+      setError(err instanceof Error ? err.message : "Revert failed.");
+    } finally {
+      setRevertingId(null);
+    }
+  }
+
+  return (
+    <details class="border-border bg-bg/30 group/history rounded-sm border" onToggle={onToggle}>
+      <summary class="font-body text-text hover:text-gold flex cursor-pointer items-center gap-2 px-4 py-3 text-[0.88rem] transition select-none [&::-webkit-details-marker]:hidden">
+        <span
+          class="text-gold inline-block transition-transform group-open/history:rotate-90"
+          aria-hidden
+        >
+          ›
+        </span>
+        Import history
+      </summary>
+
+      <div class="border-border/60 flex flex-col gap-4 border-t px-4 py-5">
+        <Show when={error()}>
+          <p class="border-error/20 bg-error/5 text-error rounded-sm border p-4 text-[0.88rem]">
+            {error()}
+          </p>
+        </Show>
+
+        <Show when={loading() && entries() === null}>
+          <p class="text-text-muted text-[0.85rem]" aria-busy="true">
+            Loading…
+          </p>
+        </Show>
+
+        <Show when={loaded() && (entries()?.length ?? 0) === 0}>
+          <p class="text-text-muted text-[0.85rem]">No imports yet.</p>
+        </Show>
+
+        <Show when={(entries()?.length ?? 0) > 0}>
+          <ul class="flex flex-col gap-3">
+            <For each={entries() ?? []}>
+              {(entry) => {
+                const reverting = () => revertingId() === entry.id;
+                return (
+                  <li class="border-border bg-surface/30 flex flex-col gap-2 rounded-sm border p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="flex flex-col gap-1">
+                      <span class="font-body text-text text-[0.88rem]">
+                        {formatDate(entry.uploadedAt)}
+                      </span>
+                      <span class="text-text-muted text-[0.82rem]">{summarise(entry.summary)}</span>
+                      <span
+                        class="font-body text-[0.66rem] tracking-[0.18em] uppercase"
+                        classList={{
+                          "text-gold": entry.status === "applied",
+                          "text-text-muted": entry.status !== "applied",
+                        }}
+                      >
+                        {STATUS_LABEL[entry.status]}
+                      </span>
+                    </div>
+
+                    <Show when={entry.status === "applied"}>
+                      <button
+                        type="button"
+                        onClick={() => void handleRevert(entry)}
+                        disabled={revertingId() !== null}
+                        aria-busy={reverting()}
+                        class="border-gold/40 font-body text-gold hover:border-gold hover:bg-gold/10 shrink-0 self-start rounded-sm border px-4 py-2 text-[0.78rem] tracking-[0.1em] uppercase transition disabled:opacity-40 sm:self-auto"
+                      >
+                        {reverting() ? "Reverting…" : "Revert"}
+                      </button>
+                    </Show>
+                  </li>
+                );
+              }}
+            </For>
+          </ul>
+        </Show>
+      </div>
+    </details>
+  );
+}

--- a/cire/organiser/src/components/ImportPanel.tsx
+++ b/cire/organiser/src/components/ImportPanel.tsx
@@ -14,6 +14,7 @@ import {
   buildEventsTemplateCsv,
   buildGuestsTemplateCsv,
 } from "../lib/import-templates";
+import ImportHistory from "./ImportHistory";
 
 interface ImportPlan {
   eventCreates: unknown[];
@@ -290,6 +291,8 @@ export default function ImportPanel(props: { weddingId: string }) {
             </div>
           )}
         </Show>
+
+        <ImportHistory weddingId={props.weddingId} />
       </div>
     </details>
   );

--- a/cire/wiki/todo/spreadsheet-import.md
+++ b/cire/wiki/todo/spreadsheet-import.md
@@ -38,7 +38,7 @@ Source spreadsheet has these columns: `Family ID, Guest First Name, Guest Last N
 - [x] `GET /api/organiser/events` — full event details (used by EventTable + GuestTable for human-readable event tags)
 - [x] Multi-origin CORS allowlist on the API so the organiser portal (`:4322`) can call the API alongside the guest web app (`:4321`)
 - [ ] Extend `OrganiserView` to display family-grouped guests with shareable publicId + password (show password only at family creation, hash thereafter — surface a "regenerate password" action)
-- [ ] Organiser portal: history / revert UI (deferred from initial cut)
+- [x] **Organiser portal: history / revert UI** (`feat/cire-import-history-ui`) — `ImportHistory.tsx` (co-located, rendered by `ImportPanel`) is a native `<details>` that lazy-loads `GET .../import/list` on open, renders each entry as date + human summary ("+12 guests, −2 guests, 3 events updated") + status (Applied / Reverted / Preview only). Applied entries get a confirm-gated **Revert** that POSTs `.../import/revert` with the import id, then mirrors Apply's post-mutation refresh (`invalidateEvents` + list re-fetch + `window.location.reload()`); revert is offered only on applied rows, 401 → `redirectToLogin`, API errors surface inline. Co-host-accessible (same `weddingMember()`-gated routes; no owner gate). The `list` + `revert` backend already existed (PR-C) — UI only. Component tests cover render, revert→endpoint+refresh, disabled-on-reverted, and error surfacing. **Visual layout still wants a browser eyeball.**
 
 ## Cloudflare wiring
 


### PR DESCRIPTION
## What

Surfaces a history of past CSV imports in the `@cire/organiser` portal, with a one-click revert per applied entry. The CSV-import `list` + `revert` backend already existed (`organiser-import.ts`, PR-C) — this PR is **UI only**.

## Changes

- **New `ImportHistory.tsx`** (co-located, rendered by `ImportPanel`): a native `<details>` that lazy-loads `GET .../import/list` the first time it's opened.
  - Each entry renders **date** + a **human diff summary** (e.g. "+12 guests, −2 guests, 3 events updated") + **status** (Applied / Reverted / Preview only).
  - Applied entries get a confirm-gated **Revert** that `POST`s `.../import/revert` with the import id, then mirrors Apply's post-mutation refresh: `invalidateEvents` + re-fetch the list + `window.location.reload()` (reloads the guest table; events tab refetches off the dropped cache). The list refresh runs first so the row flips to "Reverted" even if the reload is a no-op.
  - Revert is offered **only** on applied rows (disabled/absent for reverted + preview). `401` → `redirectToLogin` (via `isAuthExpired`); API errors surface inline, matching the existing panel.
- **`ImportPanel.tsx`**: renders `<ImportHistory>` at the foot of the panel.
- Styled consistently with the existing gold/bordered `<details>` aesthetic; accessible (real buttons, `aria-busy`, confirm before the destructive revert).

## Access

History + revert are available to the same callers as the rest of import — the routes are `weddingMember()`-gated, so **co-hosts** (not just the owner) can use them. No owner-only gate added.

## Tests

`ImportHistory.test.tsx` covers: history renders entries (summary + status), revert confirms → POSTs the import id → invalidates events + refreshes list + reloads, revert offered only on applied entries, cancel-on-confirm does not POST, and both list-load and revert API errors surface inline.

- `bun run --cwd cire/organiser test:run` → 159 passed (20 files)
- `bun run lint`, `tsc -p cire/organiser`, `bun run build --filter=@cire/organiser` → green

## Notes

- No backend change → changeset is `@cire/organiser: patch` only.
- Wiki shard `cire/wiki/todo/spreadsheet-import.md` "history / revert UI" item ticked.
- **The UI still wants a real-browser eyeball** for visual layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)