### PR TITLE
fix(zap): populate process.env so INTERNAL_SERVICE_SECRET resolves in prod

### DIFF
--- a/.changeset/zap-populate-process-env.md
+++ b/.changeset/zap-populate-process-env.md
@@ -1,0 +1,5 @@
+---
+"@zap/api": patch
+---
+
+Add the `nodejs_compat_populate_process_env` compatibility flag so `process.env.INTERNAL_SERVICE_SECRET` resolves in production (zap-api's `compatibility_date` predates the 2025-04-01 auto-populate cutoff). Fixes the `/internal/register-service` endpoint returning 501 "Service registration is disabled" and zap-api's own outbound ARC registration silently skipping — both of which read the secret via `process.env`.

--- a/zap/api/wrangler.toml
+++ b/zap/api/wrangler.toml
@@ -1,7 +1,14 @@
 name = "zap-api"
 main = "src/index.ts"
 compatibility_date = "2025-03-01"
-compatibility_flags = ["nodejs_compat"]
+# nodejs_compat_populate_process_env: surface Worker vars + secrets on
+# `process.env`. Our compatibility_date (2025-03-01) predates the 2025-04-01
+# cutoff where this became automatic under nodejs_compat, so without the explicit
+# flag `process.env.INTERNAL_SERVICE_SECRET` is undefined in production — which
+# silently disabled BOTH the inbound `/internal/register-service` endpoint (501)
+# and zap-api's own outbound ARC registration with osn-api (consent checks then
+# fail closed). See wiki/runbooks/production-deploy §9.3.
+compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 
 # No top-level binding on purpose: the `local` environment runs on bun:sqlite via
 # `bun run dev` (src/local.ts), not on Workers. The D1-backed environments are


### PR DESCRIPTION
## Summary
- zap-api reads `process.env.INTERNAL_SERVICE_SECRET` (in `src/index.ts` outbound ARC registration and `src/routes/internal.ts` `/internal/register-service`), but on Workers `process.env` is only auto-populated from vars/secrets when `nodejs_compat` runs at `compatibility_date ≥ 2025-04-01`. zap-api is pinned at **2025-03-01**, so `process.env.INTERNAL_SERVICE_SECRET` is `undefined` in production even though the secret binding exists.
- **Symptoms:** `POST /internal/register-service` returns `501 "Service registration is disabled on this instance"`, and zap-api's own outbound ARC registration with osn-api is silently skipped (its consent checks then fail closed).
- **Fix:** add the opt-in `nodejs_compat_populate_process_env` compatibility flag (Cloudflare's documented mechanism to surface vars + secrets on `process.env` before the 2025-04-01 default). No `compatibility_date` bump, so no other runtime behaviour changes.

## Workspaces affected
- `@zap/api` (patch changeset) — `wrangler.toml` compatibility flag only. No code/logic change.

## Decisions & issues

**[approach — flag vs compat-date bump vs code change]**
- **Issue:** `process.env` secrets not surfaced at zap-api's compat date.
- **Why:** Blocks the cire→zap `chat:c2b` ARC registration (Vendors S4 deploy-time step) and zap↔osn consent registration.
- **Solution:** Add only `nodejs_compat_populate_process_env` (surgical), rather than bumping `compatibility_date` (broader behaviour changes) or refactoring the handlers to thread the `env` binding (more invasive, and the flag also fixes the outbound-registration path in one line).
- **Rationale:** Minimal, reversible, Cloudflare-documented; fixes both the inbound and outbound secret reads at once.

## Test plan
- [ ] CI green (config-only change; no unit test applies).
- [ ] After merge + auto-deploy: `POST https://zap.cireweddings.com/internal/register-service` with a valid bearer returns 2xx (not 501) — verified by completing the cire→zap `chat:c2b` registration (runbook §9.3).
- [ ] Latent bonus: zap-api's outbound ARC registration with osn-api now succeeds (consent checks stop failing closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)