### PR TITLE
Security hardening (rebased): ARC cache, origin-guard, org authz, rotation CAS, JWKS, deploy

### DIFF
--- a/.changeset/osn-arc-cache-issuer-binding.md
+++ b/.changeset/osn-arc-cache-issuer-binding.md
@@ -1,0 +1,22 @@
+---
+"@shared/crypto": patch
+"@osn/api": patch
+---
+
+Harden ARC S2S auth: bind the public-key cache to `(issuer, kid)` and fix Origin-guard S2S drift.
+
+The ARC public-key cache was keyed by `kid` alone, so a cache hit returned the
+key for whatever `issuer` the caller passed — silently skipping the
+`serviceId == issuer` DB binding that only runs on the miss path. The same
+forged-`iss` token was therefore rejected on a cold cache but accepted on a warm
+one. The cache is now keyed by `(issuer, kid)` so the binding holds on both
+paths; `evictPublicKeyCacheEntry` scans the composite keys. `verifyArcToken` now
+requires `exp`/`iat`/`iss`/`aud` via jose `requiredClaims` so a token minted
+without `exp` can never be treated as non-expiring.
+
+The Origin-guard's hardcoded S2S exemption list had drifted from the real
+internal route prefixes (`/internal/*` was unlisted and `/organisation-internal`
+matched no route), so in production every ARC POST to `/internal/*` was 403'd
+before ARC verification ran. The guard now exempts on the `Authorization: ARC`
+header (immune to route renames) with segment-boundary path matching as a
+secondary signal.

--- a/.changeset/osn-deploy-and-jwks-guards.md
+++ b/.changeset/osn-deploy-and-jwks-guards.md
@@ -1,0 +1,16 @@
+---
+"@pulse/api": patch
+"@osn/api": patch
+---
+
+Harden deployment posture and the Pulse Worker's JWKS scheme check.
+
+- Pulse's Workers entry now fails closed when `OSN_JWKS_URL` is missing or
+  plaintext `http://` in a non-local env (mirrors zap-api), so a misconfigured
+  JWKS URL can't let a network attacker serve a forged key set.
+- `workers_dev = false` on the top-level (env-less) wrangler configs for osn-api
+  and cire-api, and the `deploy` scripts are now `wrangler deploy --env
+  production`. A bare `wrangler deploy` (which binds the production D1 with a
+  local security posture) now fails loudly instead of publishing a public shadow
+  Worker. Real deploys go through `--env production`; CI migrations are
+  unaffected.

--- a/.changeset/osn-jwks-amplification.md
+++ b/.changeset/osn-jwks-amplification.md
@@ -1,0 +1,16 @@
+---
+"@shared/osn-auth-client": patch
+---
+
+Bound the JWKS negative cache and throttle forced refetches (amplification DoS).
+
+Two amplification vectors in the downstream token verifier:
+
+- The negative cache had no size cap, so an unauthenticated flood of tokens with
+  random `kid`s grew the map without bound (heap-exhaustion DoS). It is now
+  FIFO-bounded to NEGATIVE_CACHE_MAX_SIZE.
+- A valid-`kid`/bad-signature token forced an unconditional JWKS refetch, and
+  because kids are public an attacker could drive one upstream fetch per
+  request against the issuer's JWKS endpoint. Forced refetches are now throttled
+  to at most once per kid per cooldown window; a genuine key rotation is still
+  picked up by the first refetch in the window.

--- a/.changeset/osn-org-authz-hardening.md
+++ b/.changeset/osn-org-authz-hardening.md
@@ -1,0 +1,16 @@
+---
+"@osn/api": patch
+---
+
+Close org privilege-escalation via add/remove and gate the member roster.
+
+The owner-only role gate (`updateMemberRole`) was bypassable: `addMember` let
+any admin insert a target as `admin`, and `removeMember` let any admin remove
+other admins — so an admin could mint or strip admins via remove+add. Granting
+`admin` now requires the owner, and removing an admin now requires the owner;
+admins may still add and remove plain members.
+
+`GET /:handle/members` returned the full roster (handles, display names, roles)
+to any authenticated user with no membership check. It is now restricted to
+members of the org. If public org pages are desired later, gate on an explicit
+`organisations.visibility` flag rather than dropping the check.

--- a/.changeset/osn-refresh-rotation-cas.md
+++ b/.changeset/osn-refresh-rotation-cas.md
@@ -1,0 +1,14 @@
+---
+"@osn/api": patch
+---
+
+Make refresh-token rotation atomic (compare-and-swap on the old session).
+
+`refreshTokens` verified the session then deleted-old/inserted-new in a batch.
+Two concurrent refreshes presenting the same token both passed verification and
+both inserted a new session, leaving two live sessions in one family with reuse
+detection never firing. The old-session DELETE is now the CAS gate: rotation
+proceeds only while the old row still exists (rows-affected == 1); a 0-rows
+result means the token was already rotated out (concurrent refresh or replay),
+which is treated as C2 reuse — the whole family is revoked instead of minting a
+sibling session. Mirrors the recovery-code CAS already in this file.

--- a/cire/CLAUDE.md
+++ b/cire/CLAUDE.md
@@ -215,7 +215,7 @@ cd cire/api && bunx wrangler d1 migrations apply cire-db            # Production
 cd cire/api && bunx wrangler types                                  # Regenerate CF binding types
 
 # Deploy
-cd cire/api && bunx wrangler deploy                                 # Deploy API worker
+cd cire/api && bunx wrangler deploy --env production                # Deploy API worker (prod env — never bare `wrangler deploy`, which the config now blocks)
 bun run --cwd cire/web build && bunx wrangler pages deploy cire/web/dist
 
 # Versioning

