### PR TITLE
chore(cire): domain reshuffle — invites→invite., organiser→host., landing→apex

### DIFF
--- a/.changeset/cire-domain-reshuffle.md
+++ b/.changeset/cire-domain-reshuffle.md
@@ -1,0 +1,21 @@
+---
+"@cire/web": patch
+"@cire/api": patch
+"@cire/landing": patch
+---
+
+Domain reshuffle: guest invites → `invite.cireweddings.com`, organiser →
+`host.cireweddings.com`, marketing landing → apex `cireweddings.com`.
+
+Code side: `cire/web/wrangler.jsonc` Worker route `cireweddings.com` →
+`invite.cireweddings.com` (custom_domain auto-provisions on deploy); deploy.yml
+`PUBLIC_SITE_URL`→`invite.`, `PUBLIC_CIRE_WEB_URL`→`invite.`,
+`PUBLIC_ORGANISER_URL`→`host.`, landing `SITE`→apex; cire-api `WEB_ORIGIN` gains
+`invite.`+`host.` (old apex+`app.` kept for the cutover window, pruned after).
+
+No apex 301 for old invite links — there are no apex-based invite links in the
+wild (guests use the full link). The remaining Cloudflare-dashboard steps (attach
+`host.` to cire-organiser Pages, move the apex custom domain to cire-landing
+Pages, confirm `invite.` on the Worker) + the osn-api manual redeploy are tracked
+in `wiki/apps/cire-landing.md` → "Apex cutover" and the production-deploy runbook.
+Passkeys are unaffected (`OSN_RP_ID` stays the registrable apex `cireweddings.com`).

--- a/.changeset/osn-api-domain-reshuffle.md
+++ b/.changeset/osn-api-domain-reshuffle.md
@@ -1,0 +1,15 @@
+---
+"@osn/api": patch
+---
+
+Domain reshuffle (organiser portal `app.cireweddings.com` → `host.cireweddings.com`):
+add the new portal origin to osn-api's prod WebAuthn/CORS allowlists.
+`[env.production].OSN_ORIGIN` and `OSN_CORS_ORIGIN` now list
+`https://host.cireweddings.com,https://app.cireweddings.com` (both kept for the
+switchover window; prune `app.` after the move + verify).
+
+`OSN_RP_ID` stays `cireweddings.com` (the registrable apex), so existing organiser
+passkeys keep working on the new subdomain with no re-registration — credentials
+are scoped to the RP ID, not the full origin. osn-api is deployed MANUALLY (not
+CI): run `cd osn/api && bunx wrangler deploy --env production` after this merges
+for the var change to take effect.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,8 +152,8 @@ jobs:
       # emits a Cloudflare Worker with Static Assets: `dist/server/entry.mjs` (the
       # SSR Worker), `dist/client/` (prerendered legal pages + JS/CSS), and a
       # generated `dist/server/wrangler.json` that EXTENDS the committed
-      # cire/web/wrangler.jsonc (worker name + cireweddings.com custom-domain
-      # route). PUBLIC_API_URL / PUBLIC_SITE_URL are read both server-side (per
+      # cire/web/wrangler.jsonc (worker name + invite.cireweddings.com
+      # custom-domain route). PUBLIC_API_URL / PUBLIC_SITE_URL are read both server-side (per
       # request) and by the client islands; they still bake in at build time.
       #   PUBLIC_GOOGLE_MAPS_EMBED_KEY is an optional referrer-restricted Embed
       #   key — wire it from a secret/var only if/when one exists.
@@ -165,7 +165,9 @@ jobs:
         run: bun run --cwd cire/web build
         env:
           PUBLIC_API_URL: https://api.cireweddings.com
-          PUBLIC_SITE_URL: https://cireweddings.com
+          # Domain reshuffle 2026-07-16: the guest site now lives on the `invite.`
+          # subdomain (apex serves the marketing landing site).
+          PUBLIC_SITE_URL: https://invite.cireweddings.com
           PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
           # Google Maps Embed API key (public, referrer-restricted to *.cireweddings.com).
           # Present ⇒ real Embed iframe; absent ⇒ CSS-card fallback (key-optional).
