### PR TITLE
Add a real-browser Vitest tier for the bugs jsdom can't see

### DIFF
--- a/.changeset/cire-web-browser-test-tier.md
+++ b/.changeset/cire-web-browser-test-tier.md
@@ -1,0 +1,80 @@
+---
+"@cire/web": patch
+---
+
+Add a real-browser Vitest project to `@cire/web`, for the bugs jsdom cannot see.
+
+**The gap this closes was measured, not assumed.** jsdom computes no CSS and no
+layout: it never parses the stylesheet, `getComputedStyle` returns roughly what
+was set inline, and `getBoundingClientRect` is all zeroes. A whole class of this
+app's bugs is therefore structurally invisible to the existing suite — including
+ones that have already shipped.
+
+`#203` put the Add-to-Calendar popover at `z-90`, below the `z-100` modal it
+opens from, so it painted behind the backdrop: invisible and unclickable. The
+guard added afterwards asserts the *numbers* in `Z_LAYER`, which is the most a
+jsdom test can do, and it leaves three ways to reintroduce the same bug. A
+`Z_CLASS` entry could name a class Tailwind never emitted — the scanner only
+sees literal source text, so a concatenated class compiles to **no CSS at all**,
+silently, while `expect(Z_CLASS.MODAL_POPOVER).toBe("z-110")` passes either way.
+An ancestor could gain a stacking context and trap the portalled popover
+regardless of how large its z-index is. Or the paint order could simply invert.
+The same blindness covers Tailwind v4's `scale-*` setting the standalone `scale`
+property rather than `transform`, conflicting utilities resolving by stylesheet
+order rather than class-attribute order, the sticky action bar whose `bottom`
+resolves against the scrollport, and whether the global `prefers-reduced-motion`
+clamp actually applies.
+
+The existing answer to all of these is text-matching drift guards
+(`styles/root-type-scale.test.ts`, `components/rsvp-saved.test.ts`,
+`components/invite-theme.test.ts`), which `readFileSync` a CSS file and regex
+it. They stay — they are fast and they catch a source change. But they pin only
+that the source *says* the right thing, never that the render *does*.
+
+**What was added.** `cire/web/vitest.config.ts` becomes two projects: `unit`
+(jsdom, unchanged behaviour, excludes `*.browser.test.*`) and `browser`
+(Playwright + headless Chromium, includes only `src/**/*.browser.test.{ts,tsx}`).
+Naming decides the project, so every file lands in exactly one and neither glob
+can swallow the other's. `bun run test` still runs the fast tier only — and so
+does CI's default path and the pre-push hook. The browser tier is opt-in via
+`bun run test:browser`, with its own CI step that installs Chromium first,
+mirroring how `test:d1` is already split out.
+
+Three files prove the tier against pre-existing, documented gaps rather than
+against new code:
+
+- `z-index.browser.test.tsx` — every `Z_CLASS` entry emits real CSS; a
+  modal-launched popover **hit-tests** above the modal via
+  `document.elementFromPoint`; no ancestor traps it in a stacking context; the
+  modal blocks the page beneath it. Verified to fail when the popover is put
+  back at `z-90`, so it reproduces #203 rather than restating the constants.
+- `RsvpModal.browser.test.tsx` — the sticky action bar sits on the scrollport's
+  bottom edge, stays put while content scrolls under it, runs full-bleed to the
+  panel's content box, and both buttons are the topmost element at their own
+  centre. `cire/CLAUDE.md` names this exact case as one to "measure the real
+  thing in a browser".
+- `reduced-motion.browser.test.tsx` — the clamp applies to transitions *and*
+  animations, `animate-spin` keeps its documented exemption, and a clamped
+  transition still lands on its end state and fires `transitionend`.
+
+**Notes for anyone extending it.** `@solidjs/testing-library` works unchanged in
+browser mode, so there is no second render API and no `vitest-browser-solid`
+dependency — a browser test reads like every other component test here. Both
+projects share `tailwindcss()`, so a browser test gets the same Tailwind build
+the app ships; import `../styles/global.css` to apply it. Two provider details
+cost real time to rediscover and are now documented: `launchOptions` belongs to
+`playwright({...})`, not to an entry in `instances` where it is accepted and
+silently ignored; and `headless` must sit at `browser` level, not inside
+`instances` (vitest-dev/vitest#7661). `prefers-reduced-motion` is a property of
+the browser context, so it is flipped per-test through an `emulateMedia` browser
+command rather than by adding a second instance that would run the whole suite
+twice.
+
+`VITEST_BROWSER_EXECUTABLE_PATH` lets dev containers and cloud sessions point at
+their prebuilt Chromium instead of downloading a ~300MB matching build. It is
+declared in `turbo.json` under `passThroughEnv`, not `env`: it says *where* the
+browser is, never *what* the tests assert, so it must not enter the cache key.
+
+New convention page at `cire/wiki/conventions/browser-tests.md`, covering what
+belongs in the tier and — as importantly — what does not, since every test that
+could have lived in the fast tier and didn't is a tax on every run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,23 @@ jobs:
       - name: D1 integration tests
         run: bun run test:d1
 
+      # The browser tier (`*.browser.test.tsx`) runs in a real Chromium, because
+      # jsdom computes no CSS and no layout — so stacking order, sticky
+      # positioning, Tailwind's compiled output and the reduced-motion clamp are
+      # all invisible to `bun run test`. Split out for the same reason as the D1
+      # step above: it needs a dependency the default path doesn't, and keeping
+      # it separate leaves the fast tier fast.
+      #
+      # `--with-deps` installs Chromium's shared libraries as well as the
+      # browser; on ubuntu-latest the browser alone is not enough. Only chromium
+      # is installed — the tier pins a single instance, so pulling Firefox and
+      # WebKit too would be ~3x the download for nothing.
+      - name: Install Chromium for browser tests
+        run: bunx playwright install --with-deps chromium
+
+      - name: Browser tests
+        run: bun run test:browser
+
   ci:
     name: CI
     if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,11 @@ wiki/.obsidian/
 
 # Private business/legal planning notes — never committed
 wiki/business/
+
+# Vitest browser-mode artifacts (transient, per-run). Vitest writes a screenshot
+# and an attachment for every FAILING browser test, next to the test file. They
+# are debugging aids for the run that produced them — regenerated on the next
+# failure and meaningless once the test is fixed. See
+# [[cire/wiki/conventions/browser-tests]].
+**/__screenshots__/
+**/.vitest-attachments/

--- a/bun.lock
+++ b/bun.lock
@@ -159,7 +159,10 @@
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
         "@testing-library/jest-dom": "^6.10.0",
+        "@vitest/browser": "4.1.10",
+        "@vitest/browser-playwright": "4.1.10",
         "jsdom": "^29.1.1",
+        "playwright": "^1.62.1",
         "vite-plugin-solid": "^2.11.14",
         "vitest": "^4.1.10",
       },
