### PR TITLE
fix(pulse): mirror zap c2b columns in zapBridge test DDL

### DIFF
--- a/.changeset/fix-pulse-zap-bridge-ddl.md
+++ b/.changeset/fix-pulse-zap-bridge-ddl.md
@@ -1,0 +1,5 @@
+---
+"@pulse/api": patch
+---
+
+Fix pulse zapBridge test: mirror the new zap `chats.class` + `messages.body` columns (and nullable ciphertext/nonce) into the test's hand-rolled DDL, so it matches the c2b-chats schema change (Vendors S4 PR A / #286). Test-only; unblocks CI Build & Test.

--- a/pulse/api/tests/services/zapBridge.test.ts
+++ b/pulse/api/tests/services/zapBridge.test.ts
@@ -23,7 +23,7 @@ function createDualTestLayer() {
   const zapSqlite = new Database(":memory:");
   zapSqlite.run(`
     CREATE TABLE chats (
-      id TEXT PRIMARY KEY, type TEXT NOT NULL, title TEXT, event_id TEXT,
+      id TEXT PRIMARY KEY, type TEXT NOT NULL, class TEXT NOT NULL DEFAULT 'c2c', title TEXT, event_id TEXT,
       created_by_profile_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
     )
   `);
@@ -37,7 +37,7 @@ function createDualTestLayer() {
   zapSqlite.run(`
     CREATE TABLE messages (
       id TEXT PRIMARY KEY, chat_id TEXT NOT NULL REFERENCES chats(id),
-      sender_profile_id TEXT NOT NULL, ciphertext TEXT NOT NULL, nonce TEXT NOT NULL,
+      sender_profile_id TEXT NOT NULL, ciphertext TEXT, nonce TEXT, body TEXT,
       created_at INTEGER NOT NULL, expires_at INTEGER
     )
   `);


### PR DESCRIPTION
## Summary
Unblocks CI Build & Test, which went red after #286 (Vendors S4 PR A — zap c2b chats). Pulse's `zapBridge` inserts into the zap `chats` table via the `@zap/db` Drizzle schema, which now emits the new `class` column; the test's hand-rolled inline DDL lacked it → `SQLiteError: table chats has no column named class` (4/4 `zapBridge.test.ts` failed → all deploy jobs skipped).

Mirrors the new zap columns into the pulse test DDL: `chats.class TEXT NOT NULL DEFAULT 'c2c'`, and `messages` gains nullable `body` + nullable `ciphertext`/`nonce` (matching the real schema; pulse only inserts chats/members, but keeps the mirror consistent).

**Test-only.** Root cause: #286's per-package zap tests passed but the full-monorepo suite (which includes pulse's zap consumer) wasn't run before merge.

## Workspaces affected
- `@pulse/api` (test only; patch changeset).

## Test plan
- [x] `pulse/api` `zapBridge` 4/4 pass; full `pulse/api` 541 pass.
- [x] Full monorepo `bun run test` — **28/28 packages green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)