### PR TITLE
chore(cire,osn): prune transitional app./apex origins post-cutover

### DIFF
--- a/.changeset/cire-api-origin-cleanup.md
+++ b/.changeset/cire-api-origin-cleanup.md
@@ -1,0 +1,7 @@
+---
+---
+
+Prune the transitional apex `cireweddings.com` (now the static marketing
+landing, makes no API calls) and `app.cireweddings.com` (old organiser origin)
+from cire-api's production `WEB_ORIGIN` allowlist now that the guest site lives
+on `invite.` and the organiser portal on `host.`. Config-only (`cire/api`).

--- a/.changeset/osn-api-origin-cleanup.md
+++ b/.changeset/osn-api-origin-cleanup.md
@@ -1,0 +1,9 @@
+---
+"@osn/api": patch
+---
+
+Prune the transitional `app.cireweddings.com` origin from osn-api's production
+`OSN_ORIGIN` / `OSN_CORS_ORIGIN` allowlists now that the organiser portal has
+cut over to `host.cireweddings.com`. RP ID stays the registrable apex, so
+existing organiser passkeys are unaffected. Also drops a stale "deploy osn-api
+manually" comment (osn-api is CI-deployed since 2026-07-16).

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -90,11 +90,11 @@ binding = "IMAGES"
 # (`host.cireweddings.com`) MUST also be present or organiser writes to
 # /api/organiser/* fail the CORS origin guard with 403.
 # Domain reshuffle 2026-07-16: guest → `invite.`, organiser → `host.`, apex →
-# landing. The old `cireweddings.com` (apex, while invites still answered there)
-# + `app.cireweddings.com` (old organiser origin) are kept ONLY for the cutover
-# window so nothing 403s mid-switch — prune both once the dashboard move + verify
-# are done (see [[wiki/apps/cire-landing]] cutover steps).
-WEB_ORIGIN = "https://invite.cireweddings.com,https://host.cireweddings.com,https://cireweddings.com,https://app.cireweddings.com"
+# landing. Only the two origins that call this API remain: the guest site
+# (`invite.`) and the organiser portal (`host.`). The transitional `cireweddings.com`
+# (apex — now the static marketing landing, makes no API calls) and
+# `app.cireweddings.com` (old organiser origin) were pruned after the cutover.
+WEB_ORIGIN = "https://invite.cireweddings.com,https://host.cireweddings.com"
 # OSN identity (osn-api) prod origin — served on the cireweddings.com zone at
 # id.cireweddings.com. OSN_ISSUER_URL MUST equal osn-api's own OSN_ISSUER_URL or
 # access-token verification fails; OSN_JWKS_URL is that origin + the JWKS path.

