### PR TITLE
feat(cire): per-wedding entitlement (feature-gate) foundation

### DIFF
--- a/.changeset/cire-platform-tiering-phase1.md
+++ b/.changeset/cire-platform-tiering-phase1.md
@@ -1,0 +1,4 @@
+---
+---
+
+cire entitlement foundation (per-wedding feature gate) — @cire/* unversioned, no release.

--- a/cire/api/scripts/grant-entitlement.test.ts
+++ b/cire/api/scripts/grant-entitlement.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "bun:test";
+
+import { buildGrants } from "./grant-entitlement";
+
+describe("buildGrants", () => {
+  it("maps requested keys to comp grants for the wedding", () => {
+    const grants = buildGrants("wed_vr", ["vendors", "capacity_1000"], "usr_owner");
+    expect(grants).toEqual([
+      { key: "vendors", opts: { source: "comp", grantedBy: "usr_owner" } },
+      { key: "capacity_1000", opts: { source: "comp", grantedBy: "usr_owner" } },
+    ]);
+  });
+  it("rejects an unknown key", () => {
+    expect(() => buildGrants("wed_vr", ["bogus" as never], "x")).toThrow();
+  });
+});

--- a/cire/api/scripts/grant-entitlement.test.ts
+++ b/cire/api/scripts/grant-entitlement.test.ts
@@ -13,4 +13,27 @@ describe("buildGrants", () => {
   it("rejects an unknown key", () => {
     expect(() => buildGrants("wed_vr", ["bogus" as never], "x")).toThrow();
   });
+
+  // S-M1: validate operator-supplied CLI args before SQL interpolation
+  it("rejects a malicious weddingId containing SQL injection payload", () => {
+    expect(() => buildGrants("wed_'; DROP TABLE x;--", ["vendors"], "operator")).toThrow(
+      "invalid weddingId",
+    );
+  });
+  it("rejects a weddingId that does not start with wed_", () => {
+    expect(() => buildGrants("evil_abc", ["vendors"], "operator")).toThrow("invalid weddingId");
+  });
+  it("rejects a malicious grantedBy containing SQL injection payload", () => {
+    expect(() => buildGrants("wed_abc", ["vendors"], "usr'; DROP TABLE x;--")).toThrow(
+      "invalid grantedBy",
+    );
+  });
+  it("rejects a grantedBy with spaces or special characters", () => {
+    expect(() => buildGrants("wed_abc", ["vendors"], "usr owner@example.com")).toThrow(
+      "invalid grantedBy",
+    );
+  });
+  it("accepts valid weddingId and grantedBy with alphanumeric and underscores", () => {
+    expect(() => buildGrants("wed_abc123", ["vendors"], "usr_owner_1")).not.toThrow();
+  });
 });

--- a/cire/api/scripts/grant-entitlement.ts
+++ b/cire/api/scripts/grant-entitlement.ts
@@ -11,7 +11,12 @@
 import { ENTITLEMENT_KEYS } from "../src/services/entitlements";
 import type { EntitlementKey } from "../src/services/entitlements";
 
+const WEDDING_ID_RE = /^wed_[A-Za-z0-9_]+$/;
+const GRANTED_BY_RE = /^[A-Za-z0-9_]+$/;
+
 export function buildGrants(weddingId: string, keys: EntitlementKey[], grantedBy: string) {
+  if (!WEDDING_ID_RE.test(weddingId)) throw new Error("invalid weddingId");
+  if (!GRANTED_BY_RE.test(grantedBy)) throw new Error("invalid grantedBy");
   for (const k of keys) {
     if (!ENTITLEMENT_KEYS.includes(k)) throw new Error(`unknown entitlement key: ${k}`);
   }

--- a/cire/api/scripts/grant-entitlement.ts
+++ b/cire/api/scripts/grant-entitlement.ts
@@ -28,7 +28,7 @@ export function grantsToSql(
   return buildGrants(weddingId, keys, grantedBy)
     .map(
       (g) =>
-        `INSERT OR IGNORE INTO wedding_entitlements (wedding_id, entitlement, source, granted_at, granted_by, stripe_ref) ` +
+        `INSERT OR IGNORE INTO wedding_entitlements (wedding_id, entitlement, source, granted_at, granted_by, provider_ref) ` +
         `VALUES ('${weddingId}', '${g.key}', 'comp', ${nowMs}, '${grantedBy}', NULL);`,
     )
     .join("\n");

--- a/cire/api/scripts/grant-entitlement.ts
+++ b/cire/api/scripts/grant-entitlement.ts
@@ -1,0 +1,51 @@
+/**
+ * Comp/manual entitlement grant CLI. The Phase-1 grant seam for V&R's full comp,
+ * "contact us" capacity_1000, and support goodwill. NOT a network surface —
+ * cire has no inbound ARC route; this runs as an operator tool.
+ *
+ * Local:  bun run cire/api/scripts/grant-entitlement.ts <weddingId> <key,key,...>
+ * Prod:   apply the equivalent rows via `wrangler d1 execute cire-db --remote`
+ *         using the SQL this prints (a prod D1 write — requires explicit human
+ *         authorization naming cire-db before running).
+ */
+import { Effect } from "effect";
+
+import { ENTITLEMENT_KEYS, entitlementService } from "../src/services/entitlements";
+import type { EntitlementKey } from "../src/services/entitlements";
+
+export function buildGrants(weddingId: string, keys: EntitlementKey[], grantedBy: string) {
+  for (const k of keys) {
+    if (!ENTITLEMENT_KEYS.includes(k)) throw new Error(`unknown entitlement key: ${k}`);
+  }
+  return keys.map((key) => ({ key, opts: { source: "comp" as const, grantedBy } }));
+}
+
+/** Print the idempotent SQL for the requested comp grants (for wrangler d1 execute). */
+export function grantsToSql(
+  weddingId: string,
+  keys: EntitlementKey[],
+  grantedBy: string,
+  nowMs: number,
+) {
+  return buildGrants(weddingId, keys, grantedBy)
+    .map(
+      (g) =>
+        `INSERT OR IGNORE INTO wedding_entitlements (wedding_id, entitlement, source, granted_at, granted_by, stripe_ref) ` +
+        `VALUES ('${weddingId}', '${g.key}', 'comp', ${nowMs}, '${grantedBy}', NULL);`,
+    )
+    .join("\n");
+}
+
+// Thin main for local runs (bun:sqlite). Guarded so importing the module in
+// tests does not execute it.
+if (import.meta.main) {
+  const [weddingId, keysCsv, grantedBy = "operator"] = Bun.argv.slice(2);
+  if (!weddingId || !keysCsv) {
+    console.error("usage: grant-entitlement.ts <weddingId> <key,key,...> [grantedBy]");
+    process.exit(1);
+  }
+  const keys = keysCsv.split(",") as EntitlementKey[];
+  // Print the prod SQL (the safe, reviewable artifact). Local application can be
+  // wired against createDb by the operator if desired.
+  console.log(grantsToSql(weddingId, keys, grantedBy, Date.now()));
+}

--- a/cire/api/scripts/grant-entitlement.ts
+++ b/cire/api/scripts/grant-entitlement.ts
@@ -8,9 +8,7 @@
  *         using the SQL this prints (a prod D1 write — requires explicit human
  *         authorization naming cire-db before running).
  */
-import { Effect } from "effect";
-
-import { ENTITLEMENT_KEYS, entitlementService } from "../src/services/entitlements";
+import { ENTITLEMENT_KEYS } from "../src/services/entitlements";
 import type { EntitlementKey } from "../src/services/entitlements";
 
 export function buildGrants(weddingId: string, keys: EntitlementKey[], grantedBy: string) {

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -29,6 +29,7 @@ import {
   createOrganiserWeddingCreateRoute,
   createOrganiserWeddingsRoutes,
 } from "./routes/organiser-weddings";
+import { createPaymentWebhookSkeleton } from "./routes/payment-webhook";
 import { createPrimaryWeddingRoutes } from "./routes/primary-wedding";
 import { createRsvpRoutes } from "./routes/rsvp";
 import { createTaskReadRoutes, createTaskWriteRoutes } from "./routes/tasks";
@@ -156,6 +157,13 @@ export interface AppOptions {
   vendorPortalLimiter?: RateLimiterBackend;
   /** Override the vendor directory browse per-user rate limiter (useful for testing). */
   directoryLimiter?: RateLimiterBackend;
+  /**
+   * Phase-2 seam: mount the inert payment-webhook skeleton only when this is
+   * `true`. Defaults to `false` — the route is NOT exposed unless explicitly
+   * enabled. In Phase 2 the provider implementation replaces the skeleton body;
+   * flipping this flag is the only change needed in production config.
+   */
+  paymentWebhookEnabled?: boolean;
   /** R2 bucket binding for the organiser import flow. */
   r2?: R2Bucket;
   /** R2 bucket binding for invite-builder images (separate from `r2`). */
@@ -248,6 +256,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
     cspReportLimiter = defaultCspReportLimiter,
     vendorPortalLimiter = defaultVendorPortalLimiter,
     directoryLimiter = defaultDirectoryLimiter,
+    paymentWebhookEnabled = false,
     r2,
     assets,
     images,
@@ -279,7 +288,8 @@ export function createApp(db: Db, options: AppOptions = {}) {
     _testKey: osnTestKey,
   };
 
-  return (
+  // Capture the chain so we can conditionally mount the payment webhook below.
+  const app =
     // `aot: false` — Elysia's ahead-of-time compilation builds handlers via
     // `new Function`, which Cloudflare Workers forbids (no dynamic code
     // evaluation). The dynamic handler is plenty for this API's traffic.
@@ -441,6 +451,10 @@ export function createApp(db: Db, options: AppOptions = {}) {
           osnAuthOptions,
           vendorPortalLimiter,
         ),
-      )
-  );
+      );
+  // Phase-2 seam: mount the inert payment-webhook skeleton ONLY when the flag
+  // is explicitly set. Default is false — the POST /api/payments/webhook route
+  // is never reachable unless a deployment opts in. This keeps Phase 1 safe
+  // (no unverified endpoint is ever exposed by default).
+  return paymentWebhookEnabled ? app.use(createPaymentWebhookSkeleton()) : app;
 }

--- a/cire/api/src/db/setup.ts
+++ b/cire/api/src/db/setup.ts
@@ -284,6 +284,15 @@ CREATE TABLE IF NOT EXISTS vendor_claims (
   consumed_at INTEGER
 );
 CREATE INDEX IF NOT EXISTS vendor_claims_vendor_idx ON vendor_claims(directory_vendor_id);
+CREATE TABLE IF NOT EXISTS wedding_entitlements (
+  wedding_id TEXT NOT NULL REFERENCES weddings(id) ON DELETE CASCADE,
+  entitlement TEXT NOT NULL,
+  source TEXT NOT NULL,
+  granted_at INTEGER NOT NULL,
+  granted_by TEXT NOT NULL,
+  stripe_ref TEXT,
+  PRIMARY KEY (wedding_id, entitlement)
+);
 `;
 
 export function createDb(path: string = ":memory:"): Db {

--- a/cire/api/src/db/setup.ts
+++ b/cire/api/src/db/setup.ts
@@ -290,7 +290,7 @@ CREATE TABLE IF NOT EXISTS wedding_entitlements (
   source TEXT NOT NULL,
   granted_at INTEGER NOT NULL,
   granted_by TEXT NOT NULL,
-  stripe_ref TEXT,
+  provider_ref TEXT,
   PRIMARY KEY (wedding_id, entitlement)
 );
 `;

