### PR TITLE
refactor(osn/api): decompose auth.ts — Phase 1 (pure helpers)

### DIFF
--- a/.changeset/osn-auth-refactor-helpers.md
+++ b/.changeset/osn-auth-refactor-helpers.md
@@ -1,0 +1,12 @@
+---
+"@osn/api": patch
+---
+
+Refactor (no behaviour change): begin splitting the ~4,500-line `auth.ts`.
+
+First slice — extract the pure, state-free helpers (ID/token/OTP generation,
+JWT sign/verify, and the boundary schemas) into `services/auth-helpers.ts`.
+`auth.ts` imports them and re-exports the externally-consumed ones (`genId`,
+`hashSessionToken`, `HandleSchema`) so `../services/auth` stays the stable
+barrel. Byte-identical behaviour; all 714 `@osn/api` tests unchanged and green.
+See `[[auth-service-refactor]]`.

--- a/osn/api/src/services/auth-helpers.ts
+++ b/osn/api/src/services/auth-helpers.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+
+import { Effect, Schema } from "effect";
+import { SignJWT, jwtVerify } from "jose";
+
+/**
+ * Pure, dependency-free helpers for the auth service — ID/token generation,
+ * JWT signing/verification, OTP generation, and the boundary schemas. Extracted
+ * from `auth.ts` (which now imports them and re-exports the externally-consumed
+ * ones) so the service factory reads as orchestration rather than a wall of
+ * primitives. None of these capture service state; they are safe to import
+ * anywhere. Behaviour is byte-identical to the previous in-file definitions.
+ */
+
+export function genId(prefix: string): string {
+  return prefix + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+/**
+ * O5: a per-request random sentinel `accountId` for the enumeration-probe
+ * burn-in SELECTs. A fixed literal (`acc_enum_probe`, `__nonexistent__`) is a
+ * stable, attacker-knowable key: an adversary who pre-seeds a row with that id
+ * (or just observes the constant in a leaked query log) could turn the
+ * latency-equalising probe back into an oracle. A fresh 128-bit random id per
+ * request is, with overwhelming probability, absent from `accounts` — so the
+ * probe SELECT still returns zero rows and pays the same indexed-lookup cost,
+ * but the key carries no information and cannot be made to match.
+ */
+export function probeAccountId(): string {
+  return genId("acc_probe_");
+}
+
+export function now(): Date {
+  return new Date();
+}
+
+export async function signJwt(
+  payload: Record<string, unknown>,
+  privateKey: CryptoKey,
+  kid: string,
+  ttl: number,
+  issuer: string,
+): Promise<string> {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "ES256", kid })
+    .setIssuedAt()
+    .setIssuer(issuer)
+    .setExpirationTime(Math.floor(Date.now() / 1000) + ttl)
+    .sign(privateKey);
+}
+
+/**
+ * O1: `issuer` is pinned to `AuthConfig.issuerUrl` so a token minted by a
+ * different OSN deployment (or any other ES256 issuer sharing nothing but the
+ * curve) is rejected. A 30s `clockTolerance` absorbs benign clock skew between
+ * the signer and verifier without materially widening the effective TTL.
+ *
+ * Cross-service rollout note (the downstream verifier half is W7): the tolerant
+ * verifier MUST deploy before the signer begins enforcing/emitting `iss`. A
+ * verifier that already pins `issuer` would otherwise reject every legacy
+ * (iss-less) token the instant the signer rolls out — so the deploy ordering is
+ * strictly verifier-first.
+ */
+export async function verifyJwt(
+  token: string,
+  publicKey: CryptoKey,
+  issuer: string,
+): Promise<Record<string, unknown>> {
+  const { payload } = await jwtVerify(token, publicKey, {
+    algorithms: ["ES256"],
+    issuer,
+    clockTolerance: 30,
+  });
+  return payload as Record<string, unknown>;
+}
+
+/**
+ * Generates a uniformly distributed 6-digit OTP via rejection sampling.
+ * `crypto.getRandomValues` returns a 32-bit value; naive `% 900_000` is biased
+ * because 2^32 is not a multiple of 900_000. We discard draws that fall in the
+ * tail and resample.
+ */
+export function genOtpCode(): string {
+  const buf = new Uint32Array(1);
+  // 2^32 = 4_294_967_296. Largest multiple of 900_000 not exceeding it.
+  const ceil = Math.floor(0x1_0000_0000 / 900_000) * 900_000;
+  do {
+    crypto.getRandomValues(buf);
+  } while (buf[0]! >= ceil);
+  return (100_000 + (buf[0]! % 900_000)).toString();
+}
+
+/**
+ * Local-dev convenience: surface a freshly minted OTP in the server log so an
+ * operator can complete an email-OTP flow (registration, step-up, email change)
+ * without a real inbox — `LogEmailLive` records the body in-memory but never
+ * logs the code. Gated strictly on a local environment (`OSN_ENV` unset or
+ * "local") so a code is NEVER logged in staging/production. Emitted at debug:
+ * local dev defaults to the debug log level (so it shows), non-local defaults to
+ * info (a second guard on top of the env check).
+ */
+export function logDevOtp(purpose: string, to: string, code: string): Effect.Effect<void> {
+  const isLocal = !process.env.OSN_ENV || process.env.OSN_ENV === "local";
+  if (!isLocal) return Effect.void;
+  return Effect.logDebug(`[dev-otp] ${purpose} to=${to} code=${code}`);
+}
+
+// ---------------------------------------------------------------------------
+// Session token helpers (Copenhagen Book C1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates an opaque session token: 20 random bytes (160-bit entropy),
+ * hex-encoded with a `ses_` prefix for developer ergonomics.
+ * The raw token is held by the client; the server stores only its SHA-256 hash.
+ */
+export function generateSessionToken(): string {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  return "ses_" + Buffer.from(bytes).toString("hex");
+}
+
+/**
+ * SHA-256 hash of the raw session token. This is what gets stored in the
+ * sessions table as the primary key. A DB leak does not expose valid tokens
+ * because the token has 160 bits of entropy — brute-forcing the preimage
+ * of SHA-256 is infeasible.
+ */
+export function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Public revocation handle for a session — first 16 hex chars of the
+ * SHA-256 hash. 64 bits of collision resistance within a single account's
+ * session list is more than enough; exposing the full hash would let a
+ * log-capturing attacker DELETE sessions by guessing the URL.
+ */
+export function sessionHandleFromHash(sessionHash: string): string {
+  return sessionHash.slice(0, 16);
+}
+
+export const EmailSchema = Schema.String.pipe(
+  Schema.filter((s) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s), {
+    message: () => "Invalid email",
+  }),
+);
+
+export const HandleSchema = Schema.String.pipe(
+  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
+    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
+  }),
+);
+
+/**
+ * User-chosen free-text nickname for a passkey. Trimmed client-side and here;
+ * upper-bounded at 64 chars so a stored label fits inside any reasonable
+ * settings-row display without having to `LIKE …%` truncate at read time.
+ * Empty strings aren't valid — the caller should PATCH `null` to clear.
+ */
+export const PasskeyLabelSchema = Schema.String.pipe(
+  Schema.filter((s) => s.trim().length > 0 && s.length <= 64, {
+    message: () => "Passkey label must be 1–64 characters",
+  }),
+);
+
+/**
+ * Normalises an identifier by stripping a leading @ sigil.
+ * Users may type "@alice" meaning handle "alice"; this strips it before dispatch.
+ */
+export function normaliseIdentifier(identifier: string): string {
+  return identifier.startsWith("@") ? identifier.slice(1) : identifier;
+}
+
+/** Returns true if the (already-normalised) identifier looks like an email address. */
+export function looksLikeEmail(identifier: string): boolean {
+  return identifier.includes("@");
+}