@@ -186,10 +188,11 @@ jobs:
         working-directory: cire/web
 
       # Deploy the SSR Worker. The adapter's generated config carries `main`, the
-      # ASSETS binding (→ dist/client), the worker name, and the cireweddings.com
-      # custom-domain route. NOTE: this replaces the previous Pages deploy
-      # (`wrangler pages deploy dist`); the Cloudflare Pages project `cire` is no
-      # longer used for the guest site — the apex now resolves to this Worker.
+      # ASSETS binding (→ dist/client), the worker name, and the
+      # invite.cireweddings.com custom-domain route. NOTE: this replaces the
+      # previous Pages deploy (`wrangler pages deploy dist`); the Cloudflare Pages
+      # project `cire` is no longer used for the guest site — invite. resolves to
+      # this Worker (the apex now serves the cire-landing marketing site).
       - name: Deploy cire/web (Worker)
         run: bunx wrangler deploy --config dist/server/wrangler.json
         working-directory: cire/web
@@ -231,7 +234,9 @@ jobs:
         env:
           PUBLIC_CIRE_API_URL: https://api.cireweddings.com
           PUBLIC_OSN_ISSUER_URL: https://id.cireweddings.com
-          PUBLIC_CIRE_WEB_URL: https://cireweddings.com
+          # Domain reshuffle 2026-07-16: the guest site (this is the organiser's
+          # "preview / view live invite" link) now lives on `invite.`.
+          PUBLIC_CIRE_WEB_URL: https://invite.cireweddings.com
           # Optional Cloudflare Turnstile sitekey (public) for organiser passkey
           # sign-in. Uncomment once the widget exists; omitted ⇒ key-optional
           # no-op. Matching TURNSTILE_SECRET_KEY is a wrangler secret on osn-api.
@@ -244,18 +249,17 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-  # ── cire landing (Astro → Cloudflare Pages, NON-APEX preview) ──────────────
+  # ── cire landing (Astro → Cloudflare Pages, APEX cireweddings.com) ─────────
   # The marketing site for the apex. Built fully static (output: "static", no
   # Cloudflare adapter) and deployed to its OWN Pages project, separate from the
-  # guest site + organiser portal. IMPORTANT: this ships to a NON-APEX preview
-  # (cire-landing.pages.dev / optionally new.cireweddings.com) — the apex
-  # cireweddings.com still serves the guest site, so live invitations are
-  # untouched. Flipping the landing site onto the apex (and moving invites →
-  # invite. / organiser → host.) is a separate, reviewed cutover — see
-  # wiki/apps/cire-landing.md. The `cire-landing` Pages project must exist in the
-  # account before first run (create once: `wrangler pages project create`).
+  # guest site + organiser portal. Domain reshuffle 2026-07-16: this now serves
+  # the APEX `cireweddings.com` (guest invites moved to `invite.`, organiser to
+  # `host.`). The apex custom domain is attached to the `cire-landing` Pages
+  # project in the Cloudflare dashboard (a Pages custom domain, not a wrangler
+  # config route) — see wiki/apps/cire-landing.md cutover steps. The
+  # `cire-landing` Pages project must exist in the account before first run.
   deploy-cire-landing:
-    name: Deploy cire/landing (Pages, preview)
+    name: Deploy cire/landing (Pages, apex)
     needs: build
     runs-on: ubuntu-latest
     environment: production
@@ -279,15 +283,14 @@ jobs:
 
       # Build-time PUBLIC_* vars (all baked in by Vite):
       #   PUBLIC_ORGANISER_URL — target of the primary "Create your invitation"
-      #     CTA. Points at the CURRENT organiser host (app.cireweddings.com) until
-      #     the cutover moves it to host.cireweddings.com — flip this then.
-      #   SITE — canonical origin for SEO meta. The preview advertises its own
-      #     URL; at apex cutover this becomes https://cireweddings.com.
+      #     CTA. Points at the organiser portal, now host.cireweddings.com
+      #     (domain reshuffle 2026-07-16, moved off app.cireweddings.com).
+      #   SITE — canonical origin for SEO meta; the apex cireweddings.com.
       - name: Build cire/landing
         run: bun run --cwd cire/landing build
         env:
