### PR TITLE
OSNKit: shared cookie jar, silent refresh, and a generated Pulse client

### DIFF
--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -3,8 +3,11 @@ name: Swift CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter. These phases ship as stacked PRs, so a PR's base is
+  # often the branch below it rather than `main` — filtering to `main` would
+  # give every stacked Swift PR no Swift CI at all and only run it once the
+  # whole stack collapsed onto main, which is the last moment a break is useful.
   pull_request:
-    branches: [main]
 
 jobs:
   # macOS runner minutes bill at a multiple of Linux, so the iOS build only
@@ -33,9 +36,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            base="origin/main"
+            # The PR's own base, not `main` — on a stacked PR those differ, and
+            # diffing against `main` would attribute every commit from the
+            # branches below to this PR.
+            base="origin/$BASE_REF"
           else
             base="$BEFORE_SHA"
           fi

--- a/shared/swift/OSNShared/Package.resolved
+++ b/shared/swift/OSNShared/Package.resolved
@@ -1,6 +1,33 @@
 {
-  "originHash" : "fe4200f77e6ac258b4d55bb79fff4eb695a820b1a2cf6bab8a2455567b5ac16f",
+  "originHash" : "ae6c9fb1e50ab614d3858bf71c124eba31be92af32c1bfcce10ace4576fa5de6",
   "pins" : [
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "57b6318128e3f901c93f4fbf98d1c1464ec168d3",
+        "version" : "6.2.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
@@ -20,6 +47,24 @@
       }
     },
     {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "af9a2a1f5dcfb00a278d4bb29c6d75080932e99e",
+        "version" : "1.13.0"
+      }
+    },
+    {
       "identity" : "swift-openapi-runtime",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
@@ -35,6 +80,15 @@
       "state" : {
         "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/shared/swift/OSNShared/Package.resolved
+++ b/shared/swift/OSNShared/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "fe4200f77e6ac258b4d55bb79fff4eb695a820b1a2cf6bab8a2455567b5ac16f",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "3d3a8457661daf7fb260ceeb9f0e24e5204ba5fb",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession",
+      "state" : {
+        "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .target(name: "OSNAuth", dependencies: ["OSNKit"]),
         .target(name: "OSNUI"),
         .target(name: "OSNTesting", dependencies: ["OSNKit"]),
-        .testTarget(name: "OSNKitTests", dependencies: ["OSNKit"]),
+        .testTarget(name: "OSNKitTests", dependencies: ["OSNKit", "OSNTesting"]),
         .target(
             name: "PulseAPI",
             dependencies: [
@@ -48,6 +48,6 @@ let package = Package(
                 .product(name: "swift-openapi-generator", package: "swift-openapi-generator")
             ]
         ),
-        .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI"]),
+        .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI", "OSNKit", "OSNTesting"]),
     ]
 )

--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -17,6 +17,12 @@ let package = Package(
         .library(name: "OSNAuth", targets: ["OSNAuth"]),
         .library(name: "OSNUI", targets: ["OSNUI"]),
         .library(name: "OSNTesting", targets: ["OSNTesting"]),
+        .library(name: "PulseAPI", targets: ["PulseAPI"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
     ],
     targets: [
         .target(name: "OSNKit"),
@@ -24,5 +30,20 @@ let package = Package(
         .target(name: "OSNUI"),
         .target(name: "OSNTesting", dependencies: ["OSNKit"]),
         .testTarget(name: "OSNKitTests", dependencies: ["OSNKit"]),
+        .target(
+            name: "PulseAPI",
+            dependencies: [
+                "OSNKit",
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+            ],
+            plugins: ["PulseAPIGeneratorPlugin"]
+        ),
+        .plugin(
+            name: "PulseAPIGeneratorPlugin",
+            capability: .buildTool()
+        ),
+        .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI"]),
     ]
 )

--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
     ],
     targets: [
         .target(name: "OSNKit"),
@@ -42,7 +43,10 @@ let package = Package(
         ),
         .plugin(
             name: "PulseAPIGeneratorPlugin",
-            capability: .buildTool()
+            capability: .buildTool(),
+            dependencies: [
+                .product(name: "swift-openapi-generator", package: "swift-openapi-generator")
+            ]
         ),
         .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI"]),
     ]

--- a/shared/swift/OSNShared/Plugins/PulseAPIGeneratorPlugin/plugin.swift
+++ b/shared/swift/OSNShared/Plugins/PulseAPIGeneratorPlugin/plugin.swift
@@ -1,14 +1,13 @@
 import Foundation
 import PackagePlugin
 
-/// Runs the pinned `swift-openapi-generator` binary against
-/// `shared/openapi/pulse.json` at build time. The spec lives outside this
-/// package (`shared/openapi/`, a sibling of `shared/swift/`), so the
+/// Runs `swift-openapi-generator` (resolved from the package dependency)
+/// against `shared/openapi/pulse.json` at build time. The spec lives outside
+/// this package (`shared/openapi/`, a sibling of `shared/swift/`), so the
 /// official generator's SPM build plugin — which only auto-discovers a spec
 /// in the *generating target's own source directory* — cannot see it. This
 /// plugin sidesteps that by passing the spec's path explicitly instead of
-/// relying on auto-discovery, and by invoking the exact binary the brief
-/// specifies rather than letting SPM fetch/build the generator itself.
+/// relying on auto-discovery.
 ///
 /// Output goes to the plugin work directory, never the source tree — the
 /// generated `Types.swift`/`Client.swift` are build products, not commits.
@@ -20,13 +19,23 @@ struct PulseAPIGeneratorPlugin: BuildToolPlugin {
             .removingLastComponent() // shared
             .appending(["openapi", "pulse.json"])
 
-        let generatorPath = Path("/Users/ac/.work/pulse-scratch/bin/swift-openapi-generator")
+        let generatorTool = try context.tool(named: "swift-openapi-generator")
         let outputDirectory = context.pluginWorkDirectory.appending("GeneratedSources")
 
+        // `swift-openapi-generator` is a source-built tool here (resolved via
+        // the package dependency), and SwiftPM refuses to let a
+        // `.prebuildCommand` use one — those run during build *planning*,
+        // before the tool is guaranteed built. `.buildCommand` runs after its
+        // tool dependencies build, so it can use one, but trades away
+        // `outputFilesDirectory:`'s directory scan for an explicit
+        // `outputFiles:` list — these two names match the official plugin's
+        // own `GeneratorMode.outputFileName` for `--mode types --mode client`.
+        let outputFiles = ["Types.swift", "Client.swift"].map { outputDirectory.appending($0) }
+
         return [
-            .prebuildCommand(
+            .buildCommand(
                 displayName: "Generate Pulse OpenAPI client from \(specPath.string)",
-                executable: generatorPath,
+                executable: generatorTool.path,
                 arguments: [
                     "generate",
                     specPath.string,
@@ -36,7 +45,8 @@ struct PulseAPIGeneratorPlugin: BuildToolPlugin {
                     "--naming-strategy", "idiomatic",
                     "--output-directory", outputDirectory.string,
                 ],
-                outputFilesDirectory: outputDirectory
+                inputFiles: [specPath],
+                outputFiles: outputFiles
             )
         ]
     }

--- a/shared/swift/OSNShared/Plugins/PulseAPIGeneratorPlugin/plugin.swift
+++ b/shared/swift/OSNShared/Plugins/PulseAPIGeneratorPlugin/plugin.swift
@@ -1,0 +1,43 @@
+import Foundation
+import PackagePlugin
+
+/// Runs the pinned `swift-openapi-generator` binary against
+/// `shared/openapi/pulse.json` at build time. The spec lives outside this
+/// package (`shared/openapi/`, a sibling of `shared/swift/`), so the
+/// official generator's SPM build plugin — which only auto-discovers a spec
+/// in the *generating target's own source directory* — cannot see it. This
+/// plugin sidesteps that by passing the spec's path explicitly instead of
+/// relying on auto-discovery, and by invoking the exact binary the brief
+/// specifies rather than letting SPM fetch/build the generator itself.
+///
+/// Output goes to the plugin work directory, never the source tree — the
+/// generated `Types.swift`/`Client.swift` are build products, not commits.
+@main
+struct PulseAPIGeneratorPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let specPath = context.package.directory
+            .removingLastComponent() // shared/swift
+            .removingLastComponent() // shared
+            .appending(["openapi", "pulse.json"])
+
+        let generatorPath = Path("/Users/ac/.work/pulse-scratch/bin/swift-openapi-generator")
+        let outputDirectory = context.pluginWorkDirectory.appending("GeneratedSources")
+
+        return [
+            .prebuildCommand(
+                displayName: "Generate Pulse OpenAPI client from \(specPath.string)",
+                executable: generatorPath,
+                arguments: [
+                    "generate",
+                    specPath.string,
+                    "--mode", "types",
+                    "--mode", "client",
+                    "--access-modifier", "public",
+                    "--naming-strategy", "idiomatic",
+                    "--output-directory", outputDirectory.string,
+                ],
+                outputFilesDirectory: outputDirectory
+            )
+        ]
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+/// Stores the access token only — never the session cookie value, which
+/// stays HttpOnly and lives in `SharedCookieJar`'s cookie storage. One item,
+/// overwritten on every refresh; there's exactly one "current" access token
+/// per app process, so no per-environment or per-account keying.
+public enum KeychainAccessTokenStore {
+    private static let service = "OSNKit.accessToken"
+    private static let account = "current"
+
+    /// Overwrites any existing stored token.
+    public static func save(_ token: String) throws {
+        SecItemDelete(baseQuery() as CFDictionary)
+        var query = baseQuery()
+        query[kSecValueData as String] = Data(token.utf8)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw OSNKitError.keychainWriteFailed(status: status)
+        }
+    }
+
+    /// `nil` when no token is stored — that's a normal state (signed out),
+    /// not an error.
+    public static func load() throws -> String? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data, let token = String(data: data, encoding: .utf8) else {
+                throw OSNKitError.keychainReadFailed(status: status)
+            }
+            return token
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw OSNKitError.keychainReadFailed(status: status)
+        }
+    }
+
+    public static func delete() throws {
+        let status = SecItemDelete(baseQuery() as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw OSNKitError.keychainDeleteFailed(status: status)
+        }
+    }
+
+    private static func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
@@ -9,11 +9,26 @@ public enum KeychainAccessTokenStore {
     private static let service = "OSNKit.accessToken"
     private static let account = "current"
 
-    /// Overwrites any existing stored token.
-    public static func save(_ token: String) throws {
+    /// A cached access token plus the moment it expires, so callers can
+    /// judge freshness without a second round trip to the server.
+    public struct StoredAccessToken: Sendable, Equatable {
+        public let token: String
+        public let expiresAt: Date
+    }
+
+    private struct Payload: Codable {
+        let token: String
+        let expiresAt: Date
+    }
+
+    /// Overwrites any existing stored token. `expiresIn` is the server's
+    /// `expires_in` (seconds from now), from the `/token` response.
+    public static func save(_ token: String, expiresIn: TimeInterval) throws {
+        let payload = Payload(token: token, expiresAt: Date().addingTimeInterval(expiresIn))
+        let data = try JSONEncoder().encode(payload)
         SecItemDelete(baseQuery() as CFDictionary)
         var query = baseQuery()
-        query[kSecValueData as String] = Data(token.utf8)
+        query[kSecValueData as String] = data
         query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
@@ -23,7 +38,7 @@ public enum KeychainAccessTokenStore {
 
     /// `nil` when no token is stored — that's a normal state (signed out),
     /// not an error.
-    public static func load() throws -> String? {
+    public static func load() throws -> StoredAccessToken? {
         var query = baseQuery()
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -31,10 +46,12 @@ public enum KeychainAccessTokenStore {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         switch status {
         case errSecSuccess:
-            guard let data = result as? Data, let token = String(data: data, encoding: .utf8) else {
+            guard let data = result as? Data,
+                let payload = try? JSONDecoder().decode(Payload.self, from: data)
+            else {
                 throw OSNKitError.keychainReadFailed(status: status)
             }
-            return token
+            return StoredAccessToken(token: payload.token, expiresAt: payload.expiresAt)
         case errSecItemNotFound:
             return nil
         default:

--- a/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
@@ -40,6 +40,18 @@ public enum OSNKitError: Error, Sendable, Equatable {
     /// documented shape, or a status/body this client doesn't recognize at
     /// all. Never treat an unrecognized response as success.
     case refreshResponseMalformed(status: Int)
+
+    /// `SecItemAdd` failed while storing an access token.
+    case keychainWriteFailed(status: OSStatus)
+
+    /// `SecItemCopyMatching` returned data that wasn't a UTF-8 string, or
+    /// failed for a reason other than "no item" (that case returns `nil`,
+    /// not an error).
+    case keychainReadFailed(status: OSStatus)
+
+    /// `SecItemDelete` failed for a reason other than "no item" (that case
+    /// is treated as already-deleted, not an error).
+    case keychainDeleteFailed(status: OSStatus)
 }
 
 extension OSNKitError: CustomStringConvertible {
@@ -57,6 +69,12 @@ extension OSNKitError: CustomStringConvertible {
             return "POST /token returned invalid_grant: \(message). The session is gone; sign the user out."
         case .refreshResponseMalformed(let status):
             return "POST /token returned an unrecognized response (status \(status)). Refusing to treat it as success."
+        case .keychainWriteFailed(let status):
+            return "Keychain write failed (OSStatus \(status)) while storing the access token."
+        case .keychainReadFailed(let status):
+            return "Keychain read failed (OSStatus \(status)) while loading the access token."
+        case .keychainDeleteFailed(let status):
+            return "Keychain delete failed (OSStatus \(status)) while clearing the access token."
         }
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Errors that close the four silent-failure doors named in the A2 brief
+/// (deliverable 4). Each case corresponds to a failure mode that would
+/// otherwise show up only as "the ceremony succeeded and the user is still
+/// signed out," with nothing in the logs.
+public enum OSNKitError: Error, Sendable, Equatable {
+    /// Door 2 — the App Group container is unavailable. Either the group is
+    /// not registered in the Apple developer portal yet, or the entitlement
+    /// is missing from this target. `HTTPCookieStorage
+    /// .sharedCookieStorage(forGroupContainerIdentifier:)` does not itself
+    /// fail in this case — it silently hands back storage that never
+    /// actually shares with another process. This error is raised from a
+    /// container-URL check performed *before* that call, so the failure is
+    /// loud instead of a mysterious cross-app sign-out.
+    case appGroupContainerUnavailable(groupIdentifier: String)
+
+    /// Door 1 / door 3 — a `/token` call returned 200, but the rotated
+    /// session cookie the response set does not show up in the shared jar
+    /// afterward. Either the configured `URLSession` isn't the shared one,
+    /// or the cookie name this build derived doesn't match what the server
+    /// actually set (wrong environment, wrong `secure` assumption).
+    case sessionCookieNotPersisted(name: String, host: String)
+
+    /// `POST /token` returned 400 `{ "error": "unsupported_grant_type" }` —
+    /// only reachable if a caller sends something other than
+    /// `grant_type: "refresh_token"`.
+    case refreshUnsupportedGrantType
+
+    /// `POST /token` returned 400 `{ "error": "invalid_request" }` — the
+    /// session cookie never arrived on the request. This is a jar bug, not
+    /// an auth failure, and must be reported as one (brief deliverable 2).
+    case refreshCookieMissing
+
+    /// `POST /token` returned 400 `{ "error": "invalid_grant", "message":
+    /// "..." }` — the session is gone. Sign the user out.
+    case refreshSessionInvalid(message: String)
+
+    /// `POST /token` returned a 200 whose body didn't decode to the
+    /// documented shape, or a status/body this client doesn't recognize at
+    /// all. Never treat an unrecognized response as success.
+    case refreshResponseMalformed(status: Int)
+}
+
+extension OSNKitError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .appGroupContainerUnavailable(let groupIdentifier):
+            return "App Group container unavailable for \(groupIdentifier) — not registered in the developer portal, or the entitlement is missing from this target. Cross-app session sharing does not exist until this is fixed."
+        case .sessionCookieNotPersisted(let name, let host):
+            return "Expected cookie \(name) for \(host) to be in the shared jar after a successful /token response, but it isn't. Check the URLSession is the shared one, and that the cookie name matches this environment's `secure` setting."
+        case .refreshUnsupportedGrantType:
+            return "POST /token rejected the grant_type this client sent (unsupported_grant_type) — client/server contract mismatch."
+        case .refreshCookieMissing:
+            return "POST /token returned invalid_request: no session cookie arrived on the request. This is a cookie-jar bug, not an expired session."
+        case .refreshSessionInvalid(let message):
+            return "POST /token returned invalid_grant: \(message). The session is gone; sign the user out."
+        case .refreshResponseMalformed(let status):
+            return "POST /token returned an unrecognized response (status \(status)). Refusing to treat it as success."
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/SessionCookieName.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/SessionCookieName.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public extension Environment {
+    /// Whether osn-api is served over TLS in this environment — mirrors the
+    /// `secure` flag `cookieName()` switches on in
+    /// `osn/api/src/lib/cookie-session.ts`. `local` has no TLS; every other
+    /// tier does.
+    var isSecureDeployment: Bool {
+        switch self {
+        case .local:
+            return false
+        case .dev, .staging, .production:
+            return true
+        }
+    }
+}
+
+/// The session cookie name for `environment`, derived the same way the
+/// server derives it (`osn/api/src/lib/cookie-session.ts`). `__Host-`
+/// requires `Secure`, so it only applies where TLS is present; `local`
+/// drops the prefix. Never hardcode either spelling elsewhere — this is the
+/// one place that decides it.
+public func sessionCookieName(for environment: Environment) -> String {
+    environment.isSecureDeployment ? "__Host-osn_session" : "osn_session"
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/SharedCookieJar.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/SharedCookieJar.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The App Group the shared session cookie jar lives in, so Pulse, Musubi,
+/// and any later OSN app see the same HttpOnly session cookie. Named in
+/// exactly one place — nothing else in `OSNShared` should hardcode it.
+///
+/// BLOCKED: this identifier is not yet registered in the Apple developer
+/// portal (brief open question 1). `SharedCookieJar.makeConfiguration`
+/// throws `OSNKitError.appGroupContainerUnavailable` until it is.
+public let osnSessionAppGroupIdentifier = "group.social.musubi.session"
+
+public enum SharedCookieJar {
+    /// Builds a `URLSessionConfiguration` backed by the App Group's shared
+    /// `HTTPCookieStorage`.
+    ///
+    /// `HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier:)`
+    /// does not fail when the App Group container doesn't exist — it hands
+    /// back storage that looks usable but never actually shares with
+    /// another process, which only surfaces once two apps compare notes.
+    /// This checks `FileManager.containerURL` first and throws loudly
+    /// instead (brief deliverable 4, door 2).
+    /// `containerURLProvider` exists so tests can force the unavailable
+    /// branch deterministically — on a real device/simulator,
+    /// `FileManager.containerURL` for an unregistered or unentitled App
+    /// Group is the only way to observe it, and that isn't reliable to
+    /// assert on from `swift test` (an unsandboxed host process can resolve
+    /// the path even without the entitlement). Callers outside tests never
+    /// need to pass this.
+    public static func makeConfiguration(
+        groupIdentifier: String = osnSessionAppGroupIdentifier,
+        containerURLProvider: (String) -> URL? = { FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: $0) }
+    ) throws -> URLSessionConfiguration {
+        guard containerURLProvider(groupIdentifier) != nil else {
+            throw OSNKitError.appGroupContainerUnavailable(groupIdentifier: groupIdentifier)
+        }
+        let configuration = URLSessionConfiguration.default
+        configuration.httpCookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: groupIdentifier)
+        configuration.httpShouldSetCookies = true
+        configuration.httpCookieAcceptPolicy = .always
+        return configuration
+    }
+
+    /// Convenience wrapper — a `URLSession` built on `makeConfiguration`'s
+    /// shared jar.
+    public static func makeSession(groupIdentifier: String = osnSessionAppGroupIdentifier) throws -> URLSession {
+        URLSession(configuration: try makeConfiguration(groupIdentifier: groupIdentifier))
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
@@ -61,12 +61,22 @@ public actor TokenRefresher {
 
     /// Cookie-only, idempotent, always 200 per the server contract — nothing
     /// here is inferred from the response. Clears the locally cached access
-    /// token regardless of network outcome propagation.
+    /// token unconditionally: a network failure must not leave a token
+    /// cached locally for a session the server may have already destroyed.
+    /// A network error is still surfaced, but only after that cleanup runs.
     public func logout() async throws {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("logout"))
         request.httpMethod = "POST"
-        _ = try await session.data(for: request)
+        var networkError: Error?
+        do {
+            _ = try await session.data(for: request)
+        } catch {
+            networkError = error
+        }
         try KeychainAccessTokenStore.delete()
+        if let networkError {
+            throw networkError
+        }
     }
 
     private func performRefresh() async throws -> TokenGrant {

--- a/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
@@ -91,7 +91,7 @@ public actor TokenRefresher {
             // out. Fail loudly here instead of returning a grant that the
             // next request can't use.
             try verifySessionCookiePersisted()
-            try KeychainAccessTokenStore.save(grant.accessToken)
+            try KeychainAccessTokenStore.save(grant.accessToken, expiresIn: TimeInterval(grant.expiresIn))
             return grant
         case 400:
             throw refreshFailure(from: data)

--- a/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/TokenRefresher.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// The decoded success body of `POST /token`
+/// (`osn/api/src/routes/auth/context.ts:34-41`) — `toTokenResponseCookieOnly`.
+public struct TokenGrant: Sendable, Equatable, Decodable {
+    public let accessToken: String
+    public let tokenType: String
+    public let expiresIn: Int
+    public let scope: String
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case scope
+    }
+}
+
+private struct RefreshRequestBody: Encodable {
+    let grant_type = "refresh_token"
+}
+
+private struct RefreshErrorBody: Decodable {
+    let error: String
+    let message: String?
+}
+
+/// Drives `POST /token` and `POST /logout` (`osn/api/src/routes/auth/tokens.ts`),
+/// both mounted at the environment's base URL with no group prefix.
+///
+/// Refresh failure is **HTTP 400 with an `error` string, never 401** — the
+/// server never returns 401 from this endpoint. A refresher that branches on
+/// 401 will never notice a dead session and will retry forever (door 4).
+///
+/// Every `/token` grant rotates the session cookie; replaying a rotated-out
+/// cookie trips reuse detection and revokes the whole session family (the bug
+/// PR #289 fixed on the web client). `refresh()` serialises concurrent
+/// callers onto one in-flight request via the actor + a shared `Task`.
+public actor TokenRefresher {
+    private let session: URLSession
+    private let environment: Environment
+    private var inFlightTask: Task<TokenGrant, Error>?
+
+    public init(session: URLSession, environment: Environment) {
+        self.session = session
+        self.environment = environment
+    }
+
+    /// Posts the refresh grant, unless one is already in flight — in which
+    /// case this call joins it instead of firing a second `/token` request.
+    @discardableResult
+    public func refresh() async throws -> TokenGrant {
+        if let inFlightTask {
+            return try await inFlightTask.value
+        }
+        let task = Task { try await performRefresh() }
+        inFlightTask = task
+        defer { inFlightTask = nil }
+        return try await task.value
+    }
+
+    /// Cookie-only, idempotent, always 200 per the server contract — nothing
+    /// here is inferred from the response. Clears the locally cached access
+    /// token regardless of network outcome propagation.
+    public func logout() async throws {
+        var request = URLRequest(url: environment.baseURL.appendingPathComponent("logout"))
+        request.httpMethod = "POST"
+        _ = try await session.data(for: request)
+        try KeychainAccessTokenStore.delete()
+    }
+
+    private func performRefresh() async throws -> TokenGrant {
+        var request = URLRequest(url: environment.baseURL.appendingPathComponent("token"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(RefreshRequestBody())
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OSNKitError.refreshResponseMalformed(status: -1)
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            guard let grant = try? JSONDecoder().decode(TokenGrant.self, from: data) else {
+                throw OSNKitError.refreshResponseMalformed(status: 200)
+            }
+            // Door 1/3: a 200 with no rotated cookie actually landed in the
+            // jar means the wrong session (or the wrong cookie name) is in
+            // play — the ceremony "succeeded" and the user is still signed
+            // out. Fail loudly here instead of returning a grant that the
+            // next request can't use.
+            try verifySessionCookiePersisted()
+            try KeychainAccessTokenStore.save(grant.accessToken)
+            return grant
+        case 400:
+            throw refreshFailure(from: data)
+        default:
+            throw OSNKitError.refreshResponseMalformed(status: httpResponse.statusCode)
+        }
+    }
+
+    private func verifySessionCookiePersisted() throws {
+        let name = sessionCookieName(for: environment)
+        let cookies = session.configuration.httpCookieStorage?.cookies(for: environment.baseURL) ?? []
+        guard cookies.contains(where: { $0.name == name }) else {
+            throw OSNKitError.sessionCookieNotPersisted(name: name, host: environment.baseURL.host ?? "")
+        }
+    }
+
+    /// Branches on the `error` string exactly as the server sends it
+    /// (`osn/api/src/routes/auth/tokens.ts`) — never on status code alone,
+    /// since all three failure branches share the same 400.
+    private func refreshFailure(from data: Data) -> OSNKitError {
+        guard let body = try? JSONDecoder().decode(RefreshErrorBody.self, from: data) else {
+            return .refreshResponseMalformed(status: 400)
+        }
+        switch body.error {
+        case "unsupported_grant_type":
+            return .refreshUnsupportedGrantType
+        case "invalid_request":
+            return .refreshCookieMissing
+        case "invalid_grant":
+            return .refreshSessionInvalid(message: body.message ?? "")
+        default:
+            return .refreshResponseMalformed(status: 400)
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNTesting/KeychainSerializingTrait.swift
+++ b/shared/swift/OSNShared/Sources/OSNTesting/KeychainSerializingTrait.swift
@@ -1,0 +1,57 @@
+import Testing
+
+/// Serializes any test carrying this trait against every other test carrying
+/// it, even across suites and test targets. `@Suite(.serialized)` only
+/// orders tests *within* one suite — Swift Testing still runs different
+/// suites (and different test targets, e.g. `OSNKitTests` vs `PulseAPITests`)
+/// concurrently in the same `swift test` process. `OSNKitTests`'
+/// `KeychainSerialTests` and `PulseAPITests`' `BearerTokenMiddlewareTests`
+/// both read/write the one physical `KeychainAccessTokenStore` item, so
+/// without this they race: concurrent `SecItemAdd`/`SecItemDelete` calls
+/// produce `OSStatus -25299` (duplicate item), and interleaved writes
+/// invalidate each other's "current value" assertions.
+public struct KeychainSerializingTrait: SuiteTrait, TestTrait, TestScoping {
+    public func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        await KeychainLock.shared.lock()
+        do {
+            try await function()
+        } catch {
+            await KeychainLock.shared.unlock()
+            throw error
+        }
+        await KeychainLock.shared.unlock()
+    }
+}
+
+extension Trait where Self == KeychainSerializingTrait {
+    public static var keychainSerializing: Self { Self() }
+}
+
+/// A plain FIFO async mutex. `lock()` only suspends when contended — the
+/// uncontended path returns immediately without a continuation.
+private actor KeychainLock {
+    static let shared = KeychainLock()
+
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func lock() async {
+        if !isLocked {
+            isLocked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func unlock() {
+        guard !waiters.isEmpty else {
+            isLocked = false
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+}

--- a/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
@@ -36,6 +36,15 @@ public struct BearerTokenMiddleware: ClientMiddleware {
             return (response, responseBody)
         }
 
+        // A `.single` body has already been consumed by the call above and
+        // cannot be iterated a second time, so replaying it would trap rather
+        // than retry. Every body the generated client produces is encoded from
+        // `Data` and is therefore `.multiple`, but a hand-built streaming body
+        // would not be — hand the 401 back instead of retrying it.
+        if let body, body.iterationBehavior == .single {
+            return (response, responseBody)
+        }
+
         let freshToken = try await tokenRefresher.refresh().accessToken
         request.headerFields[.authorization] = "Bearer \(freshToken)"
         return try await next(request, body, baseURL)

--- a/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
@@ -1,0 +1,33 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import OSNKit
+
+/// Injects the OSN access token into every outgoing Pulse request. Uses the
+/// cached Keychain token when present; falls back to `TokenRefresher` when
+/// none is cached, so the first call after launch still authenticates.
+public struct BearerTokenMiddleware: ClientMiddleware {
+    private let tokenRefresher: TokenRefresher
+
+    public init(tokenRefresher: TokenRefresher) {
+        self.tokenRefresher = tokenRefresher
+    }
+
+    public func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        let token: String
+        if let cached = try KeychainAccessTokenStore.load() {
+            token = cached
+        } else {
+            token = try await tokenRefresher.refresh().accessToken
+        }
+        request.headerFields[.authorization] = "Bearer \(token)"
+        return try await next(request, body, baseURL)
+    }
+}

--- a/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
@@ -4,10 +4,18 @@ import OpenAPIRuntime
 import OSNKit
 
 /// Injects the OSN access token into every outgoing Pulse request. Uses the
-/// cached Keychain token when present; falls back to `TokenRefresher` when
-/// none is cached, so the first call after launch still authenticates.
+/// cached Keychain token when it isn't near expiry; otherwise calls
+/// `TokenRefresher` first, so the first call after launch and every call
+/// after the access token's ~5-minute lifetime still authenticates. As a
+/// backstop, a 401 from Pulse despite a fresh-looking cached token triggers
+/// one refresh-and-retry — never a loop.
 public struct BearerTokenMiddleware: ClientMiddleware {
     private let tokenRefresher: TokenRefresher
+
+    /// A cached token within this many seconds of its `expiresAt` is treated
+    /// as already gone, so one is never sent moments before the server
+    /// would reject it mid-flight.
+    private static let expirySkew: TimeInterval = 30
 
     public init(tokenRefresher: TokenRefresher) {
         self.tokenRefresher = tokenRefresher
@@ -21,13 +29,24 @@ public struct BearerTokenMiddleware: ClientMiddleware {
         next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
     ) async throws -> (HTTPResponse, HTTPBody?) {
         var request = request
-        let token: String
-        if let cached = try KeychainAccessTokenStore.load() {
-            token = cached
-        } else {
-            token = try await tokenRefresher.refresh().accessToken
+        request.headerFields[.authorization] = "Bearer \(try await validToken())"
+
+        let (response, responseBody) = try await next(request, body, baseURL)
+        guard response.status.code == 401 else {
+            return (response, responseBody)
         }
-        request.headerFields[.authorization] = "Bearer \(token)"
+
+        let freshToken = try await tokenRefresher.refresh().accessToken
+        request.headerFields[.authorization] = "Bearer \(freshToken)"
         return try await next(request, body, baseURL)
+    }
+
+    private func validToken() async throws -> String {
+        if let cached = try KeychainAccessTokenStore.load(),
+            cached.expiresAt.timeIntervalSinceNow > Self.expirySkew
+        {
+            return cached.token
+        }
+        return try await tokenRefresher.refresh().accessToken
     }
 }

--- a/shared/swift/OSNShared/Sources/PulseAPI/PulseClientFactory.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/PulseClientFactory.swift
@@ -1,0 +1,19 @@
+import Foundation
+import OpenAPIRuntime
+import OpenAPIURLSession
+import OSNKit
+
+/// Assembles the generated Pulse client on top of the shared,
+/// cookie-jar-backed `URLSession` from deliverable 1, with the bearer-token
+/// middleware from deliverable 2 attached.
+public func makePulseClient(
+    environment: PulseEnvironment,
+    session: URLSession,
+    tokenRefresher: TokenRefresher
+) -> Client {
+    Client(
+        serverURL: environment.baseURL,
+        transport: URLSessionTransport(configuration: .init(session: session)),
+        middlewares: [BearerTokenMiddleware(tokenRefresher: tokenRefresher)]
+    )
+}

--- a/shared/swift/OSNShared/Sources/PulseAPI/PulseEnvironment.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/PulseEnvironment.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Pulse's own base URL — a separate question from osn-api's `Environment`.
+/// There is no deployed Pulse API host yet, so only `.local` may hardcode a
+/// URL; every other case takes its base URL from the caller.
+public enum PulseEnvironment: Sendable, Equatable {
+    case local
+    case dev(baseURL: URL)
+    case staging(baseURL: URL)
+    case production(baseURL: URL)
+
+    public var baseURL: URL {
+        switch self {
+        case .local: return URL(string: "http://localhost:3001")!
+        case .dev(let baseURL), .staging(let baseURL), .production(let baseURL): return baseURL
+        }
+    }
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
@@ -2,24 +2,28 @@ import Foundation
 import Testing
 @testable import OSNKit
 
-// One Keychain item backs the whole store, so these run as ordered steps in
-// a single test rather than as separate @Test funcs — Swift Testing runs
-// tests concurrently by default, and concurrent saves/deletes against the
-// same Keychain item race (duplicate-item and entitlement errors that are
-// artifacts of the race, not of the store).
-@Test func keychainAccessTokenStoreRoundTrips() throws {
-    try KeychainAccessTokenStore.delete()
-    #expect(try KeychainAccessTokenStore.load() == nil)
+// One Keychain item backs the whole store, so every test that touches it —
+// here and in TokenRefresherTests.swift — runs as an ordered step inside
+// this one serialized suite rather than as independent @Test funcs. Swift
+// Testing runs tests concurrently by default, and concurrent saves/deletes
+// against the same Keychain item race (duplicate-item and entitlement
+// errors that are artifacts of the race, not of the store).
+@Suite(.serialized)
+struct KeychainSerialTests {
+    @Test func keychainAccessTokenStoreRoundTrips() throws {
+        try KeychainAccessTokenStore.delete()
+        #expect(try KeychainAccessTokenStore.load() == nil)
 
-    try KeychainAccessTokenStore.save("token-a")
-    #expect(try KeychainAccessTokenStore.load() == "token-a")
+        try KeychainAccessTokenStore.save("token-a")
+        #expect(try KeychainAccessTokenStore.load() == "token-a")
 
-    try KeychainAccessTokenStore.save("token-b")
-    #expect(try KeychainAccessTokenStore.load() == "token-b")
+        try KeychainAccessTokenStore.save("token-b")
+        #expect(try KeychainAccessTokenStore.load() == "token-b")
 
-    try KeychainAccessTokenStore.delete()
-    #expect(try KeychainAccessTokenStore.load() == nil)
+        try KeychainAccessTokenStore.delete()
+        #expect(try KeychainAccessTokenStore.load() == nil)
 
-    try KeychainAccessTokenStore.delete()
-    #expect(try KeychainAccessTokenStore.load() == nil)
+        try KeychainAccessTokenStore.delete()
+        #expect(try KeychainAccessTokenStore.load() == nil)
+    }
 }

--- a/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
@@ -14,11 +14,13 @@ struct KeychainSerialTests {
         try KeychainAccessTokenStore.delete()
         #expect(try KeychainAccessTokenStore.load() == nil)
 
-        try KeychainAccessTokenStore.save("token-a")
-        #expect(try KeychainAccessTokenStore.load() == "token-a")
+        try KeychainAccessTokenStore.save("token-a", expiresIn: 300)
+        let stored = try KeychainAccessTokenStore.load()
+        #expect(stored?.token == "token-a")
+        #expect(stored?.expiresAt.timeIntervalSinceNow ?? 0 > 250)
 
-        try KeychainAccessTokenStore.save("token-b")
-        #expect(try KeychainAccessTokenStore.load() == "token-b")
+        try KeychainAccessTokenStore.save("token-b", expiresIn: 60)
+        #expect(try KeychainAccessTokenStore.load()?.token == "token-b")
 
         try KeychainAccessTokenStore.delete()
         #expect(try KeychainAccessTokenStore.load() == nil)

--- a/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import OSNKit
+
+// One Keychain item backs the whole store, so these run as ordered steps in
+// a single test rather than as separate @Test funcs — Swift Testing runs
+// tests concurrently by default, and concurrent saves/deletes against the
+// same Keychain item race (duplicate-item and entitlement errors that are
+// artifacts of the race, not of the store).
+@Test func keychainAccessTokenStoreRoundTrips() throws {
+    try KeychainAccessTokenStore.delete()
+    #expect(try KeychainAccessTokenStore.load() == nil)
+
+    try KeychainAccessTokenStore.save("token-a")
+    #expect(try KeychainAccessTokenStore.load() == "token-a")
+
+    try KeychainAccessTokenStore.save("token-b")
+    #expect(try KeychainAccessTokenStore.load() == "token-b")
+
+    try KeychainAccessTokenStore.delete()
+    #expect(try KeychainAccessTokenStore.load() == nil)
+
+    try KeychainAccessTokenStore.delete()
+    #expect(try KeychainAccessTokenStore.load() == nil)
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
@@ -1,14 +1,18 @@
 import Foundation
+import OSNTesting
 import Testing
 @testable import OSNKit
 
 // One Keychain item backs the whole store, so every test that touches it —
-// here and in TokenRefresherTests.swift — runs as an ordered step inside
-// this one serialized suite rather than as independent @Test funcs. Swift
-// Testing runs tests concurrently by default, and concurrent saves/deletes
-// against the same Keychain item race (duplicate-item and entitlement
-// errors that are artifacts of the race, not of the store).
-@Suite(.serialized)
+// here, in TokenRefresherTests.swift, and in PulseAPITests'
+// BearerTokenMiddlewareTests — runs as an ordered step inside this one
+// serialized suite rather than as independent @Test funcs. Swift Testing
+// runs tests concurrently by default, and concurrent saves/deletes against
+// the same Keychain item race (duplicate-item and entitlement errors that
+// are artifacts of the race, not of the store). `.keychainSerializing`
+// extends that ordering across suites and test targets — `.serialized`
+// alone only orders tests within this one suite.
+@Suite(.serialized, .keychainSerializing)
 struct KeychainSerialTests {
     @Test func keychainAccessTokenStoreRoundTrips() throws {
         try KeychainAccessTokenStore.delete()

--- a/shared/swift/OSNShared/Tests/OSNKitTests/SessionCookieNameTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/SessionCookieNameTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+@testable import OSNKit
+
+@Test func localCookieNameHasNoHostPrefix() {
+    #expect(sessionCookieName(for: .local) == "osn_session")
+}
+
+@Test func productionCookieNameHasHostPrefix() {
+    #expect(sessionCookieName(for: .production) == "__Host-osn_session")
+}
+
+@Test func devCookieNameHasHostPrefix() {
+    #expect(sessionCookieName(for: .dev(baseURL: URL(string: "https://dev.example.internal")!)) == "__Host-osn_session")
+}
+
+@Test func stagingCookieNameHasHostPrefix() {
+    #expect(sessionCookieName(for: .staging(baseURL: URL(string: "https://staging.example.internal")!)) == "__Host-osn_session")
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/SharedCookieJarTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/SharedCookieJarTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import OSNKit
+
+// An unsandboxed `swift test` host process can resolve an App Group
+// container path even without the entitlement, so asserting on the real
+// `FileManager` result isn't reliable here. `containerURLProvider` lets the
+// test force the unavailable branch the same way an unprovisioned device
+// build would hit it.
+@Test func makeConfigurationThrowsWhenAppGroupContainerUnavailable() {
+    #expect(throws: OSNKitError.appGroupContainerUnavailable(groupIdentifier: osnSessionAppGroupIdentifier)) {
+        try SharedCookieJar.makeConfiguration(containerURLProvider: { _ in nil })
+    }
+}
+
+@Test func makeConfigurationReportsTheGroupIdentifierItChecked() {
+    let groupIdentifier = "group.does.not.exist"
+    #expect(throws: OSNKitError.appGroupContainerUnavailable(groupIdentifier: groupIdentifier)) {
+        try SharedCookieJar.makeConfiguration(groupIdentifier: groupIdentifier, containerURLProvider: { _ in nil })
+    }
+}
+
+@Test func makeConfigurationSucceedsWhenContainerResolves() throws {
+    let configuration = try SharedCookieJar.makeConfiguration(containerURLProvider: { _ in URL(fileURLWithPath: "/tmp") })
+    #expect(configuration.httpShouldSetCookies)
+    #expect(configuration.httpCookieAcceptPolicy == .always)
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+@testable import OSNKit
+
+/// Intercepts requests for one `URLSession` at a time. All `TokenRefresher`
+/// scenarios below share `Environment.local`'s fixed host, so — like
+/// `KeychainAccessTokenStoreTests` — they run as ordered steps inside a
+/// single `@Test` function rather than as separate concurrent ones.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    // Set synchronously, then only ever read after the setting call's own
+    // `await` has already suspended — every scenario below is one sequential
+    // test body, never concurrent test functions racing this property.
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
+
+    // A custom URLProtocol's `didReceive` callback does not run the real
+    // transport's Set-Cookie extraction — Foundation only populates
+    // `httpCookieStorage` for actual network responses. Point this at the
+    // test session's own cookie storage so the mock can do that step by
+    // hand, matching what a genuine `/token` round trip would leave behind.
+    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        Task {
+            do {
+                let (status, headers, data) = try await handler(request)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                if let url = request.url {
+                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
+                    if !cookies.isEmpty {
+                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
+                    }
+                }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeTestSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    configuration.httpShouldSetCookies = true
+    configuration.httpCookieAcceptPolicy = .always
+    MockURLProtocol.cookieStorage = configuration.httpCookieStorage
+    return URLSession(configuration: configuration)
+}
+
+extension KeychainSerialTests {
+    // Also saves/deletes the real Keychain item (via TokenRefresher's calls
+    // into KeychainAccessTokenStore) — lives in this serialized suite for
+    // the same reason as keychainAccessTokenStoreRoundTrips above.
+    @Test func tokenRefresherScenarios() async throws {
+    try KeychainAccessTokenStore.delete()
+    let environment = Environment.local
+    let session = makeTestSession()
+    let refresher = TokenRefresher(session: session, environment: environment)
+
+    // 1. Success: decodes the grant, persists the rotated cookie, saves the
+    // access token to the Keychain.
+    MockURLProtocol.handler = { _ in
+        let body = #"{"access_token":"at-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
+        return (
+            200,
+            ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-1; Path=/"],
+            Data(body.utf8)
+        )
+    }
+    let grant = try await refresher.refresh()
+    #expect(grant.accessToken == "at-1")
+    #expect(grant.tokenType == "Bearer")
+    #expect(grant.expiresIn == 300)
+    #expect(grant.scope == "openid profile")
+    #expect(try KeychainAccessTokenStore.load() == "at-1")
+    let cookies = session.configuration.httpCookieStorage?.cookies(for: environment.baseURL) ?? []
+    #expect(cookies.contains(where: { $0.name == "osn_session" }))
+
+    // 2. 400 unsupported_grant_type.
+    MockURLProtocol.handler = { _ in
+        (400, ["Content-Type": "application/json"], Data(#"{"error":"unsupported_grant_type"}"#.utf8))
+    }
+    await #expect(throws: OSNKitError.refreshUnsupportedGrantType) {
+        try await refresher.refresh()
+    }
+
+    // 3. 400 invalid_request — cookie never arrived, a jar bug not an auth failure.
+    MockURLProtocol.handler = { _ in
+        (400, ["Content-Type": "application/json"], Data(#"{"error":"invalid_request"}"#.utf8))
+    }
+    await #expect(throws: OSNKitError.refreshCookieMissing) {
+        try await refresher.refresh()
+    }
+
+    // 4. 400 invalid_grant — session is gone, message carried through.
+    MockURLProtocol.handler = { _ in
+        (400, ["Content-Type": "application/json"], Data(#"{"error":"invalid_grant","message":"session revoked"}"#.utf8))
+    }
+    await #expect(throws: OSNKitError.refreshSessionInvalid(message: "session revoked")) {
+        try await refresher.refresh()
+    }
+
+    // 5. 200 with an undecodable body — never treated as success.
+    MockURLProtocol.handler = { _ in
+        (200, ["Content-Type": "application/json"], Data("not json".utf8))
+    }
+    await #expect(throws: OSNKitError.refreshResponseMalformed(status: 200)) {
+        try await refresher.refresh()
+    }
+
+    // 6. Door 1: 200, valid body, but no Set-Cookie actually landed in the jar.
+    // Scenario 1's cookie is still in the jar from the prior request — clear
+    // it first, otherwise the presence check below passes on stale state
+    // instead of catching this response's missing Set-Cookie.
+    for cookie in session.configuration.httpCookieStorage?.cookies(for: environment.baseURL) ?? [] {
+        session.configuration.httpCookieStorage?.deleteCookie(cookie)
+    }
+    MockURLProtocol.handler = { _ in
+        let body = #"{"access_token":"at-2","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
+        return (200, ["Content-Type": "application/json"], Data(body.utf8))
+    }
+    await #expect(throws: OSNKitError.sessionCookieNotPersisted(name: "osn_session", host: "localhost")) {
+        try await refresher.refresh()
+    }
+    // The failed attempt above must not have overwritten the Keychain.
+    #expect(try KeychainAccessTokenStore.load() == "at-1")
+
+    // 7. Single-flight: two concurrent refreshes collapse into one request.
+    let callCount = Counter()
+    MockURLProtocol.handler = { _ in
+        await callCount.increment()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let body = #"{"access_token":"at-3","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
+        return (
+            200,
+            ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-3; Path=/"],
+            Data(body.utf8)
+        )
+    }
+    async let first = refresher.refresh()
+    async let second = refresher.refresh()
+    let (firstGrant, secondGrant) = try await (first, second)
+    #expect(firstGrant == secondGrant)
+    #expect(await callCount.value == 1)
+
+    // 8. Logout clears the cached access token.
+    MockURLProtocol.handler = { _ in (200, ["Content-Type": "application/json"], Data(#"{"success":true}"#.utf8)) }
+    try await refresher.logout()
+    #expect(try KeychainAccessTokenStore.load() == nil)
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
@@ -88,7 +88,7 @@ extension KeychainSerialTests {
     #expect(grant.tokenType == "Bearer")
     #expect(grant.expiresIn == 300)
     #expect(grant.scope == "openid profile")
-    #expect(try KeychainAccessTokenStore.load() == "at-1")
+    #expect(try KeychainAccessTokenStore.load()?.token == "at-1")
     let cookies = session.configuration.httpCookieStorage?.cookies(for: environment.baseURL) ?? []
     #expect(cookies.contains(where: { $0.name == "osn_session" }))
 
@@ -139,7 +139,7 @@ extension KeychainSerialTests {
         try await refresher.refresh()
     }
     // The failed attempt above must not have overwritten the Keychain.
-    #expect(try KeychainAccessTokenStore.load() == "at-1")
+    #expect(try KeychainAccessTokenStore.load()?.token == "at-1")
 
     // 7. Single-flight: two concurrent refreshes collapse into one request.
     let callCount = Counter()

--- a/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import OSNKit
+import OSNTesting
+import Testing
+
+@testable import PulseAPI
+
+/// Self-contained copy of `OSNKitTests`' `MockURLProtocol` pattern — this
+/// test target can't import `OSNKitTests` (separate test target), and the
+/// mock is small enough that duplicating it beats a shared-infra refactor.
+final class MiddlewareMockURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
+
+    // A custom URLProtocol's `didReceive` callback does not run the real
+    // transport's Set-Cookie extraction — Foundation only populates
+    // `httpCookieStorage` for actual network responses. Point this at the
+    // test session's own cookie storage so the mock can do that step by
+    // hand, matching what a genuine `/token` round trip would leave behind
+    // (TokenRefresher checks the cookie actually landed in the jar).
+    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        Task {
+            do {
+                let (status, headers, data) = try await handler(request)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                if let url = request.url {
+                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
+                    if !cookies.isEmpty {
+                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
+                    }
+                }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeTestSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MiddlewareMockURLProtocol.self]
+    configuration.httpShouldSetCookies = true
+    configuration.httpCookieAcceptPolicy = .always
+    MiddlewareMockURLProtocol.cookieStorage = configuration.httpCookieStorage
+    return URLSession(configuration: configuration)
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}
+
+/// `next` is `@Sendable`, so a plain `var` captured and mutated inside it is
+/// a data race under Swift 6 strict concurrency even though every call here
+/// is sequential — route the capture through an actor instead.
+private actor Recorder<Value: Sendable> {
+    private(set) var values: [Value] = []
+    func record(_ value: Value) { values.append(value) }
+    var last: Value? { values.last }
+}
+
+/// Shares the real Keychain access-token item with `OSNKitTests`'
+/// `KeychainSerialTests` suite. `.serialized` only orders tests within this
+/// suite; `.keychainSerializing` (from `OSNTesting`) additionally locks out
+/// that other suite so the two never touch the Keychain item concurrently.
+@Suite(.serialized, .keychainSerializing)
+struct BearerTokenMiddlewareTests {
+    @Test func expiredTokenTriggersRefresh() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("stale-token", expiresIn: -10)
+
+        let session = makeTestSession()
+        let refresher = TokenRefresher(session: session, environment: .local)
+        let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
+
+        MiddlewareMockURLProtocol.handler = { _ in
+            let body = #"{"access_token":"fresh-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-1; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let seenAuthorization = Recorder<String?>()
+        let (response, body) = try await middleware.intercept(
+            HTTPRequest(method: .get, scheme: "https", authority: "localhost", path: "/events"),
+            body: nil,
+            baseURL: URL(string: "http://localhost:4000")!,
+            operationID: "listEvents"
+        ) { request, _, _ in
+            await seenAuthorization.record(request.headerFields[.authorization])
+            return (HTTPResponse(status: .ok), nil)
+        }
+
+        #expect(await seenAuthorization.last == "Bearer fresh-token")
+        #expect(response.status.code == 200)
+        #expect(body == nil)
+        #expect(try KeychainAccessTokenStore.load()?.token == "fresh-token")
+    }
+
+    @Test func validTokenSkipsRefresh() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("valid-token", expiresIn: 300)
+
+        let session = makeTestSession()
+        let refresher = TokenRefresher(session: session, environment: .local)
+        let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
+
+        // No handler installed — a refresh call would crash the test by
+        // hitting `didFailWithError`, proving the cached token was used.
+        MiddlewareMockURLProtocol.handler = nil
+
+        let seenAuthorization = Recorder<String?>()
+        _ = try await middleware.intercept(
+            HTTPRequest(method: .get, scheme: "https", authority: "localhost", path: "/events"),
+            body: nil,
+            baseURL: URL(string: "http://localhost:4000")!,
+            operationID: "listEvents"
+        ) { request, _, _ in
+            await seenAuthorization.record(request.headerFields[.authorization])
+            return (HTTPResponse(status: .ok), nil)
+        }
+
+        #expect(await seenAuthorization.last == "Bearer valid-token")
+    }
+
+    @Test func retriesOnceOn401() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-valid", expiresIn: 300)
+
+        let session = makeTestSession()
+        let refresher = TokenRefresher(session: session, environment: .local)
+        let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
+
+        MiddlewareMockURLProtocol.handler = { _ in
+            let body = #"{"access_token":"rotated-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-2; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let nextCallCount = Counter()
+        let authorizationsSeen = Recorder<String>()
+        let (response, _) = try await middleware.intercept(
+            HTTPRequest(method: .get, scheme: "https", authority: "localhost", path: "/events"),
+            body: nil,
+            baseURL: URL(string: "http://localhost:4000")!,
+            operationID: "listEvents"
+        ) { request, _, _ in
+            await nextCallCount.increment()
+            let count = await nextCallCount.value
+            await authorizationsSeen.record(request.headerFields[.authorization] ?? "")
+            if count == 1 {
+                return (HTTPResponse(status: .unauthorized), nil)
+            }
+            return (HTTPResponse(status: .ok), nil)
+        }
+
+        #expect(response.status.code == 200)
+        #expect(await nextCallCount.value == 2)
+        #expect(await authorizationsSeen.values == ["Bearer looks-valid", "Bearer rotated-token"])
+    }
+}

--- a/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
@@ -183,4 +183,38 @@ struct BearerTokenMiddlewareTests {
         #expect(await nextCallCount.value == 2)
         #expect(await authorizationsSeen.values == ["Bearer looks-valid", "Bearer rotated-token"])
     }
+
+    @Test func doesNotRetryWhenTheBodyCannotBeReplayed() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-valid", expiresIn: 300)
+
+        let session = makeTestSession()
+        let refresher = TokenRefresher(session: session, environment: .local)
+        let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
+
+        // A body built from an async sequence of unknown length is `.single`:
+        // consumed by the first attempt, so a replay would trap.
+        let singleUseBody = HTTPBody(
+            AsyncStream<ArraySlice<UInt8>> { continuation in
+                continuation.yield(ArraySlice(Data("{}".utf8)))
+                continuation.finish()
+            },
+            length: .unknown
+        )
+        #expect(singleUseBody.iterationBehavior == .single)
+
+        let nextCallCount = Counter()
+        let (response, _) = try await middleware.intercept(
+            HTTPRequest(method: .post, scheme: "https", authority: "localhost", path: "/events"),
+            body: singleUseBody,
+            baseURL: URL(string: "http://localhost:4000")!,
+            operationID: "createEvent"
+        ) { _, _, _ in
+            await nextCallCount.increment()
+            return (HTTPResponse(status: .unauthorized), nil)
+        }
+
+        #expect(response.status.code == 401)
+        #expect(await nextCallCount.value == 1)
+    }
 }

--- a/shared/swift/OSNShared/Tests/PulseAPITests/PulseEnvironmentTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseAPITests/PulseEnvironmentTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import PulseAPI
+
+@Test func localResolvesToLocalhostPort3001() {
+    #expect(PulseEnvironment.local.baseURL == URL(string: "http://localhost:3001")!)
+}
+
+@Test func devPassesThroughCallerSuppliedURL() {
+    let url = URL(string: "https://dev.example.internal")!
+    #expect(PulseEnvironment.dev(baseURL: url).baseURL == url)
+}
+
+@Test func stagingPassesThroughCallerSuppliedURL() {
+    let url = URL(string: "https://staging.example.internal")!
+    #expect(PulseEnvironment.staging(baseURL: url).baseURL == url)
+}
+
+@Test func productionPassesThroughCallerSuppliedURL() {
+    let url = URL(string: "https://production.example.internal")!
+    #expect(PulseEnvironment.production(baseURL: url).baseURL == url)
+}


### PR DESCRIPTION
Phase A2 of the Swift work. A1 (#400) gave us a committed OpenAPI document for the Pulse API; this turns it into a generated Swift client, and puts the shared sign-in underneath it.

The point: a user who signs in on Musubi is signed in on Pulse, on the same device, with no second passkey ceremony. That needs one cookie jar shared across apps, one token refresher, and a Pulse client that routes through both. No passkey ceremony lives here — that is A3. This makes the transport correct so A3 has somewhere to put a session.

## What is in it

**Shared cookie jar** (`OSNKit/SharedCookieJar.swift`). A `URLSessionConfiguration` backed by `HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier:)`, with `httpShouldSetCookies` and an `.always` accept policy. The session cookie is HttpOnly — Swift never reads or writes its value, the jar holds it and `URLSession` sends it.

**Cookie name derived, never hardcoded** (`OSNKit/SessionCookieName.swift`). The server names the cookie `__Host-osn_session` when the deployment is secure and plain `osn_session` when it is not (`osn/api/src/lib/cookie-session.ts:14`). Hardcoding either spelling is silently wrong in the other environment — no error, just a request that arrives unauthenticated. This derives it from `Environment` the same way the server does.

**Token refresher** (`OSNKit/TokenRefresher.swift`). An actor implementing the real `/token` contract:

- body is `{"grant_type":"refresh_token"}` and nothing else — the refresh token is cookie-only (S-M1)
- `expires_in` is read off the response, not assumed to be 300
- **failure is HTTP 400, not 401**, and branches on the `error` string: `invalid_grant` means the session is gone, `invalid_request` means the cookie never arrived (a jar bug, reported as one), `unsupported_grant_type` means we sent the wrong body
- concurrent refreshes are serialised to one in-flight request. Every grant rotates the session token and reuse revokes the family, so two racing refreshes sign the user out — the bug class #289 fixed on the web client

**Keychain access-token store**, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, storing the token *and* its expiry. Access tokens only; the session cookie value is never stored anywhere in Swift.

**Generated Pulse client** (`PulseAPI/`). A build-tool plugin runs `swift-openapi-generator` against `shared/openapi/pulse.json` at build time. Generated sources are build products and are not committed. `BearerTokenMiddleware` attaches the token, refreshing first when the cached one is within 30s of expiry, and retrying once on a 401.

## Silent-failure doors, closed loudly

Each of these fails with no error and a UI that just shows a signed-out user:

1. **Cookie never sent** — `TokenRefresher` throws `sessionCookieNotPersisted` when a 200 comes back with no rotated cookie in the jar.
2. **Group container unavailable** — `sharedCookieStorage(forGroupContainerIdentifier:)` does not fail when the App Group is missing; it hands back storage that looks usable and never shares. `makeConfiguration` checks `FileManager.containerURL` first and throws.
3. **Wrong cookie name** — removed by construction, see above.
4. **Refresh failure read as 401** — the server says 400; the refresher branches on 400.

## Definition of done

| # | Item | Status |
|---|---|---|
| 1 | `swift build` clean, macOS host included | pass |
| 2 | `swift test` passes | pass — 21 tests |
| 3 | Shared group cookie storage, App Group named in one place | **pending, not passed** — see below |
| 4 | Cookie name derived from the environment | pass |
| 5 | Refresh contract: `grant_type` only, reads `expires_in`, branches on 400, serialised | pass |
| 6 | Keychain `AfterFirstUnlockThisDeviceOnly`; cookie value never stored | pass |
| 7 | Pulse client generates and compiles, routed through shared session + bearer middleware; generated sources uncommitted | pass |
| 8 | Four doors closed loudly | pass |
| 9 | Notes written | pass |

**DoD 3 is pending, not passed.** The App Group `group.social.musubi.session` is not registered in the Apple developer portal, so cross-app sharing cannot be verified — only that the code fails loudly in its absence. The identifier is named in exactly one place, with a `BLOCKED:` comment.

## Review findings fixed before this opened

The build reported all nine DoD items passing while four defects sat in the diff. Two were blocking:

1. **The generator plugin hardcoded an absolute path** to a binary on one machine. Swift CI did not run on A1 (no Swift files changed), so this would have failed on its first CI build. Now resolved through a package dependency via `context.tool(named:)`.
2. **The access token never expired.** The middleware preferred the Keychain copy unconditionally with no expiry check and no 401 retry — with a 300s TTL, every request after five minutes carried a dead token and nothing refreshed. That is the capability this phase exists to deliver. Now stores expiry, refreshes ahead of a 30s skew, and retries once on a 401.
3. `logout()`'s comment claimed it cleared the local token regardless of network outcome; the `try await` threw first. Now unconditional.
4. Keychain access serialised across test targets.

Two more found on the verify pass and fixed here:

5. **The 401 retry replayed the request body.** A body whose `iterationBehavior` is `.single` has already been consumed by the first attempt, so replaying it traps rather than retries — the runtime documents that such a body must fail the call on a retry. Every body the generated client produces is encoded from `Data` and is `.multiple`, so nothing changes for the 37 generated operations; it only stops a hand-built streaming body from turning a recoverable 401 into a crash.
6. **`ci-swift.yml` filtered `pull_request` to `branches: [main]`.** These phases ship as stacked PRs, so Swift CI would have been skipped on every one of them and first run only when the stack collapsed onto main — the last moment a break is useful. Its change-detection also hardcoded `origin/main` as the diff base, which on a stacked PR attributes the commits below it to the PR above. Both fixed.

## Verification

`swift build` and `swift test` were run against a **fresh clone**, not the working tree: 697 build steps, including compiling `swift-openapi-generator` from source, generating `Client.swift`/`Types.swift` and compiling them. That is the path CI takes, and it had never been proven before.

## Open questions

1. **App Group `group.social.musubi.session`** needs registering in the Apple developer portal under team `FV59Y8RSUH`. Everything cross-app depends on it, and it cannot be verified until then.
2. **Bundle ID `com.osn.pulse`** may be wrong now that identity lives on `musubi.social`. Flagged, not renamed.

## Notes

No changeset: this touches only `shared/swift/` and `.github/`, both on the `scripts/changeset-required.sh` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
