### PR TITLE
fix(cire/api): fail-closed CLAIM_RATE_LIMITER in deployed tiers

### DIFF
--- a/.changeset/cire-claim-ratelimiter-fail-closed.md
+++ b/.changeset/cire-claim-ratelimiter-fail-closed.md
@@ -1,0 +1,23 @@
+---
+"@cire/api": patch
+---
+
+Fail-closed when the `CLAIM_RATE_LIMITER` native binding is missing in a deployed tier.
+
+The Worker entry (`cire/api/src/index.ts`) read the native Workers rate-limit
+binding for the pre-auth guest claim endpoint and, when absent, **silently fell
+back to a per-isolate in-memory limiter**. Because that limiter is per-isolate it
+gives almost no real cross-request protection, so a misconfigured/missing binding
+silently downgraded the claim-code brute-force defence (small keyspace) with no
+signal — the wrangler foot-gun where named envs don't inherit the top-level
+`[[unsafe.bindings]]`.
+
+Now the binding is REQUIRED in any deployed tier: when it's absent and the tier
+(from `OSN_ENV`, via `@shared/observability` `loadConfig` — the same signal that
+drives the log level) is `dev`/`staging`/`production`, the edge handler
+`Effect.logError`s and refuses with a 503 on every cold isolate, mirroring the
+Turnstile / `weddingMember` fail-closed convention. The `local` tier keeps the
+in-memory fallback so `bun run dev` and bun:sqlite tests boot without the binding.
+The prod Worker declares the binding under `[env.production.unsafe.bindings]` in
+`wrangler.toml`, so the guard only trips on a genuine misconfiguration. Regression
+tests cover local→fallback, deployed→503, and binding-present→native.

--- a/cire/api/src/index.test.ts
+++ b/cire/api/src/index.test.ts
@@ -21,10 +21,18 @@ let savedOsnEnv: string | undefined;
 
 const MF_HOOK_TIMEOUT_MS = 30_000;
 
+// A stand-in for the native Workers rate-limit binding — matches
+// `WorkersRateLimitBinding` (`{ limit({ key }): Promise<{ success }> }`).
+// `success: true` = never limited, which is all these boot tests need.
+const fakeRateLimiter = { limit: async () => ({ success: true }) };
+
 const BASE_ENV = {
   WEB_ORIGIN: "https://app.example.com",
   OSN_JWKS_URL: "https://id.example.com/.well-known/jwks.json",
   OSN_AUDIENCE: "osn-access",
+  // Deployed-tier boots now REQUIRE the claim rate-limit binding (fail-closed);
+  // supply it so these tests exercise the happy boot path, not the guard.
+  CLAIM_RATE_LIMITER: fakeRateLimiter,
 };
 
 const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext;
