### PR TITLE
docs: reach for the Obsidian MCP for wiki retrieval, plus the Cloudflare Workers notes

### DIFF
--- a/.changeset/obsidian-mcp-wiki-retrieval.md
+++ b/.changeset/obsidian-mcp-wiki-retrieval.md
@@ -1,0 +1,20 @@
+---
+"@cire/web": patch
+---
+
+Docs-only: root `CLAUDE.md` now reaches for the Obsidian MCP first when looking
+something up in the wiki. The vault is served by the `mcp-tools-istefox` MCP
+Connector plugin, registered as the `obsidian-wiki` server, so a session can
+search by meaning (`search_vault_smart`), read many pages in one call
+(`get_vault_files`), and walk the graph (`get_backlinks`) instead of grepping
+markdown. Documents the three-rung ladder (MCP → `obsidian` CLI → grep), where
+each rung exists — the first two need a local Obsidian over `127.0.0.1`, so
+remote sessions, cloud agents and CI go straight to grep. The vault path is
+baked to the `main` worktree's `wiki/`, so it answers from `main` whatever
+branch the session is on: the MCP is read-only (its write tools would edit
+`main`), a `git diff --name-only origin/main...HEAD -- wiki/` guard catches the
+pages where the branch and `main` disagree, and a `--ff-only` pull of the `main`
+worktree keeps the index fresh. Also folds in the
+Cloudflare Workers debugging notes (tail the failing service first, JSON/JWK
+secret handling, redeploy to cycle isolates, first-deploy module-eval crashes,
+named-env routes). No code change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,26 @@ Don't hunt for it, retry it, or ask for it to be started when the tools aren't l
 
 Some tools start inactive — `tool_catalog` lists them, `activate_tools` promotes several in one call.
 
-**Read only.** The vault path is the `main` worktree's `wiki/`, so the write tools (`create_vault_file`, `patch_vault_file`, `search_and_replace`, …) would edit `main`, not your branch. Retrieve over MCP; edit wiki pages in your own worktree with Edit/Write.
+**It always shows you `main`, not your branch.** The vault path is baked into the connector as the `main` worktree's `wiki/`. Obsidian stays open on that one vault; nobody re-points it per branch. Two consequences:
+
+- **Read only.** The write tools (`create_vault_file`, `patch_vault_file`, `search_and_replace`, …) would edit `main`'s working tree, not your branch. Retrieve over MCP; edit wiki pages in your own worktree with Edit/Write.
+- **Your branch's own wiki edits are invisible to it.** Before trusting a page the branch might have changed, run the guard — one command, not a re-read of the wiki:
+
+  ```bash
+  git diff --name-only origin/main...HEAD -- wiki/   # pages this branch changed
+  ```
+
+  Empty output (the usual case) → MCP results are authoritative, use them. Any page you need in that list → read the branch copy with Read; MCP has the pre-branch version.
+
+Keep the vault fresh, since a stale `main` worktree means stale answers. Obsidian re-indexes on file change, and a fast-forward of a clean worktree is safe:
+
+```bash
+git -C ~/.work/osn.git/main pull --ff-only
+```
+
+If it refuses, leave it alone — never force or reset another worktree. Grep your own `wiki/` instead.
+
+That's the whole protocol: freshen, one guard command, then lean on semantic search instead of grepping and reading whole pages.
 
 **2. Obsidian CLI** — same limits: local machine, app running:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,26 +80,53 @@ Phase 1 surfaces:
 
 ### Searching the wiki
 