--- a/cire/api/package.json
+++ b/cire/api/package.json
@@ -7,7 +7,7 @@
     "dev:wrangler": "wrangler dev",
     "build": "wrangler deploy --dry-run --outdir dist",
     "test": "bun test",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --env production",
     "types": "wrangler types"
   },
   "dependencies": {

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -3,6 +3,15 @@ main = "src/index.ts"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Refuse to publish the top-level (env-less) config to a *.workers.dev URL. This
+# block carries the PRODUCTION D1 binding but a local security posture
+# (WEB_ORIGIN=localhost, no prod secrets), so a bare `wrangler deploy` would
+# otherwise create a public shadow Worker with full read/write on prod guest
+# PII. With no top-level routes, a bare deploy now fails loudly. Real deploys go
+# through `--env production` (custom_domain routes below); CI's
+# `d1 migrations apply` still uses this block's DB binding and is unaffected.
+workers_dev = false
+
 # Scheduled expired-session sweep (C-M2/C-M15). Daily 04:00 UTC — off-peak for
 # the AU/EU guest audience, low contention with normal traffic. Sessions carry
 # a 30-day TTL so once-a-day pruning bounds the dead-row backlog to <1 day.

--- a/osn/api/package.json
+++ b/osn/api/package.json
@@ -7,7 +7,7 @@
     "dev": "bun run --watch src/local.ts",
     "dev:wrangler": "wrangler dev",
     "build": "wrangler deploy --dry-run --outdir ./dist",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --env production",
     "types": "wrangler types",
     "start": "bun run src/local.ts",
     "check": "tsc --noEmit",

--- a/osn/api/src/lib/origin-guard.ts
+++ b/osn/api/src/lib/origin-guard.ts
@@ -17,8 +17,27 @@ import { metricOriginGuardRejection } from "../metrics";
 /** HTTP methods that change state and require Origin validation. */
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-/** URL path prefixes that use S2S ARC tokens, not cookies. */
-const S2S_PREFIXES = ["/graph/internal", "/organisation-internal"];
+/**
+ * URL path prefixes that use S2S ARC tokens, not cookies. Matched on a segment
+ * boundary (prefix must be followed by `/` or end-of-path) so a future route
+ * like `/graph/internal-x` is NOT silently exempted. Kept as a secondary signal
+ * only — the load-bearing exemption is the `Authorization: ARC` header below,
+ * which cannot drift when a route is renamed.
+ *
+ * These MUST stay in sync with the internal route factories mounted in
+ * `app.ts`: `/graph/internal` (graph-internal), `/organisations/internal`
+ * (organisation-internal), `/internal` (internal-account).
+ */
+const S2S_PREFIXES = ["/graph/internal", "/organisations/internal", "/internal"];
+
+/** True when `path` equals a prefix or continues it at a segment boundary. */
+function matchesS2sPrefix(path: string): boolean {
+  return S2S_PREFIXES.some((prefix) => {
+    if (!path.startsWith(prefix)) return false;
+    const next = path.charAt(prefix.length);
+    return next === "" || next === "/" || next === "?";
+  });
+}
 
 export interface OriginGuardConfig {
   /** Allowed origins (from OSN_CORS_ORIGIN). Empty = skip validation (dev mode). */
@@ -37,11 +56,22 @@ export function createOriginGuard(config: OriginGuardConfig) {
     // Skip for non-state-changing methods (GET, HEAD, OPTIONS)
     if (!STATE_CHANGING_METHODS.has(request.method)) return;
 
-    // Skip for S2S endpoints — they use ARC tokens, not cookies.
-    // P-W1: extract pathname without full URL parse to avoid per-request allocation.
+    // Skip for S2S calls. These carry `Authorization: ARC <token>` and no
+    // cookie, so they are not a CSRF vector (a browser cannot attach the ARC
+    // header AND send our cookies cross-origin — the header forces a CORS
+    // preflight our allowlist rejects). Keying the exemption on the ARC header
+    // rather than a hardcoded path list means a renamed internal route can
+    // never silently lose its exemption (or, worse, a cookie route can never
+    // accidentally gain one). The internal routes still verify the ARC token
+    // cryptographically, so skipping Origin here grants nothing on its own.
+    const authorization = request.headers.get("authorization");
+    if (authorization && /^ARC\s/i.test(authorization)) return;
+
+    // Secondary path-based signal (segment-boundary matched). P-W1: extract
+    // pathname without a full URL parse to avoid a per-request allocation.
     const pathStart = request.url.indexOf("/", request.url.indexOf("//") + 2);
     const path = pathStart >= 0 ? request.url.slice(pathStart) : request.url;
-    if (S2S_PREFIXES.some((prefix) => path.startsWith(prefix))) return;
+    if (matchesS2sPrefix(path)) return;
 
     // In dev mode (no allowlist configured), skip validation
     if (config.allowedOrigins.size === 0) return;

--- a/osn/api/src/routes/organisation.ts
+++ b/osn/api/src/routes/organisation.ts
@@ -388,6 +388,16 @@ export function createOrganisationRoutes(
           const organisation = await resolveOrg(params.handle, set);
           if (!organisation) return { error: "Organisation not found" };
 
+          // Least-privilege: the full roster (handles, display names, roles) is
+          // visible only to members of the org, not to any authenticated user.
+          // If public org pages are ever wanted, gate this on an explicit
+          // `organisations.visibility` flag rather than dropping the check.
+          const callerRole = await run(org.getMemberRole(organisation.id, caller.profileId));
+          if (!callerRole) {
+            set.status = 403;
+            return { error: "Forbidden" };
+          }
+
           try {
             const list = await run(org.listMembers(organisation.id, parsePagination(query)));
             return {

--- a/osn/api/src/services/auth/tokens.ts
+++ b/osn/api/src/services/auth/tokens.ts
@@ -5,7 +5,6 @@
 
 import { sessions } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
-import { commitBatch } from "@shared/db-utils";
 import { desc, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 
@@ -425,28 +424,53 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
 
       const { db } = yield* Db;
       // Read the old session's metadata up front (D1 has no interactive
-      // transaction), then delete-old + insert-new commit as one atomic batch so
-      // the family never has zero rows mid-rotation.
+      // transaction) so the rotated-in row keeps the device's UA label + IP hash.
       const existing = yield* Effect.tryPromise({
         try: () => db.select().from(sessions).where(eq(sessions.id, oldSessionId)).limit(1),
         catch: (cause) => new DatabaseError({ cause }),
       });
       const old = existing[0];
+
+      // CAS gate (S-M refresh-rotation): the old-session DELETE is the atomic
+      // compare-and-swap. Two concurrent refreshes of the same token both pass
+      // verification, but only one DELETE observes the row present (rows-affected
+      // == 1) and proceeds to insert; the loser sees 0 rows — the token was
+      // already rotated out (concurrent refresh or replay), which is treated as
+      // C2 reuse: revoke the whole family instead of minting a sibling session.
+      // Mirrors the recovery-code CAS already used in this service.
+      const delResult = yield* Effect.tryPromise({
+        try: () => db.delete(sessions).where(eq(sessions.id, oldSessionId)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      const rotated =
+        (delResult as unknown as { changes?: number; rowsAffected?: number }).changes ??
+        (delResult as unknown as { changes?: number; rowsAffected?: number }).rowsAffected ??
+        0;
+
+      if (rotated === 0) {
+        metricSessionReuseDetected();
+        yield* Effect.logWarning("Session rotation CAS lost — revoking family");
+        yield* Effect.tryPromise({
+          try: () => db.delete(sessions).where(eq(sessions.familyId, familyId)),
+          catch: (cause) => new DatabaseError({ cause }),
+        });
+        yield* trackRotatedSession(oldSessionId, familyId).pipe(Effect.catchAll(() => Effect.void));
+        metricSessionFamilyRevoked();
+        return yield* Effect.fail(new AuthError({ message: "Invalid or expired session" }));
+      }
+
       yield* Effect.tryPromise({
         try: () =>
-          commitBatch(db, [
-            db.delete(sessions).where(eq(sessions.id, oldSessionId)),
-            db.insert(sessions).values({
-              id: newSessionId,
-              accountId,
-              familyId,
-              expiresAt: nowSec + refreshTokenTtl,
-              createdAt: nowSec,
-              uaLabel: old?.uaLabel ?? null,
-              ipHash: old?.ipHash ?? null,
-              lastUsedAt: nowSec,
-            }),
-          ]),
+          db.insert(sessions).values({
+            id: newSessionId,
+            accountId,
+            familyId,
+            expiresAt: nowSec + refreshTokenTtl,
+            createdAt: nowSec,
+            uaLabel: old?.uaLabel ?? null,
+            ipHash: old?.ipHash ?? null,
+            lastUsedAt: nowSec,
+          }),
         catch: (cause) => new DatabaseError({ cause }),
       });
 

--- a/osn/api/src/services/organisation.ts
+++ b/osn/api/src/services/organisation.ts
@@ -357,6 +357,13 @@ export function createOrganisationService() {
       if (callerMember.length === 0) {
         return yield* Effect.fail(new OrgError({ message: "Only admins can add members" }));
       }
+      // Only the owner may grant admin. Without this, any admin could mint new
+      // admins (or promote a colluding account) via add — the same privilege
+      // change `updateMemberRole` restricts to the owner, so the two paths must
+      // agree or the owner-only gate is bypassable through remove+add.
+      if (role === "admin" && orgRows[0].ownerId !== callerId) {
+        return yield* Effect.fail(new OrgError({ message: "Only the owner can grant admin" }));
+      }
       if (targetRows.length === 0) {
         return yield* Effect.fail(new OrgError({ message: "Target profile not found" }));
       }
@@ -442,6 +449,13 @@ export function createOrganisationService() {
 
       if (targetMember.length === 0) {
         return yield* Effect.fail(new NotFoundError({ message: "Member not found" }));
+      }
+
+      // Only the owner may remove an admin. Without this, any admin could strip
+      // rival admins (or, paired with add, demote them) — again bypassing the
+      // owner-only role gate. Admins may still remove plain members.
+      if (targetMember[0].role === "admin" && orgRows[0].ownerId !== callerId) {
+        return yield* Effect.fail(new OrgError({ message: "Only the owner can remove an admin" }));
       }
 
       yield* Effect.tryPromise({

--- a/osn/api/tests/lib/origin-guard.test.ts
+++ b/osn/api/tests/lib/origin-guard.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect } from "vitest";
 import { createOriginGuard } from "../../src/lib/origin-guard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeContext(method: string, url: string, origin?: string): any {
+function makeContext(method: string, url: string, origin?: string, authorization?: string): any {
   const headers = new Headers();
   if (origin) headers.set("origin", origin);
+  if (authorization) headers.set("authorization", authorization);
 
   return {
     request: new Request(url, { method, headers }),
@@ -35,10 +36,34 @@ describe("createOriginGuard", () => {
     expect(result).toBeUndefined();
   });
 
-  it("allows POST to S2S organisation-internal endpoints", () => {
-    const ctx = makeContext("POST", "http://localhost:4000/organisation-internal/members");
+  it("allows POST to S2S /organisations/internal endpoints", () => {
+    const ctx = makeContext("POST", "http://localhost:4000/organisations/internal/members");
     const result = guard(ctx);
     expect(result).toBeUndefined();
+  });
+
+  it("allows POST to S2S /internal endpoints (step-up verify, app-enrollment)", () => {
+    const ctx = makeContext("POST", "http://localhost:4000/internal/step-up/verify");
+    const result = guard(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("exempts any POST carrying an Authorization: ARC header, regardless of path", () => {
+    const ctx = makeContext(
+      "POST",
+      "http://localhost:4000/internal/app-enrollment/leave",
+      undefined,
+      "ARC eyJhbGciOiJFUzI1NiJ9.payload.sig",
+    );
+    const result = guard(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("does NOT exempt a look-alike route that only shares a prefix substring", () => {
+    const ctx = makeContext("POST", "http://localhost:4000/internal-looking/thing");
+    const result = guard(ctx) as { error: string };
+    expect(ctx.set.status).toBe(403);
+    expect(result.error).toBe("forbidden");
   });
 
   it("allows POST with matching Origin", () => {

--- a/osn/api/tests/routes/organisation.test.ts
+++ b/osn/api/tests/routes/organisation.test.ts
@@ -449,6 +449,30 @@ describe("organisation routes", () => {
     expect(bobMember?.role).toBe("member");
   });
 
+  it("GET /organisations/:handle/members → 403 for a non-member", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const mallory = await registerAndGetToken("mallory@example.com", "mallory");
+
+    await orgApp.handle(
+      new Request("http://localhost/organisations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${alice.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ handle: "acme", name: "Acme Corp" }),
+      }),
+    );
+
+    // Mallory is authenticated but not a member — the roster must not leak.
+    const res = await orgApp.handle(
+      new Request("http://localhost/organisations/acme/members", {
+        headers: { Authorization: `Bearer ${mallory.token}` },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
   it("POST /organisations/:handle/members/:profileHandle → 404 for unknown profile", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
 

--- a/osn/api/tests/services/organisation.test.ts
+++ b/osn/api/tests/services/organisation.test.ts
@@ -267,6 +267,32 @@ describe("addMember", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("owner can grant admin", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerProfile("bob@example.com", "bob");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "admin");
+      const role = yield* org.getMemberRole(organisation.id, bob.id);
+      expect(role).toBe("admin");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("non-owner admin cannot grant admin (owner-only role gate)", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerProfile("bob@example.com", "bob");
+      const carol = yield* registerProfile("carol@example.com", "carol");
+      // Owner makes bob an admin; bob then tries to mint another admin.
+      yield* org.addMember(organisation.id, alice.id, bob.id, "admin");
+      const error = yield* Effect.flip(org.addMember(organisation.id, bob.id, carol.id, "admin"));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner");
+      // ...but bob CAN still add a plain member.
+      yield* org.addMember(organisation.id, bob.id, carol.id, "member");
+      expect(yield* org.getMemberRole(organisation.id, carol.id)).toBe("member");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("fails when org does not exist", () =>
     Effect.gen(function* () {
       const alice = yield* registerProfile("alice@example.com", "alice");
@@ -320,6 +346,35 @@ describe("removeMember", () => {
       const bob = yield* registerProfile("bob@example.com", "bob");
       const error = yield* Effect.flip(org.removeMember(organisation.id, alice.id, bob.id));
       expect(error._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("non-owner admin cannot remove another admin", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerProfile("bob@example.com", "bob");
+      const carol = yield* registerProfile("carol@example.com", "carol");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "admin");
+      yield* org.addMember(organisation.id, alice.id, carol.id, "admin");
+      // bob (admin, not owner) tries to strip fellow admin carol.
+      const error = yield* Effect.flip(org.removeMember(organisation.id, bob.id, carol.id));
+      expect(error._tag).toBe("OrgError");
+      expect(error.message).toContain("owner");
+      // The owner still can.
+      yield* org.removeMember(organisation.id, alice.id, carol.id);
+      expect(yield* org.getMemberRole(organisation.id, carol.id)).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("admin can still remove a plain member", () =>
+    Effect.gen(function* () {
+      const { alice, organisation } = yield* setupOrgWithOwner;
+      const bob = yield* registerProfile("bob@example.com", "bob");
+      const carol = yield* registerProfile("carol@example.com", "carol");
+      yield* org.addMember(organisation.id, alice.id, bob.id, "admin");
+      yield* org.addMember(organisation.id, alice.id, carol.id, "member");
+      yield* org.removeMember(organisation.id, bob.id, carol.id);
+      expect(yield* org.getMemberRole(organisation.id, carol.id)).toBeNull();
     }).pipe(Effect.provide(createTestLayer())),
   );
 

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -3,6 +3,14 @@ main = "src/index.ts"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Refuse to publish the top-level (env-less) config to a *.workers.dev URL. The
+# top-level block is the local `wrangler dev` posture (OSN_ENV=local: ephemeral
+# JWT keys, in-memory rate limiters, non-Secure cookies), so a bare
+# `wrangler deploy` would expose a public identity API in dev posture. With no
+# top-level routes a bare deploy now fails loudly. Real deploys use
+# `--env production` (custom_domain route below).
+workers_dev = false
+
 # osn-api now runs on Cloudflare Workers via `export default { fetch, scheduled }`
 # in `src/index.ts` (Phase 6). The Bun dev server (`src/local.ts`) is unchanged
 # and remains the default fast devloop (`bun run dev`); `wrangler dev` is the

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -72,6 +72,14 @@ const misconfigured = (detail: string): Response =>
 function buildApp(env: Env): App {
   const secure = !!env.OSN_ENV && env.OSN_ENV !== "local";
 
+  // S-H (mirrors zap-api): fetching JWKS over plaintext HTTP in a deployed env
+  // lets any process with network access serve a forged key set and mint
+  // acceptable access tokens. Fail closed on a missing/plaintext URL.
+  const jwksUrl = env.OSN_JWKS_URL;
+  if (secure && (!jwksUrl || jwksUrl.startsWith("http://"))) {
+    throw new Error("OSN_JWKS_URL must be set and use HTTPS in non-local environments");
+  }
+
   // CORS allowlist — fail closed in non-local envs where PULSE_CORS_ORIGIN is
   // unset (an empty allowlist in a secure env is a misconfiguration).
   const corsOrigins = resolveCorsOrigins({ PULSE_CORS_ORIGIN: env.PULSE_CORS_ORIGIN }, secure);
@@ -81,7 +89,7 @@ function buildApp(env: Env): App {
 
   return createApp({
     dbLayer: makeDbD1Live(env.DB as D1Database),
-    jwksUrl: env.OSN_JWKS_URL,
+    jwksUrl,
     rateLimiters,
     clientIpConfig: resolveClientIpConfig(env),
     corsOrigins,

--- a/shared/crypto/src/arc.ts
+++ b/shared/crypto/src/arc.ts
@@ -113,6 +113,13 @@ export async function verifyArcToken(
     const { payload } = await jwtVerify(token, publicKey, {
       algorithms: [ARC_ALG],
       audience: expectedAudience,
+      // Defense-in-depth: require the temporal + identity claims to be present
+      // so a token minted without `exp` can never be treated as non-expiring.
+      // We deliberately keep clock tolerance at jose's default (0): ARC tokens
+      // are ≤5-min first-party S2S bearer tokens between NTP-synced Cloudflare
+      // services, so a tolerance window would only widen a stolen token's life
+      // for no real drift benefit.
+      requiredClaims: ["exp", "iat", "iss", "aud"],
       // X1: when expectedIssuer is set, jose enforces `iss` matches —
       // cryptographically binding the signed issuer to the kid→issuer DB row.
       ...(expectedIssuer ? { issuer: expectedIssuer } : {}),
@@ -172,6 +179,17 @@ const publicKeyCache = new Map<
 const publicKeyLastAccess = new Map<string, number>();
 
 /**
+ * Composite cache key. Keying by `kid` ALONE would let a cache hit return a key
+ * for whatever `issuer` the caller passed — silently skipping the
+ * `serviceId == issuer` DB binding that only runs on the miss path, so a token
+ * whose signed `iss` differs from the kid's registered owner would be rejected
+ * on a cache miss but accepted on a cache hit. Keying by `(issuer, kid)` makes
+ * the binding hold on both paths. The `\n` separator can appear in neither a
+ * kid (RFC 7638 thumbprint / UUID) nor a service id, so keys are unambiguous.
+ */
+const pkCacheKey = (issuer: string, kid: string): string => `${issuer}\n${kid}`;
+
+/**
  * Public-key cache TTL (seconds). Bounds the cross-process key-revocation
  * window (X4): an in-process call to `evictPublicKeyCacheEntry(kid)` on the
  * revoking node is immediate (S-H100), but *other* nodes that already cached
@@ -207,7 +225,8 @@ export const resolvePublicKey = (
 
     // Cache hit path — validate scopes against stored allowedScopes so we
     // never skip scope enforcement even when tokenScopes is omitted (S-M102).
-    const cached = publicKeyCache.get(kid);
+    const pkKey = pkCacheKey(issuer, kid);
+    const cached = publicKeyCache.get(pkKey);
     if (cached && cached.expiresAt > now) {
       if (tokenScopes && tokenScopes.length > 0) {
         for (const s of tokenScopes) {
@@ -223,7 +242,7 @@ export const resolvePublicKey = (
       // LRU touch: record access time in ms (P-W1). Side-map write is O(1)
       // and avoids Map delete+re-insert on the hot cache-hit path. Using
       // Date.now() (ms) gives sub-second precision for test determinism.
-      publicKeyLastAccess.set(kid, Date.now());
+      publicKeyLastAccess.set(pkKey, Date.now());
       metricArcPublicKeyCacheHit(issuer);
       return cached.key;
     }
@@ -305,12 +324,12 @@ export const resolvePublicKey = (
         publicKeyLastAccess.delete(lruKid);
       }
     }
-    publicKeyCache.set(kid, {
+    publicKeyCache.set(pkKey, {
       key,
       allowedScopes: new Set(normaliseScopes(allowedScopes)),
       expiresAt: now + PUBLIC_KEY_CACHE_TTL_SECONDS,
     });
-    publicKeyLastAccess.set(kid, Date.now());
+    publicKeyLastAccess.set(pkKey, Date.now());
 
     return key;
   });
@@ -324,13 +343,22 @@ export function clearPublicKeyCache(): void {
 }
 
 /**
- * Evicts a single entry from the public key cache by `kid`.
- * Call immediately after revoking a key so the revocation takes effect in
- * this process without waiting for the 5-minute cache TTL to expire (S-H100).
+ * Evicts every cached entry for a `kid` by scanning for the composite
+ * `(issuer, kid)` keys that end in `\n${kid}`. A kid is registered to exactly
+ * one service, so at most one entry matches — but revocation is keyed on kid
+ * only, and the cache is now keyed on `(issuer, kid)`, so we resolve the issuer
+ * side by suffix. O(n) over a ≤256-entry cache, and only on the rare
+ * revocation path. Call immediately after revoking a key so the revocation
+ * takes effect in this process without waiting for the cache TTL (S-H100).
  */
 export function evictPublicKeyCacheEntry(kid: string): void {
-  publicKeyCache.delete(kid);
-  publicKeyLastAccess.delete(kid);
+  const suffix = `\n${kid}`;
+  for (const key of publicKeyCache.keys()) {
+    if (key.endsWith(suffix)) {
+      publicKeyCache.delete(key);
+      publicKeyLastAccess.delete(key);
+    }
+  }
 }
 
 /** Returns the current public key cache size. Useful for testing. */

--- a/shared/crypto/src/recovery.ts
+++ b/shared/crypto/src/recovery.ts
@@ -10,12 +10,18 @@ import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
  * # Threat model
  *
  * Recovery codes unlock a full session if all passkeys are lost. The server
- * stores only SHA-256(code) — a database leak does not expose usable codes
- * because the preimage space is 2^64, well beyond feasible brute force per
- * hash with the salt provided by the prefix. We deliberately skip a
- * memory-hard KDF here: unlike user-chosen passwords these are uniformly
- * random high-entropy secrets, so SHA-256 is appropriate (same reasoning as
- * session tokens in `[[sessions]]`).
+ * stores only SHA-256(code) — no salt, because these are uniformly random
+ * high-entropy secrets, not user-chosen passwords, so a per-code salt buys
+ * nothing against a targeted preimage search and a memory-hard KDF is
+ * unnecessary (same reasoning as session tokens in `[[sessions]]`). A DB leak
+ * does not immediately expose usable codes: the preimage space is 2^64 and
+ * every code is single-use + wiped-and-rotated on consumption.
+ *
+ * Residual risk (tracked, not yet closed): 64 bits behind a single fast hash
+ * is within reach of a well-resourced offline attacker who exfiltrates the
+ * full table and targets one account. Raising the code to 128 bits (32 hex
+ * chars) closes this at a typing-UX cost — deferred as a product decision, and
+ * partly mitigated already by the per-account recovery-code lockout counter.
  *
  * # Code format
  *

--- a/shared/crypto/tests/arc.test.ts
+++ b/shared/crypto/tests/arc.test.ts
@@ -729,6 +729,53 @@ describe("resolvePublicKey", () => {
       expect(error.message).toContain("Unknown or invalid key");
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  // S-review: a warm cache entry for (kid, ownerIss) must NOT satisfy a lookup
+  // for the SAME kid under a DIFFERENT issuer. The cache is keyed by
+  // (issuer, kid), so a cross-issuer lookup misses the cache and falls through
+  // to the `serviceId == issuer` DB binding, which finds no row → rejection.
+  // Guards against the kid-only-keyed cache defeating the kid→issuer binding.
+  effectIt.effect("cache hit for one issuer does not satisfy another issuer's lookup", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const keyPair = yield* Effect.promise(() => generateArcKeyPair());
+      const jwk = yield* Effect.promise(() => exportKeyToJwk(keyPair.publicKey));
+      const now = new Date();
+      const keyId = "shared-kid";
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(serviceAccounts).values({
+            serviceId: "owner-svc",
+            allowedScopes: "graph:read",
+            createdAt: now,
+            updatedAt: now,
+          }),
+        catch: (e) => new ArcTokenError({ message: "insert failed", cause: e }),
+      });
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(serviceAccountKeys).values({
+            keyId,
+            serviceId: "owner-svc",
+            publicKeyJwk: jwk,
+            registeredAt: now,
+            expiresAt: null,
+            revokedAt: null,
+          }),
+        catch: (e) => new ArcTokenError({ message: "insert key failed", cause: e }),
+      });
+
+      // Warm the cache for the legitimate owner.
+      const ownerKey = yield* resolvePublicKey(keyId, "owner-svc");
+      expect(ownerKey).toBeDefined();
+
+      // Same kid, forged issuer — must be rejected, not served from cache.
+      const error = yield* Effect.flip(resolvePublicKey(keyId, "victim-svc"));
+      expect(error._tag).toBe("ArcTokenError");
+      expect(error.message).toContain("Unknown or invalid key");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/shared/osn-auth-client/src/jwks-cache.ts
+++ b/shared/osn-auth-client/src/jwks-cache.ts
@@ -35,6 +35,17 @@ const JWKS_FETCH_TIMEOUT_MS = 5000;
 // P-W2: realistic key-rotation scenarios will never exceed single digits;
 // cap prevents heap exhaustion from JWTs with crafted kid values.
 const CACHE_MAX_SIZE = 256;
+// S-review: the negative cache MUST also be bounded. Unknown/junk kids each
+// insert a distinct entry, so an unauthenticated flood of random-`kid` tokens
+// would otherwise grow the map without limit (heap-exhaustion DoS). FIFO-evict
+// the oldest entry once the cap is reached.
+const NEGATIVE_CACHE_MAX_SIZE = 1024;
+// S-review (M-A): minimum spacing between forced JWKS refetches for the SAME
+// kid. A valid-`kid`/bad-signature token forces a rotation refetch; because
+// kids are public, an attacker could otherwise drive one upstream fetch per
+// request. One forced refetch per kid per window is enough to pick up a genuine
+// rotation while capping the amplification factor.
+const FORCED_REFRESH_COOLDOWN_MS = NEGATIVE_TTL_MS;
 
 interface CachedKey {
   key: CryptoKey;
@@ -46,8 +57,19 @@ const cache = new Map<string, CachedKey>();
 const lastAccess = new Map<string, number>();
 /** Negative cache: cacheKey -> timestamp the negative result was recorded. */
 const negativeCache = new Map<string, number>();
+/** Forced-refresh throttle: cacheKey -> timestamp of the last forced refetch. */
+const lastForcedRefresh = new Map<string, number>();
 /** Single-flight: in-flight JWKS fetches keyed by jwksUrl. */
 const inFlight = new Map<string, Promise<unknown[]>>();
+
+/** Records a negative-cache entry, FIFO-evicting the oldest when at capacity. */
+function recordNegative(ck: string): void {
+  if (!negativeCache.has(ck) && negativeCache.size >= NEGATIVE_CACHE_MAX_SIZE) {
+    const oldest = negativeCache.keys().next().value;
+    if (oldest !== undefined) negativeCache.delete(oldest);
+  }
+  negativeCache.set(ck, Date.now());
+}
 
 /** S-M3: include jwksUrl in cache key to isolate keys by issuer. */
 function cacheKey(kid: string, jwksUrl: string): string {
@@ -103,7 +125,7 @@ async function fetchPublicKey(kid: string, jwksUrl: string): Promise<CryptoKey |
   try {
     keys = await fetchJwksKeys(jwksUrl);
   } catch {
-    negativeCache.set(cacheKey(kid, jwksUrl), Date.now());
+    recordNegative(cacheKey(kid, jwksUrl));
     return null;
   }
 
@@ -113,14 +135,14 @@ async function fetchPublicKey(kid: string, jwksUrl: string): Promise<CryptoKey |
   );
 
   if (!jwk) {
-    negativeCache.set(cacheKey(kid, jwksUrl), Date.now());
+    recordNegative(cacheKey(kid, jwksUrl));
     return null;
   }
 
   try {
     return await importKeyFromJwk(jwk);
   } catch {
-    negativeCache.set(cacheKey(kid, jwksUrl), Date.now());
+    recordNegative(cacheKey(kid, jwksUrl));
     return null;
   }
 }
@@ -179,6 +201,21 @@ export async function refreshPublicKeyForKid(
   jwksUrl: string,
 ): Promise<CryptoKey | null> {
   const ck = cacheKey(kid, jwksUrl);
+  const now = Date.now();
+
+  // S-review (M-A): throttle forced refetches per kid. A valid-`kid`/bad-sig
+  // token reaches here; without a throttle an attacker (kids are public) drives
+  // one upstream JWKS fetch per request. If we forced a refetch for this kid
+  // within the cooldown, skip the network call and return whatever is cached
+  // (the caller re-verifies; a bad-sig token still fails). A genuine rotation is
+  // still picked up by the first refetch in the window.
+  const last = lastForcedRefresh.get(ck);
+  if (last !== undefined && now - last < FORCED_REFRESH_COOLDOWN_MS) {
+    const cached = cache.get(ck);
+    return cached ? cached.key : null;
+  }
+  lastForcedRefresh.set(ck, now);
+
   negativeCache.delete(ck);
   const key = await fetchPublicKey(kid, jwksUrl);
   if (key) storeInCache(ck, key);
@@ -190,5 +227,6 @@ export function clearJwksCache(): void {
   cache.clear();
   lastAccess.clear();
   negativeCache.clear();
+  lastForcedRefresh.clear();
   inFlight.clear();
 }

--- a/shared/osn-auth-client/tests/jwks-cache.test.ts
+++ b/shared/osn-auth-client/tests/jwks-cache.test.ts
@@ -176,6 +176,26 @@ describe("jwks-cache", () => {
     expect(calls.get(URL_1)).toBe(2);
   });
 
+  it("M-A: a second forced refresh for the same kid within cooldown does NOT re-fetch", async () => {
+    routes.set(URL_1, [jwkA]);
+    await resolvePublicKeyForKid("shared-kid", URL_1);
+    expect(calls.get(URL_1)).toBe(1);
+
+    // First forced refresh hits upstream (rotation pickup) and updates the cache.
+    const refreshed = await refreshPublicKeyForKid("shared-kid", URL_1);
+    expect(calls.get(URL_1)).toBe(2);
+
+    // A flood of further bad-sig-driven refreshes for the same kid within the
+    // cooldown must be throttled — no additional upstream fetches, and the
+    // cached key is returned so the caller can re-verify (and still reject a
+    // genuinely bad signature).
+    for (let i = 0; i < 20; i++) {
+      const k = await refreshPublicKeyForKid("shared-kid", URL_1);
+      expect(k).toBe(refreshed);
+    }
+    expect(calls.get(URL_1)).toBe(2);
+  });
+
   it("LRU eviction at CACHE_MAX_SIZE (256)", async () => {
     // Distinct cache keys via distinct urls; one shared kid + jwk per url.
     routes = new Map();


### PR DESCRIPTION
Rebases the still-needed security hardening from #235 onto current `main`. #235
went stale/conflicting after ~3 weeks of auth/roles work landed (notably the full
`auth.ts` → `auth/` modularization, the S-M5 client-IP erasure fix via #239, and
the cire co-host roles PR #251). This PR carries over **only the sub-changes main
does not already have**, re-applied against the current code, and drops the two
that main superseded. **Do not merge #235 in favour of this — a human should
review and close #235.**

## Per-sub-change verdict

| Sub-change | Verdict | Notes |
|---|---|---|
| `osn-arc-cache-issuer-binding` | **KEPT** (clean cherry-pick) | Main still keys the ARC public-key cache by `kid` alone (`publicKeyCache.get(kid)`) and still has the drifted `S2S_PREFIXES = ["/graph/internal", "/organisation-internal"]`. Re-applied: composite `(issuer, kid)` cache key, `requiredClaims: [exp,iat,iss,aud]` on `verifyArcToken`, `Authorization: ARC` header origin-guard exemption + segment-boundary path match. Verified the updated `S2S_PREFIXES` (`/graph/internal`, `/organisations/internal`, `/internal`) exactly match main's current route mounts in `app.ts`. |
| `osn-org-authz-hardening` | **KEPT** (clean cherry-pick) | Main's `organisation.ts` still lacks the owner-gate on granting/removing `admin` (only "Only admins can add members"), and `GET /:handle/members` still calls `listMembers` with no membership check. Re-applied both owner-gates + roster gate (`getMemberRole` → 403). `caller.profileId` matches main's `requireAuth` shape. |
| `osn-refresh-rotation-cas` | **KEPT** (manual re-apply — conflict resolved) | Original patched the monolithic `auth.ts`, which no longer exists (main modularized into `services/auth/`). Manually re-applied the CAS gate into `services/auth/tokens.ts::refreshTokens`, which on main still uses the racy `commitBatch(delete+insert)`. The old-session DELETE is now the CAS gate; 0 rows ⇒ C2 reuse ⇒ family revoke (via existing `metricSessionReuseDetected` / `metricSessionFamilyRevoked` / `trackRotatedSession`). Removed the now-unused `commitBatch` import. |
| `osn-jwks-amplification` | **KEPT** (clean cherry-pick) | Main's `jwks-cache.ts` negative cache is still unbounded and `refreshPublicKeyForKid` is still unconditional. Re-applied: FIFO-bounded negative cache (1024) + per-kid forced-refetch cooldown. |
| `osn-deploy-and-jwks-guards` | **KEPT — partially redundant** (clean cherry-pick) | Deploy half still needed: main's deploy scripts were bare `wrangler deploy` and top-level wrangler configs lacked `workers_dev = false`. Now `--env production` + `workers_dev = false` (bare deploy fails loudly; verified top-level configs carry no routes). Pulse half: the branch guard lives in `pulse/api/src/index.ts` (the deployed Workers entry, `main = src/index.ts`) which on main has **no** JWKS guard — so still needed. Note main independently added an equivalent guard to `pulse/api/src/local.ts` (the local `process.env` entry); that is a *different* entrypoint, so this is not a duplicate. |
| `osn-auth-refactor-helpers` | **DROPPED — superseded** | The branch's "Phase 1: extract pure helpers into `auth-helpers.ts`" is subsumed by main's full decomposition of `auth.ts` into a `services/auth/` module (`index.ts`, `tokens.ts`, `helpers.ts`, `profiles.ts`, …). `services/auth/helpers.ts` already exports `genId`, `hashSessionToken`, `signJwt`, `verifyJwt`, etc. Re-applying would conflict/regress. |
| `osn-erasure-ip-keying` | **DROPPED — superseded** | Landed on `main` via #239 ("Code-quality sweep … S-M5"). Main's `account-erasure.ts` already uses `getClientIp(headers, { ...clientIpConfig, socketIp })` + `isUnresolvedIp` deny + `socketIpOf`, and `app.ts` threads `clientIpConfig` into `createAccountErasureRoutes`. Identical intent. |

## Needs human judgement (not in this PR)

- **cire `CLAIM_RATE_LIMITER` fail-closed boot guard** (branch commit `26842c5a`) — bundled in #235 but has **no changeset** (cire/api is version-less) so it is outside the 7 osn-* sub-changes this rebase scopes to. It is *still needed* (main's `cire/api/src/index.ts` still silently falls back to an in-memory limiter when the binding is absent). **However** the surrounding cire code moved substantially (#249–#252): the binding now guards multiple surfaces (claim / account-link / invite), the `handler`/`origins`/cache-shape context the patch depended on has drifted, and the "is prod" heuristic (`origins.some(startsWith https)`) may no longer be the right signal. Re-applying risks changing security behaviour, so per the brief I stopped rather than guess. Recommend a human port it against current `index.ts`.

## Verification (all green on this branch)

- `shared/crypto` 72 · `shared/osn-auth-client` 34 · `osn/api` 752 · `pulse/api` 541 · `cire/api` 839 — all pass (incl. the cross-issuer cache-hit rejection, ARC missing-`exp`, origin-guard `/internal/*` + look-alike-prefix, org role gates + roster 403, JWKS negative-cache bound + refetch cooldown).
- `bun run check` 20/20 typecheck · `bun run lint` exit 0 (only pre-existing unrelated a11y warnings) · `bun run fmt:check` clean · `bun run build` 11/11.

## Not fully verified / flagged

- The rotation-CAS **CAS-lost branch has no direct test** (T-E3 in #235 was deferred as needing a production test seam). The logic mirrors #235's reviewed patch 1:1 and the happy-path rotation + reuse-detection tests pass, but the 0-rows revoke path is exercised only indirectly. A human may want a deterministic concurrent-refresh test before merge.
- `scripts/validate-changesets.sh` uses `mapfile` (bash 4+) and did not run in this shell; the 5 changesets were manually verified to reference only versioned packages (no ignored/`@cire` mixing), so they satisfy the rule CI enforces.

## Files changed
`shared/crypto/src/arc.ts`, `shared/crypto/src/recovery.ts` (docstring), `shared/osn-auth-client/src/jwks-cache.ts`, `osn/api/src/lib/origin-guard.ts`, `osn/api/src/services/organisation.ts`, `osn/api/src/routes/organisation.ts`, `osn/api/src/services/auth/tokens.ts`, `pulse/api/src/index.ts`, `osn/api/wrangler.toml`, `cire/api/wrangler.toml`, `osn/api/package.json`, `cire/api/package.json`, `cire/CLAUDE.md`, + 5 changesets + their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
