### PR TITLE
feat(cire/landing): draft service ToS + privacy + refund policy pages

### DIFF
--- a/.changeset/cire-landing-legal-pages.md
+++ b/.changeset/cire-landing-legal-pages.md
@@ -1,0 +1,18 @@
+---
+"@cire/landing": patch
+---
+
+Expand the draft legal pages from site-only to full service scope.
+
+The Terms page becomes draft service Terms of Service (free plan + one-time
+per-wedding add-ons, purchases via a merchant of record, ACL non-excludable
+guarantees, NSW governing law); the Privacy Notice covers the whole service
+(organiser/guest role split, guest data handled on the couple's instructions,
+provider list, cross-border disclosure, OAIC + GDPR rights, the enforced
+1-year guest-data retention window); and a new draft Refund Policy page lands
+(14-day change-of-mind + ACL rights preserved, refunds executed via the
+merchant of record). All entity/provider/contact specifics are highlighted
+`{{PLACEHOLDER}}` values filled at publish time; draft banners stay until
+lawyer review. A vitest guard enforces banner-while-placeholders and the
+footer linking all three legal routes; `wiki/business/` is gitignored for
+private planning notes.

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ wiki/.obsidian/
 
 # Claude Code agent worktrees (transient, per-session)
 .claude/worktrees/
+
+# Private business/legal planning notes — never committed
+wiki/business/

--- a/cire/landing/src/components/SiteFooter.astro
+++ b/cire/landing/src/components/SiteFooter.astro
@@ -27,6 +27,8 @@ const year = 2026
       <a href="/privacy">Privacy Notice</a>
       <span aria-hidden="true">&middot;</span>
       <a href="/terms">Terms</a>
+      <span aria-hidden="true">&middot;</span>
+      <a href="/refunds">Refunds</a>
     </nav>
     <p class="site-footer__copy">&copy; {year} Cire. Made with care.</p>
   </div>

--- a/cire/landing/src/legal-pages.test.ts
+++ b/cire/landing/src/legal-pages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import footer from "./components/SiteFooter.astro?raw";
+import privacy from "./pages/privacy.astro?raw";
+import refunds from "./pages/refunds.astro?raw";
+import terms from "./pages/terms.astro?raw";
+
+const legalPages = { terms, privacy, refunds };
+
+describe("legal pages", () => {
+  // A page may only ship {{...}} placeholder tokens while its draft banner is
+  // still present — the lawyer-review cleanup must remove both together.
+  for (const [name, source] of Object.entries(legalPages)) {
+    it(`${name} keeps the draft banner while placeholders remain`, () => {
+      const hasPlaceholders = /\{\{[A-Z_]+\}\}/.test(source);
+      const hasDraftBanner = source.includes("draft-banner");
+      expect(!hasPlaceholders || hasDraftBanner).toBe(true);
+    });
+  }
+
+  it("footer links every legal page", () => {
+    for (const name of Object.keys(legalPages)) {
+      expect(footer).toContain(`href="/${name}"`);
+    }
+  });
+});

--- a/cire/landing/src/pages/privacy.astro
+++ b/cire/landing/src/pages/privacy.astro
@@ -5,49 +5,107 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <div class="draft-banner">
     <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
     publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value (legal entity, contact address, regulator details).
+    value (contact address, retention specifics).
   </div>
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: 2026-06-24</p>
+  <p class="meta">Last updated: 2026-07-18</p>
 
   <p>
-    This notice explains how <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span> (&ldquo;Cire&rdquo;,
-    &ldquo;we&rdquo;) handles personal information collected through our marketing site at
-    cireweddings.com. It covers visitors to this site. The separate privacy notice shown inside a
-    couple&rsquo;s invitation governs the guest data handled for that wedding.
+    This notice explains how <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire
+    (&ldquo;Cire&rdquo;, &ldquo;we&rdquo;), handles
+    personal information across the Cire service — this marketing site, the invitation site your
+    guests use, and the organiser portal.
   </p>
 
-  <h2>What we collect here</h2>
+  <h2>Two kinds of people use Cire</h2>
   <ul>
