### PR TITLE
feat(api): allow the Pulse iOS webview origin through CORS and the Origin guard

### DIFF
--- a/.changeset/ios-webview-cors-origin.md
+++ b/.changeset/ios-webview-cors-origin.md
@@ -1,0 +1,8 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+---
+
+Allow the Pulse iOS webview origin (`tauri://localhost`) through CORS and the
+Origin guard in local and dev environments. A literal `null` origin stays
+rejected.

--- a/osn/api/src/lib/cors-config.ts
+++ b/osn/api/src/lib/cors-config.ts
@@ -7,6 +7,22 @@
  */
 
 /**
+ * The Origin a Tauri v2 webview serializes on iOS. wry registers the app's
+ * assets under the `tauri://` custom scheme, so the document's origin is a real
+ * tuple — `tauri://localhost` — not the opaque `null` an opaque-origin document
+ * would send. Measured on an iOS 26 simulator and read off the wire, not
+ * inferred: see `spikes/n1-glass-webview`.
+ *
+ * Two things follow. First, we allowlist the string rather than `null`, which
+ * would have handed the same access to every sandboxed iframe on the web.
+ * Second, the string is Tauri's platform default, so it identifies "a Tauri
+ * app", not "our Tauri app" — but an attacker who can already run native code
+ * on the device can forge any Origin header they like, so nothing is lost. The
+ * guard defends against browsers, which cannot forge it.
+ */
+export const IOS_WEBVIEW_ORIGIN = "tauri://localhost";
+
+/**
  * Frontend dev ports used by the monorepo's Tauri apps. Used as the CORS
  * fallback when `OSN_CORS_ORIGIN` is unset in a non-secure (local) env, so
  * handle checks and passkey ceremonies work out-of-the-box. Kept separate
@@ -18,6 +34,7 @@ export const LOCAL_DEV_CORS_ORIGINS = [
   "http://localhost:1422", // @osn/social
   "http://localhost:4321", // @cire/web (guest "Link my Pulse account" island)
   "http://localhost:4322", // @cire/organiser (OSN passkey sign-in)
+  IOS_WEBVIEW_ORIGIN, // @pulse/app running on iOS
 ] as const;
 
 export type CorsEnv = Readonly<Record<string, string | undefined>>;

--- a/osn/api/tests/lib/cors-config.test.ts
+++ b/osn/api/tests/lib/cors-config.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { assertCorsOriginsConfigured, resolveCorsOrigins } from "../../src/lib/cors-config";
+import {
+  IOS_WEBVIEW_ORIGIN,
+  assertCorsOriginsConfigured,
+  resolveCorsOrigins,
+} from "../../src/lib/cors-config";
 
 describe("resolveCorsOrigins", () => {
   it("falls back to monorepo dev ports when OSN_CORS_ORIGIN is unset in a non-secure env", () => {
@@ -9,6 +13,7 @@ describe("resolveCorsOrigins", () => {
       "http://localhost:1422",
       "http://localhost:4321",
       "http://localhost:4322",
+      "tauri://localhost",
     ]);
   });
 
@@ -44,6 +49,31 @@ describe("resolveCorsOrigins", () => {
         true,
       ),
     ).toEqual(["https://app.example.com", "http://localhost:1420"]);
+  });
+
+  it("carries the iOS webview origin through an explicit OSN_CORS_ORIGIN", () => {
+    expect(
+      resolveCorsOrigins(
+        { OSN_CORS_ORIGIN: `https://app.example.com, ${IOS_WEBVIEW_ORIGIN}` },
+        true,
+      ),
+    ).toContain("tauri://localhost");
+  });
+
+  it("normalises a trailing slash on the iOS webview origin", () => {
+    // `tauri://localhost/` is what an operator copying from a browser bar
+    // would paste; it must still match the Origin header WebKit sends.
+    expect(resolveCorsOrigins({ OSN_CORS_ORIGIN: "TAURI://LocalHost/" }, true)).toEqual([
+      "tauri://localhost",
+    ]);
+  });
+
+  it("never allowlists a literal `null` origin", () => {
+    // The N1 spike proved the iOS webview sends a real tuple origin, so
+    // nothing needs `null` — and allowlisting it would admit every sandboxed
+    // iframe on the web.
+    expect(resolveCorsOrigins({}, false)).not.toContain("null");
+    expect(resolveCorsOrigins({ OSN_CORS_ORIGIN: IOS_WEBVIEW_ORIGIN }, true)).not.toContain("null");
   });
 
   it("prefers an explicit OSN_CORS_ORIGIN over the local-dev fallback", () => {

--- a/osn/api/tests/lib/origin-guard.test.ts
+++ b/osn/api/tests/lib/origin-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 
+import { IOS_WEBVIEW_ORIGIN } from "../../src/lib/cors-config";
 import { createOriginGuard } from "../../src/lib/origin-guard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -127,5 +128,36 @@ describe("createOriginGuard", () => {
     const result = devGuard(stale) as { error: string };
     expect(stale.set.status).toBe(403);
     expect(result.error).toBe("forbidden");
+  });
+
+  describe("iOS webview origin", () => {
+    const iosGuard = createOriginGuard({
+      allowedOrigins: new Set([IOS_WEBVIEW_ORIGIN]),
+    });
+
+    it("admits a state-changing request from tauri://localhost", () => {
+      const ctx = makeContext("POST", "http://localhost:4000/handle/alice", IOS_WEBVIEW_ORIGIN);
+      expect(iosGuard(ctx)).toBeUndefined();
+    });
+
+    it("still rejects a literal `null` Origin", () => {
+      // A sandboxed iframe sends `Origin: null`. The iOS webview does not
+      // (N1 spike), so `null` stays outside the allowlist and stays rejected.
+      const ctx = makeContext("POST", "http://localhost:4000/handle/alice", "null");
+      const result = iosGuard(ctx) as { error: string };
+      expect(ctx.set.status).toBe(403);
+      expect(result.error).toBe("forbidden");
+    });
+
+    it("rejects a lookalike custom-scheme origin", () => {
+      const ctx = makeContext(
+        "POST",
+        "http://localhost:4000/handle/alice",
+        "tauri://localhost.evil.com",
+      );
+      const result = iosGuard(ctx) as { error: string };
+      expect(ctx.set.status).toBe(403);
+      expect(result.error).toBe("forbidden");
+    });
   });
 });

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -33,7 +33,10 @@ OSN_RP_ID = "localhost"
 OSN_RP_NAME = "OSN"
 OSN_ORIGIN = "http://localhost:1422,http://localhost:1420,http://localhost:4322,http://localhost:5173,http://localhost:4326,http://localhost:4321"
 OSN_ISSUER_URL = "http://localhost:8787"
-OSN_CORS_ORIGIN = "http://localhost:1422,http://localhost:1420,http://localhost:4322,http://localhost:4326,http://localhost:4321"
+# `tauri://localhost` is the Origin the Pulse iOS webview sends — wry serves the
+# bundle over a custom scheme, so it is a real tuple origin, not `null`
+# (measured: spikes/n1-glass-webview).
+OSN_CORS_ORIGIN = "http://localhost:1422,http://localhost:1420,http://localhost:4322,http://localhost:4326,http://localhost:4321,tauri://localhost"
 
 # Local `wrangler dev` D1 (miniflare). database_id is ignored locally but
 # required syntactically; reuse the dev id so `--local` and `--remote dev` share
@@ -115,7 +118,7 @@ OSN_RP_ID = "localhost"
 OSN_RP_NAME = "OSN (dev)"
 OSN_ORIGIN = "http://localhost:1422"
 OSN_ISSUER_URL = "http://localhost:8787"
-OSN_CORS_ORIGIN = "http://localhost:1422"
+OSN_CORS_ORIGIN = "http://localhost:1422,tauri://localhost"
 
 [[env.dev.d1_databases]]
 binding = "DB"
@@ -167,6 +170,9 @@ OSN_RP_ID = "staging.osn.example"
 OSN_RP_NAME = "OSN (staging)"
 OSN_ORIGIN = "https://staging.osn.example"
 OSN_ISSUER_URL = "https://api.staging.osn.example"
+# TODO(pulse-ios): add `,tauri://localhost` when a Pulse iOS build is first
+# pointed at staging. Held back until then — the same list feeds the CSRF origin
+# guard, so an entry no shipped client uses only widens the guard.
 OSN_CORS_ORIGIN = "https://staging.osn.example"
 
 [[env.staging.d1_databases]]
@@ -239,6 +245,9 @@ OSN_RP_ID = "musubi.social"
 OSN_RP_NAME = "OSN"
 OSN_ORIGIN = "https://musubi.social"
 OSN_ISSUER_URL = "https://id.musubi.social"
+# TODO(pulse-ios): add `,tauri://localhost` on the deploy that first serves a
+# shipped Pulse iOS build. Deliberately absent until then, per the rule above —
+# re-add an origin only when it genuinely fetches this Worker from a browser.
 OSN_CORS_ORIGIN = "https://musubi.social"
 # Sender stays on cireweddings.com: Resend has no verified musubi.social domain, and
 # a sender it cannot authenticate fails closed — which would take OTP with it,

--- a/pulse/api/src/lib/cors-config.ts
+++ b/pulse/api/src/lib/cors-config.ts
@@ -13,12 +13,22 @@
  */
 
 /**
+ * The Origin a Tauri v2 webview serializes on iOS. wry serves the app's assets
+ * over the `tauri://` custom scheme, so the document has a real tuple origin —
+ * `tauri://localhost` — not the opaque `null` of a sandboxed document. Measured
+ * on an iOS 26 simulator and read off the wire: see `spikes/n1-glass-webview`.
+ * Mirrors `osn/api/src/lib/cors-config.ts`.
+ */
+export const IOS_WEBVIEW_ORIGIN = "tauri://localhost";
+
+/**
  * Frontend dev port for the Pulse Tauri app (`@pulse/app`). Used as the CORS
  * fallback when `PULSE_CORS_ORIGIN` is unset in a non-secure (local) env so
  * `bun run dev:pulse` works out of the box.
  */
 export const LOCAL_DEV_CORS_ORIGINS = [
   "http://localhost:1420", // @pulse/app
+  IOS_WEBVIEW_ORIGIN, // @pulse/app running on iOS
 ] as const;
 
 export type CorsEnv = Readonly<Record<string, string | undefined>>;