--- a/osn/api/src/services/auth.ts
+++ b/osn/api/src/services/auth.ts
@@ -41,7 +41,6 @@ import type {
 } from "@simplewebauthn/server";
 import { and, count as countFn, desc, eq, gte, inArray, isNull, like, ne, sql } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
-import { SignJWT, jwtVerify } from "jose";
 
 import { createInMemoryCeremonyStore, type CeremonyStore } from "../lib/ceremony-store";
 import {
@@ -87,6 +86,23 @@ import {
   withProfileSwitch,
   withStepUp,
 } from "../metrics";
+import {
+  genId,
+  probeAccountId,
+  now,
+  signJwt,
+  verifyJwt,
+  genOtpCode,
+  logDevOtp,
+  generateSessionToken,
+  hashSessionToken,
+  sessionHandleFromHash,
+  normaliseIdentifier,
+  looksLikeEmail,
+  EmailSchema,
+  HandleSchema,
+  PasskeyLabelSchema,
+} from "./auth-helpers";
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -423,172 +439,14 @@ function createInMemoryAccountCap(maxRequests: number, windowMs: number): Accoun
 
 // ---------------------------------------------------------------------------
 // Helpers
+//
+// The pure, state-free helpers (ID/token/OTP generation, JWT sign/verify, the
+// boundary schemas) live in `./auth-helpers` and are imported above. The
+// externally-consumed ones are re-exported here so `../services/auth` stays the
+// stable barrel for existing importers.
 // ---------------------------------------------------------------------------
 
-function genId(prefix: string): string {
-  return prefix + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
-}
-
-/**
- * O5: a per-request random sentinel `accountId` for the enumeration-probe
- * burn-in SELECTs. A fixed literal (`acc_enum_probe`, `__nonexistent__`) is a
- * stable, attacker-knowable key: an adversary who pre-seeds a row with that id
- * (or just observes the constant in a leaked query log) could turn the
- * latency-equalising probe back into an oracle. A fresh 128-bit random id per
- * request is, with overwhelming probability, absent from `accounts` — so the
- * probe SELECT still returns zero rows and pays the same indexed-lookup cost,
- * but the key carries no information and cannot be made to match.
- */
-function probeAccountId(): string {
-  return genId("acc_probe_");
-}
-
-function now(): Date {
-  return new Date();
-}
-
-async function signJwt(
-  payload: Record<string, unknown>,
-  privateKey: CryptoKey,
-  kid: string,
-  ttl: number,
-  issuer: string,
-): Promise<string> {
-  return new SignJWT(payload)
-    .setProtectedHeader({ alg: "ES256", kid })
-    .setIssuedAt()
-    .setIssuer(issuer)
-    .setExpirationTime(Math.floor(Date.now() / 1000) + ttl)
-    .sign(privateKey);
-}
-
-/**
- * O1: `issuer` is pinned to `AuthConfig.issuerUrl` so a token minted by a
- * different OSN deployment (or any other ES256 issuer sharing nothing but the
- * curve) is rejected. A 30s `clockTolerance` absorbs benign clock skew between
- * the signer and verifier without materially widening the effective TTL.
- *
- * Cross-service rollout note (the downstream verifier half is W7): the tolerant
- * verifier MUST deploy before the signer begins enforcing/emitting `iss`. A
- * verifier that already pins `issuer` would otherwise reject every legacy
- * (iss-less) token the instant the signer rolls out — so the deploy ordering is
- * strictly verifier-first.
- */
-async function verifyJwt(
-  token: string,
-  publicKey: CryptoKey,
-  issuer: string,
-): Promise<Record<string, unknown>> {
-  const { payload } = await jwtVerify(token, publicKey, {
-    algorithms: ["ES256"],
-    issuer,
-    clockTolerance: 30,
-  });
-  return payload as Record<string, unknown>;
-}
-
-/**
- * Generates a uniformly distributed 6-digit OTP via rejection sampling.
- * `crypto.getRandomValues` returns a 32-bit value; naive `% 900_000` is biased
- * because 2^32 is not a multiple of 900_000. We discard draws that fall in the
- * tail and resample.
- */
-function genOtpCode(): string {
-  const buf = new Uint32Array(1);
-  // 2^32 = 4_294_967_296. Largest multiple of 900_000 not exceeding it.
-  const ceil = Math.floor(0x1_0000_0000 / 900_000) * 900_000;
-  do {
-    crypto.getRandomValues(buf);
-  } while (buf[0]! >= ceil);
-  return (100_000 + (buf[0]! % 900_000)).toString();
-}
-
-/**
- * Local-dev convenience: surface a freshly minted OTP in the server log so an
- * operator can complete an email-OTP flow (registration, step-up, email change)
- * without a real inbox — `LogEmailLive` records the body in-memory but never
- * logs the code. Gated strictly on a local environment (`OSN_ENV` unset or
- * "local") so a code is NEVER logged in staging/production. Emitted at debug:
- * local dev defaults to the debug log level (so it shows), non-local defaults to
- * info (a second guard on top of the env check).
- */
-function logDevOtp(purpose: string, to: string, code: string): Effect.Effect<void> {
-  const isLocal = !process.env.OSN_ENV || process.env.OSN_ENV === "local";
-  if (!isLocal) return Effect.void;
-  return Effect.logDebug(`[dev-otp] ${purpose} to=${to} code=${code}`);
-}
-
-// ---------------------------------------------------------------------------
-// Session token helpers (Copenhagen Book C1)
-// ---------------------------------------------------------------------------
-
-/**
- * Generates an opaque session token: 20 random bytes (160-bit entropy),
- * hex-encoded with a `ses_` prefix for developer ergonomics.
- * The raw token is held by the client; the server stores only its SHA-256 hash.
- */
-function generateSessionToken(): string {
-  const bytes = new Uint8Array(20);
-  crypto.getRandomValues(bytes);
-  return "ses_" + Buffer.from(bytes).toString("hex");
-}
-
-/**
- * SHA-256 hash of the raw session token. This is what gets stored in the
- * sessions table as the primary key. A DB leak does not expose valid tokens
- * because the token has 160 bits of entropy — brute-forcing the preimage
- * of SHA-256 is infeasible.
- */
-function hashSessionToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
-}
-
-/**
- * Public revocation handle for a session — first 16 hex chars of the
- * SHA-256 hash. 64 bits of collision resistance within a single account's
- * session list is more than enough; exposing the full hash would let a
- * log-capturing attacker DELETE sessions by guessing the URL.
- */
-function sessionHandleFromHash(sessionHash: string): string {
-  return sessionHash.slice(0, 16);
-}
-
-const EmailSchema = Schema.String.pipe(
-  Schema.filter((s) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s), {
-    message: () => "Invalid email",
-  }),
-);
-
-const HandleSchema = Schema.String.pipe(
-  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
-    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
-  }),
-);
-
-/**
- * User-chosen free-text nickname for a passkey. Trimmed client-side and here;
- * upper-bounded at 64 chars so a stored label fits inside any reasonable
- * settings-row display without having to `LIKE …%` truncate at read time.
- * Empty strings aren't valid — the caller should PATCH `null` to clear.
- */
-const PasskeyLabelSchema = Schema.String.pipe(
-  Schema.filter((s) => s.trim().length > 0 && s.length <= 64, {
-    message: () => "Passkey label must be 1–64 characters",
-  }),
-);
-
-/**
- * Normalises an identifier by stripping a leading @ sigil.
- * Users may type "@alice" meaning handle "alice"; this strips it before dispatch.
- */
-function normaliseIdentifier(identifier: string): string {
-  return identifier.startsWith("@") ? identifier.slice(1) : identifier;
-}
-
-/** Returns true if the (already-normalised) identifier looks like an email address. */
-function looksLikeEmail(identifier: string): boolean {
-  return identifier.includes("@");
-}
+export { genId, hashSessionToken, HandleSchema } from "./auth-helpers";
 
 /**
  * A session token envelope — the shape returned by `issueTokens` and consumed


### PR DESCRIPTION
## Summary
- Phase 1 of splitting the ~4,500-line `osn/api/src/services/auth.ts` into cohesive modules, per the plan in `[[wiki/architecture/auth-service-refactor]]`. **Behaviour-preserving — no logic changes.**
- Extracts the pure, state-free helpers (ID/token/OTP generation, JWT sign/verify, boundary schemas) into `services/auth-helpers.ts`; `auth.ts` imports them and re-exports the externally-consumed ones (`genId`, `hashSessionToken`, `HandleSchema`) so `../services/auth` stays the stable barrel.
- `auth.ts` 4,513 → 4,371 lines; new `auth-helpers.ts` 178 lines. All 714 `@osn/api` tests unchanged and green; typecheck + lint + format clean.

> **Stacked on #235** (the security-hardening branch) so this sits on top of the fixed `auth.ts` (incl. the rotation CAS) and doesn't re-conflict it. Base will retarget to `main` once #235 merges.

## Workspaces affected
- `@osn/api` (patch changeset added)

## Decisions & issues

**[approach] Phased, not big-bang**
- **Issue:** `auth.ts` is one ~3,600-line `createAuthService` closure whose ~40 methods cross-reference each other and share config/stores/private helpers.
- **Why:** A single-pass 11-module split of the crown-jewel auth service is high-risk — a subtle closure/dependency mistake could regress a security-critical path with all 714 tests still passing by luck.
- **Solution:** Split in verified slices. Phase 1 (this PR) extracts only the pure, closure-independent substrate — zero behaviour risk (pure moves + re-export shim), verified by the full test suite. The closure cluster extractions (tokens, sessions, step-up, recovery, email-change, cross-device, passkey-login/mgmt, registration, profiles) each need the shared-`ctx` pattern and are the subsequent phases.
- **Rationale:** Each slice stays independently reviewable and green; the barrel never changes, so no downstream importer moves. Matches the "one PR, one concern, green at every commit" guardrail in the plan.

**[approach] Barrel stability**
- **Issue:** `genId`, `hashSessionToken`, `HandleSchema` are imported from `../services/auth` by routes and tests.
- **Why:** Moving them to a sub-module would break those importers.
- **Solution:** `auth.ts` re-exports them (`export { genId, hashSessionToken, HandleSchema } from "./auth-helpers"`).
- **Rationale:** Keeps the public surface byte-identical; importers are untouched, proven by the unchanged, green test suite.

## Test plan
- [ ] `bun run --cwd osn/api check` (tsc clean)
- [ ] `bun run --cwd osn/api test:run` — 714 pass, unchanged from before the refactor
- [ ] Confirm no diff in `auth-helpers.ts` function bodies vs the originals (pure move)
- [ ] Follow-up phases (closure cluster extractions) tracked in `[[wiki/architecture/auth-service-refactor]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cmvdfFY7cpxFdNxbAM6xu

---
_Generated by [Claude Code](https://claude.ai/code/session_017cmvdfFY7cpxFdNxbAM6xu)_