-          PUBLIC_ORGANISER_URL: https://app.cireweddings.com
-          SITE: https://cire-landing.pages.dev
+          PUBLIC_ORGANISER_URL: https://host.cireweddings.com
+          SITE: https://cireweddings.com
 
       - name: Deploy cire/landing to Cloudflare Pages
         run: bunx wrangler pages deploy dist --project-name cire-landing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ AI coding assistant ref. Full spec in README.md. Progress/decisions in `wiki/TOD
 
 OSN: Modular social platform. Users own identity + social graph. Apps opt-in/out independently.
 
-**Deployed (2026-06-18):** the cire stack is **live on `cireweddings.com`** (all Cloudflare Free tier). `osn-api` is a deployed **Cloudflare Worker** on `id.cireweddings.com` (Upstash prod secrets set; `OSN_EMAIL_OPTIONAL=true` → email degraded); `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. CI auto-deploys cire-api + Pages on merge. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
+**Deployed (2026-06-18):** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. `osn-api` is a deployed **Cloudflare Worker** on `id.cireweddings.com` (Upstash prod secrets set; `OSN_EMAIL_OPTIONAL=true` → email degraded); `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. CI auto-deploys cire-api + Pages on merge. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
 
 Phase 1 surfaces:
 
@@ -16,8 +16,8 @@ Phase 1 surfaces:
 | Identity & graph UI | `@osn/social` (port 1422) | Active |
 | Events | `@pulse/app` + `@pulse/api` (port 3001) + `@pulse/db` | Active |
 | Messaging | `@zap/api` (port 3002) + `@zap/db` | M0 scaffolded; M1 in flight; client app not started |
-| Wedding invites | @cire/api (:8787, prod `api.cireweddings.com`) + @cire/web (:4321) + @cire/organiser (:4322) + @cire/db + @cire/theme | Active — **deployed on `cireweddings.com`** |
-| Wedding marketing site | `@cire/landing` (:4323) | Active — built; ships to a non-apex Pages preview (apex cutover deferred). See `[[wiki/apps/cire-landing]]` |
+| Wedding invites | @cire/api (:8787, prod `api.cireweddings.com`) + @cire/web (:4321, prod `invite.cireweddings.com`) + @cire/organiser (:4322, prod `host.cireweddings.com`) + @cire/db + @cire/theme | Active — **deployed** (domain reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`) |
+| Wedding marketing site | `@cire/landing` (:4323) | Active — serves the **apex `cireweddings.com`** (reshuffle 2026-07-16). See `[[wiki/apps/cire-landing]]` |
 | OSN marketing site | `@osn/landing` (:4324) | Active — built (dark/dotted, connections-led). See `[[wiki/apps/osn-landing]]` |
 | Pulse marketing site | `@pulse/landing` (:4325) | Active — built (colourful + fun). See `[[wiki/apps/pulse-landing]]` |
 

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -86,11 +86,15 @@ binding = "IMAGES"
 
 [env.production.vars]
 # Comma-separated allowlist (index.ts splits on "," and trims). Entry 0 is the
-# guest site; the organiser portal origin MUST also be present or organiser
-# writes to /api/organiser/* fail the CORS origin guard with 403.
-# TODO: replace <ORGANISER-ORIGIN-PLACEHOLDER> with the real organiser portal
-# production origin (cire/organiser Cloudflare Pages deployment URL).
-WEB_ORIGIN = "https://cireweddings.com,https://app.cireweddings.com"
+# guest site (`invite.cireweddings.com`); the organiser portal origin
+# (`host.cireweddings.com`) MUST also be present or organiser writes to
+# /api/organiser/* fail the CORS origin guard with 403.
+# Domain reshuffle 2026-07-16: guest → `invite.`, organiser → `host.`, apex →
+# landing. The old `cireweddings.com` (apex, while invites still answered there)
+# + `app.cireweddings.com` (old organiser origin) are kept ONLY for the cutover
+# window so nothing 403s mid-switch — prune both once the dashboard move + verify
+# are done (see [[wiki/apps/cire-landing]] cutover steps).
+WEB_ORIGIN = "https://invite.cireweddings.com,https://host.cireweddings.com,https://cireweddings.com,https://app.cireweddings.com"
 # OSN identity (osn-api) prod origin — served on the cireweddings.com zone at
 # id.cireweddings.com. OSN_ISSUER_URL MUST equal osn-api's own OSN_ISSUER_URL or
 # access-token verification fails; OSN_JWKS_URL is that origin + the JWKS path.

