### PR TITLE
Map the event fields the nullable-drop bug was hiding

### DIFF
--- a/shared/swift/OSNShared/Sources/PulseFeature/ExploreViewModel.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/ExploreViewModel.swift
@@ -18,10 +18,17 @@ public final class ExploreViewModel {
 
     public private(set) var events: [PulseEvent] = []
     public private(set) var state: LoadState = .idle
-    public private(set) var hasMore = true
+
+    /// Whether another page exists. The server says so directly — a null
+    /// `nextCursor` is the end of the list — so this no longer guesses from
+    /// a full-looking page, which always cost one extra empty request when
+    /// the last page happened to be exactly `pageSize` long.
+    public var hasMore: Bool { !hasLoaded || nextCursor != nil }
 
     private let api: any APIProtocol
     private let pageSize: Int
+    private var nextCursor: EventPageCursor?
+    private var hasLoaded = false
 
     public init(api: any APIProtocol, pageSize: Int = 20) {
         self.api = api
@@ -30,15 +37,16 @@ public final class ExploreViewModel {
 
     public func loadFirstPage() async {
         events = []
-        hasMore = true
+        nextCursor = nil
+        hasLoaded = false
         await load(cursor: nil)
     }
 
     /// Call when a row is about to appear — triggers the next page once the
     /// last loaded row is reached.
     public func loadNextPageIfNeeded(currentItemId: String) async {
-        guard hasMore, state != .loading, events.last?.id == currentItemId else { return }
-        await load(cursor: events.keysetCursor)
+        guard let cursor = nextCursor, state != .loading, events.last?.id == currentItemId else { return }
+        await load(cursor: cursor)
     }
 
     private func load(cursor: EventPageCursor?) async {
@@ -50,13 +58,15 @@ public final class ExploreViewModel {
                 limit: .init(value2: Double(pageSize))
             )
             let output = try await api.discoverEvents(.init(query: query))
-            let page = try output.ok.body.json.events.map(PulseEvent.init)
+            let body = try output.ok.body.json
+            let page = body.events.map(PulseEvent.init)
             if cursor == nil {
                 events = page
             } else {
                 events.append(contentsOf: page)
             }
-            hasMore = page.count == pageSize
+            nextCursor = body.nextCursor.map(EventPageCursor.init)
+            hasLoaded = true
             state = .loaded
         } catch {
             state = .failed(String(describing: error))

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
@@ -1,19 +1,85 @@
 import Foundation
 import PulseAPI
 
+/// A latitude/longitude pair.
+///
+/// The wire shape is two independent nullable numbers. They are paired here
+/// because a lone latitude cannot be placed on a map — anything that wants
+/// coordinates wants both. An event carrying only one of the two therefore
+/// reads as having no coordinate at all.
+public struct PulseCoordinate: Equatable, Sendable {
+    public let latitude: Double
+    public let longitude: Double
+
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+
+    fileprivate init?(latitude: Double?, longitude: Double?) {
+        guard let latitude, let longitude else { return nil }
+        self.init(latitude: latitude, longitude: longitude)
+    }
+}
+
+/// A ticket price.
+///
+/// `minorUnits` is cents/pence/etc., not whole currency units — "$18.50" is
+/// `1850` (see the `price_amount` column comment in
+/// `pulse/db/src/schema/events.ts`). Format it with a currency-aware
+/// formatter; never print it raw.
+///
+/// Amount and currency are paired for the same reason the DB pairs them:
+/// "both columns set or both null — enforced at the service layer". An
+/// amount with no currency is not a price anyone can display.
+///
+/// The generated type carries the amount as `Double` despite the column
+/// being an integer, so it is rounded on the way in — the same judgment
+/// already made for `PulseRsvpCounts`.
+public struct PulsePrice: Equatable, Sendable {
+    public let minorUnits: Int
+    public let currency: String
+
+    /// Zero is free, per the same column comment: "null OR 0 → Free".
+    public var isFree: Bool { minorUnits == 0 }
+
+    public init(minorUnits: Int, currency: String) {
+        self.minorUnits = minorUnits
+        self.currency = currency
+    }
+
+    fileprivate init?(amount: Double?, currency: String?) {
+        guard let amount, let currency else { return nil }
+        self.init(minorUnits: Int(amount.rounded()), currency: currency)
+    }
+}
+
+/// `cancelledAt` and `hardDeleteAt` are unix *seconds* — plain integer
+/// columns, not the `timestamp` columns the four `date-time` fields come
+/// from, so the generator emits them as `Double?` and they need converting
+/// by hand. Confirmed against `pulse/db/src/schema/events.ts` and
+/// `serializeEvent` in `pulse/api/src/routes/events.ts`, which deliberately
+/// passes both through without `.toISOString()`.
+private func date(unixSeconds: Double?) -> Date? {
+    unixSeconds.map { Date(timeIntervalSince1970: $0) }
+}
+
 /// App-level event model shared by Explore and Event detail.
 ///
 /// `discoverEvents` and `getEventById` each generate their own,
 /// structurally-identical but nominally distinct payload type
 /// (`Operations.DiscoverEvents...EventsPayloadPayload` and
 /// `Operations.GetEventById...EventPayload`) — this bridges both into one
-/// shape the views can share. Fields mirror only what the generated types
-/// actually carry (13 fields, confirmed against `Types.swift`); several
-/// fields the brief describes — `description`, `location`, `venue`,
-/// `category`, `endTime`, `imageUrl`, `priceAmount`/`priceCurrency`,
-/// `createdByName`/`createdByAvatar`, `cancelledAt`, `cancellationReason` —
-/// are not present in the generated schema and so have no home here. See
-/// `a5-notes.md`.
+/// shape the views can share.
+///
+/// Every field of `eventResponseSchema` is mapped, in the order the schema
+/// declares them. That was not true when this file was written: the
+/// generator dropped every nullable property on the floor, so only the 13
+/// non-nullable fields existed and the rest — `description`, `location`,
+/// coordinates, price, `cancellationReason` and the others — had nowhere to
+/// go. The spec now spells nullability as `type: ["string", "null"]` rather
+/// than `anyOf: [X, {type: "null"}]`, which the generator understands, and
+/// the missing 15 arrived with it. See `a5-notes.md`.
 public struct PulseEvent: Identifiable, Equatable, Sendable {
     public enum Status: String, Equatable, Sendable {
         case upcoming
@@ -39,92 +105,229 @@ public struct PulseEvent: Identifiable, Equatable, Sendable {
         case guestList = "guest_list"
     }
 
+    /// Why a `cancelled` event was cancelled. `hostLeft` is the one the
+    /// public UI words differently: the event was not called off on its own
+    /// merits, the host deleted their account and it went with them.
+    public enum CancellationReason: String, Equatable, Sendable {
+        case hostLeft = "host_left"
+        case organiser
+        case admin
+    }
+
     public let id: String
     public let title: String
+    public let description: String?
+    public let location: String?
+    public let venue: String?
+    public let venueId: String?
+    public let coordinate: PulseCoordinate?
+    public let category: String?
     public let startTime: Date
+    public let endTime: Date?
     public let status: Status
+    public let imageUrl: String?
+    public let price: PulsePrice?
     public let visibility: Visibility
     public let guestListVisibility: GuestListVisibility
     public let joinPolicy: JoinPolicy
     public let allowInterested: Bool
     public let commsChannels: String
+    public let chatId: String?
+    public let seriesId: String?
     public let instanceOverride: Bool
     public let createdByProfileId: String
+    public let createdByName: String?
+    public let createdByAvatar: String?
+    public let cancelledAt: Date?
+    public let hardDeleteAt: Date?
+    public let cancellationReason: CancellationReason?
     public let createdAt: Date
     public let updatedAt: Date
+
+    /// No price at all is free, and so is a price of zero — both spellings
+    /// occur (see `PulsePrice.isFree`).
+    public var isFree: Bool { price?.isFree ?? true }
+}
+
+// The two payload types nest their own copy of each enum, so every case
+// mapping has to be written twice. They convert by exhaustive `switch` rather
+// than by `init(rawValue:)` — the raw values do match, but a `switch` is the
+// only version that fails to compile when the spec grows a case, which is
+// exactly when someone needs to be told.
+extension PulseEvent.Status {
+    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.StatusPayload) {
+        switch generated {
+        case .upcoming: self = .upcoming
+        case .ongoing: self = .ongoing
+        case .maybeFinished: self = .maybeFinished
+        case .finished: self = .finished
+        case .cancelled: self = .cancelled
+        }
+    }
+
+    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.StatusPayload) {
+        switch generated {
+        case .upcoming: self = .upcoming
+        case .ongoing: self = .ongoing
+        case .maybeFinished: self = .maybeFinished
+        case .finished: self = .finished
+        case .cancelled: self = .cancelled
+        }
+    }
+}
+
+extension PulseEvent.Visibility {
+    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.VisibilityPayload) {
+        switch generated {
+        case ._public: self = .public
+        case ._private: self = .private
+        }
+    }
+
+    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.VisibilityPayload) {
+        switch generated {
+        case ._public: self = .public
+        case ._private: self = .private
+        }
+    }
+}
+
+extension PulseEvent.GuestListVisibility {
+    init(
+        _ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
+            .GuestListVisibilityPayload
+    ) {
+        switch generated {
+        case ._public: self = .public
+        case .connections: self = .connections
+        case ._private: self = .private
+        }
+    }
+
+    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.GuestListVisibilityPayload) {
+        switch generated {
+        case ._public: self = .public
+        case .connections: self = .connections
+        case ._private: self = .private
+        }
+    }
+}
+
+extension PulseEvent.JoinPolicy {
+    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.JoinPolicyPayload) {
+        switch generated {
+        case .open: self = .open
+        case .guestList: self = .guestList
+        }
+    }
+
+    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.JoinPolicyPayload) {
+        switch generated {
+        case .open: self = .open
+        case .guestList: self = .guestList
+        }
+    }
+}
+
+extension PulseEvent.CancellationReason {
+    init(
+        _ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
+            .CancellationReasonPayload
+    ) {
+        switch generated {
+        case .hostLeft: self = .hostLeft
+        case .organiser: self = .organiser
+        case .admin: self = .admin
+        }
+    }
+
+    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.CancellationReasonPayload) {
+        switch generated {
+        case .hostLeft: self = .hostLeft
+        case .organiser: self = .organiser
+        case .admin: self = .admin
+        }
+    }
 }
 
 extension PulseEvent {
     public init(_ payload: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload) {
-        id = payload.id
-        title = payload.title
-        startTime = payload.startTime
-        switch payload.status {
-        case .upcoming: status = .upcoming
-        case .ongoing: status = .ongoing
-        case .finished: status = .finished
-        case .cancelled: status = .cancelled
-        case .maybeFinished: status = .maybeFinished
-        }
-        switch payload.visibility {
-        case ._public: visibility = .public
-        case ._private: visibility = .private
-        }
-        switch payload.guestListVisibility {
-        case ._public: guestListVisibility = .public
-        case .connections: guestListVisibility = .connections
-        case ._private: guestListVisibility = .private
-        }
-        switch payload.joinPolicy {
-        case .open: joinPolicy = .open
-        case .guestList: joinPolicy = .guestList
-        }
-        allowInterested = payload.allowInterested
-        commsChannels = payload.commsChannels
-        instanceOverride = payload.instanceOverride
-        createdByProfileId = payload.createdByProfileId
-        createdAt = payload.createdAt
-        updatedAt = payload.updatedAt
+        self.init(
+            id: payload.id,
+            title: payload.title,
+            description: payload.description,
+            location: payload.location,
+            venue: payload.venue,
+            venueId: payload.venueId,
+            coordinate: PulseCoordinate(latitude: payload.latitude, longitude: payload.longitude),
+            category: payload.category,
+            startTime: payload.startTime,
+            endTime: payload.endTime,
+            status: Status(payload.status),
+            imageUrl: payload.imageUrl,
+            price: PulsePrice(amount: payload.priceAmount, currency: payload.priceCurrency),
+            visibility: Visibility(payload.visibility),
+            guestListVisibility: GuestListVisibility(payload.guestListVisibility),
+            joinPolicy: JoinPolicy(payload.joinPolicy),
+            allowInterested: payload.allowInterested,
+            commsChannels: payload.commsChannels,
+            chatId: payload.chatId,
+            seriesId: payload.seriesId,
+            instanceOverride: payload.instanceOverride,
+            createdByProfileId: payload.createdByProfileId,
+            createdByName: payload.createdByName,
+            createdByAvatar: payload.createdByAvatar,
+            cancelledAt: date(unixSeconds: payload.cancelledAt),
+            hardDeleteAt: date(unixSeconds: payload.hardDeleteAt),
+            cancellationReason: payload.cancellationReason.map(CancellationReason.init),
+            createdAt: payload.createdAt,
+            updatedAt: payload.updatedAt
+        )
     }
 
     public init(_ payload: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload) {
-        id = payload.id
-        title = payload.title
-        startTime = payload.startTime
-        switch payload.status {
-        case .upcoming: status = .upcoming
-        case .ongoing: status = .ongoing
-        case .finished: status = .finished
-        case .cancelled: status = .cancelled
-        case .maybeFinished: status = .maybeFinished
-        }
-        switch payload.visibility {
-        case ._public: visibility = .public
-        case ._private: visibility = .private
-        }
-        switch payload.guestListVisibility {
-        case ._public: guestListVisibility = .public
-        case .connections: guestListVisibility = .connections
-        case ._private: guestListVisibility = .private
-        }
-        switch payload.joinPolicy {
-        case .open: joinPolicy = .open
-        case .guestList: joinPolicy = .guestList
-        }
-        allowInterested = payload.allowInterested
-        commsChannels = payload.commsChannels
-        instanceOverride = payload.instanceOverride
-        createdByProfileId = payload.createdByProfileId
-        createdAt = payload.createdAt
-        updatedAt = payload.updatedAt
+        self.init(
+            id: payload.id,
+            title: payload.title,
+            description: payload.description,
+            location: payload.location,
+            venue: payload.venue,
+            venueId: payload.venueId,
+            coordinate: PulseCoordinate(latitude: payload.latitude, longitude: payload.longitude),
+            category: payload.category,
+            startTime: payload.startTime,
+            endTime: payload.endTime,
+            status: Status(payload.status),
+            imageUrl: payload.imageUrl,
+            price: PulsePrice(amount: payload.priceAmount, currency: payload.priceCurrency),
+            visibility: Visibility(payload.visibility),
+            guestListVisibility: GuestListVisibility(payload.guestListVisibility),
+            joinPolicy: JoinPolicy(payload.joinPolicy),
+            allowInterested: payload.allowInterested,
+            commsChannels: payload.commsChannels,
+            chatId: payload.chatId,
+            seriesId: payload.seriesId,
+            instanceOverride: payload.instanceOverride,
+            createdByProfileId: payload.createdByProfileId,
+            createdByName: payload.createdByName,
+            createdByAvatar: payload.createdByAvatar,
+            cancelledAt: date(unixSeconds: payload.cancelledAt),
+            hardDeleteAt: date(unixSeconds: payload.hardDeleteAt),
+            cancellationReason: payload.cancellationReason.map(CancellationReason.init),
+            createdAt: payload.createdAt,
+            updatedAt: payload.updatedAt
+        )
     }
 }
 
