### PR TITLE
fix(cire/web): unbreak guest-site deploy (strip unsupported legacy_env)

### DIFF
--- a/.changeset/cire-web-deploy-legacy-env.md
+++ b/.changeset/cire-web-deploy-legacy-env.md
@@ -1,0 +1,23 @@
+---
+"@cire/web": patch
+---
+
+Fix the broken guest-site (cire/web) production deploy: strip the unsupported
+`legacy_env` field from the adapter-generated Worker config before `wrangler
+deploy`.
+
+`@astrojs/cloudflare` writes a top-level `"legacy_env": true` into the generated
+`dist/server/wrangler.json`. Wrangler **4.111.0 removed support** for that field
+and now hard-errors (`The "legacy_env" field is no longer supported`). Because
+`cire/web` pins no wrangler, the deploy job's `bunx wrangler` fetches the latest,
+so the guest-site deploy has failed on every merge since 4.111 shipped —
+`cireweddings.com` was frozen at the last-good build (the site stayed up; new
+`cire/web` changes just stopped reaching prod). `cire-api` was unaffected: it
+uses a hand-written `wrangler.toml` (no `legacy_env`) and pins `wrangler ^4.96`.
+
+`deploy.yml`'s `deploy-cire-web` job now deletes `legacy_env` from the generated
+config between build and deploy. Removing it is behaviour-neutral — `legacy_env:
+true` was already the default (each environment deploys as its own Worker), so
+the deploy is byte-identical minus the rejected field. Verified by building
+`cire/web` and running `wrangler@4.111.0 deploy --dry-run` against the stripped
+config: it bundles + validates cleanly (no second unsupported field behind it).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,20 @@ jobs:
           # Present ⇒ real Embed iframe; absent ⇒ CSS-card fallback (key-optional).
           PUBLIC_GOOGLE_MAPS_EMBED_KEY: ${{ vars.PUBLIC_GOOGLE_MAPS_EMBED_KEY }}
 
+      # `@astrojs/cloudflare` writes a top-level `"legacy_env": true` into the
+      # generated `dist/server/wrangler.json`. Wrangler 4.111+ REMOVED support for
+      # that field and hard-errors on it ("legacy_env field is no longer
+      # supported") — and because cire/web pins no wrangler, `bunx wrangler` below
+      # fetches the latest, so this broke the guest-site deploy the moment 4.111
+      # shipped (cire-api is unaffected: hand-written wrangler.toml, no legacy_env,
+      # wrangler pinned ^4.96). Removing the field is a no-op for behaviour —
+      # `legacy_env: true` WAS the default (each env deploys as its own Worker),
+      # so stripping it deploys identically. Version-proof: harmless if a future
+      # adapter stops emitting it.
+      - name: Strip unsupported legacy_env from generated config
+        run: node -e "const fs=require('fs'),f='dist/server/wrangler.json',c=JSON.parse(fs.readFileSync(f,'utf8'));delete c.legacy_env;fs.writeFileSync(f,JSON.stringify(c))"
+        working-directory: cire/web
+
       # Deploy the SSR Worker. The adapter's generated config carries `main`, the
       # ASSETS binding (→ dist/client), the worker name, and the cireweddings.com
       # custom-domain route. NOTE: this replaces the previous Pages deploy

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -9,7 +9,7 @@ related:
   - "[[database-environments]]"
   - "[[redis]]"
   - "[[email]]"
-last-reviewed: 2026-07-10
+last-reviewed: 2026-07-16
 ---
 
 # Production Deploy Runbook — osn + cire
@@ -360,6 +360,16 @@ bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|producti
 > (Worker → Domains & Routes → Add → confirm move). A Worker→Worker rename (e.g.
 > `cire-invites` → `cire-invites`) reassigns the custom domain automatically on deploy.
 > No KV namespace or Images binding to create.
+>
+> **`legacy_env` strip (deploy foot-gun, fixed 2026-07-16):** the adapter writes a
+> top-level `"legacy_env": true` into the generated `dist/server/wrangler.json`.
+> Wrangler **4.111.0 removed** that field and hard-errors on it; since `cire/web`
+> pins no wrangler, `bunx wrangler` pulls the latest, so the `deploy-cire-web` job
+> failed on every merge from the moment 4.111 shipped (the apex stayed up on the
+> last-good build — deploys just stopped landing). The job now deletes `legacy_env`
+> from the generated config between build and deploy (behaviour-neutral: `true` was
+> already the default). If a guest-site deploy fails on a config field again, check
+> the generated `dist/server/wrangler.json` against the installed wrangler's schema.
 
 `cire/organiser` is still a **static** Pages build (`output: "static"`); cire/web's
 `PUBLIC_*` are read both **server-side per request** and by the client islands but


### PR DESCRIPTION
## What

The **live guest-site (`cire/web`) production deploy has been failing on every merge** since wrangler `4.111.0` shipped. `cireweddings.com` stayed **up** (served by the last-good build) but **frozen** — no `cire/web` change has reached prod since. `cire-api` (and its D1 migrations) are unaffected, so this is isolated to the guest site.

## Root cause

`@astrojs/cloudflare` writes a top-level `"legacy_env": true` into the generated `dist/server/wrangler.json`. Wrangler **4.111.0 removed** that field and hard-errors:

```
✘ [ERROR] Processing dist/server/wrangler.json configuration:
    - The "legacy_env" field is no longer supported...
```

`cire/web` pins no wrangler, so the `deploy-cire-web` job's `bunx wrangler` fetches the **latest** (4.111) and trips this every run. `cire-api` uses a hand-written `wrangler.toml` (no `legacy_env`) and pins `wrangler ^4.96`, which is why its deploy keeps succeeding.

## Fix

`deploy.yml`'s `deploy-cire-web` job now deletes `legacy_env` from the generated config **between build and deploy** (a static `node -e` one-liner, no untrusted input). Removing it is **behaviour-neutral** — `legacy_env: true` was already wrangler's default (each env deploys as its own Worker), so the deploy is byte-identical minus the rejected field.

## Verification

- Built `cire/web` locally → confirmed the generated `dist/server/wrangler.json` carries `"legacy_env":true` at top level.
- Stripped it and ran `wrangler@4.111.0 deploy --dry-run --config dist/server/wrangler.json` → **bundles + validates cleanly** (12 modules, ASSETS binding, custom-domain route), so there is no second unsupported field hiding behind `legacy_env`.

## Notes

- Held for maintainer merge — merging re-triggers the prod deploy pipeline, which should turn the `Deploy cire/web (Worker SSR)` job green and ship the current guest site to `cireweddings.com`.
- Runbook `wiki/runbooks/production-deploy.md` §3.3 documents the foot-gun + fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)