### PR TITLE
Spell nullable OpenAPI fields as a type array so the Swift client keeps them

### DIFF
--- a/.changeset/quiet-pumas-shake.md
+++ b/.changeset/quiet-pumas-shake.md
@@ -1,0 +1,9 @@
+---
+"@pulse/api": patch
+---
+
+Emit nullable fields in the OpenAPI document as a JSON Schema type array rather than an `anyOf` with a `null` member.
+
+`anyOf: [X, { type: "null" }]` is correct for OpenAPI 3.1, but swift-openapi-generator has no representation for it: it warns `Schema "null" is not supported` and drops the property from the generated client entirely. That was 254 occurrences — around half of every event field, including `latitude` and `longitude`. `type: ["number", "null"]` is equivalent and generates `Swift.Double?` with no warning, so `generate-openapi.ts` now rewrites one into the other. Unions of string constants collapse to an `enum` at the same time, which is the only spelling a type array can carry.
+
+The served routes and their runtime validation are unchanged — this only affects how the committed document describes them.

--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -56,7 +56,13 @@ jobs:
           if changed=$(git diff --name-only "$base" HEAD 2>&1); then
             echo "$changed"
 
-            if echo "$changed" | grep -qE '^(shared/swift/|pulse/ios/|\.github/workflows/ci-swift\.yml$)'; then
+            # `shared/openapi/` counts as Swift source. `PulseAPI`'s
+            # `openapi.json` is a relative symlink to `shared/openapi/pulse.json`,
+            # and the OpenAPIGenerator plugin regenerates the whole client from
+            # it at build time — so a spec-only change can break the iOS build
+            # while touching no file under `shared/swift/`. This very PR is that
+            # case: it rewrites every nullable field's spelling and nothing else.
+            if echo "$changed" | grep -qE '^(shared/swift/|shared/openapi/|pulse/ios/|\.github/workflows/ci-swift\.yml$)'; then
               echo "ios=true" >> "$GITHUB_OUTPUT"
             else
               echo "ios=false" >> "$GITHUB_OUTPUT"

--- a/pulse/api/scripts/generate-openapi.ts
+++ b/pulse/api/scripts/generate-openapi.ts
@@ -102,6 +102,104 @@ function stripRedundantNullable(node: unknown): void {
   for (const child of Object.values(schema)) stripRedundantNullable(child);
 }
 