-    <li>Anything you choose to send us — for example your name and email when you start an invitation or contact us.</li>
-    <li>Basic, privacy-respecting analytics about how this site is used, so we can improve it.</li>
+    <li><strong>Organisers</strong> (couples and their helpers) create an account with us. For your
+      account and purchase information, we decide how it is handled, as described here.</li>
+    <li><strong>Guests</strong> don&rsquo;t create accounts. Your couple uploads your details to
+      manage their wedding, and we process them on the couple&rsquo;s behalf and instructions. If
+      you are a guest with questions about why your details are in Cire, your couple is the first
+      port of call — but you can always contact us directly too.</li>
+  </ul>
+
+  <h2>What we collect</h2>
+  <ul>
+    <li><strong>Organiser accounts</strong> — your name, email address and passkey credentials
+      (public key only — no passwords), and the weddings you manage.</li>
+    <li><strong>Wedding content</strong> — invitation wording, images, event schedules, checklists
+      and budgets you create.</li>
+    <li><strong>Guest information uploaded by organisers</strong> — guest names, household
+      groupings, RSVP responses, dietary needs and similar details the couple chooses to record.</li>
+    <li><strong>Purchases</strong> — handled by our merchant of record,
+      <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>. We receive order confirmation
+      (what was bought, for which wedding) but never see your card details.</li>
+    <li><strong>Site usage</strong> — the technical logs needed to keep the service secure. We run
+      no third-party analytics or advertising trackers.</li>
   </ul>
 
   <h2>Why we collect it</h2>
   <ul>
-    <li>To respond to your enquiry and set up your invitation.</li>
-    <li>To keep the site secure and working well.</li>
+    <li>To provide the service — hosting invitations, collecting RSVPs, powering the planning tools.</li>
+    <li>To process purchases and unlock paid add-ons.</li>
+    <li>To send transactional email (sign-in codes, security notices) — never marketing without consent.</li>
+    <li>To keep the service secure and improve it.</li>
   </ul>
-  <p>We do not sell your information, and we do not use it for third-party advertising.</p>
+  <p>We do not sell personal information, and we do not use it for third-party advertising.</p>
+
+  <h2>Who we share it with</h2>
+  <p>We use a small set of service providers to run Cire:</p>
+  <ul>
+    <li><strong>Cloudflare</strong> — hosting, content delivery and databases (global network).</li>
+    <li><span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span> — payment processing, as
+      merchant of record for purchases.</li>
+    <li><strong>Resend</strong> — transactional email delivery.</li>
+    <li><strong>Upstash</strong> — infrastructure supporting security features such as rate limiting.</li>
+    <li><strong>Grafana Cloud</strong> — service telemetry (metrics and traces; pseudonymised
+      identifiers only, never guest content).</li>
+    <li><strong>Google Fonts</strong> — our pages currently load fonts from Google&rsquo;s CDN,
+      which sees your IP address when they load. We plan to self-host these fonts.</li>
+  </ul>
+  <p>
+    We also disclose information where the law requires it. Because these providers operate
+    globally, personal information may be stored or processed outside Australia, including in the
+    United States and the European Union.
+  </p>
 
   <h2>How long we keep it</h2>
   <p>
-    Only as long as we need it for the purpose above, then we delete or anonymise it. Specific
-    retention periods: <span class="placeholder">{'{{RETENTION}}'}</span>.
+    Only as long as needed for the purposes above. Guest information (guest lists, RSVPs, dietary
+    needs) is automatically deleted <strong>one year after the wedding&rsquo;s final event</strong>.
+    Other wedding and account data is kept while your account is active and removed when you ask us
+    to; specific periods for account data:
+    <span class="placeholder">{'{{RETENTION}}'}</span>.
+  </p>
+
+  <h2>Security</h2>
+  <p>
+    Traffic is encrypted in transit, organiser sign-in uses passkeys rather than passwords, and
+    session credentials are stored hashed. No system is perfectly secure, but we design for
+    security first.
   </p>
 
   <h2>Your rights</h2>
   <p>
-    Depending on where you live, you may have rights to access, correct, delete or port your
-    information, and to object to certain uses. To exercise them, contact us at
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>. You may also complain to your local data
-    protection regulator (<span class="placeholder">{'{{REGULATOR}}'}</span>).
+    You may have rights to access, correct, delete or port your information, and to object to
+    certain uses — under the Australian Privacy Act, and for people in the EEA or UK, the GDPR and
+    UK GDPR. To exercise them, contact us at
+    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>. You can also complain to a regulator —
+    in Australia, the Office of the Australian Information Commissioner (OAIC), or your local data
+    protection authority.
+  </p>
+
+  <h2>Cookies</h2>
+  <p>
+    We use only the cookies the service needs to work (such as session cookies for signed-in
+    organisers and guests). No advertising or cross-site tracking cookies.
   </p>
 
   <h2>Contact</h2>
   <p>
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>,
+    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span> (trading as Cire),
     <span class="placeholder">{'{{POSTAL_ADDRESS}}'}</span> —
     <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
   </p>

