### PR TITLE
Fix invisible sent connection requests, add search @ prefix

### DIFF
--- a/.changeset/osn-social-sent-requests-and-handle-search.md
+++ b/.changeset/osn-social-sent-requests-and-handle-search.md
@@ -1,0 +1,30 @@
+---
+"@osn/api": minor
+"@osn/client": minor
+"@osn/social": minor
+---
+
+Add a "Sent" tab to Connections so an outgoing request is actually visible somewhere.
+
+`listPendingRequests` was always addressee-only by design (a request you sent
+never shows up there), and `listConnections` only returns accepted rows, so a
+sender had no page anywhere in `@osn/social` that showed their own outstanding
+requests — the toast on send was the only trace, and it vanished on
+navigation. Reported as "I tried connecting with someone and it didn't work,
+don't see it in pending or accepted," but the request was landing fine on the
+recipient's side the whole time.
+
+- `@osn/api`: new `graph.listOutgoingRequests` service method and
+  `GET /graph/connections/sent` route (mirrors the existing `/pending`
+  endpoint, filtered by `requesterId` instead of `addresseeId`).
+- `@osn/client`: `GraphClient.listSentRequests` + `SentRequestEntry` type.
+- `@osn/social`: a "Sent" tab on `ConnectionsPage` listing outgoing requests,
+  with a Cancel action (`removeConnection`, which already cancels a pending
+  request in either direction).
+
+Also gives the desktop rail combobox and the `/search` page search fields a
+prepended "@" inside the existing pill styling, replacing the magnifying-glass
+icon — reusing the `@osn/ui` `UsernameInput` field's own `@`-prefix visual
+convention. `UsernameInput`'s availability-check `status` machinery doesn't
+fit a live people/org combobox that also matches by display name, so this
+borrows the visual token rather than the component itself.

--- a/osn/api/src/routes/graph.ts
+++ b/osn/api/src/routes/graph.ts
@@ -276,6 +276,29 @@ export function createGraphRoutes(
         { query: PaginationQuery },
       )
       .get(
+        "/connections/sent",
+        async ({ query, headers, set }) => {
+          const caller = await requireAuth(headers.authorization, set);
+          if (!caller) return { error: "Unauthorized" };
+          try {
+            const list = await run(
+              graph.listOutgoingRequests(caller.profileId, parsePagination(query)),
+            );
+            return {
+              sent: list.map((r) =>
+                Object.assign({}, profileProjection(r.profile), {
+                  requestedAt: r.requestedAt.toISOString(),
+                }),
+              ),
+            };
+          } catch (e) {
+            set.status = 500;
+            return { error: safeError(e) };
+          }
+        },
+        { query: PaginationQuery },
+      )
+      .get(
         "/connections/:handle",
         async ({ params, headers, set }) => {
           const caller = await requireAuth(headers.authorization, set);

--- a/osn/api/src/services/graph.ts
+++ b/osn/api/src/services/graph.ts
@@ -378,6 +378,46 @@ export function createGraphService() {
       }));
     });
 
+  const listOutgoingRequests = (
+    profileId: string,
+    options: ListOptions = {},
+  ): Effect.Effect<
+    { profile: typeof users.$inferSelect; requestedAt: Date }[],
+    DatabaseError,
+    Db
+  > =>
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const limit = clampLimit(options.limit);
+      const offset = options.offset ?? 0;
+
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(connections)
+            .where(and(eq(connections.requesterId, profileId), eq(connections.status, "pending")))
+            .limit(limit)
+            .offset(offset),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      if (rows.length === 0) return [];
+
+      const addresseeIds = rows.map((r) => r.addresseeId);
+      const requestedAtMap = new Map(rows.map((r) => [r.addresseeId, r.createdAt]));
+
+      const addressees = yield* Effect.tryPromise({
+        try: () => db.select().from(users).where(inArray(users.id, addresseeIds)),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+
+      return addressees.map((u) => ({
+        profile: u,
+        requestedAt: requestedAtMap.get(u.id) ?? new Date(),
+      }));
+    });
+
   // -------------------------------------------------------------------------
   // Blocks
   // -------------------------------------------------------------------------