-/// Client-derived keyset pagination cursor for `discoverEvents`. The
-/// generated response has no `nextCursor` field — the API's own pagination
-/// contract is `cursorStartTime`/`cursorId` echoing the last item's
-/// `startTime`/`id` (see `a5-notes.md`), so this is built from the last
-/// loaded `PulseEvent`, not decoded from the server.
+/// Keyset pagination cursor for `discoverEvents`, as the server issues it.
+///
+/// This used to be rebuilt on the client from the last loaded event, because
+/// the response's `nextCursor` is nullable and the generator was dropping it
+/// along with every other nullable field. The reconstruction was right — the
+/// contract is `cursorStartTime`/`cursorId` echoing the last item — but the
+/// server's own value is authoritative, and only it can say "no more pages"
+/// without a wasted request.
 public struct EventPageCursor: Equatable, Sendable {
     public let startTime: Date
     public let id: String
@@ -133,14 +336,9 @@ public struct EventPageCursor: Equatable, Sendable {
         self.startTime = startTime
         self.id = id
     }
-}
 
-extension Array where Element == PulseEvent {
-    /// The keyset cursor for fetching the page after this one, or `nil` if
-    /// this page is empty.
-    public var keysetCursor: EventPageCursor? {
-        guard let last else { return nil }
-        return EventPageCursor(startTime: last.startTime, id: last.id)
+    public init(_ payload: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.NextCursorPayload) {
+        self.init(startTime: payload.startTime, id: payload.id)
     }
 }
 
@@ -165,10 +363,19 @@ public enum PulseRsvpTarget: String, Equatable, Sendable, CaseIterable {
     }
 }
 
