### PR TITLE
fix(cire/web): events section no longer crashes on a partial theme payload

### DIFF
--- a/.changeset/cire-invite-theme-events-resilient.md
+++ b/.changeset/cire-invite-theme-events-resilient.md
@@ -1,0 +1,21 @@
+---
+"@cire/web": patch
+---
+
+Fix the guest invite's **events section vanishing** when a malformed/partial theme
+payload reaches the render boundary. `sectionThemeVars` destructured
+`theme[section]` unguarded, so a truthy-but-partial `theme` (a missing section
+sub-object — e.g. a shape mismatch on the no-store invite revalidation, or future
+payload drift) threw a `TypeError`. That call computes the inline CSS variables
+for the events ("details") section wrapper on the guest invite, so the throw
+crashed the whole `InvitePage` island and the **events list disappeared** — the
+hero/blur change that bumped the customisation row was the trigger that re-fetched
+the theme.
+
+`sectionThemeVars` now reads the section colours defensively (`theme[section]?` →
+fall back to the built-in tokens), mirroring the resilience the organiser-side
+preview helper (`invite-theme-preview.ts`) already had (`theme.accent[section] ??
+default`). A partial theme now renders with the global fonts and the default
+section colours instead of crashing, so the events can never be taken down by a
+theme/customisation payload issue. Adds a regression test covering the
+partial-theme case.

--- a/cire/web/src/components/invite-theme.test.ts
+++ b/cire/web/src/components/invite-theme.test.ts
@@ -46,6 +46,27 @@ describe("sectionThemeVars", () => {
     expect(sectionThemeVars(undefined, "story")).toEqual({});
   });
 