-Check for Obsidian CLI first (requires Obsidian app running):
+Three ways, in order. Try each; drop to the next when it isn't there.
+
+**1. Obsidian MCP (`mcp__obsidian-wiki__*`) — preferred, local sessions only.** The MCP Connector plugin (`mcp-tools-istefox`) serving the `wiki` vault. Reachable when the `mcp__obsidian-wiki__*` tools are listed and a call returns; an error ending `is Obsidian open with the vault loaded?` means it isn't — drop to step 2.
+
+Where it exists:
+
+| Where you're running | Obsidian MCP? |
+|---|---|
+| Claude Code on Aniket's Mac, Obsidian open with the `wiki` vault | Yes — registered at user scope |
+| Claude Code on that Mac, Obsidian shut | No — the server can't resolve a port |
+| Claude Desktop | Only if the `.mcpb` is installed there as well; the Claude Code registration doesn't carry over |
+| Remote or cloud session, cloud agent, CI, another machine | **Never.** It reaches a local Obsidian over `127.0.0.1`. Skip to step 3 — the `obsidian` CLI is local-only too. |
+
+Don't hunt for it, retry it, or ask for it to be started when the tools aren't listed. Absent means absent: go to grep.
+
+| To... | Call |
+|---|---|
+| Search by meaning, not wording | `search_vault_smart` (semantic index over the vault) |
+| Search for an exact string | `search_vault_simple` (substring + surrounding context) |
+| Read one page / up to 20 pages | `get_vault_file`, `get_vault_files` |
+| Read one heading, field, or the outline only | `get_vault_file_partial`, `get_note_outline` |
+| Follow the graph | `get_backlinks`, `get_outgoing_links` |
+| Find pages by tag | `get_files_by_tag`, `list_tags` |
+| Orient in an unfamiliar area | `get_vault_overview`, `list_vault_files` |
+
+Some tools start inactive — `tool_catalog` lists them, `activate_tools` promotes several in one call.
+
+**Read only.** The vault path is the `main` worktree's `wiki/`, so the write tools (`create_vault_file`, `patch_vault_file`, `search_and_replace`, …) would edit `main`, not your branch. Retrieve over MCP; edit wiki pages in your own worktree with Edit/Write.
+
+**2. Obsidian CLI** — same limits: local machine, app running:
 
 ```bash
-# 1. Check availability
-which obsidian 2>/dev/null && OBSCLI=obsidian || OBSCLI=""
-
-# 2a. If available — use obsidian CLI (vault-aware, follows [[wikilinks]])
+which obsidian 2>/dev/null || echo "not installed"
 obsidian search query="arc tokens"                     # full-text search
 obsidian search:context query="arc tokens"             # search with line context
 obsidian tag name=systems verbose                      # list files tagged #systems
 obsidian read path=wiki/systems/arc-tokens.md          # read a page
 obsidian backlinks file=arc-tokens                     # find pages linking to it
 obsidian files folder=wiki/systems                     # list files in a folder
+```
 
-# 2b. Fallback — grep over markdown files (always works)
+**3. grep** — works everywhere, including remote and CI. Reads your worktree's own `wiki/`:
+
+```bash
 grep -r "arc token" wiki/ --include="*.md" -l          # find matching pages
 grep -r "arc token" wiki/ --include="*.md" -n          # with line numbers
 ```
-
-Note: `obsidian` CLI talks to running Obsidian app — fall back to grep if not open.
 
 ### Wiki maintenance rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,15 @@ bunx tauri build         # Build app
 bun add solid-js --cwd osn/landing
 bun add drizzle-orm --cwd pulse/db
 ```
+
+## Cloudflare Workers debugging
+
+- Multi-service request misbehaving in prod → `wrangler tail` the actual failing service FIRST, before any architecture speculation.
+- Never `source` a secrets file to set a JSON/JWK-shaped secret — bash brace-expansion mangles `{"a":"b"}` unquoted. Extract with grep/sed, pipe via `printf`:
+  ```bash
+  VAL=$(grep -m1 '^KEY=' "$SF" | sed 's/^[^=]*=//'); printf '%s' "$VAL" | wrangler secret put KEY --env production
+  ```
+- `wrangler secret put/delete` doesn't cycle warm isolates — redeploy (`wrangler deploy --env production`) after a secret change when behavior must flip now.
+- First-ever deploy of a Worker (even with existing `wrangler.toml`) can crash at deploy-time module eval: `fileURLToPath(import.meta.url)` at module top level, or module-top-level `process.env` reads/validation, both undefined/unpopulated during workerd's deploy eval. Fix: defer both into request-time/lazy thunks. Verify with a real `wrangler deploy`, not `--dry-run` (dry-run doesn't catch these).
+- Named envs don't inherit top-level routes — add `[[env.production.routes]]` with `custom_domain = true` for a never-deployed named env.
+- Changing a shared package's schema (e.g. a DB package other services import) → run the FULL monorepo test suite before merging, not just that package's own tests.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -33,6 +33,7 @@ This wiki is written for AI agents to read. Key navigation patterns:
 - Check `tags` in YAML frontmatter to filter by concern (e.g., `#runbook`, `#system`, `#observability`)
 - Check `related` in frontmatter for explicit navigation edges
 - Check `status` field: `active` = current, `planned` = not yet built, `deprecated` = avoid
+- Prefer searching this vault over the MCP Connector plugin (`mcp-tools-istefox`) when it's reachable — semantic search and partial reads cost far fewer tokens than grepping and reading whole pages. `CLAUDE.md` holds the ladder (MCP → `obsidian` CLI → grep), which tools to reach for, and why the MCP is read-only. The plugin lives under the gitignored `.obsidian/`, so each machine installs it itself.
 
 ## Conventions
 


### PR DESCRIPTION
## What

Docs only. Two things land in the root `CLAUDE.md`:

