### PR TITLE
test(cire/api): wedding-scoped reorder regression + readonly bucket keys

### DIFF
--- a/.changeset/cire-checklist-followups.md
+++ b/.changeset/cire-checklist-followups.md
@@ -1,0 +1,7 @@
+---
+---
+
+cire checklist hardening: a cross-tenant regression test proving `tasksService.reorder`
+is wedding-scoped (an owner of wedding B cannot shuffle wedding A's checklist), and a
+`readonly TimeframeBucket[]` type annotation on `TIMEFRAME_BUCKET_KEYS`. Test + type
+only, no behaviour change (`cire/api`).

--- a/cire/api/src/lib/checklist-buckets.ts
+++ b/cire/api/src/lib/checklist-buckets.ts
@@ -18,7 +18,9 @@ export const TIMEFRAME_BUCKETS = [
 
 export type TimeframeBucket = (typeof TIMEFRAME_BUCKETS)[number]["key"];
 
-export const TIMEFRAME_BUCKET_KEYS = TIMEFRAME_BUCKETS.map((b) => b.key);
+export const TIMEFRAME_BUCKET_KEYS: readonly TimeframeBucket[] = TIMEFRAME_BUCKETS.map(
+  (b) => b.key,
+);
 
 export function isTimeframeBucket(value: string): value is TimeframeBucket {
   return (TIMEFRAME_BUCKET_KEYS as readonly string[]).includes(value);

--- a/cire/api/src/services/tasks.test.ts
+++ b/cire/api/src/services/tasks.test.ts
@@ -177,4 +177,33 @@ describe("tasksService", () => {
     if (!Exit.isSuccess(list)) throw new Error("list failed");
     expect(list.value.map((t) => t.title)).toEqual(["C", "A", "B"]);
   });
+
+  it("reorder is wedding-scoped: foreign ids under another wedding are a no-op (tenancy)", async () => {
+    const db = db0();
+    // Two tasks in the bootstrap wedding's "6m" bucket (sort_order 0, 1).
+    const ids: string[] = [];
+    for (const title of ["A", "B"]) {
+      const r = await run(
+        db,
+        tasksService.create({
+          weddingId: BOOTSTRAP_WEDDING_ID,
+          title,
+          timeframeBucket: "6m",
+          notes: null,
+          dueAt: null,
+        }),
+      );
+      if (!Exit.isSuccess(r)) throw new Error("create failed");
+      ids.push(r.value.id);
+    }
+    // Attempt to reorder the bootstrap wedding's tasks while scoping the call to
+    // the OTHER wedding. Every UPDATE is (wedding, bucket)-scoped, so no row
+    // matches and the bootstrap order stays untouched — an owner of wedding B
+    // cannot shuffle wedding A's checklist.
+    await run(db, tasksService.reorder(OTHER, "6m", [ids[1]!, ids[0]!]));
+    const list = await run(db, tasksService.list(BOOTSTRAP_WEDDING_ID));
+    if (!Exit.isSuccess(list)) throw new Error("list failed");
+    expect(list.value.map((t) => t.title)).toEqual(["A", "B"]);
+    expect(list.value.map((t) => t.sortOrder)).toEqual([0, 1]);
+  });
 });

--- a/cire/wiki/systems/checklist-tasks.md
+++ b/cire/wiki/systems/checklist-tasks.md
@@ -125,3 +125,13 @@ and should be added additively:
 | Day-of → Schedule sync | Day-of tasks reference a `schedule_event_id`; surface in a run-sheet view |
 | `skipped` status | Third status alongside `open`/`done` for tasks that don't apply |
 | Cross-bucket drag | Moving a task between buckets (currently reorder is within-bucket only) |
+
+## Hardening
+
+- **Tenancy (reorder)** — `tasksService.reorder` scopes every `UPDATE` by
+  `(wedding_id, bucket)`, so foreign or wrong-bucket ids are a no-op write. A
+  regression test (`tasks.test.ts` — "reorder is wedding-scoped") proves an
+  owner of wedding B cannot shuffle wedding A's checklist. Complements the
+  existing update/delete tenancy tests.
+- **`TIMEFRAME_BUCKET_KEYS`** is annotated `readonly TimeframeBucket[]` — the
+  single source of truth for bucket keys can't be mutated by a consumer.


### PR DESCRIPTION
## Summary
- Two small Checklist hardening follow-ups parked from the Checklist v1 ship. Test + type only — **no behaviour change**.
- **Cross-tenant reorder regression test** — proves `tasksService.reorder(weddingId, bucket, ids)` is `(wedding_id, bucket)`-scoped: an owner of wedding B passing wedding A's task ids produces a no-op, not a mutation. Complements the existing update/delete tenancy tests.
- **`readonly TimeframeBucket[]`** annotation on `TIMEFRAME_BUCKET_KEYS` — the single source of truth for bucket keys can no longer be mutated by a consumer.

## Workspaces affected
- `@cire/api` (unversioned → empty changeset, validated). No other package touched.

## Decisions & issues

**approach — housekeeping, not a feature** — Two explicitly-scoped follow-ups (recorded at the Checklist v1 ship), done directly on a branch. Ran `/prep-pr` Step-6 parallel perf + security reviews before opening.

**T-R1 — reorder tenancy had no regression test**
- **Issue:** `tasksService.reorder` was `(wedding_id, bucket)`-scoped but nothing pinned that boundary; a future refactor could drop the `wedding_id` predicate unnoticed.
- **Why:** Cross-tenant write isolation is a core invariant of the per-`:weddingId` role model — a leaked task id from another wedding must never be mutable.
- **Solution:** Added `tasks.test.ts` → "reorder is wedding-scoped": create tasks under the bootstrap wedding, call `reorder` with `OTHER` as the weddingId, assert order + sort_order are unchanged.
- **Rationale:** Locks the no-op-on-foreign-id behaviour so a regression fails CI.

**quality — `TIMEFRAME_BUCKET_KEYS` was mutable**
- **Issue:** `TIMEFRAME_BUCKET_KEYS = TIMEFRAME_BUCKETS.map(...)` typed as a mutable array; the single source of truth for bucket keys could be reassigned/pushed by a consumer.
- **Why:** Defensive typing for a shared constant that the HTTP schema + bucket-ordered reads derive from.
- **Solution:** Annotated `readonly TimeframeBucket[]`. The existing `as readonly string[]` cast in `isTimeframeBucket` still holds; `schemas/tasks.ts` derives from `TIMEFRAME_BUCKETS` directly so it is unaffected.
- **Rationale:** Enforces immutability at the type level with zero runtime change.

**review — perf + security both clean**
- **Issue:** None.
- **Why:** Test + type-only diff; no new routes, auth, tokens, queries, or data.
- **Solution:** `/prep-pr` Step 6 — perf: "No performance concerns found"; security + compliance: no findings, and the reviewer verified the tenancy boundary the new test asserts is genuinely enforced in `tasks.ts` (Drizzle `and(eq(id), eq(weddingId), eq(bucket))`).
- **Rationale:** N/A — nothing to fix.

## Test plan
- [ ] `bun run --cwd cire/api test` — full suite (953/953 locally, incl. the new tenancy test).
- [ ] Confirm `bun run --cwd cire/api test tasks` shows the "reorder is wedding-scoped" case passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)