### PR TITLE
fix(pulse): filter GET /events/today by event visibility

### DIFF
--- a/.changeset/quiet-pugs-listen.md
+++ b/.changeset/quiet-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+"@pulse/api": patch
+---
+
+Fix a private-event leak in `GET /events/today`. The feed ran no visibility predicate and the route extracted no claims, so every private event starting today was readable by an unauthenticated caller. `listTodayEvents` now takes the viewer's profile id (required, not defaulted) and filters through `buildVisibilityFilter`, the same predicate `listEvents` and `discoverEvents` already use; the route reads an optional bearer token so an organiser or an RSVP'd guest still sees their own private events.

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -423,8 +423,15 @@ export const createEventsRoutes = (
       )
       .get(
         "/today",
-        async () => {
-          const result = await runtime.runPromise(listTodayEvents);
+        async ({ headers }) => {
+          // Same optional-viewer shape as `GET /events`: the feed stays
+          // public, but who is asking decides which private events belong
+          // in it. Anonymous callers see public events only.
+          const claims = await extractClaims(headers["authorization"], jwksUrl, {
+            testKey: _testKey as CryptoKey,
+            audience: "osn-access",
+          });
+          const result = await runtime.runPromise(listTodayEvents(claims?.profileId ?? null));
           return { events: result.map(serializeEvent) };
         },
         {

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -380,28 +380,46 @@ export const listEvents = (
  */
 const TODAY_EVENTS_LIMIT = 200;
 
-export const listTodayEvents: Effect.Effect<Event[], DatabaseError, Db> = Effect.gen(function* () {
-  const { db } = yield* Db;
-  const now = new Date();
-  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
+/**
+ * Today's events, filtered to what the viewer is allowed to see.
+ *
+ * `viewerId` is not optional with a default: this list shipped without any
+ * visibility predicate at all, so every private event starting today was
+ * readable by an unauthenticated caller (the S-H12..S-H16 class the
+ * `buildVisibilityFilter` header warns about). Requiring the argument means
+ * a new caller has to say who is asking rather than inherit a leak.
+ */
+export const listTodayEvents = (
+  viewerId: string | null,
+): Effect.Effect<Event[], DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const now = new Date();
+    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
 
-  const results = yield* Effect.tryPromise({
-    try: (): Promise<Event[]> =>
-      db
-        .select()
-        .from(events)
-        .where(and(gte(events.startTime, startOfDay), lte(events.startTime, endOfDay)))
-        .orderBy(events.startTime)
-        .limit(TODAY_EVENTS_LIMIT) as Promise<Event[]>,
-    catch: (cause) => new DatabaseError({ cause }),
-  });
+    const results = yield* Effect.tryPromise({
+      try: (): Promise<Event[]> =>
+        db
+          .select()
+          .from(events)
+          .where(
+            and(
+              gte(events.startTime, startOfDay),
+              lte(events.startTime, endOfDay),
+              buildVisibilityFilter(viewerId),
+            ),
+          )
+          .orderBy(events.startTime)
+          .limit(TODAY_EVENTS_LIMIT) as Promise<Event[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
 
-  // Batched status-transition writer (P-W5) — see applyTransitions.
-  const transitioned = yield* applyTransitions(results);
-  metricEventsListed("today", transitioned.length);
-  return transitioned;
-}).pipe(Effect.withSpan("events.list_today"));
+    // Batched status-transition writer (P-W5) — see applyTransitions.
+    const transitioned = yield* applyTransitions(results);
+    metricEventsListed("today", transitioned.length);
+    return transitioned;
+  }).pipe(Effect.withSpan("events.list_today"));
 
 /**
  * One row of the personal calendar: an event the viewer is going to /

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { events as eventsTable } from "@pulse/db/schema";
+import { events as eventsTable, eventRsvps } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
 import { Effect } from "effect";
 import { vi } from "vitest";
@@ -24,6 +24,21 @@ const ALICE = { createdByProfileId: "usr_alice", createdByName: "Alice", created
 
 const provide = <A, E>(effect: Effect.Effect<A, E, any>) =>
   effect.pipe(Effect.provide(createTestLayer()));
+
+/** Attendance row, so visibility tests can make a viewer a guest of an event. */
+const seedRsvp = (eventId: string, profileId: string) =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* Effect.promise(() =>
+      db.insert(eventRsvps).values({
+        id: `rsvp_${eventId}_${profileId}`,
+        eventId,
+        profileId,
+        status: "going",
+        createdAt: new Date(),
+      }),
+    );
+  });
 
 it.effect("getEvent returns event", () =>
   provide(
@@ -159,9 +174,81 @@ it.effect("listTodayEvents returns only today's events", () =>
     Effect.gen(function* () {
       yield* seedEvent({ title: "Today Event", startTime: new Date() });
       yield* createEvent({ title: "Future Event", startTime: FUTURE }, ALICE);
-      const events = yield* listTodayEvents;
+      const events = yield* listTodayEvents(null);
       expect(events.length).toBe(1);
       expect(events[0]!.title).toBe("Today Event");
+    }),
+  ),
+);
+
+// The "today" feed shipped with no visibility predicate and an unauthenticated
+// route, so every private event starting today was readable by anyone. These
+// pin the same three cases `buildVisibilityFilter` covers, at the one call site
+// that was missing it.
+
+it.effect("listTodayEvents hides private events from anonymous callers", () =>
+  provide(
+    Effect.gen(function* () {
+      yield* seedEvent({ title: "Public today", startTime: new Date() });
+      yield* seedEvent({
+        title: "Alice's private today",
+        startTime: new Date(),
+        visibility: "private",
+        createdByProfileId: "usr_alice",
+      });
+      const events = yield* listTodayEvents(null);
+      expect(events.map((e) => e.title)).toEqual(["Public today"]);
+    }),
+  ),
+);
+
+it.effect("listTodayEvents hides private events from non-owner viewers", () =>
+  provide(
+    Effect.gen(function* () {
+      yield* seedEvent({ title: "Public today", startTime: new Date() });
+      yield* seedEvent({
+        title: "Alice's private today",
+        startTime: new Date(),
+        visibility: "private",
+        createdByProfileId: "usr_alice",
+      });
+      const events = yield* listTodayEvents("usr_bob");
+      expect(events.map((e) => e.title)).toEqual(["Public today"]);
+    }),
+  ),
+);
+
+it.effect("listTodayEvents shows private events to their organiser", () =>
+  provide(
+    Effect.gen(function* () {
+      yield* seedEvent({ title: "Public today", startTime: new Date() });
+      yield* seedEvent({
+        title: "Alice's private today",
+        startTime: new Date(),
+        visibility: "private",
+        createdByProfileId: "usr_alice",
+      });
+      const events = yield* listTodayEvents("usr_alice");
+      expect(events.map((e) => e.title).toSorted()).toEqual([
+        "Alice's private today",
+        "Public today",
+      ]);
+    }),
+  ),
+);
+
+it.effect("listTodayEvents shows private events to an RSVP'd attendee", () =>
+  provide(
+    Effect.gen(function* () {
+      const priv = yield* seedEvent({
+        title: "Alice's private today",
+        startTime: new Date(),
+        visibility: "private",
+        createdByProfileId: "usr_alice",
+      });
+      yield* seedRsvp(priv.id, "usr_bob");
+      const events = yield* listTodayEvents("usr_bob");
+      expect(events.map((e) => e.title)).toEqual(["Alice's private today"]);
     }),
   ),
 );
@@ -685,7 +772,7 @@ it.effect("listTodayEvents returns transitioned statuses", () =>
   provide(
     Effect.gen(function* () {
       yield* seedEvent({ title: "Today Started", startTime: STARTED });
-      const results = yield* listTodayEvents;
+      const results = yield* listTodayEvents(null);
       const started = results.find((e) => e.title === "Today Started");
       expect(started?.status).toBe("ongoing");
     }),
@@ -747,7 +834,7 @@ it.effect("listTodayEvents caps the result set at 200 rows", () =>
         (i) => seedEvent({ title: `Bulk ${i}`, startTime: now, status: "ongoing" }),
         { concurrency: 1 },
       );
-      const results = yield* listTodayEvents;
+      const results = yield* listTodayEvents(null);
       expect(results.length).toBe(200);
     }),
   ),

--- a/wiki/changelog/security-fixes.md
+++ b/wiki/changelog/security-fixes.md
@@ -7,12 +7,17 @@ related:
   - "[[arc-tokens]]"
   - "[[redis]]"
   - "[[identity-model]]"
-last-reviewed: 2026-08-08
+  - "[[event-access]]"
+last-reviewed: 2026-08-09
 ---
 
 # Security Fixes — Completed
 
 Archived completed security findings from [[TODO]]. Finding IDs follow the [[review-findings]] format. For open findings see the Security Backlog in [[TODO]].
+
+## Pulse "today" feed leaked private events (2026-08-09)
+
+- [x] **S-H (today-feed-visibility)** — **`GET /events/today` returned private events to anonymous callers.** **Issue:** `listTodayEvents` selected on the start-of-day/end-of-day range alone, with no `buildVisibilityFilter` term, and the route extracted no claims — so every private event starting today was readable by anyone who could reach the endpoint, with organiser name and location attached. `listEvents` and `discoverEvents`, the other two multi-event surfaces, both filter correctly; this was the one that shipped without it, the class the `buildVisibilityFilter` header calls out (S-H12…S-H16). **Why:** the feed predates the visibility work and was never revisited when the predicate was introduced. **Solution:** `listTodayEvents` now takes `viewerId: string | null` as a **required** argument — not an optional one defaulting to `null` — so a new caller has to say who is asking rather than inherit the leak, and it ANDs `buildVisibilityFilter(viewerId)` into the same query. The route reads an optional bearer token exactly as `GET /events` does, so the feed stays public while an organiser or an RSVP'd guest still sees their own private events. Four service tests pin anonymous / non-owner / organiser / attendee. See [[event-access]].
 
 ## Graph/org error contract fix (2026-08-02) — prep-pr review
 

--- a/wiki/systems/event-access.md
+++ b/wiki/systems/event-access.md
@@ -24,7 +24,7 @@ finding-ids:
   - S-H16
 packages:
   - "@pulse/api"
-last-reviewed: 2026-07-22
+last-reviewed: 2026-08-09
 ---
 
 # Event Access Control
@@ -66,7 +66,7 @@ When adding a new event-scoped route, **always** load the event via `loadVisible
 
 ## Discovery vs Direct Fetch
 
-- **List / discovery** (`listEvents`, `discoverEvents`) consume the shared `buildVisibilityFilter(viewerId)` helper exported from `services/eventAccess.ts`. This is a SQL predicate mirror of `canViewEvent`, applied in the `WHERE` clause so post-LIMIT page sizes stay stable.
+- **List / discovery** (`listEvents`, `discoverEvents`, `listTodayEvents`) consume the shared `buildVisibilityFilter(viewerId)` helper exported from `services/eventAccess.ts`. This is a SQL predicate mirror of `canViewEvent`, applied in the `WHERE` clause so post-LIMIT page sizes stay stable.
 - **Direct fetch** uses `loadVisibleEvent` which loads the event first, then checks visibility in JS.
 
 `buildVisibilityFilter` and `canViewEvent` must stay byte-for-byte equivalent. The predicate is:
@@ -74,7 +74,7 @@ When adding a new event-scoped route, **always** load the event via `loadVisible
 - Public events → visible to everyone.
 - Private events → visible to `createdByProfileId = viewerId` **or** `EXISTS (SELECT 1 FROM event_rsvps WHERE event_id = events.id AND profile_id = viewerId)`.
 
-Any code that SELECTs from `events` and returns multiple rows MUST consume `buildVisibilityFilter` — divergence re-opens the S-H12..S-H16 regression class. Do not reinvent the filter.
+Any code that SELECTs from `events` and returns multiple rows MUST consume `buildVisibilityFilter` — divergence re-opens the S-H12..S-H16 regression class. Do not reinvent the filter. `listTodayEvents` was the one surface that shipped without it (S-H today-feed-visibility, fixed 2026-08-09, see [[security-fixes]]); its viewer argument is deliberately required rather than defaulted, so a new caller cannot inherit the leak by omission.
 
 P-W12 moved the SQL predicate into the `WHERE` clause to fix unstable page sizes. Before that, the `LIMIT` ran before the JS visibility filter, so the client got fewer rows than it asked for.
 
@@ -149,7 +149,7 @@ Both endpoints are unauthenticated. Per-IP fail-closed limiters make the metric 
 - [pulse/api/src/services/eventAccess.ts](../pulse/api/src/services/eventAccess.ts) -- `canViewEvent`, `loadVisibleEvent`, `checkEventVisibility`, `canViewAttendees`, `buildVisibilityFilter`
 - [pulse/api/src/lib/shareSource.ts](../pulse/api/src/lib/shareSource.ts) -- `SHARE_SOURCES`, `ShareSourceSchema`, `shareSourceTypeBox`
 - [pulse/api/src/services/rsvps.ts](../pulse/api/src/services/rsvps.ts) -- `upsertRsvp` attribution writes + organiser self-RSVP exclusion
-- [pulse/api/src/services/events.ts](../pulse/api/src/services/events.ts) -- `listEvents` (consumes `buildVisibilityFilter`)
+- [pulse/api/src/services/events.ts](../pulse/api/src/services/events.ts) -- `listEvents`, `listTodayEvents` (consume `buildVisibilityFilter`)
 - [pulse/api/src/services/discovery.ts](../pulse/api/src/services/discovery.ts) -- `discoverEvents` (consumes `buildVisibilityFilter`)
 - [pulse/api/src/routes/events.ts](../pulse/api/src/routes/events.ts) -- route-level usage including `/:id/share` + `/:id/exposure`
 - [CLAUDE.md](../CLAUDE.md) -- "Shared visibility gate" section


### PR DESCRIPTION
## Problem

`GET /events/today` returned **private events to anonymous callers**.

`listTodayEvents` selected on the start-of-day/end-of-day range alone, with no `buildVisibilityFilter` term, and the route extracted no claims. Any private event starting today — title, organiser name, venue, coordinates — was readable by anyone who could reach the endpoint, no token required.

`listEvents` and `discoverEvents`, the other two multi-event surfaces, both apply the filter. This is the one that shipped without it. It is exactly the regression class the header on `buildVisibilityFilter` warns about:

> Any surface that returns multiple events MUST filter by this predicate

Found while scoping the iOS calendar tab, which was going to be built on top of this feed.

## Fix

- `listTodayEvents` becomes a function taking `viewerId: string | null`. **Required, not defaulted to `null`** — this list leaked precisely because a caller could get results without saying who was asking, and a default would preserve that shape for the next caller.
- It ANDs `buildVisibilityFilter(viewerId)` into the same query, alongside the existing time range and the P-W3 `TODAY_EVENTS_LIMIT` cap.
- The route reads an optional bearer token, the same shape `GET /events` already uses. The feed stays public; who is asking decides which private events belong in it. Anonymous callers see public events only.

No response shape changed — `bun run --cwd pulse/api openapi:generate` leaves `shared/openapi/pulse.json` byte-identical, so no client regeneration is needed.

## Tests

Four new service tests, mirroring the existing `listEvents` visibility cases:

- private event hidden from an anonymous caller
- private event hidden from a non-owner viewer
- private event visible to its organiser
- private event visible to a viewer with an `event_rsvps` row

`bun run --cwd pulse/api test:run` → **553 passed** (was 549). `bun run --cwd pulse/api check` clean; `fmt:check` and `lint` clean (only pre-existing warnings).

## Docs

- `wiki/changelog/security-fixes.md` — new **S-H (today-feed-visibility)** entry at the top.
- `wiki/systems/event-access.md` — `listTodayEvents` added to the list of surfaces consuming the filter, plus a note on why its viewer argument is required.

## Notes

Branched off `main` rather than onto the Swift stack, so the fix can merge on its own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)