### PR TITLE
chore(hooks): install before the pre-push type check in a fresh worktree

### DIFF
--- a/.changeset/pre-push-install-guard.md
+++ b/.changeset/pre-push-install-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: install dependencies in the pre-push type check when a fresh worktree has none, so `turbo: command not found` no longer looks like a type error.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,11 @@ pre-push:
   parallel: true
   commands:
     typecheck:
-      run: bun run check
+      # Guarded wrapper, not `bun run check` directly: a worktree made with
+      # `git worktree add` has no `node_modules`, so `turbo` is absent and the
+      # hook failed with exit 127 — which reads like a type error and pushes
+      # people towards `LEFTHOOK=0`. The script installs first when it must.
+      run: bash scripts/pre-push-typecheck.sh
     audit:
       # Refuse to push if any installed package has a `high` or `critical`
       # advisory. Pairs with `bunfig.toml`'s `minimumReleaseAge` — one stops

--- a/scripts/pre-push-typecheck.sh
+++ b/scripts/pre-push-typecheck.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Pre-push type check, with a guard for fresh worktrees.
+#
+# `bun run check` shells out to `turbo`, which lives in `node_modules/.bin`.
+# A worktree created with `git worktree add` starts with no `node_modules`, so
+# the hook died with `turbo: command not found` and an exit code of 127 — a
+# tooling gap that reads like a type error. Every agent that hit it reached for
+# `LEFTHOOK=0` and pushed unchecked.
+#
+# Install first when the binary is missing, then check. Slow on the first push
+# from a new worktree; correct every time after that.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -x node_modules/.bin/turbo ]; then
+  echo "pre-push: no node_modules in this worktree — installing before the type check."
+  bun install --frozen-lockfile
+fi
+
+exec bun run check


### PR DESCRIPTION
## Problem

`bun run check` shells out to `turbo`, which lives in `node_modules/.bin`. A worktree created with `git worktree add` starts with no `node_modules`, so the pre-push hook died before checking anything:

```
┃  typecheck ❯
$ turbo check
/opt/homebrew/bin/bash: line 1: turbo: command not found
error: script "check" exited with code 127
```

Exit 127 from a hook named `typecheck` reads like a type error, and the obvious next move is `LEFTHOOK=0`. Two agents in a row pushed unchecked that way this week (#308 and #310, both markdown-only, so nothing broke — but the hook was silent for the wrong reason).

## Fix

`pre-push.typecheck` now calls `scripts/pre-push-typecheck.sh`, which runs `bun install --frozen-lockfile` when the `turbo` binary is missing and then runs `bun run check` exactly as before.

The first push from a new worktree pays for an install. Every push after that is unchanged — the guard is one `-x` test. No push skips the check because the tooling was not there yet.

`--frozen-lockfile` is deliberate: a pre-push hook must not quietly rewrite `bun.lock`. If the lockfile is stale the install fails and so does the push, which is the right outcome.

## Workspaces affected

None. `lefthook.yml` and a new script at the repo root; no package changed. The changeset carries empty frontmatter, which `scripts/validate-changesets.sh` accepts for a tooling-only change.

## Test plan

Reproduced and fixed in a genuinely fresh worktree (`git worktree add`, no install):

- Before: `bun run check` → `turbo: command not found`, exit 127.
- After: `bash scripts/pre-push-typecheck.sh` printed the install notice, installed, then reported **21 successful, 21 total**.
- The push that opened this PR ran the real hook — `typecheck` and `audit` both passed, no `LEFTHOOK=0`.
- Second run in the same worktree skips the install and finishes in under a second, so the warm path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
