### PR TITLE
Stop the calendar export inventing an end time

### DIFF
--- a/.changeset/curly-donkeys-repeat.md
+++ b/.changeset/curly-donkeys-repeat.md
@@ -1,0 +1,16 @@
+---
+"@pulse/api": patch
+---
+
+Stop the calendar export inventing an end time, and fold its lines by octet.
+
+`buildIcs` gave every event with no `endTime` a `DTEND` two hours after the
+start, so a guest's calendar showed a finish time the host never set. RFC 5545
+§3.6.1 allows a `VEVENT` with `DTSTART` and no `DTEND`, which is what the row
+actually says.
+
+Folding also counted UTF-16 code units rather than octets, so a title with an
+emoji both overran the 75-octet limit and could be sliced through a surrogate
+pair, emitting invalid UTF-8. The export now carries `STATUS` and `CATEGORIES`
+as well, and its `UID` matches the iOS client's so the same event saved from
+web and from iOS is one calendar entry rather than two.

--- a/pulse/api/src/services/calendar.ts
+++ b/pulse/api/src/services/calendar.ts
@@ -1,24 +1,46 @@
 import type { Event } from "@pulse/db/schema";
 
 /**
- * RFC 5545 line folding — lines longer than 75 octets must be split and
- * the continuation prefixed with a single space. Simple implementation —
- * splits on character count, not octets, which is close enough for the
- * ASCII-dominant fields we emit.
+ * RFC 5545 §3.1 line folding: no line may exceed 75 **octets**, and each
+ * continuation begins with a single space.
+ *
+ * The limit is octets, so the width of a character is its UTF-8 length — one
+ * emoji is four. Folding on `String.length` counts UTF-16 code units, which
+ * both lets a line past the limit and can slice through a surrogate pair,
+ * emitting invalid UTF-8 into the file. Iterating with `for...of` walks code
+ * points, so a break never lands inside a character.
  */
