### PR TITLE
Drive Explore's search from a map region

### DIFF
--- a/shared/swift/OSNShared/Sources/PulseFeature/ExploreView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/ExploreView.swift
@@ -1,10 +1,24 @@
+import MapKit
 import OSNUI
 import SwiftUI
 
-/// Explore tab: a paginated `discoverEvents` list. Real loading/empty/error
-/// states only — no placeholder or mock rows.
+/// Explore tab: a paginated `discoverEvents` list, or the same search drawn
+/// on a map. Real loading/empty/error states only — no placeholder or mock
+/// rows.
 public struct ExploreView: View {
+    private enum Mode: String, CaseIterable, Identifiable {
+        case list = "List"
+        case map = "Map"
+
+        var id: Self { self }
+        var symbol: String { self == .list ? "list.bullet" : "map" }
+    }
+
     @State private var viewModel: ExploreViewModel
+    @State private var mode: Mode = .list
+    /// Drives both the map's pin selection and a row tap, so the two modes
+    /// push the same detail screen through one destination.
+    @State private var selectedEventId: String?
 
     private let session: PulseSession
 
@@ -15,27 +29,31 @@ public struct ExploreView: View {
 
     public var body: some View {
         Group {
-            if viewModel.events.isEmpty {
-                switch viewModel.state {
-                case .idle, .loading:
-                    ProgressView()
-                case .failed(let message):
-                    ContentUnavailableView(
-                        "Couldn't load events",
-                        systemImage: "exclamationmark.triangle",
-                        description: Text(message)
-                    )
-                case .loaded:
-                    ContentUnavailableView(
-                        "No events yet",
-                        systemImage: "calendar"
-                    )
-                }
-            } else {
-                list
+            switch mode {
+            case .list:
+                listMode
+            case .map:
+                ExploreMap(
+                    events: viewModel.events,
+                    selectedEventId: $selectedEventId,
+                    onRegionChange: { await viewModel.updateRegion($0) }
+                )
             }
         }
         .navigationTitle("Explore")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Picker("View", selection: $mode) {
+                    ForEach(Mode.allCases) { mode in
+                        Label(mode.rawValue, systemImage: mode.symbol).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .navigationDestination(item: $selectedEventId) { eventId in
+            EventDetailView(session: session, eventId: eventId)
+        }
         .task {
             if viewModel.events.isEmpty {
                 await viewModel.loadFirstPage()
@@ -43,12 +61,46 @@ public struct ExploreView: View {
         }
     }
 
+    @ViewBuilder
+    private var listMode: some View {
+        if viewModel.events.isEmpty {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView()
+            case .failed(let message):
+                ContentUnavailableView(
+                    "Couldn't load events",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(message)
+                )
+            case .loaded:
+                ContentUnavailableView(
+                    viewModel.region == nil ? "No events yet" : "No events in this area",
+                    systemImage: "calendar",
+                    description: viewModel.region == nil ? nil : Text("Move the map or search everywhere.")
+                )
+            }
+        } else {
+            list
+        }
+    }
+
     private var list: some View {
         ScrollView {
             GlassEffectContainer {
                 LazyVStack(spacing: 16) {
+                    // The list inherits whatever area the map was last left
+                    // on. Say so, and offer the way out — otherwise a short
+                    // list after a zoom reads as "there is nothing on".
+                    if viewModel.region != nil {
+                        GlassButton("Searching this map area — search everywhere", kind: .secondary) {
+                            Task { await viewModel.clearRegion() }
+                        }
+                    }
                     ForEach(viewModel.events) { event in
-                        NavigationLink(value: event.id) {
+                        Button {
+                            selectedEventId = event.id
+                        } label: {
                             EventRow(event: event)
                         }
                         .buttonStyle(.plain)
@@ -60,12 +112,65 @@ public struct ExploreView: View {
                 .padding()
             }
         }
-        .navigationDestination(for: String.self) { eventId in
-            EventDetailView(session: session, eventId: eventId)
-        }
         .refreshable {
             await viewModel.loadFirstPage()
         }
+    }
+}
+
+/// The same `discoverEvents` search, drawn where the events are.
+///
+/// The visible viewport *is* the query: pan or zoom, and the map's centre and
+/// corner distance become `lat`/`lng`/`radiusKm`. Nothing asks the device
+/// where it is.
+private struct ExploreMap: View {
+    let events: [PulseEvent]
+    @Binding var selectedEventId: String?
+    let onRegionChange: (PulseSearchRegion) async -> Void
+
+    /// Starts at `.automatic`, which frames whatever pins the first
+    /// unfiltered page produced. That framing is not a user's choice of area,
+    /// so it deliberately does not trigger a search — see the guard below.
+    @State private var position: MapCameraPosition = .automatic
+    @State private var pendingRegion: PulseSearchRegion?
+
+    /// Only events the server gave coordinates for can be drawn. The rest are
+    /// still in the list; a pin at a made-up point would be worse than none.
+    private var mappable: [PulseEvent] {
+        events.filter { $0.coordinate != nil }
+    }
+
+    var body: some View {
+        Map(position: $position, selection: $selectedEventId) {
+            ForEach(mappable) { event in
+                if let coordinate = event.coordinate {
+                    Marker(
+                        event.title,
+                        systemImage: event.status == .ongoing ? "dot.radiowaves.left.and.right" : "sparkles",
+                        coordinate: CLLocationCoordinate2D(
+                            latitude: coordinate.latitude,
+                            longitude: coordinate.longitude
+                        )
+                    )
+                    .tint(OSNColor.accent)
+                    .tag(event.id)
+                }
+            }
+        }
+        .onMapCameraChange(frequency: .onEnd) { context in
+            // `.automatic` frames the pins itself, and those pins came from
+            // the last search. Querying that frame would feed a search its own
+            // output and never settle, so only a camera the user placed counts.
+            guard position.positionedByUser else { return }
+            pendingRegion = PulseSearchRegion(context.region)
+        }
+        // Keyed on the region so a gesture that lands mid-request cancels the
+        // request it superseded instead of racing it.
+        .task(id: pendingRegion) {
+            guard let pendingRegion else { return }
+            await onRegionChange(pendingRegion)
+        }
+        .ignoresSafeArea(edges: .bottom)
     }
 }
 

--- a/shared/swift/OSNShared/Sources/PulseFeature/ExploreViewModel.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/ExploreViewModel.swift
@@ -19,6 +19,11 @@ public final class ExploreViewModel {
     public private(set) var events: [PulseEvent] = []
     public private(set) var state: LoadState = .idle
 
+    /// The map viewport the search is pinned to, or `nil` for "everywhere".
+    /// Set by the map, read by the map's own framing — never guessed from the
+    /// device, which has no location permission to guess with.
+    public private(set) var region: PulseSearchRegion?
+
     /// Whether another page exists. The server says so directly — a null
     /// `nextCursor` is the end of the list — so this no longer guesses from
     /// a full-looking page, which always cost one extra empty request when
@@ -29,6 +34,7 @@ public final class ExploreViewModel {
     private let pageSize: Int
     private var nextCursor: EventPageCursor?
     private var hasLoaded = false
+    private var loadGeneration = 0
 
     public init(api: any APIProtocol, pageSize: Int = 20) {
         self.api = api
@@ -42,6 +48,24 @@ public final class ExploreViewModel {
         await load(cursor: nil)
     }
 
+    /// Point the search at a map viewport and reload from the first page.
+    ///
+    /// A pan or zoom too small to change the answer is ignored — see
+    /// `PulseSearchRegion.isMeaningfullyDifferent(from:)`. Without that, every
+    /// settled gesture would cost a page of the same events.
+    public func updateRegion(_ newRegion: PulseSearchRegion) async {
+        if let region, !newRegion.isMeaningfullyDifferent(from: region) { return }
+        region = newRegion
+        await loadFirstPage()
+    }
+
+    /// Drop the map filter and search everywhere again.
+    public func clearRegion() async {
+        guard region != nil else { return }
+        region = nil
+        await loadFirstPage()
+    }
+
     /// Call when a row is about to appear — triggers the next page once the
     /// last loaded row is reached.
     public func loadNextPageIfNeeded(currentItemId: String) async {
@@ -50,15 +74,24 @@ public final class ExploreViewModel {
     }
 
     private func load(cursor: EventPageCursor?) async {
+        loadGeneration += 1
+        let generation = loadGeneration
         state = .loading
         do {
             let query = Operations.DiscoverEvents.Input.Query(
+                lat: region.map { .init(value2: $0.center.latitude) },
+                lng: region.map { .init(value2: $0.center.longitude) },
+                radiusKm: region.map { .init(value2: $0.radiusKm) },
                 cursorStartTime: cursor?.startTime,
                 cursorId: cursor?.id,
                 limit: .init(value2: Double(pageSize))
             )
             let output = try await api.discoverEvents(.init(query: query))
             let body = try output.ok.body.json
+            // A pan that lands mid-request starts a newer load; that one owns
+            // the list from here, so this reply is stale and gets dropped
+            // rather than appended out of order.
+            guard generation == loadGeneration else { return }
             let page = body.events.map(PulseEvent.init)
             if cursor == nil {
                 events = page
@@ -69,6 +102,9 @@ public final class ExploreViewModel {
             hasLoaded = true
             state = .loaded
         } catch {
+            // The map cancels the in-flight search when the user keeps
+            // panning. That is the feature working, not a failure to show.
+            guard !Task.isCancelled, generation == loadGeneration else { return }
             state = .failed(String(describing: error))
         }
     }

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseSearchRegion.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseSearchRegion.swift
@@ -1,0 +1,84 @@
+import Foundation
+import MapKit
+
+/// A map viewport expressed the way `discoverEvents` wants it: a centre plus
+/// a radius in kilometres.
+///
+/// `lat`, `lng` and `radiusKm` are a triangle on the wire — the discovery
+/// schema rejects a request carrying one or two of them ("Location triangle"
+/// in `pulse/api/src/services/discovery.ts`). Holding all three in one value
+/// means a half-built filter can't reach the server by accident.
+///
+/// Nothing here touches CoreLocation. The search follows the map the user is
+/// looking at, not the device, so Pulse needs no location permission and no
+/// new entitlement.
+public struct PulseSearchRegion: Equatable, Sendable {
+    /// Matches `RadiusKm` in the discovery schema. Outside this range the
+    /// request is a 422, so a zoomed-right-out map clamps to 500 km and
+    /// searches what fits rather than asking for the impossible.
+    public static let radiusRangeKm: ClosedRange<Double> = 0.1...500
+
+    public let center: PulseCoordinate
+    public let radiusKm: Double
+
+    public init(center: PulseCoordinate, radiusKm: Double) {
+        self.center = center
+        self.radiusKm = min(max(radiusKm, Self.radiusRangeKm.lowerBound), Self.radiusRangeKm.upperBound)
+    }
+
+    /// The circle covering a viewport given as a centre and its full spans in
+    /// degrees: the distance from the centre to a corner, so nothing on
+    /// screen falls outside the search.
+    ///
+    /// The server's bounding box clamps `cos(lat)` away from zero to stay
+    /// conservative. This uses the real cosine instead — near the poles a
+    /// degree of longitude genuinely is short, and inflating it here would
+    /// search a band the user cannot see.
+    public init(center: PulseCoordinate, latitudeDelta: Double, longitudeDelta: Double) {
+        let northSouthKm = (latitudeDelta / 2) * kmPerDegreeLatitude
+        let eastWestKm = (longitudeDelta / 2) * kmPerDegreeLatitude * cos(center.latitude * degreesToRadians)
+        self.init(
+            center: center,
+            radiusKm: (northSouthKm * northSouthKm + eastWestKm * eastWestKm).squareRoot()
+        )
+    }
+
+    public init(_ region: MKCoordinateRegion) {
+        self.init(
+            center: PulseCoordinate(latitude: region.center.latitude, longitude: region.center.longitude),
+            latitudeDelta: region.span.latitudeDelta,
+            longitudeDelta: region.span.longitudeDelta
+        )
+    }
+
+    /// Whether this viewport sits far enough from `other` to be worth another
+    /// search.
+    ///
+    /// `onMapCameraChange` reports the end of every gesture, including the
+    /// nudge that moves the map by a few points and returns the same events.
+    /// A tenth of the current radius is about the smallest move that can pull
+    /// something new in at the edge, so anything smaller is dropped.
+    public func isMeaningfullyDifferent(from other: PulseSearchRegion) -> Bool {
+        let tolerance = other.radiusKm / 10
+        if abs(radiusKm - other.radiusKm) > tolerance { return true }
+        return distanceKm(from: center, to: other.center) > tolerance
+    }
+}
+
+/// ~111 km per degree of latitude — the constant the server's bounding box
+/// uses, so the client's idea of the visible circle matches the one being
+/// searched.
+private let kmPerDegreeLatitude = 111.0
+private let earthRadiusKm = 6371.0
+private let degreesToRadians = Double.pi / 180
+
+/// Great-circle distance, mirroring `haversineKm` in the discovery service.
+func distanceKm(from: PulseCoordinate, to: PulseCoordinate) -> Double {
+    let deltaLat = (to.latitude - from.latitude) * degreesToRadians
+    let deltaLng = (to.longitude - from.longitude) * degreesToRadians
+    let a =
+        (sin(deltaLat / 2) * sin(deltaLat / 2))
+        + cos(from.latitude * degreesToRadians) * cos(to.latitude * degreesToRadians)
+        * (sin(deltaLng / 2) * sin(deltaLng / 2))
+    return 2 * earthRadiusKm * asin(min(1, a.squareRoot()))
+}

--- a/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseSearchRegionTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseSearchRegionTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MapKit
+import Testing
+@testable import PulseFeature
+
+private let sydney = PulseCoordinate(latitude: -33.8688, longitude: 151.2093)
+
+@Test func radiusClampsToWhatTheDiscoverySchemaAccepts() {
+    #expect(PulseSearchRegion(center: sydney, radiusKm: 20_000).radiusKm == 500)
+    #expect(PulseSearchRegion(center: sydney, radiusKm: 0).radiusKm == 0.1)
+    #expect(PulseSearchRegion(center: sydney, radiusKm: 12).radiusKm == 12)
+}
+
+/// The radius has to reach the corner of the viewport, not its edge, or the
+/// events in the corners of the visible map are missing from the search.
+@Test func regionRadiusReachesTheCornerOfTheViewport() {
+    let region = PulseSearchRegion(center: sydney, latitudeDelta: 0.2, longitudeDelta: 0.2)
+    let northSouthKm = 0.1 * 111.0
+    let eastWestKm = 0.1 * 111.0 * cos(sydney.latitude * .pi / 180)
+    let corner = (northSouthKm * northSouthKm + eastWestKm * eastWestKm).squareRoot()
+    #expect(abs(region.radiusKm - corner) < 0.001)
+    #expect(region.radiusKm > northSouthKm)
+}
+
+/// A degree of longitude is narrower away from the equator, so the same span
+/// covers less ground in Sydney than on the equator.
+@Test func longitudeSpanShrinksWithLatitude() {
+    let equator = PulseSearchRegion(
+        center: PulseCoordinate(latitude: 0, longitude: 0),
+        latitudeDelta: 0,
+        longitudeDelta: 1
+    )
+    let far = PulseSearchRegion(center: sydney, latitudeDelta: 0, longitudeDelta: 1)
+    #expect(far.radiusKm < equator.radiusKm)
+}
+
+@Test func mapKitRegionConvertsToTheSameSearch() {
+    let mkRegion = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: sydney.latitude, longitude: sydney.longitude),
+        span: MKCoordinateSpan(latitudeDelta: 0.2, longitudeDelta: 0.2)
+    )
+    #expect(
+        PulseSearchRegion(mkRegion)
+            == PulseSearchRegion(center: sydney, latitudeDelta: 0.2, longitudeDelta: 0.2)
+    )
+}
+
+@Test func aNudgeIsNotANewSearch() {
+    let region = PulseSearchRegion(center: sydney, radiusKm: 10)
+    // ~100 m north — a fingertip of drift at this zoom.
+    let nudged = PulseSearchRegion(
+        center: PulseCoordinate(latitude: sydney.latitude + 0.001, longitude: sydney.longitude),
+        radiusKm: 10
+    )
+    #expect(nudged.isMeaningfullyDifferent(from: region) == false)
+}
+
+@Test func aRealPanIsANewSearch() {
+    let region = PulseSearchRegion(center: sydney, radiusKm: 10)
+    // ~11 km north, past the tenth-of-a-radius tolerance.
+    let panned = PulseSearchRegion(
+        center: PulseCoordinate(latitude: sydney.latitude + 0.1, longitude: sydney.longitude),
+        radiusKm: 10
+    )
+    #expect(panned.isMeaningfullyDifferent(from: region))
+}
+
+@Test func zoomingIsANewSearchEvenWithoutMoving() {
+    let region = PulseSearchRegion(center: sydney, radiusKm: 10)
+    #expect(PulseSearchRegion(center: sydney, radiusKm: 20).isMeaningfullyDifferent(from: region))
+    #expect(PulseSearchRegion(center: sydney, radiusKm: 10.5).isMeaningfullyDifferent(from: region) == false)
+}
+
+@Test func distanceMatchesTheServersHaversine() {
+    let melbourne = PulseCoordinate(latitude: -37.8136, longitude: 144.9631)
+    // Sydney–Melbourne great-circle distance is ~713 km.
+    #expect(abs(distanceKm(from: sydney, to: melbourne) - 713) < 5)
+    #expect(distanceKm(from: sydney, to: sydney) == 0)
+}


### PR DESCRIPTION
Stacked on #407 (which is stacked on #405). Review the top commit only.

## What

Explore gets a second mode: the same `discoverEvents` search, drawn where the events are. The visible map viewport **is** the query — its centre and its corner distance become `lat`/`lng`/`radiusKm`.

Unblocked by #405: coordinates were among the fields the nullable-drop bug was deleting from the generated types, so until it was fixed there was nothing to put a pin on.

## No new Apple-portal blocker

Nothing asks the device where it is. No CoreLocation import, so no `NSLocationWhenInUseUsageDescription`, no permission prompt, and nothing to add to the two capabilities already listed as BLOCKED in `pulse/ios/project.yml`. `project.yml` is untouched.

## Design notes

**`PulseSearchRegion` holds all three geo parameters together.** The discovery schema rejects a request carrying one or two of them — the "Location triangle" filter in `pulse/api/src/services/discovery.ts`. One value means a half-built filter can't reach the server by accident. It also clamps the radius to the 0.1–500 km the schema accepts, so a zoomed-right-out map searches what fits rather than taking a 422.

**The radius reaches the viewport's corner, not its edge**, or events in the corners of the visible map are missing from their own search. It uses the same ~111 km/degree constant as the server's bounding box so both sides mean the same circle. Unlike the server, it does *not* clamp `cos(lat)` away from zero: the server clamps to keep its bbox conservative, but near the poles a degree of longitude genuinely is short and inflating it here would search a band the user can't see.

**Three things that would otherwise misbehave:**

- The initial `.automatic` camera frames the pins the last search produced. Treating that frame as a new query would feed a search its own output, so only a camera the user placed drives a search (`position.positionedByUser`).
- `onMapCameraChange` reports every settled gesture, including the nudge that returns the same events. A move smaller than a tenth of the current radius is dropped — about the smallest move that can pull something new in at the edge.
- A pan landing mid-request cancels the request it superseded (`.task(id:)` keyed on the region), and a reply arriving after a newer load started is discarded rather than appended out of order (generation counter). A cancelled search no longer surfaces as an error banner.

**One destination for both modes.** Row taps and pin taps now push through a single `navigationDestination(item:)`, so the list row became a `Button` — there is no second registered destination to drift.

## Scope

- Events without coordinates stay in the list and get no pin. An invented point would be worse than none.
- Only the events the current page returned are drawn. Pagination on the map is still the list's `loadNextPageIfNeeded`; a "load everything in view" mode is a different feature with a different cost.
- The list keeps whatever area the map was last left on, and says so, with a button back to searching everywhere — otherwise a short list after a zoom reads as "there is nothing on".
- Category/date/price/friends-only are all live query parameters and none are wired to UI here. Filters are their own brief.

## Tests

8 new, covering the region maths and the pan/zoom threshold directly: radius clamping to the schema's range, corner-not-edge coverage, longitude narrowing with latitude, the `MKCoordinateRegion` bridge, nudge-vs-pan, zoom-without-moving, and haversine against a known Sydney–Melbourne distance.

`swift build` clean. `swift test` → 55 tests in 7 suites passed (47 before).

View-model async tests — pagination-cursor progression, RSVP optimistic rollback, and now region-driven reload — still need a fake conforming to the full generated `APIProtocol`. Same gap flagged in #404 and #407; it is its own task.

## Changeset

None. `shared/swift/*` is on the allowlist in `scripts/changeset-required.sh` — no versioned package ships from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)