### PR TITLE
refactor(pulse): name the shared response schemas in the OpenAPI spec

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@pulse/api": patch
+---
+
+Name the shared response schemas (`Event`, `Rsvp`, `Series`, `Venue`) with Elysia's `.model()` and reference them with `t.Ref`, so the OpenAPI document hoists each into `components/schemas` once instead of inlining it at every route. The spec generator resolves the bare `$ref` names TypeBox emits for nested refs, and fails the build on a name that matches no component.

--- a/pulse/api/scripts/generate-openapi.ts
+++ b/pulse/api/scripts/generate-openapi.ts
@@ -200,12 +200,76 @@ function collapseNullUnions(node: unknown, unhandled: string[], path = "#"): voi
   unhandled.push(path);
 }
 
+// A route that names its response schema at the top level (`response: { 200:
+// "Event" }`) gets a correct `#/components/schemas/Event` pointer from the
+// plugin. A `t.Ref("Event")` *nested* inside a `t.Object` or `t.Array` does
+// not: TypeBox stores the bare name it was given, and the plugin emits it
+// verbatim as `{"$ref": "Event"}`. That is a valid JSON Schema `$ref` — it just
+// resolves to nothing here — and swift-openapi-generator fails on the document.
+//
+// Elysia resolves either spelling at runtime, so the two are equivalent to the
+// server and only the document needs correcting. Every name must match a
+// component; an unresolvable one is a typo'd `t.Ref` and should stop the build
+// rather than reach the generator.
+function resolveBareRefs(doc: Record<string, unknown>): void {
+  const components = doc["components"];
+  const schemas =
+    components !== null && typeof components === "object"
+      ? (components as Record<string, unknown>)["schemas"]
+      : undefined;
+  const known = new Set(
+    schemas !== null && typeof schemas === "object"
+      ? Object.keys(schemas as Record<string, unknown>)
+      : [],
+  );
+
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    const schema = node as Record<string, unknown>;
+    const ref = schema["$ref"];
+    if (typeof ref === "string" && !ref.startsWith("#/")) {
+      if (!known.has(ref)) {
+        throw new Error(
+          `$ref "${ref}" matches no entry in components/schemas — ` +
+            `register it with \`.model({ ${ref}: … })\` on the route's Elysia instance.`,
+        );
+      }
+      schema["$ref"] = `#/components/schemas/${ref}`;
+    }
+    for (const child of Object.values(schema)) walk(child);
+  };
+  walk(doc);
+}
+
+// The plugin stamps `"$id": "#/components/schemas/Event"` onto each component
+// it hoists. `$id` is a JSON Schema identifier, not an OpenAPI schema keyword,
+// and the value is a document pointer rather than the URI reference `$id` is
+// defined to hold. It carries no information the component's key doesn't
+// already give, so drop it.
+function stripComponentIds(doc: Record<string, unknown>): void {
+  const components = doc["components"];
+  if (components === null || typeof components !== "object") return;
+  const schemas = (components as Record<string, unknown>)["schemas"];
+  if (schemas === null || typeof schemas !== "object") return;
+  for (const schema of Object.values(schemas as Record<string, unknown>)) {
+    if (schema === null || typeof schema !== "object") continue;
+    delete (schema as Record<string, unknown>)["$id"];
+  }
+}
+
 const app = createApp();
 const res = await app.handle(new Request("http://localhost/openapi/json"));
 if (!res.ok) {
   throw new Error(`GET /openapi/json returned ${res.status}`);
 }
 const doc = (await res.json()) as Record<string, unknown>;
+
+resolveBareRefs(doc);
+stripComponentIds(doc);
 
 // Order matters: `stripRedundantNullable` looks for the `anyOf` that
 // `collapseNullUnions` removes, so it has to run first.

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -186,7 +186,7 @@ export const eventResponseSchema = t.Object({
 });
 
 const calendarEntryResponseSchema = t.Object({
-  event: eventResponseSchema,
+  event: t.Ref("Event"),
   myStatus: t.Union([t.Literal("going"), t.Literal("maybe"), t.Null()]),
   isHost: t.Boolean(),
 });
@@ -399,6 +399,13 @@ export const createEventsRoutes = (
 
   return (
     new Elysia({ prefix: "/events" })
+      // Named models, so the OpenAPI document carries one `Event` (and one
+      // `Rsvp`) under `components/schemas` and every route `$ref`s it. Inlined,
+      // the same 31-field object was repeated at nine call sites, and a
+      // generated client got nine structurally identical but separate types —
+      // one set of hand-written mappings per site. Elysia validates a `$ref`
+      // exactly as it validates the inline schema.
+      .model({ Event: eventResponseSchema, Rsvp: rsvpResponseSchema })
       .get(
         "/",
         async ({ query, headers }) => {
@@ -417,7 +424,7 @@ export const createEventsRoutes = (
             category: t.Optional(t.String()),
             limit: t.Optional(t.String()),
           }),
-          response: { 200: t.Object({ events: t.Array(eventResponseSchema) }) },
+          response: { 200: t.Object({ events: t.Array(t.Ref("Event")) }) },
           detail: { operationId: "listEvents" },
         },
       )
@@ -428,7 +435,7 @@ export const createEventsRoutes = (
           return { events: result.map(serializeEvent) };
         },
         {
-          response: { 200: t.Object({ events: t.Array(eventResponseSchema) }) },
+          response: { 200: t.Object({ events: t.Array(t.Ref("Event")) }) },
           detail: { operationId: "listTodayEvents" },
         },
       )
