### PR TITLE
fix(cire/organiser): dedupe Overview countdown + themed date picker

### DIFF
--- a/.changeset/cire-overview-dedupe-date-picker.md
+++ b/.changeset/cire-overview-dedupe-date-picker.md
@@ -1,0 +1,18 @@
+---
+"@cire/organiser": patch
+---
+
+Two organiser-portal UI-polish tweaks from the product-owner IA review.
+
+- **Overview countdown de-dupe** — the wedding-date countdown printed the day
+  count twice (a big number and, redundantly, a "N days to go" line). It now
+  shows the count once: the big number with "days to go" / "days ago" as its
+  label beneath it. The "No date yet" empty-state, singular/plural handling, and
+  the "Today!" / "Tomorrow!" / past-date edge cases are preserved.
+- **Themed calendar date picker in Settings** — the wedding date is now edited
+  with a custom `DatePicker` (a month-grid calendar built on the existing
+  Kobalte `Popover` primitive — Kobalte 0.13 ships no DatePicker, so this adds
+  **no new dependency**) styled to the portal's gold/bordered aesthetic instead
+  of a plain native date input. It keeps the `YYYY-MM-DD | null` contract the
+  settings API already uses (no payload change), is keyboard-navigable with grid
+  ARIA roles and focus management, and renders read-only for co-hosts.