--- a/cire/landing/src/pages/refunds.astro
+++ b/cire/landing/src/pages/refunds.astro
@@ -1,0 +1,57 @@
+---
+import LegalLayout from '../layouts/LegalLayout.astro'
+---
+<LegalLayout title="Refund Policy">
+  <div class="draft-banner">
+    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
+    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
+    value.
+  </div>
+
+  <h1>Refund Policy</h1>
+  <p class="meta">Last updated: 2026-07-18</p>
+
+  <p>
+    Cire add-ons are one-time purchases that permanently unlock a feature for a single wedding.
+    This policy explains when and how we refund them. It is offered by
+    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire.
+  </p>
+
+  <h2>14-day change of mind</h2>
+  <p>
+    If you buy an add-on and change your mind, we will refund it in full within
+    <strong>14 days of purchase</strong>, provided you haven&rsquo;t substantially used it (for
+    example, a capacity upgrade you haven&rsquo;t imported guests against, or a template pack you
+    haven&rsquo;t published an invitation with). Just email
+    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span> with your order details.
+  </p>
+
+  <h2>Your rights under the Australian Consumer Law</h2>
+  <p>
+    Our services come with guarantees that cannot be excluded under the Australian Consumer Law.
+    If an add-on has a major failure, you are entitled to a refund or to compensation for any
+    reasonably foreseeable loss or damage; if the failure is minor, you are entitled to have it
+    fixed in a reasonable time. Nothing in this policy limits those rights — the change-of-mind
+    window above is in addition to them, not instead of them.
+  </p>
+
+  <h2>If you&rsquo;re outside Australia</h2>
+  <p>
+    Your local consumer laws (for example EU or UK consumer rights) are unaffected by this policy.
+    Where they give you stronger rights, those apply.
+  </p>
+
+  <h2>How refunds are processed</h2>
+  <p>
+    Purchases are processed by our merchant of record,
+    <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>, so refunds are issued through
+    them back to your original payment method — typically within 5&ndash;10 business days of
+    approval. When a purchase is refunded, the corresponding add-on is removed from the wedding
+    (unless the refund was a remedy for a fault we couldn&rsquo;t fix).
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Refund requests and questions: <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+  </p>
+</LegalLayout>

--- a/cire/landing/src/pages/terms.astro
+++ b/cire/landing/src/pages/terms.astro
@@ -1,45 +1,109 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
 ---
-<LegalLayout title="Terms of Use">
+<LegalLayout title="Terms of Service">
   <div class="draft-banner">
     <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
     publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
     value.
   </div>
 
-  <h1>Terms of Use</h1>
-  <p class="meta">Last updated: 2026-06-24</p>
+  <h1>Terms of Service</h1>
+  <p class="meta">Last updated: 2026-07-18</p>
 
   <p>
-    These terms govern your use of the Cire marketing site at cireweddings.com, operated by
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>. By using the site you agree to them.
+    Cire is a digital wedding invitation and wedding planning service available at cireweddings.com,
+    invite.cireweddings.com and host.cireweddings.com. It is operated by
+    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire (&ldquo;Cire&rdquo;,
+    &ldquo;we&rdquo;, &ldquo;us&rdquo;). By creating an account or using the service you agree to
+    these terms.
   </p>
 
-  <h2>Using the site</h2>
+  <h2>The service</h2>
   <p>
-    You may browse and share this site. Please don&rsquo;t misuse it — no attempts to disrupt it,
-    access it other than through the interface we provide, or use it unlawfully.
+    Cire lets couples and their organisers create wedding invitations, collect RSVPs, and plan their
+    wedding (guest lists, checklists, budgets and optional paid add-ons). Guests use the invitation
+    site with a claim code supplied by their couple; organisers sign in to the organiser portal.
   </p>
 
-  <h2>Our content</h2>
+  <h2>Your account</h2>
   <p>
