### PR TITLE
feat(pulse): add the Calendar tab

### DIFF
--- a/shared/swift/OSNShared/Sources/PulseFeature/CalendarView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/CalendarView.swift
@@ -1,0 +1,139 @@
+import OSNUI
+import SwiftUI
+
+/// Calendar tab: the signed-in viewer's own agenda — events they host and
+/// events they said `going`/`maybe` to — grouped by day, soonest first.
+///
+/// This is not the Explore feed narrowed down. Explore asks "what is on?";
+/// this asks "what am I doing?", so it shows cancelled events the viewer is
+/// still on the list for and never shows an event they have no tie to.
+public struct CalendarView: View {
+    @State private var viewModel: CalendarViewModel
+    @State private var selectedEventId: String?
+
+    private let session: PulseSession
+
+    public init(session: PulseSession) {
+        self.session = session
+        _viewModel = State(wrappedValue: CalendarViewModel(api: session.api))
+    }
+
+    public var body: some View {
+        content
+            .navigationTitle("Calendar")
+            .navigationDestination(item: $selectedEventId) { eventId in
+                EventDetailView(session: session, eventId: eventId)
+            }
+            .task {
+                if viewModel.isEmpty {
+                    await viewModel.load()
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isEmpty {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView()
+            case .failed(let message):
+                ContentUnavailableView(
+                    "Couldn't load your calendar",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(message)
+                )
+            case .loaded:
+                ContentUnavailableView(
+                    "Nothing on yet",
+                    systemImage: "calendar",
+                    description: Text("Events you host or RSVP to show up here.")
+                )
+            }
+        } else {
+            agenda
+        }
+    }
+
+    private var agenda: some View {
+        ScrollView {
+            GlassEffectContainer {
+                LazyVStack(alignment: .leading, spacing: 24, pinnedViews: .sectionHeaders) {
+                    ForEach(viewModel.days) { day in
+                        Section {
+                            VStack(spacing: 16) {
+                                ForEach(day.entries) { entry in
+                                    Button {
+                                        selectedEventId = entry.id
+                                    } label: {
+                                        CalendarRow(entry: entry)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+                        } header: {
+                            DayHeader(date: day.date)
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+        .refreshable {
+            await viewModel.load()
+        }
+    }
+}
+
+/// Sticky day heading. `.date` formatting is left to the system so the
+/// viewer's own locale and calendar decide what a day is called.
+private struct DayHeader: View {
+    let date: Date
+
+    var body: some View {
+        HStack {
+            Text(date, format: .dateTime.weekday(.wide).day().month(.wide))
+                .font(.osn(.body, size: 16))
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .background(.bar)
+    }
+}
+
+private struct CalendarRow: View {
+    let entry: PulseCalendarEntry
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(entry.event.title)
+                        .font(.osn(.body, size: 18))
+                    Spacer()
+                    if entry.event.status == .ongoing {
+                        LiveBadge()
+                    }
+                }
+                HStack(spacing: 8) {
+                    // Hosting and attending are separate facts, so an
+                    // organiser who also RSVP'd shows both rather than one
+                    // pill overwriting the other.
+                    if entry.isHost {
+                        Pill("Hosting", tint: OSNColor.accent)
+                    }
+                    if let myStatus = entry.myStatus {
+                        Pill(myStatus.rawValue, tint: OSNColor.accent)
+                    }
+                    // A cancelled event stays on the agenda — the viewer
+                    // planned around it and needs to see that it is off.
+                    if entry.event.status == .cancelled {
+                        Pill("Cancelled", tint: OSNColor.accent)
+                    }
+                }
+                Text(entry.event.startTime, style: .time)
+                    .font(.osn(.body, size: 14))
+            }
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/PulseFeature/CalendarViewModel.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/CalendarViewModel.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Observation
+import PulseAPI
+
+/// Drives the Calendar tab: loads the signed-in viewer's agenda and holds the
+/// day-grouped list plus load state. Like `ExploreViewModel` it owns no
+/// `URLSession` and no token — it only calls through the `APIProtocol` client
+/// `PulseSession` builds.
+///
+/// There is no pagination here because the endpoint has none: the agenda is a
+/// single forward-looking window the server caps at 100 rows. `limit` is the
+/// only knob, and it is a string on the wire — the route parses it and clamps
+/// it, so a value outside 1...100 is silently corrected rather than rejected.
+@MainActor
+@Observable
+public final class CalendarViewModel {
+    public enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    /// The agenda grouped by start day, in server order. Computed once per
+    /// load rather than on every render — the grouping is a full pass over the
+    /// list and the list only changes when a load finishes.
+    public private(set) var days: [PulseCalendarDay] = []
+    public private(set) var state: LoadState = .idle
+
+    /// True once the server has answered at least once, so an empty `days`
+    /// can be told apart from "nothing loaded yet".
+    public var isEmpty: Bool { days.isEmpty }
+
+    private let api: any APIProtocol
+    private let limit: Int
+    private let calendar: Calendar
+    private var loadGeneration = 0
+
+    public init(api: any APIProtocol, limit: Int = 50, calendar: Calendar = .autoupdatingCurrent) {
+        self.api = api
+        self.limit = limit
+        self.calendar = calendar
+    }
+
+    public func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        state = .loading
+        do {
+            let output = try await api.listMyCalendarEvents(
+                .init(query: .init(limit: String(limit)))
+            )
+            let body = try output.ok.body.json
+            // A pull-to-refresh landing mid-request starts a newer load; that
+            // one owns the list from here, so this reply is dropped rather
+            // than overwriting a fresher one.
+            guard generation == loadGeneration else { return }
+            days = body.entries.map(PulseCalendarEntry.init).groupedByDay(calendar: calendar)
+            state = .loaded
+        } catch {
+            // A view that goes away cancels its load. That is the screen
+            // closing, not a failure worth showing.
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            state = .failed(String(describing: error))
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseCalendarEntry.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseCalendarEntry.swift
@@ -1,0 +1,96 @@
+import Foundation
+import PulseAPI
+
+/// One row of the signed-in viewer's agenda.
+///
+/// The server builds this list from two arms — events the viewer created and
+/// events they RSVP'd `going`/`maybe` to — and merges them by event id, so a
+/// host who also RSVP'd to their own event appears once with both facts set.
+/// Neither flag implies the other: `isHost` with no `myStatus` is the usual
+/// organiser row, and `myStatus` with `isHost == false` is an ordinary guest.
+public struct PulseCalendarEntry: Identifiable, Equatable, Sendable {
+    /// The viewer's own RSVP, narrowed to the two states that put an event on
+    /// a calendar. `not_going` and `invited` are real RSVP statuses but the
+    /// agenda query excludes them, so they are unrepresentable here rather
+    /// than being cases nothing can produce.
+    public enum Attendance: String, Equatable, Sendable {
+        case going
+        case maybe
+    }
+
+    public let event: PulseEvent
+    /// `nil` when the viewer has not RSVP'd — including the common case of an
+    /// organiser who never RSVP'd to their own event.
+    public let myStatus: Attendance?
+    public let isHost: Bool
+
+    public var id: String { event.id }
+
+    public init(event: PulseEvent, myStatus: Attendance?, isHost: Bool) {
+        self.event = event
+        self.myStatus = myStatus
+        self.isHost = isHost
+    }
+}
+
+extension PulseCalendarEntry.Attendance {
+    init(_ generated: Operations.ListMyCalendarEvents.Output.Ok.Body.JsonPayload.EntriesPayloadPayload.MyStatusPayload) {
+        switch generated {
+        case .going: self = .going
+        case .maybe: self = .maybe
+        }
+    }
+}
+
+extension PulseCalendarEntry {
+    public init(_ payload: Operations.ListMyCalendarEvents.Output.Ok.Body.JsonPayload.EntriesPayloadPayload) {
+        self.init(
+            event: PulseEvent(payload.event),
+            myStatus: payload.myStatus.map(Attendance.init),
+            isHost: payload.isHost
+        )
+    }
+}
+
+/// A day's worth of agenda rows, in the order the server returned them.
+///
+/// The calendar is a list of days rather than a flat list because "when" is
+/// the only thing a viewer scans an agenda for. `date` is the start of the
+/// day in the grouping calendar, so it is safe to compare and to format as a
+/// header; the entries keep the server's sort.
+public struct PulseCalendarDay: Identifiable, Equatable, Sendable {
+    public let date: Date
+    public let entries: [PulseCalendarEntry]
+
+    public var id: Date { date }
+
+    public init(date: Date, entries: [PulseCalendarEntry]) {
+        self.date = date
+        self.entries = entries
+    }
+}
+
+extension Array where Element == PulseCalendarEntry {
+    /// Group the agenda into days by each event's **start** time.
+    ///
+    /// The calendar is passed in rather than read from the environment inside
+    /// the loop: which day an 11pm event falls on depends on the time zone,
+    /// and a test that could not fix the zone would pass or fail by where the
+    /// machine running it happens to be.
+    ///
+    /// The server already sorts by `(startTime, id)`, so a single pass keeps
+    /// both the days and the rows inside each day in that order — no re-sort,
+    /// and no dictionary to shuffle them.
+    public func groupedByDay(calendar: Calendar = .autoupdatingCurrent) -> [PulseCalendarDay] {
+        var days: [PulseCalendarDay] = []
+        for entry in self {
+            let day = calendar.startOfDay(for: entry.event.startTime)
+            if let last = days.last, last.date == day {
+                days[days.count - 1] = PulseCalendarDay(date: day, entries: last.entries + [entry])
+            } else {
+                days.append(PulseCalendarDay(date: day, entries: [entry]))
+            }
+        }
+        return days
+    }
+}

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
@@ -37,9 +37,10 @@ public struct PulseRootView: View {
     }
 }
 
-/// Post-sign-in tab navigation. Calendar/Settings/Close Friends are out of
-/// scope for this brief — if a slot exists it's an honest empty
-/// placeholder, never stubbed data.
+/// Post-sign-in tab navigation. Explore is the public feed, Calendar is the
+/// viewer's own agenda. Settings/Close Friends are still out of scope — a
+/// slot appears only once it's backed by a real endpoint, never as stubbed
+/// data.
 struct PulseTabView: View {
     let session: PulseSession
 
@@ -49,6 +50,11 @@ struct PulseTabView: View {
                 ExploreView(session: session)
             }
             .tabItem { Label("Explore", systemImage: "sparkles") }
+
+            NavigationStack {
+                CalendarView(session: session)
+            }
+            .tabItem { Label("Calendar", systemImage: "calendar") }
         }
     }
 }

--- a/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseCalendarEntryTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseFeatureTests/PulseCalendarEntryTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import PulseAPI
+@testable import PulseFeature
+
+private typealias EntryPayload = Operations.ListMyCalendarEvents.Output.Ok.Body.JsonPayload
+    .EntriesPayloadPayload
+
+/// 2023-11-14 22:13:20 UTC.
+private let lateUTCEvening = Date(timeIntervalSince1970: 1_700_000_000)
+
+/// Sydney is UTC+11 in November, so its midnight falls at 13:00 UTC. These two
+/// instants straddle it: one UTC day, two Sydney days.
+private let beforeSydneyMidnight = Date(timeIntervalSince1970: 1_699_965_000)  // 12:30 UTC
+private let afterSydneyMidnight = Date(timeIntervalSince1970: 1_699_968_600)  // 13:30 UTC
+
+private func makeEventPayload(
+    id: String,
+    startTime: Date
+) -> Components.Schemas.Event {
+    .init(
+        allowInterested: true,
+        commsChannels: "email",
+        createdAt: lateUTCEvening,
+        createdByProfileId: "profile-1",
+        guestListVisibility: .connections,
+        id: id,
+        instanceOverride: false,
+        joinPolicy: .open,
+        startTime: startTime,
+        status: .upcoming,
+        title: "Event \(id)",
+        updatedAt: lateUTCEvening,
+        visibility: ._public
+    )
+}
+
+private func makeEntryPayload(
+    id: String,
+    startTime: Date = lateUTCEvening,
+    myStatus: EntryPayload.MyStatusPayload? = nil,
+    isHost: Bool = false
+) -> EntryPayload {
+    .init(
+        event: makeEventPayload(id: id, startTime: startTime),
+        isHost: isHost,
+        myStatus: myStatus
+    )
+}
+
+private func makeEntry(
+    id: String,
+    startTime: Date = lateUTCEvening,
+    myStatus: PulseCalendarEntry.Attendance? = nil,
+    isHost: Bool = false
+) -> PulseCalendarEntry {
+    PulseCalendarEntry(
+        event: PulseEvent(makeEventPayload(id: id, startTime: startTime)),
+        myStatus: myStatus,
+        isHost: isHost
+    )
+}
+
+private func calendar(timeZone identifier: String) -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: identifier)!
+    return calendar
+}
+
+@Suite("PulseCalendarEntry")
+struct PulseCalendarEntryTests {
+    @Test("maps an attending guest's payload")
+    func mapsAttendingGuest() {
+        let entry = PulseCalendarEntry(makeEntryPayload(id: "event-1", myStatus: .going))
+
+        #expect(entry.id == "event-1")
+        #expect(entry.event.id == "event-1")
+        #expect(entry.myStatus == .going)
+        #expect(entry.isHost == false)
+    }
+
+    @Test("maps maybe")
+    func mapsMaybe() {
+        #expect(PulseCalendarEntry(makeEntryPayload(id: "event-1", myStatus: .maybe)).myStatus == .maybe)
+    }
+
+    /// The usual organiser row: hosting is the whole reason it is on the
+    /// agenda, and there is no RSVP behind it.
+    @Test("a host with no RSVP maps to a nil status, not a default one")
+    func mapsHostWithoutRsvp() {
+        let entry = PulseCalendarEntry(makeEntryPayload(id: "event-1", myStatus: nil, isHost: true))
+
+        #expect(entry.myStatus == nil)
+        #expect(entry.isHost)
+    }
+
+    /// The server merges the hosted and attending arms by event id, so both
+    /// facts can be true of one row. Neither may swallow the other.
+    @Test("a host who also RSVP'd keeps both facts")
+    func mapsHostWhoAlsoRsvpd() {
+        let entry = PulseCalendarEntry(makeEntryPayload(id: "event-1", myStatus: .going, isHost: true))
+
+        #expect(entry.myStatus == .going)
+        #expect(entry.isHost)
+    }
+}
+
+@Suite("PulseCalendarEntry.groupedByDay")
+struct PulseCalendarGroupingTests {
+    @Test("an empty agenda groups into no days")
+    func groupsEmpty() {
+        #expect([PulseCalendarEntry]().groupedByDay(calendar: calendar(timeZone: "UTC")).isEmpty)
+    }
+
+    @Test("consecutive entries on one day land in one group, in server order")
+    func groupsOneDay() {
+        let entries = [
+            makeEntry(id: "event-1", startTime: lateUTCEvening),
+            makeEntry(id: "event-2", startTime: lateUTCEvening.addingTimeInterval(600)),
+        ]
+
+        let days = entries.groupedByDay(calendar: calendar(timeZone: "UTC"))
+
+        #expect(days.count == 1)
+        #expect(days[0].entries.map(\.id) == ["event-1", "event-2"])
+    }
+
+    @Test("entries on different days split into separate groups, in order")
+    func groupsAcrossDays() {
+        let entries = [
+            makeEntry(id: "event-1", startTime: lateUTCEvening),
+            makeEntry(id: "event-2", startTime: lateUTCEvening.addingTimeInterval(86_400)),
+            makeEntry(id: "event-3", startTime: lateUTCEvening.addingTimeInterval(86_400 + 60)),
+        ]
+
+        let days = entries.groupedByDay(calendar: calendar(timeZone: "UTC"))
+
+        #expect(days.count == 2)
+        #expect(days[0].entries.map(\.id) == ["event-1"])
+        #expect(days[1].entries.map(\.id) == ["event-2", "event-3"])
+        #expect(days[0].date < days[1].date)
+    }
+
+    /// The grouping calendar decides what "a day" is. The same two instants
+    /// are one UTC evening and two Sydney days, so a viewer in Sydney must see
+    /// the split — which is why the calendar is injected rather than read from
+    /// the environment inside the loop.
+    @Test("the injected calendar's time zone decides the day boundary")
+    func groupsByInjectedTimeZone() {
+        let entries = [
+            makeEntry(id: "event-1", startTime: beforeSydneyMidnight),
+            makeEntry(id: "event-2", startTime: afterSydneyMidnight),
+        ]
+
+        #expect(entries.groupedByDay(calendar: calendar(timeZone: "UTC")).count == 1)
+        #expect(entries.groupedByDay(calendar: calendar(timeZone: "Australia/Sydney")).count == 2)
+    }
+
+    /// The single pass only merges *adjacent* entries. The server sorts by
+    /// `(startTime, id)` so same-day rows always arrive adjacent — this pins
+    /// what happens if that ever stops being true, so the behaviour is a
+    /// recorded consequence rather than a surprise.
+    @Test("a day that recurs after another day opens a second group")
+    func doesNotMergeNonAdjacentDays() {
+        let entries = [
+            makeEntry(id: "event-1", startTime: lateUTCEvening),
+            makeEntry(id: "event-2", startTime: lateUTCEvening.addingTimeInterval(86_400)),
+            makeEntry(id: "event-3", startTime: lateUTCEvening.addingTimeInterval(60)),
+        ]
+
+        let days = entries.groupedByDay(calendar: calendar(timeZone: "UTC"))
+
+        #expect(days.count == 3)
+        #expect(days[0].date == days[2].date)
+    }
+
+    @Test("a day's id is its start-of-day date")
+    func dayIdIsItsDate() {
+        let utc = calendar(timeZone: "UTC")
+        let days = [makeEntry(id: "event-1")].groupedByDay(calendar: utc)
+
+        #expect(days[0].id == days[0].date)
+        #expect(days[0].date == utc.startOfDay(for: lateUTCEvening))
+    }
+}


### PR DESCRIPTION
Stacked on #411 (`feat/pulse-openapi-refs`). **A8** of the Pulse iOS stack.

## What

A second tab in the app shell: the signed-in viewer's own agenda, from `GET /events/calendar`. Events they host, plus events they RSVP'd `going`/`maybe` to, grouped by day, soonest first.

This is not the Explore feed narrowed down. Explore answers "what is on?"; this answers "what am I doing?" — so it keeps cancelled events the viewer is still on the list for, and never shows an event they have no tie to.

| File | What |
|---|---|
| `PulseCalendarEntry.swift` | `PulseCalendarEntry` + `Attendance`, the generated-payload bridge, `PulseCalendarDay`, and `groupedByDay(calendar:)` |
| `CalendarViewModel.swift` | `@MainActor @Observable`, `LoadState`, `loadGeneration` guard |
| `CalendarView.swift` | Day-sectioned agenda with real loading / empty / error states |
| `PulseRootView.swift` | The second `.tabItem`, and its doc comment updated now that Calendar is real |
| `PulseCalendarEntryTests.swift` | 10 tests: payload bridge + grouping |

## Decisions worth reading

**Hosting and attending stay separate facts.** The server merges the hosted and attending arms by event id, so a host who also RSVP'd arrives as one row with both set. The model keeps both and the row draws both pills — neither may swallow the other. `myStatus == nil, isHost == true` is the ordinary organiser row, not a missing value.

**`Attendance` has two cases, not five.** `not_going` and `invited` are real RSVP statuses, but the agenda query excludes them. They are unrepresentable here rather than cases nothing can produce.

**The grouping calendar is injected.** Which day a 23:30 event belongs to is a time-zone question. A test that could not fix the zone would pass or fail by where the machine running it happens to be — so `groupedByDay(calendar:)` takes one, and the tests pin the Sydney-midnight case where a single UTC day is two local days.

**Single pass, no re-sort.** The server sorts by `(startTime, id)`; the grouping only merges adjacent entries and keeps that order. A test pins what happens if the server's sort ever stops holding, so the behaviour is recorded rather than surprising.

**No pagination.** The endpoint has no cursor — one forward-looking window the server caps at 100. `limit` is the only knob and it is a string on the wire; the route parses and clamps it, so an out-of-range value is corrected, not rejected.

## Verification

- `swift test` in `shared/swift/OSNShared` — **76 passed** (was 66)
- `xcodegen generate` + the exact CI line: `xcodebuild -scheme Pulse -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation -quiet CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64 build` — succeeds, one pre-existing `ASPresentationAnchor()` deprecation warning in `App.swift`
- No changeset: the diff touches only `shared/swift/`, which the `changeset-required.sh` allowlist covers

## Still open

View-model async tests (this one included) need a fake conforming to the full generated `APIProtocol` — its own task, carried from #404/#407/#408/#409. The tests here cover the pure parts: the bridge and the grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)