@@ -489,6 +529,7 @@ export function createGraphService() {
     removeConnection,
     listConnections,
     listPendingRequests,
+    listOutgoingRequests,
     blockProfile,
     unblockProfile,
     listBlocks,

--- a/osn/api/tests/routes/graph.test.ts
+++ b/osn/api/tests/routes/graph.test.ts
@@ -361,6 +361,37 @@ describe("graph routes", () => {
     expect(json.pending[0].handle).toBe("alice");
   });
 
+  it("GET /graph/connections/sent returns requests the caller sent", async () => {
+    const alice = await registerAndGetToken("alice2@example.com", "alice2");
+    const bob = await registerAndGetToken("bob2@example.com", "bob2");
+
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob2", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/sent", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { sent: { handle: string }[] };
+    expect(json.sent).toHaveLength(1);
+    expect(json.sent[0].handle).toBe("bob2");
+
+    // The recipient's own "sent" list should not include it.
+    const recipientRes = await graphApp.handle(
+      new Request("http://localhost/graph/connections/sent", {
+        headers: { Authorization: `Bearer ${bob.token}` },
+      }),
+    );
+    const recipientJson = (await recipientRes.json()) as { sent: { handle: string }[] };
+    expect(recipientJson.sent).toHaveLength(0);
+  });
+
   // -------------------------------------------------------------------------
   // isBlocked
   // -------------------------------------------------------------------------

--- a/osn/api/tests/services/graph.test.ts
+++ b/osn/api/tests/services/graph.test.ts
@@ -206,6 +206,37 @@ describe("listPendingRequests", () => {
   );
 });
 
