### PR TITLE
fix(cire/web): guests saw no events after a successful claim (unlock reveal broken under motion v12)

### DIFF
--- a/.changeset/fix-invite-events-reveal.md
+++ b/.changeset/fix-invite-events-reveal.md
@@ -1,0 +1,5 @@
+---
+"@cire/web": patch
+---
+
+Fix guests seeing no events after a successful claim: the unlock reveal was written for Motion One (v10) but runs on motion v12, which ignores the removed `easing` option and reverts elements to base styles when a keyframe animation finishes — leaving the events section at its `opacity-0` base forever. Reveal steps now persist their end state as inline styles, use the v12 `ease`/`startDelay` option names, and are guarded so a throwing or stalled animation (or a failed motion-chunk import) can never hide the invite. Also escapes the code input's `pattern` hyphen (Chrome v-flag rejected the pattern) and bakes `PUBLIC_OSN_ISSUER_URL` into the guest-site deploy build so the Pulse account-link island stops dialling localhost in production.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,6 +168,10 @@ jobs:
           # Domain reshuffle 2026-07-16: the guest site now lives on the `invite.`
           # subdomain (apex serves the marketing landing site).
           PUBLIC_SITE_URL: https://invite.cireweddings.com
+          # OSN identity issuer for the guest "Link my Pulse account" island.
+          # Without it the bundle falls back to the dev default
+          # (http://localhost:4000) and the linking flow dials localhost in prod.
+          PUBLIC_OSN_ISSUER_URL: https://id.cireweddings.com
           PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
           # Google Maps Embed API key (public, referrer-restricted to *.cireweddings.com).
           # Present ⇒ real Embed iframe; absent ⇒ CSS-card fallback (key-optional).

--- a/cire/web/src/components/InvitePage.tsx
+++ b/cire/web/src/components/InvitePage.tsx
@@ -142,8 +142,16 @@ export default function InvitePage(props: InvitePageProps) {
     await new Promise((r) => setTimeout(r, 0));
 
     if (loginFormRef && welcomeRef && eventsSectionRef) {
-      const { unlockRevealSequence } = await import("./UnlockReveal.motion");
-      unlockRevealSequence(loginFormRef, welcomeRef, eventsSectionRef);
+      try {
+        const { unlockRevealSequence } = await import("./UnlockReveal.motion");
+        await unlockRevealSequence(loginFormRef, welcomeRef, eventsSectionRef);
+      } catch {
+        // The motion chunk failed to load (offline mid-session, stale deploy) —
+        // reveal without the animation; the invite must never stay hidden.
+        eventsSectionRef.style.opacity = "1";
+      }
+    } else if (eventsSectionRef) {
+      eventsSectionRef.style.opacity = "1";
     }
   }
 

