### PR TITLE
fix(zap): make zap-api workerd-deployable (lazy db path + lazy OSN_API_URL + prod route)

### DIFF
--- a/.changeset/zap-workerd-deployable.md
+++ b/.changeset/zap-workerd-deployable.md
@@ -1,0 +1,6 @@
+---
+"@zap/api": patch
+"@zap/db": patch
+---
+
+Make zap-api actually deployable to Cloudflare Workers (first prod bring-up). Fix two workerd-hostile module-load patterns: `zap/db/src/service.ts` now passes the bun:sqlite path as a thunk so `fileURLToPath(import.meta.url)` is deferred into the lazy Layer (never runs on workerd, where `import.meta.url` is undefined at deploy-eval); `zapGraphBridge.ts` resolves + https-validates `OSN_API_URL` lazily (at call time) instead of at module load (workerd `[vars]` populate `process.env` only at runtime). Adds the `zap.cireweddings.com` custom-domain route + `OSN_API_URL` prod var to `zap/api/wrangler.toml`.

--- a/zap/api/src/services/zapGraphBridge.ts
+++ b/zap/api/src/services/zapGraphBridge.ts
@@ -23,12 +23,20 @@ export class GraphBridgeError extends Data.TaggedError("GraphBridgeError")<{
   readonly cause: unknown;
 }> {}
 