+describe("listOutgoingRequests", () => {
+  it.effect("returns requests the caller sent", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const list = yield* graph.listOutgoingRequests(alice.id);
+      expect(list).toHaveLength(1);
+      expect(list[0].profile.handle).toBe("bob");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("does not include incoming requests", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      const list = yield* graph.listOutgoingRequests(bob.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("does not include accepted connections", () =>
+    Effect.gen(function* () {
+      const { alice, bob } = yield* setupTwoUsers;
+      yield* graph.sendConnectionRequest(alice.id, bob.id);
+      yield* graph.acceptConnection(bob.id, alice.id);
+      const list = yield* graph.listOutgoingRequests(alice.id);
+      expect(list).toHaveLength(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Blocks
 // ---------------------------------------------------------------------------

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -23,6 +23,13 @@ export interface PendingRequestEntry {
   requestedAt: string;
 }
 
+export interface SentRequestEntry {
+  id: string;
+  handle: string;
+  displayName: string | null;
+  requestedAt: string;
+}
+
 export interface ProfileEntry {
   id: string;
   handle: string;
@@ -155,6 +162,10 @@ export interface GraphClient {
     token: string,
     options?: { limit?: number; offset?: number },
   ): Promise<{ pending: PendingRequestEntry[] }>;
+  listSentRequests(
+    token: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ sent: SentRequestEntry[] }>;
   listBlocks(
     token: string,
     options?: { limit?: number; offset?: number },
@@ -180,6 +191,9 @@ export function createGraphClient(config: GraphClientConfig): GraphClient {
         `${base}/connections/pending${qs(options)}`,
         token,
       ),
+
+    listSentRequests: (token, options) =>
+      authGet<{ sent: SentRequestEntry[] }>(`${base}/connections/sent${qs(options)}`, token),
 
     listBlocks: (token, options) =>
       authGet<{ blocks: ProfileEntry[] }>(`${base}/blocks${qs(options)}`, token),

--- a/osn/client/tests/graph.test.ts
+++ b/osn/client/tests/graph.test.ts
@@ -57,6 +57,27 @@ describe("createGraphClient — listPendingRequests / listBlocks", () => {
   });
 });
 
+describe("createGraphClient — listSentRequests", () => {
+  it("GETs /graph/connections/sent with Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ sent: [] }) });
+    await client.listSentRequests(TOKEN);
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toBe(`${base}/connections/sent`);
+    expectAuthHeader(call);
+  });
+
+  it("serialises limit/offset as query params", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ sent: [] }) });
+    await client.listSentRequests(TOKEN, { limit: 10, offset: 5 });
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections/sent?limit=10&offset=5`);
+  });
+
+  it("throws GraphClientError on non-2xx", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "boom" }) });
+    await expect(client.listSentRequests(TOKEN)).rejects.toBeInstanceOf(GraphClientError);
+  });
+});
+
 describe("createGraphClient — connection mutations", () => {
   it("getConnectionStatus GETs /graph/connections/:handle", async () => {
     mockFetch({ ok: true, json: () => Promise.resolve({ status: "connected" }) });

--- a/osn/social/src/components/GlobalSearch.tsx
+++ b/osn/social/src/components/GlobalSearch.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from "@solidjs/router";
 import { createSignal, For, Show } from "solid-js";
 
 import { createSearchController, type SearchRow } from "../lib/search";
-import { IconSearch } from "./nav";
 import { OrganisationRow, PersonRow, useSearchActions } from "./SearchResultRows";
 
 const LISTBOX_ID = "global-search-results";
@@ -122,12 +121,18 @@ export function GlobalSearch(props: { token: string }) {
         Search people and organisations
       </label>
       <div class="relative">
+        <span
+          class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm"
+          aria-hidden="true"
+        >
+          @
+        </span>
         <Input
           id="global-search-input"
           type="search"
           autocomplete="off"
           placeholder="Search"
-          class="rounded-pill h-9 pl-8"
+          class="rounded-pill h-9 pl-7"
           role="combobox"
           aria-expanded={showPanel()}
           aria-controls={LISTBOX_ID}
@@ -141,7 +146,6 @@ export function GlobalSearch(props: { token: string }) {
           }}
           onKeyDown={onKeyDown}
         />
-        <IconSearch class="text-subtle pointer-events-none absolute top-2.5 left-2.5 h-4 w-4" />
       </div>
 
       <Show when={showPanel()}>

--- a/osn/social/src/pages/ConnectionsPage.tsx
+++ b/osn/social/src/pages/ConnectionsPage.tsx
@@ -1,4 +1,9 @@
-import type { ConnectionEntry, PendingRequestEntry, ProfileEntry } from "@osn/client";
+import type {
+  ConnectionEntry,
+  PendingRequestEntry,
+  ProfileEntry,
+  SentRequestEntry,
+} from "@osn/client";
 import { useAuth } from "@osn/client/solid";
 import { clsx } from "@osn/ui/lib/utils";
 import { Avatar, AvatarFallback } from "@osn/ui/ui/avatar";
@@ -16,11 +21,12 @@ import { toast } from "solid-toast";
 import { ResponsiveDialogContent } from "../components/ResponsiveDialogContent";
 import { graphClient } from "../lib/api";
 
-type Tab = "all" | "pending" | "blocked";
+type Tab = "all" | "pending" | "sent" | "blocked";
 
 const TABS: { value: Tab; label: string }[] = [
   { value: "all", label: "All" },
   { value: "pending", label: "Pending" },
+  { value: "sent", label: "Sent" },
   { value: "blocked", label: "Blocked" },
 ];
 
@@ -36,6 +42,7 @@ export function ConnectionsPage() {
   type TabPayload =
     | { kind: "all"; data: Awaited<ReturnType<typeof graphClient.listConnections>> }
     | { kind: "pending"; data: Awaited<ReturnType<typeof graphClient.listPendingRequests>> }
+    | { kind: "sent"; data: Awaited<ReturnType<typeof graphClient.listSentRequests>> }
     | { kind: "blocked"; data: Awaited<ReturnType<typeof graphClient.listBlocks>> };
 
   const [payload, { refetch: refetchPayload }] = createResource<
@@ -49,6 +56,8 @@ export function ConnectionsPage() {
           return { kind: "all", data: await graphClient.listConnections(tk) };
         case "pending":
           return { kind: "pending", data: await graphClient.listPendingRequests(tk) };
+        case "sent":
+          return { kind: "sent", data: await graphClient.listSentRequests(tk) };
         case "blocked":
           return { kind: "blocked", data: await graphClient.listBlocks(tk) };
       }
@@ -64,6 +73,10 @@ export function ConnectionsPage() {
     payload()?.kind === "pending"
       ? (payload() as Extract<TabPayload, { kind: "pending" }>).data
       : undefined;
+  const sent = () =>
+    payload()?.kind === "sent"
+      ? (payload() as Extract<TabPayload, { kind: "sent" }>).data
+      : undefined;
   const blocked = () =>
     payload()?.kind === "blocked"
       ? (payload() as Extract<TabPayload, { kind: "blocked" }>).data
@@ -71,6 +84,7 @@ export function ConnectionsPage() {
 
   const refetchConnections = refetchPayload;
   const refetchPending = refetchPayload;
+  const refetchSent = refetchPayload;
 
   // Two-step friend removal: clicking "Remove" on a row opens a confirmation
   // dialog rather than mutating immediately, guarding against accidental
@@ -112,6 +126,16 @@ export function ConnectionsPage() {
       refetchPending();
     } catch {
       toast.error("Failed to reject request");
+    }
+  }
+
+  async function cancelSentRequest(handle: string) {
+    try {
+      await graphClient.removeConnection(token(), handle);
+      toast.success(`Cancelled request to @${handle}`);
+      refetchSent();
+    } catch {
+      toast.error("Failed to cancel request");
     }
   }
 
@@ -242,6 +266,48 @@ export function ConnectionsPage() {
                           onClick={() => rejectRequest(req.handle)}
                         >
                           Decline
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </Show>
+
+        {/* Sent requests */}
+        <Show when={tab() === "sent"}>
+          <Show when={!payload.loading} fallback={<LoadingSkeleton count={2} />}>
+            <Show
+              when={(sent()?.sent.length ?? 0) > 0}
+              fallback={<EmptyState message="No outgoing connection requests." />}
+            >
+              <div class="flex flex-col gap-1">
+                <For each={sent()?.sent}>
+                  {(req: SentRequestEntry) => (
+                    <div class="hover:bg-muted/50 active:bg-muted/50 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors">
+                      <Avatar class="h-9 w-9">
+                        <AvatarFallback class="text-meta">
+                          {req.handle.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div class="min-w-0 flex-1">
+                        <p class="text-foreground text-title font-medium">
+                          {req.displayName || `@${req.handle}`}
+                        </p>
+                        <p class="text-subtle text-meta">
+                          Requested {new Date(req.requestedAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div class="flex items-center gap-1.5">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="text-destructive text-body h-7 max-md:h-10"
+                          onClick={() => cancelSentRequest(req.handle)}
+                        >
+                          Cancel
                         </Button>
                       </div>
                     </div>

--- a/osn/social/src/pages/SearchPage.tsx
+++ b/osn/social/src/pages/SearchPage.tsx
@@ -2,7 +2,6 @@ import { useAuth } from "@osn/client/solid";
 import { Input } from "@osn/ui/ui/input";
 import { For, onMount, Show } from "solid-js";
 
-import { IconSearch } from "../components/nav";
 import { OrganisationLink, PersonRow, useSearchActions } from "../components/SearchResultRows";
 import { createSearchController } from "../lib/search";
 
@@ -45,17 +44,22 @@ export function SearchPage() {
           <label class="sr-only" for="search-page-input">
             Search people and organisations
           </label>
+          <span
+            class="text-muted-foreground pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-sm"
+            aria-hidden="true"
+          >
+            @
+          </span>
           <Input
             ref={inputRef}
             id="search-page-input"
             type="search"
             autocomplete="off"
             placeholder="Search by name or @handle"
-            class="rounded-pill h-11 pl-9"
+            class="rounded-pill h-11 pl-8"
             value={controller.query()}
             onInput={(event) => controller.setQuery(event.currentTarget.value)}
           />
-          <IconSearch class="text-subtle pointer-events-none absolute top-3.5 left-3 h-4 w-4" />
         </div>
 
         <Show

--- a/osn/social/tests/components/ConnectionsPage.test.tsx
+++ b/osn/social/tests/components/ConnectionsPage.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   listConnections: vi.fn(),
   listPendingRequests: vi.fn(),
+  listSentRequests: vi.fn(),
   listBlocks: vi.fn(),
   removeConnection: vi.fn(),
   acceptConnection: vi.fn(),
@@ -65,6 +66,7 @@ async function renderConnectionsPage() {
     connections: [{ handle: "bob", displayName: "Bob Jones" }],
   });
   mocks.listPendingRequests.mockResolvedValue({ pending: [] });
+  mocks.listSentRequests.mockResolvedValue({ sent: [] });
   mocks.listBlocks.mockResolvedValue({ blocks: [] });
   mocks.removeConnection.mockResolvedValue(undefined);
 
@@ -129,5 +131,32 @@ describe("<ConnectionsPage /> — remove friend confirmation", () => {
 
     expect(mocks.removeConnection).toHaveBeenCalledTimes(1);
     expect(mocks.removeConnection).toHaveBeenCalledWith("tkn", "bob");
+  });
+});
+
+describe("<ConnectionsPage /> — sent requests", () => {
+  it("shows outgoing requests under the Sent tab and cancels via removeConnection", async () => {
+    await renderConnectionsPage();
+    mocks.listSentRequests.mockResolvedValue({
+      sent: [
+        { handle: "carol", displayName: "Carol Smith", requestedAt: new Date().toISOString() },
+      ],
+    });
+
+    fireEvent.click(screen.getByText("Sent"));
+    await screen.findByText("Carol Smith");
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(mocks.removeConnection).toHaveBeenCalledTimes(1);
+    expect(mocks.removeConnection).toHaveBeenCalledWith("tkn", "carol");
+  });
+
+  it("shows an empty state when there are no outgoing requests", async () => {
+    await renderConnectionsPage();
+
+    fireEvent.click(screen.getByText("Sent"));
+    const emptyState = await screen.findByText("No outgoing connection requests.");
+    expect(emptyState).toBeDefined();
   });
 });

--- a/osn/social/tests/components/GlobalSearch.test.tsx
+++ b/osn/social/tests/components/GlobalSearch.test.tsx
@@ -76,6 +76,13 @@ afterEach(() => {
 });
 
 describe("<GlobalSearch />", () => {
+  it("renders a decorative @ prefix ahead of the input", () => {
+    renderSearch();
+    const prefix = screen.getByText("@", { selector: "span" });
+    expect(prefix).toBeDefined();
+    expect(prefix.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("does not query the API for a query that normalises to nothing", async () => {
     renderSearch();
     // A bare sigil leaves no query at all. One real character does search —

--- a/osn/social/tests/components/SearchPage.test.tsx
+++ b/osn/social/tests/components/SearchPage.test.tsx
@@ -93,6 +93,13 @@ afterEach(() => {
 });
 
 describe("<SearchPage />", () => {
+  it("renders a decorative @ prefix ahead of the input", () => {
+    renderPage();
+    const prefix = screen.getByText("@", { selector: "span" });
+    expect(prefix).toBeDefined();
+    expect(prefix.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("prompts before searching, and searches from the first character", async () => {
     renderPage();
     expect(screen.getByText(/Start typing to find people/)).toBeDefined();

--- a/wiki/TODO.md
+++ b/wiki/TODO.md
@@ -126,6 +126,7 @@ The review found these sound: the token-verification core (audience enforced ins
 
 ## OSN Core (`osn/api`)
 
+- [x] **Sent connection requests were invisible to the sender (2026-08-07).** `listPendingRequests` is addressee-only by design and `listConnections` only returns accepted rows, so a sender had no page anywhere in `@osn/social` that showed their own outstanding requests — the send toast was the only trace, and it was gone on navigation. Added `graph.listOutgoingRequests` + `GET /graph/connections/sent` (`osn/api`), `listSentRequests` (`osn/client`), and a "Sent" tab with Cancel on `ConnectionsPage` (`osn/social`, reuses `removeConnection`, which already cancels a pending request in either direction). See [[social-graph]].
 - [x] Multi-account profile CRUD (P3) — create/delete/set-default profiles, maxProfiles enforcement, cascade delete, observability
 - [x] Multi-account client SDK (P4) — multi-session storage, profile switching, schema validation, security hardening
 - [x] Multi-account UI (P5) — profile switcher component, create form, onboarding

--- a/wiki/systems/social-graph.md
+++ b/wiki/systems/social-graph.md
@@ -17,7 +17,7 @@ related:
 packages:
   - "@osn/api"
   - "@osn/db"
-last-reviewed: 2026-08-02
+last-reviewed: 2026-08-07
 ---
 
 # Social Graph
@@ -38,6 +38,21 @@ A connection is a mutual relationship between two users. It requires both partie
 - The recipient can accept or decline
 - The sender can cancel a pending request
 - Either party can remove an accepted connection
+
+**List asymmetry (by design, not a bug):** `listPendingRequests` /
+`GET /graph/connections/pending` returns only requests *received* by the
+caller (`addresseeId = caller`); it never includes ones the caller sent.
+`listConnections` / `GET /graph/connections` returns only `status: "accepted"`
+rows. Until 2026-08-07 this meant a sender had no page anywhere in
+`@osn/social` that showed their own outstanding requests — reported as "I
+connected with someone and it didn't work, don't see it in pending or
+accepted," even though the request was persisted and visible on the
+recipient's side the whole time. Fixed by adding the symmetric
+`listOutgoingRequests` / `GET /graph/connections/sent` (filters
+`requesterId = caller AND status = "pending"`) and a "Sent" tab on
+`ConnectionsPage` in `@osn/social`, whose Cancel action reuses
+`removeConnection` (it already cancels a pending request in either
+direction — no new endpoint needed for cancel).
 
 ### Blocks (unidirectional)
 


### PR DESCRIPTION
## Summary
- Fix: a sent connection request was persisted correctly but invisible to the sender everywhere in `@osn/social` — `listPendingRequests` is addressee-only by design and `listConnections` only returns accepted rows, so there was no page showing a user's own outstanding requests. Adds `graph.listOutgoingRequests` + `GET /graph/connections/sent` (`@osn/api`), `listSentRequests` (`@osn/client`), and a "Sent" tab with Cancel on `ConnectionsPage` (`@osn/social`).
- Adds a prepended "@" inside the existing pill-styled search inputs (`GlobalSearch`, `SearchPage`), replacing the magnifying-glass icon, reusing `@osn/ui`'s `UsernameInput` `@`-prefix visual token.

## Workspaces affected
- `@osn/api`, `@osn/client`, `@osn/social`

## Decisions & issues

**[bug] Root cause of "I connected with someone and it didn't work"**
- **Issue:** `listPendingRequests` (`GET /graph/connections/pending`) filters `addresseeId = caller` only — by design, per an existing regression test (`does not include outgoing requests`). `listConnections` only returns `status: "accepted"` rows. A sent request has neither, so it was invisible to its own sender everywhere in the product; the only trace was a toast that disappeared on navigation.
- **Why:** This reads exactly like "the request silently failed" from the sender's side, even though it was correctly delivered and fully visible to the recipient.
- **Solution:** Added the symmetric list — `listOutgoingRequests` filters `requesterId = caller AND status = 'pending'` — exposed as `GET /graph/connections/sent`, and a "Sent" tab on `ConnectionsPage`. Cancel reuses the existing `removeConnection`, which already cancels a pending request from either side — no new endpoint needed for that half.
- **Rationale:** Mirrors the existing `/pending` endpoint's shape (query, auth, pagination, response projection) exactly, so it inherits the same tested behavior rather than introducing a new pattern.

**[design] `UsernameInput` component wasn't a clean drop-in for the search bar**
- **Issue:** The ask was to reuse `@osn/ui`'s `UsernameInput` component in `@osn/social`. Its only existing consumers are registration/handle-claim forms with an availability-check `status` (checking/available/taken); the search inputs match by display name too, not just handle, and `UsernameInput`'s markup renders the `@` glyph as a separate flex item outside a bordered `Input` box, not inside a single pill-shaped control — incompatible with keeping the search bar's current single-pill look.
- **Why:** A literal `<UsernameInput>` swap would either drop the pill styling or awkwardly wire up availability-check machinery for a live multi-entity combobox.
- **Solution:** Reused `UsernameInput`'s own `@`-prefix visual token (`aria-hidden`, muted-foreground span) directly inside the existing pill markup in `GlobalSearch.tsx`/`SearchPage.tsx`, replacing the search icon, instead of instantiating the component itself.
- **Rationale:** Preserves the requested "keep the current styling" constraint while still visually matching the established `@`-prefix convention `UsernameInput` introduced.

**[test-coverage] Two gaps found during prep-pr review, both closed**
- **Issue (T-U1):** `listSentRequests` (new `@osn/client` method) had no direct unit test — the sibling `listPendingRequests` does.
- **Why:** The client is the layer that turns a wrong URL/header/query-param into a silent failure; `ConnectionsPage.test.tsx` mocks the client directly, so it never exercises the real `fetch` call.
- **Solution:** Added a test mirroring the existing `listPendingRequests` coverage (URL, auth header, query-param serialisation, error surfacing).
- **Rationale:** Matches the project's one-test-per-client-method convention.
- **Issue (T-S1):** No test asserted the new "@" prefix actually renders.
- **Why:** Low risk (decorative, `aria-hidden`) but no regression guard if it were silently dropped.
- **Solution:** Added a render assertion in both `GlobalSearch.test.tsx` and `SearchPage.test.tsx`.
- **Rationale:** Cheap, matches "lock in visible product surface" convention.

**[perf, no action] P-I1 — `listOutgoingRequests` has no composite index on `(requesterId, status)`**
- **Issue:** The new query filters `requesterId = ? AND status = 'pending'` against only a single-column index on `requesterId`.
- **Why:** Flagged by the performance review as a theoretical scan-per-row-on-status cost.
- **Solution:** None taken.
- **Rationale:** This is a byte-for-byte structural mirror of the pre-existing, already-shipped `listPendingRequests` (same gap on `(addresseeId, status)`), bounded by `clampLimit` (max 100) like every list endpoint in the file, and per-user row counts are small. Not a regression introduced by this diff — the reviewer's own conclusion was "no action required."

**[scope] Split out of a larger branch**
- **Issue:** This work originally shared a branch with an unrelated `@cire/web`→`@cire/invites` / `@cire/organiser`→`@cire/host` package rename.
- **Solution:** Split into two PRs off the same `main` commit; the rename is in #392.
- **Rationale:** Requested explicitly during PR prep — unrelated domains, independent review/merge.

## Test plan
- [x] `bun run check` — all 25 packages, 0 errors
- [x] `bun run test` — all 31 packages, all passing
- [x] `bun run fmt:check` / `bun run lint` — clean
- [x] `scripts/validate-changesets.sh` — valid
- [x] Performance review — 1 informational finding (P-I1), no action needed (see above)
- [x] Security + compliance review — no findings
- [ ] Manual: sign in as two accounts, send a connection request from A→B, confirm it now appears under A's "Sent" tab with a working Cancel, and B's "Pending" tab as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDMei4dPMVMbBuuX2GtEGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDMei4dPMVMbBuuX2GtEGu)_