--- a/cire/landing/astro.config.mjs
+++ b/cire/landing/astro.config.mjs
@@ -2,9 +2,10 @@ import solidJs from "@astrojs/solid-js";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
-// Pure static marketing site (apex `cireweddings.com` end-state; shipped to a
-// non-apex preview route first — see [[wiki/apps/cire-landing]]). Unlike the
-// guest site (`cire/web`, SSR Worker — it resolves a wedding per request) the
+// Pure static marketing site — serves the apex `cireweddings.com` (domain
+// reshuffle 2026-07-16; guest invites moved to `invite.`, organiser to `host.` —
+// see [[wiki/apps/cire-landing]]). Unlike the guest site (`cire/web`, SSR Worker
+// — it resolves a wedding per request) the
 // landing page is the same for everyone, so it prerenders to plain HTML and
 // deploys to Cloudflare Pages (`wrangler pages deploy dist`) exactly like the
 // organiser portal. No Cloudflare adapter is needed for a static build.

--- a/cire/web/wrangler.jsonc
+++ b/cire/web/wrangler.jsonc
@@ -13,8 +13,11 @@
   // 7-day Workers Logs retention, 100% sampling (low guest-site volume). Mirrors
   // cire-api's observability block.
   "observability": { "enabled": true },
-  // Custom-domain route: serves the guest site on the apex `cireweddings.com`.
-  // `custom_domain: true` auto-provisions DNS + edge cert because the zone lives
-  // in this Cloudflare account. Applied only by `wrangler deploy` (no named env).
-  "routes": [{ "pattern": "cireweddings.com", "custom_domain": true }],
+  // Custom-domain route: serves the guest site on `invite.cireweddings.com`.
+  // (Domain reshuffle 2026-07-16: the apex `cireweddings.com` now serves the
+  // marketing landing site; guest invites moved to the `invite.` subdomain,
+  // organisers to `host.`.) `custom_domain: true` auto-provisions DNS + edge
+  // cert because the zone lives in this Cloudflare account. Applied only by
+  // `wrangler deploy` (no named env).
+  "routes": [{ "pattern": "invite.cireweddings.com", "custom_domain": true }],
 }

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -212,17 +212,25 @@ crons = ["0 */6 * * *"]
 # OSN identity runs under the cireweddings.com zone for now (a dedicated OSN
 # domain is deferred). The custom-domain route below serves osn-api on
 # id.cireweddings.com and auto-provisions DNS + edge cert since the zone is
-# in-account. The ONLY prod passkey surface is the organiser portal
-# (app.cireweddings.com), so the WebAuthn RP ID is the registrable apex
-# `cireweddings.com` and OSN_ORIGIN is the organiser portal origin. Guests use
-# claim codes (no passkeys). Prod passkeys are now UNBLOCKED.
+# in-account. The ONLY prod passkey surface is the organiser portal, so the
+# WebAuthn RP ID is the registrable apex `cireweddings.com` and OSN_ORIGIN is the
+# organiser portal origin. Guests use claim codes (no passkeys).
+#
+# Domain reshuffle 2026-07-16: the organiser portal moves app.cireweddings.com →
+# host.cireweddings.com. RP ID stays the registrable apex `cireweddings.com`, so
+# existing organiser passkeys keep working on the new subdomain (credentials are
+# scoped to the RP ID, not the full origin) — NO re-registration. Only the origin
+# allowlists gain `host.`; `app.` is kept for the cutover window so passkey
+# sign-in never breaks mid-switch — drop it once the move + verify are done.
+# NOTE: osn-api is deployed MANUALLY (not CI) — after this merges run
+# `cd osn/api && bunx wrangler deploy --env production` for it to take effect.
 [env.production.vars]
 OSN_ENV = "production"
 OSN_RP_ID = "cireweddings.com"
 OSN_RP_NAME = "OSN"
-OSN_ORIGIN = "https://app.cireweddings.com"
+OSN_ORIGIN = "https://host.cireweddings.com,https://app.cireweddings.com"
 OSN_ISSUER_URL = "https://id.cireweddings.com"