+const encoder = new TextEncoder();
+
 function fold(line: string): string {
-  if (line.length <= 75) return line;
-  const chunks: string[] = [];
-  for (let i = 0; i < line.length; i += 74) {
-    chunks.push(i === 0 ? line.slice(i, i + 75) : " " + line.slice(i, i + 74));
+  const limit = 75;
+  let result = "";
+  let octets = 0;
+  for (const character of line) {
+    const width = encoder.encode(character).length;
+    if (octets + width > limit) {
+      result += "\r\n ";
+      octets = 1;
+    }
+    result += character;
+    octets += width;
   }
-  return chunks.join("\r\n");
+  return result;
 }
 
+/**
+ * TEXT escaping per RFC 5545 §3.3.11 — backslash, semicolon, comma and
+ * newline, and nothing else. A lone carriage return is dropped rather than
+ * escaped, or it would survive into the output as a stray line break.
+ *
+ * Not for GEO: that is a structured value whose semicolon separates the pair
+ * (§3.8.1.6), so escaping it would break the property.
+ */
 function escape(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
-    .replace(/\n/g, "\\n")
+    .replace(/\r\n|\n/g, "\\n")
+    .replace(/\r/g, "")
     .replace(/,/g, "\\,")
     .replace(/;/g, "\\;");
 }
@@ -45,41 +67,45 @@ function formatDate(date: Date): string {
  * Builds an RFC 5545 VEVENT wrapped in VCALENDAR for the given event.
  * Callers return the string as `text/calendar; charset=utf-8`.
  *
- * End time defaults to start + 2 hours when the event has no explicit
- * endTime (matches how the app renders the card for open-ended events).
+ * An event with no `endTime` gets no `DTEND`. §3.6.1 allows that, and it says
+ * what the row says: the start is known and the end is not. Inventing a
+ * duration would put a finish time the host never chose into a guest's
+ * calendar, where it looks like fact.
+ *
+ * The Swift client builds the same document locally in
+ * `shared/swift/OSNShared/Sources/PulseFeature/PulseCalendarInvite.swift` —
+ * it already holds the event, so it needs no round-trip and works offline.
+ * The two must stay in step; the UID spelling in particular, or the same
+ * event saved from web and from iOS becomes two entries in one calendar.
  */
 export function buildIcs(event: Event): string {
-  const dtStart = formatDate(event.startTime);
-  const dtEnd = formatDate(
-    event.endTime ?? new Date(event.startTime.getTime() + 2 * 60 * 60 * 1000),
-  );
-  const now = formatDate(new Date());
-  const uid = `${event.id}@pulse`;
-  const summary = escape(event.title);
-  const description = event.description ? escape(event.description) : "";
-  const locationParts = [event.venue, event.location].filter(Boolean).join(", ");
-  const location = locationParts ? escape(locationParts) : "";
-
   const lines: string[] = [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
+    // §3.7.3: `-//` marks a product id that isn't in the IANA registry.
     "PRODID:-//Pulse//Pulse Events//EN",
     "CALSCALE:GREGORIAN",
     "METHOD:PUBLISH",
     "BEGIN:VEVENT",
-    `UID:${uid}`,
-    `DTSTAMP:${now}`,
-    `DTSTART:${dtStart}`,
-    `DTEND:${dtEnd}`,
-    fold(`SUMMARY:${summary}`),
+    // Uniqueness comes from the event id, which is already unique across
+    // Pulse. No `uid@host` spelling: Pulse has no public event host to name,
+    // and a made-up one would be a lie in a field meant to be stable forever.
+    `UID:pulse-event-${event.id}`,
+    `DTSTAMP:${formatDate(new Date())}`,
+    `DTSTART:${formatDate(event.startTime)}`,
   ];
-  if (description) lines.push(fold(`DESCRIPTION:${description}`));
-  if (location) lines.push(fold(`LOCATION:${location}`));
+  if (event.endTime) lines.push(`DTEND:${formatDate(event.endTime)}`);
+  lines.push(`SUMMARY:${escape(event.title)}`);
+  if (event.description) lines.push(`DESCRIPTION:${escape(event.description)}`);
+  const locationParts = [event.venue, event.location].filter(Boolean).join(", ");
+  if (locationParts) lines.push(`LOCATION:${escape(locationParts)}`);
   if (event.latitude != null && event.longitude != null) {
     lines.push(`GEO:${event.latitude};${event.longitude}`);
   }
+  if (event.category) lines.push(`CATEGORIES:${escape(event.category)}`);
+  lines.push(`STATUS:${event.status === "cancelled" ? "CANCELLED" : "CONFIRMED"}`);
   lines.push("END:VEVENT", "END:VCALENDAR");
 
   // RFC 5545 mandates CRLF line endings.
-  return lines.join("\r\n") + "\r\n";
+  return lines.map(fold).join("\r\n") + "\r\n";
 }

--- a/pulse/api/tests/services/calendar.test.ts
+++ b/pulse/api/tests/services/calendar.test.ts
@@ -40,6 +40,11 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
   };
 }
 