@@ -82,6 +90,7 @@ describe("Worker boot (no bootstrap-owner config)", () => {
       DB,
       OSN_JWKS_URL: BASE_ENV.OSN_JWKS_URL,
       OSN_AUDIENCE: BASE_ENV.OSN_AUDIENCE,
+      CLAIM_RATE_LIMITER: fakeRateLimiter,
     } as unknown as Parameters<typeof handler.fetch>[1];
     const res = await handler.fetch!(
       new Request("https://api.example.com/api/organiser/weddings"),
@@ -89,5 +98,59 @@ describe("Worker boot (no bootstrap-owner config)", () => {
       ctx,
     );
     expect(res.status).toBe(503);
+  });
+});
+
+// C1/C4 fail-closed guard: the native claim rate-limit binding is MANDATORY in
+// any deployed tier. Absent, createApp would silently fall back to a per-isolate
+// in-memory limiter — no real cross-request brute-force defence on the guest
+// claim endpoint. The guard 503s at the edge in a deployed tier, but keeps the
+// in-memory fallback in `local` so `bun run dev` / tests boot without it.
+// Tier is read from OSN_ENV (via @shared/observability loadConfig), so these
+// tests drive it by toggling process.env.OSN_ENV inside each case.
+describe("CLAIM_RATE_LIMITER fail-closed guard", () => {
+  const runFetch = (env: Record<string, unknown>) =>
+    handler.fetch!(
+      new Request("https://api.example.com/api/organiser/weddings"),
+      { DB, ...env } as unknown as Parameters<typeof handler.fetch>[1],
+      ctx,
+    );
+
+  it("fail-closes 503 in a deployed tier when the binding is absent", async () => {
+    process.env.OSN_ENV = "production";
+    const { CLAIM_RATE_LIMITER: _omit, ...withoutBinding } = BASE_ENV;
+    void _omit;
+    const res = await runFetch(withoutBinding);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: "Worker misconfigured: missing CLAIM_RATE_LIMITER binding",
+    });
+  });
+
+  it("also fail-closes 503 in the `dev` deployed tier when the binding is absent", async () => {
+    process.env.OSN_ENV = "dev";
+    const { CLAIM_RATE_LIMITER: _omit, ...withoutBinding } = BASE_ENV;
+    void _omit;
+    const res = await runFetch(withoutBinding);
+    expect(res.status).toBe(503);
+  });
+
+  it("boots (in-memory fallback) in the `local` tier when the binding is absent", async () => {
+    process.env.OSN_ENV = "local";
+    const { CLAIM_RATE_LIMITER: _omit, ...withoutBinding } = BASE_ENV;
+    void _omit;
+    const res = await runFetch(withoutBinding);
+    // Not the guard's 503 — the app boots and the route's own auth gate answers
+    // 401 (no token), proving the in-memory fallback path was taken locally.
+    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(401);
+  });
+
+  it("boots (native binding) in a deployed tier when the binding is present", async () => {
+    process.env.OSN_ENV = "production";
+    const res = await runFetch(BASE_ENV);
+    // Binding present ⇒ no guard 503; app boots and the route answers 401.
+    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(401);
   });
 });

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -1,3 +1,4 @@
+import { loadConfig } from "@shared/observability/config";
 import { createWorkersRateLimiter } from "@shared/rate-limit";
 import type { WorkersRateLimitBinding } from "@shared/rate-limit";
 import { createTurnstileVerifier } from "@shared/turnstile";
@@ -6,6 +7,7 @@ import { Effect, Layer } from "effect";
 import { createApp } from "./app";
 import { createD1Db, DbService } from "./db";
 import { setExecutionCtx } from "./lib/execution-ctx";
+import { runCire } from "./observability";
 import { assetReconcileService } from "./services/asset-reconcile";
 import { createGoogleGeocoder } from "./services/geocode";
 import {
@@ -46,8 +48,13 @@ export interface Env {
   CIRE_API_ARC_PRIVATE_KEY?: string;
   CIRE_API_ARC_KEY_ID?: string;
   // Native Workers Rate Limiting binding (C1/C4). When present, the claim
-  // limiter is the global, atomic edge limiter; absent (local `wrangler dev`
-  // without the binding, or non-Workers runtimes) ⇒ the in-memory fallback.
+  // limiter is the global, atomic edge limiter. Absent ⇒ the per-isolate
+  // in-memory fallback — allowed ONLY in the `local` tier (`bun run dev` /
+  // bun:sqlite tests). In any deployed tier (dev/staging/production) a missing
+  // binding is a fail-closed 503 at the edge (see the guard in `fetch`), because
+  // a per-isolate limiter is no real cross-request brute-force defence and the
+  // downgrade would otherwise be silent. Optional here so the missing-binding
+  // case surfaces as that explicit 503, not a type lie.
   CLAIM_RATE_LIMITER?: WorkersRateLimitBinding;
   // Turnstile bot-protection secret (KEY-OPTIONAL). When set, the guest claim +
   // RSVP endpoints require a valid Turnstile token (fail-closed); unset ⇒ those
@@ -76,6 +83,17 @@ const misconfigured = (detail: string) =>
     status: 503,
     headers: { "Content-Type": "application/json" },
   });