--- a/cire/api/src/middleware/wedding-entitlement.test.ts
+++ b/cire/api/src/middleware/wedding-entitlement.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+
+import { weddings } from "@cire/db";
+import { Effect } from "effect";
+import { Elysia } from "elysia";
+
+import type { Db } from "../db";
+import { DbService } from "../db";
+import { createDb } from "../db/setup";
+import { entitlementService } from "../services/entitlements";
+import { appRequest } from "../test-helpers";
+import { weddingEntitlement } from "./wedding-entitlement";
+
+function buildDb(): Db {
+  const db = createDb(":memory:");
+  const now = new Date();
+  db.insert(weddings)
+    .values({
+      id: "wed_x",
+      slug: "wed-x-slug",
+      displayName: "Wedding X",
+      ownerOsnProfileId: "usr_o",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(weddings)
+    .values({
+      id: "wed_y",
+      slug: "wed-y-slug",
+      displayName: "Wedding Y",
+      ownerOsnProfileId: "usr_o",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  return db;
+}
+
+function appFor(db: Db) {
+  return new Elysia({ aot: false }).group("/w/:weddingId", (g) =>
+    g.use(weddingEntitlement(db, "vendors")).get("/thing", () => ({ ok: true })),
+  );
+}
+
+describe("weddingEntitlement", () => {
+  it("402 payment_required + entitlement when the wedding lacks the pack", async () => {
+    const db = buildDb();
+    const res = await appRequest(appFor(db), "/w/wed_x/thing");
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("passes through when the wedding holds the pack", async () => {
+    const db = buildDb();
+    await Effect.runPromise(
+      entitlementService
+        .grant("wed_y", "vendors", { source: "comp", grantedBy: "usr_o" })
+        .pipe(Effect.provideService(DbService, db)) as Effect.Effect<void, never, never>,
+    );
+    const res = await appRequest(appFor(db), "/w/wed_y/thing");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/cire/api/src/middleware/wedding-entitlement.test.ts
+++ b/cire/api/src/middleware/wedding-entitlement.test.ts
@@ -11,6 +11,17 @@ import { entitlementService } from "../services/entitlements";
 import { appRequest } from "../test-helpers";
 import { weddingEntitlement } from "./wedding-entitlement";
 
+/** A stub Db whose every query throws a transient error — simulates D1 defect. */
+function buildThrowingDb(): Db {
+  return new Proxy({} as Db, {
+    get() {
+      return () => {
+        throw new Error("simulated D1 transient failure");
+      };
+    },
+  });
+}
+
 function buildDb(): Db {
   const db = createDb(":memory:");
   const now = new Date();
@@ -44,6 +55,16 @@ function appFor(db: Db) {
 }
 
 describe("weddingEntitlement", () => {
+  it("fails closed (402) when the DB throws a defect — never grants on error", async () => {
+    const throwingDb = buildThrowingDb();
+    const app = new Elysia({ aot: false }).group("/w/:weddingId", (g) =>
+      g.use(weddingEntitlement(throwingDb, "vendors")).get("/thing", () => ({ ok: true })),
+    );
+    const res = await appRequest(app, "/w/wed_x/thing");
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
   it("402 payment_required + entitlement when the wedding lacks the pack", async () => {
     const db = buildDb();
     const res = await appRequest(appFor(db), "/w/wed_x/thing");

--- a/cire/api/src/middleware/wedding-entitlement.ts
+++ b/cire/api/src/middleware/wedding-entitlement.ts
@@ -37,7 +37,15 @@ export function weddingEntitlement(db: Db, key: EntitlementKey) {
         };
       }
       const entitled = await runCire(
-        entitlementService.has(weddingId, key).pipe(Effect.provideService(DbService, db)),
+        entitlementService.has(weddingId, key).pipe(
+          Effect.provideService(DbService, db),
+          Effect.catchAllDefect(() =>
+            Effect.logWarning("cire.entitlement.gate check failed — failing closed").pipe(
+              Effect.annotateLogs({ weddingId, entitlement: key }),
+              Effect.as(false),
+            ),
+          ),
+        ),
       );
       return {
         entitlementGateError: entitled

--- a/cire/api/src/middleware/wedding-entitlement.ts
+++ b/cire/api/src/middleware/wedding-entitlement.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect";
+import { Elysia } from "elysia";
+
+import { DbService } from "../db";
+import type { Db } from "../db";
+import { runCire } from "../observability";
+import { entitlementService } from "../services/entitlements";
+import type { EntitlementKey } from "../services/entitlements";
+
+interface EntitlementGateError {
+  status: number;
+  body: { error: string; entitlement: EntitlementKey };
+}
+
+/**
+ * Entitlement gate for /api/organiser/weddings/:weddingId/* routes whose feature
+ * is a paid pack. Sits AFTER the role gate (weddingMember/weddingEditor) and
+ * BEFORE the rate limiter: a viewer on an entitled wedding is already stopped by
+ * the role gate's 403, so a 402 here only reaches callers who ARE allowed by role
+ * but whose WEDDING has not bought `key`. Returns 402 `payment_required` +
+ * `{ entitlement }` — the contract the portal turns into an upsell.
+ *
+ * Reads `params.weddingId` directly (the role gate has already validated it);
+ * a missing weddingId degrades to 402 rather than throwing.
+ */
+export function weddingEntitlement(db: Db, key: EntitlementKey) {
+  return new Elysia()
+    .derive({ as: "scoped" }, async (ctx) => {
+      const { params } = ctx as unknown as { params?: Record<string, string | undefined> };
+      const weddingId = params?.weddingId;
+      if (!weddingId) {
+        return {
+          entitlementGateError: {
+            status: 402,
+            body: { error: "payment_required", entitlement: key },
+          } as EntitlementGateError | undefined,
+        };
+      }
+      const entitled = await runCire(
+        entitlementService.has(weddingId, key).pipe(Effect.provideService(DbService, db)),
+      );
+      return {
+        entitlementGateError: entitled
+          ? (undefined as EntitlementGateError | undefined)
+          : ({ status: 402, body: { error: "payment_required", entitlement: key } } as
+              | EntitlementGateError
+              | undefined),
+      };
+    })
+    .onBeforeHandle({ as: "scoped" }, ({ entitlementGateError, set }) => {
+      if (entitlementGateError) {
+        set.status = entitlementGateError.status;
+        return entitlementGateError.body;
+      }
+    });
+}

--- a/cire/api/src/routes/organiser-changes.test.ts
+++ b/cire/api/src/routes/organiser-changes.test.ts
@@ -518,7 +518,7 @@ describe("POST /changes/apply — 402 on capacity breach", () => {
     expect(db.select().from(guests).all()).toHaveLength(101);
   });
 
-  it("the /import alias also returns 402 on capacity breach", async () => {
+  it("the /import alias also returns 402 on capacity breach — full contract + atomicity", async () => {
     const { app, db } = buildApp();
 
     const guestsCsv = buildLargeGuestsCsv(101);
@@ -533,10 +533,14 @@ describe("POST /changes/apply — 402 on capacity breach", () => {
     const applyRes = await ownerPost(app, `${IMPORT_BASE}/apply`, { importId });
     expect(applyRes.status).toBe(402);
     const body = (await applyRes.json()) as Record<string, unknown>;
+    // Full 402 body contract — must match /changes/apply exactly.
     expect(body.error).toBe("payment_required");
     expect(body.entitlement).toBe("capacity");
+    expect(body.limit).toBe(100);
+    expect(typeof body.current).toBe("number");
 
-    // Atomic: no guests persisted via either path.
+    // Atomic: neither guests nor families persisted via the /import alias.
     expect(db.select().from(guests).all()).toHaveLength(0);
+    expect(db.select().from(families).all()).toHaveLength(0);
   });
 });

--- a/cire/api/src/routes/organiser-changes.test.ts
+++ b/cire/api/src/routes/organiser-changes.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 
-import { BOOTSTRAP_WEDDING_ID, events, families, guests, weddingHosts, weddings } from "@cire/db";
+import {
+  BOOTSTRAP_WEDDING_ID,
+  events,
+  families,
+  guests,
+  weddingEntitlements,
+  weddingHosts,
+  weddings,
+} from "@cire/db";
 
 import { createApp } from "../app";
 import { createDb, seedBootstrapWedding } from "../db/setup";
@@ -441,5 +449,94 @@ describe("authz — /changes gate", () => {
       body: JSON.stringify({ importId: id }),
     });
     expect(applyOther.status).toBe(404);
+  });
+});
+
+// ── Capacity enforcement: 402 on breach ─────────────────────────────────────
+
+describe("POST /changes/apply — 402 on capacity breach", () => {
+  /**
+   * Build a CSV with N guests in a single family, using EVENTS_CSV events.
+   * Each guest is invited to no events (all 'no') to keep the CSV simple.
+   */
+  function buildLargeGuestsCsv(n: number): string {
+    const header = "Family ID,Family Name,Guest First Name,Guest Last Name,Mehndi,Reception";
+    const rows = Array.from({ length: n }, (_, i) => `1,Bigfamily,Guest${i},Bigfamily,no,no`);
+    return [header, ...rows].join("\n");
+  }
+
+  it("applying a change that would exceed the cap returns 402 with payment_required body and persists no guests", async () => {
+    const { app, db } = buildApp();
+
+    // Preview + apply 101 guests (cap is 100, no capacity entitlement).
+    const guestsCsv = buildLargeGuestsCsv(101);
+
+    const previewRes = await ownerPost(app, `${CHANGES_BASE}/preview`, {
+      eventsCsv: EVENTS_CSV,
+      guestsCsv,
+    });
+    expect(previewRes.status).toBe(200);
+    const { changeId } = (await previewRes.json()) as { changeId: string };
+
+    const applyRes = await ownerPost(app, `${CHANGES_BASE}/apply`, { importId: changeId });
+    expect(applyRes.status).toBe(402);
+    const body = (await applyRes.json()) as Record<string, unknown>;
+    expect(body.error).toBe("payment_required");
+    expect(body.entitlement).toBe("capacity");
+    expect(body.limit).toBe(100);
+    expect(typeof body.current).toBe("number");
+
+    // Atomic: no guests were persisted.
+    expect(db.select().from(guests).all()).toHaveLength(0);
+    expect(db.select().from(families).all()).toHaveLength(0);
+  });
+
+  it("applying a change within cap succeeds; upgraded wedding (capacity_500) admits up to 500", async () => {
+    const { app, db } = buildApp();
+
+    // Grant capacity_500 to the bootstrap wedding.
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "capacity_500",
+        source: "comp",
+        grantedAt: new Date(),
+        grantedBy: "usr_admin",
+      })
+      .run();
+
+    // 101 guests < 500 → should succeed.
+    const guestsCsv = buildLargeGuestsCsv(101);
+    const previewRes = await ownerPost(app, `${CHANGES_BASE}/preview`, {
+      eventsCsv: EVENTS_CSV,
+      guestsCsv,
+    });
+    const { changeId } = (await previewRes.json()) as { changeId: string };
+
+    const applyRes = await ownerPost(app, `${CHANGES_BASE}/apply`, { importId: changeId });
+    expect(applyRes.status).toBe(200);
+    expect(db.select().from(guests).all()).toHaveLength(101);
+  });
+
+  it("the /import alias also returns 402 on capacity breach", async () => {
+    const { app, db } = buildApp();
+
+    const guestsCsv = buildLargeGuestsCsv(101);
+
+    const previewRes = await ownerPost(app, `${IMPORT_BASE}/preview`, {
+      eventsCsv: EVENTS_CSV,
+      guestsCsv,
+    });
+    expect(previewRes.status).toBe(200);
+    const { importId } = (await previewRes.json()) as { importId: string };
+
+    const applyRes = await ownerPost(app, `${IMPORT_BASE}/apply`, { importId });
+    expect(applyRes.status).toBe(402);
+    const body = (await applyRes.json()) as Record<string, unknown>;
+    expect(body.error).toBe("payment_required");
+    expect(body.entitlement).toBe("capacity");
+
+    // Atomic: no guests persisted via either path.
+    expect(db.select().from(guests).all()).toHaveLength(0);
   });
 });

--- a/cire/api/src/routes/organiser-changes.ts
+++ b/cire/api/src/routes/organiser-changes.ts
@@ -13,6 +13,7 @@ import { ApplyBody, DesiredState, RevertBody } from "../schemas/import";
 import type { ImportPlan, ParsedFamily } from "../schemas/import";
 import { decodeChangeBody, GENESIS_REVISION, headRevision } from "../services/changes";
 import { captureBeforeImage, pruneBeforeImages } from "../services/checkpoint";
+import { CapacityExceeded } from "../services/entitlements";
 import { applyImport, diffAgainstDb } from "../services/import";
 import type { DeletableBucket } from "../services/r2-cleanup";
 import { R2Service, fetchUpload, storeUpload } from "../services/r2-imports";
@@ -408,6 +409,17 @@ export const createOrganiserChangeRoutes = (
                     yield* Effect.logError("change apply failed");
                     set.status = 500;
                     return { error: "Apply failed" };
+                  }),
+                ),
+                Effect.catchTag("CapacityExceeded", (e) =>
+                  Effect.sync(() => {
+                    set.status = 402;
+                    return {
+                      error: "payment_required",
+                      entitlement: "capacity",
+                      limit: e.limit,
+                      current: e.current,
+                    };
                   }),
                 ),
               ),

--- a/cire/api/src/routes/organiser-hosts.test.ts
+++ b/cire/api/src/routes/organiser-hosts.test.ts
@@ -513,11 +513,20 @@ describe("co-host dashboard access (weddingMember)", () => {
     seedCohostAndGuest(db);
     const res = await req(app, "GET", "/api/organiser/weddings", COHOST);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { weddings: { id: string; role: string }[] };
+    const body = (await res.json()) as {
+      weddings: { id: string; role: string; entitlements: string[]; guestCap: number }[];
+    };
     expect(body.weddings).toEqual([
       // The seed omits `role`, landing on the legacy DDL default 'host'
       // (pre-0031 shape) — readers normalise it to 'editor'.
-      { id: WEDDING_ID, slug: "hosts-wedding", displayName: "Hosts Wedding", role: "editor" },
+      {
+        id: WEDDING_ID,
+        slug: "hosts-wedding",
+        displayName: "Hosts Wedding",
+        role: "editor",
+        entitlements: [],
+        guestCap: 100,
+      },
     ]);
   });
 
@@ -535,9 +544,18 @@ describe("co-host dashboard access (weddingMember)", () => {
       .run();
     const res = await req(app, "GET", "/api/organiser/weddings", "usr_list_viewer");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { weddings: { id: string; role: string }[] };
+    const body = (await res.json()) as {
+      weddings: { id: string; role: string; entitlements: string[]; guestCap: number }[];
+    };
     expect(body.weddings).toEqual([
-      { id: WEDDING_ID, slug: "hosts-wedding", displayName: "Hosts Wedding", role: "viewer" },
+      {
+        id: WEDDING_ID,
+        slug: "hosts-wedding",
+        displayName: "Hosts Wedding",
+        role: "viewer",
+        entitlements: [],
+        guestCap: 100,
+      },
     ]);
   });
 });

--- a/cire/api/src/routes/organiser-weddings.test.ts
+++ b/cire/api/src/routes/organiser-weddings.test.ts
@@ -136,7 +136,7 @@ describe("GET /api/organiser/weddings", () => {
         source: "comp",
         grantedAt: new Date(),
         grantedBy: "usr_admin",
-        stripeRef: null,
+        providerRef: null,
       })
       .run();
     const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);
@@ -159,7 +159,7 @@ describe("GET /api/organiser/weddings", () => {
         source: "comp",
         grantedAt: new Date(),
         grantedBy: "usr_admin",
-        stripeRef: null,
+        providerRef: null,
       })
       .run();
     const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);

--- a/cire/api/src/routes/organiser-weddings.test.ts
+++ b/cire/api/src/routes/organiser-weddings.test.ts
@@ -8,6 +8,7 @@ import {
   guests,
   rsvps,
   sessions,
+  weddingEntitlements,
   weddingHosts,
   weddings,
 } from "@cire/db";
@@ -123,6 +124,64 @@ describe("GET /api/organiser/weddings", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { weddings: unknown[] };
     expect(body.weddings).toEqual([]);
+  });
+
+  it("attaches entitlements and guestCap=100 when no capacity pack is granted", async () => {
+    const { db, app } = buildApp();
+    // Grant a non-capacity entitlement so entitlements array is non-empty.
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: new Date(),
+        grantedBy: "usr_admin",
+        stripeRef: null,
+      })
+      .run();
+    const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      weddings: { id: string; entitlements: string[]; guestCap: number }[];
+    };
+    const w = body.weddings.find((x) => x.id === BOOTSTRAP_WEDDING_ID)!;
+    expect(w.entitlements).toContain("vendors");
+    // No capacity pack → default 100 cap.
+    expect(w.guestCap).toBe(100);
+  });
+
+  it("derives guestCap=500 from a capacity_500 entitlement", async () => {
+    const { db, app } = buildApp();
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "capacity_500",
+        source: "comp",
+        grantedAt: new Date(),
+        grantedBy: "usr_admin",
+        stripeRef: null,
+      })
+      .run();
+    const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      weddings: { id: string; entitlements: string[]; guestCap: number }[];
+    };
+    const w = body.weddings.find((x) => x.id === BOOTSTRAP_WEDDING_ID)!;
+    expect(w.entitlements).toContain("capacity_500");
+    expect(w.guestCap).toBe(500);
+  });
+
+  it("returns empty entitlements and guestCap=100 when no entitlement is granted", async () => {
+    const { app } = buildApp();
+    const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      weddings: { id: string; entitlements: string[]; guestCap: number }[];
+    };
+    const w = body.weddings.find((x) => x.id === BOOTSTRAP_WEDDING_ID)!;
+    expect(w.entitlements).toEqual([]);
+    expect(w.guestCap).toBe(100);
   });
 });
 

--- a/cire/api/src/routes/organiser-weddings.ts
+++ b/cire/api/src/routes/organiser-weddings.ts
@@ -12,6 +12,7 @@ import { weddingOwner } from "../middleware/wedding-owner";
 import { runCire } from "../observability";
 import { CreateWeddingBody, RemintBody } from "../schemas/wedding";
 import { claimService } from "../services/claim";
