### PR TITLE
refactor: extract the OIDC relying-party server into shared packages

### DIFF
--- a/.changeset/rp-auth-server-cire.md
+++ b/.changeset/rp-auth-server-cire.md
@@ -1,0 +1,20 @@
+---
+"@cire/api": patch
+---
+
+Read the OIDC relying-party flow from `@shared/osn-auth-client` instead of
+keeping a private copy.
+
+`lib/opaque-token.ts` and `services/oidc-login.ts` are deleted; `lib/cookie.ts`
+is now nine thin wrappers naming cire's three cookies over the shared codec.
+The fake issuer in `test-helpers/oidc-issuer.ts` re-exports the shared one with
+cire's return origin bound in.
+
+One new constant, `lib/oidc.ts`'s `CIRE_OIDC_TX_HMAC_INFO` — the HKDF `info`
+cire derives its transaction-cookie MAC key under, imported by both the runtime
+config and the test helper so the two cannot drift. Changing it invalidates
+only in-flight transactions, which live ten minutes, so a bump costs at most
+one retried sign-in.
+
+`OrganiserIdentity` is now an alias of the shared `OsnIdentity`. Pure refactor:
+no route, cookie or wire format changed.

--- a/.changeset/rp-auth-server-shared.md
+++ b/.changeset/rp-auth-server-shared.md
@@ -1,0 +1,32 @@
+---
+"@shared/osn-auth-client": minor
+"@shared/crypto": minor
+---
+
+Move the OIDC relying-party server half out of cire and into the shared
+packages, so a second product can sign users in with an OSN account without
+copying four files.
+
+Three new entry points, all lifted verbatim from `cire/api` with the
+product-specific parts turned into parameters:
+
+- `@shared/crypto/tokens` — opaque token minting plus the SHA-256 hash stored
+  at rest, the primitive behind every server-side session in the monorepo.
+- `@shared/osn-auth-client/cookie` — the `Set-Cookie` builder and request-cookie
+  parser. Host-scoped by construction: no `Domain=` attribute, so the cookie
+  never widens to sibling subdomains. `SameSite=Lax` is required rather than
+  merely tolerated — the OIDC callback arrives as a top-level cross-site GET,
+  which `Strict` would strip the transaction cookie from.
+- `@shared/osn-auth-client/oidc-rp` — `beginLogin` / `completeLogin` /
+  `readReturnTo`, the PKCE transaction cookie, and the ID-token checks. A token
+  without an `osn_profile_id` claim is refused outright; client authentication
+  is `client_secret_post`, never Basic.
+- `@shared/osn-auth-client/testing/oidc-issuer` — the fake issuer the flow is
+  tested against, now product-neutral, with the return origin passed in.
+
+`OidcConfig` gains a required `txHmacInfo`: the HKDF `info` the transaction
+cookie's MAC key is derived under. It is required, not defaulted, because two
+products sharing an OIDC client secret would otherwise derive the same key, and
+one product's transaction cookie would verify at the other.
+
+No behaviour change for cire, which now imports all of the above.

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -4,6 +4,7 @@ import { EmailService, makeLogEmailLive } from "@shared/email";
 import type { SendEmailInput } from "@shared/email";
 import { createFeatureFlags } from "@shared/feature-flags";
 import type { FeatureFlags } from "@shared/feature-flags";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
 import { createRateLimiter } from "@shared/rate-limit";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import type { TurnstileVerifier } from "@shared/turnstile";
@@ -54,7 +55,6 @@ import { createDirectoryService } from "./services/directory";
 import { createEnquiryService } from "./services/enquiries";
 import type { AssetsBucket } from "./services/invite-assets";
 import type { ImagesBindingLike } from "./services/invite-image-transform";