+// Even spelled correctly for 3.1, `anyOf: [X, { type: "null" }]` loses the
+// field outright. swift-openapi-generator (via OpenAPIKit) has no
+// representation for a `null` member of a union, warns
+//
+//   warning: Schema "null" is not supported, reason: "schema type", skipping
+//
+// and then omits the whole property from the generated Swift type. That is 254
+// occurrences here — roughly half of every event field, `latitude` and
+// `longitude` among them, silently absent from the client.
+//
+// The spelling it does understand is a type array: `type: ["number", "null"]`
+// generates `Swift.Double?` with no warning, even for a `required` property.
+// The two are equivalent in JSON Schema, so this rewrites one into the other.
+//
+// Three shapes occur, all handled here:
+//   { anyOf: [{ type: "string" }, { type: "null" }] }
+//     → { type: ["string", "null"] }
+//   { anyOf: [{ anyOf: [{ const: "a" }, { const: "b" }] }, { type: "null" }] }
+//   { anyOf: [{ const: "going" }, { const: "maybe" }, { type: "null" }] }
+//     → { type: ["string", "null"], enum: ["a", "b"] }
+//
+// The const unions collapse to an `enum` because that is the only spelling a
+// type array can carry, and it generates a far better type besides: a plain
+// Swift enum, where an `anyOf` of consts generates a struct of one optional
+// per member (`value1`, `value2`, …). Nothing regresses from that — every
+// const union in this document sits inside a null union, so all of them are
+// being dropped today anyway; the 96 unions the plugin already spells as
+// `enum` are untouched.
+//
+// Anything that doesn't match a handled shape is left exactly as it was and
+// reported, so a new route shape shows up as a warning here rather than as a
+// field that quietly vanishes from the client.
+function collapseNullUnions(node: unknown, unhandled: string[], path = "#"): void {
+  if (Array.isArray(node)) {
+    for (const [index, child] of node.entries()) {
+      collapseNullUnions(child, unhandled, `${path}/${index}`);
+    }
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+
+  // Depth first: a nested union has to be collapsed before its parent can
+  // decide what it's looking at.
+  for (const [key, child] of Object.entries(node as Record<string, unknown>)) {
+    collapseNullUnions(child, unhandled, `${path}/${key}`);
+  }
+
+  const schema = node as Record<string, unknown>;
+  const anyOf = schema["anyOf"];
+  if (!Array.isArray(anyOf)) return;
+
+  const isSchema = (value: unknown): value is Record<string, unknown> =>
+    value !== null && typeof value === "object" && !Array.isArray(value);
+  const isNullMember = (value: unknown) =>
+    isSchema(value) && value["type"] === "null" && Object.keys(value).length === 1;
+
+  if (!anyOf.some(isNullMember)) return;
+
+  let members = anyOf.filter((member) => !isNullMember(member));
+  // `t.Union([t.Literal(…)])` inside `t.Nullable(…)` nests one union in the
+  // other; flatten it so both nesting depths reach the same branches below.
+  const [only] = members;
+  if (
+    members.length === 1 &&
+    isSchema(only) &&
+    Array.isArray(only["anyOf"]) &&
+    Object.keys(only).length === 1
+  ) {
+    members = only["anyOf"];
+  }
+
+  const rest = Object.fromEntries(Object.entries(schema).filter(([key]) => key !== "anyOf"));
+  const replace = (replacement: Record<string, unknown>) => {
+    for (const key of Object.keys(schema)) delete schema[key];
+    Object.assign(schema, rest, replacement);
+  };
+
+  if (
+    members.length > 0 &&
+    members.every((member) => isSchema(member) && member["const"] !== undefined)
+  ) {
+    const first = members[0] as Record<string, unknown>;
+    replace({
+      type: [first["type"] ?? "string", "null"],
+      enum: members.map((member) => (member as Record<string, unknown>)["const"]),
+    });
+    return;
+  }
+
+  const [single] = members;
+  if (members.length === 1 && isSchema(single) && typeof single["type"] === "string") {
+    replace({ ...single, type: [single["type"], "null"] });
+    return;
+  }
+
+  unhandled.push(path);
+}
+
 const app = createApp();
 const res = await app.handle(new Request("http://localhost/openapi/json"));
 if (!res.ok) {
@@ -109,7 +207,16 @@ if (!res.ok) {
 }
 const doc = (await res.json()) as Record<string, unknown>;
 
+// Order matters: `stripRedundantNullable` looks for the `anyOf` that
+// `collapseNullUnions` removes, so it has to run first.
 stripRedundantNullable(doc);
+const unhandledNullUnions: string[] = [];
+collapseNullUnions(doc, unhandledNullUnions);
+for (const path of unhandledNullUnions) {
+  // eslint-disable-next-line no-console -- CLI script output
+  console.warn(`warning: null union left as-is (unhandled shape) at ${path}`);
+}
+
 const output = `${JSON.stringify(sortKeys(stripVoidContent(doc)), null, 2)}\n`;
 
 await mkdir(dirname(OUTPUT_PATH), { recursive: true });

--- a/shared/openapi/pulse.json
+++ b/shared/openapi/pulse.json
@@ -289,33 +289,21 @@
                       "items": {
                         "properties": {
                           "avatarUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "displayName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "handle": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "profileId": {
@@ -702,56 +690,32 @@
                             "type": "boolean"
                           },
                           "cancellationReason": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "const": "host_left",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "organiser",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "admin",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "host_left",
+                              "organiser",
+                              "admin"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "cancelledAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "chatId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "commsChannels": {
@@ -762,47 +726,31 @@
                             "type": "string"
                           },
                           "createdByAvatar": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByProfileId": {
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "guestListVisibility": {
@@ -814,26 +762,18 @@
                             "type": "string"
                           },
                           "hardDeleteAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "instanceOverride": {
@@ -847,63 +787,39 @@
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "location": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "seriesId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -928,23 +844,15 @@
                             "type": "string"
                           },
                           "venue": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "visibility": {
@@ -1068,50 +976,25 @@
                     "type": "number"
                   },
                   "priceAmount": {
-                    "anyOf": [
-                      {
-                        "maximum": 99999.99,
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "maximum": 99999.99,
+                    "minimum": 0,
+                    "type": [
+                      "number",
+                      "null"
                     ]
                   },
                   "priceCurrency": {
-                    "anyOf": [
-                      {
-                        "anyOf": [
-                          {
-                            "const": "USD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "EUR",
-                            "type": "string"
-                          },
-                          {
-                            "const": "GBP",
-                            "type": "string"
-                          },
-                          {
-                            "const": "CAD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "AUD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "JPY",
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "enum": [
+                      "USD",
+                      "EUR",
+                      "GBP",
+                      "CAD",
+                      "AUD",
+                      "JPY"
+                    ],
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   },
                   "startTime": {
@@ -1164,56 +1047,32 @@
                           "type": "boolean"
                         },
                         "cancellationReason": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "const": "host_left",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "organiser",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "admin",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "enum": [
+                            "host_left",
+                            "organiser",
+                            "admin"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "cancelledAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -1224,47 +1083,31 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "endTime": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -1276,26 +1119,18 @@
                           "type": "string"
                         },
                         "hardDeleteAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "id": {
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "instanceOverride": {
@@ -1309,63 +1144,39 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceAmount": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceCurrency": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "seriesId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "startTime": {
@@ -1390,23 +1201,15 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "venueId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -1552,56 +1355,32 @@
                                 "type": "boolean"
                               },
                               "cancellationReason": {
-                                "anyOf": [
-                                  {
-                                    "anyOf": [
-                                      {
-                                        "const": "host_left",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "const": "organiser",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "const": "admin",
-                                        "type": "string"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "enum": [
+                                  "host_left",
+                                  "organiser",
+                                  "admin"
+                                ],
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "cancelledAt": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "category": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "chatId": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "commsChannels": {
@@ -1612,47 +1391,31 @@
                                 "type": "string"
                               },
                               "createdByAvatar": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "createdByName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "createdByProfileId": {
                                 "type": "string"
                               },
                               "description": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "endTime": {
-                                "anyOf": [
-                                  {
-                                    "format": "date-time",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "format": "date-time",
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "guestListVisibility": {
@@ -1664,26 +1427,18 @@
                                 "type": "string"
                               },
                               "hardDeleteAt": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "id": {
                                 "type": "string"
                               },
                               "imageUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "instanceOverride": {
@@ -1697,63 +1452,39 @@
                                 "type": "string"
                               },
                               "latitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "location": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "longitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "priceAmount": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "priceCurrency": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "seriesId": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "startTime": {
@@ -1778,23 +1509,15 @@
                                 "type": "string"
                               },
                               "venue": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "venueId": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "string",
+                                  "null"
                                 ]
                               },
                               "visibility": {
@@ -1844,18 +1567,13 @@
                             "type": "boolean"
                           },
                           "myStatus": {
-                            "anyOf": [
-                              {
-                                "const": "going",
-                                "type": "string"
-                              },
-                              {
-                                "const": "maybe",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "going",
+                              "maybe"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           }
                         },
@@ -2143,56 +1861,32 @@
                             "type": "boolean"
                           },
                           "cancellationReason": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "const": "host_left",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "organiser",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "admin",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "host_left",
+                              "organiser",
+                              "admin"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "cancelledAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "chatId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "commsChannels": {
@@ -2203,47 +1897,31 @@
                             "type": "string"
                           },
                           "createdByAvatar": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByProfileId": {
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "guestListVisibility": {
@@ -2255,26 +1933,18 @@
                             "type": "string"
                           },
                           "hardDeleteAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "instanceOverride": {
@@ -2288,63 +1958,39 @@
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "location": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "seriesId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -2369,23 +2015,15 @@
                             "type": "string"
                           },
                           "venue": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "visibility": {
@@ -2434,26 +2072,22 @@
                       "type": "array"
                     },
                     "nextCursor": {
-                      "anyOf": [
-                        {
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "startTime": {
-                              "format": "date-time",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "startTime",
-                            "id"
-                          ],
-                          "type": "object"
+                      "properties": {
+                        "id": {
+                          "type": "string"
                         },
-                        {
-                          "type": "null"
+                        "startTime": {
+                          "format": "date-time",
+                          "type": "string"
                         }
+                      },
+                      "required": [
+                        "startTime",
+                        "id"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
                       ]
                     },
                     "series": {
@@ -2597,56 +2231,32 @@
                             "type": "boolean"
                           },
                           "cancellationReason": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "const": "host_left",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "organiser",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "admin",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "host_left",
+                              "organiser",
+                              "admin"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "cancelledAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "chatId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "commsChannels": {
@@ -2657,47 +2267,31 @@
                             "type": "string"
                           },
                           "createdByAvatar": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByProfileId": {
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "guestListVisibility": {
@@ -2709,26 +2303,18 @@
                             "type": "string"
                           },
                           "hardDeleteAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "instanceOverride": {
@@ -2742,63 +2328,39 @@
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "location": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "seriesId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -2823,23 +2385,15 @@
                             "type": "string"
                           },
                           "venue": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "visibility": {
@@ -3002,56 +2556,32 @@
                           "type": "boolean"
                         },
                         "cancellationReason": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "const": "host_left",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "organiser",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "admin",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "enum": [
+                            "host_left",
+                            "organiser",
+                            "admin"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "cancelledAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -3062,47 +2592,31 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "endTime": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -3114,26 +2628,18 @@
                           "type": "string"
                         },
                         "hardDeleteAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "id": {
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "instanceOverride": {
@@ -3147,63 +2653,39 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceAmount": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceCurrency": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "seriesId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "startTime": {
@@ -3228,23 +2710,15 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "venueId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -3394,50 +2868,25 @@
                     "type": "number"
                   },
                   "priceAmount": {
-                    "anyOf": [
-                      {
-                        "maximum": 99999.99,
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "maximum": 99999.99,
+                    "minimum": 0,
+                    "type": [
+                      "number",
+                      "null"
                     ]
                   },
                   "priceCurrency": {
-                    "anyOf": [
-                      {
-                        "anyOf": [
-                          {
-                            "const": "USD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "EUR",
-                            "type": "string"
-                          },
-                          {
-                            "const": "GBP",
-                            "type": "string"
-                          },
-                          {
-                            "const": "CAD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "AUD",
-                            "type": "string"
-                          },
-                          {
-                            "const": "JPY",
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "enum": [
+                      "USD",
+                      "EUR",
+                      "GBP",
+                      "CAD",
+                      "AUD",
+                      "JPY"
+                    ],
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   },
                   "startTime": {
@@ -3486,56 +2935,32 @@
                           "type": "boolean"
                         },
                         "cancellationReason": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "const": "host_left",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "organiser",
-                                  "type": "string"
-                                },
-                                {
-                                  "const": "admin",
-                                  "type": "string"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "enum": [
+                            "host_left",
+                            "organiser",
+                            "admin"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "cancelledAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -3546,47 +2971,31 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "endTime": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -3598,26 +3007,18 @@
                           "type": "string"
                         },
                         "hardDeleteAt": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "id": {
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "instanceOverride": {
@@ -3631,63 +3032,39 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceAmount": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "priceCurrency": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "seriesId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "startTime": {
@@ -3712,23 +3089,15 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "venueId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -3922,14 +3291,10 @@
                             "type": "string"
                           },
                           "sentAt": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "sentByProfileId": {
@@ -4059,14 +3424,10 @@
                             "type": "string"
                           },
                           "sentAt": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           }
                         },
@@ -4530,60 +3891,44 @@
                             "type": "string"
                           },
                           "invitedByProfileId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "isCloseFriend": {
                             "type": "boolean"
                           },
                           "profile": {
-                            "anyOf": [
-                              {
-                                "properties": {
-                                  "avatarUrl": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "displayName": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "handle": {
-                                    "type": "string"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "id",
-                                  "handle",
-                                  "displayName",
-                                  "avatarUrl"
-                                ],
-                                "type": "object"
+                            "properties": {
+                              "avatarUrl": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
-                              {
-                                "type": "null"
+                              "displayName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "handle": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
                               }
+                            },
+                            "required": [
+                              "id",
+                              "handle",
+                              "displayName",
+                              "avatarUrl"
+                            ],
+                            "type": [
+                              "object",
+                              "null"
                             ]
                           },
                           "profileId": {
@@ -4728,58 +4073,38 @@
                           "type": "string"
                         },
                         "invitedByProfileId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "profileId": {
                           "type": "string"
                         },
                         "shareSourceFirst": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "shareSourceFirstSeenAt": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "shareSourceLast": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "shareSourceLastSeenAt": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "status": {
@@ -5031,60 +4356,44 @@
                             "type": "string"
                           },
                           "invitedByProfileId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "isCloseFriend": {
                             "type": "boolean"
                           },
                           "profile": {
-                            "anyOf": [
-                              {
-                                "properties": {
-                                  "avatarUrl": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "displayName": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "handle": {
-                                    "type": "string"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "id",
-                                  "handle",
-                                  "displayName",
-                                  "avatarUrl"
-                                ],
-                                "type": "object"
+                            "properties": {
+                              "avatarUrl": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               },
-                              {
-                                "type": "null"
+                              "displayName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "handle": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
                               }
+                            },
+                            "required": [
+                              "id",
+                              "handle",
+                              "displayName",
+                              "avatarUrl"
+                            ],
+                            "type": [
+                              "object",
+                              "null"
                             ]
                           },
                           "profileId": {
@@ -5257,14 +4566,10 @@
                 "schema": {
                   "properties": {
                     "completedAt": {
-                      "anyOf": [
-                        {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
                       ]
                     },
                     "eventRemindersOptIn": {
@@ -5460,14 +4765,10 @@
                 "schema": {
                   "properties": {
                     "completedAt": {
-                      "anyOf": [
-                        {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
                       ]
                     },
                     "eventRemindersOptIn": {
@@ -5831,56 +5132,32 @@
                             "type": "boolean"
                           },
                           "cancellationReason": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "const": "host_left",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "organiser",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "admin",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "host_left",
+                              "organiser",
+                              "admin"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "cancelledAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "chatId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "commsChannels": {
@@ -5891,47 +5168,31 @@
                             "type": "string"
                           },
                           "createdByAvatar": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByProfileId": {
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "guestListVisibility": {
@@ -5943,26 +5204,18 @@
                             "type": "string"
                           },
                           "hardDeleteAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "instanceOverride": {
@@ -5976,63 +5229,39 @@
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "location": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "seriesId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -6057,23 +5286,15 @@
                             "type": "string"
                           },
                           "venue": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "visibility": {
@@ -6127,23 +5348,15 @@
                           "type": "boolean"
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -6154,36 +5367,24 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "dtstart": {
@@ -6191,13 +5392,9 @@
                           "type": "string"
                         },
                         "durationMinutes": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -6212,13 +5409,9 @@
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "joinPolicy": {
@@ -6229,33 +5422,21 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "materializedThrough": {
@@ -6280,14 +5461,10 @@
                           "type": "string"
                         },
                         "until": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "updatedAt": {
@@ -6295,13 +5472,9 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -6569,23 +5742,15 @@
                           "type": "boolean"
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -6596,36 +5761,24 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "dtstart": {
@@ -6633,13 +5786,9 @@
                           "type": "string"
                         },
                         "durationMinutes": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -6654,13 +5803,9 @@
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "joinPolicy": {
@@ -6671,33 +5816,21 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "materializedThrough": {
@@ -6722,14 +5855,10 @@
                           "type": "string"
                         },
                         "until": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "updatedAt": {
@@ -6737,13 +5866,9 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -6937,23 +6062,15 @@
                           "type": "boolean"
                         },
                         "category": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "chatId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "commsChannels": {
@@ -6964,36 +6081,24 @@
                           "type": "string"
                         },
                         "createdByAvatar": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByName": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdByProfileId": {
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "dtstart": {
@@ -7001,13 +6106,9 @@
                           "type": "string"
                         },
                         "durationMinutes": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "guestListVisibility": {
@@ -7022,13 +6123,9 @@
                           "type": "string"
                         },
                         "imageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "joinPolicy": {
@@ -7039,33 +6136,21 @@
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "location": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "materializedThrough": {
@@ -7090,14 +6175,10 @@
                           "type": "string"
                         },
                         "until": {
-                          "anyOf": [
-                            {
-                              "format": "date-time",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "updatedAt": {
@@ -7105,13 +6186,9 @@
                           "type": "string"
                         },
                         "venue": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "visibility": {
@@ -7312,56 +6389,32 @@
                             "type": "boolean"
                           },
                           "cancellationReason": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "const": "host_left",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "organiser",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "const": "admin",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "enum": [
+                              "host_left",
+                              "organiser",
+                              "admin"
+                            ],
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "cancelledAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "chatId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "commsChannels": {
@@ -7372,47 +6425,31 @@
                             "type": "string"
                           },
                           "createdByAvatar": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByProfileId": {
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "guestListVisibility": {
@@ -7424,26 +6461,18 @@
                             "type": "string"
                           },
                           "hardDeleteAt": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "instanceOverride": {
@@ -7457,63 +6486,39 @@
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "location": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "seriesId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -7538,23 +6543,15 @@
                             "type": "string"
                           },
                           "venue": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "visibility": {
@@ -7646,43 +6643,27 @@
                       "items": {
                         "properties": {
                           "address": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "capacity": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "city": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "country": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdAt": {
@@ -7690,72 +6671,48 @@
                             "type": "string"
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "handle": {
                             "type": "string"
                           },
                           "heroImageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "hours": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "instagramHandle": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "kind": {
                             "type": "string"
                           },
                           "latitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "longitude": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "name": {
@@ -7772,13 +6729,9 @@
                             "type": "string"
                           },
                           "websiteUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           }
                         },
@@ -7868,43 +6821,27 @@
                     "venue": {
                       "properties": {
                         "address": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "capacity": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "city": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "country": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "createdAt": {
@@ -7912,72 +6849,48 @@
                           "type": "string"
                         },
                         "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "handle": {
                           "type": "string"
                         },
                         "heroImageUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "hours": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "id": {
                           "type": "string"
                         },
                         "instagramHandle": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         },
                         "kind": {
                           "type": "string"
                         },
                         "latitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "longitude": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "number",
+                            "null"
                           ]
                         },
                         "name": {
@@ -7994,13 +6907,9 @@
                           "type": "string"
                         },
                         "websiteUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
+                          "type": [
+                            "string",
+                            "null"
                           ]
                         }
                       },
@@ -8141,77 +7050,49 @@
                       "items": {
                         "properties": {
                           "category": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "createdByName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "endTime": {
-                            "anyOf": [
-                              {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "format": "date-time",
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "id": {
                             "type": "string"
                           },
                           "imageUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "priceAmount": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "number",
+                              "null"
                             ]
                           },
                           "priceCurrency": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           },
                           "startTime": {
@@ -8232,13 +7113,9 @@
                             "type": "string"
                           },
                           "venueId": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
+                            "type": [
+                              "string",
+                              "null"
                             ]
                           }
                         },


### PR DESCRIPTION
## What

`shared/openapi/pulse.json` spells every nullable field as `anyOf: [X, { type: "null" }]`. That is correct OpenAPI 3.1, and it is what `t.Nullable(...)` produces. swift-openapi-generator, through OpenAPIKit, has no representation for a `null` member of a union: it warns and then **drops the property from the generated Swift type entirely**.

```
warning: Schema "null" is not supported, reason: "schema type", skipping
```

254 occurrences — around half of every event field. Among them `latitude` and `longitude`, so the iOS client cannot read a coordinate off a discovered event at all. This blocks Explore on MapKit outright, and it silently truncates the event model the Pulse feature already maps.

It also explains the A5 note that the payload has no `cancellationReason`. It has one; it is spelled as a nullable union of string constants, so it was among the dropped fields.

## Fix

`type: ["number", "null"]` is equivalent in JSON Schema and generates `Swift.Double?` with no warning, even for a `required` property. I verified that against the generator before writing anything, alongside the object, array, `format` and `enum` variants.

A new `collapseNullUnions` transform in `pulse/api/scripts/generate-openapi.ts` rewrites one spelling into the other. It runs after `stripRedundantNullable`, which looks for the `anyOf` this removes, so the order is load-bearing.

Three shapes occur in this document, all handled:

| In | Out |
|---|---|
| `{ anyOf: [{ type: "string" }, { type: "null" }] }` | `{ type: ["string", "null"] }` |
| `{ anyOf: [{ anyOf: [{ const: "a" }, { const: "b" }] }, { type: "null" }] }` | `{ type: ["string", "null"], enum: ["a", "b"] }` |
| `{ anyOf: [{ const: "going" }, { const: "maybe" }, { type: "null" }] }` | `{ type: ["string", "null"], enum: ["going", "maybe"] }` |

The const unions collapse to an `enum` because that is the only spelling a type array can carry — and it generates a better type besides: a plain Swift enum, where an `anyOf` of consts generates a struct of one optional per member (`value1`, `value2`, …). Nothing regresses from that. Every const union in this document sits inside a null union, so all of them are being dropped today anyway; the 96 unions the plugin already spells as `enum` are untouched.

Anything not matching a handled shape is left exactly as it was and printed as a warning, so a new route shape shows up here rather than as a field that quietly vanishes from the client. No shape hit that branch on this document.

Only the document changes. The routes, their TypeBox schemas and their runtime validation are untouched.

## Verified

- `bun run --cwd pulse/api test:run` — 549 tests, 37 files, all pass
- `bun run --cwd pulse/api check` (`tsc --noEmit`) — clean
- `oxlint` — clean
- Re-running `openapi:generate` is byte-identical, so the `OpenAPI Freshness` check holds
- 0 null-unions and 0 `nullable` keywords left in the output; 254 type arrays
- Generating the Swift client from the new document: **0 warnings, 0 errors**, against 254 warnings before. Generated properties 1054 → 1314, with `latitude`, `longitude`, `description`, `imageUrl`, `venue`, `priceAmount` and `cancellationReason` (as a proper enum) all present on the response types for the first time

## Follow-up, not in this PR

`PulseModels.swift` on the Swift stack maps the generated event payload and currently maps only the fields that survived. Once this merges and that stack rebases, the mapping can be extended to the newly present fields — including the coordinates Explore-on-MapKit needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)