+import { entitlementService } from "../services/entitlements";
 import { familyDeactivateService } from "../services/family-deactivate";
 import { hostCodeService } from "../services/host-code";
 import { markSharedService } from "../services/mark-shared";
@@ -78,9 +79,21 @@ export const createOrganiserWeddingsRoutes = (db: Db, osnAuthOptions: OsnAuthOpt
         return { error: "unauthorised" };
       }
       return runCire(
-        weddingsService.listForMember(osnProfileId).pipe(
+        Effect.gen(function* () {
+          const list = yield* weddingsService.listForMember(osnProfileId);
+          const sets = yield* entitlementService.setsForWeddings(list.map((w) => w.id));
+          return {
+            weddings: list.map((w) => {
+              const keys = sets.get(w.id) ?? [];
+              return {
+                ...w,
+                entitlements: keys,
+                guestCap: entitlementService.deriveCap(keys),
+              };
+            }),
+          };
+        }).pipe(
           Effect.provideService(DbService, db),
-          Effect.map((list) => ({ weddings: list })),
           Effect.catchAllDefect(() =>
             Effect.sync(() => {
               set.status = 500;

--- a/cire/api/src/routes/payment-webhook.test.ts
+++ b/cire/api/src/routes/payment-webhook.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "bun:test";
 
+import { createApp } from "../app";
+import { createDb, seedDb } from "../db/setup";
 import { createPaymentWebhookSkeleton } from "./payment-webhook";
 
 // Elysia 1.4.x requires app.fetch (absolute URL) rather than app.handle —
@@ -12,6 +14,38 @@ describe("payment webhook skeleton (Phase 1 — inert)", () => {
     const app = createPaymentWebhookSkeleton();
     const res = await app.fetch(
       new Request("http://localhost/api/payments/webhook", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(501);
+    expect(await res.json()).toEqual({ error: "not_implemented" });
+  });
+});
+
+// Integration tests: verify the unmounted-by-default invariant via createApp.
+// Security contract: POST /api/payments/webhook MUST NOT be reachable unless
+// the deployment explicitly opts in via { paymentWebhookEnabled: true }.
+describe("payment webhook mount invariant via createApp", () => {
+  const db = createDb(":memory:");
+  seedDb(db);
+
+  it("returns 404 when paymentWebhookEnabled is absent (default)", async () => {
+    const app = createApp(db);
+    const res = await app.fetch(
+      new Request("http://localhost/api/payments/webhook", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 501 not_implemented when paymentWebhookEnabled is true", async () => {
+    const app = createApp(db, { paymentWebhookEnabled: true });
+    const res = await app.fetch(
+      new Request("http://localhost/api/payments/webhook", {
+        method: "POST",
+        body: "{}",
+        // Origin header required — createApp mounts originGuard which 403s
+        // state-changing requests without a matching Origin. The default
+        // webOrigin is http://localhost:4321 (same as claim.test.ts).
+        headers: { Origin: "http://localhost:4321" },
+      }),
     );
     expect(res.status).toBe(501);
     expect(await res.json()).toEqual({ error: "not_implemented" });

--- a/cire/api/src/routes/payment-webhook.test.ts
+++ b/cire/api/src/routes/payment-webhook.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "bun:test";
+
+import { createPaymentWebhookSkeleton } from "./payment-webhook";
+
+// Elysia 1.4.x requires app.fetch (absolute URL) rather than app.handle —
+// app.handle delegates to fetch but the Bun adapter only wires up the
+// compiled handler on fetch, so handle always 404s on an uncompiled instance.
+// All other route tests in this package use app.fetch for the same reason.
+
+describe("payment webhook skeleton (Phase 1 — inert)", () => {
+  it("returns 501 not_implemented and never processes", async () => {
+    const app = createPaymentWebhookSkeleton();
+    const res = await app.fetch(
+      new Request("http://localhost/api/payments/webhook", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(501);
+    expect(await res.json()).toEqual({ error: "not_implemented" });
+  });
+});

--- a/cire/api/src/routes/payment-webhook.ts
+++ b/cire/api/src/routes/payment-webhook.ts
@@ -1,0 +1,20 @@
+import { Elysia } from "elysia";
+
+/**
+ * Phase-2 landing spot for the payment provider's purchase webhook. Phase 2
+ * uses Lemon Squeezy (merchant of record; Paddle fallback) — this skeleton is
+ * PROVIDER-NEUTRAL so a swap is an adapter change. In Phase 1 it is INERT: it
+ * verifies nothing and grants nothing, returning 501. createApp mounts it ONLY
+ * when the webhook flag is set, so no unverified endpoint is ever exposed by
+ * default.
+ *
+ * Phase 2 will: verify the provider signature, map the purchased product →
+ * entitlement key, and call entitlementService.grant({ source: "purchase",
+ * stripeRef: <provider order id> }) — idempotent on the provider order id.
+ */
+export function createPaymentWebhookSkeleton() {
+  return new Elysia().post("/api/payments/webhook", ({ set }) => {
+    set.status = 501;
+    return { error: "not_implemented" };
+  });
+}

--- a/cire/api/src/routes/payment-webhook.ts
+++ b/cire/api/src/routes/payment-webhook.ts
@@ -9,7 +9,7 @@ import { Elysia } from "elysia";
  *
  * Phase 2 will: verify the provider signature, map the purchased product →
  * entitlement key, and call entitlementService.grant({ source: "purchase",
- * stripeRef: <provider order id> }) — idempotent on the provider order id.
+ * providerRef: <provider order id> }) — idempotent on the provider order id.
  */
 export function createPaymentWebhookSkeleton() {
   return new Elysia().post("/api/payments/webhook", ({ set }) => {

--- a/cire/api/src/routes/payment-webhook.ts
+++ b/cire/api/src/routes/payment-webhook.ts
@@ -1,12 +1,11 @@
 import { Elysia } from "elysia";
 
 /**
- * Phase-2 landing spot for the payment provider's purchase webhook. Phase 2
- * uses Lemon Squeezy (merchant of record; Paddle fallback) — this skeleton is
- * PROVIDER-NEUTRAL so a swap is an adapter change. In Phase 1 it is INERT: it
- * verifies nothing and grants nothing, returning 501. createApp mounts it ONLY
- * when the webhook flag is set, so no unverified endpoint is ever exposed by
- * default.
+ * Phase-2 landing spot for the payment provider's purchase webhook. This
+ * skeleton is PROVIDER-NEUTRAL so the provider is an adapter-level choice. In
+ * Phase 1 it is INERT: it verifies nothing and grants nothing, returning 501.
+ * createApp mounts it ONLY when the webhook flag is set, so no unverified
+ * endpoint is ever exposed by default.
  *
  * Phase 2 will: verify the provider signature, map the purchased product →
  * entitlement key, and call entitlementService.grant({ source: "purchase",

--- a/cire/api/src/routes/vendor-directory.test.ts
+++ b/cire/api/src/routes/vendor-directory.test.ts
@@ -119,7 +119,7 @@ function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
         source: "comp",
         grantedAt: now,
         grantedBy: OWNER,
-        stripeRef: null,
+        providerRef: null,
       })
       .onConflictDoNothing()
       .run();
@@ -131,7 +131,7 @@ function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
         source: "comp",
         grantedAt: now,
         grantedBy: "usr_bob",
-        stripeRef: null,
+        providerRef: null,
       })
       .onConflictDoNothing()
       .run();
@@ -347,7 +347,7 @@ function buildWriteApp({ grantVendors = true }: { grantVendors?: boolean } = {})
         source: "comp",
         grantedAt: now,
         grantedBy: OWNER,
-        stripeRef: null,
+        providerRef: null,
       })
       .onConflictDoNothing()
       .run();

--- a/cire/api/src/routes/vendor-directory.test.ts
+++ b/cire/api/src/routes/vendor-directory.test.ts
@@ -4,6 +4,7 @@ import {
   BOOTSTRAP_WEDDING_ID,
   directoryVendorCategories,
   directoryVendors,
+  weddingEntitlements,
   weddingHosts,
   weddings,
 } from "@cire/db";
@@ -31,7 +32,7 @@ beforeAll(async () => {
   auth = await makeOsnTestAuth();
 });
 
-function buildApp() {
+function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
   const db = createDb(":memory:");
   seedDb(db);
   const now = new Date();
@@ -107,6 +108,34 @@ function buildApp() {
       updatedAt: now,
     })
     .run();
+
+  // Grant the `vendors` entitlement so the route gate passes (unless opted out
+  // for an explicit 402-test that must exercise the un-entitled path).
+  if (grantVendors) {
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+        stripeRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+    // Also grant for wed_other (usr_bob's wedding) so cross-tenant tests pass.
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: "wed_other",
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: "usr_bob",
+        stripeRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
 
   const { layer: logEmailLayer } = makeLogEmailLive();
   const directoryService = createDirectoryService({
@@ -226,6 +255,23 @@ describe("vendor directory browse route", () => {
     const body = (await res.json()) as { listings: unknown[]; total: number };
     expect(Array.isArray(body.listings)).toBe(true);
   });
+
+  // ── Entitlement gate (Task 4) ──────────────────────────────────────────────
+
+  it("GET /directory → 402 payment_required when wedding lacks `vendors`", async () => {
+    // No entitlement granted — editor passes the role gate but hits 402.
+    const app = buildApp({ grantVendors: false });
+    const res = await req(app, base, OWNER);
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("with the `vendors` entitlement granted, GET /directory passes the gate (not 402)", async () => {
+    // buildApp() grants `vendors` by default — just verify the route is accessible.
+    const app = buildApp();
+    const res = await req(app, base, OWNER);
+    expect(res.status).not.toBe(402);
+  });
 });
 
 // ── Write routes ─────────────────────────────────────────────────────────────
@@ -236,7 +282,7 @@ describe("vendor directory browse route", () => {
  *  - LA: live listing with categories [venue, catering] + a contact email/phone
  *  - LD: draft listing (rejected by add route)
  */
-function buildWriteApp() {
+function buildWriteApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
   const db = createDb(":memory:");
   seedDb(db);
   const now = new Date();
@@ -290,6 +336,22 @@ function buildWriteApp() {
       updatedAt: now,
     })
     .run();
+
+  // Grant the `vendors` entitlement so write-route gate passes (unless opted out
+  // for an explicit 402-test that must exercise the un-entitled path).
+  if (grantVendors) {
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+        stripeRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
 
   const { layer: logEmailLayer } = makeLogEmailLive();
   const directoryService = createDirectoryService({
@@ -386,6 +448,26 @@ describe("vendor directory write routes (add-from-directory)", () => {
 
   it("viewer gets 403 read_only_role", async () => {
     const app = buildWriteApp();
+    const res = await postAdd(app, LA, { category: "venue" }, VIEWER);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("read_only_role");
+  });
+
+  // ── Entitlement gate (Task 4) ──────────────────────────────────────────────
+
+  it("POST /directory/:id/add → 402 when wedding lacks `vendors`", async () => {
+    // Editor passes the role gate but no entitlement → 402.
+    const app = buildWriteApp({ grantVendors: false });
+    const res = await postAdd(app, LA, { category: "venue" }, EDITOR);
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("a VIEWER still gets 403 (role wins over 402) on the write route", async () => {
+    // Viewer is stopped by weddingEditor (403) before reaching the entitlement gate.
+    // Use no-entitlement app to confirm role gate wins regardless of entitlement state.
+    const app = buildWriteApp({ grantVendors: false });
     const res = await postAdd(app, LA, { category: "venue" }, VIEWER);
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: string };

--- a/cire/api/src/routes/vendor-directory.ts
+++ b/cire/api/src/routes/vendor-directory.ts
@@ -9,6 +9,7 @@ import { osnAuth } from "../middleware/osn-auth";
 import type { OsnAuthOptions } from "../middleware/osn-auth";
 import { rateLimitMiddlewareByUser } from "../middleware/rate-limit";
 import { weddingEditor } from "../middleware/wedding-editor";
+import { weddingEntitlement } from "../middleware/wedding-entitlement";
 import { weddingMember } from "../middleware/wedding-member";
 import { runCire } from "../observability";
 import { AddFromDirectoryBody } from "../schemas/vendors";
@@ -71,6 +72,7 @@ export const createVendorDirectoryReadRoutes = (
     .group("/weddings/:weddingId", (group) =>
       group
         .use(weddingMember(db))
+        .use(weddingEntitlement(db, "vendors"))
         .use(rateLimitMiddlewareByUser(limiter))
         .get("/directory", async ({ weddingId, query, set }) => {
           if (!weddingId) return internalSync(set);
@@ -104,6 +106,7 @@ export const createVendorDirectoryWriteRoutes = (
       group.guard((write) =>
         write
           .use(weddingEditor(db))
+          .use(weddingEntitlement(db, "vendors"))
           .use(rateLimitMiddlewareByUser(limiter))
           .post(
             "/directory/:directoryVendorId/add",

--- a/cire/api/src/routes/vendors.test.ts
+++ b/cire/api/src/routes/vendors.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 
-import { BOOTSTRAP_WEDDING_ID, weddingHosts, weddings } from "@cire/db";
+import { BOOTSTRAP_WEDDING_ID, weddingEntitlements, weddingHosts, weddings } from "@cire/db";
 import { makeLogEmailLive } from "@shared/email";
 
 import { createApp } from "../app";
@@ -21,7 +21,7 @@ beforeAll(async () => {
   auth = await makeOsnTestAuth();
 });
 
-function buildApp() {
+function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
   const db = createDb(":memory:");
   seedDb(db);
   const now = new Date();
@@ -55,6 +55,34 @@ function buildApp() {
       updatedAt: now,
     })
     .run();
+
+  // Grant the `vendors` entitlement so the route gate passes (unless opted out
+  // for an explicit 402-test that must exercise the un-entitled path).
+  if (grantVendors) {
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+        stripeRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+    // Also grant for wed_other so tenancy tests involving usr_bob's wedding pass.
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: "wed_other",
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: "usr_bob",
+        stripeRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
 
   const { layer: logEmailLayer } = makeLogEmailLive();
   const directoryService = createDirectoryService({
@@ -222,5 +250,31 @@ describe("vendor CRM routes", () => {
     });
     expect(res.status).toBe(404);
     expect(((await res.json()) as { error: string }).error).toBe("vendor_not_found");
+  });
+
+  // ── Entitlement gate (Task 4) ──────────────────────────────────────────────
+
+  it("GET /vendors → 402 payment_required when wedding lacks `vendors`", async () => {
+    const res = await req(buildApp({ grantVendors: false }), "GET", base, OWNER);
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("POST /vendors → 402 payment_required when wedding lacks `vendors`", async () => {
+    const res = await req(buildApp({ grantVendors: false }), "POST", base, EDITOR, VENDOR);
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("a VIEWER still gets 403 (role wins over 402) on the write route", async () => {
+    // weddingEditor fires before weddingEntitlement → viewer gets 403, not 402.
+    const res = await req(buildApp({ grantVendors: false }), "POST", base, VIEWER, VENDOR);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("read_only_role");
+  });
+
+  it("with the `vendors` entitlement granted, GET /vendors passes the gate (not 402)", async () => {
+    const res = await req(buildApp(), "GET", base, OWNER);
+    expect(res.status).not.toBe(402);
   });
 });

--- a/cire/api/src/routes/vendors.test.ts
+++ b/cire/api/src/routes/vendors.test.ts
@@ -66,7 +66,7 @@ function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
         source: "comp",
         grantedAt: now,
         grantedBy: OWNER,
-        stripeRef: null,
+        providerRef: null,
       })
       .onConflictDoNothing()
       .run();
@@ -78,7 +78,7 @@ function buildApp({ grantVendors = true }: { grantVendors?: boolean } = {}) {
         source: "comp",
         grantedAt: now,
         grantedBy: "usr_bob",
-        stripeRef: null,
+        providerRef: null,
       })
       .onConflictDoNothing()
       .run();

--- a/cire/api/src/routes/vendors.ts
+++ b/cire/api/src/routes/vendors.ts
@@ -8,6 +8,7 @@ import { sendClaimInviteEmail } from "../lib/vendor-email";
 import { osnAuth } from "../middleware/osn-auth";
 import type { OsnAuthOptions } from "../middleware/osn-auth";
 import { weddingEditor } from "../middleware/wedding-editor";
+import { weddingEntitlement } from "../middleware/wedding-entitlement";
 import { weddingMember } from "../middleware/wedding-member";
 import { runCire } from "../observability";
 import {
@@ -63,16 +64,19 @@ export const createVendorReadRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =
   new Elysia({ prefix: "/api/organiser" })
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
-      group.use(weddingMember(db)).get("/vendors", async ({ weddingId, set }) => {
-        if (!weddingId) return internalSync(set);
-        return runCire(
-          vendorsService.list(weddingId).pipe(
-            Effect.map((vendors) => ({ vendors })),
-            Effect.provideService(DbService, db),
-            Effect.catchAllDefect(() => internal(set)),
-          ),
-        );
-      }),
+      group
+        .use(weddingMember(db))
+        .use(weddingEntitlement(db, "vendors"))
+        .get("/vendors", async ({ weddingId, set }) => {
+          if (!weddingId) return internalSync(set);
+          return runCire(
+            vendorsService.list(weddingId).pipe(
+              Effect.map((vendors) => ({ vendors })),
+              Effect.provideService(DbService, db),
+              Effect.catchAllDefect(() => internal(set)),
+            ),
+          );
+        }),
     );
 
 /**
@@ -107,6 +111,7 @@ export const createVendorWriteRoutes = (
       group.guard((write) =>
         write
           .use(weddingEditor(db))
+          .use(weddingEntitlement(db, "vendors"))
           .post(
             "/vendors",
             async ({ weddingId, request, set }) => {

--- a/cire/api/src/services/entitlements.test.ts
+++ b/cire/api/src/services/entitlements.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "bun:test";
+
+import { Effect, Exit } from "effect";
+
+import { DbService } from "../db";
+import { createDb } from "../db/setup";
+import { entitlementService, CapacityExceeded } from "./entitlements";
+
+const run = <A, E>(db: ReturnType<typeof createDb>, eff: Effect.Effect<A, E, DbService>) =>
+  Effect.runPromise(eff.pipe(Effect.provideService(DbService, db)) as Effect.Effect<A, E, never>);
+
+// deriveCap is pure — table-test it directly.
+describe("deriveCap", () => {
+  it("returns 100 with no capacity row", () => {
+    expect(entitlementService.deriveCap([])).toBe(100);
+    expect(entitlementService.deriveCap(["vendors", "ai"])).toBe(100);
+  });
+  it("returns 500 with capacity_500", () => {
+    expect(entitlementService.deriveCap(["capacity_500"])).toBe(500);
+  });
+  it("returns 1000 with capacity_1000, even alongside 500", () => {
+    expect(entitlementService.deriveCap(["capacity_1000"])).toBe(1000);
+    expect(entitlementService.deriveCap(["capacity_500", "capacity_1000"])).toBe(1000);
+  });
+});
+
+function seedWedding(db: ReturnType<typeof createDb>, id = "wed_test") {
+  const now = new Date();
+  db.$client.exec(
+    `INSERT INTO weddings (id, slug, display_name, owner_osn_profile_id, code_style, currency, created_at, updated_at)
+     VALUES ('${id}', '${id}-slug', 'Test', 'usr_owner', 'secure', 'AUD', ${now.getTime()}, ${now.getTime()});`,
+  );
+  return id;
+}
+
+describe("grant + has", () => {
+  it("grant makes has() true; absent key is false", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    expect(await run(db, entitlementService.has(w, "vendors"))).toBe(false);
+    await run(
+      db,
+      entitlementService.grant(w, "vendors", { source: "comp", grantedBy: "usr_owner" }),
+    );
+    expect(await run(db, entitlementService.has(w, "vendors"))).toBe(true);
+  });
+
+  it("grant is idempotent — a second grant is a no-op, one row", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    await run(db, entitlementService.grant(w, "ai", { source: "comp", grantedBy: "usr_owner" }));
+    await run(db, entitlementService.grant(w, "ai", { source: "comp", grantedBy: "usr_owner" }));
+    const rows = db.$client
+      .query(
+        `SELECT COUNT(*) AS n FROM wedding_entitlements WHERE wedding_id = ? AND entitlement = 'ai'`,
+      )
+      .get(w) as { n: number };
+    expect(rows.n).toBe(1);
+  });
+});
+
+describe("setsForWeddings", () => {
+  it("batch-returns each wedding's key set", async () => {
+    const db = createDb();
+    const a = seedWedding(db, "wed_a");
+    const b = seedWedding(db, "wed_b");
+    await run(db, entitlementService.grant(a, "vendors", { source: "comp", grantedBy: "x" }));
+    await run(db, entitlementService.grant(a, "capacity_500", { source: "comp", grantedBy: "x" }));
+    const map = await run(db, entitlementService.setsForWeddings([a, b]));
+    expect(new Set(map.get("wed_a"))).toEqual(new Set(["vendors", "capacity_500"]));
+    expect(map.get("wed_b") ?? []).toEqual([]);
+  });
+});
+
+describe("assertGuestCapacity", () => {
+  it("passes when current + incoming <= cap", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    // cap 100, no guests, adding 10 → ok
+    const exit = await Effect.runPromiseExit(
+      entitlementService.assertGuestCapacity(w, 10).pipe(Effect.provideService(DbService, db)),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+
+  it("fails with CapacityExceeded when the addition breaches the derived cap", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    const exit = await Effect.runPromiseExit(
+      entitlementService.assertGuestCapacity(w, 101).pipe(Effect.provideService(DbService, db)),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("upgraded wedding (capacity_500) allows more", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    await run(db, entitlementService.grant(w, "capacity_500", { source: "comp", grantedBy: "x" }));
+    const exit = await Effect.runPromiseExit(
+      entitlementService.assertGuestCapacity(w, 400).pipe(Effect.provideService(DbService, db)),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+});

--- a/cire/api/src/services/entitlements.ts
+++ b/cire/api/src/services/entitlements.ts
@@ -89,7 +89,7 @@ export const entitlementService = {
   grant(
     weddingId: string,
     key: EntitlementKey,
-    opts: { source: "purchase" | "comp"; grantedBy: string; stripeRef?: string | null },
+    opts: { source: "purchase" | "comp"; grantedBy: string; providerRef?: string | null },
   ): Effect.Effect<void, never, DbService> {
     return Effect.gen(function* () {
       const db = yield* DbService;
@@ -102,7 +102,7 @@ export const entitlementService = {
             source: opts.source,
             grantedAt: new Date(),
             grantedBy: opts.grantedBy,
-            stripeRef: opts.stripeRef ?? null,
+            providerRef: opts.providerRef ?? null,
           })
           .onConflictDoNothing()
           .run(),

--- a/cire/api/src/services/entitlements.ts
+++ b/cire/api/src/services/entitlements.ts
@@ -1,0 +1,133 @@
+import { families, guests, weddingEntitlements } from "@cire/db";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
+import { Data, Effect } from "effect";
+
+import { type Db, DbService, dbQuery } from "../db";
+
+export const ENTITLEMENT_KEYS = [
+  "premium_templates",
+  "vendors",
+  "ai",
+  "capacity_500",
+  "capacity_1000",
+] as const;
+export type EntitlementKey = (typeof ENTITLEMENT_KEYS)[number];
+
+/** Raised when a guest-adding write would breach the wedding's derived cap. */
+export class CapacityExceeded extends Data.TaggedError("CapacityExceeded")<{
+  limit: number;
+  current: number;
+}> {}
+
+/** Effective guest ceiling from the entitlement set. Pure. */
+function deriveCap(keys: readonly string[]): number {
+  if (keys.includes("capacity_1000")) return 1000;
+  if (keys.includes("capacity_500")) return 500;
+  return 100;
+}
+
+/** Count real guests on a wedding, EXCLUDING the synthetic host-preview family. */
+function countGuests(db: Db, weddingId: string): Effect.Effect<number, never, never> {
+  return dbQuery(() =>
+    db
+      .select({ n: sql<number>`count(*)` })
+      .from(guests)
+      .innerJoin(families, eq(guests.familyId, families.id))
+      .where(and(eq(families.weddingId, weddingId), ne(families.kind, "host")))
+      .all(),
+  ).pipe(Effect.map((rows) => (rows[0]?.n as number) ?? 0));
+}
+
+export const entitlementService = {
+  deriveCap,
+
+  has(weddingId: string, key: EntitlementKey): Effect.Effect<boolean, never, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const rows = yield* dbQuery(() =>
+        db
+          .select({ e: weddingEntitlements.entitlement })
+          .from(weddingEntitlements)
+          .where(
+            and(
+              eq(weddingEntitlements.weddingId, weddingId),
+              eq(weddingEntitlements.entitlement, key),
+            ),
+          )
+          .all(),
+      );
+      return rows.length > 0;
+    }).pipe(Effect.withSpan("cire.entitlements.has"));
+  },
+
+  setsForWeddings(
+    weddingIds: string[],
+  ): Effect.Effect<Map<string, EntitlementKey[]>, never, DbService> {
+    return Effect.gen(function* () {
+      const map = new Map<string, EntitlementKey[]>();
+      if (weddingIds.length === 0) return map;
+      const db = yield* DbService;
+      const rows = yield* dbQuery(() =>
+        db
+          .select({
+            weddingId: weddingEntitlements.weddingId,
+            entitlement: weddingEntitlements.entitlement,
+          })
+          .from(weddingEntitlements)
+          .where(inArray(weddingEntitlements.weddingId, weddingIds))
+          .all(),
+      );
+      for (const r of rows as { weddingId: string; entitlement: EntitlementKey }[]) {
+        const list = map.get(r.weddingId) ?? [];
+        list.push(r.entitlement);
+        map.set(r.weddingId, list);
+      }
+      return map;
+    }).pipe(Effect.withSpan("cire.entitlements.setsForWeddings"));
+  },
+
+  grant(
+    weddingId: string,
+    key: EntitlementKey,
+    opts: { source: "purchase" | "comp"; grantedBy: string; stripeRef?: string | null },
+  ): Effect.Effect<void, never, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* dbQuery(() =>
+        db
+          .insert(weddingEntitlements)
+          .values({
+            weddingId,
+            entitlement: key,
+            source: opts.source,
+            grantedAt: new Date(),
+            grantedBy: opts.grantedBy,
+            stripeRef: opts.stripeRef ?? null,
+          })
+          .onConflictDoNothing()
+          .run(),
+      );
+    }).pipe(Effect.withSpan("cire.entitlements.grant"));
+  },
+
+  assertGuestCapacity(
+    weddingId: string,
+    incomingNewGuests: number,
+  ): Effect.Effect<void, CapacityExceeded, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const rows = yield* dbQuery(() =>
+        db
+          .select({ e: weddingEntitlements.entitlement })
+          .from(weddingEntitlements)
+          .where(eq(weddingEntitlements.weddingId, weddingId))
+          .all(),
+      );
+      const cap = deriveCap((rows as { e: string }[]).map((r) => r.e));
+      const current = yield* countGuests(db, weddingId);
+      if (current + incomingNewGuests > cap) {
+        return yield* Effect.fail(new CapacityExceeded({ limit: cap, current }));
+      }
+    }).pipe(Effect.withSpan("cire.entitlements.assertGuestCapacity"));
+  },
+};

--- a/cire/api/src/services/import.test.ts
+++ b/cire/api/src/services/import.test.ts
@@ -8,15 +8,17 @@ import {
   guestEvents,
   rsvps,
   weddings,
+  weddingEntitlements,
 } from "@cire/db";
 import { eq } from "drizzle-orm";
-import { Effect, Layer } from "effect";
+import { Effect, Exit, Layer } from "effect";
 
 import { DbService } from "../db";
 import type { Db } from "../db";
 import { createDb, seedBootstrapWedding, seedDb } from "../db/setup";
 import type { ParsedEvent, ParsedFamily } from "../schemas/import";
 import { claimService } from "./claim";
+import { entitlementService } from "./entitlements";
 import { hostCodeService } from "./host-code";
 import { applyImport, diffAgainstDb } from "./import";
 import { parseEventsCsv, parseGuestsCsv } from "./spreadsheet";
@@ -653,5 +655,201 @@ describe("applyImport: optional End + Location → Address fallback", () => {
       .find((r) => r.name === "Catholic Ceremony")!;
     expect(row.address).toBe("Example Parish");
     expect(row.endAt).toBe("");
+  });
+});
+
+// ── Capacity enforcement ──────────────────────────────────────────────────────
+
+/**
+ * Build a minimal ParsedFamily with N guests (no events), for capacity tests.
+ */
+function planCreatingNGuests(
+  db: ReturnType<typeof createDb>,
+  n: number,
+  weddingId = BOOTSTRAP_WEDDING_ID,
+): Effect.Effect<import("../schemas/import").ImportPlan, never, DbService> {
+  return Effect.gen(function* () {
+    // One family, N guests, no events.
+    const parsedFamily: ParsedFamily = {
+      familyName: "CapTestFamily",
+      guests: Array.from({ length: n }, (_, i) => ({
+        firstName: `Guest${i}`,
+        lastName: "Cap",
+        nickname: null,
+        eventNames: [],
+      })),
+    };
+    return yield* diffAgainstDb([], [parsedFamily], weddingId);
+  }).pipe(Effect.provideService(DbService, db));
+}
+
+describe("applyImport — capacity enforcement", () => {
+  it("applyImport fails with CapacityExceeded when net-new guests breach the derived cap, writing nothing", async () => {
+    const db = createDb();
+    seedBootstrapWedding(db);
+    // cap 100 (no capacity entitlement), plan creates 101 guests
+    const plan = await Effect.runPromise(planCreatingNGuests(db, 101));
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_cap_1", plan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    // Atomic: no guests were written.
+    const n = (db.$client.query("SELECT COUNT(*) AS n FROM guests").get() as { n: number }).n;
+    expect(n).toBe(0);
+  });
+
+  it("applyImport succeeds at exactly the cap (100 guests)", async () => {
+    const db = createDb();
+    seedBootstrapWedding(db);
+    const plan = await Effect.runPromise(planCreatingNGuests(db, 100));
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_cap_2", plan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+    const n = (db.$client.query("SELECT COUNT(*) AS n FROM guests").get() as { n: number }).n;
+    expect(n).toBe(100);
+  });
+
+  it("host-preview family guests do NOT count toward the cap", async () => {
+    // Seed 99 real guests directly (bypassing diff so they aren't removed by
+    // subsequent diffAgainstDb calls). Then create a host family with 1 guest.
+    // The entitlementService must exclude host guests from the count:
+    //   real=99, host=1 → adding 1 real guest = 100 (≤100) → OK
+    //   then adding 1 more real guest = 101 (>100) → CapacityExceeded
+    const db = createDb();
+    seedBootstrapWedding(db);
+    const now = new Date();
+    const layer = Layer.succeed(DbService, db);
+
+    // Insert 99 real guests directly.
+    const realFamilyId = crypto.randomUUID();
+    db.insert(families)
+      .values({
+        id: realFamilyId,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        publicId: "REAL-FAM-CAP",
+        familyName: "RealFamily",
+        kind: "guest",
+        source: "import",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    for (let i = 0; i < 99; i++) {
+      db.insert(guests)
+        .values({
+          id: crypto.randomUUID(),
+          familyId: realFamilyId,
+          firstName: `RealGuest${i}`,
+          lastName: "Real",
+          sortOrder: i,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    // Provision a host family (kind='host') with its synthetic guest.
+    await Effect.runPromise(
+      hostCodeService
+        .ensureForWedding(BOOTSTRAP_WEDDING_ID)
+        .pipe(Effect.provideService(DbService, db)),
+    );
+
+    // Adding 1 real guest → 99+1=100 ≤ 100 → should succeed.
+    const addOnePlan: import("../schemas/import").ImportPlan = {
+      eventCreates: [],
+      eventUpdates: [],
+      eventRemoves: [],
+      familyCreates: [{ id: crypto.randomUUID(), publicId: "ONE-MORE-CAP", familyName: "OneMore" }],
+      familyRemoves: [],
+      guestCreates: [],
+      guestUpdates: [],
+      guestRemoves: [],
+      eventLinkCreates: [],
+      eventLinkRemoves: [],
+      warnings: [],
+    };
+    const oneMoreFamilyId = addOnePlan.familyCreates[0]!.id;
+    addOnePlan.guestCreates.push({
+      id: crypto.randomUUID(),
+      familyId: oneMoreFamilyId,
+      firstName: "Last",
+      lastName: "Guest",
+      nickname: null,
+      sortOrder: 0,
+    });
+    const exit1 = await Effect.runPromiseExit(
+      applyImport("imp_cap_host_2", addOnePlan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isSuccess(exit1)).toBe(true);
+
+    // Now adding 1 more real guest → 100+1=101 > 100 → should fail.
+    const overflowPlan: import("../schemas/import").ImportPlan = {
+      eventCreates: [],
+      eventUpdates: [],
+      eventRemoves: [],
+      familyCreates: [{ id: crypto.randomUUID(), publicId: "TOO-MANY-CAP", familyName: "TooMany" }],
+      familyRemoves: [],
+      guestCreates: [],
+      guestUpdates: [],
+      guestRemoves: [],
+      eventLinkCreates: [],
+      eventLinkRemoves: [],
+      warnings: [],
+    };
+    overflowPlan.guestCreates.push({
+      id: crypto.randomUUID(),
+      familyId: overflowPlan.familyCreates[0]!.id,
+      firstName: "Overflow",
+      lastName: "Guest",
+      nickname: null,
+      sortOrder: 0,
+    });
+    const exit2 = await Effect.runPromiseExit(
+      applyImport("imp_cap_host_3", overflowPlan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isFailure(exit2)).toBe(true);
+
+    // The overflow guest must NOT have been persisted (atomic).
+    const n = (
+      db.$client
+        .query(
+          `SELECT COUNT(*) AS n FROM guests g
+         JOIN families f ON g.family_id = f.id
+         WHERE f.kind != 'host' AND f.wedding_id = '${BOOTSTRAP_WEDDING_ID}'`,
+        )
+        .get() as { n: number }
+    ).n;
+    // 99 real + 1 "Last" from the succeeded import = 100.
+    expect(n).toBe(100);
+  });
+
+  it("upgraded wedding (capacity_500) allows more guests", async () => {
+    const db = createDb();
+    seedBootstrapWedding(db);
+    const layer = Layer.succeed(DbService, db);
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Grant capacity_500
+        yield* entitlementService.grant(BOOTSTRAP_WEDDING_ID, "capacity_500", {
+          source: "comp",
+          grantedBy: "usr_admin",
+        });
+        // 101 guests under cap of 500 → succeeds.
+        const plan = yield* planCreatingNGuests(db, 101, BOOTSTRAP_WEDDING_ID);
+        const exit = yield* Effect.exit(applyImport("imp_cap_up", plan, BOOTSTRAP_WEDDING_ID));
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }).pipe(Effect.provide(layer)),
+    );
   });
 });

--- a/cire/api/src/services/import.test.ts
+++ b/cire/api/src/services/import.test.ts
@@ -919,4 +919,150 @@ describe("applyImport — capacity enforcement", () => {
       }).pipe(Effect.provide(layer)),
     );
   });
+
+  // SWAP-AT-CAP: remove K guests and add K guests when already at the cap.
+  // Net delta = 0, so the capacity gate must NOT fire even though guestCreates.length > 0.
+  it("swap-at-cap: remove K and add K at exactly cap → succeeds (net delta = 0)", async () => {
+    const db = createDb();
+    seedBootstrapWedding(db);
+    const layer = Layer.succeed(DbService, db);
+    const now = new Date();
+
+    // Seed exactly 100 real guests (= default cap) directly as import-sourced.
+    const seedFamilyId = crypto.randomUUID();
+    db.insert(families)
+      .values({
+        id: seedFamilyId,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        publicId: "SWAP-SEED-FAM",
+        familyName: "SwapSeedFamily",
+        kind: "guest",
+        source: "import",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    const seedGuestIds: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      const id = crypto.randomUUID();
+      seedGuestIds.push(id);
+      db.insert(guests)
+        .values({
+          id,
+          familyId: seedFamilyId,
+          firstName: `SwapGuest${i}`,
+          lastName: "Seed",
+          sortOrder: i,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    const K = 5;
+    // Build a plan that removes K existing guests and adds K new guests (net = 0).
+    const swapPlan: import("../schemas/import").ImportPlan = {
+      eventCreates: [],
+      eventUpdates: [],
+      eventRemoves: [],
+      familyCreates: [],
+      familyRemoves: [],
+      guestCreates: Array.from({ length: K }, (_, i) => ({
+        id: crypto.randomUUID(),
+        familyId: seedFamilyId,
+        firstName: `NewSwapGuest${i}`,
+        lastName: "New",
+        nickname: null,
+        sortOrder: 100 + i,
+      })),
+      guestUpdates: [],
+      guestRemoves: seedGuestIds.slice(0, K).map((id) => ({ id, firstName: "SwapGuest" })),
+      eventLinkCreates: [],
+      eventLinkRemoves: [],
+      warnings: [],
+    };
+
+    // Net delta = 0 → must succeed even at cap.
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_swap_at_cap", swapPlan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+
+    // Still at cap: 100 - K + K = 100.
+    const n = (db.$client.query("SELECT COUNT(*) AS n FROM guests").get() as { n: number }).n;
+    expect(n).toBe(100);
+  });
+
+  it("swap-at-cap: remove K and add K+1 at exactly cap → CapacityExceeded", async () => {
+    const db = createDb();
+    seedBootstrapWedding(db);
+    const now = new Date();
+
+    // Seed exactly 100 real guests.
+    const seedFamilyId = crypto.randomUUID();
+    db.insert(families)
+      .values({
+        id: seedFamilyId,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        publicId: "SWAP-OVER-FAM",
+        familyName: "SwapOverFamily",
+        kind: "guest",
+        source: "import",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    const seedGuestIds: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      const id = crypto.randomUUID();
+      seedGuestIds.push(id);
+      db.insert(guests)
+        .values({
+          id,
+          familyId: seedFamilyId,
+          firstName: `OverGuest${i}`,
+          lastName: "Seed",
+          sortOrder: i,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    const K = 5;
+    // Remove K, add K+1 → net delta = +1, which breaches the cap.
+    const overPlan: import("../schemas/import").ImportPlan = {
+      eventCreates: [],
+      eventUpdates: [],
+      eventRemoves: [],
+      familyCreates: [],
+      familyRemoves: [],
+      guestCreates: Array.from({ length: K + 1 }, (_, i) => ({
+        id: crypto.randomUUID(),
+        familyId: seedFamilyId,
+        firstName: `NewOverGuest${i}`,
+        lastName: "New",
+        nickname: null,
+        sortOrder: 100 + i,
+      })),
+      guestUpdates: [],
+      guestRemoves: seedGuestIds.slice(0, K).map((id) => ({ id, firstName: "OverGuest" })),
+      eventLinkCreates: [],
+      eventLinkRemoves: [],
+      warnings: [],
+    };
+
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_swap_over_cap", overPlan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, db),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+
+    // Atomic: still 100 guests (no partial write).
+    const n = (db.$client.query("SELECT COUNT(*) AS n FROM guests").get() as { n: number }).n;
+    expect(n).toBe(100);
+  });
 });

--- a/cire/api/src/services/import.test.ts
+++ b/cire/api/src/services/import.test.ts
@@ -658,6 +658,73 @@ describe("applyImport: optional End + Location → Address fallback", () => {
   });
 });
 
+// ── diffAgainstDb capacity warning (non-blocking) ───────────────────────────
+
+describe("diffAgainstDb — non-blocking capacity warning", () => {
+  it("adds a warning when the resulting headcount exceeds the cap, but does NOT fail", async () => {
+    const db = createDb(":memory:");
+    seedBootstrapWedding(db);
+    const layer = Layer.succeed(DbService, db);
+
+    // Seed 95 real guests directly so the next import of 10 guests
+    // produces a resulting count of 105, which exceeds the default cap of 100.
+    // Use source='manual' so the CSV import (removeManual=false by default)
+    // leaves these guests in place — they count toward existingGuests.length
+    // without being added to guestRemoves.
+    const now = new Date();
+    const seedFamilyId = crypto.randomUUID();
+    db.insert(families)
+      .values({
+        id: seedFamilyId,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        publicId: "WARN-SEED-FAM",
+        familyName: "SeedFamily",
+        kind: "guest",
+        source: "manual",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    for (let i = 0; i < 95; i++) {
+      db.insert(guests)
+        .values({
+          id: crypto.randomUUID(),
+          familyId: seedFamilyId,
+          firstName: `SeedGuest${i}`,
+          lastName: "Seed",
+          sortOrder: i,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    // diffAgainstDb a plan that adds 10 new guests → resulting = 95 + 10 = 105 > 100.
+    const parsedFamily: ParsedFamily = {
+      familyName: "WarnTestFamily",
+      guests: Array.from({ length: 10 }, (_, i) => ({
+        firstName: `WarnGuest${i}`,
+        lastName: "Warn",
+        nickname: null,
+        eventNames: [],
+      })),
+    };
+
+    // Must succeed (non-blocking) — no exception or failure.
+    const plan = await Effect.runPromise(
+      diffAgainstDb([], [parsedFamily], BOOTSTRAP_WEDDING_ID).pipe(Effect.provide(layer)),
+    );
+
+    // The warning must be present and contain the stable "capped at 100" phrase.
+    expect(plan.warnings.length).toBeGreaterThan(0);
+    const capacityWarning = plan.warnings.find((w) => /capped at 100/i.test(w));
+    expect(capacityWarning).toBeDefined();
+
+    // The plan still contains the creates (diff is not blocked).
+    expect(plan.guestCreates).toHaveLength(10);
+  });
+});
+
 // ── Capacity enforcement ──────────────────────────────────────────────────────
 
 /**

--- a/cire/api/src/services/import.ts
+++ b/cire/api/src/services/import.ts
@@ -1,4 +1,12 @@
-import { events, families, guests, guestEvents, rsvps, weddings } from "@cire/db";
+import {
+  events,
+  families,
+  guests,
+  guestEvents,
+  rsvps,
+  weddings,
+  weddingEntitlements,
+} from "@cire/db";
 import { and, eq, inArray, ne } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { Effect, Data } from "effect";
@@ -21,6 +29,7 @@ import type {
   ParsedEvent,
   ParsedFamily,
 } from "../schemas/import";
+import { entitlementService, CapacityExceeded } from "./entitlements";
 import { generateFamilyCode } from "./family-code";
 import type { CodeStyle } from "./family-code";
 import { resolvePinUrl } from "./pinterest-resolve";
@@ -423,6 +432,32 @@ export function diffAgainstDb(
       }
     }
 
+    // ── Capacity preview warning (non-blocking) ──────────────────────────────
+    // Warn early when this plan would breach the derived cap. The hard atomic
+    // block lives in applyImport — this warning lets the preview UI surface the
+    // issue before the organiser commits. Host-preview families are excluded from
+    // the current-guest count (same join + ne(kind,'host') as entitlementService).
+    if (guestCreates.length > 0) {
+      const entRows = yield* dbQuery(() =>
+        db
+          .select({ e: weddingEntitlements.entitlement })
+          .from(weddingEntitlements)
+          .where(eq(weddingEntitlements.weddingId, weddingId))
+          .all(),
+      );
+      const cap = entitlementService.deriveCap((entRows as { e: string }[]).map((r) => r.e));
+      // `existingGuests` was already fetched above with ne(families.kind, 'host'),
+      // so it already excludes host-preview guests. The resulting headcount after
+      // this plan: current real guests minus removals plus new creates.
+      const currentRealGuests = existingGuests.length;
+      const resulting = currentRealGuests - guestRemoves.length + guestCreates.length;
+      if (resulting > cap) {
+        warnings.push(
+          `This import brings you to ${resulting} guests; your plan is capped at ${cap}. Upgrade to add more.`,
+        );
+      }
+    }
+
     return {
       eventCreates,
       eventUpdates,
@@ -516,7 +551,7 @@ export function applyImport(
   importId: string,
   plan: ImportPlan,
   weddingId: string,
-): Effect.Effect<ImportSummary, ImportError, DbService> {
+): Effect.Effect<ImportSummary, ImportError | CapacityExceeded, DbService> {
   return Effect.gen(function* () {
     const db = yield* DbService;
     const now = new Date();
@@ -686,6 +721,13 @@ export function applyImport(
           .values({ guestId: link.guestId, eventId: link.eventId })
           .onConflictDoNothing(),
       );
+    }
+
+    // Capacity gate — enforce the wedding's derived guest ceiling on the NET new
+    // guests this plan introduces, before any write. Atomic: a breach fails the
+    // whole apply, nothing is committed.
+    if (plan.guestCreates.length > 0) {
+      yield* entitlementService.assertGuestCapacity(weddingId, plan.guestCreates.length);
     }
 
     yield* Effect.tryPromise({

--- a/cire/api/src/services/import.ts
+++ b/cire/api/src/services/import.ts
@@ -725,9 +725,13 @@ export function applyImport(
 
     // Capacity gate — enforce the wedding's derived guest ceiling on the NET new
     // guests this plan introduces, before any write. Atomic: a breach fails the
-    // whole apply, nothing is committed.
-    if (plan.guestCreates.length > 0) {
-      yield* entitlementService.assertGuestCapacity(weddingId, plan.guestCreates.length);
+    // whole apply, nothing is committed. We pass the NET delta (creates minus
+    // removals) so a churn import that removes K guests and adds K guests at cap
+    // is correctly allowed: assertGuestCapacity does `current + incoming > cap`,
+    // and a negative or zero incoming can never exceed.
+    const netGuestDelta = plan.guestCreates.length - plan.guestRemoves.length;
+    if (netGuestDelta > 0) {
+      yield* entitlementService.assertGuestCapacity(weddingId, netGuestDelta);
     }
 
     yield* Effect.tryPromise({

--- a/cire/api/src/services/weddings.ts
+++ b/cire/api/src/services/weddings.ts
@@ -15,6 +15,12 @@ export type WeddingSummary = {
    *  `editor` (co-host with module writes) or `viewer` (read-only co-host).
    *  Lets the portal label each wedding and gate write/management surfaces. */
   role: "owner" | "editor" | "viewer";
+  /** Entitlement keys active on this wedding (e.g. `"vendors"`, `"capacity_500"`).
+   *  Merged in by the route from `entitlementService.setsForWeddings` — the
+   *  service itself stays free of entitlement logic. */
+  entitlements: string[];
+  /** Effective guest ceiling derived from the entitlement set. Defaults to 100. */
+  guestCap: number;
 };
 
 /** Raised when a new wedding row cannot be persisted (slug collisions are
@@ -98,7 +104,14 @@ export const weddingsService = {
       );
       const summaries: WeddingSummary[] = [];
       for (const w of owned) {
-        summaries.push({ id: w.id, slug: w.slug, displayName: w.displayName, role: "owner" });
+        summaries.push({
+          id: w.id,
+          slug: w.slug,
+          displayName: w.displayName,
+          role: "owner",
+          entitlements: [],
+          guestCap: 100,
+        });
       }
       for (const w of hosted) {
         summaries.push({
@@ -106,6 +119,8 @@ export const weddingsService = {
           slug: w.slug,
           displayName: w.displayName,
           role: normaliseHostRole(w.role),
+          entitlements: [],
+          guestCap: 100,
         });
       }
       return summaries;
@@ -206,7 +221,14 @@ export const weddingsService = {
         }).pipe(
           Effect.map(() => ({
             ok: true as const,
-            summary: { id, slug, displayName: trimmed, role: "owner" as const },
+            summary: {
+              id,
+              slug,
+              displayName: trimmed,
+              role: "owner" as const,
+              entitlements: [] as string[],
+              guestCap: 100,
+            },
           })),
           Effect.catchAll((cause) =>
             // A UNIQUE violation on slug/id is retryable; surface anything else

--- a/cire/db/migrations/0042_wedding_entitlements.sql
+++ b/cire/db/migrations/0042_wedding_entitlements.sql
@@ -7,6 +7,6 @@ CREATE TABLE `wedding_entitlements` (
   `source` text NOT NULL,
   `granted_at` integer NOT NULL,
   `granted_by` text NOT NULL,
-  `stripe_ref` text,
+  `provider_ref` text,
   PRIMARY KEY (`wedding_id`, `entitlement`)
 );

--- a/cire/db/migrations/0042_wedding_entitlements.sql
+++ b/cire/db/migrations/0042_wedding_entitlements.sql
@@ -1,0 +1,12 @@
+-- 0042_wedding_entitlements.sql — platform tiering Phase 1 (additive; no drops).
+-- Per-wedding unlocked packs. Row-presence = entitled. Composite PK (wedding_id,
+-- entitlement) makes a double-grant a swallowed conflict, never a duplicate row.
+CREATE TABLE `wedding_entitlements` (
+  `wedding_id` text NOT NULL REFERENCES `weddings`(`id`) ON DELETE CASCADE,
+  `entitlement` text NOT NULL,
+  `source` text NOT NULL,
+  `granted_at` integer NOT NULL,
+  `granted_by` text NOT NULL,
+  `stripe_ref` text,
+  PRIMARY KEY (`wedding_id`, `entitlement`)
+);

--- a/cire/db/src/schema.ts
+++ b/cire/db/src/schema.ts
@@ -420,6 +420,33 @@ export const vendorClaims = sqliteTable(
   (t) => [index("vendor_claims_vendor_idx").on(t.directoryVendorId)],
 );
 
+// wedding_entitlements: per-wedding unlocked packs (platform tiering, migration
+// 0042). Row-presence = entitled. The whole paid model is a SET here: a wedding
+// holds any subset of packs. Boolean packs (`premium_templates`, `vendors`,
+// `ai`) gate features by presence; capacity is LEVELED — the effective guest
+// ceiling is DERIVED from the highest capacity_* row (none→100, capacity_500→500,
+// capacity_1000→1000), so there is deliberately no guest_cap column to drift.
+// `source` distinguishes a Stripe purchase from a comp/manual grant (V&R,
+// "contact us" capacity, support goodwill). `stripe_ref` carries the
+// checkout_session/payment_intent id on purchases (NULL on comp) and is the
+// Phase-2 webhook idempotency key.
+export const weddingEntitlements = sqliteTable(
+  "wedding_entitlements",
+  {
+    weddingId: text("wedding_id")
+      .notNull()
+      .references(() => weddings.id, { onDelete: "cascade" }),
+    entitlement: text("entitlement", {
+      enum: ["premium_templates", "vendors", "ai", "capacity_500", "capacity_1000"],
+    }).notNull(),
+    source: text("source", { enum: ["purchase", "comp"] }).notNull(),
+    grantedAt: integer("granted_at", { mode: "timestamp" }).notNull(),
+    grantedBy: text("granted_by").notNull(),
+    stripeRef: text("stripe_ref"),
+  },
+  (t) => [primaryKey({ columns: [t.weddingId, t.entitlement] })],
+);
+
 export const guestEvents = sqliteTable(
   "guest_events",
   {

--- a/cire/db/src/schema.ts
+++ b/cire/db/src/schema.ts
@@ -426,9 +426,9 @@ export const vendorClaims = sqliteTable(
 // `ai`) gate features by presence; capacity is LEVELED — the effective guest
 // ceiling is DERIVED from the highest capacity_* row (none→100, capacity_500→500,
 // capacity_1000→1000), so there is deliberately no guest_cap column to drift.
-// `source` distinguishes a Stripe purchase from a comp/manual grant (V&R,
-// "contact us" capacity, support goodwill). `stripe_ref` carries the
-// checkout_session/payment_intent id on purchases (NULL on comp) and is the
+// `source` distinguishes a provider purchase from a comp/manual grant (V&R,
+// "contact us" capacity, support goodwill). `provider_ref` carries the
+// external provider reference on purchases (NULL on comp) and is the
 // Phase-2 webhook idempotency key.
 export const weddingEntitlements = sqliteTable(
   "wedding_entitlements",
@@ -442,7 +442,7 @@ export const weddingEntitlements = sqliteTable(
     source: text("source", { enum: ["purchase", "comp"] }).notNull(),
     grantedAt: integer("granted_at", { mode: "timestamp" }).notNull(),
     grantedBy: text("granted_by").notNull(),
-    stripeRef: text("stripe_ref"),
+    providerRef: text("provider_ref"),
   },
   (t) => [primaryKey({ columns: [t.weddingId, t.entitlement] })],
 );

--- a/cire/organiser/src/components/CreateWeddingForm.tsx
+++ b/cire/organiser/src/components/CreateWeddingForm.tsx
@@ -11,6 +11,11 @@ export interface WeddingSummary {
    *  codes, settings + destructive actions; editors get full module writes
    *  (import, invite builder, event locations); viewers are read-only. */
   role: "owner" | "editor" | "viewer";
+  /** Entitlement keys active on this wedding (e.g. `"vendors"`, `"capacity_500"`).
+   *  Populated by the `/api/organiser/weddings` list endpoint. */
+  entitlements: string[];
+  /** Effective guest ceiling derived from the entitlement set. Defaults to 100. */
+  guestCap: number;
 }
 
 /** Claim-code style, mirroring the API's `weddings.code_style` enum. */

--- a/cire/organiser/src/components/ModuleShell.test.tsx
+++ b/cire/organiser/src/components/ModuleShell.test.tsx
@@ -48,6 +48,25 @@ vi.mock("./HostsPanel", () => ({
 vi.mock("./SettingsPanel", () => ({
   default: (p: { weddingId: string }) => <div data-testid="settings">{p.weddingId}</div>,
 }));
+vi.mock("./VendorsView", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="vendors">{p.weddingId}</div>,
+}));
+vi.mock("./DirectoryBrowseView", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="directory-browse">{p.weddingId}</div>,
+}));
+vi.mock("./UpsellPanel", () => ({
+  default: (p: { feature: string }) => (
+    <div data-testid="upsell-panel" data-feature={p.feature}>
+      Locked
+    </div>
+  ),
+}));
+vi.mock("./ChecklistView", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="checklist">{p.weddingId}</div>,
+}));
+vi.mock("./BudgetView", () => ({
+  default: (p: { weddingId: string }) => <div data-testid="budget">{p.weddingId}</div>,
+}));
 
 import ModuleShell from "./ModuleShell";
 
@@ -58,6 +77,8 @@ function renderShell(opts: {
   canEdit?: boolean;
   module?: Module;
   sub?: string;
+  entitlements?: string[];
+  guestCap?: number;
 }) {
   const [module, setModule] = createSignal<Module>(opts.module ?? "overview");
   const [sub, setSub] = createSignal(opts.sub ?? "index");
@@ -80,6 +101,8 @@ function renderShell(opts: {
       sub={sub()}
       onModule={onModule}
       onSub={onSub}
+      entitlements={opts.entitlements ?? []}
+      guestCap={opts.guestCap ?? 100}
     />
   ));
   return { ...utils, onModule, onSub, setModule, setSub };
@@ -180,6 +203,36 @@ describe("ModuleShell", () => {
     it("still gives a viewer the read RSVPs view", () => {
       renderShell({ canManage: false, canEdit: false, module: "guests", sub: "rsvps" });
       expect(screen.getByTestId("rsvps")).toBeTruthy();
+    });
+  });
+
+  describe("entitlement gating — vendors module", () => {
+    it("renders UpsellPanel when the vendors entitlement is absent", () => {
+      // No entitlements → vendors module is locked.
+      renderShell({ module: "vendors", sub: "index", entitlements: [] });
+      expect(screen.getByTestId("upsell-panel")).toBeTruthy();
+      expect(screen.getByTestId("upsell-panel").getAttribute("data-feature")).toBe("vendors");
+      expect(screen.queryByTestId("vendors")).toBeNull();
+      expect(screen.queryByTestId("directory-browse")).toBeNull();
+    });
+
+    it("renders the vendors feature views when the vendors entitlement is present", () => {
+      renderShell({ module: "vendors", sub: "index", entitlements: ["vendors"] });
+      expect(screen.queryByTestId("upsell-panel")).toBeNull();
+      expect(screen.getByTestId("vendors")).toBeTruthy();
+    });
+
+    it("renders the browse sub-view when entitled and active() is 'browse'", () => {
+      renderShell({ module: "vendors", sub: "browse", entitlements: ["vendors"] });
+      expect(screen.queryByTestId("upsell-panel")).toBeNull();
+      expect(screen.getByTestId("directory-browse")).toBeTruthy();
+    });
+
+    it("does not show UpsellPanel for other entitlements (only absent vendors key locks)", () => {
+      // Has other entitlements but not vendors → still locked.
+      renderShell({ module: "vendors", sub: "index", entitlements: ["capacity_500", "ai"] });
+      expect(screen.getByTestId("upsell-panel")).toBeTruthy();
+      expect(screen.queryByTestId("vendors")).toBeNull();
     });
   });
 });

--- a/cire/organiser/src/components/ModuleShell.tsx
+++ b/cire/organiser/src/components/ModuleShell.tsx
@@ -17,6 +17,7 @@ import Overview from "./Overview";
 import RemintPanel from "./RemintPanel";
 import RsvpView from "./RsvpView";
 import SettingsPanel from "./SettingsPanel";
+import UpsellPanel from "./UpsellPanel";
 import VendorsView from "./VendorsView";
 
 interface ModuleShellProps {
@@ -39,6 +40,13 @@ interface ModuleShellProps {
   /** Report a sub-view switch up so the parent updates the hash. */
   onSub: (sub: string) => void;
   onWeddingUpdated?: (patch: { displayName: string; slug: string }) => void;
+  /** Entitlement keys active on this wedding (from the API list response).
+   *  Used to gate locked modules — when a module's key is absent the shell
+   *  renders an UpsellPanel instead of the feature UI. */
+  entitlements: string[];
+  /** Effective guest ceiling derived from the entitlement set. Surfaced for
+   *  informational display (e.g. Overview) — enforcement is server-side. */
+  guestCap: number;
 }
 
 /** A sub-tab within a module. `manage`/`edit` mark role-gated subs so a viewer
@@ -185,16 +193,21 @@ export default function ModuleShell(props: ModuleShellProps) {
 
         {/* ── Vendors: CRM ("My vendors") + directory Browse ──────────── */}
         <Show when={props.module === "vendors"}>
-          <Show when={active() === "index"}>
-            <VendorsView
-              weddingId={props.weddingId}
-              currency={peekCachedBudget(props.weddingId)?.currency ?? "AUD"}
-              canEdit={props.canEdit}
-              canManage={props.canManage}
-            />
-          </Show>
-          <Show when={active() === "browse"}>
-            <DirectoryBrowseView weddingId={props.weddingId} canEdit={props.canEdit} />
+          <Show
+            when={props.entitlements.includes("vendors")}
+            fallback={<UpsellPanel feature="vendors" />}
+          >
+            <Show when={active() === "index"}>
+              <VendorsView
+                weddingId={props.weddingId}
+                currency={peekCachedBudget(props.weddingId)?.currency ?? "AUD"}
+                canEdit={props.canEdit}
+                canManage={props.canManage}
+              />
+            </Show>
+            <Show when={active() === "browse"}>
+              <DirectoryBrowseView weddingId={props.weddingId} canEdit={props.canEdit} />
+            </Show>
           </Show>
         </Show>
 

--- a/cire/organiser/src/components/OrganiserApp.test.tsx
+++ b/cire/organiser/src/components/OrganiserApp.test.tsx
@@ -51,6 +51,8 @@ vi.mock("./WeddingList", () => ({
             slug: "new-x",
             displayName: "Fresh Wedding",
             role: "owner",
+            entitlements: [],
+            guestCap: 100,
           })
         }
       >
@@ -105,10 +107,19 @@ function listResponse(
     slug: string;
     displayName: string;
     role?: "owner" | "editor" | "viewer";
+    entitlements?: string[];
+    guestCap?: number;
   }[],
 ) {
   return new Response(
-    JSON.stringify({ weddings: weddings.map((w) => ({ role: "owner", ...w })) }),
+    JSON.stringify({
+      weddings: weddings.map((w) => ({
+        role: "owner",
+        entitlements: [],
+        guestCap: 100,
+        ...w,
+      })),
+    }),
     {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/cire/organiser/src/components/OrganiserApp.tsx
+++ b/cire/organiser/src/components/OrganiserApp.tsx
@@ -143,6 +143,8 @@ function WeddingDashboard(props: {
         onModule={props.onModule}
         onSub={props.onSub}
         onWeddingUpdated={props.onWeddingUpdated}
+        entitlements={props.wedding.entitlements ?? []}
+        guestCap={props.wedding.guestCap ?? 100}
       />
     </div>
   );

--- a/cire/organiser/src/components/UpsellPanel.test.tsx
+++ b/cire/organiser/src/components/UpsellPanel.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+
+import UpsellPanel from "./UpsellPanel";
+
+describe("UpsellPanel", () => {
+  afterEach(() => cleanup());
+
+  it("renders the vendors feature title and blurb", () => {
+    const { getByText } = render(() => <UpsellPanel feature="vendors" />);
+    expect(getByText(/Vendors & directory/i)).toBeTruthy();
+    expect(getByText(/Browse trusted wedding vendors/i)).toBeTruthy();
+  });
+
+  it("renders an inert CTA button (disabled — Phase 1, checkout not wired)", () => {
+    const { getByRole } = render(() => <UpsellPanel feature="vendors" />);
+    const btn = getByRole("button");
+    expect(btn).toBeTruthy();
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/cire/organiser/src/components/UpsellPanel.tsx
+++ b/cire/organiser/src/components/UpsellPanel.tsx
@@ -1,0 +1,33 @@
+import type { Component } from "solid-js";
+
+interface UpsellPanelProps {
+  feature: "vendors";
+}
+
+const COPY: Record<UpsellPanelProps["feature"], { title: string; blurb: string }> = {
+  vendors: {
+    title: "Vendors & directory",
+    blurb: "Browse trusted wedding vendors and manage your shortlist in one place.",
+  },
+};
+
+/**
+ * Upsell panel shown in place of a locked module (Phase 1: vendors only).
+ * Pricing and checkout are deferred to Phase 2 — the CTA is intentionally
+ * inert (`disabled`) so no price copy or payment flow is wired here.
+ */
+const UpsellPanel: Component<UpsellPanelProps> = (props) => {
+  const copy = () => COPY[props.feature];
+  return (
+    <section class="upsell" aria-labelledby="upsell-title">
+      <h2 id="upsell-title">{copy().title}</h2>
+      <p>{copy().blurb}</p>
+      {/* Phase 1: checkout not wired — inert CTA. Phase 2 enables it. */}
+      <button type="button" disabled aria-disabled="true">
+        Unlock — coming soon
+      </button>
+    </section>
+  );
+};
+
+export default UpsellPanel;

--- a/cire/wiki/systems/entitlements.md
+++ b/cire/wiki/systems/entitlements.md
@@ -24,7 +24,7 @@ Added by migration 0042.
 | `source` | `text NOT NULL` | `'purchase'` or `'comp'` |
 | `granted_at` | `integer` (timestamp) | When the row was written |
 | `granted_by` | `text NOT NULL` | Operator identifier (for comp rows) or system label |
-| `stripe_ref` | `text` | External provider reference on `source = 'purchase'`; `NULL` on `source = 'comp'` |
+| `provider_ref` | `text` | External provider reference on `source = 'purchase'`; `NULL` on `source = 'comp'` |
 
 **Primary key:** composite `(wedding_id, entitlement)` — one row per (wedding, capability) pair. Duplicate grants via `INSERT OR IGNORE` / `onConflictDoNothing` are idempotent.
 
@@ -69,10 +69,10 @@ All methods are Effect programs returning `Effect.Effect<A, E, DbService>`. Impl
 | `has` | `(weddingId, key) → Effect<boolean, never, DbService>` | Returns `true` if the row `(weddingId, key)` exists |
 | `setsForWeddings` | `(weddingIds[]) → Effect<Map<weddingId, EntitlementKey[]>, never, DbService>` | Batch-fetches all entitlement rows for a list of wedding IDs; used to annotate wedding-list responses |
 | `deriveCap` | `(keys: string[]) → number` | Pure — derives the effective guest ceiling from an entitlement key array |
-| `grant` | `(weddingId, key, { source, grantedBy, stripeRef? }) → Effect<void, never, DbService>` | Inserts a row; idempotent on conflict |
+| `grant` | `(weddingId, key, { source, grantedBy, providerRef? }) → Effect<void, never, DbService>` | Inserts a row; idempotent on conflict |
 | `assertGuestCapacity` | `(weddingId, incomingNewGuests) → Effect<void, CapacityExceeded, DbService>` | Fetches the wedding's entitlement set, derives the cap, counts current (non-host) guests, fails with `CapacityExceeded { limit, current }` if the import would breach the ceiling |
 
-`CapacityExceeded` is a tagged error (`Data.TaggedError`); handlers map it to a 422 response.
+`CapacityExceeded` is a tagged error (`Data.TaggedError`); handlers map it to a **402** response with body `{ error: "payment_required", entitlement: "capacity", limit, current }`.
 
 ---
 
@@ -105,7 +105,7 @@ A missing `weddingId` in `params` (should not occur after the role gate validate
 
 ## Capacity enforcement in `applyImport`
 
-`applyImport` (in `cire/api/src/services/import.ts`) calls `entitlementService.assertGuestCapacity(weddingId, plan.guestCreates.length)` **before** writing any rows. The check and the subsequent D1 batch write are sequenced atomically: if the capacity check fails, no guests are written. There are no partial writes.
+`applyImport` (in `cire/api/src/services/import.ts`) calls `entitlementService.assertGuestCapacity(weddingId, netGuestDelta)` — where `netGuestDelta = guestCreates.length - guestRemoves.length` — **before** writing any rows. The check is skipped when the net delta is zero or negative (a churn import that removes K and adds K at cap succeeds). The check and the subsequent D1 batch write are sequenced atomically: if the capacity check fails, no guests are written. There are no partial writes.
 
 The check counts real guests only — the synthetic `host`-kind family row used for invite previews is excluded from the count via a `ne(families.kind, 'host')` filter.
 
@@ -133,7 +133,7 @@ A prod D1 write requires explicit human authorization naming `cire-db` before ru
 
 ## Phase-2 payment seam
 
-`grant()` accepts `source: 'purchase'` and a `stripeRef` field. A webhook skeleton (`cire/api/src/routes/payment-webhook.ts`) exists but is inert in Phase 1 — all Phase-1 grants use `source: 'comp'`. The `stripeRef` column is the idempotency anchor for Phase-2 event-driven grants. Provider selection is tracked outside this repository.
+`grant()` accepts `source: 'purchase'` and a `providerRef` field. A webhook skeleton (`cire/api/src/routes/payment-webhook.ts`) exists but is inert in Phase 1 — all Phase-1 grants use `source: 'comp'`. The `provider_ref` column is the idempotency anchor for Phase-2 event-driven grants. Provider selection is tracked outside this repository.
 
 ---
 

--- a/cire/wiki/systems/entitlements.md
+++ b/cire/wiki/systems/entitlements.md
@@ -1,0 +1,143 @@
+---
+title: Entitlements — per-wedding capability gates
+tags: [systems, cire, entitlements, phase1]
+related:
+  - "[[vendors]]"
+  - "[[cire-auth]]"
+last-reviewed: 2026-07-18
+---
+
+# Entitlements — per-wedding capability gates
+
+The entitlement system is a row-presence gate: a row in `wedding_entitlements` means that wedding has the named capability. No row means the capability is absent. There are no enum columns to decode, no flag columns to toggle — the table acts as a sparse capability set.
+
+---
+
+## Database — `wedding_entitlements` table
+
+Added by migration 0042.
+
+| Column | Type | Notes |
+|---|---|---|
+| `wedding_id` | `text NOT NULL` | FK → `weddings.id` ON DELETE CASCADE |
+| `entitlement` | `text NOT NULL` | One of the capability keys (see below) |
+| `source` | `text NOT NULL` | `'purchase'` or `'comp'` |
+| `granted_at` | `integer` (timestamp) | When the row was written |
+| `granted_by` | `text NOT NULL` | Operator identifier (for comp rows) or system label |
+| `stripe_ref` | `text` | External provider reference on `source = 'purchase'`; `NULL` on `source = 'comp'` |
+
+**Primary key:** composite `(wedding_id, entitlement)` — one row per (wedding, capability) pair. Duplicate grants via `INSERT OR IGNORE` / `onConflictDoNothing` are idempotent.
+
+---
+
+## Entitlement keys
+
+Five opaque capability flags. Keys are stored as plain strings; the meaning is determined by how the application checks for them.
+
+| Key | What its presence enables |
+|---|---|
+| `premium_templates` | Access to extended invite template designs |
+| `vendors` | Vendor CRM (wedding-scoped) + Directory browse/add routes |
+| `ai` | AI-assisted content generation features |
+| `capacity_500` | Guest import ceiling raised to 500 |
+| `capacity_1000` | Guest import ceiling raised to 1000 |
+
+Boolean capability flags (`premium_templates`, `vendors`, `ai`) are presence-only: the row either exists or it doesn't. Capacity flags are treated differently — see below.
+
+---
+
+## Derived guest capacity
+
+Guest capacity is not stored as a column. It is **derived** from the entitlement set at the moment of enforcement. `deriveCap` (a pure function in `cire/api/src/services/entitlements.ts`) inspects the set and returns the ceiling:
+
+| Entitlement row present | Effective guest ceiling |
+|---|---|
+| `capacity_1000` | 1000 |
+| `capacity_500` (and NOT `capacity_1000`) | 500 |
+| neither capacity row | 100 |
+
+`capacity_1000` wins over `capacity_500` if both rows happen to exist. The ceiling deliberately has no stored column — it cannot drift from the entitlement set.
+
+---
+
+## `entitlementService` — methods
+
+All methods are Effect programs returning `Effect.Effect<A, E, DbService>`. Implemented in `cire/api/src/services/entitlements.ts`.
+
+| Method | Signature | Description |
+|---|---|---|
+| `has` | `(weddingId, key) → Effect<boolean, never, DbService>` | Returns `true` if the row `(weddingId, key)` exists |
+| `setsForWeddings` | `(weddingIds[]) → Effect<Map<weddingId, EntitlementKey[]>, never, DbService>` | Batch-fetches all entitlement rows for a list of wedding IDs; used to annotate wedding-list responses |
+| `deriveCap` | `(keys: string[]) → number` | Pure — derives the effective guest ceiling from an entitlement key array |
+| `grant` | `(weddingId, key, { source, grantedBy, stripeRef? }) → Effect<void, never, DbService>` | Inserts a row; idempotent on conflict |
+| `assertGuestCapacity` | `(weddingId, incomingNewGuests) → Effect<void, CapacityExceeded, DbService>` | Fetches the wedding's entitlement set, derives the cap, counts current (non-host) guests, fails with `CapacityExceeded { limit, current }` if the import would breach the ceiling |
+
+`CapacityExceeded` is a tagged error (`Data.TaggedError`); handlers map it to a 422 response.
+
+---
+
+## `weddingEntitlement(db, key)` middleware
+
+Implemented in `cire/api/src/middleware/wedding-entitlement.ts`. Returns an Elysia plugin (scoped derive + onBeforeHandle).
+
+**Ordering in the middleware chain:**
+
+```
+osnAuth()              ← verifies OSN access JWT
+weddingOwner/Editor/Member()  ← role gate (403 if wrong role)
+weddingEntitlement(db, key)   ← entitlement gate (402 if capability absent)
+rateLimiter            ← rate limiting
+```
+
+The entitlement gate sits **after** the role gate. A viewer on an entitled wedding is already blocked by a 403 from the role gate before reaching this middleware. A `402` from this middleware means: the caller's role is sufficient, but the wedding itself does not have the capability.
+
+**402 response contract:**
+
+```json
+{ "error": "payment_required", "entitlement": "<key>" }
+```
+
+HTTP status `402`. The organiser portal reads the `entitlement` field to display the relevant upsell UI panel.
+
+A missing `weddingId` in `params` (should not occur after the role gate validates it) degrades to a `402` rather than throwing.
+
+---
+
+## Capacity enforcement in `applyImport`
+
+`applyImport` (in `cire/api/src/services/import.ts`) calls `entitlementService.assertGuestCapacity(weddingId, plan.guestCreates.length)` **before** writing any rows. The check and the subsequent D1 batch write are sequenced atomically: if the capacity check fails, no guests are written. There are no partial writes.
+
+The check counts real guests only — the synthetic `host`-kind family row used for invite previews is excluded from the count via a `ne(families.kind, 'host')` filter.
+
+---
+
+## Comp-grant CLI
+
+`cire/api/scripts/grant-entitlement.ts` is an operator tool for manual (comp) grants. It is not a network-accessible route.
+
+**Local run (bun:sqlite):**
+
+```bash
+bun run cire/api/scripts/grant-entitlement.ts <weddingId> <key,key,...> [grantedBy]
+```
+
+**Production (D1):** the script prints idempotent `INSERT OR IGNORE` SQL. Apply via:
+
+```bash
+wrangler d1 execute cire-db --remote --command "<printed SQL>"
+```
+
+A prod D1 write requires explicit human authorization naming `cire-db` before running — this is a deploy-time step, not an automated path.
+
+---
+
+## Phase-2 payment seam
+
+`grant()` accepts `source: 'purchase'` and a `stripeRef` field. A webhook skeleton (`cire/api/src/routes/payment-webhook.ts`) exists but is inert in Phase 1 — all Phase-1 grants use `source: 'comp'`. The `stripeRef` column is the idempotency anchor for Phase-2 event-driven grants. Provider selection is tracked outside this repository.
+
+---
+
+## Related
+
+- [[vendors]] — Vendor CRM + Directory; both route groups gate on the `vendors` entitlement
+- [[cire-auth]] — role gate middleware; ordering of role vs entitlement vs rate-limit gates

--- a/cire/wiki/systems/vendors.md
+++ b/cire/wiki/systems/vendors.md
@@ -10,6 +10,8 @@ last-reviewed: 2026-07-18
 
 # Vendors — directory, CRM, and email-verification claim
 
+> **Entitlement gate:** the Vendor CRM routes (`/api/organiser/weddings/:weddingId/vendors/*`) and the Directory browse/add routes (`/api/organiser/weddings/:weddingId/directory/*`) both require the `vendors` entitlement (a row in `wedding_entitlements` with `entitlement = 'vendors'`). Requests from a wedding without this capability receive `402 { "error": "payment_required", "entitlement": "vendors" }`. The gate sits after the role check — see [[entitlements]].
+
 The Vendors slice introduces a **three-tier principal model** (guests / organisers / vendors), a wedding-scoped **Vendor CRM** for organisers, a global **directory** of vendor profiles, and an **email-verification claim flow** that lets a vendor bind their directory listing to their OSN org. PR A ships the backend foundation, CRM, and claim backend. PR B ships the `vendor.cireweddings.com` portal app (`cire/vendor`), CORS allowlist widening, and the deploy pipeline.
 
 ---

--- a/cire/wiki/todo/perf.md
+++ b/cire/wiki/todo/perf.md
@@ -4,7 +4,7 @@ tags: [todo, performance]
 related:
   - "[[index]]"
   - "[[review-findings]]"
-last-reviewed: 2026-07-17
+last-reviewed: 2026-07-18
 ---
 
 # Performance Backlog
@@ -122,3 +122,12 @@ Deferred (scale-dependent, not blocking at wedding-directory scale — hundreds 
 - [ ] **VD-P-I1** — OFFSET pagination is O(offset); fine at current scale (50-row cap). Switch to a keyed cursor on `(name, id)` if the directory reaches tens of thousands.
 - [ ] **VD-P-I2** — `getLiveListingById` does fetch + fetchCategories sequentially (matches `getListingByOrg`/`consumeClaim`); low-frequency write path. Parallelize if the service is extended.
 - [ ] **VD-P-I4** — `directory_vendors_listed_idx` becomes a no-op on the hot path once most rows are `live`; a partial `WHERE listed='live'` index is the future option if a scan ever shows up.
+
+### Platform tiering Phase 1 (entitlement foundation) — /prep-pr perf review notes (`feat/cire-platform-tiering`)
+
+Deferred (not blocking at Phase-1 scale — single wedding, low organiser traffic; all queries are PK/indexed):
+- [ ] **ENT-P-W1** — `weddingEntitlement(db,key)` issues a separate `wedding_entitlements` point lookup after the role gate (`weddingMember`/`weddingEditor`) already round-tripped to the wedding. Fold the entitlement-set fetch into the role-gate `derive` (add an `entitlementSet` to its result) so gated vendor/directory requests drop from ~3 to ~2 D1 queries. Touches the shared role gates — do as a deliberate follow-up.
+- [ ] **ENT-P-W2** — `assertGuestCapacity` re-fetches the wedding's entitlement rows that `diffAgainstDb` already fetched for its preview warning, so the import apply path runs the entitlement scan twice. Thread the derived cap from `diffAgainstDb` through `ImportPlan` into `applyImport`.
+- [ ] **ENT-P-I1** — `ModuleShell` calls `props.entitlements.includes("vendors")` in JSX (O(n) in the reactive graph); convert the entitlement list to a `Set` (or `createMemo`) once in `OrganiserApp` for O(1) `has`.
+- [ ] **ENT-P-I2** — `diffAgainstDb` fetches entitlement rows whenever `guestCreates.length>0`, even when the wedding is far below cap; a cheap `existingGuests.length + guestCreates.length > 100` pre-check before the DB query would skip it for the common case.
+- [ ] **ENT-P-I3** — `assertGuestCapacity` / `diffAgainstDb` fetch ALL entitlement rows to derive the cap; narrow to `WHERE entitlement IN ('capacity_500','capacity_1000')`.

--- a/wiki/compliance/data-map.md
+++ b/wiki/compliance/data-map.md
@@ -140,6 +140,12 @@ Vendor personal data arises when a vendor is a **sole trader** and their contact
 
 **S3 browse surface (2026-07-18).** `directory_vendors.email` and `directory_vendors.phone` are now **displayed to a wedding's authenticated organisers** via the `GET …/directory` browse endpoint (new recipient/surface — organiser-only, access-controlled); no new data is collected and the lawful basis is unchanged (Art. 6(1)(f)).
 
+## Cire tiering (`@cire/api` — `wedding_entitlements`)
+
+| Field | Purpose | Lawful basis | Retention | Recipients | System page |
+|---|---|---|---|---|---|
+| `wedding_entitlements.granted_by` | Audit trail for manual capability grants — records which internal operator OSN profile id authorised a comp or manual entitlement grant | Art. 6(1)(f) — legitimate interest (internal audit of operator actions; not a data-subject right-facing field) | Life of the wedding record — row is deleted via `ON DELETE CASCADE` on `weddings.id` | Internal operators only (`@cire/api`; not exposed to wedding owners or guests) | [[cire]] |
+
 **Controller note for vendor data.** For `directory_vendors` contact data supplied initially by an organiser (before the vendor claims the listing): the organiser is the original source of entry and cire is the platform. Once the vendor claims the listing and becomes an OSN org-holder, the vendor themselves is the data subject exercising control over the listing fields (controller = cire/OSN for the platform; DSAR + right-to-erasure via standard organiser or vendor account flows).
 
 **Controller / processor note.** For guest data the organiser is the

--- a/wiki/compliance/retention.md
+++ b/wiki/compliance/retention.md
@@ -8,7 +8,7 @@ related:
   - "[[dsar]]"
   - "[[cire]]"
   - "[[changelog/compliance-fixes]]"
-last-reviewed: 2026-07-17
+last-reviewed: 2026-07-18
 ---
 
 # Retention
@@ -56,6 +56,7 @@ already enforced in code; others need a sweeper job.
 | Cire `directory_vendors.email` / `phone` (sole-trader contact on the directory listing) | While listing active; removed on org or cire admin request | App code (organiser or vendor deletes listing / account-delete flow) | **TODO** — no automated path yet; low-volume, operator-managed today | Cire |
 | Cire `vendors.email` / `phone` / `contact_name` (sole-trader contact in the per-wedding CRM) | Tied to wedding lifecycle — cascades when the organiser removes the CRM entry or the wedding is deleted | DB `ON DELETE cascade` from `vendors`/`weddings` | **OK for cascade path**; no independent sweeper needed (CRM entry is organiser-controlled) | Cire |
 | Cire `vendor_claims.email` (sole-trader email recorded on a claim token) | 7-day claim TTL; `status` flips to `expired`/`consumed` at expiry/consumption | App code (TTL enforced at consume-time check); claim rows retained indefinitely after expiry (no purge today) | **TODO** — add a sweeper once claim volumes warrant (e.g. purge `expired`/`consumed` rows older than 90 d) | Cire |
+| Cire `wedding_entitlements` (incl. `granted_by` audit field) | Life of the wedding record | DB `ON DELETE CASCADE` on `weddings.id` — when the wedding row is deleted the entitlement rows cascade automatically; no independent sweeper required | **OK** — fully covered by the wedding-deletion cascade | Cire |
 | Grafana Cloud traces | 14 days (free tier) | Vendor-enforced | OK | Platform |
 | Grafana Cloud logs | 50 GB rolling (~30 d typical) | Vendor-enforced | OK | Platform |
 | Grafana Cloud metrics | 30 days (free tier) | Vendor-enforced | OK | Platform |


### PR DESCRIPTION
## Summary
Introduces a per-wedding **entitlement** system — opaque capability flags that gate optional platform modules — with the gate, enforcement, an operator grant tool, and the organiser UI wiring. No external payment/provider integration in this slice (an inert, flag-gated, unmounted webhook skeleton reserves the Phase-2 seam).

- `wedding_entitlements` table (migration `0042`, additive) — capability flags `premium_templates | vendors | ai | capacity_500 | capacity_1000`, composite PK `(wedding_id, entitlement)`; row-presence = granted. Three-surface lockstep (migration ↔ `setup.ts` DDL ↔ `schema.ts`).
- `entitlementService` — `has`, `setsForWeddings` (batched), `deriveCap` (none→100, `capacity_500`→500, `capacity_1000`→1000), idempotent `grant`, `assertGuestCapacity`.
- `weddingEntitlement(db,key)` Elysia middleware — composes AFTER the three-tier role gate; returns `402 { error: "payment_required", entitlement }`; **fail-closed** (missing weddingId or DB defect → 402, logged). Gates the Vendor CRM + Directory routes behind `vendors`.
- Guest-capacity enforcement inside `applyImport` (the single path both CSV import and the editor's change-apply share) — atomic (no partial writes on breach), removal-aware net delta, host-preview family excluded.
- Operator comp-grant CLI (`cire/api/scripts/grant-entitlement.ts`) — prints idempotent `INSERT OR IGNORE` SQL for `wrangler d1 execute`; argv allow-list-validated.
- Organiser portal threads each wedding's entitlement set + derived cap through `/weddings`; a locked module renders an inert upsell panel instead of the feature.

## Workspaces affected
- `@cire/db` (schema + migration 0042), `@cire/api` (service, middleware, route gating, capacity, CLI, webhook skeleton), `@cire/organiser` (context + upsell UI), `cire/wiki` + `wiki/compliance` (docs). Empty changeset (`@cire/*` unversioned).

## Decisions & issues

**[approach] Entitlement-set table, not boolean columns**
- **Issue:** How to represent an open-ended, per-wedding capability set.
- **Why:** New capabilities will be added over time; boolean columns churn the schema each time.
- **Solution:** One row per granted capability in `wedding_entitlements`; presence = granted; the guest cap is *derived* from the capacity rows (no stored `guest_cap` column to drift).
- **Rationale:** Adding a capability is a new enum value, not a migration; nothing can desync.

**[S-H1 / High] Entitlement gate could fail open on a DB error**
- **Issue:** The middleware bridges Effect→Elysia via `runCire(has(...))`; a DB defect could leave the gate result undefined and let the handler run.
- **Why:** A transient D1 error becoming a silent grant is a broken-access-control (fail-open authz) defect.
- **Solution:** `has(...)` is piped through `Effect.catchAllDefect` → `logWarning` → `as(false)`, so any DB error deterministically yields *not entitled* (402) and emits an observability signal. Added a defect-path test asserting 402.
- **Rationale:** Matches the middleware's stated fail-closed contract and the existing directory-browse fail-soft pattern.

**[I1 / correctness] Capacity block ignored removals**
- **Issue:** The hard block counted `guestCreates` only, so a churn import (remove N, add N) at cap was falsely rejected while the preview said fine.
- **Why:** Preview and enforcement must agree; a false 402 blocks a legitimate swap.
- **Solution:** The block now uses the net delta (`creates − removes`), mirroring the `diffAgainstDb` preview; added swap-at-cap tests (net 0 succeeds, net +1 fails).
- **Rationale:** Single source of truth for the resulting-headcount computation across preview and enforcement.

**[S-M1 / Medium] Operator CLI interpolated argv into printed SQL**
- **Issue:** `weddingId`/`grantedBy` were spliced into the emitted `INSERT` unescaped (the capability key was already allow-listed).
- **Why:** A crafted arg could produce malformed/injectable SQL in the review artifact.
- **Solution:** Regex allow-lists (`/^wed_[A-Za-z0-9_]+$/`, `/^[A-Za-z0-9_]+$/`) validated before interpolation; throw on mismatch; injection tests added.
- **Rationale:** The printed SQL is the canonical operator artifact — it must be safe to run verbatim. (Surface is operator-only, not network-reachable.)

**[C-L1 / Compliance] New audit field registered**
- **Issue:** `wedding_entitlements.granted_by` (operator OSN profile id) is pseudonymous personal data with no data-map entry.
- **Why:** GDPR Art. 30 records-of-processing.
- **Solution:** Added `data-map.md` + `retention.md` rows (purpose = grant audit trail; basis = Art. 6(1)(f); retention = life of the wedding — cascades on `weddings.id` delete).
- **Rationale:** The whole table cascades on wedding deletion, satisfying erasure; the operator-id retention is now declared.

**[ref column] External-reference column named provider-neutrally**
- **Issue:** The Phase-2 reference column needs a name now.
- **Why:** Avoid coupling the schema to any specific external integration.
- **Solution:** `provider_ref` (nullable; unique when set — the Phase-2 idempotency key).
- **Rationale:** Provider selection is tracked outside this repository; the column stays neutral.

**[perf ENT-P-* / deferred] Extra per-request entitlement reads**
- **Issue:** The gate adds a DB read after the role gate; `assertGuestCapacity` re-reads entitlements already fetched by the preview.
- **Why:** Marginal extra D1 queries on gated/import paths.
- **Solution:** Deferred — logged as `ENT-P-W1/W2/I1/I2/I3` in `cire/wiki/todo/perf.md` (fold entitlement fetch into the role-gate round-trip; thread the derived cap through `ImportPlan`; Set-memo the UI check; narrow the cap query).
- **Rationale:** All queries are PK/indexed; negligible at Phase-1 scale (single wedding); the fold touches the shared role gates, so it's a deliberate follow-up.

## Test plan
- [ ] `bun run --cwd cire/api test` green (1096 pass) incl. `ddl-lockstep`, `entitlements`, `wedding-entitlement` (incl. fail-closed defect path), `import`/`organiser-changes` (capacity + swap-at-cap), `grant-entitlement` (injection), `payment-webhook` (inert + unmounted-by-default).
- [ ] `bun run --cwd cire/organiser test` green (412 pass) incl. `UpsellPanel` + `ModuleShell` gated-vs-entitled render.
- [ ] Confirm viewer on an un-entitled wedding → 403 (role wins), not 402.
- [ ] Confirm the payment-webhook route 404s by default (unmounted) and only 501s when the flag is set.

> [!warning]
> **Do NOT merge without explicit authorization.** Merging auto-applies migration `0042` to the production `cire-db` D1 (additive, but a prod schema write), and the live wedding's comp grant is a separate authorized prod-D1 write to run at deploy time. Both are deploy-time steps, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)