+/** Undo 75-octet folding, so a test can assert on a whole property value. */
+function unfold(ics: string): string {
+  return ics.replaceAll("\r\n ", "");
+}
+
 describe("buildIcs", () => {
   it("emits a well-formed VCALENDAR + VEVENT", () => {
     const ics = buildIcs(makeEvent({ title: "Concert" }));
@@ -47,7 +52,7 @@ describe("buildIcs", () => {
     expect(ics).toContain("VERSION:2.0");
     expect(ics).toContain("BEGIN:VEVENT");
     expect(ics).toContain("SUMMARY:Concert");
-    expect(ics).toContain("UID:evt_cal_test@pulse");
+    expect(ics).toContain("UID:pulse-event-evt_cal_test");
     expect(ics).toContain("END:VEVENT");
     expect(ics).toContain("END:VCALENDAR");
   });
@@ -63,14 +68,16 @@ describe("buildIcs", () => {
     expect(ics).toContain("DTSTART:20300601T103045Z");
   });
 
-  it("defaults DTEND to start + 2h when endTime is null", () => {
+  it("omits DTEND when the event has no end time", () => {
     const ics = buildIcs(
       makeEvent({
         startTime: new Date("2030-06-01T10:00:00.000Z"),
         endTime: null,
       }),
     );
-    expect(ics).toContain("DTEND:20300601T120000Z");
+    // RFC 5545 §3.6.1 allows a VEVENT with DTSTART and no DTEND. A default
+    // duration would show the guest a finish time the host never set.
+    expect(ics).not.toContain("DTEND");
   });
 
   it("uses explicit endTime when provided", () => {
@@ -107,12 +114,37 @@ describe("buildIcs", () => {
     expect(ics).toContain("LOCATION:The Venue\\, 123 Main St");
   });
 
-  it("folds lines longer than 75 characters per RFC 5545", () => {
+  it("folds lines longer than 75 octets per RFC 5545", () => {
     const longTitle = "A".repeat(200);
     const ics = buildIcs(makeEvent({ title: longTitle }));
-    // Line folding inserts CRLF + space for continuation; check that the
-    // SUMMARY line has been split.
-    const summaryRegion = ics.slice(ics.indexOf("SUMMARY:"));
-    expect(summaryRegion.split("\r\n ").length).toBeGreaterThan(1);
+    for (const line of ics.split("\r\n")) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+    }
+    // Folding is a transport detail — unfolding gives the value back whole.
+    expect(unfold(ics)).toContain(`SUMMARY:${longTitle}`);
+  });
+
+  // The limit counts octets, so a line of emoji must break four times sooner
+  // than a line of ASCII — and never through a character.
+  it("counts octets, not string length, when folding", () => {
+    const title = "🎉".repeat(40);
+    const ics = buildIcs(makeEvent({ title }));
+    for (const line of ics.split("\r\n")) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+    }
+    expect(unfold(ics)).toContain(`SUMMARY:${title}`);
+    // A fold through a surrogate pair would leave a replacement character
+    // behind once the file round-trips through UTF-8.
+    expect(ics).not.toContain("�");
+  });
+
+  it("marks a cancelled event CANCELLED", () => {
+    expect(buildIcs(makeEvent())).toContain("STATUS:CONFIRMED");
+    expect(buildIcs(makeEvent({ status: "cancelled" }))).toContain("STATUS:CANCELLED");
+  });
+
+  it("carries the category when the event has one", () => {
+    expect(buildIcs(makeEvent({ category: "music" }))).toContain("CATEGORIES:music");
+    expect(buildIcs(makeEvent())).not.toContain("CATEGORIES:");
   });
 });


### PR DESCRIPTION
Found while building "Add to Calendar" on iOS (#409): the server already exports `.ics` at `GET /events/{id}/ics`, and the web app links to it from `AddToCalendarButton.tsx`. Reading it turned up three bugs that reach real calendars.

## What was wrong

**1. It invented a `DTEND`.** Every event with no `endTime` got a finish two hours after the start. `endTime` is nullable in `pulse/db/src/schema/events.ts` and RFC 5545 §3.6.1 allows a `VEVENT` with `DTSTART` and no `DTEND` — so the guess wasn't needed, and it put a finish time the host never chose into a guest's calendar where it reads as fact.

**2. Folding counted the wrong thing.** §3.1 caps a line at 75 **octets**; `fold()` measured `String.length`, which counts UTF-16 code units. A title with an emoji overran the limit — and because the split used `slice()` by index, it could cut through a surrogate pair and emit invalid UTF-8. Folding now walks code points and measures each one's UTF-8 width, so a break never lands inside a character.

**3. A lone `\r` survived escaping.** A CRLF in a description became `\r` + `\n` escaped, leaving a stray carriage return inside the line. It's dropped now.

## Also added

- `STATUS:CANCELLED` / `CONFIRMED`, so a cancelled event says so in the calendar instead of sitting there looking live.
- `CATEGORIES` when the event has one.
- `UID` changed from `<id>@pulse` to `pulse-event-<id>`, matching the iOS client. Without that, the same event saved from web and from iOS is two entries in one calendar rather than one. Neither spelling names a real host — Pulse has no public event host — and the event id is already globally unique.

## Checks

- `bun run --cwd pulse/api test:run` — 552 tests in 37 files pass, 13 of them in `calendar.test.ts` (4 new, including a 40 × 🎉 title that asserts no line exceeds 75 octets and no replacement character appears).
- The old test asserting the 2-hour default is replaced by one asserting no `DTEND` at all.
- Changeset included (`@pulse/api` patch).

Independent of the Swift stack, so this branches off `main`, not off #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)