+  it("never throws on a truthy-but-partial theme (the section sub-object missing)", () => {
+    // Regression: a malformed/partial theme payload (a missing section — e.g. a
+    // mid-deploy shape mismatch on the guest invite's no-store revalidation) must
+    // NOT throw. This map styles the events ("details") section wrapper, and a
+    // throw here would crash the InvitePage island and make the events vanish.
+    const partial = {
+      headingFont: "cormorant",
+      bodyFont: null,
+      hero: { accentColor: "#d4af37", surfaceColor: null },
+      // `story` + `details` deliberately absent — an out-of-contract payload.
+    } as unknown as InviteTheme;
+
+    expect(() => sectionThemeVars(partial, "details")).not.toThrow();
+    const vars = sectionThemeVars(partial, "details");
+    // No section colours (fall back to the built-in tokens), but the global font
+    // still applies — exactly as a section with both colours null would render.
+    expect(vars["--invite-accent"]).toBeUndefined();
+    expect(vars["--invite-surface"]).toBeUndefined();
+    expect(vars["--invite-heading"]).toContain("Cormorant Garamond");
+  });
+
   it("drops a colour that fails the allow-list (defence in depth at the render boundary)", () => {
     const malicious: InviteTheme = {
       ...fullTheme,

--- a/cire/web/src/components/invite-theme.ts
+++ b/cire/web/src/components/invite-theme.ts
@@ -64,7 +64,18 @@ export function sectionThemeVars(
   const body = fontStack(theme.bodyFont);
   if (body) vars["--invite-body"] = body;
 
-  const { accentColor, surfaceColor } = theme[section];
+  // Defensive: a truthy-but-partial theme (the requested section's sub-object
+  // missing — e.g. a mid-deploy payload-shape mismatch on the no-store
+  // revalidation, or future shape drift) must NEVER throw here. This map styles
+  // the guest invite's events ("details") section wrapper, so a throw would crash
+  // the InvitePage island and make the EVENTS list disappear entirely. Mirror the
+  // organiser preview helper's `?? default` resilience (`invite-theme-preview.ts`)
+  // and simply omit the section colours, falling back to the built-in tokens.
+  const sectionColors = theme[section] as
+    | { accentColor: string | null; surfaceColor: string | null }
+    | undefined;
+  const accentColor = sectionColors?.accentColor ?? null;
+  const surfaceColor = sectionColors?.surfaceColor ?? null;
   if (accentColor && isValidColor(accentColor)) vars["--invite-accent"] = accentColor;
   if (surfaceColor && isValidColor(surfaceColor)) vars["--invite-surface"] = surfaceColor;
 

--- a/cire/wiki/architecture/invite-builder.md
+++ b/cire/wiki/architecture/invite-builder.md
@@ -4,7 +4,7 @@ tags: [architecture, api, web, db]
 related:
   - "[[index]]"
   - "[[monorepo-structure]]"
-last-reviewed: 2026-06-19
+last-reviewed: 2026-06-28
 ---
 
 # Invite Builder
@@ -336,6 +336,14 @@ gold / surface / display token. `cire/web/src/components/invite-theme.ts`
 colours + resolving the font key). The hero + story sections read the live theme
 from `InviteHeader`'s resource; the "details"/events section reads the live theme
 from `InvitePage`'s own resource (both override the build-time snapshot above).
+
+> **Render-boundary resilience.** `sectionThemeVars` reads the section sub-object
+> defensively (`theme[section]?` → fall back to the built-in tokens) and never
+> throws on a truthy-but-partial theme. This matters because the "details" map
+> styles the **events** section wrapper, so a throw here would crash the
+> `InvitePage` island and make the whole events list vanish. A malformed/partial
+> payload now degrades to the default section colours rather than taking events
+> down — mirroring the organiser preview helper's `?? default` behaviour.
 
 `PUBLIC_WEDDING_SLUG` (env) selects which wedding's customisation the guest site
 renders (default `cire-wedding`, the bootstrap wedding slug).


### PR DESCRIPTION
## The bug

> "I changed the image blur and then the events disappeared."

The literal **"Hero image blur"** slider lives in the cire organiser portal (`InviteBuilder.tsx`) and is saved via `PUT /api/organiser/weddings/:weddingId/invite/theme`, which writes `hero_blur` to `wedding_invite_customisations` and **bumps `updatedAt`**.

On the **guest** invite, the events list is rendered inside:

```tsx
<section style={{ ...detailsVars(), ... }}>
  <For each={data().events}>...</For>
</section>
```

…where `detailsVars()` → `sectionThemeVars(liveTheme(), "details")`. That helper (`cire/web/src/components/invite-theme.ts`) destructured the section sub-object **unguarded**:

```ts
const { accentColor, surfaceColor } = theme[section]; // throws if theme[section] is undefined
```

If `theme` is truthy but partial (a missing section sub-object), this throws a `TypeError`, which **crashes the `InvitePage` island and makes the entire events list vanish**. The blur/theme save is the trigger that re-fetches the theme (the guest invite revalidates `/api/invite/:slug` with `cache: "no-store"` on mount), so a payload-shape mismatch on that revalidation surfaces exactly as "I changed the blur and the events disappeared."

Notably, the organiser-side mirror of this helper (`invite-theme-preview.ts`) was **already** resilient (`theme.accent[section] ?? default`) — only the guest copy could throw.

## Investigation scope

I ruled out a data-deletion cause across all three candidate apps before landing on this:
- **cire** — blur and events are decoupled on the data side (theme save only touches `wedding_invite_customisations`; organiser events use a separate module-scoped cache the builder never touches; guest events come from the separate `/api/claim` flow). The only way events vanish on that page is the render-time throw above.
- **Pulse** (`@pulse/*`) — no blur/sensitive/image setting touches event listing; the sole user setting (`attendance_visibility`) is decoupled from the Explore feed.
- **OSN** (`@osn/social`, `@osn/api`) — no image/blur/privacy setting, and `@osn/social` doesn't render events at all.

## The fix

`sectionThemeVars` now reads the section colours defensively and never throws on a partial/malformed theme — it falls back to the built-in tokens, matching the organiser preview helper's behaviour. This also hardens the hero/story sections (same helper).

## Tests

- Added a regression test in `invite-theme.test.ts` for a truthy-but-partial theme. It fails on the old code with the exact `TypeError: Cannot destructure property…` and passes with the fix.
- Full `@cire/web` suite green: **358 tests passing**. oxlint + oxfmt clean (pre-commit hooks pass).

## Notes

- Wiki: added a "render-boundary resilience" note to `cire/wiki/architecture/invite-builder.md` and bumped `last-reviewed`.
- Changeset: `@cire/web` patch.
- Confidence: this is the only code path in the monorepo where changing the image blur can make events disappear, and the regression test reproduces the crash. I could not deterministically reproduce the *source* of a partial payload in committed code (the API always serializes a complete theme today), so this is a robustness fix that eliminates the exact failure mode rather than a fix to a reproduced producer — worth a reviewer's eye on whether a producer (e.g. a mid-deploy shape skew) should also be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6CEcSqMaJgv3xhYrEaEbT)_