### PR TITLE
feat(pulse): read API and issuer hosts per environment, tighten the release CSP

### DIFF
--- a/.changeset/pulse-per-env-issuer-csp.md
+++ b/.changeset/pulse-per-env-issuer-csp.md
@@ -1,0 +1,7 @@
+---
+"@pulse/app": minor
+---
+
+Read the API and OIDC issuer hosts from `VITE_API_URL` / `VITE_OSN_ISSUER_URL`
+per build mode, and add a production Tauri config that narrows `connect-src` to
+the hosts that environment actually talks to.

--- a/pulse/app/.env.development
+++ b/pulse/app/.env.development
@@ -1,0 +1,4 @@
+# @pulse/app development environment
+
+VITE_API_URL=http://localhost:3001
+VITE_OSN_ISSUER_URL=http://localhost:4000

--- a/pulse/app/.env.example
+++ b/pulse/app/.env.example
@@ -1,0 +1,15 @@
+# @pulse/app environment variables
+#
+# Copy to `.env.local` to override. Defaults live in `.env.development` (read by
+# the dev server) and `.env.production` (read by `vite build`).
+#
+# Leave a variable commented out rather than setting it empty. An empty string
+# is not nullish, so it defeats the `?? "http://localhost:…"` fallback in
+# `src/lib/api.ts` and `src/lib/auth.ts`, and the app silently issues requests
+# relative to its own origin instead.
+
+# @pulse/api
+VITE_API_URL=http://localhost:3001
+
+# @osn/api, the OIDC issuer
+VITE_OSN_ISSUER_URL=http://localhost:4000

--- a/pulse/app/.env.production
+++ b/pulse/app/.env.production
@@ -1,0 +1,8 @@
+# @pulse/app production environment
+
+# TODO(pulse-hosts): `pulse/api/wrangler.toml` declares no route in any
+# environment, so pulse-api has no production hostname to point at yet.
+# VITE_API_URL=
+
+# osn-api, routed as a custom domain in `osn/api/wrangler.toml`.
+VITE_OSN_ISSUER_URL=https://id.musubi.social

--- a/pulse/app/README.md
+++ b/pulse/app/README.md
@@ -22,8 +22,42 @@ bun run --cwd pulse/app tauri dev     # desktop shell via Tauri
 
 ## Env
 
-See `.env.example`. Defaults assume `@osn/api` on `localhost:4000` and
-`@pulse/api` on `localhost:3001`.
+Two hosts are configurable: `VITE_API_URL` (`@pulse/api`) and
+`VITE_OSN_ISSUER_URL` (`@osn/api`, the OIDC issuer). See `.env.example`.
+
+Vite picks the file from its mode, and its mode already matches what we want:
+the dev server reads `.env.development`, `vite build` reads `.env.production`.
+No flag, no extra script. Both files are committed — they hold hostnames, not
+secrets. Local overrides go in `.env.local`, which is ignored.
+
+A variable that should not be set must be left **commented out**, never set
+empty. An empty string is not nullish, so it defeats the
+`?? "http://localhost:…"` fallback in `src/lib/api.ts` and `src/lib/auth.ts`,
+and the app quietly issues requests relative to its own origin.
+
+### CSP
+
+`tauri.conf.json` carries the development CSP, so `tauri dev` and `dev:ios`
+need no flags. `tauri.prod.conf.json` overlays it for release builds, dropping
+the `localhost` origins and naming `https://id.musubi.social`:
+
+```bash
+bun run --cwd pulse/app build:ios   # tauri ios build --config src-tauri/tauri.prod.conf.json
+```
+
+Tauri replaces arrays rather than merging them, so each overlay repeats the
+whole `connect-src` list.
+
+Two gaps, both deploy-time:
+
+- `@pulse/api` has no route in any environment (`pulse/api/wrangler.toml`), so
+  it has no hostname yet. `VITE_API_URL` stays commented out in
+  `.env.production` and `connect-src` still ends in a bare `https:`.
+- There is no staging environment. `@osn/api` routes production only. When
+  staging gets a host, add `.env.staging` and `tauri.staging.conf.json`
+  alongside the two that exist.
+
+Grep `TODO(pulse-hosts)`.
 
 ## Tooling
 

--- a/pulse/app/package.json
+++ b/pulse/app/package.json
@@ -8,7 +8,7 @@
     "dev": "vite --port 1420",
     "dev:ios": "tauri ios dev",
     "build": "vite build",
-    "build:ios": "tauri ios build",
+    "build:ios": "tauri ios build --config src-tauri/tauri.prod.conf.json",
     "preview": "vite preview",
     "tauri": "tauri",
     "check": "tsc --noEmit",

--- a/pulse/app/src-tauri/tauri.prod.conf.json
+++ b/pulse/app/src-tauri/tauri.prod.conf.json
@@ -1,0 +1,16 @@
+{
+  "app": {
+    "security": {
+      "csp": {
+        "connect-src": [
+          "'self'",
+          "ipc:",
+          "http://ipc.localhost",
+          "https://photon.komoot.io",
+          "https://id.musubi.social",
+          "https:"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

`pulse/app` already read `VITE_API_URL` and `VITE_OSN_ISSUER_URL` in six places
(`src/lib/api.ts`, `series.ts`, `rsvps.ts`, `venues.ts`, `closeFriends.ts`,
`calendar.ts`, `auth.ts`) but nothing supplied them, so every caller fell
through to its `localhost` default. The Tauri CSP therefore had to end in a
bare `https:` to let a release build reach anything.

This adds the env files those variables come from, plus a production Tauri
config that overlays `connect-src` with the one host we can actually name.

- `.env.example`, `.env.development`, `.env.production`
- `src-tauri/tauri.prod.conf.json` — adds `https://id.musubi.social`, drops the
  `localhost` origins
- `build:ios` now passes `--config src-tauri/tauri.prod.conf.json`

Vite's own modes already do the selection: the dev server reads
`.env.development`, `vite build` reads `.env.production`. No mode flag, no
extra script.

## Hosts that do not exist yet

`pulse/api/wrangler.toml` declares **no route in any environment**, and
`osn/api/wrangler.toml` routes production only (`id.musubi.social`,
lines 267-269). So there is no `@pulse/api` hostname and no staging environment
at all.

Both are marked `TODO(pulse-hosts)` and left **commented out**, not set empty.
An empty string is not nullish, so `VITE_API_URL=` would defeat the
`?? "http://localhost:3001"` fallback and the app would silently fetch relative
to `tauri://localhost`. Commented out, the localhost default survives and fails
where someone will see it.

Because `@pulse/api` has no host, `connect-src` still ends in `https:`.
Narrowing it is the follow-up task, and that task is blocked on the host, not
on this change.

## Verified

- `bun run check` — 23/23.
- `bun run lint` — only the pre-existing `cire`/`zap` warnings.
- `bun run fmt:check` — 1143 files clean.
- `scripts/validate-changesets.sh` — passes.
- Both Tauri configs and `package.json` parse as JSON.
- **Built it.** `vite build` bakes `https://id.musubi.social` into the bundle
  and, with `VITE_API_URL` commented out, falls back to `localhost:3001` — the
  intended visible failure rather than a silent relative-URL one.

## Not verified

No iOS build was run against `tauri.prod.conf.json`. Tauri replaces arrays
rather than merging them, which is why the overlay repeats the whole
`connect-src` list; that behaviour is assumed from the docs, not measured here.

## Review

Reviewed inline rather than by parallel review subagents, which this session
does not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BZDQzPKHJssJrQToXT8K7