@@ -194,7 +197,7 @@
     },
     "osn/client": {
       "name": "@osn/client",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "dependencies": {
         "effect": "^3.22.0",
       },
@@ -253,7 +256,7 @@
     },
     "osn/social": {
       "name": "@osn/social",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -278,7 +281,7 @@
     },
     "osn/ui": {
       "name": "@osn/ui",
-      "version": "1.7.6",
+      "version": "1.7.7",
       "dependencies": {
         "@kobalte/core": "^0.13.12",
         "@osn/client": "workspace:*",
@@ -333,7 +336,7 @@
     },
     "pulse/app": {
       "name": "@pulse/app",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -714,6 +717,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -1203,6 +1208,8 @@
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -1510,6 +1517,10 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@upstash/redis": ["@upstash/redis@1.38.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg=="],
+
+    "@vitest/browser": ["@vitest/browser@4.1.10", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng=="],
+
+    "@vitest/browser-playwright": ["@vitest/browser-playwright@4.1.10", "", { "dependencies": { "@vitest/browser": "4.1.10", "@vitest/mocker": "4.1.10", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "playwright": "*", "vitest": "4.1.10" } }, "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw=="],
 
     "@vitest/coverage-istanbul": ["@vitest/coverage-istanbul@4.1.10", "", { "dependencies": { "@babel/core": "^7.29.0", "@istanbuljs/schema": "^0.1.3", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/trace-mapping": "0.3.31", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww=="],
 
@@ -2109,6 +2120,12 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -2213,6 +2230,8 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -2302,6 +2321,8 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
@@ -2600,6 +2621,8 @@
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "solid-refresh/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
 

--- a/cire/CLAUDE.md
+++ b/cire/CLAUDE.md
@@ -43,6 +43,7 @@ Update the relevant shard when: a task is completed, a new concern is discovered
 | Check PR/branch conventions     | `[[wiki/conventions/contributing]]`           |
 | Add a third-party embed / script to the guest site | `[[wiki/architecture/consent]]` |
 | Add drag-to-reorder to a list (solid-dnd + the keyboard path it lacks) | `[[wiki/architecture/drag-and-drop]]` |
+| Write a test that needs real CSS, layout or paint order | `[[wiki/conventions/browser-tests]]` |
 | Understand observability rules  | `[[wiki/observability/overview]]`             |
 | Look up review finding IDs      | `[[wiki/conventions/review-findings]]`        |
 | Debug a production issue        | Browse `wiki/runbooks/`                       |
@@ -157,6 +158,7 @@ describe("POST /api/claim", () => {
 ```
 
 - Test files live alongside source: `*.test.ts` co-located with the module
+- **`*.browser.test.tsx` runs in a real Chromium**, not jsdom — for anything needing computed CSS, layout, paint/stacking order, sticky behaviour or media emulation. Opt-in (`bun run --cwd cire/web test:browser`), its own CI step. jsdom parses no stylesheet and reports zeroed rects, so a class-contract assertion in the fast tier and a measurement in the browser tier are complements, not duplicates. See `[[wiki/conventions/browser-tests]]`
 - Run tests: `bun run test` (all workspaces, turbo) or `bun run --cwd cire/api test`
 - Integration tests use a local D1 instance via `wrangler dev` — do not mock the database
 - Note: platform convention elsewhere in the monorepo is `it.effect` + `createTestLayer()` — cire alignment is tracked in root `wiki/TODO.md` (Deferred Decisions)
@@ -208,6 +210,8 @@ bun run test                         # All packages (turbo)
 bun run --cwd cire/api test
 bun run --cwd cire/web test
 bun run --cwd cire/organiser test    # SolidJS islands (vitest + happy-dom)
+bun run --cwd cire/web test:browser  # real-Chromium tier (CSS/layout/paint) — see [[wiki/conventions/browser-tests]]
+bun run test:browser                 # every package with a browser tier (turbo)
 
 # Lint + Format (root config)
 bun run lint                         # oxlint

--- a/cire/web/package.json
+++ b/cire/web/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "vitest run"
+    "test": "vitest run --project unit",
+    "test:browser": "vitest run --project browser"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^14.1.4",
@@ -22,10 +23,13 @@
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
-    "@solidjs/testing-library": "^0.8.10",
     "@shared/typescript-config": "workspace:*",
+    "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.10.0",
+    "@vitest/browser": "4.1.10",
+    "@vitest/browser-playwright": "4.1.10",
     "jsdom": "^29.1.1",
+    "playwright": "^1.62.1",
     "vite-plugin-solid": "^2.11.14",
     "vitest": "^4.1.10"
   }

--- a/cire/web/src/components/RsvpModal.browser.test.tsx
+++ b/cire/web/src/components/RsvpModal.browser.test.tsx
@@ -1,0 +1,127 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+
+import "../styles/global.css";
+import { RsvpModal } from "./RsvpModal";
+import type { EventSummary, FamilyMember } from "./types";
+
+/**
+ * The RSVP sheet's sticky action bar, measured.
+ *
+ * `cire/CLAUDE.md` states the rule this file exists to enforce, and states in
+ * the same breath why no other test can:
+ *
+ *   > A `position: sticky` box resolves its `bottom` offset against the
+ *   > SCROLLPORT, not against its parent's content box — so the usual "cancel
+ *   > the container's padding with a negative margin" trick inverts on a sticky
+ *   > element: a negative bottom margin *hoists it up* over the content instead
+ *   > of stretching it down into the padding. […] Layout bugs of this shape are
+ *   > invisible to the test tier (jsdom/happy-dom compute no layout), so pin the
+ *   > class contract in tests and measure the real thing in a browser.
+ *
+ * `RsvpModal.test.tsx` does the first half — it pins `pb-0`, `-mx-6`, `px-6`,
+ * `sticky`, and the absence of any `-mb-*`. This is the second half. The class
+ * contract cannot catch a regression that arrives through `AnimatedModal`
+ * (dropping `flushBottom`, or making the panel a scroll container), through a
+ * Tailwind upgrade, or through any change that satisfies every asserted class
+ * and still lays out wrong.
+ */
+
+const event: EventSummary = {
+  id: "event-1",
+  name: "Mehndi",
+  description: "Henna evening",
+  startAt: "2026-09-18T16:00:00+10:00",
+  endAt: "2026-09-18T22:00:00+10:00",
+  timezone: "Australia/Sydney",
+  address: "12 Banksia Lane",
+  dressCodeDescription: null,
+  dressCodePalette: null,
+  pinterestUrl: null,
+  mapsUrl: null,
+  sortOrder: 0,
+};
+
+/** Enough of a party to overflow the sheet, so the scrollport is real. */
+const members: FamilyMember[] = Array.from({ length: 12 }, (_, i) => ({
+  guestId: `guest-${i}`,
+  firstName: `Guest${i}`,
+  lastName: "Sharma",
+  eventIds: ["event-1"],
+}));
+
+function open() {
+  const view = render(() => (
+    <RsvpModal event={event} members={members} apiUrl="https://api.test" onClose={() => {}} />
+  ));
+  const panel = document.querySelector('[role="dialog"]') as HTMLElement;
+  const scroller = panel.lastElementChild as HTMLElement;
+  const bar = view.getByRole("button", { name: "Save" }).parentElement as HTMLElement;
+  return { ...view, panel, scroller, bar };
+}
+
+describe("RSVP action bar, as laid out", () => {
+  it("gives the sheet a scrollport that actually scrolls", () => {
+    // Everything below is vacuous without this — and in jsdom it is always
+    // false, because no layout is computed at all.
+    const { scroller } = open();
+    expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+  });
+
+  it("seats the bar ON the scrollport's bottom edge, not hoisted above it", () => {
+    // The exact inversion the rule is about: a negative bottom margin would lift
+    // the bar up over the last card, leaving a gap below it. Both edges must
+    // coincide.
+    const { scroller, bar } = open();
+    const gap = scroller.getBoundingClientRect().bottom - bar.getBoundingClientRect().bottom;
+    expect(Math.abs(gap)).toBeLessThan(1);
+  });
+
+  it("keeps the bar in view while the content scrolls under it", () => {
+    // `sticky` doing its job. If the panel ever became the scroll container, or
+    // an ancestor gained `overflow: hidden`, sticky would silently degrade to
+    // static and the bar would scroll away with the content.
+    const { scroller, bar } = open();
+    const before = bar.getBoundingClientRect().bottom;
+
+    scroller.scrollTop = 0;
+    const atTop = bar.getBoundingClientRect().bottom;
+    scroller.scrollTop = scroller.scrollHeight;
+    const atBottom = bar.getBoundingClientRect().bottom;
+
+    expect(Math.abs(atTop - before)).toBeLessThan(1);
+    expect(Math.abs(atBottom - atTop)).toBeLessThan(1);
+    // And it is genuinely inside the visible scrollport at both extremes.
+    const port = scroller.getBoundingClientRect();
+    expect(atTop).toBeLessThanOrEqual(port.bottom + 1);
+    expect(bar.getBoundingClientRect().top).toBeGreaterThanOrEqual(port.top - 1);
+  });
+
+  it("runs the bar full-bleed, edge to edge of the panel", () => {
+    // `-mx-6` exactly cancels the scroller's `px-6`. Asserting the two class
+    // literals (as the unit test does) cannot catch one of them changing value
+    // while both remain present.
+    const { panel, bar } = open();
+    const panelRect = panel.getBoundingClientRect();
+    const barRect = bar.getBoundingClientRect();
+    // Against the panel's CONTENT box, not its border box: the panel carries a
+    // 1px border that the bar correctly sits inside. `clientLeft` is exactly
+    // that border width, so this stays honest if the border ever changes.
+    const contentLeft = panelRect.left + panel.clientLeft;
+    expect(Math.abs(barRect.left - contentLeft)).toBeLessThan(1);
+    expect(Math.abs(barRect.width - panel.clientWidth)).toBeLessThan(1);
+  });
+
+  it("keeps both actions inside the sheet and reachable at a mobile viewport", () => {
+    // The failure a guest would report as "I can't press Save": the bar is
+    // there, but the button's centre is not what a tap at that point hits.
+    const { getByRole } = open();
+    for (const name of ["Cancel", "Save"]) {
+      const btn = getByRole("button", { name });
+      const r = btn.getBoundingClientRect();
+      expect(r.width).toBeGreaterThan(0);
+      const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+      expect(btn.contains(hit), `${name} is not the topmost element at its own centre`).toBe(true);
+    }
+  });
+});

--- a/cire/web/src/lib/z-index.browser.test.tsx
+++ b/cire/web/src/lib/z-index.browser.test.tsx
@@ -1,0 +1,152 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { AnimatedModal } from "../components/AnimatedModal";
+
+import "../styles/global.css";
+import { Z_CLASS, Z_LAYER } from "./z-index";
+
+/**
+ * The #203 invariant, asserted against what the browser actually paints.
+ *
+ * `z-index.test.ts` (jsdom) guards the *numbers* in `Z_LAYER` and the *strings*
+ * in `Z_CLASS`. That is the most a jsdom test can do, and it leaves three ways
+ * to reintroduce the exact bug it was written for — a modal-launched popover
+ * rendering behind the modal, "Add to Calendar doesn't work":
+ *
+ *  1. `Z_CLASS.MODAL_POPOVER` could hold a class Tailwind never emits. The
+ *     scanner only sees literal source text, so a class assembled by
+ *     concatenation compiles to no CSS at all — silently, because an unknown
+ *     class is simply ignored. `expect(Z_CLASS.MODAL_POPOVER).toBe("z-110")`
+ *     passes either way; the element then has `z-index: auto`.
+ *  2. An ancestor could introduce a **stacking context** (`transform`,
+ *     `filter`, `opacity < 1`, `will-change`, `contain`…). A descendant's
+ *     z-index is then resolved *inside* that context and cannot compete with
+ *     the modal's, however large the number. The popover is portalled to
+ *     `<body>` specifically to avoid this, and nothing tests that it still is.
+ *  3. The paint order could invert for any reason the numbers don't capture.
+ *
+ * Each check below therefore reads computed style or hit-tests real geometry,
+ * rather than re-asserting the constants.
+ */
+
+/** A stand-in for the portalled popover: same z-class, same `fixed`, real geometry. */
+function Popover() {
+  return (
+    <div
+      data-testid="popover"
+      class={`fixed ${Z_CLASS.MODAL_POPOVER} bg-surface-raised`}
+      style={{ top: "100px", left: "100px", width: "200px", height: "80px" }}
+    >
+      Add to calendar
+    </div>
+  );
+}
+
+describe("stacking order, as painted", () => {
+  it("emits real CSS for every layer class — not just a matching string constant", () => {
+    // Catches failure mode 1: a `Z_CLASS` entry Tailwind never compiled. jsdom
+    // cannot see this at all, because it never parses the stylesheet.
+    const { container } = render(() => (
+      <>
+        {Object.entries(Z_CLASS).map(([layer, cls]) => (
+          <div data-layer={layer} class={`fixed ${cls}`} />
+        ))}
+      </>
+    ));
+
+    for (const [layer, expected] of Object.entries(Z_LAYER)) {
+      const el = container.querySelector(`[data-layer="${layer}"]`) as HTMLElement;
+      const painted = getComputedStyle(el).zIndex;
+      expect(
+        painted,
+        `${layer} (${Z_CLASS[layer as keyof typeof Z_CLASS]}) emitted no z-index`,
+      ).toBe(String(expected));
+    }
+  });
+
+  it("paints a modal-launched popover ABOVE the modal it opens from (#203)", async () => {
+    // The regression as a user would meet it: is the menu actually on top?
+    const { getByTestId } = render(() => (
+      <>
+        <AnimatedModal onClose={() => {}} label="Event details">
+          <p style={{ height: "400px" }}>Details</p>
+        </AnimatedModal>
+        <Popover />
+      </>
+    ));
+
+    const popover = getByTestId("popover");
+    const rect = popover.getBoundingClientRect();
+    // Real layout — in jsdom this rect is all zeroes and the test is vacuous.
+    expect(rect.width).toBeGreaterThan(0);
+
+    // The question the numbers can't answer: what does the user's click hit?
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    expect(hit).not.toBeNull();
+    expect(popover.contains(hit)).toBe(true);
+  });
+
+  it("keeps the popover out of any ancestor stacking context", () => {
+    // Catches failure mode 2. `<Portal>` puts the real popover directly under
+    // <body>; if a future refactor nested it inside the modal's panel instead,
+    // the panel (or the backdrop) would become its containing stacking context
+    // and the z-index would stop competing with the modal's.
+    const { getByTestId } = render(() => (
+      <>
+        <AnimatedModal onClose={() => {}} label="Event details">
+          <p>Details</p>
+        </AnimatedModal>
+        <Popover />
+      </>
+    ));
+
+    const popover = getByTestId("popover");
+    for (let el = popover.parentElement; el && el !== document.body; el = el.parentElement) {
+      const cs = getComputedStyle(el);
+      const createsContext =
+        cs.transform !== "none" ||
+        cs.filter !== "none" ||
+        cs.perspective !== "none" ||
+        cs.contain.includes("paint") ||
+        cs.willChange.includes("transform") ||
+        cs.willChange.includes("opacity") ||
+        (cs.opacity !== "" && Number(cs.opacity) < 1) ||
+        (cs.isolation === "isolate" && cs.zIndex === "auto");
+      expect(
+        createsContext,
+        `<${el.tagName.toLowerCase()}> traps the popover in a new stacking context`,
+      ).toBe(false);
+    }
+  });
+
+  it("paints the modal above ordinary page content", () => {
+    const { getByTestId } = render(() => (
+      <>
+        <div
+          data-testid="page"
+          class={Z_CLASS.EVENT_CARD}
+          style={{
+            position: "fixed",
+            top: "100px",
+            left: "100px",
+            width: "300px",
+            height: "200px",
+          }}
+        >
+          Event card
+        </div>
+        <AnimatedModal onClose={() => {}} label="Event details">
+          <p>Details</p>
+        </AnimatedModal>
+      </>
+    ));
+
+    const card = getByTestId("page");
+    const r = card.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+    // The modal backdrop covers the viewport, so anything under it must not be
+    // reachable — that is what "modal" means, and what z-100 buys.
+    expect(card.contains(hit)).toBe(false);
+  });
+});

--- a/cire/web/src/styles/reduced-motion.browser.test.tsx
+++ b/cire/web/src/styles/reduced-motion.browser.test.tsx
@@ -1,0 +1,101 @@
+import { render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { commands } from "vitest/browser";
+
+import "./global.css";
+
+/**
+ * The invite's reduced-motion promise, checked against the engine rather than
+ * against the text of `global.css`.
+ *
+ * Every existing assertion about that block is a regex over the stylesheet as a
+ * string (`components/rsvp-saved.test.ts`, and the pattern
+ * `styles/root-type-scale.test.ts` established). Those prove the rule was
+ * *written*. They cannot prove it *applies* — a selector the cascade never
+ * reaches, a specificity loss, or a Tailwind layer that outranks it would leave
+ * every one of them green while a guest who asked for no motion got the full
+ * choreography.
+ *
+ * This file emulates the preference for real and reads the computed durations
+ * back, which is only meaningful in a browser: jsdom parses no stylesheet and
+ * `matchMedia` there is a stub that never matches anything.
+ */
+
+/** Typed accessor for the command registered in `vitest.config.ts`. */
+const emulate = (options: { reducedMotion?: "reduce" | "no-preference" }) =>
+  (commands as unknown as { emulateMedia: (o: typeof options) => Promise<void> }).emulateMedia(
+    options,
+  );
+
+afterEach(async () => {
+  // The browser context is shared across tests in this file, so a leaked
+  // preference would silently rewrite every later assertion about motion.
+  await emulate({ reducedMotion: "no-preference" });
+});
+
+describe("prefers-reduced-motion", () => {
+  it("leaves animation at full length by default", async () => {
+    const { container } = render(() => <div class="transition-transform duration-500 ease-out" />);
+    const cs = getComputedStyle(container.firstElementChild as HTMLElement);
+    expect(cs.transitionDuration).toBe("0.5s");
+  });
+
+  it("clamps transitions to effectively zero when the guest asks for less motion", async () => {
+    // The half that matters for the RSVP sweep and the modal's fades: these are
+    // `transition`s, and a block that only clamped `animation-*` would leave
+    // them running at full length.
+    await emulate({ reducedMotion: "reduce" });
+    const { container } = render(() => <div class="transition-transform duration-500 ease-out" />);
+    const cs = getComputedStyle(container.firstElementChild as HTMLElement);
+    expect(Number.parseFloat(cs.transitionDuration)).toBeLessThan(0.001);
+    expect(cs.transitionDelay).toBe("0s");
+  });
+
+  it("clamps keyframe animations too", async () => {
+    // Deliberately NOT `animate-spin` — that class is the block's one documented
+    // exemption (covered below), and its `!important` duration would beat the
+    // inline style here, making this assert the opposite of what it means to.
+    // Any ordinary animated element stands in for a future keyframe.
+    await emulate({ reducedMotion: "reduce" });
+    const { container } = render(() => <div />);
+    const el = container.firstElementChild as HTMLElement;
+    el.style.animation = "fade 2s linear";
+
+    const cs = getComputedStyle(el);
+    expect(Number.parseFloat(cs.animationDuration)).toBeLessThan(0.001);
+    expect(cs.animationIterationCount).toBe("1");
+  });
+
+  it("keeps the spinner turning, because a frozen spinner reads as 'nothing is happening'", async () => {
+    // The one documented exemption. Losing it would be an accessibility
+    // regression dressed as compliance, and no text assertion covers it.
+    await emulate({ reducedMotion: "reduce" });
+    const { container } = render(() => <div class="animate-spin" />);
+    const cs = getComputedStyle(container.firstElementChild as HTMLElement);
+    expect(Number.parseFloat(cs.animationDuration)).toBeGreaterThan(0.5);
+    expect(cs.animationIterationCount).toBe("infinite");
+  });
+
+  it("lands a transition on its END state rather than skipping it", async () => {
+    // Why the clamp is 0.01ms and not `none`: `transitionend` must still fire,
+    // or any state machine awaiting it stalls forever. This is the behaviour
+    // the comment in global.css claims, asserted.
+    await emulate({ reducedMotion: "reduce" });
+    const { container } = render(() => (
+      <div class="origin-left scale-x-0 transition-transform duration-500" />
+    ));
+    const el = container.firstElementChild as HTMLElement;
+
+    const ended = new Promise<boolean>((resolve) => {
+      el.addEventListener("transitionend", () => resolve(true), { once: true });
+      setTimeout(() => resolve(false), 1000);
+    });
+    // Force a frame so the starting style is committed before the class flips.
+    el.getBoundingClientRect();
+    el.classList.remove("scale-x-0");
+    el.classList.add("scale-x-100");
+
+    expect(await ended).toBe(true);
+    expect(getComputedStyle(el).scale).toBe("1");
+  });
+});

--- a/cire/web/src/test-support/browser-commands.ts
+++ b/cire/web/src/test-support/browser-commands.ts
@@ -1,0 +1,28 @@
+import { defineBrowserCommand } from "@vitest/browser-playwright";
+
+/**
+ * Browser commands available to `*.browser.test.ts(x)` files.
+ *
+ * A command runs in the Vitest **node** process with the Playwright `page`
+ * handle, while the test body runs inside the browser. That split is why media
+ * emulation has to be a command: `prefers-reduced-motion` is a property of the
+ * browser context, so nothing running inside the page can change it.
+ *
+ * The alternative — a second `browser.instances` entry with
+ * `contextOptions.reducedMotion` — would run the *entire* suite twice, once per
+ * motion preference, to test the handful of rules that care. A per-test command
+ * keeps it to the tests that actually assert it.
+ */
+
+/**
+ * Emulate a media preference for the remainder of the current test.
+ *
+ * Always restore it in an `afterEach` (`{ reducedMotion: "no-preference" }`) —
+ * the browser context is shared across tests in a file, so a leaked preference
+ * silently changes every later assertion about animation.
+ */
+export const emulateMedia = defineBrowserCommand<[{ reducedMotion?: "reduce" | "no-preference" }]>(
+  async (ctx, options) => {
+    await ctx.page.emulateMedia(options);
+  },
+);

--- a/cire/web/vitest.config.ts
+++ b/cire/web/vitest.config.ts
@@ -1,11 +1,102 @@
+import tailwindcss from "@tailwindcss/vite";
+import { playwright } from "@vitest/browser-playwright";
 import solidPlugin from "vite-plugin-solid";
 import { defineConfig } from "vitest/config";
 
+import { emulateMedia } from "./src/test-support/browser-commands.ts";
+
+/**
+ * Two test projects, deliberately separated.
+ *
+ * ## Why a second tier exists at all
+ *
+ * jsdom computes **no CSS and no layout**. `getComputedStyle` returns roughly
+ * what was set inline, `getBoundingClientRect` is all zeroes, and the app's
+ * stylesheet is never even parsed. That makes a whole class of this app's bugs
+ * structurally invisible to the `unit` project below — and they are not
+ * hypothetical:
+ *
+ * - **#203** shipped the Add-to-Calendar popover at `z-90`, below the `z-100`
+ *   modal it opens from, so it painted behind the backdrop: invisible and
+ *   unclickable. `lib/z-index.test.ts` now guards the *numbers*, which is the
+ *   most a jsdom test can do. It cannot check that the popover actually paints
+ *   above the modal, that `.z-110` was emitted into the stylesheet at all, or
+ *   that no ancestor introduced a stacking context that traps it.
+ * - Tailwind v4's `scale-*` utilities set the standalone `scale` property, not
+ *   `transform`, so a `transition-transform` that failed to list `scale` would
+ *   animate nothing — silently.
+ * - Two conflicting utilities on one element resolve by **stylesheet order**,
+ *   not class-attribute order: a property of Tailwind's generated output that
+ *   can invert under a version bump.
+ * - The global `prefers-reduced-motion` clamp is load-bearing for accessibility
+ *   and is asserted today only by regex-matching `global.css` as text.
+ *
+ * The existing answer to all of these is text-matching drift guards
+ * (`styles/root-type-scale.test.ts`, `components/rsvp-saved.test.ts`,
+ * `components/invite-theme.test.ts`). Those pin that the *source* says the
+ * right thing. They can never pin that the *render* does. This project can.
+ *
+ * ## Why they are separate projects rather than one
+ *
+ * A real browser costs roughly an order of magnitude more to start than jsdom
+ * and needs a downloaded Chromium. Keeping the fast tier fast is the point:
+ * `bun run test` — and therefore CI's default path — runs `unit` only. The
+ * browser tier is opt-in through `bun run test:browser`, with its own CI step
+ * that installs the browser first, mirroring how `test:d1` is already split
+ * out.
+ *
+ * Browser tests are named `*.browser.test.ts(x)` and are excluded from `unit`
+ * by that name, so every file lands in exactly one project and neither glob can
+ * accidentally swallow the other's files.
+ */
+
+/** Shared by both projects — same compiler, and the same Tailwind build the app ships. */
+const plugins = () => [solidPlugin(), tailwindcss()];
+
+/**
+ * Escape hatch for environments that ship a prebuilt Chromium whose build
+ * number doesn't match the pinned Playwright (dev containers and this repo's
+ * cloud sessions both provide one under `$PLAYWRIGHT_BROWSERS_PATH` and set
+ * `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`). Without this, Playwright insists on a
+ * build it cannot find and the tier is unrunnable there short of a ~300MB
+ * download. CI installs the matching browser and leaves this unset.
+ */
+const executablePath = process.env.VITEST_BROWSER_EXECUTABLE_PATH;
+
 export default defineConfig({
-  plugins: [solidPlugin()],
   test: {
-    environment: "jsdom",
-    transformMode: { web: [/\.[jt]sx?$/] },
-    passWithNoTests: true,
+    projects: [
+      {
+        plugins: plugins(),
+        test: {
+          name: "unit",
+          environment: "jsdom",
+          transformMode: { web: [/\.[jt]sx?$/] },
+          passWithNoTests: true,
+          exclude: ["**/node_modules/**", "**/dist/**", "**/*.browser.test.{ts,tsx}"],
+        },
+      },
+      {
+        plugins: plugins(),
+        test: {
+          name: "browser",
+          include: ["src/**/*.browser.test.{ts,tsx}"],
+          passWithNoTests: true,
+          browser: {
+            enabled: true,
+            // `launchOptions` belongs to the PROVIDER, not to an entry in
+            // `instances` — passed there it is accepted and silently ignored.
+            provider: playwright(executablePath ? { launchOptions: { executablePath } } : {}),
+            // `headless` must sit at this level too: set inside `instances` it
+            // does not take effect (vitest-dev/vitest#7661).
+            headless: true,
+            instances: [{ browser: "chromium" }],
+            // Lets a test flip `prefers-reduced-motion` for itself instead of
+            // running the whole suite twice under a second browser instance.
+            commands: { emulateMedia },
+          },
+        },
+      },
+    ],
   },
 });

--- a/cire/wiki/conventions/browser-tests.md
+++ b/cire/wiki/conventions/browser-tests.md
@@ -1,0 +1,161 @@
+---
+title: "Browser Tests"
+tags: [conventions, testing]
+related:
+  - "[[contributing]]"
+  - "[[review-findings]]"
+  - "[[index]]"
+packages:
+  - "@cire/web"
+last-reviewed: 2026-08-06
+---
+
+# Browser Tests
+
+A second Vitest project in `@cire/web` that runs a handful of tests in a **real
+Chromium** instead of jsdom. Files are named `*.browser.test.ts(x)`.
+
+```bash
+bun run --cwd cire/web test           # fast tier (jsdom) — the default
+bun run --cwd cire/web test:browser   # browser tier
+bun run test:browser                  # every package that has one (turbo)
+```
+
+## Why it exists
+
+jsdom computes **no CSS and no layout**. It never parses the stylesheet,
+`getComputedStyle` returns roughly what was set inline, and
+`getBoundingClientRect` is all zeroes. A whole class of this app's bugs is
+therefore structurally invisible to the default tier — not hypothetically, but
+in ways that have already shipped:
+
+| Failure mode | Why jsdom can't see it |
+|---|---|
+| **#203** — the Add-to-Calendar popover shipped at `z-90`, below the `z-100` modal it opens from, so it painted behind the backdrop: invisible and unclickable | jsdom has no paint order. `z-index.test.ts` can only assert the *numbers* in `Z_LAYER` |
+| A `Z_CLASS` entry naming a class Tailwind never emitted | The scanner only sees literal source text, so a concatenated class compiles to **no CSS at all**, silently. `expect(Z_CLASS.MODAL_POPOVER).toBe("z-110")` passes either way |
+| An ancestor gaining a stacking context (`transform`, `filter`, `opacity < 1`, `contain`) and trapping a portalled overlay | Requires resolving containing blocks |
+| Tailwind v4's `scale-*` setting the standalone `scale` property, not `transform` — so a `transition-transform` that didn't list `scale` animates nothing | Requires the compiled `transition-property` |
+| Two conflicting utilities on one element resolving by **stylesheet order**, not class-attribute order | Requires the generated stylesheet |
+| A `position: sticky` action bar resolving `bottom` against the scrollport (see `[[contributing]]` and the rule in `cire/CLAUDE.md`) | Requires layout |
+| The global `prefers-reduced-motion` clamp actually applying | Requires the cascade plus media emulation |
+
+The pre-existing answer to all of these is **text-matching drift guards** —
+`styles/root-type-scale.test.ts`, `components/rsvp-saved.test.ts`,
+`components/invite-theme.test.ts` all `readFileSync` a CSS file and regex it.
+Those are still worth having: they are fast, and they catch a source change. But
+they pin only that the source *says* the right thing, never that the render
+*does*. This tier is the other half.
+
+## What belongs here (and what doesn't)
+
+Put a test here **only if it needs a real engine.** The browser tier is ~10x the
+startup cost of jsdom and needs a downloaded Chromium; every test that could
+have lived in the fast tier and didn't is a tax on every CI run.
+
+Good reasons: computed style from a real stylesheet, real geometry
+(`getBoundingClientRect`, `elementFromPoint`), paint/stacking order, sticky or
+scroll behaviour, media-query emulation, focus behaviour that depends on real
+layout.
+
+Not reasons: component logic, props, ARIA attributes, event handlers, class
+strings. Those all belong in the fast tier — and a class-contract assertion
+there is a genuinely useful complement, because it names the mechanism while the
+browser test proves the outcome. `RsvpModal.test.tsx` and
+`RsvpModal.browser.test.tsx` are the worked example of that pairing.
+
+## How it is wired
+
+`cire/web/vitest.config.ts` defines two projects:
+
+- **`unit`** — jsdom, `exclude`s `**/*.browser.test.{ts,tsx}`
+- **`browser`** — `include`s only `src/**/*.browser.test.{ts,tsx}`, Playwright
+  provider, headless Chromium
+
+Naming rather than directory placement decides the project, so a file lands in
+exactly one and neither glob can swallow the other's files. Browser tests sit
+next to the code they cover, like every other test in the repo.
+
+Both projects share `solidPlugin()` and `tailwindcss()`, so a browser test gets
+the **same Tailwind build the app ships**. Import `../styles/global.css` at the
+top of the file to have it applied.
+
+### Two provider gotchas
+
+Both cost real time to rediscover:
+
+- **`launchOptions` belongs to the provider**, i.e. `playwright({ launchOptions })`
+  — not to an entry in `browser.instances`, where it is accepted and silently
+  ignored.
+- **`headless` must sit at `browser` level**, not inside `instances`
+  ([vitest-dev/vitest#7661](https://github.com/vitest-dev/vitest/issues/7661)).
+
+### Rendering
+
+`@solidjs/testing-library` works unchanged in browser mode — same `render`,
+same queries, same `cleanup`. There is no separate render API to learn and no
+`vitest-browser-solid` dependency; a browser test reads like every other
+component test in the package.
+
+### Media emulation
+
+`prefers-reduced-motion` is a property of the browser *context*, so nothing
+inside the page can change it. `src/test-support/browser-commands.ts` registers
+an `emulateMedia` browser command that runs in the node process with the
+Playwright `page` handle:
+
+```ts
+await emulate({ reducedMotion: "reduce" });
+```
+
+Always restore it in an `afterEach` — the context is shared across tests in a
+file, so a leaked preference silently rewrites every later assertion about
+motion. A second `browser.instances` entry with `contextOptions.reducedMotion`
+would also work, but runs the *entire* suite twice to serve the few tests that
+care.
+
+## Running it locally
+
+Nothing extra on a normal machine — `playwright` is a devDependency of
+`@cire/web` and `bunx playwright install chromium` fetches the browser once.
+
+Dev containers and this repo's cloud sessions ship a **prebuilt Chromium** whose
+build number won't match the pinned Playwright, which otherwise makes the tier
+unrunnable there short of a ~300MB download. Point it at the existing binary:
+
+```bash
+VITEST_BROWSER_EXECUTABLE_PATH=/opt/pw-browsers/chromium bun run test:browser
+```
+
+The variable is declared in `turbo.json` under `passThroughEnv`, not `env` — it
+says *where* Chromium is, never *what* the tests assert, so it must not enter
+the cache key.
+
+## CI
+
+A separate step in `.github/workflows/ci.yml`, after the D1 step and for the
+same reason: it needs a dependency the default path doesn't, and splitting it
+keeps the fast tier fast.
+
+```yaml
+- name: Install Chromium for browser tests
+  run: bunx playwright install --with-deps chromium
+
+- name: Browser tests
+  run: bun run test:browser
+```
+
+`--with-deps` is required on `ubuntu-latest` — the browser alone won't launch
+without its shared libraries. Only `chromium` is installed: the tier pins a
+single instance, so pulling Firefox and WebKit too would triple the download for
+nothing.
+
+## Current coverage
+
+| File | Pins |
+|---|---|
+| `src/lib/z-index.browser.test.tsx` | Every `Z_CLASS` entry emits real CSS; a modal-launched popover hit-tests **above** the modal (#203); no ancestor traps it in a stacking context; the modal blocks page content beneath it |
+| `src/components/RsvpModal.browser.test.tsx` | The sticky action bar sits on the scrollport's bottom edge, stays put while content scrolls under it, runs full-bleed to the panel's content box, and both buttons are the topmost element at their own centre |
+| `src/styles/reduced-motion.browser.test.tsx` | The clamp applies to transitions *and* animations, `animate-spin` keeps its documented exemption, and a clamped transition still lands on its end state and fires `transitionend` |
+
+The #203 test was verified to fail when the popover is put back at `z-90` — it
+reproduces the original bug, rather than restating the constants.

--- a/cire/wiki/conventions/contributing.md
+++ b/cire/wiki/conventions/contributing.md
@@ -2,7 +2,7 @@
 title: "Contributing Conventions"
 tags: [convention]
 related: [[review-findings]], [[monorepo-structure]], [[overview]]
-last-reviewed: 2026-07-23
+last-reviewed: 2026-08-06
 ---
 
 # Contributing Conventions

--- a/cire/wiki/index.md
+++ b/cire/wiki/index.md
@@ -3,7 +3,7 @@ title: "Cire Wiki — Map of Content"
 tags: [index]
 aliases: [home, map of content, MOC]
 related: []
-last-reviewed: 2026-07-31
+last-reviewed: 2026-08-06
 ---
 
 # Cire Wiki
@@ -41,6 +41,7 @@ Map of Content for the Cire wedding invite project.
 
 ## Conventions
 
+- [[browser-tests]] — the real-Chromium Vitest project: what belongs in it, why jsdom can't cover it, and how it is wired
 - [[contributing]] — branch strategy, commit signing, hooks, observability rules
 - [[review-findings]] — severity prefixes, four-field format, backlog maintenance
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check": "turbo check",
     "test": "turbo test --continue",
     "test:d1": "turbo test:d1 --continue --concurrency=1",
+    "test:browser": "turbo test:browser --continue",
     "clean": "git clean -fdX",
     "db:reset": "bun run --cwd osn/db db:reset && bun run --cwd pulse/db db:reset && bun run --cwd zap/db db:reset && bun run --cwd cire/db db:reset",
     "fmt": "bunx --bun oxfmt osn pulse zap shared cire '!**/*.{json,jsonc,md,yml,yaml,css,html,astro}'",

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,16 @@
         "^build"
       ]
     },
+    "test:browser": {
+      "dependsOn": [
+        "^build"
+      ],
+      "passThroughEnv": [
+        "VITEST_BROWSER_EXECUTABLE_PATH",
+        "PLAYWRIGHT_BROWSERS_PATH",
+        "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"
+      ]
+    },
     "db:migrate": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

- jsdom computes **no CSS and no layout** — it never parses the stylesheet, `getComputedStyle` returns roughly what was set inline, and `getBoundingClientRect` is all zeroes. A class of this app's bugs is structurally invisible to the existing suite, *including ones that have already shipped*.
- Adds a second Vitest project to `@cire/web` running `*.browser.test.tsx` in a real headless Chromium. The fast jsdom tier is unchanged and still the default.
- Three test files prove the tier against **pre-existing, documented gaps** rather than against new code — including a hit-test that reproduces the #203 popover bug.

This was chosen over Storybook after building the RSVP confirmation (#380) surfaced three CSS-invisible failure modes I could only catch by driving the built CSS through headless Chromium by hand. The need that exposed was *assertions against real computed style*, not a component gallery — and Vitest 4 already ships browser mode, so this needs no community-maintained renderer on the critical path.

## Workspaces affected

- `@cire/web` — the new project, three test files, one test-support module.
- CI/infra: `.github/workflows/ci.yml`, `turbo.json`, root `package.json`, `.gitignore`.
- Docs: new `cire/wiki/conventions/browser-tests.md`, plus `cire/CLAUDE.md` and `cire/wiki/index.md`.

## Decisions & issues

**[approach]** — Vitest browser mode rather than Storybook
- **Issue:** The recorded deferred decision (added in #380) weighed Storybook, Vitest browser mode, and status quo.
- **Why:** SolidJS support in Storybook is [community-maintained](https://github.com/storybookjs/solidjs), and the previous adapter went unmaintained and broke on Storybook 9 — demonstrated maintainer risk, not hypothetical. It also answers a different question (component discovery, design review) than the one that was actually hurting.
- **Solution:** Vitest browser mode. Every package is already on Vitest 4, which ships it; Playwright is one devDependency; there is no second authoring format.
- **Rationale:** The demonstrated need is asserting against real computed style. Storybook remains the better answer if the driver later turns out to be cross-package component discovery — that is a separate call, not this one.

**[approach]** — Two projects, split by filename
- **Issue:** A real browser is roughly an order of magnitude more expensive to start than jsdom and needs a downloaded Chromium.
- **Why:** Making every test pay that cost would be a large, permanent tax on `bun run test`, CI's default path and the pre-push hook.
- **Solution:** `unit` (jsdom, excludes `*.browser.test.*`) and `browser` (includes only `src/**/*.browser.test.{ts,tsx}`). Opt-in via `bun run test:browser`, with its own CI step that installs Chromium first — mirroring how `test:d1` is already split out.
- **Rationale:** Naming rather than directory placement decides the project, so every file lands in exactly one and neither glob can swallow the other's. Browser tests still sit next to the code they cover, like every other test here.

**[approach]** — `@solidjs/testing-library`, not `vitest-browser-solid`
- **Issue:** There's a dedicated Solid renderer for Vitest browser mode.
- **Why:** It would add a dependency and a second render API to learn.
- **Solution:** Verified `@solidjs/testing-library` works unchanged in browser mode — same `render`, same queries, same `cleanup`.
- **Rationale:** A browser test now reads exactly like every other component test in the package. The only import that differs is the `global.css` the test needs applied.

**[gotcha]** — `launchOptions` is silently ignored on a browser instance
- **Issue:** Placing `launchOptions` inside a `browser.instances` entry is accepted and does nothing; the browser launches with defaults.
- **Why:** It fails as "Playwright can't find its browser", which points nowhere near the real cause. Cost real time to find.
- **Solution:** It belongs to the provider — `playwright({ launchOptions })`. Documented in the config and the wiki page.
- **Rationale:** Silent-ignore failures are exactly what a comment at the call site is for.

**[gotcha]** — `headless` must sit at `browser` level
- **Issue:** Set inside `instances`, it has no effect ([vitest-dev/vitest#7661](https://github.com/vitest-dev/vitest/issues/7661)).
- **Why:** Same class of problem — config that looks applied and isn't.
- **Solution:** Set at `browser` level, with the issue linked inline.
- **Rationale:** An upstream bug worth citing rather than restating.

**[env]** — `VITEST_BROWSER_EXECUTABLE_PATH` is `passThroughEnv`, not `env`
- **Issue:** Dev containers and this repo's cloud sessions ship a prebuilt Chromium whose build number won't match the pinned Playwright, which makes the tier unrunnable there short of a ~300MB download.
- **Why:** Declaring it under turbo's `env` would fold it into the cache key, so the same tests would miss cache on every machine with a different browser path.
- **Solution:** `passThroughEnv`, alongside `PLAYWRIGHT_BROWSERS_PATH` and `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`.
- **Rationale:** It says *where* the browser is, never *what* the tests assert. (This bit me first as a turbo failure while the direct run passed — turbo strips undeclared vars.)

**[test-quality]** — Every test verified to be load-bearing, not decorative
- **Issue:** A browser test that passes for the wrong reason is worse than none — it reads as coverage.
- **Why:** Two of them nearly were. The keyframe-clamp test initially left `animate-spin` on the element, whose `!important` exemption beat the inline style, so it asserted the opposite of what it meant to. The full-bleed test compared against the panel's border box and was off by the 1px border.
- **Solution:** Both corrected — the clamp test uses a plain element, the full-bleed test compares against the content box via `clientLeft`/`clientWidth`. The #203 test was then verified to **fail** when the popover is put back at `z-90`.
- **Rationale:** The point of the tier is catching what the source-text guards can't; a test that can't fail for the right reason doesn't do that.

**[hygiene]** — Vitest writes a screenshot per failing browser test
- **Issue:** Failing runs left `__screenshots__/` and `.vitest-attachments/` next to the test files, and they were initially staged.
- **Why:** They're debugging aids for the run that produced them, regenerated on the next failure and meaningless once the test is fixed.
- **Solution:** Both patterns added to `.gitignore` with a comment explaining what they are.
- **Rationale:** Better caught now than as binary churn in a later PR.

**[deferred]** — Storybook decision row not updated here
- **Issue:** The deferred-decision row this PR resolves lives in root `wiki/TODO.md` and was added on #380, which isn't merged.
- **Why:** Editing the same table region on both branches would conflict.
- **Solution:** Left alone. Once #380 merges, that row should be marked resolved in favour of this tier.
- **Rationale:** Avoiding a merge conflict is worth one follow-up edit; the reasoning is captured in the new wiki page either way.

## Test plan

- [ ] `bun run --cwd cire/web test` — 717 pass, and it does **not** run the browser tier (was 49 files, still 49).
- [ ] `bun run test:browser` — 14 pass in a real Chromium.
- [ ] In a dev container: `VITEST_BROWSER_EXECUTABLE_PATH=/opt/pw-browsers/chromium bun run test:browser`.
- [ ] Confirm the #203 guard is load-bearing: change the popover in `z-index.browser.test.tsx` to `z-90` and watch the hit-test fail.
- [ ] CI: the new "Install Chromium" + "Browser tests" steps pass on `ubuntu-latest` — this is the first run of them, so the `--with-deps` install is the thing to watch.
- [ ] Confirm the pre-push hook and CI's default `bun run test` are unchanged in duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyaRCndx5mTfa4gYKPTisH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyaRCndx5mTfa4gYKPTisH)_