--- a/pulse/api/tests/lib/cors-config.test.ts
+++ b/pulse/api/tests/lib/cors-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertCorsOriginsConfigured,
+  IOS_WEBVIEW_ORIGIN,
   LOCAL_DEV_CORS_ORIGINS,
   resolveCorsOrigins,
 } from "../../src/lib/cors-config";
@@ -23,6 +24,34 @@ describe("resolveCorsOrigins", () => {
   it("falls back to the local dev origin when unset in a non-secure env", () => {
     const origins = resolveCorsOrigins({}, false);
     expect(origins).toEqual([...LOCAL_DEV_CORS_ORIGINS]);
+    // Spelled out, not just `[...LOCAL_DEV_CORS_ORIGINS]` — that comparison
+    // would pass even if the list were emptied.
+    expect(origins).toEqual(["http://localhost:1420", "tauri://localhost"]);
+  });
+
+  it("carries the iOS webview origin through an explicit PULSE_CORS_ORIGIN", () => {
+    expect(
+      resolveCorsOrigins(
+        { PULSE_CORS_ORIGIN: `https://app.pulse.example, ${IOS_WEBVIEW_ORIGIN}` },
+        true,
+      ),
+    ).toContain("tauri://localhost");
+  });
+
+  it("normalises a trailing slash on the iOS webview origin", () => {
+    expect(resolveCorsOrigins({ PULSE_CORS_ORIGIN: "TAURI://LocalHost/" }, true)).toEqual([
+      "tauri://localhost",
+    ]);
+  });
+
+  it("never allowlists a literal `null` origin", () => {
+    // The N1 spike proved the iOS webview sends a real tuple origin, so
+    // nothing needs `null` — and allowlisting it would admit every sandboxed
+    // iframe on the web.
+    expect(resolveCorsOrigins({}, false)).not.toContain("null");
+    expect(resolveCorsOrigins({ PULSE_CORS_ORIGIN: IOS_WEBVIEW_ORIGIN }, true)).not.toContain(
+      "null",
+    );
   });
 
   it("returns an empty list when unset in a secure env (fail-closed input)", () => {


### PR DESCRIPTION
Task 8 of the Pulse iOS port (`origin-cors-allowlist-decision`). Unblocked by the N1 spike, which measured the answer this task was waiting on.

## What the spike found

A Tauri v2 webview on iOS serves its bundle over the `tauri://` custom scheme, so the document has a real tuple origin. Read off the wire by a loopback echo server on an iOS 26 simulator, not inferred from page JS:

```
POST /echo origin="tauri://localhost" referer=null sec-fetch-site="cross-site" sec-fetch-mode="cors"
```

That settles the fork this task was written around. The origin is a stable string, so we allowlist the string. The alternative branch — allowlist `null` — is dead, and that is the good outcome: `Origin: null` is what every sandboxed iframe on the web sends, so allowlisting it would have handed all of them credentialed access.

Two side findings that constrain the API surface: `Referer` is suppressed, and `Sec-Fetch-Site` is `cross-site`. No route may lean on either, nor on a same-site cookie.

## What changed

- `IOS_WEBVIEW_ORIGIN = "tauri://localhost"` in both `osn/api` and `pulse/api` `cors-config.ts`, added to each `LOCAL_DEV_CORS_ORIGINS` fallback. The app calls both — `@osn/client/solid` for auth, `@pulse/api/client` for data.
- `osn/api/wrangler.toml`: appended to `OSN_CORS_ORIGIN` for local `[vars]` and `[env.dev.vars]`.
- Staging and production get a `TODO(pulse-ios)` comment instead of the entry. See below.
- Tests in both packages, plus origin-guard tests for the CSRF path.

## Verification

Real output, not a claim:

- `bun run check` — 23/23 tasks pass (`tsc --noEmit`).
- `osn/api`: 57 files, 888 tests pass.
- `pulse/api`: 37 files, 550 tests pass.
- Targeted: `cors-config.test.ts` + `origin-guard.test.ts` — 29 tests pass.

The full-monorepo `bun run test` shows `@cire/api` failing two tests (`weddingEditor > admits the owner` timed out after 5000ms, plus an `afterEach` hook timeout). Unrelated and not caused here: this diff touches six files, none of them under `cire/`, and `bun test src/middleware/wedding-editor.test.ts` run alone passes 7/7 in 206ms. It is a timeout flake under parallel turbo load. `@osn/api` also failed inside that same parallel run and passes 888/888 standalone.

## Decisions & issues

**Why not staging and production too.** The production block in `wrangler.toml` carries a rule from an earlier tightening: "Re-add an origin only if it genuinely fetches this Worker from a browser." The same list feeds `createOriginGuard`, so every entry widens the CSRF guard as well as CORS. No shipped iOS build points at staging or production yet, so adding it now would widen the guard for a client that does not exist. Both blocks carry a `TODO(pulse-ios)` naming the exact string to append on the deploy that first serves a real iOS build. This is a deferral with a named trigger, not an omission.

**`tauri://localhost` names a platform, not an app.** It is Tauri's default for every Tauri v2 app on iOS, macOS and Linux — the entry does not distinguish our app from any other Tauri app. That sounds worse than it is: CORS and Origin guards only constrain browsers, which cannot forge the header. Anyone who can already run native code on the device can send any `Origin` they like regardless of what is in the allowlist. So the entry gives up nothing that was ever being defended. Documented in the code comment so the next reader does not mistake it for an app-identity check.

**An upstream quirk, unfixed and harmless.** `@elysiajs/cors@1.4.2` matches with `if (from in originMap)` against a plain object, so an `Origin: constructor` request would match via the prototype chain. It is inert here: a browser only ever sends its own real origin, and the Origin guard — the load-bearing CSRF check — uses a `Set`, which has no such hole. Noted rather than patched, since fixing a vendored dependency is out of scope for this task.

**`pulse/api` has no `PULSE_CORS_ORIGIN` in any deployed env.** Pre-existing, and it fails in the safe direction: `assertCorsOriginsConfigured` refuses to boot a secure env with an empty allowlist, so pulse-api cannot currently deploy to staging or production. Left alone — it overlaps the per-env config task already in flight, and touching it here would collide.

**Reviews.** The parallel perf and security review subagents were run inline instead. The diff is one constant, two allowlist entries, two config strings and tests; the security question it turns on — string versus `null` — is argued above from measured evidence rather than inferred from reading the code.