### PR TITLE
ci: auto-deploy osn-api to production (deploy-osn-api job)

### DIFF
--- a/.changeset/ci-deploy-osn-api.md
+++ b/.changeset/ci-deploy-osn-api.md
@@ -1,0 +1,16 @@
+---
+"@osn/api": patch
+---
+
+CI: auto-deploy osn-api to production. Add a `deploy-osn-api` job to
+`.github/workflows/deploy.yml` (mirrors `deploy-cire-api`): on merge to `main` it
+applies the prod osn D1 migrations (`wrangler d1 migrations apply osn-db-prod
+--remote --env production`) then deploys the Worker (`wrangler deploy --env
+production`) against the already-set out-of-band secrets.
+
+Removes the last manual production deploy step. osn-api has been a deployed
+Cloudflare Worker (workerd + Upstash + native rate-limiters) since the 2026-06
+cutover, so the old "gated until the ioredis→Workers-Redis swap" reason in the
+`deploy.yml` stub was stale. Merging this PR runs the job, which also picks up the
+domain-reshuffle `OSN_ORIGIN`/`OSN_CORS_ORIGIN` (`host.cireweddings.com`) already
+on `main`. As with cire-api, osn's D1 migrations now auto-apply on merge.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -299,25 +299,51 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-  # ── osn/api ────────────────────────────────────────────────────────────────
-  # NOTE: osn/api is NOT deployed by CI yet. Its Worker entry exists
-  # (`main = "src/index.ts"`, Phase 6) and its prod config is wired — the
-  # `[env.production]` custom-domain route serves it at id.cireweddings.com — but
-  # the CI deploy job stays gated until the ioredis rate-limiters/session stores
-  # are swapped for a Workers-compatible Redis (see osn/api/wrangler.toml and
-  # wiki/TODO.md). Until then deploy osn-api manually per the runbook §5.1. When
-  # the Redis swap lands, add a `deploy-osn-api` job here mirroring
-  # deploy-cire-api:
-  #
-  #   deploy-osn-api:
-  #     name: Deploy osn/api
-  #     needs: build
-  #     runs-on: ubuntu-latest
-  #     environment: production
-  #     steps:
-  #       - ... checkout / setup-bun / install ...
-  #       - run: bunx wrangler deploy --env production
-  #         working-directory: osn/api
-  #         env:
-  #           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  #           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  # ── osn/api (Worker + D1 migrate) ──────────────────────────────────────────
+  # osn-api (identity/auth) is a Cloudflare Worker (`main = "src/index.ts"`,
+  # `[env.production]` custom-domain route → id.cireweddings.com). It runs on
+  # workerd with Upstash + native Workers rate-limiters — the old ioredis gate
+  # that kept it out of CI is long resolved (it's been a deployed Worker since the
+  # 2026-06 cutover), so it now deploys here alongside cire-api instead of by hand.
+  # Prod secrets are set out-of-band (`wrangler secret put … --env production`,
+  # runbook §1/§5.1); this job only runs migrate + deploy against them.
+  deploy-osn-api:
+    name: Deploy osn/api (+ D1 migrate)
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      # Apply pending migrations to the remote prod osn D1 (`osn-db-prod`, the
+      # `[env.production].d1_databases` binding) BEFORE the new Worker serves.
+      # `--env production` selects that binding (top-level `osn-db` is the dev DB);
+      # idempotent — wrangler skips already-applied migrations.
+      - name: Apply osn D1 migrations (remote prod)
+        run: bunx wrangler d1 migrations apply osn-db-prod --remote --env production
+        working-directory: osn/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy osn/api Worker
+        run: bunx wrangler deploy --env production
+        working-directory: osn/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ AI coding assistant ref. Full spec in README.md. Progress/decisions in `wiki/TOD
 
 OSN: Modular social platform. Users own identity + social graph. Apps opt-in/out independently.
 
-**Deployed (2026-06-18):** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. `osn-api` is a deployed **Cloudflare Worker** on `id.cireweddings.com` (Upstash prod secrets set; `OSN_EMAIL_OPTIONAL=true` → email degraded); `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. CI auto-deploys cire-api + Pages on merge. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
+**Deployed (2026-06-18):** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. `osn-api` is a deployed **Cloudflare Worker** on `id.cireweddings.com` (Upstash prod secrets set; `OSN_EMAIL_OPTIONAL=true` → email degraded); `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. CI auto-deploys cire-api + **osn-api** + Pages on merge (osn-api joined the `deploy.yml` pipeline 2026-07-16 — no more manual `wrangler deploy`; its D1 migrations auto-apply too). Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
 
 Phase 1 surfaces:
 

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -64,7 +64,7 @@ marked **TBD** blocks the deploy.
 | `OSN_JWT_PRIVATE_KEY` / `OSN_JWT_PUBLIC_KEY` (ES256 JWK, base64) | osn-api | **generate** (section 1) |
 | `OSN_SESSION_IP_PEPPER` (≥32 bytes) | osn-api | **generate** (section 1) |
 | `OSN_RP_ID` (WebAuthn RP ID — registrable domain) | osn-api WebAuthn | **DONE — `cireweddings.com`** (registrable apex; organiser portal is the only prod passkey surface). Unchanged by the 2026-07-16 reshuffle — RP ID stays the apex, so passkeys survive the `app.`→`host.` move. |
-| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal = the passkey origin; reshuffle moved it `app.`→`host.`, `app.` kept for the window then pruned). **osn-api is deployed MANUALLY — redeploy after this change.** |
+| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal = the passkey origin; reshuffle moved it `app.`→`host.`, `app.` kept for the window then pruned). Picked up on the next merge — **osn-api now auto-deploys via CI** (`deploy-osn-api` in `deploy.yml`, added 2026-07-16); no manual `wrangler deploy` needed. |
 | `OSN_ISSUER_URL` (public https base of osn-api) | osn-api + cire | **DONE — `https://id.cireweddings.com`** (custom-domain route in `osn/api/wrangler.toml` `[env.production]`) |
 | `OSN_CORS_ORIGIN` (prod app origins, comma-sep) | osn-api | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal calls osn-api; reshuffle `app.`→`host.`) |
 | `OSN_EMAIL_FROM` (verified sender) | osn-api | **DONE — `hello@cireweddings.com`** (Resend sender-domain verification for `cireweddings.com` still required — §1.1) |
