### PR TITLE
Drop the Tauri template greet command from the pulse app

### DIFF
--- a/.changeset/pulse-drop-greet-command.md
+++ b/.changeset/pulse-drop-greet-command.md
@@ -1,0 +1,5 @@
+---
+"@pulse/app": patch
+---
+
+Drop the `greet` command left over from the Tauri template.

--- a/pulse/app/src-tauri/src/lib.rs
+++ b/pulse/app/src-tauri/src/lib.rs
@@ -1,14 +1,8 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- Removes the `greet` command and its `invoke_handler` registration from `pulse/app/src-tauri/src/lib.rs`. It was scaffolding from `create-tauri-app` and nothing in the frontend calls it.
- First of the foundation tasks for the pulse iOS port.

## Workspaces affected
- `@pulse/app`

## Decisions & issues

**approach** — command removed rather than kept as a smoke test
- **Issue:** `greet` was the only registered Tauri command, so deleting it leaves `invoke_handler` empty.
- **Why:** An unused command that echoes its input back is a live IPC surface with no caller — small, but it is reachable from any script running in the webview.
- **Solution:** Removed both the function and the `invoke_handler` call.
- **Rationale:** The plugin work (`pulse-bridge`) supplies real commands with real permission entries; a template stub is not worth keeping as a canary.

**worker output** — the local worker never committed
- **Issue:** The task ran to completion in the worktree but the change was left uncommitted and no done-file was written.
- **Why:** A silent non-finish looks identical to a finished task from the outside.
- **Solution:** Verified the working-tree diff by hand, ran `cargo build`, and committed it.
- **Rationale:** The diff was correct and minimal; only the reporting step was missing.

## Test plan
- [ ] `cd pulse/app/src-tauri && cargo build` succeeds
- [ ] No reference to `greet` remains: `rg greet pulse/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)