1. **Wiki retrieval goes through the Obsidian MCP first.** The `wiki/` vault is served by the MCP Connector plugin (`mcp-tools-istefox`), now registered as a user-scope Claude Code server named `obsidian-wiki`. A session can search by meaning (`search_vault_smart`), read many pages in one call (`get_vault_files`), read a single heading (`get_vault_file_partial`), and walk the graph (`get_backlinks`) instead of grepping markdown and reading whole pages. That is the point: fewer tokens per answer.
2. **The Cloudflare Workers debugging notes** move into the repo — tail the failing service first, never `source` JSON/JWK secrets, redeploy to cycle isolates after a secret change, first-deploy module-eval crashes, named-environment routes.

The retrieval section is a ladder of three rungs, tried in order:

| Rung | Where it works |
|---|---|
| Obsidian MCP | Local machine, Obsidian open with the `wiki` vault |
| `obsidian` CLI | Same limits |
| grep | Everywhere, including remote sessions, cloud agents and CI |

Both of the first two reach a local Obsidian over `127.0.0.1`, so a remote or cloud session never has them and goes straight to grep. `CLAUDE.md` says so in a table, and says not to hunt for the server, retry it, or ask for it to be started when its tools aren't listed — absent means absent.

`wiki/README.md` gets one line in its "For AI Agents" section pointing at the ladder, with the detail left in `CLAUDE.md` so there is one copy of it.

## Why the MCP is read-only here

The connector bakes the vault path into itself, and it points at the **`main` worktree's** `wiki/`. Obsidian stays open on that one vault; nothing re-points it per branch. So a session on any branch gets `main`'s answers. Two consequences, both written into `CLAUDE.md`:

- **Retrieve, never write.** The write tools (`create_vault_file`, `patch_vault_file`, …) would edit `main`'s working tree rather than the branch. Wiki edits happen in the session's own worktree with Edit/Write.
- **One guard command** covers the gap, instead of asking for Obsidian to be re-pointed per worktree:

  ```bash
  git diff --name-only origin/main...HEAD -- wiki/
  ```

  Empty — the usual case — means the MCP results stand. A page you need in that list means read the branch copy with Read, because the MCP holds the pre-branch version. Plus a `git -C ~/.work/osn.git/main pull --ff-only` to keep the index fresh, and a standing rule never to force or reset another worktree.

## Testing

- `bash scripts/validate-changesets.sh` → `✅ All changeset package references are valid.`
- MCP reachability checked by hand before writing any of this: `initialize` returns `serverInfo "Obsidian - wiki"`, `tools/list` returns ~55 tools, and the unreachable path fails with the documented `is Obsidian open with the vault loaded?`.
- The guard command was run on this branch: empty, as the doc predicts for a branch that doesn't touch `wiki/` content.

No test suites and no lint work apply — the diff is three markdown files and lefthook's pre-commit globs are `*.{js,jsx,ts,tsx}` only.

## Decisions & issues

**Decisions made:**
- Registered the connector at **user scope**, from a stable copy of the shim at `/Users/ac/.config/obsidian-mcp-connector/`, rather than pointing the registration at the `.mcpb` on the Desktop. A bundle on the Desktop is easy to move or delete, and every worktree and session should see the same server.
- Wrote the vault-scope problem down as a **protocol** (freshen, one guard command, retrieval only) instead of a setup instruction (open Obsidian on whichever worktree this session runs in). Per-branch vault juggling is manual work that would get skipped, and skipping it fails silently with a wrong answer.
- The guard checks `origin/main...HEAD -- wiki/`, not the whole diff. It is one cheap command whose usual answer is "nothing", so it costs almost nothing to obey.
- Changeset names `@cire/web`, an unversioned package, so nothing gets bumped — the repo's existing pattern for docs-only changes, and `validate-changesets.sh` forbids mixing ignored with versioned packages in one file.

**Deferred / not addressed:**
- The MCP is not available to cloud agents or CI and won't be; those keep grepping. Making the vault reachable off this machine is a different job (a hosted index) and isn't worth it yet.
- `.obsidian/` is gitignored, so the plugin is a per-machine install. Not automated.
- The bearer token can go stale (HTTP 401), which needs the `.mcpb` re-exported and re-copied. Manual, and rare enough to leave manual.

**Review focus:**
- The availability table and the "absent means absent" rule — that's the part that decides whether a session wastes turns on a server it can't reach.
- Whether the read-only rule reads as absolute. A session that ignores it edits `main`'s working tree from a feature branch.

**Known risks:**
- If the `main` worktree drifts far behind `origin/main`, the MCP answers from stale pages and the guard won't catch it — the guard only compares the branch against `origin/main`, not the vault against `origin/main`. The `--ff-only` pull is the mitigation and it depends on being run.
- Nothing enforces any of this; it's a document. A session that skips the guard gets `main`'s version of a page the branch changed, with no error to signal it.