@@ -512,6 +512,12 @@ apply all `0000`→latest cleanly after the `0002_add_user_handle` data-copy fix
 > The commands below are the manual equivalents — they document what the pipeline runs.
 
 ### 5.1 osn-api (Worker)
+
+> **CI (prod):** as of 2026-07-16 the `deploy-osn-api` job in `.github/workflows/deploy.yml`
+> auto-deploys prod osn-api on every merge to `main` — migrate (`wrangler d1 migrations
+> apply osn-db-prod --remote --env production`) then `wrangler deploy --env production`,
+> mirroring cire-api. The manual commands below stay the reference for dev/staging and for
+> what the pipeline runs; a manual prod deploy is now only needed out-of-cycle.
 
 osn-api is a Cloudflare Worker (§2.3). With the §3.1 vars in `wrangler.toml` and the
 §3.1 secrets set (`wrangler secret put … --env <env>`), and the D1 migrations applied


### PR DESCRIPTION
## Why

`osn-api` was the last service deployed by hand — every prod change (like the domain-reshuffle `OSN_ORIGIN` update) needed a manual `wrangler deploy`. The `deploy.yml` stub that kept it out of CI cited a stale reason:

> *"the CI deploy job stays gated until the ioredis rate-limiters/session stores are swapped for a Workers-compatible Redis"*

That swap is long done — osn-api has been a deployed Cloudflare Worker (workerd + Upstash + native Workers rate-limiters) on `id.cireweddings.com` since the 2026-06 cutover. So there's no reason it can't deploy from Actions like cire-api.

## What

Replaces the commented-out stub with a real **`deploy-osn-api`** job mirroring `deploy-cire-api`:
1. Apply prod osn D1 migrations — `wrangler d1 migrations apply osn-db-prod --remote --env production` (the `[env.production].d1_databases` binding; `--env` selects prod over the top-level dev `osn-db`).
2. Deploy the Worker — `wrangler deploy --env production`.

Runs against the already-set out-of-band secrets; uses the existing `CLOUDFLARE_API_TOKEN`/`ACCOUNT_ID` (same account/token as cire-api). Gated on `needs: build` like every other deploy job.

## Two things to know

- **Merging this deploys osn-api** — so it doubles as the pending manual deploy, picking up the reshuffle `OSN_ORIGIN`/`OSN_CORS_ORIGIN` (`host.cireweddings.com`) already on `main`. After merge, fresh passkey sign-in at `host.` works with no manual step.
- **osn's D1 migrations now auto-apply on merge** (same model as cire-db). Standard trade for CI deploys — flagged so it's not a surprise.

Docs updated: runbook §5.1 + `OSN_ORIGIN` row, root `CLAUDE.md` deployed-state line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)