--- a/cire/web/src/components/LoginSection.tsx
+++ b/cire/web/src/components/LoginSection.tsx
@@ -164,7 +164,10 @@ export function LoginSection(props: LoginSectionProps) {
               spellcheck={false}
               disabled={loading()}
               maxLength={48}
-              pattern="[A-Za-z0-9-]+"
+              // NB: the hyphen must be escaped — Chrome compiles `pattern` with
+              // the `v` flag, where a trailing unescaped `-` is a syntax error
+              // that voids the whole pattern.
+              pattern="[A-Za-z0-9\-]+"
             />
             <Show when={error()}>
               <p class="font-body text-error py-2 text-[0.82rem]" role="alert">

--- a/cire/web/src/components/Modal.motion.ts
+++ b/cire/web/src/components/Modal.motion.ts
@@ -1,26 +1,26 @@
 import { animate } from "motion";
 
 export function modalEnter(backdrop: HTMLElement, panel: HTMLElement) {
-  animate(backdrop, { opacity: [0, 1] }, { duration: 0.25, easing: "ease-out" });
+  animate(backdrop, { opacity: [0, 1] }, { duration: 0.25, ease: "easeOut" });
   animate(
     panel,
     {
       opacity: [0, 1],
       transform: ["translateY(40px) scale(0.97)", "translateY(0) scale(1)"],
     },
-    { duration: 0.35, easing: [0.22, 1, 0.36, 1] },
+    { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
   );
 }
 
 export async function modalExit(backdrop: HTMLElement, panel: HTMLElement) {
-  animate(backdrop, { opacity: [1, 0] }, { duration: 0.2, easing: "ease-in" });
+  animate(backdrop, { opacity: [1, 0] }, { duration: 0.2, ease: "easeIn" });
   const panelAnim = animate(
     panel,
     {
       opacity: [1, 0],
       transform: ["translateY(0) scale(1)", "translateY(24px) scale(0.97)"],
     },
-    { duration: 0.2, easing: [0.4, 0, 1, 1] },
+    { duration: 0.2, ease: [0.4, 0, 1, 1] },
   );
   await panelAnim.finished;
 }

--- a/cire/web/src/components/UnlockReveal.motion.test.ts
+++ b/cire/web/src/components/UnlockReveal.motion.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { animateMock, staggerMock } = vi.hoisted(() => ({
   animateMock: vi.fn(() => ({ finished: Promise.resolve() })),
-  staggerMock: vi.fn((duration: number, opts: { start: number }) => duration + opts.start),
+  staggerMock: vi.fn(
+    (duration: number, opts: { startDelay: number }) => duration + opts.startDelay,
+  ),
 }));
 vi.mock("motion", () => ({ animate: animateMock, stagger: staggerMock }));
 
@@ -16,6 +18,7 @@ describe("unlockRevealSequence", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     animateMock.mockClear();
+    animateMock.mockImplementation(() => ({ finished: Promise.resolve() }));
     staggerMock.mockClear();
     loginForm = document.createElement("div");
     welcomeEl = document.createElement("div");
@@ -45,6 +48,52 @@ describe("unlockRevealSequence", () => {
     expect(eventsSection.style.display).toBe("");
   });
 
+  // Motion v12 reverts an element to its base styles when a keyframe animation
+  // finishes — the events section's base is the `opacity-0` utility class, so
+  // without an inline end-state the section ends up invisible after the reveal
+  // (the prod "no events" bug).
+  it("persists the events section's final opacity as an inline style", async () => {
+    const p = unlockRevealSequence(loginForm, welcomeEl, eventsSection);
+    await vi.advanceTimersByTimeAsync(300);
+    await p;
+    expect(eventsSection.style.opacity).toBe("1");
+  });
+
+  it("still reveals everything when animate throws", async () => {
+    animateMock.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const p = unlockRevealSequence(loginForm, welcomeEl, eventsSection);
+    await vi.advanceTimersByTimeAsync(300);
+    await p;
+    expect(loginForm.style.display).toBe("none");
+    expect(welcomeEl.style.display).toBe("");
+    expect(eventsSection.style.display).toBe("");
+    expect(eventsSection.style.opacity).toBe("1");
+  });
+
+  it("still reveals the events section when the fade-out never settles", async () => {
+    animateMock.mockImplementation(() => ({ finished: new Promise(() => {}) }));
+    const p = unlockRevealSequence(loginForm, welcomeEl, eventsSection);
+    await vi.advanceTimersByTimeAsync(5000);
+    await p;
+    expect(eventsSection.style.opacity).toBe("1");
+  });
+
+  // Motion v12 renamed Motion One's `easing` option to `ease` — the old key is
+  // silently ignored, which dropped every custom curve in the sequence.
+  it("passes v12 `ease` options, never the removed `easing` key", async () => {
+    const p = unlockRevealSequence(loginForm, welcomeEl, eventsSection);
+    await vi.advanceTimersByTimeAsync(300);
+    await p;
+    expect(animateMock).toHaveBeenCalled();
+    for (const call of animateMock.mock.calls) {
+      const options = call[2] as Record<string, unknown>;
+      expect(options).not.toHaveProperty("easing");
+      expect(options).toHaveProperty("ease");
+    }
+  });
+
   it("animates heading shimmer when h2 exists", async () => {
     const h2 = document.createElement("h2");
     welcomeEl.appendChild(h2);
@@ -70,12 +119,14 @@ describe("unlockRevealSequence", () => {
     expect(h2Calls).toHaveLength(0);
   });
 
+  // Motion One's `{ start }` stagger option is `{ startDelay }` in v12 — the
+  // old key was silently ignored too.
   it("staggers event cards when present", async () => {
     eventsSection.innerHTML = "<div data-event-card></div><div data-event-card></div>";
     const p = unlockRevealSequence(loginForm, welcomeEl, eventsSection);
     await vi.advanceTimersByTimeAsync(300);
     await p;
-    expect(staggerMock).toHaveBeenCalledWith(0.12, { start: 0.15 });
+    expect(staggerMock).toHaveBeenCalledWith(0.12, { startDelay: 0.15 });
   });
 
   it("skips stagger when no event cards exist", async () => {

--- a/cire/web/src/components/UnlockReveal.motion.ts
+++ b/cire/web/src/components/UnlockReveal.motion.ts
@@ -1,6 +1,32 @@
 import { animate, stagger } from "motion";
 
 /**
+ * Motion v12 does NOT persist a keyframe animation's final value: when the
+ * animation finishes, the element reverts to its base styles. The events
+ * section's base is the `opacity-0` utility class, so relying on the animation
+ * alone left the whole invite invisible after the reveal (guests saw no
+ * events). Every step below therefore writes its end state as an inline style
+ * — the keyframes only paint the transition — and each animate call is guarded
+ * so a throwing or stalled animation can never hide the invite.
+ */
+
+/** Longest we wait on one animation before the reveal proceeds without it. */
+const STEP_TIMEOUT_MS = 1000;
+
+function tryAnimate(run: () => { finished: Promise<unknown> }): Promise<unknown> {
+  try {
+    const { finished } = run();
+    // Race against a cap so a stalled animation can't wedge the sequence.
+    return Promise.race([
+      finished,
+      new Promise((resolve) => setTimeout(resolve, STEP_TIMEOUT_MS)),
+    ]).catch(() => {});
+  } catch {
+    return Promise.resolve();
+  }
+}
+
+/**
  * Plays the unlock reveal sequence:
  * 1. Login form fades out
  * 2. Welcome message fades in with a gold shimmer
@@ -12,55 +38,68 @@ export async function unlockRevealSequence(
   eventsSection: HTMLElement,
 ) {
   // 1. Fade out the login form
-  const fadeOut = animate(
-    loginForm,
-    { opacity: [1, 0], transform: ["translateY(0)", "translateY(-12px)"] },
-    { duration: 0.35, easing: "ease-in" },
+  await tryAnimate(() =>
+    animate(
+      loginForm,
+      { opacity: [1, 0], transform: ["translateY(0)", "translateY(-12px)"] },
+      { duration: 0.35, ease: "easeIn" },
+    ),
   );
-  await fadeOut.finished;
   loginForm.style.display = "none";
 
   // 2. Reveal welcome message
   welcomeEl.style.display = "";
-  animate(
-    welcomeEl,
-    { opacity: [0, 1], transform: ["translateY(16px)", "translateY(0)"] },
-    { duration: 0.5, easing: [0.22, 1, 0.36, 1] },
+  welcomeEl.style.opacity = "1";
+  void tryAnimate(() =>
+    animate(
+      welcomeEl,
+      { opacity: [0, 1], transform: ["translateY(16px)", "translateY(0)"] },
+      { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
+    ),
   );
 
   // Gold shimmer on the heading
   const heading = welcomeEl.querySelector("h2");
   if (heading) {
-    animate(
-      heading,
-      { opacity: [0.4, 1, 0.85, 1] },
-      {
-        duration: 1.2,
-        easing: "ease-in-out",
-      },
+    void tryAnimate(() =>
+      animate(
+        heading,
+        { opacity: [0.4, 1, 0.85, 1] },
+        {
+          duration: 1.2,
+          ease: "easeInOut",
+        },
+      ),
     );
   }
 
-  // 3. Reveal events section with staggered cards
+  // 3. Reveal events section with staggered cards. The inline opacity is the
+  // real reveal (it outlives the animation and overrides the `opacity-0`
+  // class); the keyframes replay 0 → 1 on top of it for the entrance.
   eventsSection.style.display = "";
   await new Promise((r) => setTimeout(r, 200));
+  eventsSection.style.opacity = "1";
 
-  animate(
-    eventsSection,
-    { opacity: [0, 1], transform: ["translateY(32px)", "translateY(0)"] },
-    { duration: 0.5, easing: [0.22, 1, 0.36, 1] },
+  void tryAnimate(() =>
+    animate(
+      eventsSection,
+      { opacity: [0, 1], transform: ["translateY(32px)", "translateY(0)"] },
+      { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
+    ),
   );
 
   const cards = eventsSection.querySelectorAll("[data-event-card]");
   if (cards.length > 0) {
-    animate(
-      cards as NodeListOf<HTMLElement>,
-      { opacity: [0, 1], transform: ["translateY(24px)", "translateY(0)"] },
-      {
-        duration: 0.45,
-        easing: [0.22, 1, 0.36, 1],
-        delay: stagger(0.12, { start: 0.15 }),
-      },
+    void tryAnimate(() =>
+      animate(
+        cards as NodeListOf<HTMLElement>,
+        { opacity: [0, 1], transform: ["translateY(24px)", "translateY(0)"] },
+        {
+          duration: 0.45,
+          ease: [0.22, 1, 0.36, 1],
+          delay: stagger(0.12, { startDelay: 0.15 }),
+        },
+      ),
     );
   }
 }

--- a/cire/wiki/todo/web.md
+++ b/cire/wiki/todo/web.md
@@ -4,7 +4,7 @@ tags: [todo, web]
 related:
   - "[[index]]"
   - "[[invite-builder]]"
-last-reviewed: 2026-07-17
+last-reviewed: 2026-07-22
 ---
 
 # cire/web
@@ -24,6 +24,8 @@ Completed feature history is archived in `[[changelog/completed-features]]` (Mig
 - [x] **"Link my Pulse account" affordance (account-linking frontend)** (`feat/cire-pulse-account-link`) — `PulseAccountLink.tsx` renders post-claim (non-preview) inside `InvitePage.tsx`, wrapped in its own `@osn/client` `AuthProvider`. Probes `GET /api/account/link` first: 503 ⇒ feature hidden (linking disabled). Signed-out guests get an OSN passkey ceremony (reuses `@osn/ui`'s `SignIn`/`Register`, same as the organiser portal — `@osn/client` + `@osn/ui` added to `cire/web`); signed-in guests pick which household member they are, then `POST /api/account/link` with `{ guestId }` via `useAuth().authFetch` (OSN bearer + silent 401 refresh) and the `cire_session` cookie. 409 already-linked is treated as linked (not an error); per-member linked/unlinked indicators come from the GET; unlink issues `DELETE /api/account/link/:guestId` (optimistic). Purely additive — every failure path degrades quietly, never breaking the core invite. CSP `connect-src` gained `id.cireweddings.com` (+ localhost:4000) for the OSN issuer. Tests: `PulseAccountLink.test.tsx` (probe/disabled, sign-in gate, pick→POST, GET indicator, 409, unlink→DELETE) + `InvitePage.test.tsx` post-claim/preview mount assertions. **Wants a real-browser eyeball** — the OSN passkey ceremony + gold-panel layout render in a real browser, not jsdom.
 
 ## Recently completed (kept inline for context)
+
+- [x] **Guest saw NO events after a successful claim — Motion One → v12 API drift in the unlock reveal** (`fix/invite-events-reveal`) — prod bug (claim `NGUYEN-KOI-AYXVP4`): claim succeeded, welcome banner rendered, all event cards were in the DOM, but the events `<section>` sat at its base `opacity-0` class forever. Root cause: `UnlockReveal.motion.ts` was written against Motion One (v10) semantics but the repo has shipped `motion` v12 since the animation landed — v12 silently ignores the removed `easing` option AND does not persist a keyframe animation's final value, so the section animated 0→1 then reverted to the `opacity-0` base. Fix: each reveal step now writes its end state as an inline style (keyframes only paint the transition), `easing`→`ease` + stagger `{start}`→`{startDelay}` across `UnlockReveal.motion.ts`/`Modal.motion.ts`, every animate call guarded (throw or stalled `finished` can no longer hide the invite; 1s cap per step), and `InvitePage.handleClaimed` force-reveals on a failed motion-chunk import. Drive-bys: escaped the code input's `pattern` hyphen (Chrome v-flag rejected the whole pattern), and `deploy.yml` now bakes `PUBLIC_OSN_ISSUER_URL` into the guest-site build (bundle was dialling `http://localhost:4000` for the Pulse account-link island in prod). Verified end-to-end with headless Chromium against the live site with the fixed chunk route-swapped in.
 
 Full history in `[[changelog/completed-features]]`.
 


### PR DESCRIPTION
## Problem

Entering a valid claim code (e.g. `NGUYEN-KOI-AYXVP4`) on invite.cireweddings.com showed the welcome banner but **zero events**, even though the family has four (`hindu-ceremony`, `catholic-ceremony`, `reception`, `mehendi`).

## Investigation

- Prod D1 data is correct: family active, 5 `guest_events` links, all 4 events exist, same wedding.
- `POST /api/claim` on prod returns all 4 events with correct CORS + cookie headers — backend fine.
- Reproduced in headless Chromium against the live site: after claim, all 4 event cards are **in the DOM** but the events `<section>` sits at computed `opacity: 0` forever.

## Root cause

`UnlockReveal.motion.ts` was written against the Motion One (v10) API, but the repo has shipped `motion` v12 since the animation landed:

1. v12 **does not persist a keyframe animation's final value** — on finish the element reverts to its base styles. The section's base is the `opacity-0` utility class, so it animated 0→1 and snapped back to invisible.
2. v12 renamed `easing` → `ease` and stagger `{ start }` → `{ startDelay }`; the old keys were silently ignored (all custom curves dropped).

Proven in-page on the deployed bundle: the sequence completes, computed opacity stays 0.

## Fix

- **`UnlockReveal.motion.ts`** — each reveal step writes its end state as an inline style (which outlives the animation and overrides `opacity-0`); keyframes only paint the transition. v12 option names. Every animate call guarded: a throw or a stalled `finished` promise (1s cap per step) can no longer leave the invite hidden.
- **`InvitePage.tsx`** — force-reveals the events section if the motion chunk fails to import.
- **`Modal.motion.ts`** — `easing` → `ease` (curves were silently dropped; behaviour otherwise unchanged).
- **`LoginSection.tsx`** — escaped the `pattern` hyphen: Chrome compiles `pattern` with the v flag, where the trailing unescaped `-` is a syntax error that voided the whole attribute (console error on every load).
- **`deploy.yml`** — the guest-site build now bakes `PUBLIC_OSN_ISSUER_URL`; the prod bundle was falling back to `http://localhost:4000` for the Pulse account-link island (visible `ERR_CONNECTION_REFUSED` spam post-claim).

## Verification

- New unit tests: inline end-state persistence, v12 option names, throw/stall resilience (12 cases; suite 393 passing).
- End-to-end: headless Chromium against the **live site** with the fixed chunk route-swapped in — claim `NGUYEN-KOI-AYXVP4` reveals the welcome banner and all four event cards (screenshot verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGDyUkhTgdi86ubDARnEuN