### PR TITLE
perf(cire/organiser): Overview budget memoization + midnight-fresh countdown

### DIFF
--- a/.changeset/overview-perf-followups.md
+++ b/.changeset/overview-perf-followups.md
@@ -1,0 +1,4 @@
+---
+---
+
+perf(cire/organiser): Overview budget memoization + midnight-fresh countdown (OV-P-W1/I2/W3)

--- a/cire/organiser/src/components/Overview.tsx
+++ b/cire/organiser/src/components/Overview.tsx
@@ -72,10 +72,12 @@ interface OverviewData {
   guests: OrganiserGuestRow[];
 }
 
-/** Whole days from now (local midnight) to the wedding date (its local midnight),
+/** Whole days from `nowMs` (local midnight) to the wedding date (its local midnight),
  *  so "today" reads 0 and a future date reads a positive day count. Returns null
- *  for an unparseable date. */
-function daysUntil(isoDate: string): number | null {
+ *  for an unparseable date. `nowMs` defaults to `Date.now()` but callers should
+ *  pass the midnight-refreshing `nowMs()` signal value so the result stays fresh
+ *  if the dashboard is left open across midnight. */
+function daysUntil(isoDate: string, nowMs: number = Date.now()): number | null {
   // `YYYY-MM-DD` — parse as a local date (not UTC) so the countdown matches the
   // organiser's calendar rather than shifting a day across timezones.
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
@@ -83,7 +85,7 @@ function daysUntil(isoDate: string): number | null {
   const [, y, mo, d] = m;
   const target = new Date(Number(y), Number(mo) - 1, Number(d));
   if (Number.isNaN(target.getTime())) return null;
-  const now = new Date();
+  const now = new Date(nowMs);
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const MS_PER_DAY = 24 * 60 * 60 * 1000;
   return Math.round((target.getTime() - today.getTime()) / MS_PER_DAY);
@@ -289,10 +291,6 @@ export default function Overview(props: {
   const isFresh = createMemo(() => eventCount() === 0 && householdCount() === 0);
 
   const weddingDate = createMemo(() => data()?.profile?.weddingDate ?? null);
-  const countdown = createMemo(() => {
-    const iso = weddingDate();
-    return iso ? daysUntil(iso) : null;
-  });
 
   const budgetCurrency = () =>
     peekCachedBudget(props.weddingId)?.currency ?? data()?.profile?.currency ?? "AUD";
@@ -329,6 +327,13 @@ export default function Overview(props: {
     });
   }
 
+  // OV-P-W3: countdown depends on nowMs() so it recomputes at midnight rather
+  // than using a stale Date captured at render time.
+  const countdown = createMemo(() => {
+    const iso = weddingDate();
+    return iso ? daysUntil(iso, nowMs()) : null;
+  });
+
   const agenda = createMemo(() =>
     buildAgenda({
       events: (data()?.events ?? []).map((e) => ({ id: e.id, name: e.name, startAt: e.startAt })),
@@ -342,6 +347,14 @@ export default function Overview(props: {
   );
 
   const vendorCountValue = createMemo(() => vendorCount(props.weddingId));
+
+  // OV-P-W1: memoize upcomingPayments — each call re-filters + re-sorts the
+  // full payments array; three raw calls per Budget card render becomes one.
+  const upcomingPaymentsMemo = createMemo(() => upcomingPayments(props.weddingId));
+
+  // OV-P-I2: memoize spentSoFar — each call re-reduces all budget items; two
+  // raw calls per Budget card render becomes one.
+  const spentSoFarMemo = createMemo(() => spentSoFar(props.weddingId));
 
   const WhatsNext = () => (
     <div class="border-border bg-surface/20 flex flex-col gap-3 rounded-sm border p-5">
@@ -691,7 +704,7 @@ export default function Overview(props: {
                   Budget
                 </p>
                 <Show
-                  when={spentSoFar(props.weddingId) !== null}
+                  when={spentSoFarMemo() !== null}
                   fallback={<p class="text-text-muted text-[0.82rem]">Loading your budget…</p>}
                 >
                   <Show
@@ -701,15 +714,15 @@ export default function Overview(props: {
                     }
                     fallback={
                       <p class="text-text-muted text-[0.82rem]">
-                        {(spentSoFar(props.weddingId) ?? 0) > 0
-                          ? `${fmtBudget(spentSoFar(props.weddingId)!, budgetCurrency())} tracked — set a total →`
+                        {(spentSoFarMemo() ?? 0) > 0
+                          ? `${fmtBudget(spentSoFarMemo()!, budgetCurrency())} tracked — set a total →`
                           : "No budget yet — add your first item."}
                       </p>
                     }
                   >
                     <p class="text-text text-[0.95rem]">
                       <span class="text-gold text-[1.2rem] font-semibold">
-                        {fmtBudget(spentSoFar(props.weddingId) ?? 0, budgetCurrency())}
+                        {fmtBudget(spentSoFarMemo() ?? 0, budgetCurrency())}
                       </span>{" "}
                       <span class="text-text-muted">
                         of{" "}
@@ -724,7 +737,7 @@ export default function Overview(props: {
                       const cap =
                         peekCachedBudget(props.weddingId)?.budgetTotalMinor ??
                         data()?.profile?.budgetTotalMinor;
-                      const spent = spentSoFar(props.weddingId) ?? 0;
+                      const spent = spentSoFarMemo() ?? 0;
                       return (
                         <Show when={cap != null}>
                           <ProgressBar
@@ -740,12 +753,12 @@ export default function Overview(props: {
                       );
                     })()}
                   </Show>
-                  <Show when={upcomingPayments(props.weddingId).length > 0}>
+                  <Show when={upcomingPaymentsMemo().length > 0}>
                     <p class="text-text-muted text-[0.78rem]">
-                      Next: {upcomingPayments(props.weddingId)[0]!.label}
-                      <Show when={upcomingPayments(props.weddingId)[0]!.dueAt}>
+                      Next: {upcomingPaymentsMemo()[0]!.label}
+                      <Show when={upcomingPaymentsMemo()[0]!.dueAt}>
                         {" "}
-                        · due {upcomingPayments(props.weddingId)[0]!.dueAt}
+                        · due {upcomingPaymentsMemo()[0]!.dueAt}
                       </Show>
                     </p>
                   </Show>

--- a/cire/wiki/todo/perf.md
+++ b/cire/wiki/todo/perf.md
@@ -4,7 +4,7 @@ tags: [todo, performance]
 related:
   - "[[index]]"
   - "[[review-findings]]"
-last-reviewed: 2026-07-12
+last-reviewed: 2026-07-17
 ---
 
 # Performance Backlog
@@ -100,9 +100,9 @@ were FIXED on the branch (`dd7e50b3`). The rest are deferred — all in
 `cire/organiser/src/components/Overview.tsx`, all micro-inefficiencies at the
 current data scale (a wedding has tens of payments/tasks, not thousands):
 
-- [ ] **OV-P-W1** — Budget card calls `upcomingPayments(weddingId)` 3× per render (`.length`, `[0].label`, `[0].dueAt`); each re-filters + re-sorts the payments array. Wrap in one component-level `createMemo` when convenient. Only bites if a wedding ever holds hundreds of payment rows.
-- [ ] **OV-P-I2** — Budget card calls `spentSoFar(weddingId)` 2× per render (outer `Show` + amount format); each re-reduces all budget items. Same `createMemo` fix as OV-P-W1.
-- [ ] **OV-P-W3** — Countdown card's `daysUntil` reads a fresh `new Date()` at render, so the countdown (and its "Today!/Tomorrow!" copy) goes stale if the dashboard is left open across midnight — the same class of bug as the fixed OV-P-W2 but on the Countdown, which was outside that fix's agenda-only scope. Fix by feeding the Countdown from the same midnight-refreshing `nowMs()` signal already added for the agenda.
+- [x] **OV-P-W1** — Budget card calls `upcomingPayments(weddingId)` 3× per render (`.length`, `[0].label`, `[0].dueAt`); each re-filters + re-sorts the payments array. Wrap in one component-level `createMemo` when convenient. Only bites if a wedding ever holds hundreds of payment rows. — **Fixed** (feat/cire-overview-perf-followups): added `upcomingPaymentsMemo = createMemo(() => upcomingPayments(props.weddingId))` at component scope; all three Budget-card reads now access the memo.
+- [x] **OV-P-I2** — Budget card calls `spentSoFar(weddingId)` 2× per render (outer `Show` + amount format); each re-reduces all budget items. Same `createMemo` fix as OV-P-W1. — **Fixed** (feat/cire-overview-perf-followups): added `spentSoFarMemo = createMemo(() => spentSoFar(props.weddingId))` at component scope; both Budget-card reads now access the memo.
+- [x] **OV-P-W3** — Countdown card's `daysUntil` reads a fresh `new Date()` at render, so the countdown (and its "Today!/Tomorrow!" copy) goes stale if the dashboard is left open across midnight — the same class of bug as the fixed OV-P-W2 but on the Countdown, which was outside that fix's agenda-only scope. Fix by feeding the Countdown from the same midnight-refreshing `nowMs()` signal already added for the agenda. — **Fixed** (feat/cire-overview-perf-followups): `daysUntil` now accepts an optional `nowMs` parameter (defaults to `Date.now()`); the `countdown` memo is defined after the `nowMs` signal and passes `nowMs()` so it recomputes at midnight.
 
 ### Vendors PR B — vendor portal review notes (`feat/cire-vendor-portal`)
 


### PR DESCRIPTION
## Summary
Three deferred Overview performance follow-ups (all `cire/organiser/src/components/Overview.tsx`), no behavioral change except the countdown now stays correct past midnight.

## Workspaces affected
- `@cire/organiser` (unversioned) → empty changeset.

## Decisions & issues

**OV-P-W1 — Budget card re-filtered/re-sorted payments 3× per render**
- **Issue:** `upcomingPayments(weddingId)` called 3× (`.length`, `[0].label`, `[0].dueAt`), each re-filtering + re-sorting.
- **Why:** Redundant work every render; bites if a wedding holds many payments.
- **Solution:** One component-level `createMemo`, read in all three places.
- **Rationale:** Idiomatic Solid derived-state dedup.

**OV-P-I2 — Budget card re-reduced budget items 2× per render**
- **Issue:** `spentSoFar(weddingId)` called twice (Show guard + amount format), each re-reducing all items.
- **Why:** Same redundancy.
- **Solution:** One `createMemo`, read in both places.
- **Rationale:** Same as OV-P-W1.

**OV-P-W3 — Countdown went stale past midnight**
- **Issue:** `daysUntil` read a fresh `new Date()` at render, so the countdown + "Today!/Tomorrow!" copy didn't update if the dashboard stayed open across midnight.
- **Why:** Same class of bug as the already-fixed OV-P-W2 (agenda), but on the Countdown card.
- **Solution:** `daysUntil(iso, nowMs)` now takes the midnight-refreshing `nowMs()` signal (reused from the agenda — no second clock); the `countdown` memo recomputes at the midnight tick.
- **Rationale:** Single source of "now" already exists; the countdown just subscribes to it.

## Test plan
- [ ] `bun run --cwd cire/organiser test:run` → 368 green
- [ ] `bun run --cwd cire/organiser build` → clean
- [ ] Leave dashboard open across local midnight → countdown decrements

🤖 Generated with [Claude Code](https://claude.com/claude-code)