-    The Cire name, design, copy and imagery are owned by us or our licensors and may not be reused
-    without permission. Photography on this site is used under the licences of its respective
-    photographers.
+    Organisers sign in with a passkey. Keep your sign-in method secure — you are responsible for
+    activity under your account. Provide accurate information and keep it up to date.
   </p>
 
-  <h2>Invitations are a separate agreement</h2>
+  <h2>Free plan and paid add-ons</h2>
+  <ul>
+    <li>The free plan includes invitations, RSVPs, guest management, the checklist and the budget,
+      with a guest capacity of 100.</li>
+    <li>Paid add-ons (for example premium templates, the vendor directory and CRM, AI features, and
+      guest-capacity upgrades) are <strong>one-time purchases that apply to a single wedding</strong>.
+      Once purchased, an add-on remains unlocked for that wedding permanently. Add-ons are not
+      transferable between weddings or accounts.</li>
+    <li>We may change what is included in the free plan for future weddings, but we will never
+      revoke an add-on you have purchased.</li>
+  </ul>
+
+  <h2>Purchases and payment</h2>
   <p>
-    Creating and sending invitations is governed by a separate agreement entered into when you start
-    an invitation. These site terms do not grant any right to the invitation service.
+    Purchases are processed by our merchant of record,
+    <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>. When you buy an add-on, your
+    contract of sale (including payment, applicable taxes and invoicing) is with the merchant of
+    record, and their terms of sale apply to the transaction. We then unlock the purchased add-on
+    for your wedding. Prices are shown in or converted to your local currency at checkout. Refunds are
+    handled under our <a href="/refunds">Refund Policy</a>.
   </p>
 
-  <h2>No warranty &amp; liability</h2>
+  <h2>Your content and your guests&rsquo; information</h2>
+  <ul>
+    <li>You keep ownership of everything you upload — invitation wording, images, schedules, guest
+      lists. You grant us the licence needed to host, display and process it solely to provide the
+      service.</li>
+    <li>When you upload guest information (names, contact details, dietary needs), you confirm you
+      are entitled to share it with us for managing your wedding. We handle it on your behalf as
+      described in our <a href="/privacy">Privacy Notice</a> and don&rsquo;t use it for anything
+      else.</li>
+  </ul>
+
+  <h2>Acceptable use</h2>
   <p>
-    This site is provided &ldquo;as is&rdquo;. To the extent permitted by law we exclude implied
-    warranties and limit our liability for your use of it. Nothing here limits liability that cannot
-    be limited by law.
+    Don&rsquo;t misuse the service — no unlawful content, no attempts to disrupt or gain
+    unauthorised access to it, no using it to spam or harass, and no accessing it other than through
+    the interfaces we provide.
+  </p>
+
+  <h2>Australian Consumer Law</h2>
+  <p>
+    Our services come with guarantees that cannot be excluded under the Australian Consumer Law.
+    Nothing in these terms excludes, restricts or modifies any consumer guarantee, right or remedy
+    you have under the Australian Consumer Law or any other law that cannot lawfully be excluded.
+  </p>
+
+  <h2>Liability</h2>
+  <p>
+    To the extent permitted by law, and subject to the consumer guarantees above, our liability in
+    connection with the service is limited to re-supplying the service or paying the cost of having
+    it re-supplied, and we are not liable for indirect or consequential loss. We provide the service
+    with due care and skill but do not promise it will be uninterrupted or error-free.
+  </p>
+
+  <h2>Ending the service</h2>
+  <p>
+    You can stop using Cire and ask us to delete your wedding data at any time. We may suspend or
+    close accounts that seriously or repeatedly breach these terms. If we ever discontinue the
+    service, we will give you reasonable notice and a way to export your data.
+  </p>
+
+  <h2>Changes to these terms</h2>
+  <p>
+    We may update these terms from time to time. Material changes will be notified on the site or by
+    email before they take effect. Changes are not retroactive.
+  </p>
+
+  <h2>Governing law</h2>
+  <p>
+    These terms are governed by the laws of New South Wales, Australia. This does not deprive you of
+    protections you have under the consumer laws of the place where you live.
   </p>
 
   <h2>Contact</h2>