--- a/cire/organiser/src/components/DatePicker.test.tsx
+++ b/cire/organiser/src/components/DatePicker.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import DatePicker from "./DatePicker";
+
+/**
+ * DatePicker is the custom-on-Kobalte-Popover month-grid calendar that replaced
+ * the bare native `<input type="date">` in Settings. It must keep the
+ * `YYYY-MM-DD | null` round-trip contract SettingsPanel + the settings API speak:
+ * emit a `YYYY-MM-DD` string on a pick, `null` on clear, handle an unset value,
+ * be keyboard-navigable, and render read-only (no popover) for co-hosts.
+ */
+describe("DatePicker", () => {
+  afterEach(cleanup);
+
+  it("shows a placeholder trigger when unset and opens the grid on click", async () => {
+    render(() => <DatePicker label="Wedding date" value={null} onChange={() => {}} />);
+    const trigger = screen.getByLabelText(/Wedding date, no date set/);
+    expect(trigger.textContent).toContain("Pick a date");
+
+    fireEvent.click(trigger);
+    // The month grid appears once open.
+    await waitFor(() => expect(screen.getByRole("grid")).toBeTruthy());
+  });
+
+  it("surfaces the current date on the trigger when set", () => {
+    render(() => <DatePicker label="Wedding date" value="2027-03-20" onChange={() => {}} />);
+    // Long form, in the organiser's local calendar (no UTC day-shift).
+    expect(screen.getByText(/20 March 2027/)).toBeTruthy();
+  });
+
+  it("emits YYYY-MM-DD when a day cell is clicked", async () => {
+    const onChange = vi.fn();
+    render(() => <DatePicker label="Wedding date" value="2027-03-20" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/20 March 2027/));
+    await waitFor(() => expect(screen.getByRole("grid")).toBeTruthy());
+
+    // Pick the 25th of the shown month (March 2027 — seeded from the value).
+    fireEvent.click(screen.getByRole("gridcell", { name: /25 March 2027/ }));
+    expect(onChange).toHaveBeenCalledWith("2027-03-25");
+  });
+
+  it("navigates days with the arrow keys and selects with Enter", async () => {
+    const onChange = vi.fn();
+    render(() => <DatePicker label="Wedding date" value="2027-03-20" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/20 March 2027/));
+    const grid = await waitFor(() => screen.getByRole("grid"));
+
+    // From the 20th, ArrowRight → 21st, ArrowDown → +7 → 28th, then Enter selects.
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    fireEvent.keyDown(grid, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("2027-03-28");
+  });
+
+  it("moves across a month boundary with the arrow keys", async () => {
+    const onChange = vi.fn();
+    // 31 March 2027 → ArrowRight lands on 1 April 2027 (next month).
+    render(() => <DatePicker label="Wedding date" value="2027-03-31" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/31 March 2027/));
+    const grid = await waitFor(() => screen.getByRole("grid"));
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    fireEvent.keyDown(grid, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("2027-04-01");
+  });
+
+  it("pages to the next month with the header button", async () => {
+    const onChange = vi.fn();
+    render(() => <DatePicker label="Wedding date" value="2027-03-20" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/20 March 2027/));
+    await waitFor(() => expect(screen.getByRole("grid")).toBeTruthy());
+    fireEvent.click(screen.getByLabelText("Next month"));
+
+    // April now shown — pick its 5th.
+    await waitFor(() =>
+      expect(screen.getByRole("gridcell", { name: /\b5 April 2027/ })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("gridcell", { name: /\b5 April 2027/ }));
+    expect(onChange).toHaveBeenCalledWith("2027-04-05");
+  });
+
+  it("emits null when 'Clear date' is clicked", async () => {
+    const onChange = vi.fn();
+    render(() => <DatePicker label="Wedding date" value="2027-03-20" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/20 March 2027/));
+    const clear = await waitFor(() => screen.getByText("Clear date"));
+    fireEvent.click(clear);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("has no 'Clear date' control when unset", async () => {
+    render(() => <DatePicker label="Wedding date" value={null} onChange={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Wedding date, no date set/));
+    await waitFor(() => expect(screen.getByRole("grid")).toBeTruthy());
+    expect(screen.queryByText("Clear date")).toBeNull();
+  });
+
+  it("renders read-only (no popover) for a co-host", () => {
+    render(() => (
+      <DatePicker label="Wedding date" value="2027-03-20" onChange={() => {}} readOnly />
+    ));
+    expect(screen.getByText(/20 March 2027/)).toBeTruthy();
+    // No interactive trigger — a co-host can't open a picker.
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("read-only shows a placeholder when the date is unset", () => {
+    render(() => <DatePicker label="Wedding date" value={null} onChange={() => {}} readOnly />);
+    expect(screen.getByText(/No date set/)).toBeTruthy();
+  });
+
+  it("reflects an external value change on the trigger", async () => {
+    const [value, setValue] = createSignal<string | null>("2027-03-20");
+    render(() => <DatePicker label="Wedding date" value={value()} onChange={() => {}} />);
+    expect(screen.getByText(/20 March 2027/)).toBeTruthy();
+
+    setValue("2027-06-14");
+    await waitFor(() => expect(screen.getByText(/14 June 2027/)).toBeTruthy());
+  });
+});

--- a/cire/organiser/src/components/DatePicker.tsx
+++ b/cire/organiser/src/components/DatePicker.tsx
@@ -1,0 +1,371 @@
+import { Popover } from "@kobalte/core/popover";
+import { createEffect, createSignal, For, Show } from "solid-js";
+
+/**
+ * A themed calendar date picker built on the Kobalte `Popover` primitive —
+ * Kobalte 0.13 ships NO DatePicker, so this is a small self-contained month grid
+ * rather than a new dependency. It mirrors `ColorPicker.tsx`'s shape (a trigger
+ * button showing the current value + a popover panel holding the picker) and
+ * reuses the portal's gold/bordered aesthetic (the same tokens SettingsPanel's
+ * `inputClass` uses).
+ *
+ * Contract: the date round-trips as a `YYYY-MM-DD` string (or `null` when unset),
+ * exactly what SettingsPanel + the settings API already speak — no change to
+ * `buildBody()` / the PUT payload. `onChange` emits `YYYY-MM-DD` on a pick or
+ * `null` when the organiser clears it.
+ *
+ * Accessibility: the grid is a `role="grid"` of `role="gridcell"` day buttons
+ * with a `role="columnheader"` weekday row; arrow keys move day-by-day (a full
+ * roving-focus month, wrapping across weeks + months), Enter/Space selects, Esc
+ * closes (Kobalte's Popover handles Esc + focus return to the trigger). Focus
+ * lands on the selected (or today's) day when the panel opens.
+ *
+ * Read-only mode (co-hosts, per SettingsPanel's owner-only gate): no popover —
+ * just the formatted date (or an em-dash placeholder), so the same call-site can
+ * render both without branching.
+ */
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] as const;
+
+/** Parse a `YYYY-MM-DD` string into a LOCAL calendar date, or null if malformed.
+ *  Local (not UTC) so the grid + selection match the organiser's own calendar,
+ *  the same choice Overview's countdown makes. */
+function parseIso(value: string | null): Date | null {
+  if (!value) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const date = new Date(Number(y), Number(mo) - 1, Number(d));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** A local Date → `YYYY-MM-DD` (no timezone shift — `toISOString` would). */
+function toIso(date: Date): string {
+  const y = String(date.getFullYear()).padStart(4, "0");
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${d}`;
+}
+
+/** Human-readable long form for the trigger + read-only view. */
+function formatLong(date: Date): string {
+  return new Intl.DateTimeFormat("en-AU", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/** The Sunday-anchored grid of dates covering the month `cursor` sits in — a
+ *  leading run of trailing-previous-month days, the month itself, then enough
+ *  next-month days to fill the final week (a 6×7 = 42-cell grid, so the panel
+ *  height never jumps between months). */
+function monthGrid(cursor: Date): Date[] {
+  const first = new Date(cursor.getFullYear(), cursor.getMonth(), 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
+  return Array.from({ length: 42 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+}
+
+export default function DatePicker(props: {
+  label: string;
+  value: string | null;
+  onChange: (v: string | null) => void;
+  /** Co-hosts see the date read-only (SettingsPanel's owner-only gate). */
+  readOnly?: boolean;
+  /** Disable the trigger while a save is in flight (mirrors SettingsPanel). */
+  disabled?: boolean;
+}) {
+  const selected = () => parseIso(props.value);
+
+  // The month the grid is showing. Seeded from the value (or today), and
+  // re-seeded when the popover opens so a cleared/changed value lands the grid on
+  // the right month. `focusedIso` drives roving focus within the open grid.
+  const [cursor, setCursor] = createSignal(selected() ?? startOfDay(new Date()));
+  const [open, setOpen] = createSignal(false);
+  const [focusedIso, setFocusedIso] = createSignal<string | null>(null);
+  let gridRef: HTMLDivElement | undefined;
+
+  // When the panel opens, land the cursor + roving focus on the selected day
+  // (or today), then move DOM focus onto that cell so arrow keys work at once.
+  createEffect(() => {
+    if (!open()) return;
+    const anchor = selected() ?? startOfDay(new Date());
+    setCursor(anchor);
+    setFocusedIso(toIso(anchor));
+    queueMicrotask(() => {
+      const cell = gridRef?.querySelector<HTMLButtonElement>('[data-focused="true"]');
+      cell?.focus();
+    });
+  });
+
+  const monthLabel = () =>
+    new Intl.DateTimeFormat("en-AU", { month: "long", year: "numeric" }).format(cursor());
+
+  const shiftMonth = (delta: number) => {
+    const next = new Date(cursor().getFullYear(), cursor().getMonth() + delta, 1);
+    setCursor(next);
+  };
+
+  const commit = (date: Date) => {
+    props.onChange(toIso(date));
+    setOpen(false);
+  };
+
+  /** Move roving focus by `deltaDays`, following into the next/previous month if
+   *  the target day falls outside the visible one. */
+  const moveFocus = (deltaDays: number) => {
+    const base = parseIso(focusedIso()) ?? cursor();
+    const next = new Date(base);
+    next.setDate(base.getDate() + deltaDays);
+    if (next.getMonth() !== cursor().getMonth() || next.getFullYear() !== cursor().getFullYear()) {
+      setCursor(new Date(next.getFullYear(), next.getMonth(), 1));
+    }
+    setFocusedIso(toIso(next));
+    queueMicrotask(() => {
+      gridRef?.querySelector<HTMLButtonElement>('[data-focused="true"]')?.focus();
+    });
+  };
+
+  const onGridKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowLeft":
+        e.preventDefault();
+        moveFocus(-1);
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        moveFocus(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        moveFocus(-7);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        moveFocus(7);
+        break;
+      case "Home":
+        e.preventDefault();
+        moveFocus(-(parseIso(focusedIso()) ?? cursor()).getDay());
+        break;
+      case "End":
+        e.preventDefault();
+        moveFocus(6 - (parseIso(focusedIso()) ?? cursor()).getDay());
+        break;
+      case "PageUp":
+        e.preventDefault();
+        shiftMonth(-1);
+        break;
+      case "PageDown":
+        e.preventDefault();
+        shiftMonth(1);
+        break;
+      case "Enter":
+      case " ": {
+        e.preventDefault();
+        const focused = parseIso(focusedIso());
+        if (focused) commit(focused);
+        break;
+      }
+    }
+  };
+
+  // ── Read-only: co-hosts just see the formatted date, no popover. ──────────
+  if (props.readOnly) {
+    return (
+      <div class="flex flex-col gap-1.5">
+        <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
+          {props.label}
+        </span>
+        <p class="font-body text-text border-border bg-bg/50 rounded-sm border px-3 py-2 text-[0.95rem] opacity-70">
+          <Show when={selected()} fallback={<span class="opacity-60">No date set</span>}>
+            {(d) => formatLong(d())}
+          </Show>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div class="flex flex-col gap-1.5">
+      <span class="font-body text-text-muted text-[0.72rem] tracking-[0.1em] uppercase">
+        {props.label}
+      </span>
+      <Popover open={open()} onOpenChange={setOpen} gutter={8} placement="bottom-start">
+        <Popover.Trigger
+          aria-label={`${props.label}${selected() ? `: ${formatLong(selected()!)}` : ", no date set"}`}
+          disabled={props.disabled}
+          class="border-border bg-bg font-body text-text hover:border-gold focus-visible:border-gold focus-visible:ring-gold/40 flex items-center justify-between gap-2 rounded-sm border px-3 py-2 text-left text-[0.95rem] transition-colors outline-none focus-visible:ring-2 disabled:opacity-40"
+        >
+          <Show
+            when={selected()}
+            fallback={<span class="text-text-muted italic opacity-60">Pick a date…</span>}
+          >
+            {(d) => <span>{formatLong(d())}</span>}
+          </Show>
+          <svg
+            class="text-gold-dim h-4 w-4 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            aria-hidden="true"
+          >
+            <rect x="3" y="4.5" width="18" height="16" rx="2" />
+            <path d="M3 9h18M8 2.5v4M16 2.5v4" stroke-linecap="round" />
+          </svg>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content class="border-border bg-surface-raised z-50 flex w-64 flex-col gap-3 rounded-sm border p-3 shadow-lg outline-none">
+            {/* ── Month header: prev / label / next ─────────────────────── */}
+            <div class="flex items-center justify-between gap-2">
+              <button
+                type="button"
+                aria-label="Previous month"
+                onClick={() => shiftMonth(-1)}
+                class="border-border text-text-muted hover:border-gold hover:text-gold flex h-7 w-7 items-center justify-center rounded-sm border transition-colors"
+              >
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  aria-hidden="true"
+                >
+                  <path d="M15 6l-6 6 6 6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+              <span class="font-body text-text text-[0.85rem] tracking-[0.04em]">
+                {monthLabel()}
+              </span>
+              <button
+                type="button"
+                aria-label="Next month"
+                onClick={() => shiftMonth(1)}
+                class="border-border text-text-muted hover:border-gold hover:text-gold flex h-7 w-7 items-center justify-center rounded-sm border transition-colors"
+              >
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  aria-hidden="true"
+                >
+                  <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+            </div>
+
+            {/* ── Weekday header row ────────────────────────────────────── */}
+            <div
+              role="grid"
+              tabindex={-1}
+              aria-label={monthLabel()}
+              class="flex flex-col gap-1 outline-none"
+              ref={gridRef}
+              onKeyDown={onGridKeyDown}
+            >
+              <div role="row" class="grid grid-cols-7 gap-1">
+                <For each={WEEKDAYS}>
+                  {(wd) => (
+                    <span
+                      role="columnheader"
+                      class="font-body text-text-muted flex h-6 items-center justify-center text-[0.62rem] tracking-[0.08em] uppercase"
+                    >
+                      {wd}
+                    </span>
+                  )}
+                </For>
+              </div>
+
+              {/* ── Day cells (6 weeks × 7) ─────────────────────────────── */}
+              <For each={Array.from({ length: 6 }, (_, w) => w)}>
+                {(week) => (
+                  <div role="row" class="grid grid-cols-7 gap-1">
+                    <For each={monthGrid(cursor()).slice(week * 7, week * 7 + 7)}>
+                      {(day) => {
+                        const iso = toIso(day);
+                        const inMonth = () => day.getMonth() === cursor().getMonth();
+                        const isSelected = () => {
+                          const s = selected();
+                          return s ? sameDay(s, day) : false;
+                        };
+                        const isToday = () => sameDay(startOfDay(new Date()), day);
+                        const isFocused = () => focusedIso() === iso;
+                        return (
+                          <button
+                            type="button"
+                            role="gridcell"
+                            data-focused={isFocused() ? "true" : undefined}
+                            aria-label={formatLong(day)}
+                            aria-selected={isSelected()}
+                            aria-current={isToday() ? "date" : undefined}
+                            tabindex={isFocused() ? 0 : -1}
+                            onClick={() => commit(day)}
+                            classList={{
+                              "flex h-8 w-8 items-center justify-center rounded-sm text-[0.8rem] tabular-nums outline-none transition-colors focus-visible:ring-2 focus-visible:ring-gold/50": true,
+                              "bg-gold text-bg font-medium": isSelected(),
+                              "text-text hover:bg-gold/15": !isSelected() && inMonth(),
+                              "text-text-muted opacity-40 hover:opacity-70":
+                                !isSelected() && !inMonth(),
+                              "ring-1 ring-gold/40": isToday() && !isSelected(),
+                            }}
+                          >
+                            {day.getDate()}
+                          </button>
+                        );
+                      }}
+                    </For>
+                  </div>
+                )}
+              </For>
+            </div>
+
+            {/* ── Clear / today shortcuts ───────────────────────────────── */}
+            <div class="flex items-center justify-between gap-2 pt-0.5">
+              <button
+                type="button"
+                onClick={() => commit(startOfDay(new Date()))}
+                class="font-body text-gold-dim hover:text-gold text-[0.72rem] underline-offset-4 transition-colors hover:underline"
+              >
+                Today
+              </button>
+              <Show when={selected()}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    props.onChange(null);
+                    setOpen(false);
+                  }}
+                  class="font-body text-text-muted hover:text-text text-[0.72rem] underline-offset-4 transition-colors hover:underline"
+                >
+                  Clear date
+                </button>
+              </Show>
+            </div>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover>
+    </div>
+  );
+}

--- a/cire/organiser/src/components/Overview.test.tsx
+++ b/cire/organiser/src/components/Overview.test.tsx
@@ -141,6 +141,19 @@ describe("Overview", () => {
 
     // Countdown: ~30 days out (allow ±1 for the local-midnight rounding boundary).
     await waitFor(() => expect(screen.getByText(/days to go/i)).toBeTruthy());
+    // The day count is shown ONCE (a headline number + a "days to go" label) —
+    // no second line repeating the same figure (product-owner de-dupe). The exact
+    // count floats ±1 across the local-midnight boundary, so read whatever the
+    // headline renders and assert no OTHER element on the page holds that same
+    // bare number (the old markup printed it twice: a big "30" + "30 days to go").
+    const headline = screen
+      .getByText(/days to go/i)
+      .closest("div")!
+      .querySelector(".tabular-nums")!;
+    const count = headline.textContent!.trim();
+    expect(count).toMatch(/^\d+$/);
+    // getAllByText(exact) matches only elements whose OWN text is exactly `count`.
+    expect(screen.getAllByText(count, { exact: true })).toHaveLength(1);
     // RSVP roll-up: attending = 6 + 4 = 10 across 2 events.
     expect(screen.getByText(/attending across 2 events/i)).toBeTruthy();
     // Households deduped from the repeated-per-member rows: fam_a + fam_b = 2.

--- a/cire/organiser/src/components/Overview.tsx
+++ b/cire/organiser/src/components/Overview.tsx
@@ -248,21 +248,35 @@ export default function Overview(props: {
                     >
                       {(() => {
                         const days = countdown()!;
-                        const label =
-                          days > 1
-                            ? `${days} days to go`
-                            : days === 1
-                              ? "Tomorrow!"
-                              : days === 0
-                                ? "Today!"
-                                : `${Math.abs(days)} ${Math.abs(days) === 1 ? "day" : "days"} ago`;
-                        return (
-                          <>
-                            <p class="font-display text-gold text-[2rem] leading-none font-light tabular-nums">
-                              {days >= 0 ? days : `+${Math.abs(days)}`}
+                        // Show the count ONCE: a headline number/word with a single
+                        // label beneath it (no separate "N days to go" line that
+                        // repeats the same figure). "Tomorrow!"/"Today!" and past
+                        // dates read as words with no redundant numeral above them.
+                        if (days === 0) {
+                          return (
+                            <p class="font-display text-gold text-[2rem] leading-none font-light">
+                              Today!
                             </p>
-                            <p class="font-body text-text text-[0.9rem]">{label}</p>
-                          </>
+                          );
+                        }
+                        if (days === 1) {
+                          return (
+                            <p class="font-display text-gold text-[2rem] leading-none font-light">
+                              Tomorrow!
+                            </p>
+                          );
+                        }
+                        const abs = Math.abs(days);
+                        const unit = abs === 1 ? "day" : "days";
+                        return (
+                          <div class="flex flex-col gap-0.5">
+                            <p class="font-display text-gold text-[2rem] leading-none font-light tabular-nums">
+                              {abs}
+                            </p>
+                            <p class="font-body text-text text-[0.9rem]">
+                              {days > 0 ? `${unit} to go` : `${unit} ago`}
+                            </p>
+                          </div>
                         );
                       })()}
                     </Show>

--- a/cire/organiser/src/components/SettingsPanel.test.tsx
+++ b/cire/organiser/src/components/SettingsPanel.test.tsx
@@ -75,7 +75,9 @@ describe("SettingsPanel", () => {
     expect(screen.getByText("aisha-and-ben")).toBeTruthy();
     expect(screen.queryByDisplayValue("aisha-and-ben")).toBeNull();
     expect(screen.getByText(/can.t be changed/)).toBeTruthy();
-    expect(screen.getByDisplayValue("2027-03-20")).toBeTruthy();
+    // The date is edited through the custom DatePicker (a Popover trigger showing
+    // the formatted date), not a native <input type="date">.
+    expect(screen.getByText(/20 March 2027/)).toBeTruthy();
     expect(screen.getByDisplayValue("120")).toBeTruthy();
     // Budget renders in whole-currency units (minor / 100).
     expect(screen.getByDisplayValue("45000")).toBeTruthy();
@@ -109,6 +111,28 @@ describe("SettingsPanel", () => {
       displayName: "Aisha & Benjamin",
       slug: "aisha-and-ben",
     });
+  });
+
+  it("saves a date picked through the DatePicker", async () => {
+    authFetchMock.mockResolvedValueOnce(json({ wedding: PROFILE }));
+    render(() => <SettingsPanel weddingId="wed_1" canManage />);
+    await waitFor(() => expect(screen.getByDisplayValue("Aisha & Ben")).toBeTruthy());
+
+    // Open the DatePicker (its trigger shows the current formatted date) and pick
+    // a new day in the shown month (March 2027, seeded from the loaded profile).
+    fireEvent.click(screen.getByText(/20 March 2027/));
+    await waitFor(() => expect(screen.getByRole("grid")).toBeTruthy());
+    fireEvent.click(screen.getByRole("gridcell", { name: /28 March 2027/ }));
+
+    authFetchMock.mockResolvedValueOnce(
+      json({ wedding: { ...PROFILE, weddingDate: "2027-03-28" } }),
+    );
+    fireEvent.click(screen.getByText("Save settings"));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("Settings saved"));
+    const [, init] = authFetchMock.mock.calls[1] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.weddingDate).toBe("2027-03-28");
   });
 
   it("sends nulls for cleared optional fields", async () => {

--- a/cire/organiser/src/components/SettingsPanel.tsx
+++ b/cire/organiser/src/components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { createSignal, onMount, Show } from "solid-js";
 import { toast } from "solid-toast";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import DatePicker from "./DatePicker";
 import SectionIntro from "./SectionIntro";
 
 /** The wedding profile as the settings API reads/writes it. Location is
@@ -212,19 +213,20 @@ export default function SettingsPanel(props: SettingsPanelProps) {
               </span>
             </div>
 
-            <label class="flex flex-col gap-1.5">
-              <span class={labelClass}>Wedding date</span>
-              <input
-                type="date"
-                value={weddingDate()}
-                onInput={(e) => setWeddingDate(e.currentTarget.value)}
-                disabled={disabled()}
-                class={inputClass}
+            <div class="flex flex-col gap-1.5">
+              <DatePicker
+                label="Wedding date"
+                value={weddingDate() || null}
+                onChange={(v) => setWeddingDate(v ?? "")}
+                readOnly={readOnly()}
+                disabled={saving()}
               />
-              <span class={hintClass}>
-                Leave this empty if you haven&apos;t set a date yet — you can add it any time.
-              </span>
-            </label>
+              <Show when={!readOnly()}>
+                <span class={hintClass}>
+                  Leave this empty if you haven&apos;t set a date yet — you can add it any time.
+                </span>
+              </Show>
+            </div>
 
             <label class="flex flex-col gap-1.5">
               <span class={labelClass}>Expected guests</span>

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -4,7 +4,7 @@ tags: [todo, web]
 related:
   - "[[index]]"
   - "[[invite-builder]]"
-last-reviewed: 2026-07-05
+last-reviewed: 2026-07-15
 ---
 
 # cire/web
@@ -27,6 +27,7 @@ Completed feature history is archived in `[[changelog/completed-features]]` (Mig
 
 Full history in `[[changelog/completed-features]]`.
 
+- [x] **Overview countdown de-dupe + themed Settings date picker** (`fix/cire-overview-dedupe-date-picker`) — two product-owner IA-review tweaks: (1) the Overview countdown printed the day count twice (a big number *and* a "N days to go" line); collapsed to a single presentation — the big number with "days to go"/"days ago" as its label, keeping the "No date yet" empty-state + Today!/Tomorrow! + past-date edge cases. (2) SettingsPanel's plain `<input type="date">` is replaced by a new custom `DatePicker.tsx` — a themed month-grid calendar built on the existing Kobalte `Popover` primitive (Kobalte 0.13 has no DatePicker; **no new dependency**), mirroring `ColorPicker.tsx`'s trigger+panel shape and the portal's gold/bordered tokens. Keeps the `YYYY-MM-DD | null` contract (no `buildBody()`/PUT change); keyboard-navigable (`role="grid"`, arrow keys wrap across weeks/months, Enter/Space selects, Esc closes, focus lands on selected/today on open); co-hosts get the read-only formatted-date view. Tests: `DatePicker.test.tsx` (open, pick→emit, keyboard nav incl. month boundary, clear/null, unset, read-only), Overview count-once assertion, SettingsPanel save-through-picker. **Wants a real-browser eyeball** — the popover calendar + gold styling render in a real browser, not happy-dom.
 - [x] **Guest event card renders date + venue purely from canonical fields** (`refactor/cire-retire-deprecated-event-cols`) — `EventCard.tsx` no longer reads the deprecated `EventSummary.date` / `.location` (both removed from the type + the `/api/claim` response). The day now comes from `formatEventDay(startAt, timezone)` and the venue from `venueLine(address)` (rendered inside a `<Show>` so a venue-less event simply omits the line). `event-details.ts` `venueLine` / `resolveMapsUrl` / `resolveMapsEmbedUrl` dropped their `location` fallback (address-only); `calendar.ts` ICS/Google `location` now derives from `address`; the dead `formatDate` util + its tests were removed. `EventCard.test.tsx` proves the render is from `startAt`/`address` (and omits the line when address is null). See `[[db]]`.
 
 - [x] **Personalised greeting — individuals vs families** (`feat/cire-individual-greeting`) — the post-claim greeting in `LoginSection.tsx` now branches on household size: a code covering exactly ONE guest is greeted as an individual ("Dear {name}") instead of "The {familyName} Family"; multi-guest codes keep the family greeting + member list. An optional "Guest Nickname" CSV column (→ `guests.nickname`, migration 0022) overrides the displayed first name for the individual case (blank/whitespace ⇒ first name). Threaded CSV → schema → import diff → `/api/claim` members → `FamilyMember.nickname`. New `LoginSection.test.tsx` covers family vs individual vs nickname vs blank-nickname. See `[[db]]` + `[[spreadsheet-import]]` + `[[api]]`.


### PR DESCRIPTION
Two small UI-polish tweaks from the product-owner review of the just-merged portal IA (#252), scoped to the organiser portal.

## 1 — Overview countdown de-dupe
The wedding-date countdown printed the day count **twice** — a big headline number and, redundantly, a "N days to go" line repeating the same figure. It now shows the count **once**: the big number with "days to go" / "days ago" as its label beneath it. Preserved: the "No date yet" empty-state, singular/plural (1 day vs N days), and the "Today!" / "Tomorrow!" / past-date edge cases (these render as words with no redundant numeral above them). The full formatted date line stays as the sub-label.

## 2 — Themed calendar date picker in Settings
SettingsPanel's plain `<input type="date">` is replaced by a new custom **`DatePicker.tsx`**.

- **Custom-on-Kobalte-Popover, no new dependency** — Kobalte 0.13.11 ships no DatePicker, so this is a small self-contained month grid built on the existing Kobalte `Popover` primitive, mirroring `ColorPicker.tsx`'s trigger-button + popover-panel shape. Styled to the portal's gold/bordered aesthetic (reuses the same tokens as SettingsPanel's `inputClass`).
- **Same contract** — takes/returns the date as a `YYYY-MM-DD` string (or `null`), exactly what SettingsPanel + the settings API already use. No change to `buildBody()` / the PUT payload. Handles empty/unset gracefully.
- **Accessibility** — `role="grid"` with `role="row"` / `role="columnheader"` / `role="gridcell"`; arrow keys move day-by-day (wrapping across weeks and months), Home/End jump to week edges, PageUp/PageDown page months, Enter/Space selects, Esc closes (Kobalte returns focus to the trigger). Focus lands on the selected day (or today) when the panel opens.
- **Owner-only** — co-hosts see a read-only formatted-date view (no popover), respecting SettingsPanel's existing gate.

## Tests
- `DatePicker.test.tsx` — opens, pick→emits `YYYY-MM-DD`, keyboard nav (incl. a month-boundary move), clear→`null`, unset placeholder, read-only view.
- `Overview.test.tsx` — asserts the day count renders exactly once.
- `SettingsPanel.test.tsx` — still saves the date, now through the picker.

## Verification
`bun run --cwd cire/organiser test:run` (272 passed), `bun run check`, `bun run lint`, `bun run build --filter=@cire/organiser` — all green.

⚠️ **Wants a real-browser eyeball** — the popover calendar layout, gold styling, and focus behaviour render in a real browser, not happy-dom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)