-OSN_CORS_ORIGIN = "https://app.cireweddings.com"
+OSN_CORS_ORIGIN = "https://host.cireweddings.com,https://app.cireweddings.com"
 OSN_EMAIL_FROM = "hello@cireweddings.com"
 # Email is sent via Resend (RESEND_API_KEY secret, §1.1) — confirmed delivering
 # from hello@cireweddings.com on 2026-06-18. Email is REQUIRED in prod: if

--- a/wiki/apps/cire-landing.md
+++ b/wiki/apps/cire-landing.md
@@ -10,7 +10,7 @@ related:
   - "[[cire-auth]]"
   - "[[production-deploy]]"
   - "[[free-tier-limits]]"
-last-reviewed: 2026-06-27
+last-reviewed: 2026-07-16
 ---
 
 # Cire Landing
@@ -142,26 +142,37 @@ allow-lists `images.unsplash.com` for `img-src`.
 
 ## Deploy + the domain migration
 
-**This pass ships to a NON-apex preview only** — a `cire-landing` Cloudflare Pages
-project (→ `cire-landing.pages.dev`, optionally `new.cireweddings.com`). The apex
-is untouched, so live invitations don't break. CI job `deploy-cire-landing` in
+**Apex cutover — done in code 2026-07-16 (domain reshuffle).** End state: apex
+`cireweddings.com` → this landing site; `invite.cireweddings.com` → guest site
+(`cire/web`); `host.cireweddings.com` → organiser portal (`cire/organiser`, moved
+off `app.cireweddings.com`). CI job `deploy-cire-landing` in
 `.github/workflows/deploy.yml` mirrors `deploy-cire-organiser` (the `cire-landing`
-Pages project must exist in the account before first run). The CI gate's
-`bun run build` + `bun run test` already cover `@cire/landing` via the `cire/*`
-turbo glob.
+Pages project must exist in the account before first run).
 
-**The apex cutover is a separate, reviewed change** (do it when ready):
+**Passkey safety:** prod `OSN_RP_ID = cireweddings.com` (the registrable apex), so
+WebAuthn credentials are scoped to the whole domain — moving the organiser portal
+`app.` → `host.` does NOT invalidate existing organiser passkeys (no
+re-registration). Only the origin allowlists gain `host.`; `app.` + the old apex
+stay in the allowlists for the switchover window, then get pruned.
 
-1. Move `cire/web` route → `invite.cireweddings.com` (+ 301 from old invite paths).
-2. Move `cire/organiser` → `host.cireweddings.com`; update its custom domain +
-   the OSN WebAuthn `OSN_ORIGIN` / CORS for the new portal host (see
-   [[production-deploy]]).
-3. Point `PUBLIC_ORGANISER_URL` at `https://host.cireweddings.com` and `SITE` at
-   `https://cireweddings.com` in the landing deploy job.
-4. Flip `cire/landing` onto the apex custom-domain route.
+The code side (this PR): `cire/web/wrangler.jsonc` route → `invite.`; deploy.yml
+`PUBLIC_SITE_URL` → `invite.`, `PUBLIC_CIRE_WEB_URL` → `invite.`,
+`PUBLIC_ORGANISER_URL` → `host.`, landing `SITE` → apex; cire-api `WEB_ORIGIN` +
+osn-api `OSN_ORIGIN`/`OSN_CORS_ORIGIN` gain `invite.`/`host.` (keep `app.`/apex for
+the window). **No apex 301 for old invite links — decided 2026-07-16 there are no
+apex-based invite links in the wild (guests use the full link).**
 