-const OSN_API_URL = process.env.OSN_API_URL ?? "http://localhost:4000";
-
-// Validate the URL scheme in production to prevent ARC tokens being sent over
-// plaintext. Runs once at module load; never fires in tests (NODE_ENV=test).
-if (process.env.NODE_ENV === "production" && !OSN_API_URL.startsWith("https://")) {
-  throw new Error(`OSN_API_URL must use https:// in production (got: ${OSN_API_URL})`);
+// Resolve + validate the osn-api base URL LAZILY (at call time), NOT at module
+// load. On Cloudflare Workers, `[vars]` populate `process.env` only at runtime;
+// wrangler's deploy-time module evaluation runs top-level code with an EMPTY
+// process.env, so a module-load read would see the localhost default and the
+// https guard below would abort the deploy. Reading it inside a function defers
+// both the read and the guard to the first real request (env is populated), and
+// tests (NODE_ENV=test) never trip the guard.
+function getOsnApiUrl(): string {
+  const url = process.env.OSN_API_URL ?? "http://localhost:4000";
+  // Prevent ARC tokens being sent over plaintext in production.
+  if (process.env.NODE_ENV === "production" && !url.startsWith("https://")) {
+    throw new Error(`OSN_API_URL must use https:// in production (got: ${url})`);
+  }
+  return url;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,7 +126,7 @@ export async function registerWithOsnApi(): Promise<boolean> {
   _keyInitPromise = Promise.resolve({ privateKey: pair.privateKey, keyId });
 
   const publicKeyJwk = await exportKeyToJwk(pair.publicKey);
-  const res = await fetch(`${OSN_API_URL}/graph/internal/register-service`, {
+  const res = await fetch(`${getOsnApiUrl()}/graph/internal/register-service`, {
     method: "POST",
     headers: { "content-type": "application/json", authorization: `Bearer ${secret}` },
     body: JSON.stringify({
@@ -160,7 +168,7 @@ export const areConnected = (
             targetId: targetProfileId,
           });
           const res = await fetch(
-            `${OSN_API_URL}/graph/internal/connection-status?${qs.toString()}`,
+            `${getOsnApiUrl()}/graph/internal/connection-status?${qs.toString()}`,
             { headers: { authorization: await arcAuthHeader() } },
           );
           if (!res.ok) {

--- a/zap/api/wrangler.toml
+++ b/zap/api/wrangler.toml
@@ -23,6 +23,17 @@ database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
 
 # ── production ───────────────────────────────────────────────────────────────
+# Custom-domain route: serves zap-api on zap.cireweddings.com (mirrors cire-api's
+# api.cireweddings.com + osn-api's id.cireweddings.com — all on the account's
+# cireweddings.com zone). `custom_domain = true` auto-provisions the DNS record +
+# cert. Named envs do NOT inherit top-level routes, so a deploy target must be
+# declared here; without it `wrangler deploy --env production` errors (no target).
+# zap-api is internal S2S (ARC-gated) + user routes (osnAuth) — auth-gated, so a
+# public subdomain is fine. cire-api reaches it via ZAP_API_URL = this origin.
+[[env.production.routes]]
+pattern = "zap.cireweddings.com"
+custom_domain = true
+
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "zap-db-prod"
@@ -35,6 +46,9 @@ migrations_dir = "../db/drizzle"
 # and osn-api (id.cireweddings.com). Set before first deploy.
 [env.production.vars]
 OSN_JWKS_URL = "https://id.cireweddings.com/.well-known/jwks.json"
+# zapGraphBridge validates OSN_API_URL is https at module load in production
+# (it sends ARC tokens to osn-api's graph). osn-api serves on id.cireweddings.com.
+OSN_API_URL = "https://id.cireweddings.com"
 
 # OSN_JWT_SECRET is sensitive — set it per environment as a Worker secret, not a
 # plaintext var:

--- a/zap/db/src/service.ts
+++ b/zap/db/src/service.ts
@@ -7,8 +7,6 @@ import { Context, type Layer } from "effect";
 
 import * as schema from "./schema";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
 export interface DbService {
   // Broadened over both SQLite result kinds so the same query code runs against
   // bun:sqlite (the `local` env) and Cloudflare D1 (`dev`/`staging`/`prod`).
@@ -17,10 +15,20 @@ export interface DbService {
 
 export class Db extends Context.Tag("@zap/db/Db")<Db, DbService>() {}
 
-/** bun:sqlite-backed layer — the `local` environment (dev servers + tests). */
+/**
+ * bun:sqlite-backed layer — the `local` environment (dev servers + tests).
+ * The path is a THUNK so the Bun-only `fileURLToPath(import.meta.url)` derivation
+ * is deferred INTO the lazy Layer — it must NOT run at module load, because the
+ * Workers entry imports this module (for `makeDbD1Live`) and `import.meta.url` is
+ * undefined on workerd (deploy-time module eval crashes otherwise). On Workers
+ * `DbLive`'s layer is never built (the entry uses the D1 layer), so the thunk
+ * never runs there.
+ */
 export const DbLive = makeDbLive(
   Db,
-  process.env.ZAP_DATABASE_URL || resolve(__dirname, "../../../data/zap.db"),
+  () =>
+    process.env.ZAP_DATABASE_URL ||
+    resolve(dirname(fileURLToPath(import.meta.url)), "../../../data/zap.db"),
   schema,
 );
 


### PR DESCRIPTION
## Summary
zap-api's first real Cloudflare Workers deploy (authorized zap infra bring-up) exposed two **module-load** patterns that crash workerd's deploy-time evaluation — zap-api had a `wrangler.toml` but had never actually been deployed, so these were latent. Fixes both + adds the prod deploy target. **zap-api is now live in prod at `zap.cireweddings.com`** (migrations applied to `zap-db-prod`, health 200) via a manual deploy; this PR lands the same fixes so CI's `deploy-zap-api` job succeeds on every future merge.

- `zap/db/src/service.ts` — pass the bun:sqlite path as a **thunk** so `fileURLToPath(import.meta.url)` (undefined on workerd at deploy-eval) is deferred into the lazy `DbLive` Layer (which the Workers entry never builds — it uses the D1 layer). `makeDbLive` already supports the thunk form for exactly this.
- `zap/api/src/services/zapGraphBridge.ts` — resolve + https-validate `OSN_API_URL` **lazily** (`getOsnApiUrl()`, at call time) instead of at module load. On workerd, `[vars]` populate `process.env` only at *runtime*; the module-load read saw the localhost default and the https guard aborted the deploy.
- `zap/api/wrangler.toml` — add the `zap.cireweddings.com` `custom_domain` route (named envs don't inherit a target → deploy needs one; mirrors cire-api/osn-api) + the `OSN_API_URL` prod var.

**Note (latent elsewhere):** `pulse/api`'s graphBridge mirrors the same module-load `OSN_API_URL` pattern; pulse-api has never been Workers-deployed, so it'll need the same lazy fix if/when it is.

## Workspaces affected
- `@zap/api`, `@zap/db` (patch changeset).

## Test plan
- [x] zap/db 13, zap/api 130, pulse/api 541 pass. Full suite green except a local-only `@pulse/app` `ExploreMap` network flake (ECONNREFUSED in the sandbox; passes in CI).
- [x] Manual `wrangler deploy --env production` succeeded → `zap.cireweddings.com/health` = 200; `zap-db-prod` has the c2b schema (`chats.class` present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)