### PR TITLE
OSNUI: Pulse tokens, type roles and Liquid Glass primitives

### DIFF
--- a/shared/swift/OSNShared/Sources/OSNUI/AvatarView.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/AvatarView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Circular avatar frame with an optional `closeFriend` ring. The ring is a
+/// state the view resolves for itself (`isCloseFriend`), not a color the
+/// caller passes in — `OSNUI` must not know what "close friend" means beyond
+/// that one token.
+///
+/// Layer: a flat, non-glass frame. Safe on top of any surface, including a
+/// `GlassCard`.
+public struct AvatarView<Content: View>: View {
+    private let isCloseFriend: Bool
+    private let content: Content
+
+    public init(isCloseFriend: Bool = false, @ViewBuilder content: () -> Content) {
+        self.isCloseFriend = isCloseFriend
+        self.content = content()
+    }
+
+    public var body: some View {
+        content
+            .clipShape(Circle())
+            .overlay {
+                if isCloseFriend {
+                    Circle()
+                        .strokeBorder(OSNColor.closeFriend, lineWidth: 2)
+                }
+            }
+    }
+}
+
+#Preview("AvatarView — Light") {
+    HStack(spacing: 16) {
+        AvatarView {
+            Circle().fill(.gray.opacity(0.3))
+        }
+        .frame(width: 48, height: 48)
+
+        AvatarView(isCloseFriend: true) {
+            Circle().fill(.gray.opacity(0.3))
+        }
+        .frame(width: 48, height: 48)
+    }
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("AvatarView — Dark") {
+    HStack(spacing: 16) {
+        AvatarView {
+            Circle().fill(.gray.opacity(0.3))
+        }
+        .frame(width: 48, height: 48)
+
+        AvatarView(isCloseFriend: true) {
+            Circle().fill(.gray.opacity(0.3))
+        }
+        .frame(width: 48, height: 48)
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/Colors.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/Colors.swift
@@ -18,7 +18,10 @@ public enum OSNColor {
     public static let accentStrong = Color(.displayP3, red: 0.7620, green: 0.2939, blue: 0.1632)
 
     /// `--pulse-accent-soft` — oklch(0.95 0.05 45). Pale coral wash; subtle fills.
-    /// Source R channel (1.0651) is out of Display P3 gamut; clamped to 1.0.
+    /// Out of Display P3 gamut on red — linear 1.0650, encoded 1.0280 —
+    /// so R alone is clamped to 1.0. That shifts the hue very slightly
+    /// toward pink rather than desaturating the whole colour, which is the
+    /// right trade for a near-white wash.
     public static let accentSoft = Color(.displayP3, red: 1.0000, green: 0.9031, blue: 0.8386)
 
     /// `--close-friend` — oklch(0.66 0.16 145). Green; close-friend ring state.

--- a/shared/swift/OSNShared/Sources/OSNUI/Colors.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/Colors.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Pulse brand tokens, ported from `pulse/app/src/App.css:56-73` (oklch source).
+/// Conversion: oklch -> OKLab -> linear sRGB (Ottosson matrices) -> XYZ (D65)
+/// -> linear Display P3 -> gamma-encoded (sRGB OETF). Arithmetic and full
+/// output in `a4-notes.md`. `.displayP3` used throughout per brief: these are
+/// wide-gamut values, not representable in sRGB.
+public enum OSNColor {
+    /// `--pulse-accent` — oklch(0.68 0.18 38). Coral; brand mark, hero italic, CTAs.
+    public static let accent = Color(.displayP3, red: 0.8806, green: 0.4389, blue: 0.2824)
+
+    /// `--pulse-accent-strong` — oklch(0.58 0.19 35). Darker coral; pressed/emphasis states.
+    public static let accentStrong = Color(.displayP3, red: 0.7620, green: 0.2939, blue: 0.1632)
+
+    /// `--pulse-accent-soft` — oklch(0.95 0.05 45). Pale coral wash; subtle fills.
+    /// Source R channel (1.0651) is out of Display P3 gamut; clamped to 1.0.
+    public static let accentSoft = Color(.displayP3, red: 1.0000, green: 0.9031, blue: 0.8386)
+
+    /// `--close-friend` — oklch(0.66 0.16 145). Green; close-friend ring state.
+    public static let closeFriend = Color(.displayP3, red: 0.3861, green: 0.6612, blue: 0.3523)
+
+    /// `--badge-live` — oklch(0.72 0.17 22). Red-coral; `LiveBadge` dot.
+    public static let badgeLive = Color(.displayP3, red: 0.9253, green: 0.4804, blue: 0.4675)
+
+    /// `--pulse-accent-fg` — light `oklch(0.99 0.004 80)` / dark `oklch(0.17 0.008 60)`.
+    /// A single scheme-adapting color (no call-site branching): backed by a
+    /// dynamic-provider platform color so it resolves per active trait/appearance.
+    public static let accentForeground: Color = {
+        #if canImport(UIKit)
+        return Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(displayP3Red: 0.0687, green: 0.0579, blue: 0.0482, alpha: 1)
+                : UIColor(displayP3Red: 0.9916, green: 0.9863, blue: 0.9765, alpha: 1)
+        })
+        #elseif canImport(AppKit)
+        return Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return isDark
+                ? NSColor(displayP3Red: 0.0687, green: 0.0579, blue: 0.0482, alpha: 1)
+                : NSColor(displayP3Red: 0.9916, green: 0.9863, blue: 0.9765, alpha: 1)
+        }))
+        #endif
+    }()
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/GlassButton.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/GlassButton.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Primary (accent-filled) or secondary (glass) call to action. Wraps the
+/// SDK's own glass button styles (`GlassProminentButtonStyle` / `GlassButtonStyle`,
+/// exposed as `.glassProminent` / `.glass`) rather than reimplementing the
+/// material by hand.
+///
+/// Layer: its own glass surface. Don't place it inside a `GlassCard` or other
+/// glass container — glass over glass reads as mud. It belongs directly on
+/// opaque content, or as a sibling of other glass controls inside a shared
+/// `GlassEffectContainer`.
+public enum GlassButtonKind {
+    case primary
+    case secondary
+}
+
+public struct GlassButton: View {
+    private let title: String
+    private let kind: GlassButtonKind
+    private let action: () -> Void
+
+    public init(_ title: String, kind: GlassButtonKind = .primary, action: @escaping () -> Void) {
+        self.title = title
+        self.kind = kind
+        self.action = action
+    }
+
+    public var body: some View {
+        switch kind {
+        case .primary:
+            Button(title, action: action)
+                .tint(OSNColor.accent)
+                .buttonStyle(.glassProminent)
+        case .secondary:
+            Button(title, action: action)
+                .buttonStyle(.glass)
+        }
+    }
+}
+
+#Preview("GlassButton — Light") {
+    VStack(spacing: 16) {
+        GlassButton("Join event") {}
+        GlassButton("Not now", kind: .secondary) {}
+    }
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("GlassButton — Dark") {
+    VStack(spacing: 16) {
+        GlassButton("Join event") {}
+        GlassButton("Not now", kind: .secondary) {}
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/GlassButton.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/GlassButton.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+/// Which of the two `GlassButton` treatments to render.
+public enum GlassButtonKind {
+    /// Accent-filled — the one action a screen wants you to take.
+    case primary
+    /// Plain glass — everything else.
+    case secondary
+}
+
 /// Primary (accent-filled) or secondary (glass) call to action. Wraps the
 /// SDK's own glass button styles (`GlassProminentButtonStyle` / `GlassButtonStyle`,
 /// exposed as `.glassProminent` / `.glass`) rather than reimplementing the
@@ -9,11 +17,6 @@ import SwiftUI
 /// glass container — glass over glass reads as mud. It belongs directly on
 /// opaque content, or as a sibling of other glass controls inside a shared
 /// `GlassEffectContainer`.
-public enum GlassButtonKind {
-    case primary
-    case secondary
-}
-
 public struct GlassButton: View {
     private let title: String
     private let kind: GlassButtonKind

--- a/shared/swift/OSNShared/Sources/OSNUI/GlassCard.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/GlassCard.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// The container an event card (or any other content) sits in. Content-agnostic:
+/// takes a `@ViewBuilder`, not a domain model — `OSNUI` must not know what an
+/// event is.
+///
+/// Layer: base glass surface. Sits over opaque content behind it, never over
+/// another glass surface. Placing several `GlassCard`s side by side (a feed, a
+/// grid)? Wrap the group in a `GlassEffectContainer` so they blend and morph as
+/// one instead of each rendering its own separately-lit slab.
+public struct GlassCard<Content: View>: View {
+    private let content: Content
+
+    public init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    public var body: some View {
+        content
+            .padding()
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}
+
+#Preview("GlassCard — Light") {
+    GlassCard {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Rooftop Sundown")
+                .font(.headline)
+            Text("Saturday, 6:00 PM")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("GlassCard — Dark") {
+    GlassCard {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Rooftop Sundown")
+                .font(.headline)
+            Text("Saturday, 6:00 PM")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/LiveBadge.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/LiveBadge.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// The pulsing `badgeLive` dot marking something happening now.
+///
+/// Layer: a flat, non-glass indicator. Safe on top of any surface, including
+/// a `GlassCard`.
+///
+/// Respects Reduce Motion: when `accessibilityReduceMotion` is on, the dot is
+/// static rather than slowed — an animation that never stops is a genuine
+/// accessibility problem for vestibular and attention disorders, not a
+/// preference to merely tone down.
+public struct LiveBadge: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPulsing = false
+
+    public init() {}
+
+    public var body: some View {
+        Circle()
+            .fill(OSNColor.badgeLive)
+            .frame(width: 8, height: 8)
+            .scaleEffect(reduceMotion ? 1 : (isPulsing ? 1.4 : 1))
+            .opacity(reduceMotion ? 1 : (isPulsing ? 0.4 : 1))
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: 0.9).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear {
+                guard !reduceMotion else { return }
+                isPulsing = true
+            }
+            .accessibilityLabel("Live")
+    }
+}
+
+#Preview("LiveBadge — Light") {
+    LiveBadge()
+        .padding()
+        .preferredColorScheme(.light)
+}
+
+#Preview("LiveBadge — Dark") {
+    LiveBadge()
+        .padding()
+        .preferredColorScheme(.dark)
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/OSNUI.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/OSNUI.swift
@@ -1,2 +1,0 @@
-// OSNUI: empty SwiftUI module in A0. Later tasks add shared components here.
-import SwiftUI

--- a/shared/swift/OSNShared/Sources/OSNUI/Pill.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/Pill.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Small mono-type label for categories, status tags and eyebrow text. Takes
+/// a string and a tint — no domain knowledge of what the label means.
+///
+/// Layer: a flat, non-glass fill. Safe on top of any surface, including a
+/// `GlassCard`, since it never introduces its own glass material.
+public struct Pill: View {
+    private let text: String
+    private let tint: Color
+
+    public init(_ text: String, tint: Color) {
+        self.text = text
+        self.tint = tint
+    }
+
+    public var body: some View {
+        Text(text.uppercased())
+            .font(.osn(.mono, size: 11, relativeTo: .caption2))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.15), in: Capsule())
+    }
+}
+
+#Preview("Pill — Light") {
+    HStack {
+        Pill("Live", tint: OSNColor.badgeLive)
+        Pill("Music", tint: OSNColor.accent)
+    }
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("Pill — Dark") {
+    HStack {
+        Pill("Live", tint: OSNColor.badgeLive)
+        Pill("Music", tint: OSNColor.accent)
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/shared/swift/OSNShared/Sources/OSNUI/Typography.swift
+++ b/shared/swift/OSNShared/Sources/OSNUI/Typography.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Type roles named in `pulse/DESIGN.md`. Each resolves to its named family
+/// via `Font.custom(_:size:relativeTo:)`, which scales with Dynamic Type and
+/// (per Apple platform behavior) substitutes the system font at the same
+/// point size when the named family isn't installed — so these roles work
+/// today and sharpen once font files are vendored. Web's fixed px sizes in
+/// `DESIGN.md` are a starting ratio, not copied literally: `size` is left to
+/// call sites, which should pick a `TextStyle`-relative value.
+///
+/// BLOCKED: font files not vendored. Instrument Serif and Geist/Geist Mono
+/// are OFL 1.1 (pulled from Google Fonts in the web app at
+/// `pulse/app/index.html:9`); vendoring the `.ttf`/`.otf` files into this
+/// package and registering them (Info.plist `UIAppFonts` / `CTFontManager`)
+/// is a decision for the app target, not made here. Until then `Font.custom`
+/// falls back to the system font.
+public enum OSNTypeRole {
+    /// Hero headlines, section headers. Family: Instrument Serif.
+    case display
+    /// Navigation, card body, labels, buttons. Family: Geist.
+    case body
+    /// Timestamps, eyebrow text, category tags. Family: Geist Mono.
+    case mono
+}
+
+extension Font {
+    /// Resolves an `OSNTypeRole` to its named family at `size`, scaling with
+    /// Dynamic Type relative to `textStyle`.
+    public static func osn(_ role: OSNTypeRole, size: CGFloat, relativeTo textStyle: Font.TextStyle = .body) -> Font {
+        switch role {
+        case .display:
+            return .custom("Instrument Serif", size: size, relativeTo: textStyle)
+        case .body:
+            return .custom("Geist", size: size, relativeTo: textStyle)
+        case .mono:
+            return .custom("Geist Mono", size: size, relativeTo: textStyle)
+        }
+    }
+}

--- a/shared/swift/OSNShared/a4-notes.md
+++ b/shared/swift/OSNShared/a4-notes.md
@@ -1,0 +1,75 @@
+# A4 notes — OSNUI
+
+Verified/not-verified/BLOCKED per brief section. "It compiles" is not evidence of correctness — flagged where that's all I have.
+
+## Glass API — grepped from real SDK, not inferred
+
+```
+SDK=$(xcrun --sdk macosx --show-sdk-path)
+grep -rn "public struct Glass \|glassEffect(_:in:\|struct GlassEffectContainer\|glassEffectID(_:in:\|glassEffectUnion(id:namespace:\|struct GlassEffectTransition\|struct DefaultGlassEffectShape" \
+  "$SDK/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/"*.swiftinterface
+```
+
+Found in `SwiftUICore` (macOS 26.5 SDK, `arm64e-apple-macos.swiftinterface`):
+
+- `public struct Glass : Swift.Equatable, Swift.Sendable` (line 5753)
+- `public struct GlassEffectContainer<Content> : SwiftUICore.View` (line 9045)
+- `public struct GlassEffectTransition : Swift.Sendable` (line 2847)
+- `public struct DefaultGlassEffectShape : SwiftUICore.Shape` (line 2534)
+- `func glassEffect(_ glass: Glass = .regular, in shape: some Shape = DefaultGlassEffectShape()) -> some View` (line 2529)
+- `func glassEffectTransition(_ transition: GlassEffectTransition) -> some View` (line 2861)
+- `func glassEffectUnion(id: (some (Hashable & Sendable))?, namespace: Namespace.ID) -> some View` (line 9880)
+- `func glassEffectID(_ id: (some (Hashable & Sendable))?, in namespace: Namespace.ID) -> some View` (line 17372)
+
+Found in `SwiftUI` module (button styles):
+
+- `extension PrimitiveButtonStyle where Self == GlassButtonStyle { static var glass: GlassButtonStyle }`
+- `public struct GlassButtonStyle : PrimitiveButtonStyle`
+- `extension PrimitiveButtonStyle where Self == GlassProminentButtonStyle { static var glassProminent: GlassProminentButtonStyle }`
+- `public struct GlassProminentButtonStyle : PrimitiveButtonStyle`
+
+Used: `.glassEffect(.regular, in: RoundedRectangle(cornerRadius: 20, style: .continuous))` in `GlassCard`, `.buttonStyle(.glass)` / `.buttonStyle(.glassProminent)` in `GlassButton`. `GlassEffectContainer` exists and is documented (doc comments on `GlassCard`/`GlassButton` tell callers to group siblings in one) but is **not used** anywhere in this package — no screen assembles multiple glass siblings yet, that's A5's job.
+
+## Token conversion — oklch → Display P3
+
+Method: oklch → OKLab → linear sRGB (Björn Ottosson's published matrices) → CIE XYZ (D65) → linear Display P3 → gamma-encode (sRGB OETF, which Display P3 shares). Computed with a standalone Python script (not committed — one-off arithmetic, not project code), values transcribed into `Colors.swift`.
+
+| Token | oklch source | Display P3 (R, G, B) | Note |
+|---|---|---|---|
+| `accent` | `oklch(0.68 0.18 38)` | `0.8806, 0.4389, 0.2824` | |
+| `accentStrong` | `oklch(0.58 0.19 35)` | `0.7620, 0.2939, 0.1632` | |
+| `accentSoft` | `oklch(0.95 0.05 45)` | `1.0000, 0.9031, 0.8386` | source R (1.0651) out of P3 gamut, clamped to 1.0 |
+| `closeFriend` | `oklch(0.66 0.16 145)` | `0.3861, 0.6612, 0.3523` | |
+| `badgeLive` | `oklch(0.72 0.17 22)` | `0.9253, 0.4804, 0.4675` | |
+| `accentForeground` (light) | `oklch(0.99 0.004 80)` | `0.9916, 0.9863, 0.9765` | |
+| `accentForeground` (dark) | `oklch(0.17 0.008 60)` | `0.0687, 0.0579, 0.0482` | |
+
+`accentForeground` is a single `Color` resolved from a dynamic-provider platform color (`UIColor(dynamicProvider:)` on iOS via `#if canImport(UIKit)`, `NSColor(name:dynamicProvider:)` on macOS via `#elseif canImport(AppKit)`) — no call-site branching, matches by trait/appearance at draw time.
+
+**Guessed / not SDK-confirmed this session:** the UIKit half (`UIColor(dynamicProvider:)`, `Color(uiColor:)`) rests on iOS platform knowledge, not a grep — this machine has no iOS SDK to check against. Only the AppKit/macOS half was exercised by `swift build`/`swift test` (host is macOS). If the iOS API name or behavior is wrong, `OSNUI` still won't compile on this host to catch it — an app-target/iOS build is the only thing that would.
+
+Neutral ramp: not ported, per brief — call sites use system semantic colors (`.primary`, `.secondary`, etc.) for text/fills, e.g. `GlassCard`'s preview content.
+
+## Typography
+
+`Font.osn(_:size:relativeTo:)` resolves `.display`/`.body`/`.mono` to `Font.custom("Instrument Serif"/"Geist"/"Geist Mono", size:relativeTo:)`. `Font.custom(_:size:relativeTo:)` is Dynamic Type-scaling by construction (relative to a `TextStyle`) — that part is SDK-documented API, confirmed by successful compilation and matches the documented signature.
+
+**Guessed / not empirically tested:** that `Font.custom` silently substitutes the system font at the same point size when the named family isn't installed, rather than rendering nothing or asserting. This is standard platform behavior from general iOS/macOS knowledge, not something I ran and observed in this environment (no visual rendering harness here), and not grepped from any doc comment in the swiftinterface (the interface only gives the signature, not the fallback behavior).
+
+**BLOCKED: font files not vendored.** Instrument Serif, Geist, Geist Mono are OFL 1.1, pulled from Google Fonts in the web app (`pulse/app/index.html:9`). To close: obtain the `.ttf`/`.otf` files, vendor them into this package or the app target, and register them (`UIAppFonts` in Info.plist for iOS / `CTFontManagerRegisterFontsForURL` or an Xcode font-registration mechanism for macOS). Not decided here per brief — deferred to whoever owns the app target.
+
+## Components
+
+All five (`GlassCard`, `GlassButton`, `Pill`, `LiveBadge`, `AvatarView`) have a doc comment stating purpose + glass/non-glass layer, both-color-scheme `#Preview`s, and take no domain model — confirmed by reading each file, not just by the build.
+
+`GlassButton` wraps `.glass`/`.glassProminent` rather than reimplementing the material — confirmed by SDK grep before writing (see above), not guessed.
+
+## DoD item 6 — Reduce Motion testability
+
+**Not testable, and no test was added.** `LiveBadge` reads `@Environment(\.accessibilityReduceMotion)`, which SwiftUI resolves from the live system accessibility setting when a view is part of a rendered hierarchy. A Swift Testing `@Test` function has no view host and no way to construct or inject an `EnvironmentValues` into a `View`'s `body` without actually mounting it (e.g. via a snapshot/host harness) — this package has no such dependency, and the brief prohibits inventing one. I did not find, and did not add, a way to instantiate `LiveBadge` and assert its rendered `scaleEffect`/`opacity`/`animation` under a forced `accessibilityReduceMotion = true` using only Swift Testing + SwiftUI. Saying "test if it's readable, and if not, say so" — this is the "say so": DoD item 6 is unverified by test. The logic itself (`reduceMotion ? 1 : ...`, `animation(reduceMotion ? nil : ...)`) is inspectable by reading `LiveBadge.swift` but that is not the same as a passing test.
+
+No `OSNUITests` target was added, since there is nothing else in `OSNUI` that has meaningful unit-testable logic beyond this one untestable case — `Colors.swift`'s values are checked by reading the conversion table above, not by a runtime assertion the brief asked for.
+
+## Leaf-package check
+
+`Package.swift`: `.target(name: "OSNUI")` — no `dependencies:` argument, so zero dependencies. None of the seven files added under `Sources/OSNUI/` import `OSNKit`, `OSNAuth`, or `PulseAPI`; only `SwiftUI` and, conditionally, `UIKit`/`AppKit`. Confirmed by reading `Package.swift` and every new file's import list, not inferred.

--- a/shared/swift/OSNShared/a4-notes.md
+++ b/shared/swift/OSNShared/a4-notes.md
@@ -38,7 +38,7 @@ Method: oklch → OKLab → linear sRGB (Björn Ottosson's published matrices) �
 |---|---|---|---|
 | `accent` | `oklch(0.68 0.18 38)` | `0.8806, 0.4389, 0.2824` | |
 | `accentStrong` | `oklch(0.58 0.19 35)` | `0.7620, 0.2939, 0.1632` | |
-| `accentSoft` | `oklch(0.95 0.05 45)` | `1.0000, 0.9031, 0.8386` | source R (1.0651) out of P3 gamut, clamped to 1.0 |
+| `accentSoft` | `oklch(0.95 0.05 45)` | `1.0000, 0.9031, 0.8386` | out of P3 gamut on red — linear 1.0650, encoded 1.0280 — R alone clamped to 1.0 |
 | `closeFriend` | `oklch(0.66 0.16 145)` | `0.3861, 0.6612, 0.3523` | |
 | `badgeLive` | `oklch(0.72 0.17 22)` | `0.9253, 0.4804, 0.4675` | |
 | `accentForeground` (light) | `oklch(0.99 0.004 80)` | `0.9916, 0.9863, 0.9765` | |
@@ -69,6 +69,23 @@ All five (`GlassCard`, `GlassButton`, `Pill`, `LiveBadge`, `AvatarView`) have a 
 **Not testable, and no test was added.** `LiveBadge` reads `@Environment(\.accessibilityReduceMotion)`, which SwiftUI resolves from the live system accessibility setting when a view is part of a rendered hierarchy. A Swift Testing `@Test` function has no view host and no way to construct or inject an `EnvironmentValues` into a `View`'s `body` without actually mounting it (e.g. via a snapshot/host harness) — this package has no such dependency, and the brief prohibits inventing one. I did not find, and did not add, a way to instantiate `LiveBadge` and assert its rendered `scaleEffect`/`opacity`/`animation` under a forced `accessibilityReduceMotion = true` using only Swift Testing + SwiftUI. Saying "test if it's readable, and if not, say so" — this is the "say so": DoD item 6 is unverified by test. The logic itself (`reduceMotion ? 1 : ...`, `animation(reduceMotion ? nil : ...)`) is inspectable by reading `LiveBadge.swift` but that is not the same as a passing test.
 
 No `OSNUITests` target was added, since there is nothing else in `OSNUI` that has meaningful unit-testable logic beyond this one untestable case — `Colors.swift`'s values are checked by reading the conversion table above, not by a runtime assertion the brief asked for.
+
+## Independent re-check (orchestrator, on review)
+
+- `swift build` + `swift test` re-run on the macOS host after the review edits
+  below: 32 tests, 7 suites, 0 failures.
+- All seven conversions re-derived from scratch with an independent
+  implementation of the same pipeline (oklch → OKLab → linear sRGB → XYZ D65 →
+  linear P3 → sRGB OETF). Every channel matches the committed values to
+  ±0.0001. The one correction is the gamut note on `accentSoft`: 1.0651 is the
+  *linear* out-of-range figure, 1.0280 the encoded one — both now recorded, so
+  the clamp is checkable at either stage.
+- `GlassButton`'s doc comment sat on `GlassButtonKind`, so the component itself
+  had none — DoD 5 wasn't actually met for it. Moved onto the struct, with a
+  separate comment on the enum.
+- `Package.swift` confirmed: `.target(name: "OSNUI")`, no `dependencies:`. The
+  only imports across the seven files are `SwiftUI` plus `UIKit`/`AppKit` under
+  `canImport` in `Colors.swift`.
 
 ## Leaf-package check
 


### PR DESCRIPTION
Stacked on #402 (`feat/osnauth-passkeys`), which is stacked on #401 (`feat/osnkit`). **Review the top two commits only** — everything below is the parent PRs. Merge #401 and #402 first.

A2 and A3 built the plumbing. Nothing was on screen. This is the vocabulary the native screens get written in: brand tokens, type roles, and five Liquid Glass primitives, so A5 assembles components instead of inventing one per screen.

`OSNUI` is a leaf. It has no dependency on `OSNKit`, `OSNAuth` or `PulseAPI` and must not gain one — a design system that imports the network layer can't be previewed or tested on its own, and every later feature target would drag in the whole graph.

## Glass, grepped rather than guessed

The glass APIs are new in iOS 26 / macOS 26, so the names came out of the SDK's own `.swiftinterface` rather than from memory. What's there and what's called:

- `glassEffect(_ glass: Glass = .regular, in shape: some Shape)` — `GlassCard`
- `GlassButtonStyle` / `GlassProminentButtonStyle`, as `.glass` / `.glassProminent` — `GlassButton` wraps these rather than rebuilding the material
- `GlassEffectContainer`, `glassEffectID(_:in:)`, `glassEffectUnion(id:namespace:)` — present in the SDK, documented in the components' doc comments, deliberately **not** used here: nothing in this package assembles a cluster of glass siblings yet. That's A5's job.

Two rules the doc comments carry so callers don't have to rediscover them: group glass rather than sprinkling it, and never stack glass on glass.

## Tokens

Six brand tokens ported from `pulse/app/src/App.css:56-73`, authored in oklch, which SwiftUI `Color` cannot take. Each is converted at authoring time to `Color(.displayP3, …)` with the oklch source in a comment on the same line, and the full pipeline written down in `a4-notes.md` — oklch → OKLab → linear sRGB → XYZ (D65) → linear Display P3 → sRGB OETF. Display P3 rather than sRGB because the coral sits outside sRGB.

Every conversion was re-derived a second time, independently, during review. All seven values match to ±0.0001. `accentSoft` is out of P3 gamut on red and clamps; both the linear and the encoded figure are recorded so the clamp is checkable at either stage.

`accentForeground` has two values by scheme and resolves through a dynamic-provider platform colour, so no call site ever asks which mode it is in.

The warm neutral ramp is deliberately not ported. The system semantic colours already adapt for contrast, elevation and accessibility settings; hardcoded greys throw all of that away. Whether the warm tint survives dark mode and increased contrast is a judgement for a real screen in A5.

## Type

Three roles — `.display` (Instrument Serif), `.body` (Geist), `.mono` (Geist Mono) — each resolved through `Font.custom(_:size:relativeTo:)`, so every one scales with Dynamic Type. A design system that ships fixed point sizes is one a user with large text cannot read, and retrofitting that means touching every screen.

**BLOCKED: the font files are not in the repo.** The web app pulls all three from Google Fonts at `pulse/app/index.html:9`. Both families are OFL 1.1 so vendoring is allowed, but committing binary font files is your call, not mine. Until then `Font.custom` falls back to the system font and the roles still work.

## Components

Five, each with a doc comment saying what it is for and which layer it belongs on, and a `#Preview` in both colour schemes. None takes a domain model.

`GlassCard` (takes a `@ViewBuilder`, not an event), `GlassButton` (primary/secondary), `Pill`, `LiveBadge`, `AvatarView` (close-friend ring is a state, not a colour the caller passes).

`LiveBadge` respects Reduce Motion by going **static**, not slow. An animation that never stops is a real accessibility problem for vestibular and attention disorders, not a preference to tone down.

## What is not verified

- **Nothing has been rendered.** `swift build` and `swift test` pass on the macOS host (32 tests, 7 suites) but neither is evidence that a glass effect looks right or that a colour is right on a real display. First honest look is the A5 app target.
- **The iOS half of `accentForeground` is unexercised.** `UIColor(dynamicProvider:)` rests on platform knowledge, not on a grep — there is no iOS SDK on this machine, and the host build takes the AppKit branch. An iOS build is the only thing that catches it if the spelling is wrong.
- **Reduce Motion is not covered by a test.** `LiveBadge` reads `@Environment(\.accessibilityReduceMotion)`, which SwiftUI only resolves inside a rendered hierarchy; asserting on it needs a view host this package does not have and the brief did not permit inventing. The logic is readable in `LiveBadge.swift`. That is not the same as a passing test, so it is recorded as unverified rather than green.
- `Font.custom`'s fallback when a family is missing is standard platform behaviour, not something observed here.

Full verified / not-verified / BLOCKED breakdown in `shared/swift/OSNShared/a4-notes.md`.

## Review found

The doc comment describing `GlassButton` sat on `GlassButtonKind`, so the component itself had none and the both-schemes-preview-plus-doc-comment bar wasn't actually met for it. Fixed, along with the `accentSoft` gamut figure.

## No changeset

Touches only `shared/swift/`, which is on the allowlist in `scripts/changeset-required.sh` — no versioned package ships from this diff, so there is no honest package to name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