-This touches DNS/custom-domain routes and the passkey origin, so it's worth doing
-deliberately rather than in the same pass as the build.
+Remaining **manual** steps (Cloudflare dashboard + one deploy), sequenced in
+[[production-deploy]]:
+1. Attach `host.cireweddings.com` custom domain → `cire-organiser` Pages.
+2. Attach apex `cireweddings.com` → `cire-landing` Pages (Cloudflare offers to
+   *move* it off the `cire-invites` Worker — confirm).
+3. Confirm `invite.cireweddings.com` auto-provisioned on the `cire-invites` Worker
+   (custom_domain on deploy).
+4. Redeploy osn-api manually (`cd osn/api && bunx wrangler deploy --env production`)
+   — it is NOT in CI — so `OSN_ORIGIN` picks up `host.`.
+5. Cleanup PR: drop apex route from the Worker config; prune `app.`/apex from the
+   allowlists.
 
 ## Roadmap — toward a wedding platform
 

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -41,6 +41,17 @@ last-reviewed: 2026-07-16
 below is set out-of-band with `wrangler secret put` (osn-api **and** cire-api are
 both Workers).
 
+> **🔀 Domain reshuffle (2026-07-16) — end-state supersedes older `app.`/apex
+> framing below.** Apex `cireweddings.com` → marketing **landing** site;
+> `invite.cireweddings.com` → **guest** site (`cire/web`); `host.cireweddings.com`
+> → **organiser** portal (moved off `app.cireweddings.com`); `api.` / `id.`
+> unchanged. Passkeys survive the move (`OSN_RP_ID` stays the registrable apex
+> `cireweddings.com`). The full cutover — code changes already merged + the manual
+> Cloudflare dashboard steps + the osn-api manual redeploy — is in
+> **[[cire-landing]] → "Apex cutover"**. Where a line below still says
+> `app.cireweddings.com` as the organiser origin or apex-as-guest-site, read it as
+> `host.cireweddings.com` / `invite.cireweddings.com` post-reshuffle.
+
 ---
 
 ## 0. Values to fill before deploy (read this first)
@@ -52,10 +63,10 @@ marked **TBD** blocks the deploy.
 |---|---|---|
 | `OSN_JWT_PRIVATE_KEY` / `OSN_JWT_PUBLIC_KEY` (ES256 JWK, base64) | osn-api | **generate** (section 1) |
 | `OSN_SESSION_IP_PEPPER` (≥32 bytes) | osn-api | **generate** (section 1) |
-| `OSN_RP_ID` (WebAuthn RP ID — registrable domain) | osn-api WebAuthn | **DONE — `cireweddings.com`** (registrable apex; the organiser portal `app.cireweddings.com` is the only prod passkey surface). Prod passkeys now UNBLOCKED. |
-| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://app.cireweddings.com`** (organiser portal = the passkey origin) |
+| `OSN_RP_ID` (WebAuthn RP ID — registrable domain) | osn-api WebAuthn | **DONE — `cireweddings.com`** (registrable apex; organiser portal is the only prod passkey surface). Unchanged by the 2026-07-16 reshuffle — RP ID stays the apex, so passkeys survive the `app.`→`host.` move. |
+| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal = the passkey origin; reshuffle moved it `app.`→`host.`, `app.` kept for the window then pruned). **osn-api is deployed MANUALLY — redeploy after this change.** |
 | `OSN_ISSUER_URL` (public https base of osn-api) | osn-api + cire | **DONE — `https://id.cireweddings.com`** (custom-domain route in `osn/api/wrangler.toml` `[env.production]`) |
-| `OSN_CORS_ORIGIN` (prod app origins, comma-sep) | osn-api | **DONE — `https://app.cireweddings.com`** (organiser portal calls osn-api) |
+| `OSN_CORS_ORIGIN` (prod app origins, comma-sep) | osn-api | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal calls osn-api; reshuffle `app.`→`host.`) |
 | `OSN_EMAIL_FROM` (verified sender) | osn-api | **DONE — `hello@cireweddings.com`** (Resend sender-domain verification for `cireweddings.com` still required — §1.1) |
 | `RESEND_API_KEY` (live email transport) | osn-api | **provision** (Resend domain verify + key — §1.1) |
 | `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_EMAIL_API_TOKEN` | osn-api | optional / **legacy** (Cloudflare-email fallback transport; not used now Resend is the live path — §1.1) |
@@ -67,7 +78,7 @@ marked **TBD** blocks the deploy.
 | `INTERNAL_SERVICE_SECRET` | osn-api | needed only to register cire's ARC key (section 6.2) |
 | cire D1 `database_id` | cire-api wrangler.toml | **DONE** — `6e835474-e0a7-4db9-8883-3247c3c891cd` |
 | cire R2 buckets | cire-api | **DONE** — `cire-sheets[-preview]`, `cire-assets[-preview]` |