--- a/osn/api/tests/build-deps-ratelimit.test.ts
+++ b/osn/api/tests/build-deps-ratelimit.test.ts
@@ -29,8 +29,8 @@ function nonLocalEnv(over: Partial<Record<string, string>> = {}): EnvRecord {
   return {
     OSN_ENV: "production",
     OSN_ISSUER_URL: "https://id.cireweddings.com",
-    OSN_CORS_ORIGIN: "https://app.cireweddings.com",
-    OSN_ORIGIN: "https://app.cireweddings.com",
+    OSN_CORS_ORIGIN: "https://host.cireweddings.com",
+    OSN_ORIGIN: "https://host.cireweddings.com",
     OSN_RP_ID: "cireweddings.com",
     OSN_JWT_PRIVATE_KEY: privB64,
     OSN_JWT_PUBLIC_KEY: pubB64,

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -216,21 +216,19 @@ crons = ["0 */6 * * *"]
 # WebAuthn RP ID is the registrable apex `cireweddings.com` and OSN_ORIGIN is the
 # organiser portal origin. Guests use claim codes (no passkeys).
 #
-# Domain reshuffle 2026-07-16: the organiser portal moves app.cireweddings.com →
+# Domain reshuffle 2026-07-16: the organiser portal moved app.cireweddings.com →
 # host.cireweddings.com. RP ID stays the registrable apex `cireweddings.com`, so
 # existing organiser passkeys keep working on the new subdomain (credentials are
-# scoped to the RP ID, not the full origin) — NO re-registration. Only the origin
-# allowlists gain `host.`; `app.` is kept for the cutover window so passkey
-# sign-in never breaks mid-switch — drop it once the move + verify are done.
-# NOTE: osn-api is deployed MANUALLY (not CI) — after this merges run
-# `cd osn/api && bunx wrangler deploy --env production` for it to take effect.
+# scoped to the RP ID, not the full origin) — NO re-registration. The transitional
+# `app.cireweddings.com` allowlist entries were pruned after the cutover; only
+# `host.` remains.
 [env.production.vars]
 OSN_ENV = "production"
 OSN_RP_ID = "cireweddings.com"
 OSN_RP_NAME = "OSN"
-OSN_ORIGIN = "https://host.cireweddings.com,https://app.cireweddings.com"
+OSN_ORIGIN = "https://host.cireweddings.com"
 OSN_ISSUER_URL = "https://id.cireweddings.com"
-OSN_CORS_ORIGIN = "https://host.cireweddings.com,https://app.cireweddings.com"
+OSN_CORS_ORIGIN = "https://host.cireweddings.com"
 OSN_EMAIL_FROM = "hello@cireweddings.com"
 # Email is sent via Resend (RESEND_API_KEY secret, §1.1) — confirmed delivering
 # from hello@cireweddings.com on 2026-06-18. Email is REQUIRED in prod: if

--- a/wiki/apps/cire-landing.md
+++ b/wiki/apps/cire-landing.md
@@ -169,10 +169,13 @@ Remaining **manual** steps (Cloudflare dashboard + one deploy), sequenced in
    *move* it off the `cire-invites` Worker — confirm).
 3. Confirm `invite.cireweddings.com` auto-provisioned on the `cire-invites` Worker
    (custom_domain on deploy).
-4. Redeploy osn-api manually (`cd osn/api && bunx wrangler deploy --env production`)
-   — it is NOT in CI — so `OSN_ORIGIN` picks up `host.`.
-5. Cleanup PR: drop apex route from the Worker config; prune `app.`/apex from the
-   allowlists.
+4. ~~Redeploy osn-api manually~~ — osn-api is now CI-deployed (`deploy-osn-api`
+   in `deploy.yml`, added 2026-07-16); `OSN_ORIGIN` picks up on the next merge.
+5. Cleanup PR — **DONE 2026-07-16**: pruned the transitional apex + `app.` from
+   cire-api `WEB_ORIGIN` and `app.` from osn-api `OSN_ORIGIN`/`OSN_CORS_ORIGIN`
+   (`cire/web`'s Worker route was already `invite.`-only, no apex route to drop).
+   **Remaining manual dashboard step:** remove the `app.cireweddings.com` custom
+   domain from the `cire-organiser` Pages project so `app.` stops resolving.
 
 ## Roadmap — toward a wedding platform
 

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -64,9 +64,9 @@ marked **TBD** blocks the deploy.
 | `OSN_JWT_PRIVATE_KEY` / `OSN_JWT_PUBLIC_KEY` (ES256 JWK, base64) | osn-api | **generate** (section 1) |
 | `OSN_SESSION_IP_PEPPER` (≥32 bytes) | osn-api | **generate** (section 1) |
 | `OSN_RP_ID` (WebAuthn RP ID — registrable domain) | osn-api WebAuthn | **DONE — `cireweddings.com`** (registrable apex; organiser portal is the only prod passkey surface). Unchanged by the 2026-07-16 reshuffle — RP ID stays the apex, so passkeys survive the `app.`→`host.` move. |
-| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal = the passkey origin; reshuffle moved it `app.`→`host.`, `app.` kept for the window then pruned). Picked up on the next merge — **osn-api now auto-deploys via CI** (`deploy-osn-api` in `deploy.yml`, added 2026-07-16); no manual `wrangler deploy` needed. |
+| `OSN_ORIGIN` (prod https origins, comma-sep) | osn-api WebAuthn | **DONE — `https://host.cireweddings.com`** (organiser portal = the passkey origin; reshuffle moved it `app.`→`host.`; the transitional `app.` entry was pruned post-cutover 2026-07-16). Picked up on merge — **osn-api auto-deploys via CI** (`deploy-osn-api` in `deploy.yml`); no manual `wrangler deploy` needed. |
 | `OSN_ISSUER_URL` (public https base of osn-api) | osn-api + cire | **DONE — `https://id.cireweddings.com`** (custom-domain route in `osn/api/wrangler.toml` `[env.production]`) |
-| `OSN_CORS_ORIGIN` (prod app origins, comma-sep) | osn-api | **DONE — `https://host.cireweddings.com,https://app.cireweddings.com`** (organiser portal calls osn-api; reshuffle `app.`→`host.`) |
+| `OSN_CORS_ORIGIN` (prod app origins, comma-sep) | osn-api | **DONE — `https://host.cireweddings.com`** (organiser portal calls osn-api; reshuffle `app.`→`host.`; transitional `app.` pruned post-cutover 2026-07-16) |
 | `OSN_EMAIL_FROM` (verified sender) | osn-api | **DONE — `hello@cireweddings.com`** (Resend sender-domain verification for `cireweddings.com` still required — §1.1) |
 | `RESEND_API_KEY` (live email transport) | osn-api | **provision** (Resend domain verify + key — §1.1) |
 | `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_EMAIL_API_TOKEN` | osn-api | optional / **legacy** (Cloudflare-email fallback transport; not used now Resend is the live path — §1.1) |
@@ -78,7 +78,7 @@ marked **TBD** blocks the deploy.
 | `INTERNAL_SERVICE_SECRET` | osn-api | needed only to register cire's ARC key (section 6.2) |
 | cire D1 `database_id` | cire-api wrangler.toml | **DONE** — `6e835474-e0a7-4db9-8883-3247c3c891cd` |
 | cire R2 buckets | cire-api | **DONE** — `cire-sheets[-preview]`, `cire-assets[-preview]` |
-| cire `WEB_ORIGIN` allowlist (guest **and** organiser origins) | cire-api | **DONE — `https://invite.cireweddings.com,https://host.cireweddings.com,https://cireweddings.com,https://app.cireweddings.com`** (reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; old apex+`app.` kept for the cutover window then pruned) |
+| cire `WEB_ORIGIN` allowlist (guest **and** organiser origins) | cire-api | **DONE — `https://invite.cireweddings.com,https://host.cireweddings.com`** (reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; transitional apex + `app.` pruned post-cutover 2026-07-16) |
 | cire `OSN_JWKS_URL` / `OSN_ISSUER_URL` | cire-api | **DONE — `https://id.cireweddings.com/.well-known/jwks.json` / `https://id.cireweddings.com`** (must equal osn-api's own `OSN_ISSUER_URL`) |
 | `CIRE_API_ARC_PRIVATE_KEY` + `CIRE_API_ARC_KEY_ID` + `OSN_API_URL` | cire-api | needed only if guest account-linking is enabled (section 6.2) |
 | cire/web `PUBLIC_API_URL`, `PUBLIC_SITE_URL` (build-time) | cire/web **SSR Worker** | **DONE — `https://api.cireweddings.com` / `https://cireweddings.com`** (set in `deploy.yml`). No `PUBLIC_WEDDING_SLUG` — wedding resolved from the path. Apex now served by the `cire-invites` Worker (custom-domain route), not the Pages project — see §3.3. |


### PR DESCRIPTION
## Summary
- Post-cutover cleanup of the 2026-07-16 domain reshuffle (organiser portal `app.cireweddings.com` → `host.cireweddings.com`). The transitional origins kept "for the cutover window" are now pruned. **Config + docs only** — no source logic.
- **cire-api** `WEB_ORIGIN`: `invite. , host. , cireweddings.com(apex) , app.` → **`invite. , host.`** only.
- **osn-api** `OSN_ORIGIN` + `OSN_CORS_ORIGIN`: `host. , app.` → **`host.`** only. `OSN_RP_ID` stays the registrable apex, so organiser passkeys are unaffected.
- Refreshed the deploy runbook + cutover doc; removed a stale "deploy osn-api manually" comment (osn-api is CI-deployed since 2026-07-16); updated one test fixture's sample origin.

## Workspaces affected
- `@osn/api` (versioned → `patch` changeset) and `@cire/api` (unversioned → empty changeset). Two changesets, split by versioning class.

## Decisions & issues

**timing — ran the cleanup same-day as the cutover (product-owner decision)**
- **Issue:** The `app.`→`host.` cutover merged 2026-07-16 07:48; pruning `app.` hours later risks breaking any organiser still on an `app.` bookmark (origin guard 403 on writes / passkey sign-in).
- **Why:** The `app.` entries were explicitly kept "for the cutover window"; same-day is not a drained window.
- **Solution:** Flagged the risk; the product owner chose to proceed with the full cleanup now. Narrowing the allowlist is the safe *security* direction; the tradeoff is availability for lingering `app.` traffic, accepted deliberately.
- **Rationale:** It's the owner's call on a small, known set of users who have the new `host.` URL.

**passkey safety — RP ID unchanged**
- **Issue:** Could dropping `app.` from `OSN_ORIGIN` invalidate existing organiser passkeys?
- **Why:** Passkey loss would lock organisers out.
- **Solution:** `OSN_RP_ID` stays `cireweddings.com` (registrable apex). WebAuthn credentials are scoped to the RP ID, not the full origin, so sign-in from `host.` works with credentials registered under `app.` — no re-registration.
- **Rationale:** Verified in the security review.

**apex safety — landing makes no API calls**
- **Issue:** Is removing apex `cireweddings.com` from cire-api `WEB_ORIGIN` safe?
- **Why:** If the apex landing called cire-api, this would break it.
- **Solution:** `cire/landing/src` has no cire-api/fetch calls — the apex is a static marketing site. Apex was only in the allowlist "while invites still answered there"; invites moved to `invite.`.
- **Rationale:** Verified by grep; no dynamic API surface on the apex.

**review — perf + security both clean**
- **Issue:** None.
- **Why:** Config narrowing; no new attack surface, no hot-path change.
- **Solution:** `/prep-pr` Step 6 — security: "No security concerns found" (confirmed narrowing/tightening, RP ID preserved); perf: "No performance concerns found" (marginally shorter origin-guard scan).
- **Rationale:** N/A.

## ⚠️ Remaining manual step (dashboard, not in this PR)
Merging redeploys cire-api + osn-api with the narrowed allowlists. To fully retire `app.`, **remove the `app.cireweddings.com` custom domain from the `cire-organiser` Pages project** in the Cloudflare dashboard so `app.` stops resolving. (I can't do this programmatically without prod credentials — it needs a dashboard action.)

## Test plan
- [ ] osn/api (754) + cire/api (953) suites pass locally.
- [ ] After merge + deploy: `curl -I` an organiser write from `host.` → succeeds; confirm passkey sign-in from `host.` still works.
- [ ] Confirm apex `cireweddings.com` still serves the landing (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)