+
+// Is this a *deployed* tier (dev/staging/production) rather than `local`? Reuse
+// the canonical four-tier signal — `OSN_ENV`, parsed by `@shared/observability`'s
+// `loadConfig` into local|dev|staging|production (the same value that drives the
+// log level in observability.ts). On workerd `nodejs_compat` populates
+// `process.env` from wrangler `[vars]`/secrets; in bun:sqlite/local dev it's
+// native. Using `loadConfig` rather than an ad-hoc "https WEB_ORIGIN" heuristic
+// keeps the tier decision drift-proof: it is the ONE place the repo decides the
+// environment, so this guard can never disagree with the logger about which tier
+// we're in.
+const isDeployedTier = (): boolean => loadConfig({ serviceName: "cire-api" }).env !== "local";
 
 const handler: ExportedHandler<Env> = {
   async fetch(request, env, ctx) {
@@ -107,6 +125,31 @@ const handler: ExportedHandler<Env> = {
       return misconfigured(
         `WEB_ORIGIN entry "${badOrigin}" must be https:// (or http://localhost in dev)`,
       );
+    }
+
+    // C1/C4 (fail-closed): in a *deployed* tier the native Workers rate-limit
+    // binding is MANDATORY. createApp otherwise silently falls back to a
+    // per-isolate in-memory limiter, so the pre-auth claim-code brute-force
+    // guard (small keyspace) would reset per cold isolate with NO signal — a
+    // silent downgrade of the only cross-request throttle on the guest claim
+    // endpoint. This is the wrangler foot-gun the config warns about: named
+    // envs do NOT inherit the top-level `[[unsafe.bindings]]`, so a missing
+    // `[[env.production.unsafe.bindings]]` block would ship prod with the
+    // limiter unbound. Fail closed instead — mirrors the Turnstile /
+    // weddingMember fail-closed convention and the other pre-cache boot checks
+    // above (so it fires on every cold isolate, not only the first app build).
+    // In `local` (the four-tier local dev / bun:sqlite tier) the in-memory
+    // fallback is kept so `bun run dev` works without the binding. The real prod
+    // Worker HAS the binding declared under `[env.production.unsafe.bindings]`
+    // in wrangler.toml, so this only ever trips on a genuine misconfiguration.
+    if (!env.CLAIM_RATE_LIMITER && isDeployedTier()) {
+      await runCire(
+        Effect.logError("CLAIM_RATE_LIMITER binding missing in a deployed tier", {
+          detail:
+            "refusing to serve with the per-isolate in-memory claim limiter as the only brute-force defence",
+        }),
+      );
+      return misconfigured("missing CLAIM_RATE_LIMITER binding");
     }
 
     if (!cached || cached.dbBinding !== env.DB) {

--- a/cire/wiki/todo/security.md
+++ b/cire/wiki/todo/security.md
@@ -5,12 +5,16 @@ related:
   - "[[index]]"
   - "[[overview]]"
   - "[[review-findings]]"
-last-reviewed: 2026-07-10
+last-reviewed: 2026-07-15
 ---
 
 # Security Backlog
 
 See [[overview]] for observability rules that apply to all security-sensitive code paths. See [[review-findings]] for severity prefix conventions.
+
+### Claim rate-limiter fail-closed (re-port of closed PR #235)
+
+- [x] **RL-S-M1** (fixed) — `cire/api/src/index.ts` read the native Workers `CLAIM_RATE_LIMITER` binding and, when absent, **silently fell back to a per-isolate in-memory limiter**. Because an in-memory limiter is per-isolate it gives almost no cross-request protection, so a misconfigured/missing binding silently downgraded the pre-auth claim-code brute-force defence (small keyspace) with no signal — the wrangler foot-gun where named envs don't inherit the top-level `[[unsafe.bindings]]`. Now **fail-closed in any deployed tier**: when the binding is absent and the tier (from `OSN_ENV` via `@shared/observability` `loadConfig`) is `dev`/`staging`/`production`, the edge handler `Effect.logError`s and refuses with a 503 (`missing CLAIM_RATE_LIMITER binding`) on every cold isolate — matching the Turnstile / `weddingMember` fail-closed convention. The `local` tier keeps the in-memory fallback so `bun run dev` / bun:sqlite tests boot without the binding. The prod Worker declares the binding under `[env.production.unsafe.bindings]` in `wrangler.toml`, so the guard never trips on a correctly-configured prod. Regression tests in `index.test.ts` cover all three paths (local→fallback, deployed→503, binding→native).
 
 ### Optional End/Location CSV spec — review findings (wedding-management-platform branch)
 


### PR DESCRIPTION
## The risk

`cire/api/src/index.ts` (the deployed Workers `fetch` entry) reads the native Workers rate-limit binding `CLAIM_RATE_LIMITER` used to blunt brute-forcing the pre-auth guest **claim code**. When that binding was absent, `createApp` **silently fell back to a per-isolate in-memory limiter**. In production this is a real weakness: an in-memory limiter resets per cold isolate, so it gives almost no cross-request protection — a misconfigured/missing binding silently downgraded the brute-force defence (small claim-code keyspace) **with no signal**. This is the wrangler foot-gun the config already warns about: named envs do **not** inherit the top-level `[[unsafe.bindings]]`, so a missing `[[env.production.unsafe.bindings]]` block would ship prod with the claim limiter unbound and no error.

## Original #235 intent

A fix existed on now-closed PR **#235** (commit `26842c5a`). Its message: *"createApp silently fell back to a per-isolate in-memory limiter when CLAIM_RATE_LIMITER was unbound … Boot now 503s in a deployed env … alongside the other pre-cache boot-config checks so it fires on every cold isolate."* It detected "deployed" via an **`https` WEB_ORIGIN heuristic** (`origins.some(o => o.startsWith("https://"))`) and returned the shared `misconfigured()` 503. It wasn't ported during the #235 rehab because `index.ts` moved a lot (#249–#252) and that prod-heuristic drifted.

## Chosen behaviour + justification

**Fail-closed (hard 503) in deployed tiers; keep the in-memory fallback only in `local`.** This mirrors the fail-closed convention already used elsewhere in cire (Turnstile, `weddingMember`) and sits with the other pre-cache boot-config checks so it fires on every cold isolate.

Two deliberate differences from #235:
- **Tier detection is drift-proof.** Instead of re-deriving "prod" from an `https` WEB_ORIGIN heuristic (which drifted), the guard uses the **canonical four-tier signal** — `OSN_ENV`, parsed by `@shared/observability` `loadConfig` into `local|dev|staging|production` — the *same* value that already drives the cire log level in `observability.ts`. This is the one place the repo decides the environment, so the guard can never disagree with the rest of the app about which tier it's in. Deployed = anything that isn't `local`.
- **It logs.** No `console.*` — the guard emits `Effect.logError("CLAIM_RATE_LIMITER binding missing in a deployed tier", …)` via the redacting `runCire` runtime before returning the 503, so a genuine misconfiguration is loud in Workers Logs, not just a bare 503.

`local` (the four-tier local dev / bun:sqlite tier) keeps the in-memory fallback so `bun run dev` and the unit tests boot without the binding.

## Why it won't break the live site

The real prod Worker **has the binding wired**: `cire/api/wrangler.toml` declares `CLAIM_RATE_LIMITER` under **`[[env.production.unsafe.bindings]]`** (namespace `1001`, `simple = { limit = 5, period = 60 }`), redeclared from the top-level block precisely because named envs don't inherit it. `bun run build --filter=@cire/api` confirms the binding resolves (`env.CLAIM_RATE_LIMITER (ratelimit)`). So the guard **only** trips on a genuine misconfiguration (someone drops the `[[env.production.unsafe.bindings]]` block) — which is exactly the case we want to fail loud on rather than silently serve a weakened limiter.

## Tests

`cire/api/src/index.test.ts` now covers all three paths:
- `local` tier, no binding → boots (in-memory fallback), route answers 401 — not the guard's 503;
- deployed tier (`production` and `dev`), no binding → **503** `missing CLAIM_RATE_LIMITER binding` (+ asserts the error body, not a silent in-memory path);
- deployed tier, binding present → boots on the native limiter (401 from the route, no guard 503).

The pre-existing deployed-tier boot test now supplies the (now-required) binding.

## Verification

- `bun run --cwd cire/api test` — **869 pass, 0 fail** (guard's `Effect.logError` observed firing only in the two deployed-missing-binding cases)
- `bun run check` — green (FULL TURBO)
- `bun run lint` — green (only pre-existing warnings, exit 0)
- `bun run build --filter=@cire/api` — green; binding confirmed present

Also: `cire/wiki/todo/security.md` records the fix (**RL-S-M1**) and bumps `last-reviewed`; changeset `@cire/api: patch`.

## Note

**Security-adjacent — please review before merge.** Only `cire/api/src/index.ts` (+ its test), the changeset, and one security.md entry are touched, to avoid conflicting with the concurrent cire/api services/schema PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)