-import type { OidcConfig } from "./services/oidc-login";
 import type {
   OsnAccountResolver,
   OsnConnectionSearchResolver,

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -9,6 +9,7 @@ import { Effect, Layer } from "effect";
 import { createApp } from "./app";
 import { createD1Db, DbService } from "./db";
 import { setExecutionCtx } from "./lib/execution-ctx";
+import { CIRE_OIDC_TX_HMAC_INFO } from "./lib/oidc";
 import { runCire } from "./observability";
 import { assetReconcileService } from "./services/asset-reconcile";
 import { maintenanceSweeps } from "./services/maintenance-sweeps";
@@ -331,6 +332,7 @@ const handler: ExportedHandler<Env> = {
               clientSecret: env.CIRE_OIDC_CLIENT_SECRET,
               redirectUri: `${apiOrigin}/api/auth/oidc/callback`,
               allowedReturnOrigins: origins,
+              txHmacInfo: CIRE_OIDC_TX_HMAC_INFO,
             }
           : null;
       if (!oidc && isDeployedTier()) {

--- a/cire/api/src/lib/cookie.ts
+++ b/cire/api/src/lib/cookie.ts
@@ -1,14 +1,12 @@
+import { buildClearCookie, buildCookie, parseCookie } from "@shared/osn-auth-client/cookie";
+import type { SessionCookieOptions } from "@shared/osn-auth-client/cookie";
+
 /**
- * Cookie helpers. **Every cookie here is host-scoped by design (no `Domain=`).**
- * They are set by cire-api (`api.cireweddings.com`) and sent back ONLY to
- * cire-api — same-origin to the API and HttpOnly (no browser code reads them).
- * Host-scoping is the correct, tighter choice: a broad `Domain=.cireweddings.com`
- * would needlessly widen them to every subdomain (the Pages hosts, future ones)
- * with no consumer that needs it. Audited `feat/cire-assets-reconcile` — keep
- * host-scoped; do NOT add `Domain=` unless a subdomain genuinely needs to read
- * one (none does today). See `cire/wiki/todo/api.md`.
+ * Cire's cookie names, over the shared codec in `@shared/osn-auth-client/cookie`
+ * — which is where the host-scoping and `SameSite=Lax` reasoning lives. Names
+ * are fixed here so no caller passes one as a string.
  *
- * Three cookies live here:
+ * Three cookies:
  *
  * - `cire_session`  — the guest household session, minted by `POST /api/claim`.
  * - `cire_org_session` — the organiser session, minted by the OSN OIDC callback.
@@ -16,74 +14,18 @@
  *                     `state`, `nonce`, return URL) held between `/start` and
  *                     `/callback`.
  *
- * `SameSite=Lax` on all three. It is not merely tolerable but required for the
- * OIDC pair: the callback arrives as a top-level GET navigation from
- * `id.musubi.social`, which `Lax` allows and `Strict` would drop — the browser
- * would land on the callback with no transaction cookie and every sign-in would
- * fail. `Lax` still withholds all three from cross-site subrequests, which is
- * the protection that matters, and the organiser and guest sites reaching
- * `api.cireweddings.com` are same-site anyway.
+ * All three are host-scoped: set by cire-api (`api.cireweddings.com`) and sent
+ * back only there. The organiser and guest sites are same-site with it, so
+ * `Lax` costs nothing. Audited `feat/cire-assets-reconcile` — do NOT add
+ * `Domain=` unless a subdomain genuinely needs to read one (none does today).
+ * See `cire/wiki/todo/api.md`.
  */
 
 const GUEST_COOKIE_NAME = "cire_session";
 const ORGANISER_COOKIE_NAME = "cire_org_session";
 const OIDC_TX_COOKIE_NAME = "cire_oidc_tx";
 
-export interface SessionCookieOptions {
-  secure: boolean;
-  maxAgeSeconds: number;
-}
-
-/**
- * Programmer-error guard: values come from `generateToken` (which only emits
- * `[A-Za-z0-9_-]`) or from a base64url-encoded payload. A malformed value here
- * means a caller (or future bug) is feeding raw input straight into a
- * Set-Cookie header — throw fast so it shows up in tests rather than producing
- * a corrupted cookie at runtime. `lib/` helpers are allowed to throw on
- * programmer error; services aren't.
- */
-function buildCookie(name: string, value: string, opts: SessionCookieOptions): string {
-  // `.` is permitted (and cookie-safe per RFC 6265 cookie-octet): the OIDC
-  // transaction cookie is `<b64url payload>.<b64url HMAC>`, so its value carries
-  // one dot separating the payload from its integrity tag. Opaque session tokens
-  // (guest + organiser) never contain a dot; the guard still rejects the unsafe
-  // set (`; , " \` and whitespace) that would corrupt a Set-Cookie header.
-  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
-    throw new TypeError(`${name} value contains invalid chars`);
-  }
-  const parts = [
-    `${name}=${value}`,
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Lax",
-    `Max-Age=${opts.maxAgeSeconds}`,
-  ];
-  if (opts.secure) parts.push("Secure");
-  return parts.join("; ");
-}
-
-function buildClearCookie(name: string, opts: { secure: boolean }): string {
-  const parts = [`${name}=`, "Path=/", "HttpOnly", "SameSite=Lax", "Max-Age=0"];
-  if (opts.secure) parts.push("Secure");
-  return parts.join("; ");
-}
-
-function parseCookie(cookieHeader: string | null, name: string): string | null {
-  if (!cookieHeader) return null;
-  // `Cookie:` is `name=value; name2=value2`. Each pair is separated by `; `.
-  const pairs = cookieHeader.split(";");
-  for (const raw of pairs) {
-    const pair = raw.trim();
-    if (!pair) continue;
-    const eq = pair.indexOf("=");
-    if (eq < 0) continue;
-    const cookieName = pair.slice(0, eq).trim();
-    if (cookieName !== name) continue;
-    const value = pair.slice(eq + 1).trim();
-    return value.length > 0 ? value : null;
-  }
-  return null;
-}
+export type { SessionCookieOptions };
 
 export function buildSessionCookie(token: string, opts: SessionCookieOptions): string {
   return buildCookie(GUEST_COOKIE_NAME, token, opts);
@@ -111,8 +53,9 @@ export function parseOrganiserSessionToken(cookieHeader: string | null): string 
 
 /**
  * The transaction value is `<base64url JSON>.<base64url HMAC>` — HMAC-signed by
- * `oidc-login.ts` so a planted/tampered cookie is rejected (session-fixation
- * guard). Both halves are base64url and the single dot is cookie-safe.
+ * `@shared/osn-auth-client/oidc-rp` so a planted/tampered cookie is rejected
+ * (session-fixation guard). Both halves are base64url and the single dot is
+ * cookie-safe.
  */
 export function buildOidcTxCookie(value: string, opts: SessionCookieOptions): string {
   return buildCookie(OIDC_TX_COOKIE_NAME, value, opts);

--- a/cire/api/src/lib/oidc.ts
+++ b/cire/api/src/lib/oidc.ts
@@ -1,0 +1,13 @@
+/**
+ * The HKDF `info` cire derives its OIDC transaction-cookie MAC key under.
+ *
+ * Per-product by design: two relying parties that ever end up sharing an OSN
+ * client secret must not be able to verify each other's transaction cookies, or
+ * one product's planted transaction could fixate a sign-in at the other. One
+ * constant, imported by the runtime config and the test helper alike, so the
+ * two cannot drift.
+ *
+ * Changing this value invalidates only in-flight transactions — a ten-minute
+ * TTL — so a bump costs at most one retried sign-in.
+ */
+export const CIRE_OIDC_TX_HMAC_INFO = "cire-oidc-tx-hmac-v1";

--- a/cire/api/src/routes/auth-oidc.test.ts
+++ b/cire/api/src/routes/auth-oidc.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 
+import { beginLogin } from "@shared/osn-auth-client/oidc-rp";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
 import { createRateLimiter } from "@shared/rate-limit";
 
 import { createApp } from "../app";
 import type { Db } from "../db";
 import { createDb, seedDb } from "../db/setup";
-import { beginLogin } from "../services/oidc-login";
-import type { OidcConfig } from "../services/oidc-login";
 import { appRequest } from "../test-helpers";
 import {
   TEST_ISSUER,
@@ -316,9 +316,9 @@ describe("GET /api/auth/session", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body["signedIn"]).toBe(true);
     expect(body["osnProfileId"]).toBe(TEST_PROFILE_ID);
-    expect(body["email"]).toBe("organiser@example.test");
-    expect(body["handle"]).toBe("organiser");
-    expect(body["displayName"]).toBe("Test Organiser");
+    expect(body["email"]).toBe("person@example.test");
+    expect(body["handle"]).toBe("person");
+    expect(body["displayName"]).toBe("Test Person");
     expect(typeof body["expiresAt"]).toBe("string");
     // The pairwise subject is an internal join key, not something to hand out.
     expect(body["osnSub"]).toBeUndefined();

--- a/cire/api/src/routes/auth-oidc.ts
+++ b/cire/api/src/routes/auth-oidc.ts
@@ -1,3 +1,5 @@
+import { beginLogin, completeLogin, readReturnTo } from "@shared/osn-auth-client/oidc-rp";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { Elysia } from "elysia";
@@ -15,8 +17,6 @@ import {
 import { metricOidcLogin } from "../metrics";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import { runCire } from "../observability";
-import { beginLogin, completeLogin, readReturnTo } from "../services/oidc-login";
-import type { OidcConfig } from "../services/oidc-login";
 import { organiserSessionService } from "../services/organiser-session";
 
 const PREFIX = "/api/auth";
@@ -27,8 +27,8 @@ const PREFIX = "/api/auth";
  * The browser never holds an OSN token here. It bounces to the issuer, comes
  * back with a code, and leaves with a cire session cookie — host-scoped to
  * `api.cireweddings.com`, opaque, SHA-256 hashed at rest, exactly like the
- * guest session. See `services/oidc-login.ts` for why the redirect URI is a
- * constant and why a token without `osn_profile_id` is refused.
+ * guest session. See `@shared/osn-auth-client/oidc-rp` for why the redirect URI
+ * is a constant and why a token without `osn_profile_id` is refused.
  *
  * **CSRF.** Moving organiser auth from a bearer header to a cookie makes
  * organiser writes CSRF-eligible for the first time. Two things cover that, and

--- a/cire/api/src/services/organiser-session.ts
+++ b/cire/api/src/services/organiser-session.ts
@@ -1,10 +1,11 @@
 import { organiserSessions } from "@cire/db";
+import { generateToken, hashToken } from "@shared/crypto/tokens";
 import { rowsChanged } from "@shared/db-utils";
+import type { OsnIdentity } from "@shared/osn-auth-client/oidc-rp";
 import { eq, lte } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
 import { DbService, dbQuery } from "../db";
-import { generateToken, hashToken } from "../lib/opaque-token";
 import { metricOrganiserSessionCreated, metricOrganiserSessionSwept } from "../metrics";
 
 export class OrganiserSessionInvalid extends Data.TaggedError("OrganiserSessionInvalid")<{
@@ -27,15 +28,11 @@ export class OrganiserSessionWriteError extends Data.TaggedError("OrganiserSessi
  */
 const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-/** Login-time snapshot of the ID token's profile claims. */
-export interface OrganiserIdentity {
-  osnProfileId: string;
-  osnSub: string;
-  email: string | null;
-  handle: string | null;
-  displayName: string | null;
-  avatarUrl: string | null;
-}
+/**
+ * Login-time snapshot of the ID token's profile claims — the same shape the
+ * shared relying party hands back, named for this file's own vocabulary.
+ */
+export type OrganiserIdentity = OsnIdentity;
 
 export interface CreatedOrganiserSession {
   token: string;

--- a/cire/api/src/services/session.ts
+++ b/cire/api/src/services/session.ts
@@ -1,11 +1,11 @@
 import { sessions } from "@cire/db";
+import { generateToken, hashToken } from "@shared/crypto/tokens";
 import { rowsChanged } from "@shared/db-utils";
 import { eq, lte } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { Effect, Data } from "effect";
 
 import { DbService, dbQuery } from "../db";
-import { generateToken, hashToken } from "../lib/opaque-token";
 import { metricSessionCreated, metricSessionSwept } from "../metrics";
 
 export class SessionInvalid extends Data.TaggedError("SessionInvalid")<{

--- a/cire/api/src/test-helpers/oidc-issuer.ts
+++ b/cire/api/src/test-helpers/oidc-issuer.ts
@@ -1,13 +1,16 @@
-import { SignJWT, generateKeyPair } from "jose";
-
-import type { OidcConfig } from "../services/oidc-login";
+import {
+  TEST_TX_HMAC_INFO,
+  makeOidcTestIssuer as makeSharedOidcTestIssuer,
+} from "@shared/osn-auth-client/testing/oidc-issuer";
 
 /**
- * A fake OSN issuer for the OIDC relying-party tests.
+ * Cire's view of the shared fake OSN issuer.
  *
- * Two seams stand in for the network: `_testKey` on the config replaces the
- * JWKS fetch, and `_fetch` replaces the back-channel token exchange. Nothing
- * here touches a socket.
+ * The issuer itself lives in `@shared/osn-auth-client/testing/oidc-issuer`, so
+ * every product signing in through the shared relying party tests against the
+ * same issuer behaviour. Only two things are cire's: the return origin (which
+ * must match `createApp`'s default `webOrigin`, so route tests need no
+ * override) and the paths built on it.
  *
  * Sibling of `test-helpers/osn-token.ts`, which mints ACCESS tokens
  * (`aud: "osn-access"`, `sub` = the real profile id). These are ID tokens:
@@ -15,129 +18,38 @@ import type { OidcConfig } from "../services/oidc-login";
  * in the first-party `osn_profile_id` claim.
  */
 
-export const TEST_ISSUER = "https://id.test.invalid";
-export const TEST_CLIENT_ID = "cid_test";
-export const TEST_CLIENT_SECRET = "shh-test-secret";
-export const TEST_REDIRECT_URI = "https://api.test.invalid/api/auth/oidc/callback";
+export {
+  TEST_CLIENT_ID,
+  TEST_CLIENT_SECRET,
+  TEST_ISSUER,
+  TEST_PAIRWISE_SUB,
+  TEST_PROFILE_ID,
+  TEST_REDIRECT_URI,
+  stubTokenEndpoint,
+  tokenResponse,
+} from "@shared/osn-auth-client/testing/oidc-issuer";
+export type {
+  IdTokenOverrides,
+  OidcTestIssuer,
+  TokenEndpointCall,
+  TokenEndpointStub,
+} from "@shared/osn-auth-client/testing/oidc-issuer";
+
 /** Matches `createApp`'s default `webOrigin`, so route tests need no override. */
 export const TEST_RETURN_ORIGIN = "http://localhost:4321";
 export const TEST_RETURN_TO = `${TEST_RETURN_ORIGIN}/weddings`;
-export const TEST_PROFILE_ID = "usr_test_organiser";
-export const TEST_PAIRWISE_SUB = "pw_test_pairwise_subject";
 
-export interface IdTokenOverrides {
-  /** Pairwise subject. */
-  sub?: string;
-  /** First-party profile-id claim; `null` omits it entirely. */
-  osnProfileId?: string | null;
-  /** Replay binding — the test must pass the `nonce` its own tx carries. */
-  nonce?: string;
-  email?: string | null;
-  handle?: string | null;
-  displayName?: string | null;
-  avatarUrl?: string | null;
-  authTime?: number;
-  issuer?: string;
-  audience?: string;
-  /** jose duration string; negative values mint an already-expired token. */
-  expiresIn?: string;
+/**
+ * The shared issuer, with its allowlist pointed at cire's dev origin. Test
+ * files import this rather than the shared factory so the origin is set once.
+ *
+ * `txHmacInfo` comes from the shared helper's `TEST_TX_HMAC_INFO`, not cire's
+ * production `CIRE_OIDC_TX_HMAC_INFO` — the tests exercise the mechanism, and
+ * pinning them to the production value would make a future bump of it a test
+ * churn for no gain.
+ */
+export function makeOidcTestIssuer() {
+  return makeSharedOidcTestIssuer({ returnOrigin: TEST_RETURN_ORIGIN });
 }
 
-export interface OidcTestIssuer {
-  /** Public verifying key — goes on the config as `_testKey`. */
-  publicKey: CryptoKey;
-  /** Mints an ES256 ID token. Every field has a working default. */
-  signIdToken(overrides?: IdTokenOverrides): Promise<string>;
-  /** RP config for this issuer. Pass `_fetch` per test. */
-  config(overrides?: Partial<OidcConfig>): OidcConfig;
-}
-
-export async function makeOidcTestIssuer(): Promise<OidcTestIssuer> {
-  const { privateKey, publicKey } = await generateKeyPair("ES256");
-
-  return {
-    publicKey,
-
-    signIdToken(overrides: IdTokenOverrides = {}): Promise<string> {
-      const claims: Record<string, unknown> = {
-        email: overrides.email === undefined ? "organiser@example.test" : overrides.email,
-        preferred_username: overrides.handle === undefined ? "organiser" : overrides.handle,
-        name: overrides.displayName === undefined ? "Test Organiser" : overrides.displayName,
-        picture:
-          overrides.avatarUrl === undefined
-            ? "https://cdn.test.invalid/a.png"
-            : overrides.avatarUrl,
-      };
-      // `null` means "issuer did not treat us as first-party" — omit the claim
-      // rather than sending a null, which is what a real non-first-party token
-      // looks like.
-      const profileId =
-        overrides.osnProfileId === undefined ? TEST_PROFILE_ID : overrides.osnProfileId;
-      if (profileId !== null) claims["osn_profile_id"] = profileId;
-      if (overrides.nonce !== undefined) claims["nonce"] = overrides.nonce;
-      if (overrides.authTime !== undefined) claims["auth_time"] = overrides.authTime;
-
-      return new SignJWT(claims)
-        .setProtectedHeader({ alg: "ES256", kid: "test-oidc-kid" })
-        .setSubject(overrides.sub ?? TEST_PAIRWISE_SUB)
-        .setIssuer(overrides.issuer ?? TEST_ISSUER)
-        .setAudience(overrides.audience ?? TEST_CLIENT_ID)
-        .setIssuedAt()
-        .setExpirationTime(overrides.expiresIn ?? "5m")
-        .sign(privateKey);
-    },
-
-    config(overrides: Partial<OidcConfig> = {}): OidcConfig {
-      return {
-        issuer: TEST_ISSUER,
-        jwksUrl: `${TEST_ISSUER}/.well-known/jwks.json`,
-        clientId: TEST_CLIENT_ID,
-        clientSecret: TEST_CLIENT_SECRET,
-        redirectUri: TEST_REDIRECT_URI,
-        allowedReturnOrigins: [TEST_RETURN_ORIGIN],
-        _testKey: publicKey,
-        ...overrides,
-      };
-    },
-  };
-}
-
-export interface TokenEndpointCall {
-  url: string;
-  /** The form body — the exchange is `client_secret_post`, never Basic. */
-  params: URLSearchParams;
-  headers: Headers;
-}
-
-export interface TokenEndpointStub {
-  /** Drop-in for `OidcConfig._fetch`. */
-  fetch: typeof fetch;
-  /** Every exchange the RP attempted, in order. */
-  calls: TokenEndpointCall[];
-}
-
-/** Records each token-endpoint POST and answers with whatever `respond` returns. */
-export function stubTokenEndpoint(
-  respond: (call: TokenEndpointCall) => Response | Promise<Response>,
-): TokenEndpointStub {
-  const calls: TokenEndpointCall[] = [];
-  const doFetch = async (input: unknown, init?: RequestInit): Promise<Response> => {
-    const url = input instanceof Request ? input.url : String(input);
-    const body = init?.body;
-    const params = new URLSearchParams(
-      body instanceof URLSearchParams ? body.toString() : String(body ?? ""),
-    );
-    const call: TokenEndpointCall = { url, params, headers: new Headers(init?.headers) };
-    calls.push(call);
-    return respond(call);
-  };
-  return { fetch: doFetch as unknown as typeof fetch, calls };
-}
-
-/** The shape a healthy token endpoint returns. */
-export function tokenResponse(idToken: string): Response {
-  return new Response(
-    JSON.stringify({ id_token: idToken, access_token: "at_ignored", token_type: "Bearer" }),
-    { status: 200, headers: { "content-type": "application/json" } },
-  );
-}
+export { TEST_TX_HMAC_INFO };

--- a/shared/crypto/package.json
+++ b/shared/crypto/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.ts",
     "./jwk": "./src/jwk.ts",
     "./testing": "./src/testing.ts",
-    "./timing-safe": "./src/timing-safe.ts"
+    "./timing-safe": "./src/timing-safe.ts",
+    "./tokens": "./src/tokens.ts"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/shared/crypto/src/tokens.ts
+++ b/shared/crypto/src/tokens.ts
@@ -1,12 +1,17 @@
 import { Effect } from "effect";
 
 /**
- * Opaque bearer-token primitives, shared by every cookie-backed session cire
- * issues (guest households, organisers, and the OIDC transaction state).
+ * Opaque bearer-token primitives, shared by every cookie-backed session an OSN
+ * relying party issues (cire's guest households and organisers, pulse's web
+ * sessions, and the OIDC transaction state in between).
  *
- * The scheme is the same in all three places: a random token goes to the
- * browser, only its SHA-256 hash is stored, and lookups hash the presented
- * value and match on that.
+ * The scheme is the same everywhere: a random token goes to the browser, only
+ * its SHA-256 hash is stored, and lookups hash the presented value and match on
+ * that.
+ *
+ * Deliberately its own module with only an `effect` import: `@shared/crypto`'s
+ * index pulls in `@osn/db` and the observability stack, which a relying party
+ * minting a cookie has no business loading.
  */
 
 /**

--- a/shared/osn-auth-client/package.json
+++ b/shared/osn-auth-client/package.json
@@ -8,7 +8,10 @@
     "./verify": "./src/verify.ts",
     "./verify-id-token": "./src/verify-id-token.ts",
     "./jwks-cache": "./src/jwks-cache.ts",
-    "./middleware/elysia": "./src/middleware/elysia.ts"
+    "./middleware/elysia": "./src/middleware/elysia.ts",
+    "./cookie": "./src/cookie.ts",
+    "./oidc-rp": "./src/oidc-rp.ts",
+    "./testing/oidc-issuer": "./src/testing/oidc-issuer.ts"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/shared/osn-auth-client/src/cookie.ts
+++ b/shared/osn-auth-client/src/cookie.ts
@@ -1,0 +1,85 @@
+/**
+ * Set-Cookie / Cookie codec for a relying party's OWN session cookies — the
+ * server-side counterpart to `@shared/rp-auth`, which reads none of them
+ * (they are all `HttpOnly`).
+ *
+ * **Every cookie built here is host-scoped by design (no `Domain=`).** It is
+ * set by the app's API host and sent back ONLY to that host. Host-scoping is
+ * the tighter choice: a broad `Domain=.example.com` would widen the cookie to
+ * every subdomain with no consumer that needs it. Do NOT add `Domain=` unless
+ * a subdomain genuinely has to read one.
+ *
+ * `SameSite=Lax` on all of them. It is not merely tolerable but required for
+ * an OIDC pair: the callback arrives as a top-level GET navigation from the
+ * issuer, which `Lax` allows and `Strict` would drop — the browser would land
+ * on the callback with no transaction cookie and every sign-in would fail.
+ * `Lax` still withholds the cookie from cross-site subrequests, which is the
+ * protection that matters. It does mean the API host must be **same-site with
+ * the app's own origin**: `api.example.com` and `app.example.com` share the
+ * registrable domain, so the cookie rides along; a cookie set on an unrelated
+ * host never will.
+ *
+ * Callers wrap these in named helpers (`buildSessionCookie`, …) so a cookie
+ * NAME is fixed in one place per product rather than passed around as a string.
+ */
+
+export interface SessionCookieOptions {
+  secure: boolean;
+  maxAgeSeconds: number;
+}
+
+/**
+ * Programmer-error guard: values come from `generateToken` (which only emits
+ * `[A-Za-z0-9_-]`) or from a base64url-encoded payload. A malformed value here
+ * means a caller (or future bug) is feeding raw input straight into a
+ * Set-Cookie header — throw fast so it shows up in tests rather than producing
+ * a corrupted cookie at runtime.
+ *
+ * `.` is permitted (and cookie-safe per RFC 6265 cookie-octet): an OIDC
+ * transaction cookie is `<b64url payload>.<b64url HMAC>`, so its value carries
+ * one dot separating the payload from its integrity tag. Opaque session tokens
+ * never contain a dot; the guard still rejects the unsafe set (`; , " \` and
+ * whitespace) that would corrupt a Set-Cookie header.
+ */
+export function buildCookie(name: string, value: string, opts: SessionCookieOptions): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new TypeError(`${name} value contains invalid chars`);
+  }
+  const parts = [
+    `${name}=${value}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${opts.maxAgeSeconds}`,
+  ];
+  if (opts.secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+/**
+ * The expiring twin of `buildCookie`. `Path` and `Secure` must match the
+ * original or the browser keeps the cookie and clears nothing.
+ */
+export function buildClearCookie(name: string, opts: { secure: boolean }): string {
+  const parts = [`${name}=`, "Path=/", "HttpOnly", "SameSite=Lax", "Max-Age=0"];
+  if (opts.secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+/** One named cookie out of a raw `Cookie:` header, or `null`. */
+export function parseCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  // `Cookie:` is `name=value; name2=value2`. Each pair is separated by `; `.
+  const pairs = cookieHeader.split(";");
+  for (const raw of pairs) {
+    const pair = raw.trim();
+    if (!pair) continue;
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    const cookieName = pair.slice(0, eq).trim();
+    if (cookieName !== name) continue;
+    const value = pair.slice(eq + 1).trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}

--- a/shared/osn-auth-client/src/oidc-rp.ts
+++ b/shared/osn-auth-client/src/oidc-rp.ts
@@ -1,38 +1,47 @@
 import { timingSafeEqualString } from "@shared/crypto/timing-safe";
-import { verifyIdToken } from "@shared/osn-auth-client/verify-id-token";
+import { generateToken, sha256Base64Url } from "@shared/crypto/tokens";
 
-import { generateToken, sha256Base64Url } from "../lib/opaque-token";
-import type { OrganiserIdentity } from "./organiser-session";
+import { verifyIdToken } from "./verify-id-token";
 
 /**
- * OIDC relying-party half of organiser sign-in.
+ * OIDC **relying-party** half of signing in with an OSN account — the server
+ * side of the flow whose browser side is `@shared/rp-auth`.
  *
- * cire used to run the passkey ceremony itself against `@osn/client`. It can't
- * any more: identity moved to its own zone (`musubi.social`) and a WebAuthn
- * ceremony may only run on an origin same-site with the RP ID, so
- * `host.cireweddings.com` cannot mint an OSN credential. Instead cire is a
- * plain OIDC relying party — redirect to the issuer's `/authorize`, take an
- * authorization code back, exchange it back-channel, and mint cire's OWN
- * session from the ID token.
+ * Every product here used to run the passkey ceremony itself against
+ * `@osn/client`. None of them can any more: identity moved to its own zone
+ * (`musubi.social`) and a WebAuthn ceremony may only run on an origin same-site
+ * with the RP ID, so no other product's origin can mint an OSN credential.
+ * Instead each product is a plain OIDC relying party — redirect to the issuer's
+ * `/authorize`, take an authorization code back, exchange it back-channel, and
+ * mint its OWN session from the ID token.
  *
- * Two things about this flow are load-bearing:
+ * It is shared rather than copied because the subtle parts — session-fixation
+ * defence on the transaction cookie, the open-redirect guard, PKCE, and the
+ * `osn_profile_id` requirement — must be fixed in one place, not in each
+ * product that happened to copy them.
  *
- * 1. **One registered redirect URI.** Three organiser-facing origins exist
- *    (`host.`, `vendor.`, `invite.`) but only `.../api/auth/oidc/callback` on
- *    the API host is registered with the issuer. The final destination rides in
- *    our own transaction state and is re-validated against the CORS allowlist
- *    on the way out, so the redirect URI stays a constant and there is no open
- *    redirect to hand the issuer.
+ * Three things about this flow are load-bearing:
+ *
+ * 1. **One registered redirect URI.** A product may serve several organiser- or
+ *    guest-facing origins, but only `.../api/auth/oidc/callback` on its API host
+ *    is registered with the issuer. The final destination rides in our own
+ *    transaction state and is re-validated against the CORS allowlist on the way
+ *    out, so the redirect URI stays a constant and there is no open redirect to
+ *    hand the issuer.
  *
  * 2. **`osn_profile_id`, not `sub`.** The ID token's `sub` is the PAIRWISE
  *    subject — deliberately per-client and meaningless to the OSN graph. Every
- *    row cire owns (`weddings.owner_osn_profile_id`, `wedding_hosts`, all three
- *    ARC bridges) is keyed on the real `usr_*` profile id, which arrives only in
- *    the first-party `osn_profile_id` claim. A token without it is refused
- *    outright — falling back to `sub` would silently orphan every existing row.
+ *    row a relying party owns is keyed on the real `usr_*` profile id, which
+ *    arrives only in the first-party `osn_profile_id` claim. A token without it
+ *    is refused outright — falling back to `sub` would silently orphan every
+ *    existing row.
+ *
+ * 3. **client_secret_post, never Basic.** The issuer's token endpoint refuses a
+ *    request that carries both (RFC 6749 §2.3), so sending one and only one is
+ *    not a style choice.
  */
 
-/** Scopes we ask for. `email` is separate consent; the organiser UI shows it. */
+/** Scopes we ask for. `email` is separate consent; the product's UI shows it. */
 const SCOPE = "openid profile email";
 
 /**
@@ -41,6 +50,21 @@ const SCOPE = "openid profile email";
  * transaction cookie left in a browser is worthless.
  */
 const TX_TTL_SECONDS = 10 * 60;
+
+/**
+ * Who the ID token says signed in. A relying party hangs its own session on
+ * this — `osnProfileId` is the only field its rows may be keyed on.
+ */
+export interface OsnIdentity {
+  /** The real `usr_*` profile id, from the first-party `osn_profile_id` claim. */
+  osnProfileId: string;
+  /** The pairwise `sub`. Kept for audit; never a foreign key. */
+  osnSub: string;
+  email: string | null;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
 
 export interface OidcConfig {
   /** Issuer origin, e.g. `https://id.musubi.social`. No trailing slash. */
@@ -53,6 +77,15 @@ export interface OidcConfig {
   redirectUri: string;
   /** Origins a `return_to` may point at — the same allowlist CORS echoes. */
   allowedReturnOrigins: readonly string[];
+  /**
+   * HKDF `info` string for the transaction-cookie MAC key — **distinct per
+   * product** (`cire-oidc-tx-hmac-v1`, `pulse-oidc-tx-hmac-v1`, …). Required
+   * rather than defaulted: two products that shared a client secret would
+   * otherwise silently share a MAC key, and one's transaction cookie would
+   * verify at the other. Changing it invalidates only in-flight transactions,
+   * which live ten minutes.
+   */
+  txHmacInfo: string;
   /** Test seam: skip the JWKS fetch and verify with this key. */
   _testKey?: CryptoKey;
   /** Test seam: injectable `fetch` for the back-channel token exchange. */
@@ -62,7 +95,7 @@ export interface OidcConfig {
 /** What `/start` hands the route: where to send the browser, and what to remember. */
 export interface OidcStart {
   authorizeUrl: string;
-  /** Opaque cookie value — base64url JSON, safe for a Set-Cookie header. */
+  /** Opaque cookie value — `<b64url payload>.<b64url HMAC>`, Set-Cookie safe. */
   tx: string;
   txMaxAgeSeconds: number;
 }
@@ -74,7 +107,7 @@ export type OidcFailureReason =
   | "token_invalid";
 
 export type OidcComplete =
-  | { ok: true; identity: OrganiserIdentity; returnTo: string }
+  | { ok: true; identity: OsnIdentity; returnTo: string }
   | { ok: false; reason: OidcFailureReason; returnTo: string | null };
 
 interface TxState {
@@ -95,15 +128,15 @@ interface TxState {
 // ---------------------------------------------------------------------------
 // Transaction cookie integrity (HMAC-SHA256).
 //
-// The `cire_oidc_tx` cookie carries the whole login transaction — `state`,
-// `nonce`, PKCE verifier and return destination. It is host-scoped to cire-api,
-// but a sibling `*.cireweddings.com` origin (or any code able to write a cookie
-// the browser will send here) could otherwise PLANT a transaction of its own:
-// a base64url JSON blob with no integrity protection is forgeable by anyone.
-// A planted transaction fixates the victim's sign-in on the ATTACKER's `state`
-// / `nonce` / verifier, so the code the victim's issuer mints exchanges into
-// the attacker's identity and the victim ends up signed into the attacker's
-// account (a classic OAuth session-fixation / login-CSRF).
+// The transaction cookie carries the whole login transaction — `state`,
+// `nonce`, PKCE verifier and return destination. It is host-scoped to the app's
+// API, but a sibling origin (or any code able to write a cookie the browser
+// will send here) could otherwise PLANT a transaction of its own: a base64url
+// JSON blob with no integrity protection is forgeable by anyone. A planted
+// transaction fixates the victim's sign-in on the ATTACKER's `state` / `nonce`
+// / verifier, so the code the victim's issuer mints exchanges into the
+// attacker's identity and the victim ends up signed into the attacker's account
+// (a classic OAuth session-fixation / login-CSRF).
 //
 // So the payload is authenticated: `<b64url(json)>.<b64url(hmac)>`, where the
 // MAC is HMAC-SHA256 over the base64url PAYLOAD string under a key derived from
@@ -111,12 +144,11 @@ interface TxState {
 // with a constant-time compare — a forged or tampered cookie decodes to `null`
 // and the flow fails closed with `state_mismatch`.
 //
-// KEY: derived (HKDF-SHA256, fixed info string) from the OIDC client secret
-// (`CIRE_OIDC_CLIENT_SECRET`) rather than reusing it raw — the client secret is
-// already threaded into every place that touches this cookie (`OidcConfig`),
-// present exactly when the OIDC routes are, and never leaves the server. No new
-// secret to provision.
-const TX_HMAC_INFO = new TextEncoder().encode("cire-oidc-tx-hmac-v1");
+// KEY: derived (HKDF-SHA256, per-product `info` string) from the OIDC client
+// secret rather than reusing it raw — the client secret is already threaded
+// into every place that touches this cookie (`OidcConfig`), present exactly
+// when the OIDC routes are, and never leaves the server. No new secret to
+// provision.
 
 const bytesToB64url = (bytes: Uint8Array): string =>
   btoa(String.fromCharCode(...bytes))
@@ -128,7 +160,7 @@ const b64urlToBytes = (raw: string): Uint8Array =>
   Uint8Array.from(atob(raw.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0));
 
 /** HKDF-SHA256 derive a dedicated HMAC key from the OIDC client secret. */
-async function deriveTxHmacKey(secret: string): Promise<CryptoKey> {
+async function deriveTxHmacKey(secret: string, info: string): Promise<CryptoKey> {
   const ikm = await crypto.subtle.importKey(
     "raw",
     new TextEncoder().encode(secret),
@@ -137,7 +169,12 @@ async function deriveTxHmacKey(secret: string): Promise<CryptoKey> {
     ["deriveKey"],
   );
   return crypto.subtle.deriveKey(
-    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: TX_HMAC_INFO },
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(0),
+      info: new TextEncoder().encode(info),
+    },
     ikm,
     { name: "HMAC", hash: "SHA-256", length: 256 },
     false,
@@ -146,19 +183,23 @@ async function deriveTxHmacKey(secret: string): Promise<CryptoKey> {
 }
 
 /** MAC over the base64url payload, as a base64url string. */
-async function txMac(payload: string, secret: string): Promise<string> {
-  const key = await deriveTxHmacKey(secret);
+async function txMac(payload: string, secret: string, info: string): Promise<string> {
+  const key = await deriveTxHmacKey(secret, info);
   const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
   return bytesToB64url(new Uint8Array(sig));
 }
 
-export const encodeTx = async (state: TxState, secret: string): Promise<string> => {
+export const encodeTx = async (state: TxState, secret: string, info: string): Promise<string> => {
   const payload = bytesToB64url(new TextEncoder().encode(JSON.stringify(state)));
-  const mac = await txMac(payload, secret);
+  const mac = await txMac(payload, secret, info);
   return `${payload}.${mac}`;
 };
 
-export const decodeTx = async (raw: string, secret: string): Promise<TxState | null> => {
+export const decodeTx = async (
+  raw: string,
+  secret: string,
+  info: string,
+): Promise<TxState | null> => {
   const dot = raw.indexOf(".");
   if (dot <= 0 || dot === raw.length - 1) return null;
   const payload = raw.slice(0, dot);
@@ -166,7 +207,7 @@ export const decodeTx = async (raw: string, secret: string): Promise<TxState | n
 
   let expectedMac: string;
   try {
-    expectedMac = await txMac(payload, secret);
+    expectedMac = await txMac(payload, secret, info);
   } catch {
     return null;
   }
@@ -197,8 +238,9 @@ export const decodeTx = async (raw: string, secret: string): Promise<TxState | n
 /**
  * Open-redirect guard. A `return_to` is only honoured when its ORIGIN is one we
  * already trust enough to echo in `Access-Control-Allow-Origin`. Checked on the
- * way in (so a bad link fails fast) AND on the way out (the transaction cookie
- * is unauthenticated — anything read back from it is untrusted input).
+ * way in (so a bad link fails fast) AND on the way out — the MAC proves the
+ * cookie is ours, not that the allowlist still holds, and an origin dropped
+ * from the allowlist mid-transaction must stop being a destination.
  */
 export function isAllowedReturnTo(returnTo: string, allowed: readonly string[]): boolean {
   let url: URL;
@@ -268,6 +310,7 @@ export async function beginLogin(
         x: Date.now() + TX_TTL_SECONDS * 1000,
       },
       config.clientSecret,
+      config.txHmacInfo,
     ),
     txMaxAgeSeconds: TX_TTL_SECONDS,
   };
@@ -280,7 +323,7 @@ export async function beginLogin(
  * still has to land somewhere.
  */
 export async function readReturnTo(config: OidcConfig, tx: string | null): Promise<string | null> {
-  const state = tx ? await decodeTx(tx, config.clientSecret) : null;
+  const state = tx ? await decodeTx(tx, config.clientSecret, config.txHmacInfo) : null;
   if (!state) return null;
   return isAllowedReturnTo(state.r, config.allowedReturnOrigins) ? state.r : null;
 }
@@ -288,25 +331,21 @@ export async function readReturnTo(config: OidcConfig, tx: string | null): Promi
 export interface CallbackInput {
   code: string | null;
   state: string | null;
-  /** Raw `cire_oidc_tx` cookie value. */
+  /** Raw transaction cookie value. */
   tx: string | null;
 }
 
 /**
  * Leg 2: match `state`, exchange the code, verify the ID token, and hand back
- * the identity to hang a cire session on.
- *
- * Client authentication is **client_secret_post**, never Basic. The issuer's
- * token endpoint refuses a request that carries both (RFC 6749 §2.3), so
- * sending one and only one is not a style choice.
+ * the identity to hang the product's own session on.
  */
 export async function completeLogin(
   config: OidcConfig,
   input: CallbackInput,
 ): Promise<OidcComplete> {
-  const tx = input.tx ? await decodeTx(input.tx, config.clientSecret) : null;
-  // Re-validate the destination out of the untrusted cookie before it is used
-  // for anything, including an error redirect.
+  const tx = input.tx ? await decodeTx(input.tx, config.clientSecret, config.txHmacInfo) : null;
+  // Re-validate the destination out of the cookie before it is used for
+  // anything, including an error redirect.
   const returnTo = tx && isAllowedReturnTo(tx.r, config.allowedReturnOrigins) ? tx.r : null;
 
   if (!tx || !input.state) return { ok: false, reason: "state_mismatch", returnTo };
@@ -358,9 +397,9 @@ export async function completeLogin(
   });
   if (!claims) return { ok: false, reason: "token_invalid", returnTo };
 
-  // No profile id ⇒ the issuer does not treat us as first-party. Every cire row
-  // is keyed on `usr_*`; there is nothing safe to do with a pairwise subject
-  // alone, so refuse rather than invent an identity.
+  // No profile id ⇒ the issuer does not treat us as first-party. Every row a
+  // relying party owns is keyed on `usr_*`; there is nothing safe to do with a
+  // pairwise subject alone, so refuse rather than invent an identity.
   if (!claims.osnProfileId) return { ok: false, reason: "token_invalid", returnTo };
 
   return {

--- a/shared/osn-auth-client/src/testing/oidc-issuer.ts
+++ b/shared/osn-auth-client/src/testing/oidc-issuer.ts
@@ -1,0 +1,160 @@
+import { SignJWT, generateKeyPair } from "jose";
+
+import type { OidcConfig } from "../oidc-rp";
+
+/**
+ * A fake OSN issuer for relying-party tests — shared so every product that
+ * signs in through `./oidc-rp` tests against the same issuer behaviour instead
+ * of hand-rolling one.
+ *
+ * Two seams stand in for the network: `_testKey` on the config replaces the
+ * JWKS fetch, and `_fetch` replaces the back-channel token exchange. Nothing
+ * here touches a socket.
+ *
+ * These are ID tokens: `aud` is the client id and `sub` is the pairwise
+ * subject, with the profile id in the first-party `osn_profile_id` claim. An
+ * ACCESS token (`aud: "osn-access"`, `sub` = the real profile id) is a
+ * different thing and each product mints its own fixtures for those.
+ */
+
+export const TEST_ISSUER = "https://id.test.invalid";
+export const TEST_CLIENT_ID = "cid_test";
+export const TEST_CLIENT_SECRET = "shh-test-secret";
+export const TEST_REDIRECT_URI = "https://api.test.invalid/api/auth/oidc/callback";
+/** Per-product HKDF info for the transaction-cookie MAC key. */
+export const TEST_TX_HMAC_INFO = "test-oidc-tx-hmac-v1";
+/** Default app origin a `return_to` may point at. Products override it. */
+export const TEST_RETURN_ORIGIN = "https://app.test.invalid";
+export const TEST_RETURN_TO = `${TEST_RETURN_ORIGIN}/home`;
+export const TEST_PROFILE_ID = "usr_test_person";
+export const TEST_PAIRWISE_SUB = "pw_test_pairwise_subject";
+
+export interface IdTokenOverrides {
+  /** Pairwise subject. */
+  sub?: string;
+  /** First-party profile-id claim; `null` omits it entirely. */
+  osnProfileId?: string | null;
+  /** Replay binding — the test must pass the `nonce` its own tx carries. */
+  nonce?: string;
+  email?: string | null;
+  handle?: string | null;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  authTime?: number;
+  issuer?: string;
+  audience?: string;
+  /** jose duration string; negative values mint an already-expired token. */
+  expiresIn?: string;
+}
+
+export interface OidcTestIssuer {
+  /** Public verifying key — goes on the config as `_testKey`. */
+  publicKey: CryptoKey;
+  /** Mints an ES256 ID token. Every field has a working default. */
+  signIdToken(overrides?: IdTokenOverrides): Promise<string>;
+  /** RP config for this issuer. Pass `_fetch` per test. */
+  config(overrides?: Partial<OidcConfig>): OidcConfig;
+}
+
+export interface OidcTestIssuerOptions {
+  /**
+   * The one origin `allowedReturnOrigins` starts with. A product whose route
+   * tests run against its own dev origin passes that here rather than
+   * overriding the allowlist at every call.
+   */
+  returnOrigin?: string;
+}
+
+export async function makeOidcTestIssuer(
+  options: OidcTestIssuerOptions = {},
+): Promise<OidcTestIssuer> {
+  const { privateKey, publicKey } = await generateKeyPair("ES256");
+  const returnOrigin = options.returnOrigin ?? TEST_RETURN_ORIGIN;
+
+  return {
+    publicKey,
+
+    signIdToken(overrides: IdTokenOverrides = {}): Promise<string> {
+      const claims: Record<string, unknown> = {
+        email: overrides.email === undefined ? "person@example.test" : overrides.email,
+        preferred_username: overrides.handle === undefined ? "person" : overrides.handle,
+        name: overrides.displayName === undefined ? "Test Person" : overrides.displayName,
+        picture:
+          overrides.avatarUrl === undefined
+            ? "https://cdn.test.invalid/a.png"
+            : overrides.avatarUrl,
+      };
+      // `null` means "issuer did not treat us as first-party" — omit the claim
+      // rather than sending a null, which is what a real non-first-party token
+      // looks like.
+      const profileId =
+        overrides.osnProfileId === undefined ? TEST_PROFILE_ID : overrides.osnProfileId;
+      if (profileId !== null) claims["osn_profile_id"] = profileId;
+      if (overrides.nonce !== undefined) claims["nonce"] = overrides.nonce;
+      if (overrides.authTime !== undefined) claims["auth_time"] = overrides.authTime;
+
+      return new SignJWT(claims)
+        .setProtectedHeader({ alg: "ES256", kid: "test-oidc-kid" })
+        .setSubject(overrides.sub ?? TEST_PAIRWISE_SUB)
+        .setIssuer(overrides.issuer ?? TEST_ISSUER)
+        .setAudience(overrides.audience ?? TEST_CLIENT_ID)
+        .setIssuedAt()
+        .setExpirationTime(overrides.expiresIn ?? "5m")
+        .sign(privateKey);
+    },
+
+    config(overrides: Partial<OidcConfig> = {}): OidcConfig {
+      return {
+        issuer: TEST_ISSUER,
+        jwksUrl: `${TEST_ISSUER}/.well-known/jwks.json`,
+        clientId: TEST_CLIENT_ID,
+        clientSecret: TEST_CLIENT_SECRET,
+        redirectUri: TEST_REDIRECT_URI,
+        allowedReturnOrigins: [returnOrigin],
+        txHmacInfo: TEST_TX_HMAC_INFO,
+        _testKey: publicKey,
+        ...overrides,
+      };
+    },
+  };
+}
+
+export interface TokenEndpointCall {
+  url: string;
+  /** The form body — the exchange is `client_secret_post`, never Basic. */
+  params: URLSearchParams;
+  headers: Headers;
+}
+
+export interface TokenEndpointStub {
+  /** Drop-in for `OidcConfig._fetch`. */
+  fetch: typeof fetch;
+  /** Every exchange the RP attempted, in order. */
+  calls: TokenEndpointCall[];
+}
+
+/** Records each token-endpoint POST and answers with whatever `respond` returns. */
+export function stubTokenEndpoint(
+  respond: (call: TokenEndpointCall) => Response | Promise<Response>,
+): TokenEndpointStub {
+  const calls: TokenEndpointCall[] = [];
+  const doFetch = async (input: unknown, init?: RequestInit): Promise<Response> => {
+    const url = input instanceof Request ? input.url : String(input);
+    const body = init?.body;
+    const params = new URLSearchParams(
+      body instanceof URLSearchParams ? body.toString() : String(body ?? ""),
+    );
+    const call: TokenEndpointCall = { url, params, headers: new Headers(init?.headers) };
+    calls.push(call);
+    return respond(call);
+  };
+  return { fetch: doFetch as unknown as typeof fetch, calls };
+}
+
+/** The shape a healthy token endpoint returns. */
+export function tokenResponse(idToken: string): Response {
+  return new Response(
+    JSON.stringify({ id_token: idToken, access_token: "at_ignored", token_type: "Bearer" }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/shared/osn-auth-client/tests/oidc-rp.test.ts
+++ b/shared/osn-auth-client/tests/oidc-rp.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, beforeAll } from "bun:test";
+import { sha256Base64Url } from "@shared/crypto/tokens";
+import { beforeAll, describe, expect, it } from "vitest";
 
-import { sha256Base64Url } from "../lib/opaque-token";
+import {
+  beginLogin,
+  completeLogin,
+  decodeTx,
+  encodeTx,
+  isAllowedReturnTo,
+  readReturnTo,
+} from "../src/oidc-rp";
+import type { OidcConfig } from "../src/oidc-rp";
 import {
   TEST_CLIENT_ID,
   TEST_CLIENT_SECRET,
@@ -10,20 +19,12 @@ import {
   TEST_REDIRECT_URI,
   TEST_RETURN_ORIGIN,
   TEST_RETURN_TO,
+  TEST_TX_HMAC_INFO,
   makeOidcTestIssuer,
   stubTokenEndpoint,
   tokenResponse,
-} from "../test-helpers/oidc-issuer";
-import type { OidcTestIssuer } from "../test-helpers/oidc-issuer";
-import {
-  beginLogin,
-  completeLogin,
-  decodeTx,
-  encodeTx,
-  isAllowedReturnTo,
-  readReturnTo,
-} from "./oidc-login";
-import type { OidcConfig } from "./oidc-login";
+} from "../src/testing/oidc-issuer";
+import type { OidcTestIssuer } from "../src/testing/oidc-issuer";
 
 let issuer: OidcTestIssuer;
 beforeAll(async () => {
@@ -37,13 +38,13 @@ beforeAll(async () => {
  * with a cast so a v:9-style shape can be built.
  */
 const forgeTx = (shape: Record<string, unknown>, secret: string): Promise<string> =>
-  encodeTx(shape as unknown as Parameters<typeof encodeTx>[0], secret);
+  encodeTx(shape as unknown as Parameters<typeof encodeTx>[0], secret, TEST_TX_HMAC_INFO);
 
 /** A started login: the decoded tx plus the `state` the issuer would echo back. */
 async function startLogin(config: OidcConfig, returnTo = TEST_RETURN_TO) {
   const started = await beginLogin(config, returnTo);
   if (!started) throw new Error("beginLogin refused an allowed return_to");
-  const tx = await decodeTx(started.tx, config.clientSecret);
+  const tx = await decodeTx(started.tx, config.clientSecret, config.txHmacInfo);
   if (!tx) throw new Error("decodeTx rejected a freshly minted transaction");
   return { started, tx, cookie: started.tx };
 }
@@ -53,7 +54,7 @@ describe("isAllowedReturnTo", () => {
 
   it("accepts any path or query on an allowlisted origin", () => {
     expect(isAllowedReturnTo(TEST_RETURN_ORIGIN, allowed)).toBe(true);
-    expect(isAllowedReturnTo(`${TEST_RETURN_ORIGIN}/weddings?tab=guests`, allowed)).toBe(true);
+    expect(isAllowedReturnTo(`${TEST_RETURN_ORIGIN}/home?tab=guests`, allowed)).toBe(true);
     expect(isAllowedReturnTo("https://host.example.test/deep/path#frag", allowed)).toBe(true);
   });
 
@@ -69,7 +70,7 @@ describe("isAllowedReturnTo", () => {
   it("rejects non-http(s) schemes and unparseable input", () => {
     expect(isAllowedReturnTo("javascript:alert(1)", allowed)).toBe(false);
     expect(isAllowedReturnTo("data:text/html,x", allowed)).toBe(false);
-    expect(isAllowedReturnTo("/weddings", allowed)).toBe(false);
+    expect(isAllowedReturnTo("/home", allowed)).toBe(false);
     expect(isAllowedReturnTo("", allowed)).toBe(false);
   });
 
@@ -113,6 +114,17 @@ describe("beginLogin", () => {
     expect(tx.s).not.toBe(tx.n);
   });
 
+  it("sends no prompt unless the caller asks for one", async () => {
+    const { started } = await startLogin(issuer.config());
+    expect(new URL(started.authorizeUrl).searchParams.get("prompt")).toBeNull();
+  });
+
+  it("asks the issuer to lead with sign-up when told to", async () => {
+    const started = await beginLogin(issuer.config(), TEST_RETURN_TO, { prompt: "create" });
+    if (!started) throw new Error("beginLogin refused an allowed return_to");
+    expect(new URL(started.authorizeUrl).searchParams.get("prompt")).toBe("create");
+  });
+
   it("mints fresh state, nonce and verifier on every call", async () => {
     const a = await startLogin(issuer.config());
     const b = await startLogin(issuer.config());
@@ -123,9 +135,9 @@ describe("beginLogin", () => {
 
   it("remembers the destination and expires the transaction in ten minutes", async () => {
     const before = Date.now();
-    const { started, tx } = await startLogin(issuer.config(), `${TEST_RETURN_ORIGIN}/weddings/x`);
+    const { started, tx } = await startLogin(issuer.config(), `${TEST_RETURN_ORIGIN}/home/x`);
     expect(tx.v).toBe(1);
-    expect(tx.r).toBe(`${TEST_RETURN_ORIGIN}/weddings/x`);
+    expect(tx.r).toBe(`${TEST_RETURN_ORIGIN}/home/x`);
     expect(started.txMaxAgeSeconds).toBe(600);
     expect(tx.x).toBeGreaterThanOrEqual(before + 600_000);
     expect(tx.x).toBeLessThanOrEqual(Date.now() + 600_000);
@@ -168,22 +180,23 @@ describe("readReturnTo", () => {
 
 describe("tx cookie integrity (HMAC)", () => {
   const state = { v: 1 as const, s: "st", n: "no", cv: "cv", r: TEST_RETURN_TO, x: Date.now() };
+  const info = TEST_TX_HMAC_INFO;
 
   it("round-trips a freshly signed transaction", async () => {
     const secret = TEST_CLIENT_SECRET;
-    const decoded = await decodeTx(await encodeTx(state, secret), secret);
+    const decoded = await decodeTx(await encodeTx(state, secret, info), secret, info);
     expect(decoded).toEqual(state);
   });
 
   it("carries a MAC — the value is `<payload>.<mac>`", async () => {
-    const cookie = await encodeTx(state, TEST_CLIENT_SECRET);
+    const cookie = await encodeTx(state, TEST_CLIENT_SECRET, info);
     expect(cookie.split(".")).toHaveLength(2);
     expect(cookie).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
   });
 
   it("rejects a tampered payload (session-fixation guard)", async () => {
     const secret = TEST_CLIENT_SECRET;
-    const cookie = await encodeTx(state, secret);
+    const cookie = await encodeTx(state, secret, info);
     const [payload, mac] = cookie.split(".");
     // Re-point the return destination while keeping the original MAC.
     const forgedPayload = btoa(
@@ -192,15 +205,25 @@ describe("tx cookie integrity (HMAC)", () => {
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
-    expect(await decodeTx(`${forgedPayload}.${mac}`, secret)).toBeNull();
+    expect(await decodeTx(`${forgedPayload}.${mac}`, secret, info)).toBeNull();
     // A flipped MAC is rejected too.
     const flipped = mac!.slice(0, -1) + (mac!.endsWith("A") ? "B" : "A");
-    expect(await decodeTx(`${payload}.${flipped}`, secret)).toBeNull();
+    expect(await decodeTx(`${payload}.${flipped}`, secret, info)).toBeNull();
   });
 
   it("rejects a cookie signed under a different secret", async () => {
-    const cookie = await encodeTx(state, "secret-one");
-    expect(await decodeTx(cookie, "secret-two")).toBeNull();
+    const cookie = await encodeTx(state, "secret-one", info);
+    expect(await decodeTx(cookie, "secret-two", info)).toBeNull();
+  });
+
+  /**
+   * The whole point of the per-product `info`: two relying parties that end up
+   * sharing a client secret must NOT be able to verify each other's transaction
+   * cookies, or one product's planted transaction fixates a sign-in at the other.
+   */
+  it("rejects a cookie minted by another product under the same secret", async () => {
+    const cookie = await encodeTx(state, TEST_CLIENT_SECRET, "cire-oidc-tx-hmac-v1");
+    expect(await decodeTx(cookie, TEST_CLIENT_SECRET, "pulse-oidc-tx-hmac-v1")).toBeNull();
   });
 
   it("rejects an unsigned legacy cookie (no MAC segment)", async () => {
@@ -209,7 +232,7 @@ describe("tx cookie integrity (HMAC)", () => {
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
-    expect(await decodeTx(bare, TEST_CLIENT_SECRET)).toBeNull();
+    expect(await decodeTx(bare, TEST_CLIENT_SECRET, info)).toBeNull();
   });
 });
 
@@ -246,7 +269,11 @@ describe("completeLogin — transaction checks", () => {
   it("fails with state_mismatch once the transaction has expired", async () => {
     const config = issuer.config();
     const { tx } = await startLogin(config);
-    const stale = await encodeTx({ ...tx, x: Date.now() - 1_000 }, config.clientSecret);
+    const stale = await encodeTx(
+      { ...tx, x: Date.now() - 1_000 },
+      config.clientSecret,
+      config.txHmacInfo,
+    );
     const result = await completeLogin(config, { code: "c", state: tx.s, tx: stale });
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unreachable");
@@ -378,9 +405,9 @@ describe("completeLogin — ID token verification", () => {
     expect(result.identity).toEqual({
       osnProfileId: TEST_PROFILE_ID,
       osnSub: TEST_PAIRWISE_SUB,
-      email: "organiser@example.test",
-      handle: "organiser",
-      displayName: "Test Organiser",
+      email: "person@example.test",
+      handle: "person",
+      displayName: "Test Person",
       avatarUrl: "https://cdn.test.invalid/a.png",
     });
   });
@@ -389,8 +416,8 @@ describe("completeLogin — ID token verification", () => {
     const result = await completeWith({ sub: "pw_someone_else" });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unreachable");
-    // `sub` is per-client and meaningless to the graph; every cire row is keyed
-    // on the `usr_*` id, which must come from `osn_profile_id` alone.
+    // `sub` is per-client and meaningless to the graph; every relying party's
+    // rows are keyed on the `usr_*` id, which must come from `osn_profile_id`.
     expect(result.identity.osnSub).toBe("pw_someone_else");
     expect(result.identity.osnProfileId).toBe(TEST_PROFILE_ID);
   });


### PR DESCRIPTION
## Why

Cire signs organisers in through OSN's OIDC provider. Pulse needs the same flow, and the goal is one Musubi sign-in shared across the products — so the relying-party **server** half moves out of `cire/api` into the shared workspace, where the next product depends on it instead of copying it.

This is PR A of three. B adds the pulse-api session backend on top; C wires the pulse web frontend.

## What moves

| From | To |
|---|---|
| `cire/api/src/lib/opaque-token.ts` | `@shared/crypto/tokens` |
| `cire/api/src/services/oidc-login.ts` | `@shared/osn-auth-client/oidc-rp` |
| cookie codec, split out of `cire/api/src/lib/cookie.ts` | `@shared/osn-auth-client/cookie` |
| `cire/api/src/test-helpers/oidc-issuer.ts` | `@shared/osn-auth-client/testing/oidc-issuer` |

The cookie codec and the fake issuer were the only parts carrying cire's name; both now take what they need as arguments. What is genuinely cire's — three cookie names, its dev origin — stays in cire, as nine one-line wrappers.

## The one behavioural addition

`OidcConfig` gains a **required** `txHmacInfo`.

The PKCE transaction cookie is MAC'd under a key derived (HKDF-SHA256) from the OIDC client secret. Two products sharing a client secret would derive the same key, and one product's transaction cookie would verify at the other's callback. Making the `info` required rather than defaulted means a new relying party cannot forget it. Cire's value lives in the new `cire/api/src/lib/oidc.ts`, imported by both the runtime config and the test helper so the two cannot drift. Changing it invalidates only in-flight transactions — a ten-minute TTL — so a bump costs at most one retried sign-in.

## Constraint this documents for pulse

`@shared/osn-auth-client/cookie` now records why `SameSite=Lax` is required rather than merely tolerated: the OIDC callback arrives as a top-level cross-site GET, which `Strict` would strip the transaction cookie from. The corollary matters for the not-yet-chosen Pulse domain — **the API host must be same-site with the app origin** (`api.<pulse-domain>`) for the host-scoped session cookie to ride along.

## Tests

The 485-line RP test moves with the code, ported from `bun:test` to vitest, plus one new case the split made worth asserting: a cookie minted under one product's `info` is rejected under another's.

- `shared/osn-auth-client`: 89 pass
- `cire/api`: 1492 pass, 0 fail
- Full monorepo: 31/31 turbo tasks green, `bun run check` 25/25

No route, cookie, or wire format changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)