### PR TITLE
Give the event screen a map, a price and an .ics

### DIFF
--- a/shared/swift/OSNShared/Sources/PulseFeature/EventDetailView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/EventDetailView.swift
@@ -1,11 +1,22 @@
+import MapKit
 import OSNUI
 import SwiftUI
 
-/// Event detail + RSVP screen. Renders `status == .cancelled`; the real
-/// generated schema has no `cancellationReason` field, so none is shown
-/// (see `a5-notes.md`).
+/// Event detail + RSVP screen. Renders every field `eventResponseSchema`
+/// carries that means something to a guest: what it is, when, where, what it
+/// costs, who is hosting, and — for a cancelled event — why.
+///
+/// "Add to Calendar" hands over an `.ics` document rather than writing to the
+/// calendar directly; see `PulseCalendarInvite` for why.
+///
+/// There is no share button. The web one builds its URL from
+/// `window.location.origin`, and no Pulse web host is deployed for iOS to
+/// name in its place.
 public struct EventDetailView: View {
     @State private var viewModel: EventDetailViewModel
+    /// The `.ics` written to a temporary file so `ShareLink` has something to
+    /// hand to Calendar. Nil until the event has loaded and the write lands.
+    @State private var calendarFile: URL?
 
     public init(session: PulseSession, eventId: String) {
         let profileId: String
@@ -48,20 +59,18 @@ public struct EventDetailView: View {
         ScrollView {
             GlassEffectContainer {
                 VStack(alignment: .leading, spacing: 16) {
-                    GlassCard {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(event.title)
-                                .font(.osn(.display, size: 28))
-                            if event.status == .cancelled {
-                                Pill("Cancelled", tint: .red)
-                            } else if event.status == .ongoing {
-                                LiveBadge()
-                            }
-                            Text(event.startTime, style: .date)
-                                .font(.osn(.body, size: 14))
+                    header(for: event)
+                    if let host = event.createdByName {
+                        hostRow(name: host, avatar: event.createdByAvatar)
+                    }
+                    if let description = event.description, !description.isEmpty {
+                        GlassCard {
+                            Text(description)
+                                .font(.osn(.body, size: 16))
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
-
+                    place(for: event)
                     if let counts = viewModel.counts {
                         GlassCard {
                             HStack(spacing: 16) {
@@ -69,6 +78,12 @@ public struct EventDetailView: View {
                                 countLabel("Maybe", counts.maybe)
                                 countLabel("Can't go", counts.notGoing)
                             }
+                        }
+                    }
+                    if let calendarFile {
+                        ShareLink(item: calendarFile) {
+                            Label("Add to Calendar", systemImage: "calendar.badge.plus")
+                                .font(.osn(.body, size: 16))
                         }
                     }
 
@@ -86,6 +101,117 @@ public struct EventDetailView: View {
             }
         }
         .navigationTitle(event.title)
+        // Keyed on the id so opening a second event replaces the first
+        // event's file rather than offering it again.
+        .task(id: event.id) {
+            calendarFile = await writeCalendarFile(for: event)
+        }
+    }
+
+    @ViewBuilder
+    private func header(for event: PulseEvent) -> some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(event.title)
+                    .font(.osn(.display, size: 28))
+                HStack(spacing: 8) {
+                    if event.status == .cancelled {
+                        Pill("Cancelled", tint: .red)
+                    } else if event.status == .ongoing {
+                        LiveBadge()
+                    }
+                    if let category = event.category, !category.isEmpty {
+                        Pill(category, tint: OSNColor.accent)
+                    }
+                    Pill(priceLabel(for: event), tint: OSNColor.accentStrong)
+                }
+                schedule(for: event)
+                    .font(.osn(.body, size: 14))
+                if let reason = event.cancellationReason {
+                    Text(cancellationText(reason))
+                        .font(.osn(.body, size: 14))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// A start and an end read as a range; a start on its own is stated on its
+    /// own, because the server genuinely does not know when some events
+    /// finish and a guessed duration would be worse than none.
+    @ViewBuilder
+    private func schedule(for event: PulseEvent) -> some View {
+        if let endTime = event.endTime, endTime > event.startTime {
+            Text(event.startTime...endTime)
+        } else {
+            Text(event.startTime, format: .dateTime.weekday(.wide).day().month(.wide).hour().minute())
+        }
+    }
+
+    @ViewBuilder
+    private func hostRow(name: String, avatar: String?) -> some View {
+        HStack(spacing: 8) {
+            AvatarView {
+                AsyncImage(url: avatar.flatMap(URL.init(string:))) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Circle().fill(OSNColor.accentSoft)
+                }
+            }
+            .frame(width: 36, height: 36)
+            Text("Hosted by \(name)")
+                .font(.osn(.body, size: 14))
+        }
+    }
+
+    /// Address text and map are separate: an event can carry either without
+    /// the other, and a pin with no name is as useful as a name with no pin.
+    @ViewBuilder
+    private func place(for event: PulseEvent) -> some View {
+        if event.venue != nil || event.location != nil || event.coordinate != nil {
+            GlassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let venue = event.venue, !venue.isEmpty {
+                        Text(venue)
+                            .font(.osn(.body, size: 16))
+                    }
+                    if let location = event.location, !location.isEmpty {
+                        Text(location)
+                            .font(.osn(.body, size: 14))
+                            .foregroundStyle(.secondary)
+                    }
+                    if let coordinate = event.coordinate {
+                        // A still picture of where it is, not a second map to
+                        // pan — Explore owns that job.
+                        Map(
+                            initialPosition: .region(
+                                MKCoordinateRegion(
+                                    center: CLLocationCoordinate2D(
+                                        latitude: coordinate.latitude,
+                                        longitude: coordinate.longitude
+                                    ),
+                                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                                )
+                            ),
+                            interactionModes: []
+                        ) {
+                            Marker(
+                                event.title,
+                                coordinate: CLLocationCoordinate2D(
+                                    latitude: coordinate.latitude,
+                                    longitude: coordinate.longitude
+                                )
+                            )
+                            .tint(OSNColor.accent)
+                        }
+                        .frame(height: 160)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
     }
 
     private var rsvpButtons: some View {
@@ -98,6 +224,21 @@ public struct EventDetailView: View {
                     Task { await viewModel.rsvp(target) }
                 }
             }
+        }
+    }
+
+    private func priceLabel(for event: PulseEvent) -> String {
+        guard let price = event.price, !price.isFree else { return "Free" }
+        return price.formatted()
+    }
+
+    /// `hostLeft` is worded for a guest, who did not lose an account and only
+    /// needs to know the event is off and nobody is running it.
+    private func cancellationText(_ reason: PulseEvent.CancellationReason) -> String {
+        switch reason {
+        case .hostLeft: "Cancelled — the host is no longer on Pulse."
+        case .organiser: "Cancelled by the host."
+        case .admin: "Cancelled by Pulse."
         }
     }
 
@@ -116,5 +257,22 @@ public struct EventDetailView: View {
             Text(title)
                 .font(.osn(.body, size: 12))
         }
+    }
+}
+
+/// Writes the event's `.ics` to a temporary file and returns its URL.
+///
+/// `ShareLink` needs a file on disk to give Calendar a document rather than a
+/// wall of text. Nonisolated, so the write runs off the main actor; a failure
+/// returns nil and the button simply doesn't appear, which is better than a
+/// button that shares nothing.
+private func writeCalendarFile(for event: PulseEvent) async -> URL? {
+    let invite = PulseCalendarInvite(event: event)
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(invite.filename)
+    do {
+        try invite.text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    } catch {
+        return nil
     }
 }

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseCalendarInvite.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseCalendarInvite.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// An event as an `.ics` document, ready to hand to a share sheet.
+///
+/// Why a document and not EventKit. Writing straight into the user's calendar
+/// needs `NSCalendarsWriteOnlyAccessUsageDescription`, a permission prompt and
+/// a new entitlement — and `EKEvent` requires an `endDate`. Pulse events are
+/// allowed to have no end time (`endTime` is nullable in
+/// `pulse/db/src/schema/events.ts`), so EventKit would force a made-up
+/// duration onto every one of them. RFC 5545 §3.6.1 lets a `VEVENT` carry
+/// `DTSTART` with no `DTEND`, meaning exactly what the server means: the
+/// start is known and the end is not.
+///
+/// Calendar.app also shows the user what it is before anything is saved, and
+/// this type is pure Swift — no UIKit, so it compiles against the macOS SDK
+/// and is testable without a simulator.
+///
+/// No `URL` property is written. The document would need a public event page
+/// to point at, and no Pulse web host is deployed yet — inventing a hostname
+/// here would put a dead link in the user's calendar forever.
+public struct PulseCalendarInvite: Equatable, Sendable {
+    /// Suggested filename, including the `.ics` extension.
+    public let filename: String
+    /// The full document, CRLF-delimited per RFC 5545 §3.1.
+    public let text: String
+
+    public init(event: PulseEvent, stamp: Date = Date()) {
+        filename = Self.filename(for: event)
+        text = Self.document(for: event, stamp: stamp)
+    }
+
+    private static func document(for event: PulseEvent, stamp: Date) -> String {
+        var lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            // The `-//` prefix marks a non-registered product id, which is
+            // what RFC 5545 §3.7.3 asks of anyone not in the IANA registry.
+            "PRODID:-//OSN//Pulse//EN",
+            "CALSCALE:GREGORIAN",
+            "METHOD:PUBLISH",
+            "BEGIN:VEVENT",
+            // Uniqueness comes from the event id, which is already unique
+            // across Pulse. The usual `uid@host` spelling is skipped for the
+            // same reason `URL` is: there is no host to name.
+            "UID:pulse-event-\(event.id)",
+            "DTSTAMP:\(timestamp(stamp))",
+            "DTSTART:\(timestamp(event.startTime))",
+        ]
+        if let endTime = event.endTime {
+            lines.append("DTEND:\(timestamp(endTime))")
+        }
+        lines.append("SUMMARY:\(escaped(event.title))")
+        if let description = event.description, !description.isEmpty {
+            lines.append("DESCRIPTION:\(escaped(description))")
+        }
+        if let location = location(for: event) {
+            lines.append("LOCATION:\(escaped(location))")
+        }
+        if let coordinate = event.coordinate {
+            // GEO is a structured value, not TEXT — the separator is a real
+            // semicolon and must not be escaped (RFC 5545 §3.8.1.6).
+            lines.append("GEO:\(coordinate.latitude);\(coordinate.longitude)")
+        }
+        if let category = event.category, !category.isEmpty {
+            lines.append("CATEGORIES:\(escaped(category))")
+        }
+        lines.append("STATUS:\(event.status == .cancelled ? "CANCELLED" : "CONFIRMED")")
+        lines.append(contentsOf: ["END:VEVENT", "END:VCALENDAR"])
+        return lines.map(folded).joined(separator: "\r\n") + "\r\n"
+    }
+
+    /// `venue` and `location` are different columns and both are free text —
+    /// `venue` names the place, `location` says where it is — so a calendar
+    /// entry wants whichever of the two exists, and both when both do.
+    private static func location(for event: PulseEvent) -> String? {
+        let parts = [event.venue, event.location]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    private static func filename(for event: PulseEvent) -> String {
+        let allowed = CharacterSet.alphanumerics.union(.whitespaces).union(CharacterSet(charactersIn: "-_"))
+        let cleaned = String(
+            event.title.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        )
+        // Trim the replacements too, or a title that is all punctuation
+        // becomes a filename of nothing but dashes.
+        .trimmingCharacters(in: .whitespaces.union(CharacterSet(charactersIn: "-")))
+        let stem = cleaned.isEmpty ? "event" : String(cleaned.prefix(60))
+        return "\(stem).ics"
+    }
+}
+
+/// UTC, in the `DATE-TIME` form RFC 5545 §3.3.5 calls form 2.
+///
+/// Built from calendar components rather than a `DateFormatter`, which is not
+/// `Sendable` and could not be shared from a static context without unchecked
+/// escapes.
+private func timestamp(_ date: Date) -> String {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = .gmt
+    let parts = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+    return String(
+        format: "%04d%02d%02dT%02d%02d%02dZ",
+        parts.year ?? 0,
+        parts.month ?? 0,
+        parts.day ?? 0,
+        parts.hour ?? 0,
+        parts.minute ?? 0,
+        parts.second ?? 0
+    )
+}
+
+/// TEXT escaping per RFC 5545 §3.3.11. A colon is deliberately not escaped —
+/// only backslash, semicolon, comma and newlines are.
+private func escaped(_ value: String) -> String {
+    var result = ""
+    for character in value {
+        switch character {
+        case "\\": result += "\\\\"
+        case ";": result += "\\;"
+        case ",": result += "\\,"
+        // A CRLF in the source collapses to one escaped newline; the lone
+        // carriage return is dropped so it can't reappear as a line break.
+        case "\n": result += "\\n"
+        case "\r": continue
+        default: result.append(character)
+        }
+    }
+    return result
+}
+
+/// Line folding per RFC 5545 §3.1: no line over 75 octets, continuations
+/// begin with a single space.
+///
+/// The limit counts octets, not characters, so the width of each character is
+/// its UTF-8 length — an emoji in a title is four, and folding on character
+/// count would let a line past the limit. Folding between characters (never
+/// inside one) also keeps every continuation valid UTF-8.
+private func folded(_ line: String) -> String {
+    let limit = 75
+    var result = ""
+    var octets = 0
+    for character in line {
+        let width = String(character).utf8.count
+        if octets + width > limit {
+            result += "\r\n "
+            octets = 1
+        }
+        result.append(character)
+        octets += width
+    }
+    return result
+}

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
@@ -52,6 +52,24 @@ public struct PulsePrice: Equatable, Sendable {
         guard let amount, let currency else { return nil }
         self.init(minorUnits: Int(amount.rounded()), currency: currency)
     }
+
+    /// The price as a string, in the user's locale.
+    ///
+    /// The number of minor units in one major unit is a property of the
+    /// currency, not a constant: USD has 100, JPY has 1, KWD has 1000.
+    /// Dividing by 100 would print ¥1850 as ¥18.50. `NumberFormatter` knows
+    /// the right exponent for a currency code, so the scale is read back off
+    /// its `maximumFractionDigits` instead of being hardcoded.
+    public func formatted(locale: Locale = .autoupdatingCurrent) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = locale
+        formatter.currencyCode = currency
+        let amount = Double(minorUnits) / pow(10, Double(formatter.maximumFractionDigits))
+        // The fallback prints the currency code beside the amount rather than
+        // a bare number, so an unrecognised code is still an honest price.
+        return formatter.string(from: NSNumber(value: amount)) ?? "\(currency) \(amount)"
+    }
 }
 
 /// `cancelledAt` and `hardDeleteAt` are unix *seconds* — plain integer

--- a/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseCalendarInviteTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseCalendarInviteTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+@testable import PulseFeature
+
+private let start = Date(timeIntervalSince1970: 1_700_000_000) // 20231114T221320Z
+private let end = Date(timeIntervalSince1970: 1_700_007_200) // 20231115T001320Z
+private let stamp = Date(timeIntervalSince1970: 1_699_999_000) // 20231114T215640Z
+
+private func makeEvent(
+    id: String = "evt_1",
+    title: String = "Rooftop Session",
+    description: String? = nil,
+    location: String? = nil,
+    venue: String? = nil,
+    coordinate: PulseCoordinate? = nil,
+    category: String? = nil,
+    endTime: Date? = nil,
+    status: PulseEvent.Status = .upcoming,
+    price: PulsePrice? = nil
+) -> PulseEvent {
+    PulseEvent(
+        id: id,
+        title: title,
+        description: description,
+        location: location,
+        venue: venue,
+        venueId: nil,
+        coordinate: coordinate,
+        category: category,
+        startTime: start,
+        endTime: endTime,
+        status: status,
+        imageUrl: nil,
+        price: price,
+        visibility: .public,
+        guestListVisibility: .public,
+        joinPolicy: .open,
+        allowInterested: true,
+        commsChannels: "none",
+        chatId: nil,
+        seriesId: nil,
+        instanceOverride: false,
+        createdByProfileId: "prf_1",
+        createdByName: nil,
+        createdByAvatar: nil,
+        cancelledAt: nil,
+        hardDeleteAt: nil,
+        cancellationReason: nil,
+        createdAt: start,
+        updatedAt: start
+    )
+}
+
+/// Undo the 75-octet folding, so a test can assert on whole property values
+/// without caring where the line happened to break.
+private func unfolded(_ document: String) -> String {
+    document.replacingOccurrences(of: "\r\n ", with: "")
+}
+
+private func lines(_ document: String) -> [String] {
+    unfolded(document).components(separatedBy: "\r\n").filter { !$0.isEmpty }
+}
+
+@Test func documentCarriesTheEventWithNoEndTime() {
+    let ics = PulseCalendarInvite(event: makeEvent(), stamp: stamp).text
+    let properties = lines(ics)
+    #expect(properties.first == "BEGIN:VCALENDAR")
+    #expect(properties.last == "END:VCALENDAR")
+    #expect(properties.contains("UID:pulse-event-evt_1"))
+    #expect(properties.contains("DTSTAMP:20231114T215640Z"))
+    #expect(properties.contains("DTSTART:20231114T221320Z"))
+    #expect(properties.contains("SUMMARY:Rooftop Session"))
+    #expect(properties.contains("STATUS:CONFIRMED"))
+    // The whole point of writing the document by hand: an event with no end
+    // time gets no DTEND, rather than an invented duration.
+    #expect(properties.contains { $0.hasPrefix("DTEND") } == false)
+}
+
+@Test func anEndTimeBecomesDtend() {
+    let ics = PulseCalendarInvite(event: makeEvent(endTime: end), stamp: stamp).text
+    #expect(lines(ics).contains("DTEND:20231115T001320Z"))
+}
+
+@Test func everyLineEndsWithCrlf() {
+    let ics = PulseCalendarInvite(event: makeEvent(), stamp: stamp).text
+    #expect(ics.hasSuffix("\r\n"))
+    // A bare LF anywhere would be a line break RFC 5545 doesn't allow.
+    #expect(ics.components(separatedBy: "\n").dropLast().allSatisfy { $0.hasSuffix("\r") })
+}
+
+@Test func textValuesAreEscaped() {
+    let event = makeEvent(
+        title: "Drinks, snacks; maybe a \\ or two",
+        description: "First line\nSecond line"
+    )
+    let properties = lines(PulseCalendarInvite(event: event, stamp: stamp).text)
+    #expect(properties.contains(#"SUMMARY:Drinks\, snacks\; maybe a \\ or two"#))
+    #expect(properties.contains(#"DESCRIPTION:First line\nSecond line"#))
+}
+
+/// GEO is a structured value, so its semicolon separates the pair rather than
+/// being part of a text run — escaping it would break the property.
+@Test func coordinatesAreNotTextEscaped() {
+    let event = makeEvent(coordinate: PulseCoordinate(latitude: -33.8688, longitude: 151.2093))
+    #expect(lines(PulseCalendarInvite(event: event, stamp: stamp).text).contains("GEO:-33.8688;151.2093"))
+}
+
+@Test func venueAndLocationBothLandInOneLocationProperty() {
+    let both = makeEvent(location: "Surry Hills", venue: "The Clock Hotel")
+    #expect(lines(PulseCalendarInvite(event: both, stamp: stamp).text).contains("LOCATION:The Clock Hotel\\, Surry Hills"))
+
+    let venueOnly = makeEvent(venue: "The Clock Hotel")
+    #expect(lines(PulseCalendarInvite(event: venueOnly, stamp: stamp).text).contains("LOCATION:The Clock Hotel"))
+
+    let neither = makeEvent()
+    #expect(lines(PulseCalendarInvite(event: neither, stamp: stamp).text).contains { $0.hasPrefix("LOCATION") } == false)
+}
+
+@Test func aCancelledEventSaysSo() {
+    let ics = PulseCalendarInvite(event: makeEvent(status: .cancelled), stamp: stamp).text
+    #expect(lines(ics).contains("STATUS:CANCELLED"))
+}
+
+@Test func longValuesFoldAtSeventyFiveOctets() {
+    let event = makeEvent(description: String(repeating: "long enough to fold. ", count: 20))
+    let ics = PulseCalendarInvite(event: event, stamp: stamp).text
+    for line in ics.components(separatedBy: "\r\n") {
+        #expect(line.utf8.count <= 75)
+    }
+    // Folding is only a transport detail — unfolding returns the value whole.
+    #expect(unfolded(ics).contains("DESCRIPTION:\(event.description ?? "")"))
+}
+
+/// The fold counts octets, so a line of emoji has to break four times sooner
+/// than a line of ASCII — and never inside a character.
+@Test func foldingCountsOctetsNotCharacters() {
+    let event = makeEvent(title: String(repeating: "🎉", count: 40))
+    let ics = PulseCalendarInvite(event: event, stamp: stamp).text
+    for line in ics.components(separatedBy: "\r\n") {
+        #expect(line.utf8.count <= 75)
+    }
+    #expect(unfolded(ics).contains("SUMMARY:\(event.title)"))
+}
+
+@Test func filenameDropsCharactersAPathCannotHold() {
+    #expect(PulseCalendarInvite(event: makeEvent(title: "Drinks: 8/10"), stamp: stamp).filename == "Drinks- 8-10.ics")
+    #expect(PulseCalendarInvite(event: makeEvent(title: "///"), stamp: stamp).filename == "event.ics")
+    #expect(PulseCalendarInvite(event: makeEvent(title: String(repeating: "a", count: 200)), stamp: stamp).filename.count == 64)
+}
+
+/// Minor units per major unit is a property of the currency. Dividing by 100
+/// everywhere would print ¥1850 as ¥18.50.
+@Test func priceScalesByTheCurrencysOwnExponent() {
+    let locale = Locale(identifier: "en_AU")
+    #expect(PulsePrice(minorUnits: 1850, currency: "AUD").formatted(locale: locale) == "$18.50")
+    #expect(PulsePrice(minorUnits: 1850, currency: "JPY").formatted(locale: locale).contains("1,850"))
+    #expect(PulsePrice(minorUnits: 1850, currency: "KWD").formatted(locale: locale).contains("1.850"))
+}
+
+@Test func zeroIsFree() {
+    #expect(PulsePrice(minorUnits: 0, currency: "AUD").isFree)
+    #expect(makeEvent().isFree)
+    #expect(makeEvent(price: PulsePrice(minorUnits: 500, currency: "AUD")).isFree == false)
+}


### PR DESCRIPTION
Phase **A7** of the Swift stack. Stacks on #408 → #407 → #405.

Event detail showed the title, the time and the RSVP buttons and dropped the rest of what `eventResponseSchema` carries. This fills the screen in and adds "Add to Calendar".

## What's on the screen now

- Host name + avatar.
- Venue and address, plus a still, non-interactive `Map` of the pin when the event has coordinates. Explore owns panning; this is a picture of where it is.
- Price pill, or `Free`.
- Category pill, `Cancelled` pill or a live badge.
- A cancellation line when the event is off, worded for a guest: `hostLeft` reads "the host is no longer on Pulse", not "the host deleted their account".
- Start–end as a range when there is an end, start alone when there isn't.

## Why an `.ics` document and not EventKit

`EKEvent` requires an `endDate`. `endTime` is nullable in `pulse/db/src/schema/events.ts`, so EventKit would put an invented duration on every event that has no end. RFC 5545 §3.6.1 lets a `VEVENT` carry `DTSTART` with no `DTEND` — which says exactly what the server says: the start is known, the end is not.

It also costs nothing on the Apple side: no `NSCalendarsWriteOnlyAccessUsageDescription`, no permission prompt, no new Info.plist key, no portal surface. `pulse/ios/project.yml` is untouched. And the generator is pure Swift with no UIKit, so it compiles against the macOS SDK and is unit-tested without a simulator.

The document is written by hand rather than pulled from a library:

- CRLF line endings, and folding at **75 octets** — octets, not characters. An emoji in a title is four bytes; folding on character count would emit over-long lines. There's a test with 40 × 🎉.
- TEXT escaping of `\`, `;`, `,` and newline only. A colon is deliberately left alone.
- `GEO` is a *structured* value, so its `;` is a real separator and is **not** escaped (§3.8.1.6).
- `PRODID` uses the `-//` non-registered prefix (§3.7.3).
- `venue` and `location` are separate free-text columns — one names the place, the other says where it is — so both are joined into one `LOCATION`.

## Price scaling

`PulsePrice.formatted(locale:)` reads its scale off `NumberFormatter.maximumFractionDigits` for the currency code instead of dividing by 100. Minor units per major unit is a property of the currency: JPY has 1, KWD has 1000. A hardcoded 100 prints ¥1850 as ¥18.50. Verified empirically before the code was written — setting `currencyCode` on a `.currency` formatter does recompute the digit count (USD 2, JPY 0, AUD 2, KWD 3).

## BLOCKED: no share button

The web share button builds its URL from `window.location.origin + /events/<id>`. iOS has no origin, and the API exposes no canonical public event URL. So there is **no share sheet in this PR**, the `.ics` writes **no `URL` property**, and the `UID` is `pulse-event-<id>` rather than the usual `uid@host` — each of those would need a hostname that doesn't exist yet.

**Question for you: what public host will serve Pulse event pages?** Once that's answered, share is a small follow-up. Inventing a hostname now would put a dead link in someone's calendar permanently.

## Checks

- `swift test` — 67 tests in 7 suites pass (12 new).
- `xcodebuild -scheme Pulse -destination 'generic/platform=iOS Simulator'` — builds clean locally.
- No changeset: Swift-only, and `shared/swift/*` + `pulse/ios/*` are on the `scripts/changeset-required.sh` allowlist.

## Still open, not in this PR

View-model async tests (RSVP optimistic rollback, pagination cursors, region-driven reload) need a fake conforming to the full generated `APIProtocol` — carried forward from #404, #407 and #408 as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The server already has an `.ics` route — read this before reviewing

`GET /events/{id}/ics` exists (`pulse/api/src/services/calendar.ts`) and the web app links to it from `AddToCalendarButton.tsx`. I found it after writing the Swift generator, so here is the honest reasoning for keeping both rather than fetching the server's copy.

Keeping the Swift one: the app already holds the whole event, so building the file locally costs no round-trip and works with no network. Fetching would also mean plumbing a `text/calendar` string body through the generated client for a file the client can already write.

But the two must agree, and today they don't — the server version has two real bugs that hit web users now:

1. **It invents a 2-hour `DTEND`** when `endTime` is null. That is the exact thing this PR refuses to do; a guest gets a made-up finish time in their calendar.
2. **It folds on JavaScript string length, not octets**, and slices by UTF-16 code unit. A title with an emoji both overruns 75 octets and can be split through a surrogate pair, which emits invalid UTF-8.

Fixing the TypeScript generator to match is a separate PR off `main` — it is a server-side correctness fix with its own tests and changeset, and it should not ride on the Swift stack.