### PR DESCRIPTION
## Summary
- Expands the draft legal pages on the marketing site from site-only scope to the full Cire service, ahead of enabling paid add-ons.
- **Terms of Service**: free plan + one-time per-wedding add-on model, purchases via a merchant of record, ACL non-excludable consumer guarantees with a re-supply liability cap, NSW governing law.
- **Privacy Notice**: service-wide — organiser vs guest role split (guest data processed on the couple's instructions), data categories, provider list, cross-border disclosure, OAIC + GDPR/UK GDPR rights, the already-enforced 1-year guest-data retention window, essential-cookies-only.
- **Refund Policy** (new page): 14-day change-of-mind where the add-on is substantially unused, ACL rights explicitly preserved above the voluntary policy, EU/UK statutory rights unaffected, refunds executed via the merchant of record.
- All entity/provider/contact specifics remain highlighted `{{PLACEHOLDER}}` tokens filled at publish time; draft banners stay until lawyer review. Footer links all three pages. `wiki/business/` added to .gitignore for private planning notes.

## Workspaces affected
- `@cire/landing` (changeset included)

## Decisions & issues

**[P-C1 / S-M1]** — Test file inside `src/pages/` breaks `astro build`
- **Issue:** The new vitest guard originally lived at `src/pages/legal-pages.test.ts`; Astro's route scanner treats any non-underscore `.ts` under `src/pages/` as an endpoint route and imports it during build, which throws (`describe()` outside a runner) and would block CI + the Pages deploy pipeline.
- **Why:** Hard build failure on the auto-deployed apex site; in a tolerant-import future it would even publish test infra as a servable route.
- **Solution:** Moved to `src/legal-pages.test.ts` and rewrote on Vite `?raw` imports (no node types needed; a missing page fails at import).
- **Rationale:** Outside `src/pages/` the route scanner never sees it; vitest's default glob still collects it; `?raw` sidesteps the missing `@types/node` in the landing tsconfig.

**[T-S1/T-S2]** — Placeholder-leak + footer-link guards
- **Issue:** Nothing would catch removing a draft banner while `{{...}}` tokens remain, or a footer refactor dropping a legal link.
- **Why:** The realistic failure mode for static legal pages is shipping a half-finished cleanup to the live site.
- **Solution:** `legal-pages.test.ts` asserts each page keeps its draft banner while placeholders remain, and the footer links `/terms`, `/privacy`, `/refunds`.
- **Rationale:** Encodes the branch's own invariant as an executable check; the lawyer-review cleanup can't half-finish silently.

**[copy-accuracy]** — Notice claims aligned with shipped capability
- **Issue:** Early drafts claimed analytics that don't exist, a self-service wedding-delete flow that doesn't exist yet, and described telemetry as carrying "no personal data".
- **Why:** GDPR Art. 12 / APP transparency — a published notice must describe what the service actually does.
- **Solution:** Analytics claim dropped; retention copy states the enforced 1-year-after-final-event guest-data sweep and manual removal on request for the rest; telemetry bullet reworded to "pseudonymised identifiers only, never guest content"; the Google Fonts CDN load is disclosed in the provider list.
- **Rationale:** Copy that matches reality now is cheaper than defending an inaccurate published notice later.

**[lint]** — oxlint `vitest(no-conditional-expect)`
- **Issue:** The placeholder guard originally wrapped `expect` in an `if`, failing the pre-commit hook.
- **Why:** Conditional expects can silently skip assertions.
- **Solution:** Rewrote as an unconditional boolean-implication assertion.
- **Rationale:** Same invariant, hook-clean.

**[scope]** — Placeholders instead of real values
- **Issue:** Entity, merchant-of-record, contact and retention specifics could have been filled in directly.
- **Why:** Business/legal specifics are deliberately kept out of the repo; the pages are drafts pending lawyer review either way.
- **Solution:** Everything identity-specific is a highlighted `{{PLACEHOLDER}}`, filled at publish time; `wiki/business/` gitignored for the private notes.
- **Rationale:** The draft-banner + placeholder pattern (already used by the guest-site legal pages, PR #124) keeps the repo clean while letting the page structure land and be reviewed.

## Test plan
- [ ] `bun run --cwd cire/landing build` — 4 pages build, including `/refunds`
- [ ] `bun run --cwd cire/landing test:run` — 23 tests green (incl. the new legal-pages guards)
- [ ] Visual check: `/terms`, `/privacy`, `/refunds` render with draft banners + highlighted placeholders; footer shows all three links
- [ ] Confirm no real entity/provider/contact values appear anywhere in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)