@@ -549,7 +556,7 @@ export const createEventsRoutes = (
           }),
           response: {
             200: t.Object({
-              events: t.Array(eventResponseSchema),
+              events: t.Array(t.Ref("Event")),
               nextCursor: t.Nullable(
                 t.Object({ startTime: t.String({ format: "date-time" }), id: t.String() }),
               ),
@@ -593,7 +600,7 @@ export const createEventsRoutes = (
             id: t.String(),
           }),
           response: {
-            200: t.Object({ event: eventResponseSchema }),
+            200: t.Object({ event: t.Ref("Event") }),
             404: messageResponse,
           },
           detail: { operationId: "getEventById" },
@@ -659,7 +666,7 @@ export const createEventsRoutes = (
             priceCurrency: priceCurrencySchema,
           }),
           response: {
-            201: t.Object({ event: eventResponseSchema }),
+            201: t.Object({ event: t.Ref("Event") }),
             401: messageResponse,
             422: errorResponse,
             429: errorResponse,
@@ -732,7 +739,7 @@ export const createEventsRoutes = (
             priceCurrency: priceCurrencySchema,
           }),
           response: {
-            200: t.Object({ event: eventResponseSchema }),
+            200: t.Object({ event: t.Ref("Event") }),
             401: messageResponse,
             403: messageResponse,
             404: messageResponse,
@@ -851,7 +858,7 @@ export const createEventsRoutes = (
           }),
           response: {
             200: t.Object({
-              rsvps: t.Array(rsvpResponseSchema),
+              rsvps: t.Array(t.Ref("Rsvp")),
               canViewAttendees: t.Boolean(),
             }),
             404: messageResponse,
@@ -953,7 +960,7 @@ export const createEventsRoutes = (
           query: t.Object({ limit: t.Optional(t.String()) }),
           response: {
             200: t.Object({
-              rsvps: t.Array(rsvpResponseSchema),
+              rsvps: t.Array(t.Ref("Rsvp")),
               canViewAttendees: t.Boolean(),
             }),
             404: messageResponse,

--- a/pulse/api/src/routes/series.ts
+++ b/pulse/api/src/routes/series.ts
@@ -104,284 +104,299 @@ export const createSeriesRoutes = (
     writeRateLimiters.seriesCreate ?? createDefaultWriteRateLimiter("series_create");
   const seriesUpdateLimiter =
     writeRateLimiters.seriesUpdate ?? createDefaultWriteRateLimiter("series_update");
-  return new Elysia({ prefix: "/series" })
-    .post(
-      "/",
-      async ({ body, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
-        if (!claims) {
-          set.status = 401;
-          return { message: "Unauthorized" } as const;
-        }
-        if (!(await checkWriteRateLimit(seriesCreateLimiter, "series_create", claims.profileId))) {
-          set.status = 429;
-          return { error: "Too many requests" } as const;
-        }
-        const creator = {
-          createdByProfileId: claims.profileId,
-          createdByName:
-            claims.displayName ??
-            (claims.handle ? `@${claims.handle}` : null) ??
-            (claims.email ? (claims.email.split("@")[0] ?? null) : null),
-          createdByAvatar: null,
-        };
-        const result = await runtime.runPromise(
-          createSeries(body, creator).pipe(
-            Effect.catchTag("ValidationError", (e) =>
-              Effect.sync(() => {
-                set.status = 422;
-                return { error: String(e.cause) } as const;
-              }),
-            ),
-            Effect.catchTag("SeriesRRuleInvalid", (e) =>
-              Effect.sync(() => {
-                set.status = 422;
-                return { error: e.message, reason: e.reason } as const;
-              }),
-            ),
-          ),
-        );
-        if ("error" in result) return result;
-        set.status = 201;
-        return {
-          series: serializeSeries(result.series),
-          instances: result.instances.map(serializeEvent),
-        };
-      },
-      {
-        parse: "application/json",
-        body: t.Object({
-          title: t.String({ minLength: 1, maxLength: 200 }),
-          description: t.Optional(t.String({ maxLength: 5000 })),
-          location: t.Optional(t.String({ maxLength: 500 })),
-          venue: t.Optional(t.String({ maxLength: 500 })),
-          latitude: t.Optional(t.Number({ minimum: -90, maximum: 90 })),
-          longitude: t.Optional(t.Number({ minimum: -180, maximum: 180 })),
-          category: t.Optional(t.String({ maxLength: 100 })),
-          imageUrl: t.Optional(t.String()),
-          durationMinutes: t.Optional(t.Number({ minimum: 1, maximum: 60 * 24 * 14 })),
-          visibility: visibilityEnum,
-          guestListVisibility: guestListVisibilityEnum,
-          joinPolicy: joinPolicyEnum,
-          allowInterested: t.Optional(t.Boolean()),
-          commsChannels: commsChannelsSchema,
-          rrule: t.String({ minLength: 1, maxLength: 500 }),
-          dtstart: t.String({ format: "date-time" }),
-          timezone: t.Optional(t.String({ maxLength: 100 })),
-        }),
-        response: {
-          201: t.Object({ series: seriesResponseSchema, instances: t.Array(eventResponseSchema) }),
-          401: messageResponse,
-          422: t.Union([
-            errorResponse,
-            t.Object({ error: t.String(), reason: rruleInvalidReasonEnum }),
-          ]),
-          429: errorResponse,
-        },
-        detail: { operationId: "createSeries", security: [{ bearerAuth: [] }] },
-      },
-    )
-    .get(
-      "/:id",
-      async ({ params, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
-        const viewerId = claims?.profileId ?? null;
-
-        const series = await runtime.runPromise(
-          getSeries(params.id).pipe(Effect.catchTag("SeriesNotFound", () => Effect.succeed(null))),
-        );
-        if (series === null) {
-          set.status = 404;
-          return { message: "Series not found" } as const;
-        }
-
-        // For private series, only the organiser or someone who can see at
-        // least one instance may see the metadata. We reuse the
-        // per-event visibility gate via a synthesized row keyed on the
-        // first instance so the same access rules apply.
-        if (series.visibility === "private") {
-          // Probe: does the viewer see any instance?
-          const instances = await runtime.runPromise(
-            listInstances(params.id, { scope: "all", viewerId, limit: 1 }).pipe(
-              Effect.catchTag("SeriesNotFound", () => Effect.succeed([])),
+  return (
+    new Elysia({ prefix: "/series" })
+      // Same named models as `routes/events.ts`: registering `Event` again with
+      // the identical schema dedupes by name in the root document, and keeping
+      // the registration local means this plugin resolves its own `$ref`s
+      // whether or not the events plugin is mounted alongside it.
+      .model({ Event: eventResponseSchema, Series: seriesResponseSchema })
+      .post(
+        "/",
+        async ({ body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          if (
+            !(await checkWriteRateLimit(seriesCreateLimiter, "series_create", claims.profileId))
+          ) {
+            set.status = 429;
+            return { error: "Too many requests" } as const;
+          }
+          const creator = {
+            createdByProfileId: claims.profileId,
+            createdByName:
+              claims.displayName ??
+              (claims.handle ? `@${claims.handle}` : null) ??
+              (claims.email ? (claims.email.split("@")[0] ?? null) : null),
+            createdByAvatar: null,
+          };
+          const result = await runtime.runPromise(
+            createSeries(body, creator).pipe(
+              Effect.catchTag("ValidationError", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: String(e.cause) } as const;
+                }),
+              ),
+              Effect.catchTag("SeriesRRuleInvalid", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: e.message, reason: e.reason } as const;
+                }),
+              ),
             ),
           );
-          if (instances.length === 0 && viewerId !== series.createdByProfileId) {
-            // Viewer can't see the series. Return 404 (not 403) to avoid
-            // disclosing existence — mirrors the event-level policy.
+          if ("error" in result) return result;
+          set.status = 201;
+          return {
+            series: serializeSeries(result.series),
+            instances: result.instances.map(serializeEvent),
+          };
+        },
+        {
+          parse: "application/json",
+          body: t.Object({
+            title: t.String({ minLength: 1, maxLength: 200 }),
+            description: t.Optional(t.String({ maxLength: 5000 })),
+            location: t.Optional(t.String({ maxLength: 500 })),
+            venue: t.Optional(t.String({ maxLength: 500 })),
+            latitude: t.Optional(t.Number({ minimum: -90, maximum: 90 })),
+            longitude: t.Optional(t.Number({ minimum: -180, maximum: 180 })),
+            category: t.Optional(t.String({ maxLength: 100 })),
+            imageUrl: t.Optional(t.String()),
+            durationMinutes: t.Optional(t.Number({ minimum: 1, maximum: 60 * 24 * 14 })),
+            visibility: visibilityEnum,
+            guestListVisibility: guestListVisibilityEnum,
+            joinPolicy: joinPolicyEnum,
+            allowInterested: t.Optional(t.Boolean()),
+            commsChannels: commsChannelsSchema,
+            rrule: t.String({ minLength: 1, maxLength: 500 }),
+            dtstart: t.String({ format: "date-time" }),
+            timezone: t.Optional(t.String({ maxLength: 100 })),
+          }),
+          response: {
+            201: t.Object({ series: t.Ref("Series"), instances: t.Array(t.Ref("Event")) }),
+            401: messageResponse,
+            422: t.Union([
+              errorResponse,
+              t.Object({ error: t.String(), reason: rruleInvalidReasonEnum }),
+            ]),
+            429: errorResponse,
+          },
+          detail: { operationId: "createSeries", security: [{ bearerAuth: [] }] },
+        },
+      )
+      .get(
+        "/:id",
+        async ({ params, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          const viewerId = claims?.profileId ?? null;
+
+          const series = await runtime.runPromise(
+            getSeries(params.id).pipe(
+              Effect.catchTag("SeriesNotFound", () => Effect.succeed(null)),
+            ),
+          );
+          if (series === null) {
             set.status = 404;
             return { message: "Series not found" } as const;
           }
-          // Also do the explicit canViewEvent gate on the first instance so
-          // an invited-to-instance viewer can reach the series page.
-          if (instances.length > 0) {
-            const canSee = await runtime.runPromise(canViewEvent(instances[0]!, viewerId));
-            if (!canSee && viewerId !== series.createdByProfileId) {
+
+          // For private series, only the organiser or someone who can see at
+          // least one instance may see the metadata. We reuse the
+          // per-event visibility gate via a synthesized row keyed on the
+          // first instance so the same access rules apply.
+          if (series.visibility === "private") {
+            // Probe: does the viewer see any instance?
+            const instances = await runtime.runPromise(
+              listInstances(params.id, { scope: "all", viewerId, limit: 1 }).pipe(
+                Effect.catchTag("SeriesNotFound", () => Effect.succeed([])),
+              ),
+            );
+            if (instances.length === 0 && viewerId !== series.createdByProfileId) {
+              // Viewer can't see the series. Return 404 (not 403) to avoid
+              // disclosing existence — mirrors the event-level policy.
               set.status = 404;
               return { message: "Series not found" } as const;
             }
+            // Also do the explicit canViewEvent gate on the first instance so
+            // an invited-to-instance viewer can reach the series page.
+            if (instances.length > 0) {
+              const canSee = await runtime.runPromise(canViewEvent(instances[0]!, viewerId));
+              if (!canSee && viewerId !== series.createdByProfileId) {
+                set.status = 404;
+                return { message: "Series not found" } as const;
+              }
+            }
           }
-        }
 
-        return { series: serializeSeries(series) };
-      },
-      {
-        params: t.Object({ id: t.String() }),
-        response: {
-          200: t.Object({ series: seriesResponseSchema }),
-          404: messageResponse,
+          return { series: serializeSeries(series) };
         },
-        detail: { operationId: "getSeries" },
-      },
-    )
-    .get(
-      "/:id/instances",
-      async ({ params, query, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
-        const result = await runtime.runPromise(
-          listInstances(params.id, {
-            scope: query.scope ?? "upcoming",
-            viewerId: claims?.profileId ?? null,
-            limit: query.limit ? Number(query.limit) : undefined,
-          }).pipe(Effect.catchTag("SeriesNotFound", () => Effect.succeed(null))),
-        );
-        if (result === null) {
-          set.status = 404;
-          return { message: "Series not found" } as const;
-        }
-        return { instances: result.map(serializeEvent) };
-      },
-      {
-        params: t.Object({ id: t.String() }),
-        query: t.Object({
-          scope: t.Optional(t.Union([t.Literal("past"), t.Literal("upcoming"), t.Literal("all")])),
-          limit: t.Optional(t.String()),
-        }),
-        response: {
-          200: t.Object({ instances: t.Array(eventResponseSchema) }),
-          404: messageResponse,
+        {
+          params: t.Object({ id: t.String() }),
+          response: {
+            200: t.Object({ series: t.Ref("Series") }),
+            404: messageResponse,
+          },
+          detail: { operationId: "getSeries" },
         },
-        detail: { operationId: "listSeriesInstances" },
-      },
-    )
-    .patch(
-      "/:id",
-      async ({ params, body, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
-        if (!claims) {
-          set.status = 401;
-          return { message: "Unauthorized" } as const;
-        }
-        if (!(await checkWriteRateLimit(seriesUpdateLimiter, "series_update", claims.profileId))) {
-          set.status = 429;
-          return { error: "Too many requests" } as const;
-        }
-        const result = await runtime.runPromise(
-          updateSeries(params.id, body, claims.profileId).pipe(
-            Effect.catchTag("SeriesNotFound", () => Effect.succeed(null)),
-            Effect.catchTag("NotEventOwner", () =>
-              Effect.sync(() => {
-                set.status = 403;
-                return { message: "Forbidden" } as const;
-              }),
+      )
+      .get(
+        "/:id/instances",
+        async ({ params, query, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          const result = await runtime.runPromise(
+            listInstances(params.id, {
+              scope: query.scope ?? "upcoming",
+              viewerId: claims?.profileId ?? null,
+              limit: query.limit ? Number(query.limit) : undefined,
+            }).pipe(Effect.catchTag("SeriesNotFound", () => Effect.succeed(null))),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Series not found" } as const;
+          }
+          return { instances: result.map(serializeEvent) };
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          query: t.Object({
+            scope: t.Optional(
+              t.Union([t.Literal("past"), t.Literal("upcoming"), t.Literal("all")]),
             ),
-            Effect.catchTag("ValidationError", (e) =>
-              Effect.sync(() => {
-                set.status = 422;
-                return { error: String(e.cause) } as const;
-              }),
-            ),
-          ),
-        );
-        if (result === null) {
-          set.status = 404;
-          return { message: "Series not found" } as const;
-        }
-        if ("error" in result || "message" in result) return result;
-        return { series: serializeSeries(result.series), updated: result.updated };
-      },
-      {
-        parse: "application/json",
-        params: t.Object({ id: t.String() }),
-        body: t.Object({
-          title: t.Optional(t.String({ minLength: 1, maxLength: 200 })),
-          description: t.Optional(t.String({ maxLength: 5000 })),
-          location: t.Optional(t.String({ maxLength: 500 })),
-          venue: t.Optional(t.String({ maxLength: 500 })),
-          latitude: t.Optional(t.Number({ minimum: -90, maximum: 90 })),
-          longitude: t.Optional(t.Number({ minimum: -180, maximum: 180 })),
-          category: t.Optional(t.String({ maxLength: 100 })),
-          imageUrl: t.Optional(t.String()),
-          durationMinutes: t.Optional(t.Number({ minimum: 1, maximum: 60 * 24 * 14 })),
-          visibility: visibilityEnum,
-          guestListVisibility: guestListVisibilityEnum,
-          joinPolicy: joinPolicyEnum,
-          allowInterested: t.Optional(t.Boolean()),
-          commsChannels: commsChannelsSchema,
-          scope: t.Optional(t.Union([t.Literal("this_and_following"), t.Literal("all_future")])),
-          from: t.Optional(t.String()),
-        }),
-        response: {
-          200: t.Object({ series: seriesResponseSchema, updated: t.Number() }),
-          401: messageResponse,
-          403: messageResponse,
-          404: messageResponse,
-          422: errorResponse,
-          429: errorResponse,
+            limit: t.Optional(t.String()),
+          }),
+          response: {
+            200: t.Object({ instances: t.Array(t.Ref("Event")) }),
+            404: messageResponse,
+          },
+          detail: { operationId: "listSeriesInstances" },
         },
-        detail: { operationId: "updateSeries", security: [{ bearerAuth: [] }] },
-      },
-    )
-    .delete(
-      "/:id",
-      async ({ params, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
-        if (!claims) {
-          set.status = 401;
-          return { message: "Unauthorized" } as const;
-        }
-        const result = await runtime.runPromise(
-          cancelSeries(params.id, claims.profileId).pipe(
-            Effect.catchTag("SeriesNotFound", () => Effect.succeed(null)),
-            Effect.catchTag("NotEventOwner", () =>
-              Effect.sync(() => {
-                set.status = 403;
-                return { message: "Forbidden" } as const;
-              }),
+      )
+      .patch(
+        "/:id",
+        async ({ params, body, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          if (
+            !(await checkWriteRateLimit(seriesUpdateLimiter, "series_update", claims.profileId))
+          ) {
+            set.status = 429;
+            return { error: "Too many requests" } as const;
+          }
+          const result = await runtime.runPromise(
+            updateSeries(params.id, body, claims.profileId).pipe(
+              Effect.catchTag("SeriesNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotEventOwner", () =>
+                Effect.sync(() => {
+                  set.status = 403;
+                  return { message: "Forbidden" } as const;
+                }),
+              ),
+              Effect.catchTag("ValidationError", (e) =>
+                Effect.sync(() => {
+                  set.status = 422;
+                  return { error: String(e.cause) } as const;
+                }),
+              ),
             ),
-          ),
-        );
-        if (result === null) {
-          set.status = 404;
-          return { message: "Series not found" } as const;
-        }
-        if ("message" in result) return result;
-        return result;
-      },
-      {
-        params: t.Object({ id: t.String() }),
-        response: {
-          200: t.Object({ cancelled: t.Number() }),
-          401: messageResponse,
-          403: messageResponse,
-          404: messageResponse,
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Series not found" } as const;
+          }
+          if ("error" in result || "message" in result) return result;
+          return { series: serializeSeries(result.series), updated: result.updated };
         },
-        detail: { operationId: "cancelSeries", security: [{ bearerAuth: [] }] },
-      },
-    );
+        {
+          parse: "application/json",
+          params: t.Object({ id: t.String() }),
+          body: t.Object({
+            title: t.Optional(t.String({ minLength: 1, maxLength: 200 })),
+            description: t.Optional(t.String({ maxLength: 5000 })),
+            location: t.Optional(t.String({ maxLength: 500 })),
+            venue: t.Optional(t.String({ maxLength: 500 })),
+            latitude: t.Optional(t.Number({ minimum: -90, maximum: 90 })),
+            longitude: t.Optional(t.Number({ minimum: -180, maximum: 180 })),
+            category: t.Optional(t.String({ maxLength: 100 })),
+            imageUrl: t.Optional(t.String()),
+            durationMinutes: t.Optional(t.Number({ minimum: 1, maximum: 60 * 24 * 14 })),
+            visibility: visibilityEnum,
+            guestListVisibility: guestListVisibilityEnum,
+            joinPolicy: joinPolicyEnum,
+            allowInterested: t.Optional(t.Boolean()),
+            commsChannels: commsChannelsSchema,
+            scope: t.Optional(t.Union([t.Literal("this_and_following"), t.Literal("all_future")])),
+            from: t.Optional(t.String()),
+          }),
+          response: {
+            200: t.Object({ series: t.Ref("Series"), updated: t.Number() }),
+            401: messageResponse,
+            403: messageResponse,
+            404: messageResponse,
+            422: errorResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "updateSeries", security: [{ bearerAuth: [] }] },
+        },
+      )
+      .delete(
+        "/:id",
+        async ({ params, headers, set }) => {
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          if (!claims) {
+            set.status = 401;
+            return { message: "Unauthorized" } as const;
+          }
+          const result = await runtime.runPromise(
+            cancelSeries(params.id, claims.profileId).pipe(
+              Effect.catchTag("SeriesNotFound", () => Effect.succeed(null)),
+              Effect.catchTag("NotEventOwner", () =>
+                Effect.sync(() => {
+                  set.status = 403;
+                  return { message: "Forbidden" } as const;
+                }),
+              ),
+            ),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Series not found" } as const;
+          }
+          if ("message" in result) return result;
+          return result;
+        },
+        {
+          params: t.Object({ id: t.String() }),
+          response: {
+            200: t.Object({ cancelled: t.Number() }),
+            401: messageResponse,
+            403: messageResponse,
+            404: messageResponse,
+          },
+          detail: { operationId: "cancelSeries", security: [{ bearerAuth: [] }] },
+        },
+      )
+  );
 };

--- a/pulse/api/src/routes/venues.ts
+++ b/pulse/api/src/routes/venues.ts
@@ -147,133 +147,140 @@ export const createVenuesRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  return new Elysia({ prefix: "/venues" })
-    .onBeforeHandle(async ({ headers, set }) => {
-      // S-L1: fail-closed per-IP limit, matching the discover route —
-      // a broken limiter backend must not become a bypass.
-      const ip = getClientIp(headers);
-      let allowed: boolean;
-      try {
-        allowed = await venuesRateLimiter.check(ip);
-      } catch {
-        allowed = false;
-      }
-      if (!allowed) {
-        set.status = 429;
-        return { error: "Too many requests" } as const;
-      }
-    })
-    .get(
-      "/",
-      async () => {
-        // TODO(venue-bbox-search): swap for bbox-filtered query — see
-        // wiki/TODO.md → Performance Backlog P-W28 (explore).
-        const venues = await runtime.runPromise(listAllVenues());
-        return { venues: venues.map(serializeVenue) };
-      },
-      {
-        response: {
-          200: t.Object({ venues: t.Array(venueSchema) }),
-          429: errorResponse,
-        },
-        detail: { operationId: "listVenues" },
-      },
-    )
-    .get(
-      "/:orgHandle/:venueHandle",
-      async ({ params, set }) => {
-        const venue = await runtime.runPromise(
-          getVenue(params.orgHandle, params.venueHandle, { recordMetric: true }).pipe(
-            Effect.catchTag("VenueNotFound", () => Effect.succeed(null)),
-          ),
-        );
-        if (venue === null) {
-          set.status = 404;
-          return { message: "Venue not found" } as const;
+  return (
+    new Elysia({ prefix: "/venues" })
+      // Named model, so the venue object lands once in `components/schemas` and
+      // both routes `$ref` it — see the longer note in `routes/events.ts`.
+      .model({ Venue: venueSchema })
+      .onBeforeHandle(async ({ headers, set }) => {
+        // S-L1: fail-closed per-IP limit, matching the discover route —
+        // a broken limiter backend must not become a bypass.
+        const ip = getClientIp(headers);
+        let allowed: boolean;
+        try {
+          allowed = await venuesRateLimiter.check(ip);
+        } catch {
+          allowed = false;
         }
-        return { venue: serializeVenue(venue) };
-      },
-      {
-        params: t.Object({ orgHandle: t.String(), venueHandle: t.String() }),
-        response: {
-          200: t.Object({ venue: venueSchema }),
-          404: messageResponse,
-          429: errorResponse,
-        },
-        detail: { operationId: "getVenue" },
-      },
-    )
-    .get(
-      "/:orgHandle/:venueHandle/events",
-      async ({ params, query, set }) => {
-        const result = await runtime.runPromise(
-          listVenueEvents(params.orgHandle, params.venueHandle, {
-            scope: query.scope ?? "upcoming",
-            limit: query.limit,
-          }).pipe(Effect.catchTag("VenueNotFound", () => Effect.succeed(null))),
-        );
-        if (result === null) {
-          set.status = 404;
-          return { message: "Venue not found" } as const;
+        if (!allowed) {
+          set.status = 429;
+          return { error: "Too many requests" } as const;
         }
-        return { events: result.map(toPublicVenueEvent) };
-      },
-      {
-        params: t.Object({ orgHandle: t.String(), venueHandle: t.String() }),
-        query: t.Object({
-          scope: t.Optional(t.Union([t.Literal("upcoming"), t.Literal("past"), t.Literal("all")])),
-          // P-I1: numeric validation at the boundary so `?limit=abc`
-          // 422s instead of flowing into `.limit(NaN)`.
-          limit: t.Optional(t.Numeric({ minimum: 1, maximum: 200 })),
-        }),
-        response: {
-          200: t.Object({ events: t.Array(publicVenueEventSchema) }),
-          404: messageResponse,
-          429: errorResponse,
+      })
+      .get(
+        "/",
+        async () => {
+          // TODO(venue-bbox-search): swap for bbox-filtered query — see
+          // wiki/TODO.md → Performance Backlog P-W28 (explore).
+          const venues = await runtime.runPromise(listAllVenues());
+          return { venues: venues.map(serializeVenue) };
         },
-        detail: { operationId: "listVenueEvents" },
-      },
-    )
-    .get(
-      "/:orgHandle/:venueHandle/events/:eventId/lineup",
-      async ({ params, set }) => {
-        // Confirm the venue exists first so a wrong handle returns 404
-        // even when an attacker guesses a real eventId.
-        const venue = await runtime.runPromise(
-          getVenue(params.orgHandle, params.venueHandle).pipe(
-            Effect.catchTag("VenueNotFound", () => Effect.succeed(null)),
-          ),
-        );
-        if (venue === null) {
-          set.status = 404;
-          return { message: "Venue not found" } as const;
-        }
-        // S-H1: the lineup is an event sub-resource, so it goes through
-        // the same visibility gate as every other direct event fetch
-        // (anonymous viewer → public events only), AND the event must
-        // belong to the venue in the URL — otherwise any valid venue
-        // path would unlock any event's programme.
-        const event = await runtime.runPromise(loadVisibleEvent(params.eventId, null));
-        if (event === null || event.venueId !== venue.id) {
-          metricEventAccessDenied("lineup", event === null ? "private_anonymous" : "other");
-          set.status = 404;
-          return { message: "Event not found" } as const;
-        }
-        const slots = await runtime.runPromise(listEventLineup(params.eventId));
-        return { slots: slots.map(serializeLineupSlot) };
-      },
-      {
-        params: t.Object({
-          orgHandle: t.String(),
-          venueHandle: t.String(),
-          eventId: t.String(),
-        }),
-        response: {
-          200: t.Object({ slots: t.Array(lineupSlotSchema) }),
-          404: messageResponse,
-          429: errorResponse,
+        {
+          response: {
+            200: t.Object({ venues: t.Array(t.Ref("Venue")) }),
+            429: errorResponse,
+          },
+          detail: { operationId: "listVenues" },
         },
-        detail: { operationId: "getVenueEventLineup" },
-      },
-    );
+      )
+      .get(
+        "/:orgHandle/:venueHandle",
+        async ({ params, set }) => {
+          const venue = await runtime.runPromise(
+            getVenue(params.orgHandle, params.venueHandle, { recordMetric: true }).pipe(
+              Effect.catchTag("VenueNotFound", () => Effect.succeed(null)),
+            ),
+          );
+          if (venue === null) {
+            set.status = 404;
+            return { message: "Venue not found" } as const;
+          }
+          return { venue: serializeVenue(venue) };
+        },
+        {
+          params: t.Object({ orgHandle: t.String(), venueHandle: t.String() }),
+          response: {
+            200: t.Object({ venue: t.Ref("Venue") }),
+            404: messageResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "getVenue" },
+        },
+      )
+      .get(
+        "/:orgHandle/:venueHandle/events",
+        async ({ params, query, set }) => {
+          const result = await runtime.runPromise(
+            listVenueEvents(params.orgHandle, params.venueHandle, {
+              scope: query.scope ?? "upcoming",
+              limit: query.limit,
+            }).pipe(Effect.catchTag("VenueNotFound", () => Effect.succeed(null))),
+          );
+          if (result === null) {
+            set.status = 404;
+            return { message: "Venue not found" } as const;
+          }
+          return { events: result.map(toPublicVenueEvent) };
+        },
+        {
+          params: t.Object({ orgHandle: t.String(), venueHandle: t.String() }),
+          query: t.Object({
+            scope: t.Optional(
+              t.Union([t.Literal("upcoming"), t.Literal("past"), t.Literal("all")]),
+            ),
+            // P-I1: numeric validation at the boundary so `?limit=abc`
+            // 422s instead of flowing into `.limit(NaN)`.
+            limit: t.Optional(t.Numeric({ minimum: 1, maximum: 200 })),
+          }),
+          response: {
+            200: t.Object({ events: t.Array(publicVenueEventSchema) }),
+            404: messageResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "listVenueEvents" },
+        },
+      )
+      .get(
+        "/:orgHandle/:venueHandle/events/:eventId/lineup",
+        async ({ params, set }) => {
+          // Confirm the venue exists first so a wrong handle returns 404
+          // even when an attacker guesses a real eventId.
+          const venue = await runtime.runPromise(
+            getVenue(params.orgHandle, params.venueHandle).pipe(
+              Effect.catchTag("VenueNotFound", () => Effect.succeed(null)),
+            ),
+          );
+          if (venue === null) {
+            set.status = 404;
+            return { message: "Venue not found" } as const;
+          }
+          // S-H1: the lineup is an event sub-resource, so it goes through
+          // the same visibility gate as every other direct event fetch
+          // (anonymous viewer → public events only), AND the event must
+          // belong to the venue in the URL — otherwise any valid venue
+          // path would unlock any event's programme.
+          const event = await runtime.runPromise(loadVisibleEvent(params.eventId, null));
+          if (event === null || event.venueId !== venue.id) {
+            metricEventAccessDenied("lineup", event === null ? "private_anonymous" : "other");
+            set.status = 404;
+            return { message: "Event not found" } as const;
+          }
+          const slots = await runtime.runPromise(listEventLineup(params.eventId));
+          return { slots: slots.map(serializeLineupSlot) };
+        },
+        {
+          params: t.Object({
+            orgHandle: t.String(),
+            venueHandle: t.String(),
+            eventId: t.String(),
+          }),
+          response: {
+            200: t.Object({ slots: t.Array(lineupSlotSchema) }),
+            404: messageResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "getVenueEventLineup" },
+        },
+      )
+  );
 };

--- a/shared/openapi/pulse.json
+++ b/shared/openapi/pulse.json
@@ -1,6 +1,591 @@
 {
   "components": {
-    "schemas": {},
+    "schemas": {
+      "Event": {
+        "properties": {
+          "allowInterested": {
+            "type": "boolean"
+          },
+          "cancellationReason": {
+            "enum": [
+              "host_left",
+              "organiser",
+              "admin"
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cancelledAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "chatId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "commsChannels": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "createdByAvatar": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdByName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdByProfileId": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endTime": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "guestListVisibility": {
+            "enum": [
+              "public",
+              "connections",
+              "private"
+            ],
+            "type": "string"
+          },
+          "hardDeleteAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "instanceOverride": {
+            "type": "boolean"
+          },
+          "joinPolicy": {
+            "enum": [
+              "open",
+              "guest_list"
+            ],
+            "type": "string"
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "priceAmount": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "priceCurrency": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "seriesId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startTime": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "upcoming",
+              "ongoing",
+              "maybe_finished",
+              "finished",
+              "cancelled"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "venue": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "venueId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "visibility": {
+            "enum": [
+              "public",
+              "private"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description",
+          "location",
+          "venue",
+          "venueId",
+          "latitude",
+          "longitude",
+          "category",
+          "startTime",
+          "endTime",
+          "status",
+          "imageUrl",
+          "priceAmount",
+          "priceCurrency",
+          "visibility",
+          "guestListVisibility",
+          "joinPolicy",
+          "allowInterested",
+          "commsChannels",
+          "chatId",
+          "seriesId",
+          "instanceOverride",
+          "createdByProfileId",
+          "createdByName",
+          "createdByAvatar",
+          "cancelledAt",
+          "hardDeleteAt",
+          "cancellationReason",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "Rsvp": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "invitedByProfileId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "isCloseFriend": {
+            "type": "boolean"
+          },
+          "profile": {
+            "properties": {
+              "avatarUrl": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "displayName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "handle": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "handle",
+              "displayName",
+              "avatarUrl"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "profileId": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "going",
+              "maybe",
+              "not_going",
+              "invited"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "eventId",
+          "profileId",
+          "status",
+          "invitedByProfileId",
+          "isCloseFriend",
+          "createdAt",
+          "profile"
+        ],
+        "type": "object"
+      },
+      "Series": {
+        "properties": {
+          "allowInterested": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "chatId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "commsChannels": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "createdByAvatar": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdByName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdByProfileId": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dtstart": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "durationMinutes": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "guestListVisibility": {
+            "enum": [
+              "public",
+              "connections",
+              "private"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "joinPolicy": {
+            "enum": [
+              "open",
+              "guest_list"
+            ],
+            "type": "string"
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "materializedThrough": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "rrule": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "ended",
+              "cancelled"
+            ],
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "until": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "venue": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "visibility": {
+            "enum": [
+              "public",
+              "private"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description",
+          "location",
+          "venue",
+          "latitude",
+          "longitude",
+          "category",
+          "imageUrl",
+          "durationMinutes",
+          "visibility",
+          "guestListVisibility",
+          "joinPolicy",
+          "allowInterested",
+          "commsChannels",
+          "rrule",
+          "dtstart",
+          "until",
+          "materializedThrough",
+          "timezone",
+          "status",
+          "chatId",
+          "createdByProfileId",
+          "createdByName",
+          "createdByAvatar",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "Venue": {
+        "properties": {
+          "address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "capacity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "handle": {
+            "type": "string"
+          },
+          "heroImageUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "hours": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "instagramHandle": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": "string"
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "orgHandle": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "websiteUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "orgHandle",
+          "handle",
+          "name",
+          "kind",
+          "description",
+          "address",
+          "city",
+          "country",
+          "latitude",
+          "longitude",
+          "capacity",
+          "hours",
+          "heroImageUrl",
+          "websiteUrl",
+          "instagramHandle",
+          "timezone",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
     "securitySchemes": {
       "bearerAuth": {
         "bearerFormat": "JWT",
@@ -685,218 +1270,7 @@
                   "properties": {
                     "events": {
                       "items": {
-                        "properties": {
-                          "allowInterested": {
-                            "type": "boolean"
-                          },
-                          "cancellationReason": {
-                            "enum": [
-                              "host_left",
-                              "organiser",
-                              "admin"
-                            ],
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "cancelledAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "category": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "chatId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "commsChannels": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "createdByAvatar": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByName": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByProfileId": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "endTime": {
-                            "format": "date-time",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "guestListVisibility": {
-                            "enum": [
-                              "public",
-                              "connections",
-                              "private"
-                            ],
-                            "type": "string"
-                          },
-                          "hardDeleteAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "imageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "instanceOverride": {
-                            "type": "boolean"
-                          },
-                          "joinPolicy": {
-                            "enum": [
-                              "open",
-                              "guest_list"
-                            ],
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "location": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceAmount": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceCurrency": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "seriesId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "startTime": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "upcoming",
-                              "ongoing",
-                              "maybe_finished",
-                              "finished",
-                              "cancelled"
-                            ],
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "venue": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "venueId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "public",
-                              "private"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title",
-                          "description",
-                          "location",
-                          "venue",
-                          "venueId",
-                          "latitude",
-                          "longitude",
-                          "category",
-                          "startTime",
-                          "endTime",
-                          "status",
-                          "imageUrl",
-                          "priceAmount",
-                          "priceCurrency",
-                          "visibility",
-                          "guestListVisibility",
-                          "joinPolicy",
-                          "allowInterested",
-                          "commsChannels",
-                          "chatId",
-                          "seriesId",
-                          "instanceOverride",
-                          "createdByProfileId",
-                          "createdByName",
-                          "createdByAvatar",
-                          "cancelledAt",
-                          "hardDeleteAt",
-                          "cancellationReason",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Event"
                       },
                       "type": "array"
                     }
@@ -1042,218 +1416,7 @@
                 "schema": {
                   "properties": {
                     "event": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "cancellationReason": {
-                          "enum": [
-                            "host_left",
-                            "organiser",
-                            "admin"
-                          ],
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "cancelledAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "endTime": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "hardDeleteAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "instanceOverride": {
-                          "type": "boolean"
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceAmount": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceCurrency": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "seriesId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "startTime": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "upcoming",
-                            "ongoing",
-                            "maybe_finished",
-                            "finished",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "venueId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "venueId",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "startTime",
-                        "endTime",
-                        "status",
-                        "imageUrl",
-                        "priceAmount",
-                        "priceCurrency",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "chatId",
-                        "seriesId",
-                        "instanceOverride",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "cancelledAt",
-                        "hardDeleteAt",
-                        "cancellationReason",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Event"
                     }
                   },
                   "required": [
@@ -1350,218 +1513,7 @@
                       "items": {
                         "properties": {
                           "event": {
-                            "properties": {
-                              "allowInterested": {
-                                "type": "boolean"
-                              },
-                              "cancellationReason": {
-                                "enum": [
-                                  "host_left",
-                                  "organiser",
-                                  "admin"
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "cancelledAt": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "category": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "chatId": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "commsChannels": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              "createdByAvatar": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "createdByName": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "createdByProfileId": {
-                                "type": "string"
-                              },
-                              "description": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "endTime": {
-                                "format": "date-time",
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "guestListVisibility": {
-                                "enum": [
-                                  "public",
-                                  "connections",
-                                  "private"
-                                ],
-                                "type": "string"
-                              },
-                              "hardDeleteAt": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "id": {
-                                "type": "string"
-                              },
-                              "imageUrl": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "instanceOverride": {
-                                "type": "boolean"
-                              },
-                              "joinPolicy": {
-                                "enum": [
-                                  "open",
-                                  "guest_list"
-                                ],
-                                "type": "string"
-                              },
-                              "latitude": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "location": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "longitude": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "priceAmount": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "priceCurrency": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "seriesId": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "startTime": {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              "status": {
-                                "enum": [
-                                  "upcoming",
-                                  "ongoing",
-                                  "maybe_finished",
-                                  "finished",
-                                  "cancelled"
-                                ],
-                                "type": "string"
-                              },
-                              "title": {
-                                "type": "string"
-                              },
-                              "updatedAt": {
-                                "format": "date-time",
-                                "type": "string"
-                              },
-                              "venue": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "venueId": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "visibility": {
-                                "enum": [
-                                  "public",
-                                  "private"
-                                ],
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "title",
-                              "description",
-                              "location",
-                              "venue",
-                              "venueId",
-                              "latitude",
-                              "longitude",
-                              "category",
-                              "startTime",
-                              "endTime",
-                              "status",
-                              "imageUrl",
-                              "priceAmount",
-                              "priceCurrency",
-                              "visibility",
-                              "guestListVisibility",
-                              "joinPolicy",
-                              "allowInterested",
-                              "commsChannels",
-                              "chatId",
-                              "seriesId",
-                              "instanceOverride",
-                              "createdByProfileId",
-                              "createdByName",
-                              "createdByAvatar",
-                              "cancelledAt",
-                              "hardDeleteAt",
-                              "cancellationReason",
-                              "createdAt",
-                              "updatedAt"
-                            ],
-                            "type": "object"
+                            "$ref": "#/components/schemas/Event"
                           },
                           "isHost": {
                             "type": "boolean"
@@ -1856,218 +1808,7 @@
                   "properties": {
                     "events": {
                       "items": {
-                        "properties": {
-                          "allowInterested": {
-                            "type": "boolean"
-                          },
-                          "cancellationReason": {
-                            "enum": [
-                              "host_left",
-                              "organiser",
-                              "admin"
-                            ],
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "cancelledAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "category": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "chatId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "commsChannels": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "createdByAvatar": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByName": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByProfileId": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "endTime": {
-                            "format": "date-time",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "guestListVisibility": {
-                            "enum": [
-                              "public",
-                              "connections",
-                              "private"
-                            ],
-                            "type": "string"
-                          },
-                          "hardDeleteAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "imageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "instanceOverride": {
-                            "type": "boolean"
-                          },
-                          "joinPolicy": {
-                            "enum": [
-                              "open",
-                              "guest_list"
-                            ],
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "location": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceAmount": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceCurrency": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "seriesId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "startTime": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "upcoming",
-                              "ongoing",
-                              "maybe_finished",
-                              "finished",
-                              "cancelled"
-                            ],
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "venue": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "venueId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "public",
-                              "private"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title",
-                          "description",
-                          "location",
-                          "venue",
-                          "venueId",
-                          "latitude",
-                          "longitude",
-                          "category",
-                          "startTime",
-                          "endTime",
-                          "status",
-                          "imageUrl",
-                          "priceAmount",
-                          "priceCurrency",
-                          "visibility",
-                          "guestListVisibility",
-                          "joinPolicy",
-                          "allowInterested",
-                          "commsChannels",
-                          "chatId",
-                          "seriesId",
-                          "instanceOverride",
-                          "createdByProfileId",
-                          "createdByName",
-                          "createdByAvatar",
-                          "cancelledAt",
-                          "hardDeleteAt",
-                          "cancellationReason",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Event"
                       },
                       "type": "array"
                     },
@@ -2226,218 +1967,7 @@
                   "properties": {
                     "events": {
                       "items": {
-                        "properties": {
-                          "allowInterested": {
-                            "type": "boolean"
-                          },
-                          "cancellationReason": {
-                            "enum": [
-                              "host_left",
-                              "organiser",
-                              "admin"
-                            ],
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "cancelledAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "category": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "chatId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "commsChannels": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "createdByAvatar": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByName": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByProfileId": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "endTime": {
-                            "format": "date-time",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "guestListVisibility": {
-                            "enum": [
-                              "public",
-                              "connections",
-                              "private"
-                            ],
-                            "type": "string"
-                          },
-                          "hardDeleteAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "imageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "instanceOverride": {
-                            "type": "boolean"
-                          },
-                          "joinPolicy": {
-                            "enum": [
-                              "open",
-                              "guest_list"
-                            ],
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "location": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceAmount": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceCurrency": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "seriesId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "startTime": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "upcoming",
-                              "ongoing",
-                              "maybe_finished",
-                              "finished",
-                              "cancelled"
-                            ],
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "venue": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "venueId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "public",
-                              "private"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title",
-                          "description",
-                          "location",
-                          "venue",
-                          "venueId",
-                          "latitude",
-                          "longitude",
-                          "category",
-                          "startTime",
-                          "endTime",
-                          "status",
-                          "imageUrl",
-                          "priceAmount",
-                          "priceCurrency",
-                          "visibility",
-                          "guestListVisibility",
-                          "joinPolicy",
-                          "allowInterested",
-                          "commsChannels",
-                          "chatId",
-                          "seriesId",
-                          "instanceOverride",
-                          "createdByProfileId",
-                          "createdByName",
-                          "createdByAvatar",
-                          "cancelledAt",
-                          "hardDeleteAt",
-                          "cancellationReason",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Event"
                       },
                       "type": "array"
                     }
@@ -2551,218 +2081,7 @@
                 "schema": {
                   "properties": {
                     "event": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "cancellationReason": {
-                          "enum": [
-                            "host_left",
-                            "organiser",
-                            "admin"
-                          ],
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "cancelledAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "endTime": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "hardDeleteAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "instanceOverride": {
-                          "type": "boolean"
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceAmount": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceCurrency": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "seriesId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "startTime": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "upcoming",
-                            "ongoing",
-                            "maybe_finished",
-                            "finished",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "venueId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "venueId",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "startTime",
-                        "endTime",
-                        "status",
-                        "imageUrl",
-                        "priceAmount",
-                        "priceCurrency",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "chatId",
-                        "seriesId",
-                        "instanceOverride",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "cancelledAt",
-                        "hardDeleteAt",
-                        "cancellationReason",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Event"
                     }
                   },
                   "required": [
@@ -2930,218 +2249,7 @@
                 "schema": {
                   "properties": {
                     "event": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "cancellationReason": {
-                          "enum": [
-                            "host_left",
-                            "organiser",
-                            "admin"
-                          ],
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "cancelledAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "endTime": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "hardDeleteAt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "instanceOverride": {
-                          "type": "boolean"
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceAmount": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "priceCurrency": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "seriesId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "startTime": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "upcoming",
-                            "ongoing",
-                            "maybe_finished",
-                            "finished",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "venueId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "venueId",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "startTime",
-                        "endTime",
-                        "status",
-                        "imageUrl",
-                        "priceAmount",
-                        "priceCurrency",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "chatId",
-                        "seriesId",
-                        "instanceOverride",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "cancelledAt",
-                        "hardDeleteAt",
-                        "cancellationReason",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Event"
                     }
                   },
                   "required": [
@@ -3879,82 +2987,7 @@
                     },
                     "rsvps": {
                       "items": {
-                        "properties": {
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "eventId": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "invitedByProfileId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "isCloseFriend": {
-                            "type": "boolean"
-                          },
-                          "profile": {
-                            "properties": {
-                              "avatarUrl": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "displayName": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "handle": {
-                                "type": "string"
-                              },
-                              "id": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "handle",
-                              "displayName",
-                              "avatarUrl"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "profileId": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "going",
-                              "maybe",
-                              "not_going",
-                              "invited"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "eventId",
-                          "profileId",
-                          "status",
-                          "invitedByProfileId",
-                          "isCloseFriend",
-                          "createdAt",
-                          "profile"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Rsvp"
                       },
                       "type": "array"
                     }
@@ -4344,82 +3377,7 @@
                     },
                     "rsvps": {
                       "items": {
-                        "properties": {
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "eventId": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "invitedByProfileId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "isCloseFriend": {
-                            "type": "boolean"
-                          },
-                          "profile": {
-                            "properties": {
-                              "avatarUrl": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "displayName": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "handle": {
-                                "type": "string"
-                              },
-                              "id": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "handle",
-                              "displayName",
-                              "avatarUrl"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "profileId": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "going",
-                              "maybe",
-                              "not_going",
-                              "invited"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "eventId",
-                          "profileId",
-                          "status",
-                          "invitedByProfileId",
-                          "isCloseFriend",
-                          "createdAt",
-                          "profile"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Rsvp"
                       },
                       "type": "array"
                     }
@@ -5127,394 +4085,12 @@
                   "properties": {
                     "instances": {
                       "items": {
-                        "properties": {
-                          "allowInterested": {
-                            "type": "boolean"
-                          },
-                          "cancellationReason": {
-                            "enum": [
-                              "host_left",
-                              "organiser",
-                              "admin"
-                            ],
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "cancelledAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "category": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "chatId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "commsChannels": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "createdByAvatar": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByName": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByProfileId": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "endTime": {
-                            "format": "date-time",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "guestListVisibility": {
-                            "enum": [
-                              "public",
-                              "connections",
-                              "private"
-                            ],
-                            "type": "string"
-                          },
-                          "hardDeleteAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "imageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "instanceOverride": {
-                            "type": "boolean"
-                          },
-                          "joinPolicy": {
-                            "enum": [
-                              "open",
-                              "guest_list"
-                            ],
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "location": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceAmount": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceCurrency": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "seriesId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "startTime": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "upcoming",
-                              "ongoing",
-                              "maybe_finished",
-                              "finished",
-                              "cancelled"
-                            ],
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "venue": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "venueId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "public",
-                              "private"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title",
-                          "description",
-                          "location",
-                          "venue",
-                          "venueId",
-                          "latitude",
-                          "longitude",
-                          "category",
-                          "startTime",
-                          "endTime",
-                          "status",
-                          "imageUrl",
-                          "priceAmount",
-                          "priceCurrency",
-                          "visibility",
-                          "guestListVisibility",
-                          "joinPolicy",
-                          "allowInterested",
-                          "commsChannels",
-                          "chatId",
-                          "seriesId",
-                          "instanceOverride",
-                          "createdByProfileId",
-                          "createdByName",
-                          "createdByAvatar",
-                          "cancelledAt",
-                          "hardDeleteAt",
-                          "cancellationReason",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Event"
                       },
                       "type": "array"
                     },
                     "series": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "dtstart": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "durationMinutes": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "materializedThrough": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "rrule": {
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "active",
-                            "ended",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "timezone": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "until": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "imageUrl",
-                        "durationMinutes",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "rrule",
-                        "dtstart",
-                        "until",
-                        "materializedThrough",
-                        "timezone",
-                        "status",
-                        "chatId",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Series"
                     }
                   },
                   "required": [
@@ -5737,178 +4313,7 @@
                 "schema": {
                   "properties": {
                     "series": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "dtstart": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "durationMinutes": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "materializedThrough": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "rrule": {
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "active",
-                            "ended",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "timezone": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "until": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "imageUrl",
-                        "durationMinutes",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "rrule",
-                        "dtstart",
-                        "until",
-                        "materializedThrough",
-                        "timezone",
-                        "status",
-                        "chatId",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Series"
                     }
                   },
                   "required": [
@@ -6057,178 +4462,7 @@
                 "schema": {
                   "properties": {
                     "series": {
-                      "properties": {
-                        "allowInterested": {
-                          "type": "boolean"
-                        },
-                        "category": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "chatId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "commsChannels": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "createdByAvatar": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByName": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdByProfileId": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "dtstart": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "durationMinutes": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "guestListVisibility": {
-                          "enum": [
-                            "public",
-                            "connections",
-                            "private"
-                          ],
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "joinPolicy": {
-                          "enum": [
-                            "open",
-                            "guest_list"
-                          ],
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "materializedThrough": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "rrule": {
-                          "type": "string"
-                        },
-                        "status": {
-                          "enum": [
-                            "active",
-                            "ended",
-                            "cancelled"
-                          ],
-                          "type": "string"
-                        },
-                        "timezone": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "until": {
-                          "format": "date-time",
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "venue": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "visibility": {
-                          "enum": [
-                            "public",
-                            "private"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "title",
-                        "description",
-                        "location",
-                        "venue",
-                        "latitude",
-                        "longitude",
-                        "category",
-                        "imageUrl",
-                        "durationMinutes",
-                        "visibility",
-                        "guestListVisibility",
-                        "joinPolicy",
-                        "allowInterested",
-                        "commsChannels",
-                        "rrule",
-                        "dtstart",
-                        "until",
-                        "materializedThrough",
-                        "timezone",
-                        "status",
-                        "chatId",
-                        "createdByProfileId",
-                        "createdByName",
-                        "createdByAvatar",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Series"
                     },
                     "updated": {
                       "type": "number"
@@ -6384,218 +4618,7 @@
                   "properties": {
                     "instances": {
                       "items": {
-                        "properties": {
-                          "allowInterested": {
-                            "type": "boolean"
-                          },
-                          "cancellationReason": {
-                            "enum": [
-                              "host_left",
-                              "organiser",
-                              "admin"
-                            ],
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "cancelledAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "category": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "chatId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "commsChannels": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "createdByAvatar": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByName": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdByProfileId": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "endTime": {
-                            "format": "date-time",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "guestListVisibility": {
-                            "enum": [
-                              "public",
-                              "connections",
-                              "private"
-                            ],
-                            "type": "string"
-                          },
-                          "hardDeleteAt": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "imageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "instanceOverride": {
-                            "type": "boolean"
-                          },
-                          "joinPolicy": {
-                            "enum": [
-                              "open",
-                              "guest_list"
-                            ],
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "location": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceAmount": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "priceCurrency": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "seriesId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "startTime": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "upcoming",
-                              "ongoing",
-                              "maybe_finished",
-                              "finished",
-                              "cancelled"
-                            ],
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "venue": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "venueId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "public",
-                              "private"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title",
-                          "description",
-                          "location",
-                          "venue",
-                          "venueId",
-                          "latitude",
-                          "longitude",
-                          "category",
-                          "startTime",
-                          "endTime",
-                          "status",
-                          "imageUrl",
-                          "priceAmount",
-                          "priceCurrency",
-                          "visibility",
-                          "guestListVisibility",
-                          "joinPolicy",
-                          "allowInterested",
-                          "commsChannels",
-                          "chatId",
-                          "seriesId",
-                          "instanceOverride",
-                          "createdByProfileId",
-                          "createdByName",
-                          "createdByAvatar",
-                          "cancelledAt",
-                          "hardDeleteAt",
-                          "cancellationReason",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Event"
                       },
                       "type": "array"
                     }
@@ -6641,122 +4664,7 @@
                   "properties": {
                     "venues": {
                       "items": {
-                        "properties": {
-                          "address": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "capacity": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "city": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "country": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "createdAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "handle": {
-                            "type": "string"
-                          },
-                          "heroImageUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "hours": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "instagramHandle": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "latitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "longitude": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "orgHandle": {
-                            "type": "string"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "format": "date-time",
-                            "type": "string"
-                          },
-                          "websiteUrl": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "orgHandle",
-                          "handle",
-                          "name",
-                          "kind",
-                          "description",
-                          "address",
-                          "city",
-                          "country",
-                          "latitude",
-                          "longitude",
-                          "capacity",
-                          "hours",
-                          "heroImageUrl",
-                          "websiteUrl",
-                          "instagramHandle",
-                          "timezone",
-                          "createdAt",
-                          "updatedAt"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/Venue"
                       },
                       "type": "array"
                     }
@@ -6819,122 +4727,7 @@
                 "schema": {
                   "properties": {
                     "venue": {
-                      "properties": {
-                        "address": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "capacity": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "city": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "country": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "createdAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "handle": {
-                          "type": "string"
-                        },
-                        "heroImageUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "hours": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "instagramHandle": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "kind": {
-                          "type": "string"
-                        },
-                        "latitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "longitude": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "orgHandle": {
-                          "type": "string"
-                        },
-                        "timezone": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "format": "date-time",
-                          "type": "string"
-                        },
-                        "websiteUrl": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "orgHandle",
-                        "handle",
-                        "name",
-                        "kind",
-                        "description",
-                        "address",
-                        "city",
-                        "country",
-                        "latitude",
-                        "longitude",
-                        "capacity",
-                        "hours",
-                        "heroImageUrl",
-                        "websiteUrl",
-                        "instagramHandle",
-                        "timezone",
-                        "createdAt",
-                        "updatedAt"
-                      ],
-                      "type": "object"
+                      "$ref": "#/components/schemas/Venue"
                     }
                   },
                   "required": [

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseModels.swift
@@ -84,11 +84,12 @@ private func date(unixSeconds: Double?) -> Date? {
 
 /// App-level event model shared by Explore and Event detail.
 ///
-/// `discoverEvents` and `getEventById` each generate their own,
-/// structurally-identical but nominally distinct payload type
-/// (`Operations.DiscoverEvents...EventsPayloadPayload` and
-/// `Operations.GetEventById...EventPayload`) — this bridges both into one
-/// shape the views can share.
+/// It wraps one generated type, `Components.Schemas.Event`, because the spec
+/// names the schema once and every route `$ref`s it. It did not always: the
+/// schema was inlined at each route, so `discoverEvents` and `getEventById`
+/// generated separate, structurally identical payload types and this file
+/// carried a second copy of every enum mapping and of the whole 29-field
+/// initialiser — a third copy per new screen.
 ///
 /// Every field of `eventResponseSchema` is mapped, in the order the schema
 /// declares them. That was not true when this file was written: the
@@ -167,23 +168,12 @@ public struct PulseEvent: Identifiable, Equatable, Sendable {
     public var isFree: Bool { price?.isFree ?? true }
 }
 
-// The two payload types nest their own copy of each enum, so every case
-// mapping has to be written twice. They convert by exhaustive `switch` rather
-// than by `init(rawValue:)` — the raw values do match, but a `switch` is the
-// only version that fails to compile when the spec grows a case, which is
-// exactly when someone needs to be told.
+// The mappings convert by exhaustive `switch` rather than by
+// `init(rawValue:)` — the raw values do match, but a `switch` is the only
+// version that fails to compile when the spec grows a case, which is exactly
+// when someone needs to be told.
 extension PulseEvent.Status {
-    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.StatusPayload) {
-        switch generated {
-        case .upcoming: self = .upcoming
-        case .ongoing: self = .ongoing
-        case .maybeFinished: self = .maybeFinished
-        case .finished: self = .finished
-        case .cancelled: self = .cancelled
-        }
-    }
-
-    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.StatusPayload) {
+    init(_ generated: Components.Schemas.Event.StatusPayload) {
         switch generated {
         case .upcoming: self = .upcoming
         case .ongoing: self = .ongoing
@@ -195,14 +185,7 @@ extension PulseEvent.Status {
 }
 
 extension PulseEvent.Visibility {
-    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.VisibilityPayload) {
-        switch generated {
-        case ._public: self = .public
-        case ._private: self = .private
-        }
-    }
-
-    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.VisibilityPayload) {
+    init(_ generated: Components.Schemas.Event.VisibilityPayload) {
         switch generated {
         case ._public: self = .public
         case ._private: self = .private
@@ -211,18 +194,7 @@ extension PulseEvent.Visibility {
 }
 
 extension PulseEvent.GuestListVisibility {
-    init(
-        _ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
-            .GuestListVisibilityPayload
-    ) {
-        switch generated {
-        case ._public: self = .public
-        case .connections: self = .connections
-        case ._private: self = .private
-        }
-    }
-
-    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.GuestListVisibilityPayload) {
+    init(_ generated: Components.Schemas.Event.GuestListVisibilityPayload) {
         switch generated {
         case ._public: self = .public
         case .connections: self = .connections
@@ -232,14 +204,7 @@ extension PulseEvent.GuestListVisibility {
 }
 
 extension PulseEvent.JoinPolicy {
-    init(_ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.JoinPolicyPayload) {
-        switch generated {
-        case .open: self = .open
-        case .guestList: self = .guestList
-        }
-    }
-
-    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.JoinPolicyPayload) {
+    init(_ generated: Components.Schemas.Event.JoinPolicyPayload) {
         switch generated {
         case .open: self = .open
         case .guestList: self = .guestList
@@ -248,18 +213,7 @@ extension PulseEvent.JoinPolicy {
 }
 
 extension PulseEvent.CancellationReason {
-    init(
-        _ generated: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
-            .CancellationReasonPayload
-    ) {
-        switch generated {
-        case .hostLeft: self = .hostLeft
-        case .organiser: self = .organiser
-        case .admin: self = .admin
-        }
-    }
-
-    init(_ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.CancellationReasonPayload) {
+    init(_ generated: Components.Schemas.Event.CancellationReasonPayload) {
         switch generated {
         case .hostLeft: self = .hostLeft
         case .organiser: self = .organiser
@@ -269,41 +223,7 @@ extension PulseEvent.CancellationReason {
 }
 
 extension PulseEvent {
-    public init(_ payload: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload) {
-        self.init(
-            id: payload.id,
-            title: payload.title,
-            description: payload.description,
-            location: payload.location,
-            venue: payload.venue,
-            venueId: payload.venueId,
-            coordinate: PulseCoordinate(latitude: payload.latitude, longitude: payload.longitude),
-            category: payload.category,
-            startTime: payload.startTime,
-            endTime: payload.endTime,
-            status: Status(payload.status),
-            imageUrl: payload.imageUrl,
-            price: PulsePrice(amount: payload.priceAmount, currency: payload.priceCurrency),
-            visibility: Visibility(payload.visibility),
-            guestListVisibility: GuestListVisibility(payload.guestListVisibility),
-            joinPolicy: JoinPolicy(payload.joinPolicy),
-            allowInterested: payload.allowInterested,
-            commsChannels: payload.commsChannels,
-            chatId: payload.chatId,
-            seriesId: payload.seriesId,
-            instanceOverride: payload.instanceOverride,
-            createdByProfileId: payload.createdByProfileId,
-            createdByName: payload.createdByName,
-            createdByAvatar: payload.createdByAvatar,
-            cancelledAt: date(unixSeconds: payload.cancelledAt),
-            hardDeleteAt: date(unixSeconds: payload.hardDeleteAt),
-            cancellationReason: payload.cancellationReason.map(CancellationReason.init),
-            createdAt: payload.createdAt,
-            updatedAt: payload.updatedAt
-        )
-    }
-
-    public init(_ payload: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload) {
+    public init(_ payload: Components.Schemas.Event) {
         self.init(
             id: payload.id,
             title: payload.title,

--- a/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseModelsTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseModelsTests.swift
@@ -5,10 +5,10 @@ import Testing
 
 private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
 
-private func makeDiscoverEventsPayload(
+private func makeEventPayload(
     id: String = "event-1",
-    status: Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload.StatusPayload = .upcoming
-) -> Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload {
+    status: Components.Schemas.Event.StatusPayload = .upcoming
+) -> Components.Schemas.Event {
     .init(
         allowInterested: true,
         commsChannels: "email",
@@ -30,9 +30,7 @@ private func makeDiscoverEventsPayload(
 /// one shows up as a failed expectation rather than as a `nil` nobody
 /// notices. `cancelledAt`/`hardDeleteAt` are unix seconds, not `date-time`,
 /// hence the bare numbers.
-private func makeFullDiscoverEventsPayload()
-    -> Operations.DiscoverEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload
-{
+private func makeFullEventPayload() -> Components.Schemas.Event {
     .init(
         allowInterested: true,
         cancellationReason: .hostLeft,
@@ -68,8 +66,8 @@ private func makeFullDiscoverEventsPayload()
     )
 }
 
-@Test func pulseEventMapsEveryDiscoverEventsField() {
-    let event = PulseEvent(makeFullDiscoverEventsPayload())
+@Test func pulseEventMapsEveryEventField() {
+    let event = PulseEvent(makeFullEventPayload())
     #expect(event.description == "Sunset set on the roof")
     #expect(event.location == "Sydney")
     #expect(event.venue == "The Roof")
@@ -90,13 +88,13 @@ private func makeFullDiscoverEventsPayload()
 }
 
 @Test func cancelledAtAndHardDeleteAtAreReadAsUnixSeconds() {
-    let event = PulseEvent(makeFullDiscoverEventsPayload())
+    let event = PulseEvent(makeFullEventPayload())
     #expect(event.cancelledAt == Date(timeIntervalSince1970: 1_700_000_500))
     #expect(event.hardDeleteAt == Date(timeIntervalSince1970: 1_701_000_000))
 }
 
 @Test func absentOptionalFieldsMapToNil() {
-    let event = PulseEvent(makeDiscoverEventsPayload())
+    let event = PulseEvent(makeEventPayload())
     #expect(event.description == nil)
     #expect(event.location == nil)
     #expect(event.venue == nil)
@@ -116,27 +114,27 @@ private func makeFullDiscoverEventsPayload()
 }
 
 @Test func halfACoordinateIsNoCoordinate() {
-    var payload = makeFullDiscoverEventsPayload()
+    var payload = makeFullEventPayload()
     payload.longitude = nil
     #expect(PulseEvent(payload).coordinate == nil)
 }
 
 @Test func anAmountWithoutACurrencyIsNoPrice() {
-    var payload = makeFullDiscoverEventsPayload()
+    var payload = makeFullEventPayload()
     payload.priceCurrency = nil
     #expect(PulseEvent(payload).price == nil)
 }
 
 @Test func zeroAndAbsentPriceBothReadAsFree() {
-    var payload = makeFullDiscoverEventsPayload()
+    var payload = makeFullEventPayload()
     payload.priceAmount = 0
     #expect(PulseEvent(payload).isFree == true)
-    #expect(PulseEvent(makeDiscoverEventsPayload()).isFree == true)
-    #expect(PulseEvent(makeFullDiscoverEventsPayload()).isFree == false)
+    #expect(PulseEvent(makeEventPayload()).isFree == true)
+    #expect(PulseEvent(makeFullEventPayload()).isFree == false)
 }
 
-@Test func pulseEventMapsDiscoverEventsPayloadFields() {
-    let event = PulseEvent(makeDiscoverEventsPayload())
+@Test func pulseEventMapsRequiredEventFields() {
+    let event = PulseEvent(makeEventPayload())
     #expect(event.id == "event-1")
     #expect(event.title == "Rooftop Party")
     #expect(event.status == .upcoming)
@@ -151,65 +149,19 @@ private func makeFullDiscoverEventsPayload()
     #expect(event.updatedAt == referenceDate)
 }
 
-@Test func pulseEventMapsAllDiscoverEventsStatusCases() {
-    #expect(PulseEvent(makeDiscoverEventsPayload(status: .upcoming)).status == .upcoming)
-    #expect(PulseEvent(makeDiscoverEventsPayload(status: .ongoing)).status == .ongoing)
-    #expect(PulseEvent(makeDiscoverEventsPayload(status: .finished)).status == .finished)
-    #expect(PulseEvent(makeDiscoverEventsPayload(status: .cancelled)).status == .cancelled)
-    #expect(PulseEvent(makeDiscoverEventsPayload(status: .maybeFinished)).status == .maybeFinished)
-}
-
-/// The same event, spelled in the detail endpoint's own payload type.
-private func makeFullGetEventByIdPayload() -> Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload {
-    .init(
-        allowInterested: true,
-        cancellationReason: .hostLeft,
-        cancelledAt: 1_700_000_500,
-        category: "music",
-        chatId: "chat-1",
-        commsChannels: "email",
-        createdAt: referenceDate,
-        createdByAvatar: "https://cdn.example/avatar.png",
-        createdByName: "Ada",
-        createdByProfileId: "profile-1",
-        description: "Sunset set on the roof",
-        endTime: referenceDate.addingTimeInterval(7200),
-        guestListVisibility: .connections,
-        hardDeleteAt: 1_701_000_000,
-        id: "event-1",
-        imageUrl: "https://cdn.example/event.jpg",
-        instanceOverride: true,
-        joinPolicy: .guestList,
-        latitude: -33.8688,
-        location: "Sydney",
-        longitude: 151.2093,
-        priceAmount: 1850,
-        priceCurrency: "AUD",
-        seriesId: "series-1",
-        startTime: referenceDate,
-        status: .cancelled,
-        title: "Rooftop Party",
-        updatedAt: referenceDate,
-        venue: "The Roof",
-        venueId: "venue-1",
-        visibility: ._private
-    )
-}
-
-/// The point of the two bridges is that Explore and Event detail can share
-/// one model, so the only interesting property is that they agree. Written
-/// as a single equality rather than a second field-by-field sweep: the two
-/// mappings are duplicated by necessity (the generated types nest their own
-/// enums), and this is what catches one drifting from the other.
-@Test func bothBridgesProduceTheSameEvent() {
-    #expect(PulseEvent(makeFullDiscoverEventsPayload()) == PulseEvent(makeFullGetEventByIdPayload()))
+@Test func pulseEventMapsAllStatusCases() {
+    #expect(PulseEvent(makeEventPayload(status: .upcoming)).status == .upcoming)
+    #expect(PulseEvent(makeEventPayload(status: .ongoing)).status == .ongoing)
+    #expect(PulseEvent(makeEventPayload(status: .finished)).status == .finished)
+    #expect(PulseEvent(makeEventPayload(status: .cancelled)).status == .cancelled)
+    #expect(PulseEvent(makeEventPayload(status: .maybeFinished)).status == .maybeFinished)
 }
 
 @Test func pulseEventMapsAllCancellationReasons() {
     func reason(
-        _ generated: Operations.GetEventById.Output.Ok.Body.JsonPayload.EventPayload.CancellationReasonPayload
+        _ generated: Components.Schemas.Event.CancellationReasonPayload
     ) -> PulseEvent.CancellationReason? {
-        var payload = makeFullGetEventByIdPayload()
+        var payload = makeFullEventPayload()
         payload.cancellationReason = generated
         return PulseEvent(payload).cancellationReason
     }


### PR DESCRIPTION
Stacked on #409 (`feat/pulse-event-detail`). Review the last commit only.

## The problem

`@elysiajs/openapi` inlines every TypeBox schema at its use site. `components/schemas` was empty, so swift-openapi-generator gave each operation its own structurally identical but nominally distinct payload type: `Operations.DiscoverEvents.…EventsPayloadPayload` and `Operations.GetEventById.…EventPayload` were the same 31 fields under two names.

`PulseModels.swift` paid for that twice over — two copies of all five enum mappings and two copies of the whole 29-field `PulseEvent` initialiser. The calendar tab reads events too, and so does every screen after it; each one would have added another copy. Fixing it before adding tabs.

## The fix

Register the four schemas the Swift side hand-maps — `Event`, `Rsvp`, `Series`, `Venue` — with Elysia's `.model()`, and reference them with `t.Ref`. The plugin already builds `components/schemas` from the registered models, so naming them is the whole fix; no hoist pass of our own.

Models registered on sibling plugins dedupe by name in the root document, so each route file registers what it uses and resolves its own refs whether or not the others are mounted. `series.ts` therefore registers `Event` again with the same schema rather than relying on `events.ts` being present.

Schemas with one call site (`publicVenueEventSchema`, `lineupSlotSchema`, the 46 one-field `message`/`error` objects) stay inline — a name buys nothing there.

## Two spec passes

A route that names its response at the top level gets a correct `#/components/schemas/X` pointer from the plugin. A `t.Ref("X")` **nested** inside a `t.Object` or `t.Array` does not: TypeBox stores the bare name and the plugin emits `{"$ref": "X"}`, which is a valid JSON Schema ref that resolves to nothing here, and swift-openapi-generator rejects the document over it. Elysia resolves either spelling at runtime, so only the document is wrong. `resolveBareRefs` rewrites it, and throws on a name matching no component — a typo'd ref now fails `openapi:generate` with a message naming the fix, instead of surfacing as a Swift type that quietly isn't there.

`stripComponentIds` drops the `"$id": "#/components/schemas/Event"` the plugin stamps onto each hoisted schema. `$id` is a JSON Schema identifier, not an OpenAPI keyword, and the value carries nothing the component's key doesn't.

Both run before the existing nullable passes; the ordering comment on `stripRedundantNullable` still holds.

## Result

- `shared/openapi/pulse.json`: four components, ~2100 lines smaller.
- `PulseModels.swift`: one bridge per enum, one struct initialiser.
- `bothBridgesProduceTheSameEvent` deleted. It existed to catch the two duplicated mappings drifting apart; there is one mapping now, so the test could no longer fail.
- `PulseRsvp` and `PulseRsvpCounts` still bind per-operation types, correctly — `rsvpToEvent` returns the raw row shape, not `rsvpResponseSchema`.

## Checks

- `bun run --cwd pulse/api check` clean — `t.Ref` does not degrade handler return-type inference, which was the risk worth proving.
- `bun run --cwd pulse/api test:run` — 549 tests pass. Refs still validate strictly at runtime.
- `bun run check` — 25/25.
- `swift test` — 66 tests pass.
- The CI `xcodebuild` line builds clean.