-| cire `WEB_ORIGIN` allowlist (guest **and** organiser origins) | cire-api | **DONE — `https://cireweddings.com,https://app.cireweddings.com`** |
+| cire `WEB_ORIGIN` allowlist (guest **and** organiser origins) | cire-api | **DONE — `https://invite.cireweddings.com,https://host.cireweddings.com,https://cireweddings.com,https://app.cireweddings.com`** (reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; old apex+`app.` kept for the cutover window then pruned) |
 | cire `OSN_JWKS_URL` / `OSN_ISSUER_URL` | cire-api | **DONE — `https://id.cireweddings.com/.well-known/jwks.json` / `https://id.cireweddings.com`** (must equal osn-api's own `OSN_ISSUER_URL`) |
 | `CIRE_API_ARC_PRIVATE_KEY` + `CIRE_API_ARC_KEY_ID` + `OSN_API_URL` | cire-api | needed only if guest account-linking is enabled (section 6.2) |
 | cire/web `PUBLIC_API_URL`, `PUBLIC_SITE_URL` (build-time) | cire/web **SSR Worker** | **DONE — `https://api.cireweddings.com` / `https://cireweddings.com`** (set in `deploy.yml`). No `PUBLIC_WEDDING_SLUG` — wedding resolved from the path. Apex now served by the `cire-invites` Worker (custom-domain route), not the Pages project — see §3.3. |


### PR DESCRIPTION
## What

Moves the three cire surfaces onto their intended hosts:

| Domain | Before | After |
|---|---|---|
| `cireweddings.com` (apex) | guest invites | **marketing landing** |
| `invite.cireweddings.com` | — | **guest invites** (`cire/web`) |
| `host.cireweddings.com` | — | **organiser portal** (`cire/organiser`, off `app.cireweddings.com`) |
| `api.` / `id.` | cire-api / osn-api | unchanged |

This is **code/config only.** The Cloudflare custom-domain moves + the osn-api manual redeploy are operator dashboard steps, documented below and in `wiki/apps/cire-landing.md` → "Apex cutover".

## ✅ Passkeys survive the organiser move

Prod `OSN_RP_ID = cireweddings.com` (the registrable apex), so WebAuthn credentials are scoped to the whole domain — moving the organiser portal `app.` → `host.` does **not** invalidate existing organiser passkeys (no re-registration). Only the origin allowlists gain `host.`; `app.` + the old apex stay in the allowlists **for the cutover window**, then a cleanup PR prunes them.

## Code changes
- `cire/web/wrangler.jsonc` — Worker route `cireweddings.com` → `invite.cireweddings.com` (`custom_domain` auto-provisions on deploy).
- `deploy.yml` — `PUBLIC_SITE_URL`/`PUBLIC_CIRE_WEB_URL` → `invite.`, `PUBLIC_ORGANISER_URL` → `host.`, landing `SITE` → apex, landing job relabelled apex.
- `cire/api/wrangler.toml` `WEB_ORIGIN` + `osn/api/wrangler.toml` `OSN_ORIGIN`/`OSN_CORS_ORIGIN` gain `invite.`/`host.` (keep `app.`/apex for the window).
- Docs: `cire-landing.md`, `production-deploy.md` (banner + origin values), root `CLAUDE.md`.

**No apex 301** — decided there are no apex-based invite links in the wild (guests use the full link).

## ⚠️ Operator steps (after merge)

**Cloudflare dashboard:**
1. Pages → `cire-organiser` → Custom domains → add `host.cireweddings.com`.
2. Pages → `cire-landing` → Custom domains → add `cireweddings.com` (apex) — confirm the "move it off the Worker" prompt.
3. Workers → `cire-invites` → Domains & Routes → confirm `invite.cireweddings.com` auto-provisioned.

**Manual deploy (osn-api is NOT in CI):**
```
cd osn/api && bunx wrangler deploy --env production
```

**Follow-up cleanup PR:** drop the apex route from the Worker config; prune `app.`/apex from `WEB_ORIGIN` / `OSN_ORIGIN` / `OSN_CORS_ORIGIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)