### PR TITLE
Keep the auth session out of localStorage on iOS

### DIFF
--- a/.changeset/pulse-storage-adapter-ios.md
+++ b/.changeset/pulse-storage-adapter-ios.md
@@ -1,0 +1,19 @@
+---
+"@osn/client": minor
+"@pulse/app": patch
+---
+
+Keep the auth session out of `localStorage` on iOS.
+
+`@osn/client` promotes its in-memory `Storage` layer to a real export,
+`createEphemeralStorage()` (was test-only `createMemoryStorage`), and
+`AuthProvider` (`osn/client/src/solid/context.tsx`) gains an optional `storage`
+prop that defaults to `StorageLive`. `@pulse/app` passes
+`createEphemeralStorage()` on an iOS Tauri webview (`App.tsx`), so no access
+token or account metadata ever reaches `localStorage` there — the session
+still survives a cold start through the Keychain-backed refresh cookie
+(`bootstrapFromCookie`). Browser and desktop Tauri behaviour is unchanged.
+
+The `isIosWebview()` platform check moves out of `nativeSession.ts` into its
+own module, `pulse/app/src/lib/platform.ts`, so both `nativeSession.ts` and
+`App.tsx` can use it.

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -11,7 +11,7 @@ import {
 } from "solid-js";
 
 import { OsnAuth, createOsnAuthLive, type OsnAuthConfig } from "../service";