-/// An RSVP as returned by `rsvpToEvent` — 5 fields, confirmed against
-/// `Types.swift`. The brief's stated shape additionally lists
-/// `invitedByProfileId` and four `shareSource*` fields; none of those are in
-/// the generated response body.
+/// An RSVP as returned by `rsvpToEvent` — the raw `event_rsvps` row, with no
+/// `profile` join and no `isCloseFriend` stamp (a different shape from the
+/// guest-list RSVP the same file's `rsvpResponseSchema` describes).
+///
+/// `invitedByProfileId` and the four `shareSource*` fields were recorded here
+/// as absent from the generated body. They never were: they are nullable, and
+/// the generator was dropping every nullable property. See `a5-notes.md`.
+///
+/// The share sources stay `String?` rather than becoming an enum. The server
+/// writes a closed set (`pulse/api/src/lib/shareSource.ts`), but the response
+/// schema types them as plain strings, and a client that narrowed an open
+/// wire type to a closed one would have to invent a case for values it does
+/// not recognise.
 public struct PulseRsvp: Equatable, Sendable {
     public enum Status: String, Equatable, Sendable {
         case going
@@ -189,12 +396,22 @@ public struct PulseRsvp: Equatable, Sendable {
     public let eventId: String
     public let profileId: String
     public let status: Status
+    public let invitedByProfileId: String?
+    public let shareSourceFirst: String?
+    public let shareSourceFirstSeenAt: Date?
+    public let shareSourceLast: String?
+    public let shareSourceLastSeenAt: Date?
     public let createdAt: Date
 
     public init(_ payload: Operations.RsvpToEvent.Output.Ok.Body.JsonPayload.RsvpPayload) {
         id = payload.id
         eventId = payload.eventId
         profileId = payload.profileId
+        invitedByProfileId = payload.invitedByProfileId
+        shareSourceFirst = payload.shareSourceFirst
+        shareSourceFirstSeenAt = payload.shareSourceFirstSeenAt
+        shareSourceLast = payload.shareSourceLast
+        shareSourceLastSeenAt = payload.shareSourceLastSeenAt
         createdAt = payload.createdAt
         switch payload.status {
         case .going: status = .going
@@ -205,12 +422,19 @@ public struct PulseRsvp: Equatable, Sendable {
     }
 
     /// The optimistic value to show immediately after requesting `target`,
-    /// before the server responds.
+    /// before the server responds. Everything the server assigns — the id,
+    /// the invite and share-source attribution, the timestamp — is empty
+    /// until it answers.
     public init(optimistic target: PulseRsvpTarget, eventId: String, profileId: String) {
         id = ""
         self.eventId = eventId
         self.profileId = profileId
         status = Status(target)
+        invitedByProfileId = nil
+        shareSourceFirst = nil
+        shareSourceFirstSeenAt = nil
+        shareSourceLast = nil
+        shareSourceLastSeenAt = nil
         createdAt = Date(timeIntervalSince1970: 0)
     }
 }

--- a/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseModelsTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseModelsTests.swift
@@ -26,6 +26,115 @@ private func makeDiscoverEventsPayload(
     )
 }
 
+/// Every field of `eventResponseSchema` populated, so a mapping that drops
+/// one shows up as a failed expectation rather than as a `nil` nobody
+/// notices. `cancelledAt`/`hardDeleteAt` are unix seconds, not `date-time`,
+/// hence the bare numbers.
+private func makeFullDiscoverEventsPayload()
+    -> Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
+{
+    .init(
+        allowInterested: true,
+        cancellationReason: .hostLeft,
+        cancelledAt: 1_700_000_500,
+        category: "music",
+        chatId: "chat-1",
+        commsChannels: "email",
+        createdAt: referenceDate,
+        createdByAvatar: "https://cdn.example/avatar.png",
+        createdByName: "Ada",
+        createdByProfileId: "profile-1",
+        description: "Sunset set on the roof",
+        endTime: referenceDate.addingTimeInterval(7200),
+        guestListVisibility: .connections,
+        hardDeleteAt: 1_701_000_000,
+        id: "event-1",
+        imageUrl: "https://cdn.example/event.jpg",
+        instanceOverride: true,
+        joinPolicy: .guestList,
+        latitude: -33.8688,
+        location: "Sydney",
+        longitude: 151.2093,
+        priceAmount: 1850,
+        priceCurrency: "AUD",
+        seriesId: "series-1",
+        startTime: referenceDate,
+        status: .cancelled,
+        title: "Rooftop Party",
+        updatedAt: referenceDate,
+        venue: "The Roof",
+        venueId: "venue-1",
+        visibility: ._private
+    )
+}
+
+@Test func pulseEventMapsEveryDiscoverEventsField() {
+    let event = PulseEvent(makeFullDiscoverEventsPayload())
+    #expect(event.description == "Sunset set on the roof")
+    #expect(event.location == "Sydney")
+    #expect(event.venue == "The Roof")
+    #expect(event.venueId == "venue-1")
+    #expect(event.coordinate == PulseCoordinate(latitude: -33.8688, longitude: 151.2093))
+    #expect(event.category == "music")
+    #expect(event.endTime == referenceDate.addingTimeInterval(7200))
+    #expect(event.imageUrl == "https://cdn.example/event.jpg")
+    #expect(event.price == PulsePrice(minorUnits: 1850, currency: "AUD"))
+    #expect(event.chatId == "chat-1")
+    #expect(event.seriesId == "series-1")
+    #expect(event.createdByName == "Ada")
+    #expect(event.createdByAvatar == "https://cdn.example/avatar.png")
+    #expect(event.cancellationReason == .hostLeft)
+    #expect(event.visibility == .private)
+    #expect(event.joinPolicy == .guestList)
+    #expect(event.instanceOverride == true)
+}
+
+@Test func cancelledAtAndHardDeleteAtAreReadAsUnixSeconds() {
+    let event = PulseEvent(makeFullDiscoverEventsPayload())
+    #expect(event.cancelledAt == Date(timeIntervalSince1970: 1_700_000_500))
+    #expect(event.hardDeleteAt == Date(timeIntervalSince1970: 1_701_000_000))
+}
+
+@Test func absentOptionalFieldsMapToNil() {
+    let event = PulseEvent(makeDiscoverEventsPayload())
+    #expect(event.description == nil)
+    #expect(event.location == nil)
+    #expect(event.venue == nil)
+    #expect(event.venueId == nil)
+    #expect(event.coordinate == nil)
+    #expect(event.category == nil)
+    #expect(event.endTime == nil)
+    #expect(event.imageUrl == nil)
+    #expect(event.price == nil)
+    #expect(event.chatId == nil)
+    #expect(event.seriesId == nil)
+    #expect(event.createdByName == nil)
+    #expect(event.createdByAvatar == nil)
+    #expect(event.cancelledAt == nil)
+    #expect(event.hardDeleteAt == nil)
+    #expect(event.cancellationReason == nil)
+}
+
+@Test func halfACoordinateIsNoCoordinate() {
+    var payload = makeFullDiscoverEventsPayload()
+    payload.longitude = nil
+    #expect(PulseEvent(payload).coordinate == nil)
+}
+
+@Test func anAmountWithoutACurrencyIsNoPrice() {
+    var payload = makeFullDiscoverEventsPayload()
+    payload.priceCurrency = nil
+    #expect(PulseEvent(payload).price == nil)
+}
+
+@Test func zeroAndAbsentPriceBothReadAsFree() {
+    var payload = makeFullDiscoverEventsPayload()
+    payload.priceAmount = 0
+    #expect(PulseEvent(payload).isFree == true)
+    #expect(PulseEvent(makeDiscoverEventsPayload()).isFree == true)
+    #expect(PulseEvent(makeFullDiscoverEventsPayload()).isFree == false)
+}
+
 @Test func pulseEventMapsDiscoverEventsPayloadFields() {
     let event = PulseEvent(makeDiscoverEventsPayload())
     #expect(event.id == "event-1")
@@ -50,16 +159,73 @@ private func makeDiscoverEventsPayload(
     #expect(PulseEvent(makeDiscoverEventsPayload(status: .maybeFinished)).status == .maybeFinished)
 }
 
-@Test func keysetCursorIsNilForEmptyPage() {
-    let events: [PulseEvent] = []
-    #expect(events.keysetCursor == nil)
+/// The same event, spelled in the detail endpoint's own payload type.
+private func makeFullGetEventByIdPayload() -> Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload {
+    .init(
+        allowInterested: true,
+        cancellationReason: .hostLeft,
+        cancelledAt: 1_700_000_500,
+        category: "music",
+        chatId: "chat-1",
+        commsChannels: "email",
+        createdAt: referenceDate,
+        createdByAvatar: "https://cdn.example/avatar.png",
+        createdByName: "Ada",
+        createdByProfileId: "profile-1",
+        description: "Sunset set on the roof",
+        endTime: referenceDate.addingTimeInterval(7200),
+        guestListVisibility: .connections,
+        hardDeleteAt: 1_701_000_000,
+        id: "event-1",
+        imageUrl: "https://cdn.example/event.jpg",
+        instanceOverride: true,
+        joinPolicy: .guestList,
+        latitude: -33.8688,
+        location: "Sydney",
+        longitude: 151.2093,
+        priceAmount: 1850,
+        priceCurrency: "AUD",
+        seriesId: "series-1",
+        startTime: referenceDate,
+        status: .cancelled,
+        title: "Rooftop Party",
+        updatedAt: referenceDate,
+        venue: "The Roof",
+        venueId: "venue-1",
+        visibility: ._private
+    )
 }
 
-@Test func keysetCursorEchoesLastEventsStartTimeAndId() {
-    let events = [PulseEvent(makeDiscoverEventsPayload(id: "a")), PulseEvent(makeDiscoverEventsPayload(id: "b"))]
-    let cursor = events.keysetCursor
-    #expect(cursor?.id == "b")
-    #expect(cursor?.startTime == referenceDate)
+/// The point of the two bridges is that Explore and Event detail can share
+/// one model, so the only interesting property is that they agree. Written
+/// as a single equality rather than a second field-by-field sweep: the two
+/// mappings are duplicated by necessity (the generated types nest their own
+/// enums), and this is what catches one drifting from the other.
+@Test func bothBridgesProduceTheSameEvent() {
+    #expect(PulseEvent(makeFullDiscoverEventsPayload()) == PulseEvent(makeFullGetEventByIdPayload()))
+}
+
+@Test func pulseEventMapsAllCancellationReasons() {
+    func reason(
+        _ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.CancellationReasonPayload
+    ) -> PulseEvent.CancellationReason? {
+        var payload = makeFullGetEventByIdPayload()
+        payload.cancellationReason = generated
+        return PulseEvent(payload).cancellationReason
+    }
+    #expect(reason(.hostLeft) == .hostLeft)
+    #expect(reason(.organiser) == .organiser)
+    #expect(reason(.admin) == .admin)
+}
+
+@Test func eventPageCursorReadsTheServersNextCursor() {
+    let payload = Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.NextCursorPayload(
+        id: "event-9",
+        startTime: referenceDate
+    )
+    let cursor = EventPageCursor(payload)
+    #expect(cursor.id == "event-9")
+    #expect(cursor.startTime == referenceDate)
 }
 
 @Test func rsvpTargetMapsToGeneratedRequestStatus() {

--- a/shared/swift/OSNShared/a5-notes.md
+++ b/shared/swift/OSNShared/a5-notes.md
@@ -70,7 +70,9 @@ Directly confirmed by reading the generated file, not inferred: `EventsPayloadPa
 
 ## DoD 6 — tests for testable logic
 
-**Verified**, model layer only. `Tests/PulseFeatureTests/PulseModelsTests.swift`, 8 tests, all passing: `PulseEvent.init(_:)` field mapping and full status-enum coverage, `Array.keysetCursor` (empty + non-empty), `PulseRsvpTarget.generated` mapping, `PulseRsvp.init(optimistic:...)`, `PulseRsvp.init(_:)` decoding, `PulseRsvpCounts.init(_:)` rounding.
+**Verified**, model layer only. `Tests/PulseFeatureTests/PulseModelsTests.swift`, all passing: `PulseEvent.init(_:)` field mapping and full status-enum coverage, `Array.keysetCursor` (empty + non-empty), `PulseRsvpTarget.generated` mapping, `PulseRsvp.init(optimistic:...)`, `PulseRsvp.init(_:)` decoding, `PulseRsvpCounts.init(_:)` rounding.
+
+Extended 2026-08-09 when the nullable-drop fix made the rest of `eventResponseSchema` reachable: every field mapped from both payload types, unix-second `cancelledAt`/`hardDeleteAt`, absent-optionals-are-nil, the coordinate and price pairing rules, free-vs-priced, all cancellation reasons, and one equality test asserting the two bridges agree — the duplicated mappings are the thing most likely to drift. `Array.keysetCursor` and its two tests are gone: the server's own `nextCursor` is now visible, so the cursor is decoded rather than rebuilt.
 
 **Not tested — scope decision, not an oversight:** view-model async logic (`ExploreViewModel`'s pagination-cursor progression, `EventDetailViewModel`'s optimistic-update/rollback on RSVP). Both call through `APIProtocol`, which has no in-repo fake/mock implementation, and the brief prohibits inventing infrastructure (a fake conforming to the full generated `APIProtocol` is a non-trivial surface, not a small fixture). Left for whoever picks this up next to decide whether that's worth building; the pure mapping logic those view models rely on (this file) is tested.
 
@@ -84,7 +86,7 @@ No `BLOCKED:` was needed this brief — no identifier had to be invented. Test f
 
 ## Known field-shape gaps vs. the brief's assumed shapes
 
-- `EventDetailView` renders `status == .cancelled` as a plain "Cancelled" pill; the real generated `EventsPayloadPayload`/detail payload has no `cancellationReason` field, so none is shown — the brief's mention of a cancellation reason doesn't match what the API actually returns.
+- ~~`EventDetailView` renders `status == .cancelled` as a plain "Cancelled" pill; the real generated `EventsPayloadPayload`/detail payload has no `cancellationReason` field, so none is shown — the brief's mention of a cancellation reason doesn't match what the API actually returns.~~ **Wrong diagnosis, corrected 2026-08-09.** The API returned `cancellationReason` all along, along with 14 other fields the brief described and this file recorded as absent. The generator was dropping every nullable property: `t.Nullable(...)` emits `anyOf: [X, {type: "null"}]`, which swift-openapi-generator cannot represent, so it warned `Schema "null" is not supported` and omitted the property. 254 of them. `pulse/api/scripts/generate-openapi.ts` now emits the equivalent `type: ["string", "null"]` spelling instead, and `PulseModels.swift` maps the full `eventResponseSchema` — including `cancellationReason` (now a proper enum), coordinates, price and `description`. `EventDetailView` still shows only the pill; wiring the reason into the copy is UI work, not a schema gap.
 - `RsvpPayload.StatusPayload` has 4 cases (`going`, `maybe`, `notGoing` — wire key `not_going` — `invited`); `PulseRsvpTarget` (the user-actionable subset) has 3, matching the three RSVP buttons in `EventDetailView`. `invited` is a receive-only status, never a target.
 
 ## Stale SourceKit diagnostics (recurring, not real)


### PR DESCRIPTION
Stacked on #405 — review that first; this diff is against it, not `main`.

#405 stopped swift-openapi-generator dropping nullable properties. This maps what became reachable, and corrects the places where the bug's symptoms had been written down as API facts.

## `PulseEvent` — all 29 fields

Every field of `eventResponseSchema`, in schema order: `description`, `location`, `venue`, `venueId`, coordinates, `category`, `endTime`, `imageUrl`, price, `chatId`, `seriesId`, `createdByName`, `createdByAvatar`, `cancelledAt`, `hardDeleteAt`, `cancellationReason`. Previously only the 13 non-nullable ones existed.

Two need care rather than a straight copy:

- **`cancelledAt`/`hardDeleteAt` are unix seconds.** Plain `integer` columns (`pulse/db/src/schema/events.ts:102-103`), not the `timestamp` columns the four date-time fields come from — `serializeEvent` deliberately passes them through without `.toISOString()` (`pulse/api/src/routes/events.ts:124`). The generator emits `Double?`; converted with `Date(timeIntervalSince1970:)`.
- **`priceAmount` is minor units** — 1850 is $18.50 — and the DB pairs it with `priceCurrency`: *"Both columns set or both null — enforced at the service layer. null OR 0 → Free"*. `PulsePrice` keeps that pairing and exposes `isFree`. `PulseCoordinate` does the same for latitude/longitude: a lone latitude cannot be placed on a map.

`cancellationReason` becomes a real enum (`hostLeft`/`organiser`/`admin`) — `host_left` is the case the public UI words differently, since the event wasn't called off on its merits, the host deleted their account.

### Why the enum conversions are duplicated

`discoverEvents` and `getEventById` generate two structurally-identical but nominally distinct payload types, each nesting its own copy of all five enums. So every case mapping is written twice. They convert by exhaustive `switch`, not `init(rawValue:)` — the raw values do match, but a `switch` is the only version that fails to compile when the spec grows a case. `bothBridgesProduceTheSameEvent()` asserts the two produce equal events, which is what catches one copy drifting from the other.

## Same root cause, also corrected

- **`PulseRsvp`** recorded `invitedByProfileId` and the four `shareSource*` fields as absent from the response body. They never were. Added; the comment now says what happened. The share sources stay `String?` — the server writes a closed set (`pulse/api/src/lib/shareSource.ts`), but the *response schema* types them as open strings, and narrowing an open wire type client-side means inventing a case for values we don't recognise.
- **`ExploreViewModel`** now reads the server's `nextCursor` instead of rebuilding the cursor from the last loaded event. The reconstruction was correct, but only the server can say "no more pages": the old `hasMore = page.count == pageSize` guess always cost one extra empty request whenever the final page happened to be exactly `pageSize` long. `Array<PulseEvent>.keysetCursor` and its two tests are deleted.
- **`a5-notes.md`** line 87 recorded the missing `cancellationReason` as something the API doesn't return. It was a generator artefact. Struck through, with the real diagnosis.

## Tests

`swift build` clean. `swift test`: **47 tests in 7 suites passed**.

New: every-field mapping from both payload types, unix-second conversion, absent-optionals-are-nil, half-a-coordinate-is-no-coordinate, amount-without-currency-is-no-price, zero-and-absent-both-read-as-free, all cancellation reasons, the two-bridges equality, and the server cursor decode.

## Deliberately not in this PR

- **Rendering** the new fields. `EventDetailView` still shows a bare "Cancelled" pill and no description, venue or price. UI work for the detail-view brief.
- **The `series` map** in the discover response (`{id, title}` per key) is still unmodelled in Swift.
- **View-model async tests** — `ExploreViewModel`'s pagination progression is exactly the untested area flagged in #404, and this PR changes it. Testing it needs a fake conforming to the full generated `APIProtocol`, which is its own task.

No changeset: `shared/swift/*` is on the allowlist in `scripts/changeset-required.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