-import { StorageLive } from "../storage";
+import { Storage, StorageLive } from "../storage";
 import type { PublicProfile, Session } from "../tokens";
 
 interface AuthContextValue {
@@ -40,10 +40,17 @@ export const AuthContext = createContext<AuthContextValue>();
 
 interface AuthProviderProps extends ParentProps {
   config: OsnAuthConfig;
+  /**
+   * The `Storage` layer backing the session. Defaults to `StorageLive`
+   * (`localStorage`). Callers on a platform where `localStorage` must never
+   * hold auth data (e.g. iOS) pass a different layer, such as
+   * `createEphemeralStorage()`.
+   */
+  storage?: Layer.Layer<Storage>;
 }
 
 export function AuthProvider(props: AuthProviderProps) {
-  const layer = createOsnAuthLive(props.config).pipe(Layer.provide(StorageLive));
+  const layer = createOsnAuthLive(props.config).pipe(Layer.provide(props.storage ?? StorageLive));
 
   const run = <A,>(eff: Effect.Effect<A, unknown, OsnAuth>): Promise<A> =>
     Effect.runPromise(

--- a/osn/client/src/storage.ts
+++ b/osn/client/src/storage.ts
@@ -32,8 +32,14 @@ export const StorageLive = Layer.succeed(Storage, {
     }),
 });
 
-/** In-memory storage layer for tests — creates an isolated store per call */
-export function createMemoryStorage(): Layer.Layer<Storage> {
+/**
+ * In-memory `Storage` layer: persists nothing past the process, so nothing
+ * written through it ever reaches disk. Used on iOS to keep the auth session
+ * out of `localStorage` (the app has no other way to persist across a cold
+ * start there — see `bootstrapFromCookie`), and in tests for isolation.
+ * Each call returns a fresh, independent store.
+ */
+export function createEphemeralStorage(): Layer.Layer<Storage> {
   const store = new Map<string, string>();
   return Layer.succeed(Storage, {
     get: (key) => Effect.succeed(store.get(key) ?? null),

--- a/osn/client/tests/cold-start-bootstrap.test.ts
+++ b/osn/client/tests/cold-start-bootstrap.test.ts
@@ -3,12 +3,12 @@ import { Effect, Layer } from "effect";
 import { vi } from "vitest";
 
 import { OsnAuth, createOsnAuthLive } from "../src/service";
-import { createMemoryStorage } from "../src/storage";
+import { createEphemeralStorage } from "../src/storage";
 
 const config = { issuerUrl: "https://osn.example.com" };
 
 function createTestLayer() {
-  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+  return createOsnAuthLive(config).pipe(Layer.provide(createEphemeralStorage()));
 }
 
 /** Build a fake JWT whose payload contains the given `sub` claim. */

--- a/osn/client/tests/profiles.test.ts
+++ b/osn/client/tests/profiles.test.ts
@@ -3,12 +3,12 @@ import { Effect, Layer } from "effect";
 import { vi } from "vitest";
 
 import { OsnAuth, createOsnAuthLive } from "../src/service";
-import { createMemoryStorage } from "../src/storage";
+import { createEphemeralStorage } from "../src/storage";
 
 const config = { issuerUrl: "https://osn.example.com" };
 
 function createTestLayer() {
-  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+  return createOsnAuthLive(config).pipe(Layer.provide(createEphemeralStorage()));
 }
 
 /** Build a fake JWT whose payload contains the given `sub` claim. */

--- a/osn/client/tests/service.test.ts
+++ b/osn/client/tests/service.test.ts
@@ -3,12 +3,12 @@ import { Effect, Layer } from "effect";
 import { vi } from "vitest";
 
 import { OsnAuth, createOsnAuthLive } from "../src/service";
-import { createMemoryStorage } from "../src/storage";
+import { createEphemeralStorage } from "../src/storage";
 
 const config = { issuerUrl: "https://osn.example.com" };
 
 function createTestLayer() {
-  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+  return createOsnAuthLive(config).pipe(Layer.provide(createEphemeralStorage()));
 }
 
 it.effect("getSession returns null before any login", () =>

--- a/osn/client/tests/session-fetch.test.ts
+++ b/osn/client/tests/session-fetch.test.ts
@@ -4,12 +4,12 @@ import { afterEach, describe, vi } from "vitest";
 
 import { OsnAuth, createOsnAuthLive } from "../src/service";
 import { setSessionFetch, type SessionFetch } from "../src/session-fetch";
-import { createMemoryStorage } from "../src/storage";
+import { createEphemeralStorage } from "../src/storage";
 
 const config = { issuerUrl: "https://osn.example.com" };
 
 function createTestLayer() {
-  return createOsnAuthLive(config).pipe(Layer.provide(createMemoryStorage()));
+  return createOsnAuthLive(config).pipe(Layer.provide(createEphemeralStorage()));
 }
 
 /**

--- a/pulse/app/src/App.tsx
+++ b/pulse/app/src/App.tsx
@@ -1,3 +1,4 @@
+import { createEphemeralStorage } from "@osn/client";
 import { AuthProvider } from "@osn/client/solid";
 import { Router, Route, useLocation } from "@solidjs/router";
 import { lazy, Show } from "solid-js";
@@ -7,6 +8,7 @@ import { Header } from "./components/Header";
 import { NativeTabBar } from "./components/NativeTabBar";
 import { OnboardingGate } from "./components/OnboardingGate";
 import { OSN_ISSUER_URL } from "./lib/auth";
+import { isIosWebview } from "./lib/platform";
 
 import "./App.css";
 
@@ -62,8 +64,13 @@ function Layout(props: { children?: unknown }) {
 }
 
 export default function App() {
+  // On iOS, localStorage must never hold auth session data (no access token,
+  // no account metadata) — the session survives a cold start through the
+  // Keychain-backed refresh cookie instead (see `nativeSession.ts`).
+  const storage = isIosWebview() ? createEphemeralStorage() : undefined;
+
   return (
-    <AuthProvider config={{ issuerUrl: OSN_ISSUER_URL }}>
+    <AuthProvider config={{ issuerUrl: OSN_ISSUER_URL }} storage={storage}>
       <Router root={Layout}>
         <Route path="/" component={ExplorePage} />
         <Route path="/events/:id" component={EventDetailPage} />

--- a/pulse/app/src/lib/nativeSession.ts
+++ b/pulse/app/src/lib/nativeSession.ts
@@ -2,6 +2,7 @@ import { setSessionFetch, type SessionFetch } from "@osn/client";
 import { invoke } from "@tauri-apps/api/core";
 
 import { OSN_ISSUER_URL } from "./auth";
+import { isIosWebview } from "./platform";
 
 /**
  * Routes the native transport handles, mirroring `ALLOWED_PATHS` in
@@ -26,20 +27,6 @@ interface NativeResponse {
   status: number;
   headers: [string, string][];
   body: string;
-}
-
-/**
- * True on an iOS Tauri webview, false on desktop Tauri and in a browser.
- *
- * Both halves matter. Without the Tauri check there is no `invoke` to call;
- * without the iOS check a desktop build would route through a plugin whose
- * desktop implementation deliberately fails, when its own cookie jar works
- * perfectly well.
- */
-function isIosWebview(): boolean {
-  if (typeof window === "undefined") return false;
-  if (!("__TAURI_INTERNALS__" in window)) return false;
-  return /iPad|iPhone|iPod/.test(navigator.userAgent);
 }
 
 /** Turn the plugin's plain response into a real `Response`. */

--- a/pulse/app/src/lib/platform.ts
+++ b/pulse/app/src/lib/platform.ts
@@ -1,0 +1,13 @@
+/**
+ * True on an iOS Tauri webview, false on desktop Tauri and in a browser.
+ *
+ * Both halves matter. Without the Tauri check there is no `invoke` to call;
+ * without the iOS check a desktop build would route through code paths
+ * (native session transport, ephemeral storage) that only make sense where
+ * the Keychain and native bridge actually exist.
+ */
+export function isIosWebview(): boolean {
+  if (typeof window === "undefined") return false;
+  if (!("__TAURI_INTERNALS__" in window)) return false;
+  return /iPad|iPhone|iPod/.test(navigator.userAgent);
+}

--- a/pulse/app/tests/components/AuthProviderStorage.test.tsx
+++ b/pulse/app/tests/components/AuthProviderStorage.test.tsx
@@ -1,0 +1,76 @@
+import type { Session } from "@osn/client";
+import { createEphemeralStorage } from "@osn/client";
+import { AuthProvider, useAuth } from "@osn/client/solid";
+// @vitest-environment happy-dom
+import { render, cleanup, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, it, expect, beforeEach } from "vitest";
+
+/**
+ * Task 12: on iOS, `AuthProvider` is given `createEphemeralStorage()` instead
+ * of the default `StorageLive` so nothing from the auth session reaches
+ * `localStorage`. These tests pin the two behaviours that guard: the memory
+ * layer leaks nothing, and the unmodified default (no `storage` prop) still
+ * persists — so this can't silently regress into "nobody stores anything
+ * anywhere".
+ */
+
+const fixture: Session = {
+  accessToken: "acc_ios",
+  refreshToken: "ref_ios",
+  idToken: null,
+  expiresAt: Date.now() + 60_000,
+  scopes: ["openid", "profile"],
+};
+
+function LoginHarness(props: { session: Session }) {
+  const { session, adoptSession } = useAuth();
+  return (
+    <div>
+      <p data-testid="status">{session() ? `signed-in:${session()!.accessToken}` : "anon"}</p>
+      <button data-testid="adopt" onClick={() => void adoptSession(props.session)}>
+        Adopt
+      </button>
+    </div>
+  );
+}
+
+async function login(storage?: Parameters<typeof AuthProvider>[0]["storage"]) {
+  render(() => (
+    <AuthProvider config={{ issuerUrl: "https://osn.example.com" }} storage={storage}>
+      <LoginHarness session={fixture} />
+    </AuthProvider>
+  ));
+
+  await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+  screen.getByTestId("adopt").click();
+  await waitFor(() => {
+    expect(screen.getByTestId("status").textContent).toBe("signed-in:acc_ios");
+  });
+}
+
+describe("AuthProvider storage layer selection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("leaves localStorage completely empty after a full login when given the ephemeral layer", async () => {
+    await login(createEphemeralStorage());
+
+    // The whole store, not just the account-session key — the point is that
+    // nothing leaks, including keys a future change might add.
+    expect(localStorage.length).toBe(0);
+  });
+
+  it("still persists to localStorage after a full login when no storage prop is passed, because that defaults to StorageLive", async () => {
+    await login(undefined);
+
+    const stored = localStorage.getItem("@osn/client:account_session");
+    expect(stored).not.toBeNull();
+    const account = JSON.parse(stored!);
+    expect(account.profileTokens[account.activeProfileId].accessToken).toBe("acc_ios");
+  });
+});


### PR DESCRIPTION
## Summary
- `AuthProvider` now takes an optional `storage` layer, defaulting to `StorageLive` (`localStorage`) exactly as before.
- `@pulse/app` passes an in-memory layer when it detects an iOS Tauri webview, so no access token and no account metadata ever reach `localStorage` on the device. The session still survives a cold start: with nothing in storage, `loadSession` falls through to `bootstrapFromCookie`, which rides the Keychain-backed refresh cookie added in N3.
- `createMemoryStorage` is promoted out of test-only use and renamed `createEphemeralStorage` — the old name described the mechanism, the new one describes the purpose.
- `isIosWebview()` moves out of `nativeSession.ts` into `pulse/app/src/lib/platform.ts`, now shared by the session transport and `App.tsx`.

Task 12 of the pulse iOS port (`storage-adapter-ios-branch`).

## Workspaces affected
- `@osn/client` (minor — new optional prop, renamed export)
- `@pulse/app` (patch)

## Decisions & issues

**approach** — an injected layer, not a platform branch inside `@osn/client`
- **Issue:** `@osn/client` had `StorageLive` hard-wired into `AuthProvider`, so the iOS app had no way to keep tokens off disk.
- **Why:** On iOS, `localStorage` sits in the app container as an unencrypted file. Anything written there is readable from a device backup, which is the wrong place for an access token and account metadata when the platform already offers the Keychain.
- **Solution:** `AuthProvider` gained `storage?: Layer.Layer<Storage>`, and `@pulse/app` chooses the layer.
- **Rationale:** `@osn/client` is a shared client library and should not learn what an iOS webview is. The caller knows its own platform; the library keeps one code path.

**naming** — `createMemoryStorage` → `createEphemeralStorage`
- **Issue:** The layer was documented "for tests" but is now a production path on iOS.
- **Why:** A name that says "memory" invites someone to treat it as a test fixture and swap it out.
- **Solution:** Renamed across every call site (source plus four test files) rather than aliasing the old name.
- **Rationale:** Pre-launch, with no external consumers, a clean rename beats a compat shim.

**security review (inline)** — where session data can still land
- **Issue:** A rename plus a prop is easy to defeat by some other code writing to `localStorage` directly.
- **Why:** The guarantee is only worth as much as its weakest writer.
- **Solution:** Grepped `pulse/app/src` and `osn/client/src` for `localStorage`; the only real uses are inside `StorageLive` itself. The new test asserts `localStorage.length === 0` after a full login on the ephemeral layer — the whole store, not just the account key, so a future key added elsewhere fails the test too.
- **Rationale:** Catches the regression class, not just today's key.

**risk** — "nobody stores anything anywhere"
- **Issue:** A wrong default would silently log every browser user out on reload.
- **Why:** The failure is invisible in an iOS-only test.
- **Solution:** A second test renders `AuthProvider` with no `storage` prop and asserts the account session *is* written to `localStorage`.
- **Rationale:** Pins both sides of the branch.

**process** — reviews run inline, not by subagent
- **Issue:** prep-pr step 6 dispatches parallel performance and security review agents.
- **Why:** This session runs under a standing instruction not to use the Agent tool.
- **Solution:** I read the diff and ran every gate myself; findings are the entries above. Performance: no new work on any hot path — one boolean check at app startup.
- **Rationale:** Disclosed rather than skipped silently.

## Test plan
- [ ] `bun run test` — 31/31 tasks, including `@pulse/app` 44 files / 484 tests and `@osn/client` 20 files / 184 tests
- [ ] `bun run check` — 23/23
- [ ] `bun run lint`, `bun run fmt:check` — clean
- [ ] On device/simulator: sign in, force-quit, relaunch — still signed in (cookie bootstrap), and the app container's `localStorage` holds no session data
- [ ] In a browser: sign in, reload — still signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)