### PR TITLE
feat(pulse): sign a browser in with an OSN account over OIDC

### DIFF
--- a/.changeset/pulse-api-web-sessions.md
+++ b/.changeset/pulse-api-web-sessions.md
@@ -1,0 +1,29 @@
+---
+"@pulse/api": minor
+"@pulse/db": minor
+---
+
+Sign a browser in to Pulse with an OSN account, over OIDC.
+
+Pulse web could not sign anyone in. A passkey ceremony only runs on an origin
+same-site with the WebAuthn RP ID, which is now `musubi.social`, so no Pulse
+origin can mint an OSN credential. Pulse becomes a plain OIDC relying party
+instead: the browser bounces to the issuer, comes back with a code, and leaves
+with a Pulse session of its own.
+
+- `pulse_web_sessions`: opaque tokens, SHA-256 hashed at rest, seven-day TTL,
+  keyed on the `usr_*` profile id rather than the pairwise `sub`.
+- `GET /api/auth/oidc/start` and `/oidc/callback` for the two legs, plus
+  `GET /api/auth/session` (200 `{ signedIn: false }` for a visitor, never a 401)
+  and `POST /api/auth/signout` (idempotent; `?all=1` clears every browser).
+- Every authenticated route now accepts either credential. A bearer token is
+  checked first and decides the request outright — present-but-invalid is a
+  rejection, never a fall back to whoever the cookie names. The iOS app is
+  untouched and never pays for the cookie lookup.
+- The session cookie is host-scoped, `HttpOnly`, `SameSite=Lax`, with no
+  `Domain=`. Cookie credentials make Pulse writes CSRF-eligible for the first
+  time, so an origin guard covers state-changing requests — it fires only when
+  the session cookie is present, because the native app sends no `Origin`.
+
+Deploy note: the API must be served from a host same-site with the web origin
+(`api.<pulse-domain>`), or the browser will not send the session cookie back.

--- a/.changeset/pulse-api-web-sessions.md
+++ b/.changeset/pulse-api-web-sessions.md
@@ -20,6 +20,10 @@ with a Pulse session of its own.
   checked first and decides the request outright — present-but-invalid is a
   rejection, never a fall back to whoever the cookie names. The iOS app is
   untouched and never pays for the cookie lookup.
+- `GET /api/close-friends/candidates` returns the caller's OSN connections
+  with handle, name and avatar. The picker used to read the graph straight
+  from the issuer with a bearer token; a browser has no OSN token to do that
+  with, so Pulse fans the two S2S bridge calls out server-side instead.
 - The session cookie is host-scoped, `HttpOnly`, `SameSite=Lax`, with no
   `Domain=`. Cookie credentials make Pulse writes CSRF-eligible for the first
   time, so an origin guard covers state-changing requests — it fires only when

--- a/pulse/api/src/app.ts
+++ b/pulse/api/src/app.ts
@@ -2,12 +2,15 @@ import { cors } from "@elysiajs/cors";
 import { openapi } from "@elysiajs/openapi";
 import { DbLive, type Db } from "@pulse/db/service";
 import { healthRoutes, observabilityPlugin } from "@shared/observability";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
 import type { ClientIpOptions } from "@shared/rate-limit";
 import type { Layer } from "effect";
 import { Elysia } from "elysia";
 
+import { originGuard } from "./lib/origin-guard";
 import { makeMemoryRateLimiters, type PulseRateLimiters } from "./redis";
 import { createAccountRoutes } from "./routes/account";
+import { createAuthRoutes } from "./routes/auth";
 import { createCloseFriendsRoutes } from "./routes/closeFriends";
 import { createEventsRoutes } from "./routes/events";
 import { createInternalRoutes } from "./routes/internal";
@@ -47,6 +50,21 @@ export interface AppOptions {
    * → wildcard `cors()` (tests only).
    */
   corsOrigins?: string[];
+  /**
+   * OIDC relying-party config for browser sign-in. `null`/omitted ⇒ the tier
+   * has no OSN client credentials, and `/api/auth/oidc/*` answers with the
+   * `sign_in_unavailable` marker instead of half-starting a flow. The
+   * composition root builds it from env (see `lib/oidc.ts` for the HMAC info).
+   */
+  oidc?: OidcConfig | null;
+  /** Cookie `Secure` flag — true on every https tier, false for local http. */
+  secureCookies?: boolean;
+  /**
+   * Absolute URL of the Pulse web login page. Terminal sign-in failures with
+   * no trusted `return_to` land here with an `?auth_error` marker. Defaults to
+   * the local web app.
+   */
+  loginFallbackUrl?: string;
 }
 
 /**
@@ -63,9 +81,12 @@ export function createApp(options: AppOptions = {}) {
     rateLimiters = makeMemoryRateLimiters(),
     clientIpConfig = {},
     corsOrigins,
+    oidc = null,
+    secureCookies = false,
+    loginFallbackUrl = "http://localhost:1420/",
   } = options;
 
-  const { write, discovery, share, exposure } = rateLimiters;
+  const { write, discovery, share, exposure, authStart, authSession } = rateLimiters;
 
   return (
     // `aot: false` — Elysia's ahead-of-time compilation builds handlers via
@@ -73,6 +94,11 @@ export function createApp(options: AppOptions = {}) {
     new Elysia({ aot: false })
       .use(corsOrigins ? cors({ origin: corsOrigins, credentials: true }) : cors())
       .use(observabilityPlugin({ serviceName: SERVICE_NAME }))
+      // CSRF guard for the cookie-authenticated surface — mounted before any
+      // route factory so it gates the whole app. Only fires when the request
+      // carries `pulse_web_session`; see `lib/origin-guard.ts` for why Pulse
+      // cannot guard every state-changing request the way cire does.
+      .use(originGuard(corsOrigins ?? []))
       .use(healthRoutes({ serviceName: SERVICE_NAME }))
       .get("/", () => ({ status: "ok", service: SERVICE_NAME }))
       .use(
@@ -101,6 +127,16 @@ export function createApp(options: AppOptions = {}) {
               "/internal/account-export",
             ],
           },
+        }),
+      )
+      .use(
+        createAuthRoutes(dbLayer, {
+          oidc,
+          secureCookies,
+          loginFallbackUrl,
+          startLimiter: authStart,
+          sessionLimiter: authSession,
+          clientIpConfig,
         }),
       )
       .use(

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -1,9 +1,11 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { makeDbD1Live } from "@pulse/db/service";
 import type { ClientIpOptions } from "@shared/rate-limit";
+import { Effect } from "effect";
 
 import { createApp, type App } from "./app";
 import { assertCorsOriginsConfigured, resolveCorsOrigins } from "./lib/cors-config";
+import { buildPulseOidcConfig } from "./lib/oidc";
 import { makeMemoryRateLimiters, type PulseRateLimiters } from "./redis";
 
 // Re-export the Eden treaty type so `@pulse/api` consumers and `./client` keep
@@ -30,6 +32,21 @@ export interface Env {
   PULSE_TRUSTED_PROXY_COUNT?: string;
   /** Environment discriminator — `local` vs anything else. */
   OSN_ENV?: string;
+  /** OSN issuer origin — the OIDC provider this app is a relying party of. */
+  OSN_ISSUER_URL?: string;
+  /**
+   * Public origin of this Worker. The registered redirect URI is
+   * `${PULSE_API_ORIGIN}/api/auth/oidc/callback`, and the session cookie is
+   * host-scoped to it — so it must be same-site with the Pulse web origin
+   * (`api.<pulse-domain>`) or a `SameSite=Lax` cookie is never sent.
+   */
+  PULSE_API_ORIGIN?: string;
+  /** OIDC client id registered with osn-api (var). */
+  OSN_OIDC_CLIENT_ID?: string;
+  /** OIDC client secret (secret, never a var). */
+  OSN_OIDC_CLIENT_SECRET?: string;
+  /** Absolute URL of the Pulse web login page — the `?auth_error` landing. */
+  PULSE_LOGIN_URL?: string;
 }
 
 /**
@@ -87,12 +104,28 @@ function buildApp(env: Env): App {
 
   const rateLimiters: PulseRateLimiters = makeMemoryRateLimiters();
 
+  // Browser sign-in (OIDC relying party). All five pieces or none — see
+  // `lib/oidc.ts`. On a deployed tier an incomplete set is a misconfiguration
+  // worth a log line, but not worth refusing to serve: every other route works
+  // without it, and the sign-in legs answer `sign_in_unavailable`.
+  const oidc = buildPulseOidcConfig(env, corsOrigins);
+  if (secure && !oidc) {
+    void Effect.runPromise(
+      Effect.logError(
+        "pulse-api: OIDC sign-in disabled — set OSN_ISSUER_URL, OSN_JWKS_URL, PULSE_API_ORIGIN, OSN_OIDC_CLIENT_ID and OSN_OIDC_CLIENT_SECRET to enable it",
+      ),
+    ).catch(() => undefined);
+  }
+
   return createApp({
     dbLayer: makeDbD1Live(env.DB as D1Database),
     jwksUrl,
     rateLimiters,
     clientIpConfig: resolveClientIpConfig(env),
     corsOrigins,
+    oidc,
+    secureCookies: secure,
+    ...(env.PULSE_LOGIN_URL ? { loginFallbackUrl: env.PULSE_LOGIN_URL } : {}),
   });
 }
 

--- a/pulse/api/src/lib/caller.ts
+++ b/pulse/api/src/lib/caller.ts
@@ -1,0 +1,77 @@
+import type { Db } from "@pulse/db/service";
+import { extractClaims, type Claims } from "@shared/osn-auth-client/verify";
+import { Effect, type ManagedRuntime } from "effect";
+
+import { metricCallerAuth } from "../metrics";
+import { webSessionService } from "../services/webSession";
+import { parseWebSessionToken } from "./cookie";
+
+/**
+ * Resolve the caller of a Pulse request from either credential.
+ *
+ * Pulse has two kinds of client and they authenticate differently. The iOS app
+ * holds an OSN refresh token and presents a five-minute bearer access JWT. The
+ * web app cannot: a passkey ceremony is bound to `musubi.social`, so the
+ * browser signs in through the OIDC redirect flow and carries the
+ * `pulse_web_session` cookie instead. Every authenticated route accepts both,
+ * and nothing downstream needs to know which arrived — both resolve to the same
+ * `Claims`, so the existing call sites change by one line.
+ *
+ * Order matters. A bearer token is checked first and, if present, decides the
+ * request outright: an `Authorization` header is an explicit claim about who
+ * the caller is, and falling back to the cookie when it fails to verify would
+ * silently answer as somebody else. Present-but-invalid is a rejection.
+ *
+ * The cookie path costs a hashed single-row lookup. It runs only when there is
+ * no bearer token, so the native app never pays for it.
+ */
+export type CallerHeaders = Record<string, string | undefined>;
+
+export type ResolveCaller = (headers: CallerHeaders) => Promise<Claims | null>;
+
+export interface CallerResolverOptions {
+  /** The route factory's own runtime — the cookie lookup needs `Db`. */
+  runtime: ManagedRuntime.ManagedRuntime<Db, never>;
+  /** JWKS endpoint of the OSN issuer that signs access tokens. */
+  jwksUrl: string;
+  /** Injected verifying key for tests (skips the JWKS fetch). */
+  testKey?: CryptoKey | undefined;
+}
+
+export function makeCallerResolver({
+  runtime,
+  jwksUrl,
+  testKey,
+}: CallerResolverOptions): ResolveCaller {
+  return async (headers) => {
+    const authorization = headers["authorization"];
+    if (authorization) {
+      const claims = await extractClaims(authorization, jwksUrl, {
+        testKey: testKey as CryptoKey,
+        audience: "osn-access",
+      });
+      metricCallerAuth("bearer", claims ? "ok" : "rejected");
+      return claims;
+    }
+
+    const token = parseWebSessionToken(headers["cookie"] ?? null);
+    if (!token) return null;
+
+    const session = await runtime.runPromise(
+      webSessionService
+        .validate(token)
+        .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null))),
+    );
+    metricCallerAuth("cookie", session ? "ok" : "rejected");
+    if (!session) return null;
+
+    // `osn_profile_id`, not the pairwise `sub` — the graph is keyed on the
+    // profile, and the two are deliberately different values.
+    return {
+      profileId: session.osnProfileId,
+      email: session.email,
+      handle: session.handle,
+      displayName: session.displayName,
+    };
+  };
+}

--- a/pulse/api/src/lib/cookie.ts
+++ b/pulse/api/src/lib/cookie.ts
@@ -1,0 +1,65 @@
+import { buildClearCookie, buildCookie, parseCookie } from "@shared/osn-auth-client/cookie";
+import type { SessionCookieOptions } from "@shared/osn-auth-client/cookie";
+
+/**
+ * Pulse's cookie names, over the shared codec in `@shared/osn-auth-client/cookie`
+ * — which is where the host-scoping and `SameSite=Lax` reasoning lives. Names
+ * are fixed here so no caller passes one as a string.
+ *
+ * Two cookies, both minted by the OSN OIDC redirect flow:
+ *
+ * - `pulse_web_session` — the browser session for the Pulse web app.
+ * - `pulse_oidc_tx`     — the short-lived transaction state (PKCE verifier,
+ *                         `state`, `nonce`, return URL) held between
+ *                         `/api/auth/oidc/start` and `/api/auth/oidc/callback`.
+ *
+ * The iOS app has no cookie: it holds an OSN refresh token and presents a
+ * bearer access JWT. These two exist only because a browser cannot run a
+ * passkey ceremony against `musubi.social` from a Pulse origin.
+ *
+ * Both are host-scoped — set by pulse-api and sent back only there. That makes
+ * the Pulse API host and the Pulse web origin same-site by requirement, not by
+ * preference: `api.<pulse-domain>` and `<pulse-domain>` share a registrable
+ * domain, so `Lax` lets the cookie ride along. A Pulse web origin on an
+ * unrelated domain would never receive it. Do NOT add `Domain=`.
+ */
+
+const SESSION_COOKIE_NAME = "pulse_web_session";
+const OIDC_TX_COOKIE_NAME = "pulse_oidc_tx";
+
+export type { SessionCookieOptions };
+
+export function buildWebSessionCookie(token: string, opts: SessionCookieOptions): string {
+  return buildCookie(SESSION_COOKIE_NAME, token, opts);
+}
+
+export function clearWebSessionCookie(opts: { secure: boolean }): string {
+  return buildClearCookie(SESSION_COOKIE_NAME, opts);
+}
+
+export function parseWebSessionToken(cookieHeader: string | null): string | null {
+  return parseCookie(cookieHeader, SESSION_COOKIE_NAME);
+}
+
+/** True when the request carries a Pulse session cookie at all — the CSRF signal the origin guard keys on. */
+export function hasWebSessionCookie(cookieHeader: string | null): boolean {
+  return parseWebSessionToken(cookieHeader) !== null;
+}
+
+/**
+ * The transaction value is `<base64url JSON>.<base64url HMAC>` — HMAC-signed by
+ * `@shared/osn-auth-client/oidc-rp` so a planted or tampered cookie is rejected
+ * (session-fixation guard). Both halves are base64url and the single dot is
+ * cookie-safe.
+ */
+export function buildOidcTxCookie(value: string, opts: SessionCookieOptions): string {
+  return buildCookie(OIDC_TX_COOKIE_NAME, value, opts);
+}
+
+export function clearOidcTxCookie(opts: { secure: boolean }): string {
+  return buildClearCookie(OIDC_TX_COOKIE_NAME, opts);
+}
+
+export function parseOidcTxCookie(cookieHeader: string | null): string | null {
+  return parseCookie(cookieHeader, OIDC_TX_COOKIE_NAME);
+}

--- a/pulse/api/src/lib/oidc.ts
+++ b/pulse/api/src/lib/oidc.ts
@@ -1,0 +1,60 @@
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
+
+/**
+ * The HKDF `info` Pulse derives its OIDC transaction-cookie MAC key under.
+ *
+ * Per-product by design: two relying parties that ever end up sharing an OSN
+ * client secret must not be able to verify each other's transaction cookies, or
+ * a transaction planted at one product could fixate a sign-in at the other. One
+ * constant, imported by the runtime config and the test helper alike, so the
+ * two cannot drift.
+ *
+ * Changing this value invalidates only in-flight transactions — a ten-minute
+ * TTL — so a bump costs at most one retried sign-in.
+ */
+export const PULSE_OIDC_TX_HMAC_INFO = "pulse-oidc-tx-hmac-v1";
+
+/** The env pieces the relying-party config is assembled from. */
+export interface PulseOidcEnv {
+  /** Issuer origin, e.g. `https://id.musubi.social`. */
+  OSN_ISSUER_URL?: string | undefined;
+  /** JWKS endpoint of that issuer. */
+  OSN_JWKS_URL?: string | undefined;
+  /** Public origin of pulse-api itself — the registered redirect URI's host. */
+  PULSE_API_ORIGIN?: string | undefined;
+  OSN_OIDC_CLIENT_ID?: string | undefined;
+  OSN_OIDC_CLIENT_SECRET?: string | undefined;
+}
+
+/**
+ * Assemble the relying-party config, or `null`.
+ *
+ * All five pieces or none: a half-configured client cannot complete a single
+ * exchange, so `null` — which makes the sign-in routes answer with the
+ * `sign_in_unavailable` marker — is the honest state rather than a flow that
+ * starts and then dies at the token endpoint. Callers log the incomplete case
+ * on deployed tiers; locally `bun run dev:pulse` runs without an issuer.
+ *
+ * `allowedReturnOrigins` is the CORS allowlist, so a `return_to` can only point
+ * at an origin this tier already serves.
+ */
+export function buildPulseOidcConfig(
+  env: PulseOidcEnv,
+  allowedReturnOrigins: readonly string[],
+): OidcConfig | null {
+  const issuer = env.OSN_ISSUER_URL?.replace(/\/+$/, "");
+  const apiOrigin = env.PULSE_API_ORIGIN?.replace(/\/+$/, "");
+  const jwksUrl = env.OSN_JWKS_URL;
+  const clientId = env.OSN_OIDC_CLIENT_ID;
+  const clientSecret = env.OSN_OIDC_CLIENT_SECRET;
+  if (!issuer || !apiOrigin || !jwksUrl || !clientId || !clientSecret) return null;
+  return {
+    issuer,
+    jwksUrl,
+    clientId,
+    clientSecret,
+    redirectUri: `${apiOrigin}/api/auth/oidc/callback`,
+    allowedReturnOrigins,
+    txHmacInfo: PULSE_OIDC_TX_HMAC_INFO,
+  };
+}

--- a/pulse/api/src/lib/origin-guard.ts
+++ b/pulse/api/src/lib/origin-guard.ts
@@ -1,0 +1,60 @@
+/**
+ * CSRF origin guard for Pulse's cookie-authenticated surface — Copenhagen
+ * Book M1.
+ *
+ * Until the web session landed, Pulse held no ambient browser credential: every
+ * authenticated call carried a bearer access JWT (iOS) or an ARC token (S2S),
+ * neither of which a cross-site page can attach. `pulse_web_session` changes
+ * that, so state-changing requests that carry it need server-side `Origin`
+ * validation on top of the cookie's own `SameSite=Lax`.
+ *
+ * **The guard fires only when the request carries the session cookie.** That is
+ * the whole point of the check: CSRF is the theft of ambient authority, and a
+ * request with no cookie has none to steal. Guarding every state-changing
+ * request instead — which is what cire and osn-api do, because every one of
+ * their write callers is a browser — would 403 the iOS app, which sends no
+ * `Origin` header at all, and the unauthenticated `POST /events/:id/share` and
+ * `/exposure` pings along with it.
+ *
+ * A cross-site attacker cannot escape the check by adding a header: a request
+ * that carries `Authorization` is no longer a simple request, so the browser
+ * preflights it and the CORS allowlist refuses. Cookie present ⇒ checked;
+ * cookie absent ⇒ nothing to protect.
+ *
+ * Mounted as a root-level `onBeforeHandle` in `createApp`, before the route
+ * factories, so it gates the whole app uniformly.
+ */
+
+import { Elysia } from "elysia";
+
+import { metricOriginGuardRejection } from "../metrics";
+import { hasWebSessionCookie } from "./cookie";
+
+/** Methods that mutate state and therefore require Origin validation. */
+const STATE_CHANGING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Elysia plugin that 403s cookie-carrying state-changing requests whose
+ * `Origin` is missing or not in `allowedOrigins`. An empty allowlist disables
+ * the guard (local dev, where `createApp` is called without `corsOrigins`).
+ */
+export function originGuard(allowedOrigins: readonly string[]) {
+  const allow = new Set(allowedOrigins);
+  return new Elysia().onBeforeHandle({ as: "global" }, ({ request, set }) => {
+    if (!STATE_CHANGING.has(request.method)) return;
+    if (allow.size === 0) return;
+    if (!hasWebSessionCookie(request.headers.get("cookie"))) return;
+
+    const origin = request.headers.get("origin");
+    if (!origin) {
+      metricOriginGuardRejection("missing");
+      set.status = 403;
+      return { error: "forbidden", message: "Missing Origin header" };
+    }
+    if (!allow.has(origin)) {
+      metricOriginGuardRejection("mismatch");
+      set.status = 403;
+      return { error: "forbidden", message: "Origin not allowed" };
+    }
+  });
+}

--- a/pulse/api/src/lib/redis-rate-limiters.ts
+++ b/pulse/api/src/lib/redis-rate-limiters.ts
@@ -74,6 +74,33 @@ export function createRedisShareRateLimiter(client: RedisClient): RateLimiterBac
 }
 
 /**
+ * Per-IP limiter for the OIDC redirect legs (`GET /api/auth/oidc/start` and
+ * `/callback`). Namespace `pulse:auth:start` — key is the client IP. Matches
+ * the 20/min in-memory default (`createDefaultAuthStartRateLimiter`).
+ */
+export function createRedisAuthStartRateLimiter(client: RedisClient): RateLimiterBackend {
+  return createRedisRateLimiter(client, {
+    namespace: "pulse:auth:start",
+    maxRequests: 20,
+    windowMs: ONE_MINUTE_MS,
+  });
+}
+
+/**
+ * Per-IP limiter for `GET /api/auth/session` + `POST /api/auth/signout`.
+ * Namespace `pulse:auth:session` — key is the client IP. The 120/min ceiling
+ * mirrors `createDefaultAuthSessionRateLimiter`: the probe runs on every page
+ * load, and a shared NAT egress puts many users behind one key.
+ */
+export function createRedisAuthSessionRateLimiter(client: RedisClient): RateLimiterBackend {
+  return createRedisRateLimiter(client, {
+    namespace: "pulse:auth:session",
+    maxRequests: 120,
+    windowMs: ONE_MINUTE_MS,
+  });
+}
+
+/**
  * Per-IP limiter for the unauthenticated `POST /events/:id/exposure` ping.
  * Namespace `pulse:exposure` — key is the client IP. Higher 120/min ceiling
  * mirrors `createDefaultExposureRateLimiter` (legitimate page reloads /

--- a/pulse/api/src/local.ts
+++ b/pulse/api/src/local.ts
@@ -5,6 +5,7 @@ import { Effect, Logger } from "effect";
 
 import { createApp, SERVICE_NAME } from "./app";
 import { assertCorsOriginsConfigured, resolveCorsOrigins } from "./lib/cors-config";
+import { buildPulseOidcConfig } from "./lib/oidc";
 import { registerLeaveAppKeyWithOsnApi } from "./lib/outbound-arc";
 import { initRedisClient, makeRateLimiters } from "./redis";
 import * as accountErasure from "./services/accountErasure";
@@ -68,7 +69,36 @@ const clientIpConfig: Omit<ClientIpOptions, "socketIp"> = { trustedProxyCount };
 const corsOrigins = resolveCorsOrigins(process.env, !!nonLocal);
 assertCorsOriginsConfigured(corsOrigins, !!nonLocal);
 
-const app = createApp({ jwksUrl, rateLimiters, clientIpConfig, corsOrigins });
+// Browser sign-in (OIDC relying party) — all five env pieces or none, see
+// `lib/oidc.ts`. Unset locally, so `bun run dev:pulse` boots without an OSN
+// client registration and the sign-in legs answer `sign_in_unavailable`.
+const oidc = buildPulseOidcConfig(
+  {
+    OSN_ISSUER_URL: process.env.OSN_ISSUER_URL,
+    OSN_JWKS_URL: process.env.OSN_JWKS_URL,
+    PULSE_API_ORIGIN: process.env.PULSE_API_ORIGIN,
+    OSN_OIDC_CLIENT_ID: process.env.OSN_OIDC_CLIENT_ID,
+    OSN_OIDC_CLIENT_SECRET: process.env.OSN_OIDC_CLIENT_SECRET,
+  },
+  corsOrigins,
+);
+if (nonLocal && !oidc) {
+  void Effect.runPromise(
+    Effect.logError(
+      "pulse-api: OIDC sign-in disabled — set OSN_ISSUER_URL, OSN_JWKS_URL, PULSE_API_ORIGIN, OSN_OIDC_CLIENT_ID and OSN_OIDC_CLIENT_SECRET to enable it",
+    ).pipe(Effect.provide(Logger.pretty), Effect.provide(observabilityLayer)),
+  ).catch(() => undefined);
+}
+
+const app = createApp({
+  jwksUrl,
+  rateLimiters,
+  clientIpConfig,
+  corsOrigins,
+  oidc,
+  secureCookies: !!nonLocal,
+  ...(process.env.PULSE_LOGIN_URL ? { loginFallbackUrl: process.env.PULSE_LOGIN_URL } : {}),
+});
 
 const port = process.env.PORT || 3001;
 

--- a/pulse/api/src/metrics.ts
+++ b/pulse/api/src/metrics.ts
@@ -19,6 +19,7 @@ import type {
   DeletionCompletedSource,
   DeletionPhase,
   EventStatus,
+  OriginGuardRejectionReason,
   Result,
 } from "@shared/observability/metrics";
 import { Effect } from "effect";
@@ -94,6 +95,14 @@ export const PULSE_METRICS = {
   hostCancelledHardDeleted: "pulse.events.host_cancelled.hard_delete",
   // Per-user write rate limiting (W4 — events/RSVP/invite/blast/series/close-friends)
   writeRateLimited: "pulse.write.rate_limited",
+  // Browser sign-in: the OSN OIDC redirect flow and the session cookie it mints
+  webSessionCreated: "pulse.web_session.created",
+  webSessionSwept: "pulse.web_session.swept",
+  oidcLogin: "pulse.oidc.login",
+  // Which credential authenticated a request — bearer (native app) or cookie (web)
+  callerAuth: "pulse.caller.auth",
+  // CSRF origin guard over the cookie-authenticated surface
+  originGuardRejections: "pulse.origin_guard.rejections",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -1033,6 +1042,95 @@ const writeRateLimited = createCounter<WriteRateLimitedAttrs>({
 
 export const metricWriteRateLimited = (endpoint: PulseWriteEndpoint): void =>
   writeRateLimited.inc({ endpoint });
+
+// --- Browser sign-in (OSN OIDC redirect flow + the Pulse web session) ---
+
+type WebSessionCreatedAttrs = { result: "ok" | "error" };
+type WebSessionSweptAttrs = { result: "ok" | "error" };
+
+/**
+ * Which leg of the OIDC redirect flow ended, and how. Closed set — never carry
+ * a client id, profile id, or the provider's error string, all of which are
+ * unbounded. Mirrors cire's `OidcLoginOutcome`.
+ *
+ * `start` — we redirected the browser to the OSN authorize endpoint.
+ * `callback_ok` — the code exchanged, the ID token verified, a session exists.
+ * `provider_error` — OSN handed us back an `error=` instead of a code.
+ * `state_mismatch` — no transaction cookie, or its `state` did not match.
+ * `exchange_failed` — the back-channel token request was refused or unreachable.
+ * `token_invalid` — the ID token failed verification, or lacked a profile id.
+ * `bad_request` — the caller's own inputs were wrong (e.g. a foreign
+ *   `return_to`); nothing reached the provider.
+ */
+export type OidcLoginOutcome =
+  | "start"
+  | "callback_ok"
+  | "provider_error"
+  | "state_mismatch"
+  | "exchange_failed"
+  | "token_invalid"
+  | "bad_request";
+type OidcLoginAttrs = { outcome: OidcLoginOutcome };
+
+const webSessionCreated = createCounter<WebSessionCreatedAttrs>({
+  name: PULSE_METRICS.webSessionCreated,
+  description: "Pulse web session-cookie creations after an OSN OIDC sign-in, by outcome",
+  unit: "{session}",
+});
+
+const webSessionSwept = createCounter<WebSessionSweptAttrs>({
+  name: PULSE_METRICS.webSessionSwept,
+  description:
+    "Expired Pulse web sessions deleted by the sweeper — increment is the row count, so the sum tracks reclaimed rows",
+  unit: "{session}",
+});
+
+const oidcLogin = createCounter<OidcLoginAttrs>({
+  name: PULSE_METRICS.oidcLogin,
+  description: "OSN OIDC sign-in legs, by outcome",
+  unit: "{attempt}",
+});
+
+export const metricWebSessionCreated = (result: "ok" | "error"): void =>
+  webSessionCreated.inc({ result });
+
+/** On success `count` is the number of expired rows deleted, so the counter sum
+ *  tracks reclaimed sessions. A failed sweep records a single `error`. */
+export const metricWebSessionSwept = (result: "ok" | "error", count = 1): void =>
+  webSessionSwept.add(count, { result });
+
+/** Record one leg of an OIDC sign-in. See `OidcLoginOutcome` for the values. */
+export const metricOidcLogin = (outcome: OidcLoginOutcome): void => oidcLogin.inc({ outcome });
+
+/**
+ * Which credential a request presented. `bearer` is the iOS app's access JWT,
+ * `cookie` the browser's Pulse web session — the split shows how the web
+ * surface's traffic moves off bearer tokens as sign-in rolls out. A request
+ * with no credential at all is not counted: on the many optional-auth reads
+ * that is the ordinary case, not an event.
+ */
+export type CallerCredential = "bearer" | "cookie";
+type CallerAuthAttrs = { credential: CallerCredential; result: "ok" | "rejected" };
+
+const callerAuth = createCounter<CallerAuthAttrs>({
+  name: PULSE_METRICS.callerAuth,
+  description: "Requests carrying a credential, by credential kind and whether it resolved",
+  unit: "{request}",
+});
+
+/** Record one credential presentation. See `CallerCredential`. */
+export const metricCallerAuth = (credential: CallerCredential, result: "ok" | "rejected"): void =>
+  callerAuth.inc({ credential, result });
+
+const originGuardRejections = createCounter<{ reason: OriginGuardRejectionReason }>({
+  name: PULSE_METRICS.originGuardRejections,
+  description: "State-changing cookie-authenticated requests refused by the origin guard",
+  unit: "{request}",
+});
+
+/** A cookie-carrying write was refused for a missing or non-allowlisted `Origin`. */
+export const metricOriginGuardRejection = (reason: OriginGuardRejectionReason): void =>
+  originGuardRejections.inc({ reason });
 
 const measureSecondsHelper =
   (onDuration: (seconds: number, outcome: "ok" | "error") => void) =>

--- a/pulse/api/src/redis.ts
+++ b/pulse/api/src/redis.ts
@@ -26,6 +26,8 @@ import { createClientFromUrl } from "@shared/redis/ioredis";
 import { Effect, type Layer } from "effect";
 
 import {
+  createRedisAuthSessionRateLimiter,
+  createRedisAuthStartRateLimiter,
   createRedisDiscoveryRateLimiter,
   createRedisExposureRateLimiter,
   createRedisShareRateLimiter,
@@ -46,6 +48,10 @@ export interface PulseRateLimiters {
   discovery: RateLimiterBackend;
   share: RateLimiterBackend;
   exposure: RateLimiterBackend;
+  /** Redirect legs of the OIDC sign-in (`/api/auth/oidc/*`) — tight bucket. */
+  authStart: RateLimiterBackend;
+  /** Session probe + sign-out (`/api/auth/session`, `/api/auth/signout`). */
+  authSession: RateLimiterBackend;
 }
 
 /** Build every Pulse rate-limiter backend from a single `RedisClient`. */
@@ -55,6 +61,8 @@ export function makeRateLimiters(client: RedisClient): PulseRateLimiters {
     discovery: createRedisDiscoveryRateLimiter(client),
     share: createRedisShareRateLimiter(client),
     exposure: createRedisExposureRateLimiter(client),
+    authStart: createRedisAuthStartRateLimiter(client),
+    authSession: createRedisAuthSessionRateLimiter(client),
   };
 }
 

--- a/pulse/api/src/routes/account.ts
+++ b/pulse/api/src/routes/account.ts
@@ -1,8 +1,8 @@
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import { notifyAppLeft, verifyStepUp } from "../lib/osn-bridge";
 import {
@@ -35,14 +35,12 @@ export const createAccountRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   return new Elysia({ prefix: "/account" })
     .delete(
       "",
       async ({ body, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           metricPulseAccountDeletionRequested("error");
@@ -149,10 +147,7 @@ export const createAccountRoutes = (
     .post(
       "/restore",
       async ({ headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { error: "unauthorized" } as const;
@@ -183,10 +178,7 @@ export const createAccountRoutes = (
     .get(
       "/deletion-status",
       async ({ headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { error: "unauthorized" } as const;

--- a/pulse/api/src/routes/auth.ts
+++ b/pulse/api/src/routes/auth.ts
@@ -1,0 +1,348 @@
+import { DbLive, type Db } from "@pulse/db/service";
+import { beginLogin, completeLogin, readReturnTo } from "@shared/osn-auth-client/oidc-rp";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
+import {
+  createRateLimiter,
+  getClientIp,
+  isUnresolvedIp,
+  type ClientIpOptions,
+  type RateLimiterBackend,
+} from "@shared/rate-limit";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { Elysia } from "elysia";
+
+import {
+  buildOidcTxCookie,
+  buildWebSessionCookie,
+  clearOidcTxCookie,
+  clearWebSessionCookie,
+  parseOidcTxCookie,
+  parseWebSessionToken,
+} from "../lib/cookie";
+import { metricOidcLogin } from "../metrics";
+import { webSessionService } from "../services/webSession";
+
+/**
+ * Pulse web sign-in, the OIDC relying-party side.
+ *
+ * The browser never holds an OSN token. It bounces to the issuer, comes back
+ * with a code, and leaves with a Pulse session cookie — host-scoped, opaque,
+ * SHA-256 hashed at rest. The iOS app is untouched: it still holds an OSN
+ * refresh token and presents a bearer access JWT, and every route here is
+ * reachable only by a browser.
+ *
+ * **CSRF.** A cookie credential makes Pulse writes CSRF-eligible for the first
+ * time. Two things cover that: `SameSite=Lax` on the cookie, and the app-wide
+ * `originGuard`, which — unlike cire's — fires only when the session cookie is
+ * present, because Pulse's write callers include a native app that sends no
+ * `Origin` header. See `lib/origin-guard.ts`.
+ *
+ * Both OIDC legs are GETs, so the origin guard does not apply to them; the
+ * `state` match is what protects the callback.
+ */
+
+const PREFIX = "/api/auth";
+
+/** Seven days — must match `webSessionService`'s default TTL. */
+const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+const ONE_MINUTE_MS = 60_000;
+
+/**
+ * Tight per-IP bucket for the redirect legs. Each `/oidc/start` mints a
+ * transaction and each `/oidc/callback` costs an issuer token exchange plus a
+ * session insert, so a low ceiling is both safe and generous: a human signs in
+ * once, and a retry loop after a failure is a handful of clicks.
+ */
+export function createDefaultAuthStartRateLimiter(): RateLimiterBackend {
+  return createRateLimiter({ maxRequests: 20, windowMs: ONE_MINUTE_MS });
+}
+
+/**
+ * Looser per-IP bucket for `GET /session` + `POST /signout`. The session probe
+ * runs on every page load of the web app, and a shared NAT egress puts many
+ * legitimate users behind one key, so this needs far more headroom than the
+ * redirect legs.
+ */
+export function createDefaultAuthSessionRateLimiter(): RateLimiterBackend {
+  return createRateLimiter({ maxRequests: 120, windowMs: ONE_MINUTE_MS });
+}
+
+const redirect = (location: string, cookies: string[]): Response => {
+  const headers = new Headers({ location, "cache-control": "no-store" });
+  // One `Set-Cookie` per cookie: `Headers.append` is the only way to emit the
+  // repeated header, and a joined string would be one malformed cookie.
+  for (const cookie of cookies) headers.append("set-cookie", cookie);
+  return new Response(null, { status: 302, headers });
+};
+
+/**
+ * Terminal sign-in failure on a top-level browser navigation. Rather than
+ * render raw JSON the user would see in the address bar, bounce to a page the
+ * web app controls — their `return_to` when we still trust one, else the login
+ * page — with `?auth_error=<code>` for it to turn into a friendly message.
+ * `loginFallbackUrl` is a server-configured, allowlisted origin, so this is
+ * never an open redirect even when the transaction cookie (the usual source of
+ * `returnTo`) is missing, expired, or forged.
+ */
+const errorRedirect = (
+  returnTo: string | null,
+  loginFallbackUrl: string,
+  reason: string,
+  secure: boolean,
+): Response => {
+  const clear = clearOidcTxCookie({ secure });
+  const url = new URL(returnTo ?? loginFallbackUrl);
+  url.searchParams.set("auth_error", reason);
+  return redirect(url.toString(), [clear]);
+};
+
+export interface AuthRouteOptions {
+  /** Fully-built RP config; `null` ⇒ the tier has no OIDC credentials. */
+  oidc: OidcConfig | null;
+  /** Cookie `Secure` flag — set for every https tier. */
+  secureCookies: boolean;
+  /**
+   * Absolute URL of the Pulse web login page (an allowlisted origin). Terminal
+   * callback/start failures with no trusted `return_to` land here with an
+   * `?auth_error` marker instead of rendering JSON to the browser.
+   */
+  loginFallbackUrl: string;
+  /** Per-IP limiter for the redirect legs. Defaults to the in-memory backend. */
+  startLimiter?: RateLimiterBackend;
+  /** Per-IP limiter for the session probe + sign-out. */
+  sessionLimiter?: RateLimiterBackend;
+  /**
+   * Client-IP trust policy (S-M34), same value the events routes get. Defaults
+   * to `{}` — direct mode, socket peer only, never a spoofable
+   * `x-forwarded-for`.
+   */
+  clientIpConfig?: Omit<ClientIpOptions, "socketIp">;
+}
+
+export const createAuthRoutes = (
+  dbLayer: Layer.Layer<Db> = DbLive,
+  {
+    oidc,
+    secureCookies,
+    loginFallbackUrl,
+    startLimiter = createDefaultAuthStartRateLimiter(),
+    sessionLimiter = createDefaultAuthSessionRateLimiter(),
+    clientIpConfig = {},
+  }: AuthRouteOptions,
+) => {
+  // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
+  const runtime = ManagedRuntime.make(dbLayer);
+
+  /**
+   * Resolve the trusted per-IP key under the configured policy (S-M34), the
+   * same helper pair the unauthenticated events surfaces use — Pulse limits
+   * per-IP inline in the route factory rather than through a middleware.
+   */
+  const resolveIp = (
+    headers: Record<string, string | undefined>,
+    server: { requestIP?: (req: Request) => { address?: string } | null } | null,
+    request: Request,
+  ): string =>
+    getClientIp(headers, {
+      ...clientIpConfig,
+      socketIp: server?.requestIP?.(request)?.address ?? null,
+    });
+
+  /** Fail-closed: an unresolved IP or a backend error both deny. */
+  const checkPerIpLimit = async (ip: string, limiter: RateLimiterBackend): Promise<boolean> => {
+    if (isUnresolvedIp(ip)) return false;
+    try {
+      return await limiter.check(ip);
+    } catch {
+      return false;
+    }
+  };
+
+  const redirectLegs = new Elysia({ prefix: PREFIX })
+    // -----------------------------------------------------------------------
+    // GET /api/auth/oidc/start?return_to=…&prompt=create — leg 1.
+    //
+    // A plain link the web app points its "Sign in" button at. `return_to` is
+    // where the browser lands afterwards; it must be an allowlisted origin.
+    //
+    // `prompt` is optional and allowlisted to `create` — the "Create account"
+    // button asks the issuer to open on its sign-up screen. Every other value
+    // is dropped rather than rejected: the query string is attacker-reachable,
+    // and forwarding it blind would let anyone turn a sign-in link into
+    // `prompt=none`, which asks for a silent grant with no screen at all.
+    // -----------------------------------------------------------------------
+    .get("/oidc/start", async ({ query, headers, server, request }) => {
+      const ip = resolveIp(headers, server, request);
+      if (!(await checkPerIpLimit(ip, startLimiter))) {
+        return new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (!oidc) {
+        // A top-level navigation from the "Sign in" button — send the browser
+        // to the login page with a marker, not a raw 503 JSON body it would
+        // render in the address bar.
+        metricOidcLogin("bad_request");
+        return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
+      }
+      const returnTo = typeof query["return_to"] === "string" ? query["return_to"] : "";
+      const started = await beginLogin(
+        oidc,
+        returnTo,
+        query["prompt"] === "create" ? { prompt: "create" } : {},
+      );
+      if (!started) {
+        metricOidcLogin("bad_request");
+        return new Response(JSON.stringify({ error: "invalid_return_to" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      metricOidcLogin("start");
+      return redirect(started.authorizeUrl, [
+        buildOidcTxCookie(started.tx, {
+          secure: secureCookies,
+          maxAgeSeconds: started.txMaxAgeSeconds,
+        }),
+      ]);
+    })
+    // -----------------------------------------------------------------------
+    // GET /api/auth/oidc/callback — leg 2.
+    //
+    // Arrives as a top-level navigation from the issuer. Every failure path
+    // clears the transaction cookie: it is single-use by construction, and
+    // leaving a spent PKCE verifier in the browser buys nothing.
+    // -----------------------------------------------------------------------
+    .get("/oidc/callback", async ({ query, headers, server, request }) => {
+      const ip = resolveIp(headers, server, request);
+      if (!(await checkPerIpLimit(ip, startLimiter))) {
+        return new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (!oidc) {
+        metricOidcLogin("bad_request");
+        return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
+      }
+      const tx = parseOidcTxCookie(request.headers.get("cookie"));
+
+      // The issuer refused (consent denied, `login_required`, …). Its own
+      // `error` string is never echoed onward — it is unbounded text from
+      // outside, and the frontend only needs to know the sign-in did not
+      // happen.
+      if (typeof query["error"] === "string") {
+        metricOidcLogin("provider_error");
+        return errorRedirect(
+          await readReturnTo(oidc, tx),
+          loginFallbackUrl,
+          "sign_in_declined",
+          secureCookies,
+        );
+      }
+
+      const result = await completeLogin(oidc, {
+        code: typeof query["code"] === "string" ? query["code"] : null,
+        state: typeof query["state"] === "string" ? query["state"] : null,
+        tx,
+      });
+
+      if (!result.ok) {
+        metricOidcLogin(result.reason);
+        return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
+      }
+
+      const session = await runtime.runPromise(
+        webSessionService
+          .create(result.identity, SESSION_TTL_SECONDS)
+          .pipe(Effect.catchTag("WebSessionWriteError", () => Effect.succeed(null))),
+      );
+      if (!session) {
+        // The database refused the insert. Nothing to sign the user in with,
+        // and a retry is a single click, so send them back with the same
+        // generic marker.
+        metricOidcLogin("exchange_failed");
+        return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
+      }
+
+      metricOidcLogin("callback_ok");
+      return redirect(result.returnTo, [
+        buildWebSessionCookie(session.token, {
+          secure: secureCookies,
+          maxAgeSeconds: SESSION_TTL_SECONDS,
+        }),
+        clearOidcTxCookie({ secure: secureCookies }),
+      ]);
+    });
+
+  const sessionRoutes = new Elysia({ prefix: PREFIX })
+    // -----------------------------------------------------------------------
+    // GET /api/auth/session — who is signed in.
+    //
+    // 200 with the profile snapshot, or 200 with `{ signedIn: false }`. NOT a
+    // 401: this is the probe every page runs on load to decide whether to show
+    // the sign-in button, and a signed-out visitor is the expected case, not an
+    // error.
+    // -----------------------------------------------------------------------
+    .get("/session", async ({ headers, server, request, set }) => {
+      const ip = resolveIp(headers, server, request);
+      if (!(await checkPerIpLimit(ip, sessionLimiter))) {
+        set.status = 429;
+        return { error: "rate_limited" } as const;
+      }
+      const token = parseWebSessionToken(request.headers.get("cookie"));
+      if (!token) return { signedIn: false as const };
+      const session = await runtime.runPromise(
+        webSessionService
+          .validate(token)
+          .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null))),
+      );
+      if (!session) return { signedIn: false as const };
+      return {
+        signedIn: true as const,
+        osnProfileId: session.osnProfileId,
+        email: session.email,
+        handle: session.handle,
+        displayName: session.displayName,
+        avatarUrl: session.avatarUrl,
+        expiresAt: session.expiresAt.toISOString(),
+      };
+    })
+    // -----------------------------------------------------------------------
+    // POST /api/auth/signout — drop the session row and the cookie.
+    //
+    // `?all=1` drops every session for the profile (all browsers). Always 200,
+    // even with no cookie: signing out is idempotent, and telling a caller
+    // whether a token was live is a free oracle.
+    // -----------------------------------------------------------------------
+    .post("/signout", async ({ query, headers, server, request, set }) => {
+      const ip = resolveIp(headers, server, request);
+      if (!(await checkPerIpLimit(ip, sessionLimiter))) {
+        set.status = 429;
+        return { error: "rate_limited" } as const;
+      }
+      const token = parseWebSessionToken(request.headers.get("cookie"));
+      if (token) {
+        await runtime.runPromise(
+          Effect.gen(function* () {
+            if (query["all"] === "1") {
+              const session = yield* webSessionService
+                .validate(token)
+                .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null)));
+              if (session) {
+                yield* webSessionService.revokeAllForProfile(session.osnProfileId);
+                return;
+              }
+            }
+            yield* webSessionService.revoke(token);
+          }).pipe(Effect.catchTag("WebSessionWriteError", () => Effect.void)),
+        );
+      }
+      set.headers["set-cookie"] = clearWebSessionCookie({ secure: secureCookies });
+      return { ok: true } as const;
+    });
+
+  return new Elysia().use(redirectLegs).use(sessionRoutes);
+};

--- a/pulse/api/src/routes/auth.ts
+++ b/pulse/api/src/routes/auth.ts
@@ -43,6 +43,37 @@ import { webSessionService } from "../services/webSession";
 
 const PREFIX = "/api/auth";
 
+/**
+ * Hand-written OpenAPI responses for the four routes below.
+ *
+ * swift-openapi-generator refuses a document in which any operation carries no
+ * responses at all, and `@elysiajs/openapi` discards `detail.responses` the
+ * moment a route declares `response:` — so a route is either validated at
+ * runtime or documented by hand, never both. Every leg here returns a raw
+ * `Response` (302s carrying `set-cookie`) or a shape a TypeBox `response:`
+ * schema would describe worse than prose, so all four are documented by hand.
+ *
+ * `detail` is typed against OpenAPI 3.0, but the document the plugin emits is
+ * 3.1 — where `type: ["string", "null"]` is legal, and is the only nullable
+ * spelling swift-openapi-generator keeps (see `scripts/generate-openapi.ts`).
+ * The cast in `docSchema` is what lets a 3.1 schema be written here.
+ */
+const docSchema = (schema: Record<string, unknown>) => schema as never;
+
+const jsonResponse = (description: string, schema: Record<string, unknown>) => ({
+  description,
+  content: { "application/json": { schema: docSchema(schema) } },
+});
+
+const jsonErrorResponse = (description: string) =>
+  jsonResponse(description, {
+    type: "object",
+    properties: { error: { type: "string" } },
+    required: ["error"],
+  });
+
+const rateLimitedResponse = jsonErrorResponse("Per-IP rate limit exceeded.");
+
 /** Seven days — must match `webSessionService`'s default TTL. */
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 
@@ -172,42 +203,59 @@ export const createAuthRoutes = (
     // and forwarding it blind would let anyone turn a sign-in link into
     // `prompt=none`, which asks for a silent grant with no screen at all.
     // -----------------------------------------------------------------------
-    .get("/oidc/start", async ({ query, headers, server, request }) => {
-      const ip = resolveIp(headers, server, request);
-      if (!(await checkPerIpLimit(ip, startLimiter))) {
-        return new Response(JSON.stringify({ error: "rate_limited" }), {
-          status: 429,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      if (!oidc) {
-        // A top-level navigation from the "Sign in" button — send the browser
-        // to the login page with a marker, not a raw 503 JSON body it would
-        // render in the address bar.
-        metricOidcLogin("bad_request");
-        return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
-      }
-      const returnTo = typeof query["return_to"] === "string" ? query["return_to"] : "";
-      const started = await beginLogin(
-        oidc,
-        returnTo,
-        query["prompt"] === "create" ? { prompt: "create" } : {},
-      );
-      if (!started) {
-        metricOidcLogin("bad_request");
-        return new Response(JSON.stringify({ error: "invalid_return_to" }), {
-          status: 400,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      metricOidcLogin("start");
-      return redirect(started.authorizeUrl, [
-        buildOidcTxCookie(started.tx, {
-          secure: secureCookies,
-          maxAgeSeconds: started.txMaxAgeSeconds,
-        }),
-      ]);
-    })
+    .get(
+      "/oidc/start",
+      async ({ query, headers, server, request }) => {
+        const ip = resolveIp(headers, server, request);
+        if (!(await checkPerIpLimit(ip, startLimiter))) {
+          return new Response(JSON.stringify({ error: "rate_limited" }), {
+            status: 429,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (!oidc) {
+          // A top-level navigation from the "Sign in" button — send the browser
+          // to the login page with a marker, not a raw 503 JSON body it would
+          // render in the address bar.
+          metricOidcLogin("bad_request");
+          return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
+        }
+        const returnTo = typeof query["return_to"] === "string" ? query["return_to"] : "";
+        const started = await beginLogin(
+          oidc,
+          returnTo,
+          query["prompt"] === "create" ? { prompt: "create" } : {},
+        );
+        if (!started) {
+          metricOidcLogin("bad_request");
+          return new Response(JSON.stringify({ error: "invalid_return_to" }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        metricOidcLogin("start");
+        return redirect(started.authorizeUrl, [
+          buildOidcTxCookie(started.tx, {
+            secure: secureCookies,
+            maxAgeSeconds: started.txMaxAgeSeconds,
+          }),
+        ]);
+      },
+      {
+        detail: {
+          operationId: "startOidcSignIn",
+          summary: "Begin OSN OIDC sign-in",
+          responses: {
+            302: {
+              description:
+                "Redirect to the OSN authorize endpoint, carrying the transaction cookie. On a misconfigured issuer, a redirect back to the app with an `?auth_error=` marker instead.",
+            },
+            400: jsonErrorResponse("`return_to` is missing or not an allowlisted origin."),
+            429: rateLimitedResponse,
+          },
+        },
+      },
+    )
     // -----------------------------------------------------------------------
     // GET /api/auth/oidc/callback — leg 2.
     //
@@ -215,67 +263,83 @@ export const createAuthRoutes = (
     // clears the transaction cookie: it is single-use by construction, and
     // leaving a spent PKCE verifier in the browser buys nothing.
     // -----------------------------------------------------------------------
-    .get("/oidc/callback", async ({ query, headers, server, request }) => {
-      const ip = resolveIp(headers, server, request);
-      if (!(await checkPerIpLimit(ip, startLimiter))) {
-        return new Response(JSON.stringify({ error: "rate_limited" }), {
-          status: 429,
-          headers: { "content-type": "application/json" },
+    .get(
+      "/oidc/callback",
+      async ({ query, headers, server, request }) => {
+        const ip = resolveIp(headers, server, request);
+        if (!(await checkPerIpLimit(ip, startLimiter))) {
+          return new Response(JSON.stringify({ error: "rate_limited" }), {
+            status: 429,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (!oidc) {
+          metricOidcLogin("bad_request");
+          return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
+        }
+        const tx = parseOidcTxCookie(request.headers.get("cookie"));
+
+        // The issuer refused (consent denied, `login_required`, …). Its own
+        // `error` string is never echoed onward — it is unbounded text from
+        // outside, and the frontend only needs to know the sign-in did not
+        // happen.
+        if (typeof query["error"] === "string") {
+          metricOidcLogin("provider_error");
+          return errorRedirect(
+            await readReturnTo(oidc, tx),
+            loginFallbackUrl,
+            "sign_in_declined",
+            secureCookies,
+          );
+        }
+
+        const result = await completeLogin(oidc, {
+          code: typeof query["code"] === "string" ? query["code"] : null,
+          state: typeof query["state"] === "string" ? query["state"] : null,
+          tx,
         });
-      }
-      if (!oidc) {
-        metricOidcLogin("bad_request");
-        return errorRedirect(null, loginFallbackUrl, "sign_in_unavailable", secureCookies);
-      }
-      const tx = parseOidcTxCookie(request.headers.get("cookie"));
 
-      // The issuer refused (consent denied, `login_required`, …). Its own
-      // `error` string is never echoed onward — it is unbounded text from
-      // outside, and the frontend only needs to know the sign-in did not
-      // happen.
-      if (typeof query["error"] === "string") {
-        metricOidcLogin("provider_error");
-        return errorRedirect(
-          await readReturnTo(oidc, tx),
-          loginFallbackUrl,
-          "sign_in_declined",
-          secureCookies,
+        if (!result.ok) {
+          metricOidcLogin(result.reason);
+          return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
+        }
+
+        const session = await runtime.runPromise(
+          webSessionService
+            .create(result.identity, SESSION_TTL_SECONDS)
+            .pipe(Effect.catchTag("WebSessionWriteError", () => Effect.succeed(null))),
         );
-      }
+        if (!session) {
+          // The database refused the insert. Nothing to sign the user in with,
+          // and a retry is a single click, so send them back with the same
+          // generic marker.
+          metricOidcLogin("exchange_failed");
+          return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
+        }
 
-      const result = await completeLogin(oidc, {
-        code: typeof query["code"] === "string" ? query["code"] : null,
-        state: typeof query["state"] === "string" ? query["state"] : null,
-        tx,
-      });
-
-      if (!result.ok) {
-        metricOidcLogin(result.reason);
-        return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
-      }
-
-      const session = await runtime.runPromise(
-        webSessionService
-          .create(result.identity, SESSION_TTL_SECONDS)
-          .pipe(Effect.catchTag("WebSessionWriteError", () => Effect.succeed(null))),
-      );
-      if (!session) {
-        // The database refused the insert. Nothing to sign the user in with,
-        // and a retry is a single click, so send them back with the same
-        // generic marker.
-        metricOidcLogin("exchange_failed");
-        return errorRedirect(result.returnTo, loginFallbackUrl, "sign_in_failed", secureCookies);
-      }
-
-      metricOidcLogin("callback_ok");
-      return redirect(result.returnTo, [
-        buildWebSessionCookie(session.token, {
-          secure: secureCookies,
-          maxAgeSeconds: SESSION_TTL_SECONDS,
-        }),
-        clearOidcTxCookie({ secure: secureCookies }),
-      ]);
-    });
+        metricOidcLogin("callback_ok");
+        return redirect(result.returnTo, [
+          buildWebSessionCookie(session.token, {
+            secure: secureCookies,
+            maxAgeSeconds: SESSION_TTL_SECONDS,
+          }),
+          clearOidcTxCookie({ secure: secureCookies }),
+        ]);
+      },
+      {
+        detail: {
+          operationId: "completeOidcSignIn",
+          summary: "Complete OSN OIDC sign-in",
+          responses: {
+            302: {
+              description:
+                "Redirect back to `return_to`, setting the Pulse session cookie and clearing the transaction cookie. Every failure path redirects to the same place with an `?auth_error=` marker instead.",
+            },
+            429: rateLimitedResponse,
+          },
+        },
+      },
+    );
 
   const sessionRoutes = new Elysia({ prefix: PREFIX })
     // -----------------------------------------------------------------------
@@ -286,30 +350,58 @@ export const createAuthRoutes = (
     // the sign-in button, and a signed-out visitor is the expected case, not an
     // error.
     // -----------------------------------------------------------------------
-    .get("/session", async ({ headers, server, request, set }) => {
-      const ip = resolveIp(headers, server, request);
-      if (!(await checkPerIpLimit(ip, sessionLimiter))) {
-        set.status = 429;
-        return { error: "rate_limited" } as const;
-      }
-      const token = parseWebSessionToken(request.headers.get("cookie"));
-      if (!token) return { signedIn: false as const };
-      const session = await runtime.runPromise(
-        webSessionService
-          .validate(token)
-          .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null))),
-      );
-      if (!session) return { signedIn: false as const };
-      return {
-        signedIn: true as const,
-        osnProfileId: session.osnProfileId,
-        email: session.email,
-        handle: session.handle,
-        displayName: session.displayName,
-        avatarUrl: session.avatarUrl,
-        expiresAt: session.expiresAt.toISOString(),
-      };
-    })
+    .get(
+      "/session",
+      async ({ headers, server, request, set }) => {
+        const ip = resolveIp(headers, server, request);
+        if (!(await checkPerIpLimit(ip, sessionLimiter))) {
+          set.status = 429;
+          return { error: "rate_limited" } as const;
+        }
+        const token = parseWebSessionToken(request.headers.get("cookie"));
+        if (!token) return { signedIn: false as const };
+        const session = await runtime.runPromise(
+          webSessionService
+            .validate(token)
+            .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null))),
+        );
+        if (!session) return { signedIn: false as const };
+        return {
+          signedIn: true as const,
+          osnProfileId: session.osnProfileId,
+          email: session.email,
+          handle: session.handle,
+          displayName: session.displayName,
+          avatarUrl: session.avatarUrl,
+          expiresAt: session.expiresAt.toISOString(),
+        };
+      },
+      {
+        detail: {
+          operationId: "getWebSession",
+          summary: "Who is signed in",
+          responses: {
+            200: jsonResponse(
+              "The viewer's session. The identity fields are present only when `signedIn` is true.",
+              {
+                type: "object",
+                properties: {
+                  signedIn: { type: "boolean" },
+                  osnProfileId: { type: "string" },
+                  email: { type: "string" },
+                  handle: { type: "string" },
+                  displayName: { type: "string" },
+                  avatarUrl: { type: ["string", "null"] },
+                  expiresAt: { type: "string", format: "date-time" },
+                },
+                required: ["signedIn"],
+              },
+            ),
+            429: rateLimitedResponse,
+          },
+        },
+      },
+    )
     // -----------------------------------------------------------------------
     // POST /api/auth/signout — drop the session row and the cookie.
     //
@@ -317,32 +409,49 @@ export const createAuthRoutes = (
     // even with no cookie: signing out is idempotent, and telling a caller
     // whether a token was live is a free oracle.
     // -----------------------------------------------------------------------
-    .post("/signout", async ({ query, headers, server, request, set }) => {
-      const ip = resolveIp(headers, server, request);
-      if (!(await checkPerIpLimit(ip, sessionLimiter))) {
-        set.status = 429;
-        return { error: "rate_limited" } as const;
-      }
-      const token = parseWebSessionToken(request.headers.get("cookie"));
-      if (token) {
-        await runtime.runPromise(
-          Effect.gen(function* () {
-            if (query["all"] === "1") {
-              const session = yield* webSessionService
-                .validate(token)
-                .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null)));
-              if (session) {
-                yield* webSessionService.revokeAllForProfile(session.osnProfileId);
-                return;
+    .post(
+      "/signout",
+      async ({ query, headers, server, request, set }) => {
+        const ip = resolveIp(headers, server, request);
+        if (!(await checkPerIpLimit(ip, sessionLimiter))) {
+          set.status = 429;
+          return { error: "rate_limited" } as const;
+        }
+        const token = parseWebSessionToken(request.headers.get("cookie"));
+        if (token) {
+          await runtime.runPromise(
+            Effect.gen(function* () {
+              if (query["all"] === "1") {
+                const session = yield* webSessionService
+                  .validate(token)
+                  .pipe(Effect.catchTag("WebSessionInvalid", () => Effect.succeed(null)));
+                if (session) {
+                  yield* webSessionService.revokeAllForProfile(session.osnProfileId);
+                  return;
+                }
               }
-            }
-            yield* webSessionService.revoke(token);
-          }).pipe(Effect.catchTag("WebSessionWriteError", () => Effect.void)),
-        );
-      }
-      set.headers["set-cookie"] = clearWebSessionCookie({ secure: secureCookies });
-      return { ok: true } as const;
-    });
+              yield* webSessionService.revoke(token);
+            }).pipe(Effect.catchTag("WebSessionWriteError", () => Effect.void)),
+          );
+        }
+        set.headers["set-cookie"] = clearWebSessionCookie({ secure: secureCookies });
+        return { ok: true } as const;
+      },
+      {
+        detail: {
+          operationId: "signOutWebSession",
+          summary: "Drop the Pulse session cookie",
+          responses: {
+            200: jsonResponse("Signed out. Always 200, with or without a live session.", {
+              type: "object",
+              properties: { ok: { type: "boolean" } },
+              required: ["ok"],
+            }),
+            429: rateLimitedResponse,
+          },
+        },
+      },
+    );
 
   return new Elysia().use(redirectLegs).use(sessionRoutes);
 };

--- a/pulse/api/src/routes/closeFriends.ts
+++ b/pulse/api/src/routes/closeFriends.ts
@@ -124,7 +124,9 @@ export const createCloseFriendsRoutes = (
               displayName: p.displayName,
               avatarUrl: p.avatarUrl,
             }))
-            .sort((a, b) => (a.displayName ?? a.handle).localeCompare(b.displayName ?? b.handle)),
+            .toSorted((a, b) =>
+              (a.displayName ?? a.handle).localeCompare(b.displayName ?? b.handle),
+            ),
         };
       },
       {

--- a/pulse/api/src/routes/closeFriends.ts
+++ b/pulse/api/src/routes/closeFriends.ts
@@ -12,7 +12,7 @@ import {
   listCloseFriendIds,
   removeCloseFriend,
 } from "../services/closeFriends";
-import { getProfileDisplays } from "../services/graphBridge";
+import { getConnectionIds, getProfileDisplays } from "../services/graphBridge";
 
 /**
  * Pulse-scoped close-friends routes. The list lives in `pulse_close_friends`
@@ -22,6 +22,11 @@ import { getProfileDisplays } from "../services/graphBridge";
  * Profile metadata for `GET /close-friends` is joined from OSN via the
  * graph bridge so the client gets handle/displayName/avatar without
  * having to look up each id separately.
+ *
+ * `GET /close-friends/candidates` serves the picker: the caller's OSN
+ * connections with the same display fields. Clients can't read the graph
+ * themselves — a browser holds a Pulse session cookie, not an OSN token —
+ * so the fan-out over both bridge calls happens here.
  */
 export const createCloseFriendsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
@@ -84,6 +89,60 @@ export const createCloseFriendsRoutes = (
           401: t.Object({ message: t.String() }),
         },
         detail: { operationId: "listCloseFriends", security: [{ bearerAuth: [] }] },
+      },
+    )
+    .get(
+      "/candidates",
+      async ({ headers, set }) => {
+        const claims = await resolveCaller(headers);
+        if (!claims) {
+          set.status = 401;
+          return { message: "Unauthorized" } as const;
+        }
+        // The eligible set is exactly the caller's accepted connections —
+        // `addCloseFriend` rejects anything else with `not_a_connection`, so
+        // the picker and the write gate read the same list.
+        const connections = await runtime.runPromise(
+          getConnectionIds(claims.profileId).pipe(
+            Effect.flatMap((ids) => getProfileDisplays([...ids])),
+            Effect.map((displays) => [...displays.values()]),
+            Effect.catchTag("GraphBridgeError", () => Effect.succeed(null)),
+          ),
+        );
+        if (connections === null) {
+          // Unlike `GET /close-friends`, there's nothing to degrade to: an
+          // unnamed picker row is unusable, so say the graph is unreachable.
+          set.status = 502;
+          return { error: "Connections unavailable" } as const;
+        }
+        set.headers["cache-control"] = "private, max-age=30";
+        return {
+          connections: connections
+            .map((p) => ({
+              profileId: p.id,
+              handle: p.handle,
+              displayName: p.displayName,
+              avatarUrl: p.avatarUrl,
+            }))
+            .sort((a, b) => (a.displayName ?? a.handle).localeCompare(b.displayName ?? b.handle)),
+        };
+      },
+      {
+        response: {
+          200: t.Object({
+            connections: t.Array(
+              t.Object({
+                profileId: t.String(),
+                handle: t.String(),
+                displayName: t.Nullable(t.String()),
+                avatarUrl: t.Nullable(t.String()),
+              }),
+            ),
+          }),
+          401: t.Object({ message: t.String() }),
+          502: t.Object({ error: t.String() }),
+        },
+        detail: { operationId: "listCloseFriendCandidates", security: [{ bearerAuth: [] }] },
       },
     )
     .post(

--- a/pulse/api/src/routes/closeFriends.ts
+++ b/pulse/api/src/routes/closeFriends.ts
@@ -1,9 +1,9 @@
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import { checkWriteRateLimit, createDefaultWriteRateLimiter } from "../lib/rate-limit";
 import {
@@ -36,14 +36,12 @@ export const createCloseFriendsRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   return new Elysia({ prefix: "/close-friends" })
     .get(
       "/",
       async ({ headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;
@@ -91,10 +89,7 @@ export const createCloseFriendsRoutes = (
     .post(
       "/:friendId",
       async ({ params, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;
@@ -145,10 +140,7 @@ export const createCloseFriendsRoutes = (
     .delete(
       "/:friendId",
       async ({ params, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;
@@ -195,10 +187,7 @@ export const createCloseFriendsRoutes = (
     .get(
       "/:friendId/check",
       async ({ params, headers, set }) => {
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -1,6 +1,5 @@
 import type { Event, EventRsvp } from "@pulse/db/schema";
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import {
   createRateLimiter,
   getClientIp,
@@ -11,6 +10,7 @@ import {
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { MAX_PRICE_MAJOR } from "../lib/currency";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import { MAX_EVENT_GUESTS } from "../lib/limits";
@@ -355,6 +355,7 @@ export const createEventsRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   const eventCreateLimiter =
     writeRateLimiters.eventCreate ?? createDefaultWriteRateLimiter("event_create");
   const eventUpdateLimiter =
@@ -409,10 +410,7 @@ export const createEventsRoutes = (
       .get(
         "/",
         async ({ query, headers }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const result = await runtime.runPromise(
             listEvents({ ...query, viewerId: claims?.profileId ?? null }),
           );
@@ -444,10 +442,7 @@ export const createEventsRoutes = (
         async ({ query, headers, set }) => {
           // The personal agenda is viewer-scoped, so authentication is
           // required — an anonymous caller has no events to show.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -491,10 +486,7 @@ export const createEventsRoutes = (
             set.status = 429;
             return { error: "Too many requests" } as const;
           }
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const viewerId = claims?.profileId ?? null;
           // `friendsOnly` without a viewer is a validation error — the
           // service raises `DiscoveryValidationError`, which we map to
@@ -578,10 +570,7 @@ export const createEventsRoutes = (
           // only returned to the organiser or to invited / RSVP'd users.
           // 404 (not 403) for non-authorised viewers so we don't leak
           // existence.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const result = await runtime.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null),
           );
@@ -609,10 +598,7 @@ export const createEventsRoutes = (
       .post(
         "/",
         async ({ body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -677,10 +663,7 @@ export const createEventsRoutes = (
       .patch(
         "/:id",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -752,10 +735,7 @@ export const createEventsRoutes = (
       .delete(
         "/:id",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -795,10 +775,7 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps",
         async ({ params, query, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const viewerId = claims?.profileId ?? null;
           // Visibility gate first — private events are 404 to non-viewers.
           const event = await runtime.runPromise(loadVisibleEvent(params.id, viewerId));
@@ -870,10 +847,7 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps/counts",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           // S-H5: gate counts by visibility — leaking the existence /
           // activity of a private event is its own information disclosure.
           const event = await runtime.runPromise(
@@ -912,10 +886,7 @@ export const createEventsRoutes = (
       .get(
         "/:id/rsvps/latest",
         async ({ params, query, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const viewerId = claims?.profileId ?? null;
           const event = await runtime.runPromise(loadVisibleEvent(params.id, viewerId));
           if (event === null) {
@@ -972,10 +943,7 @@ export const createEventsRoutes = (
       .post(
         "/:id/rsvps",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -1045,10 +1013,7 @@ export const createEventsRoutes = (
           // Visibility gate: we don't want a private event's share count
           // to be derivable by anyone with the URL — same posture as
           // every other direct-fetch surface on this controller.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const meta = await runtime.runPromise(
             checkEventVisibility(params.id, claims?.profileId ?? null),
           );
@@ -1083,10 +1048,7 @@ export const createEventsRoutes = (
             set.status = 429;
             return { error: "Too many requests" } as const;
           }
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const meta = await runtime.runPromise(
             checkEventVisibility(params.id, claims?.profileId ?? null),
           );
@@ -1119,10 +1081,7 @@ export const createEventsRoutes = (
       .post(
         "/:id/invite",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -1178,10 +1137,7 @@ export const createEventsRoutes = (
           // S-H2: gate ICS export by visibility. Otherwise the file
           // download leaks event metadata (incl. GEO coordinates) for
           // private events to anyone with the URL.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const event = await runtime.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null),
           );
@@ -1270,10 +1226,7 @@ export const createEventsRoutes = (
           // S-H3: gate comms by visibility. Blast bodies often contain
           // venue codes, addresses, dress codes — they should never be
           // visible to viewers who can't see the event.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const event = await runtime.runPromise(
             loadVisibleEvent(params.id, claims?.profileId ?? null),
           );
@@ -1326,10 +1279,7 @@ export const createEventsRoutes = (
       .post(
         "/:id/comms/blasts",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -432,10 +432,7 @@ export const createEventsRoutes = (
           // Same optional-viewer shape as `GET /events`: the feed stays
           // public, but who is asking decides which private events belong
           // in it. Anonymous callers see public events only.
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const result = await runtime.runPromise(listTodayEvents(claims?.profileId ?? null));
           return { events: result.map(serializeEvent) };
         },

--- a/pulse/api/src/routes/onboarding.ts
+++ b/pulse/api/src/routes/onboarding.ts
@@ -1,9 +1,9 @@
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import { createRateLimiter, getClientIp, type RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import {
   completeOnboarding,
@@ -122,6 +122,7 @@ export const createOnboardingRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   return new Elysia({ prefix: "/me/onboarding" })
     .get(
       "/",
@@ -141,10 +142,7 @@ export const createOnboardingRoutes = (
           set.status = 429;
           return { error: "Too many requests" } as const;
         }
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;
@@ -206,10 +204,7 @@ export const createOnboardingRoutes = (
           set.status = 429;
           return { error: "Too many requests" } as const;
         }
-        const claims = await extractClaims(headers["authorization"], jwksUrl, {
-          testKey: _testKey as CryptoKey,
-          audience: "osn-access",
-        });
+        const claims = await resolveCaller(headers);
         if (!claims) {
           set.status = 401;
           return { message: "Unauthorized" } as const;

--- a/pulse/api/src/routes/series.ts
+++ b/pulse/api/src/routes/series.ts
@@ -1,10 +1,10 @@
 import type { EventSeries } from "@pulse/db/schema";
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import { checkWriteRateLimit, createDefaultWriteRateLimiter } from "../lib/rate-limit";
 import { canViewEvent } from "../services/eventAccess";
@@ -100,6 +100,7 @@ export const createSeriesRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   const seriesCreateLimiter =
     writeRateLimiters.seriesCreate ?? createDefaultWriteRateLimiter("series_create");
   const seriesUpdateLimiter =
@@ -114,10 +115,7 @@ export const createSeriesRoutes = (
       .post(
         "/",
         async ({ body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -195,10 +193,7 @@ export const createSeriesRoutes = (
       .get(
         "/:id",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const viewerId = claims?.profileId ?? null;
 
           const series = await runtime.runPromise(
@@ -253,10 +248,7 @@ export const createSeriesRoutes = (
       .get(
         "/:id/instances",
         async ({ params, query, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           const result = await runtime.runPromise(
             listInstances(params.id, {
               scope: query.scope ?? "upcoming",
@@ -288,10 +280,7 @@ export const createSeriesRoutes = (
       .patch(
         "/:id",
         async ({ params, body, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -361,10 +350,7 @@ export const createSeriesRoutes = (
       .delete(
         "/:id",
         async ({ params, headers, set }) => {
-          const claims = await extractClaims(headers["authorization"], jwksUrl, {
-            testKey: _testKey as CryptoKey,
-            audience: "osn-access",
-          });
+          const claims = await resolveCaller(headers);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;

--- a/pulse/api/src/routes/settings.ts
+++ b/pulse/api/src/routes/settings.ts
@@ -1,8 +1,8 @@
 import { DbLive, type Db } from "@pulse/db/service";
-import { extractClaims } from "@shared/osn-auth-client/verify";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { makeCallerResolver } from "../lib/caller";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
 import { metricSettingsUpdated } from "../metrics";
 import { updateSettings } from "../services/pulseUsers";
@@ -21,13 +21,11 @@ export const createSettingsRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
+  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
   return new Elysia({ prefix: "/me" }).patch(
     "/settings",
     async ({ body, headers, set }) => {
-      const claims = await extractClaims(headers["authorization"], jwksUrl, {
-        testKey: _testKey as CryptoKey,
-        audience: "osn-access",
-      });
+      const claims = await resolveCaller(headers);
       if (!claims) {
         metricSettingsUpdated("attendance_visibility", "unauthorized");
         set.status = 401;

--- a/pulse/api/src/services/webSession.ts
+++ b/pulse/api/src/services/webSession.ts
@@ -1,0 +1,184 @@
+import { pulseWebSessions } from "@pulse/db/schema";
+import { Db } from "@pulse/db/service";
+import { generateToken, hashToken } from "@shared/crypto/tokens";
+import { rowsChanged } from "@shared/db-utils";
+import type { OsnIdentity } from "@shared/osn-auth-client/oidc-rp";
+import { eq, lte } from "drizzle-orm";
+import { Data, Effect } from "effect";
+
+import { metricWebSessionCreated, metricWebSessionSwept } from "../metrics";
+
+export class WebSessionInvalid extends Data.TaggedError("WebSessionInvalid")<{
+  reason: "missing" | "expired";
+}> {}
+
+export class WebSessionWriteError extends Data.TaggedError("WebSessionWriteError")<{
+  op: "insert" | "delete" | "deleteAllForProfile" | "sweep";
+  reason: string;
+}> {}
+
+/**
+ * Seven days, matching cire's organiser session.
+ *
+ * Renewal costs the user nothing: while their OSN session is alive — thirty
+ * days — the OIDC redirect round-trips without a prompt, so a lapsed Pulse
+ * session is an invisible flicker, not a passkey ceremony. Short window, free
+ * renewal.
+ */
+const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Login-time snapshot of the ID token's profile claims — the same shape the
+ * shared relying party hands back, named for this file's own vocabulary.
+ */
+export type WebIdentity = OsnIdentity;
+
+export interface CreatedWebSession {
+  token: string;
+  expiresAt: Date;
+}
+
+export interface ValidatedWebSession extends WebIdentity {
+  expiresAt: Date;
+}
+
+export const webSessionService = {
+  create(
+    identity: WebIdentity,
+    ttlSeconds: number = DEFAULT_TTL_SECONDS,
+  ): Effect.Effect<CreatedWebSession, WebSessionWriteError, Db> {
+    return Effect.gen(function* () {
+      const { db } = yield* Db;
+      const token = generateToken();
+      const tokenHash = yield* hashToken(token);
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(pulseWebSessions).values({
+            id: `pws_${crypto.randomUUID()}`,
+            token: tokenHash,
+            osnProfileId: identity.osnProfileId,
+            osnSub: identity.osnSub,
+            email: identity.email,
+            handle: identity.handle,
+            displayName: identity.displayName,
+            avatarUrl: identity.avatarUrl,
+            expiresAt,
+            createdAt: now,
+          }),
+        catch: (e) => new WebSessionWriteError({ op: "insert", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("web session insert failed", { reason: err.reason }),
+        ),
+      );
+      yield* Effect.sync(() => metricWebSessionCreated("ok"));
+      return { token, expiresAt };
+    }).pipe(
+      Effect.tapError(() => Effect.sync(() => metricWebSessionCreated("error"))),
+      Effect.withSpan("pulse.webSession.create"),
+    );
+  },
+
+  /**
+   * Resolve a cookie value to its identity. A database read cannot mint a
+   * session — only the SHA-256 hash is stored, so the lookup hashes first.
+   *
+   * Expiry is reported, not deleted: `sweepExpired` owns removal, and a read
+   * path that wrote would turn every unauthenticated GET into a write.
+   */
+  validate(token: string): Effect.Effect<ValidatedWebSession, WebSessionInvalid, Db> {
+    return Effect.gen(function* () {
+      const { db } = yield* Db;
+      if (!token) {
+        return yield* Effect.fail(new WebSessionInvalid({ reason: "missing" }));
+      }
+      const tokenHash = yield* hashToken(token);
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db.select().from(pulseWebSessions).where(eq(pulseWebSessions.token, tokenHash)).limit(1),
+        // A failed read is indistinguishable from no row to the caller: both
+        // mean "not signed in". Nothing here is worth a 500.
+        catch: () => new WebSessionInvalid({ reason: "missing" }),
+      });
+      const row = rows[0];
+      if (!row) {
+        return yield* Effect.fail(new WebSessionInvalid({ reason: "missing" }));
+      }
+      if (row.expiresAt.getTime() <= Date.now()) {
+        return yield* Effect.fail(new WebSessionInvalid({ reason: "expired" }));
+      }
+      return {
+        osnProfileId: row.osnProfileId,
+        osnSub: row.osnSub,
+        email: row.email,
+        handle: row.handle,
+        displayName: row.displayName,
+        avatarUrl: row.avatarUrl,
+        expiresAt: row.expiresAt,
+      };
+    }).pipe(Effect.withSpan("pulse.webSession.validate"));
+  },
+
+  revoke(token: string): Effect.Effect<void, WebSessionWriteError, Db> {
+    return Effect.gen(function* () {
+      const { db } = yield* Db;
+      const tokenHash = yield* hashToken(token);
+      yield* Effect.tryPromise({
+        try: () => db.delete(pulseWebSessions).where(eq(pulseWebSessions.token, tokenHash)),
+        catch: (e) => new WebSessionWriteError({ op: "delete", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("web session delete failed", { reason: err.reason }),
+        ),
+      );
+    }).pipe(Effect.withSpan("pulse.webSession.revoke"));
+  },
+
+  /**
+   * Sign out everywhere for one OSN profile. Called on `?all=1` sign-out, and
+   * the hook an OSN-side account deletion or OIDC connection revocation should
+   * reach for: this is the only browser credential Pulse holds.
+   */
+  revokeAllForProfile(osnProfileId: string): Effect.Effect<void, WebSessionWriteError, Db> {
+    return Effect.gen(function* () {
+      const { db } = yield* Db;
+      yield* Effect.tryPromise({
+        try: () =>
+          db.delete(pulseWebSessions).where(eq(pulseWebSessions.osnProfileId, osnProfileId)),
+        catch: (e) => new WebSessionWriteError({ op: "deleteAllForProfile", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("web session deleteAllForProfile failed", { reason: err.reason }),
+        ),
+      );
+    }).pipe(Effect.withSpan("pulse.webSession.revokeAllForProfile"));
+  },
+
+  /**
+   * Prune every session past its expiry (`<= now`). `validate` only *reports*
+   * expiry, so without this the table grows without bound. Returns the number
+   * of rows deleted.
+   */
+  sweepExpired(now: Date = new Date()): Effect.Effect<number, WebSessionWriteError, Db> {
+    return Effect.gen(function* () {
+      const { db } = yield* Db;
+      const result = yield* Effect.tryPromise({
+        try: () => db.delete(pulseWebSessions).where(lte(pulseWebSessions.expiresAt, now)),
+        catch: (e) => new WebSessionWriteError({ op: "sweep", reason: String(e) }),
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("web session sweep failed", { reason: err.reason }),
+        ),
+      );
+      const deleted = rowsChanged(result);
+      yield* Effect.sync(() => metricWebSessionSwept("ok", deleted));
+      yield* Effect.logInfo("web session sweep complete", { deleted });
+      return deleted;
+    }).pipe(
+      Effect.tapError(() => Effect.sync(() => metricWebSessionSwept("error"))),
+      Effect.withSpan("pulse.webSession.sweepExpired"),
+    );
+  },
+};

--- a/pulse/api/tests/lib/caller.test.ts
+++ b/pulse/api/tests/lib/caller.test.ts
@@ -1,0 +1,105 @@
+import type { Db } from "@pulse/db/service";
+import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/testing";
+import { ManagedRuntime } from "effect";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { makeCallerResolver, type ResolveCaller } from "../../src/lib/caller";
+import { webSessionService, type WebIdentity } from "../../src/services/webSession";
+import { createTestLayer } from "../helpers/db";
+
+// The JWKS URL is never fetched: every verify path here is given `testKey`.
+const JWKS_URL = "http://localhost:4000/.well-known/jwks.json";
+
+const identity: WebIdentity = {
+  osnProfileId: "usr_alice",
+  osnSub: "pairwise-sub-for-pulse",
+  email: "alice@example.com",
+  handle: "alice",
+  displayName: "Alice",
+  avatarUrl: "https://cdn.example/a.png",
+};
+
+let signer: AccessTokenSigner;
+let runtime: ManagedRuntime.ManagedRuntime<Db, never>;
+let resolveCaller: ResolveCaller;
+
+beforeAll(async () => {
+  signer = await makeAccessTokenSigner();
+});
+
+beforeEach(() => {
+  // Fresh in-memory DB per test — a leaked session row would make the
+  // "bearer does not fall back" test pass for the wrong reason.
+  runtime = ManagedRuntime.make(createTestLayer());
+  resolveCaller = makeCallerResolver({
+    runtime,
+    jwksUrl: JWKS_URL,
+    testKey: signer.publicKey,
+  });
+});
+
+const mintCookieSession = async (over: Partial<WebIdentity> = {}): Promise<string> => {
+  const created = await runtime.runPromise(webSessionService.create({ ...identity, ...over }));
+  return `pulse_web_session=${created.token}`;
+};
+
+describe("makeCallerResolver", () => {
+  it("resolves a bearer access token to its claims", async () => {
+    const token = await signer.sign("usr_bob", { email: "bob@example.com" });
+    const claims = await resolveCaller({ authorization: `Bearer ${token}` });
+    expect(claims?.profileId).toBe("usr_bob");
+    expect(claims?.email).toBe("bob@example.com");
+  });
+
+  it("resolves a session cookie to the profile id, not the pairwise sub", async () => {
+    const cookie = await mintCookieSession();
+    const claims = await resolveCaller({ cookie });
+    // `osnSub` is pairwise and meaningless to the OSN graph; everything
+    // downstream keys on the profile.
+    expect(claims?.profileId).toBe("usr_alice");
+    expect(claims?.profileId).not.toBe(identity.osnSub);
+    expect(claims?.email).toBe("alice@example.com");
+    expect(claims?.handle).toBe("alice");
+    expect(claims?.displayName).toBe("Alice");
+  });
+
+  it("returns null with no credential at all", async () => {
+    expect(await resolveCaller({})).toBeNull();
+  });
+
+  it("returns null for a cookie whose session was never issued", async () => {
+    expect(await resolveCaller({ cookie: "pulse_web_session=never-issued" })).toBeNull();
+  });
+
+  it("returns null for an expired session cookie", async () => {
+    const created = await runtime.runPromise(webSessionService.create(identity, -1));
+    expect(await resolveCaller({ cookie: `pulse_web_session=${created.token}` })).toBeNull();
+  });
+
+  it("lets a bearer token decide the request outright — no cookie fallback", async () => {
+    // A present-but-invalid Authorization header is a rejection, not an
+    // invitation to answer as whoever the cookie names.
+    const cookie = await mintCookieSession();
+    const expired = await signer.sign("usr_bob", { expiresIn: "-120s" });
+
+    expect(await resolveCaller({ authorization: `Bearer ${expired}`, cookie })).toBeNull();
+    expect(await resolveCaller({ authorization: "Bearer garbage", cookie })).toBeNull();
+    expect(await resolveCaller({ authorization: "Basic abc", cookie })).toBeNull();
+
+    // The cookie alone still works — the null above is the header's doing.
+    expect((await resolveCaller({ cookie }))?.profileId).toBe("usr_alice");
+  });
+
+  it("prefers a valid bearer token over a valid cookie for a different profile", async () => {
+    const cookie = await mintCookieSession();
+    const token = await signer.sign("usr_bob");
+    expect((await resolveCaller({ authorization: `Bearer ${token}`, cookie }))?.profileId).toBe(
+      "usr_bob",
+    );
+  });
+
+  it("rejects a token minted for another audience", async () => {
+    const token = await signer.sign("usr_bob", { audience: "osn-step-up" });
+    expect(await resolveCaller({ authorization: `Bearer ${token}` })).toBeNull();
+  });
+});

--- a/pulse/api/tests/lib/cookie.test.ts
+++ b/pulse/api/tests/lib/cookie.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOidcTxCookie,
+  buildWebSessionCookie,
+  clearOidcTxCookie,
+  clearWebSessionCookie,
+  hasWebSessionCookie,
+  parseOidcTxCookie,
+  parseWebSessionToken,
+} from "../../src/lib/cookie";
+
+// The codec itself lives in `@shared/osn-auth-client/cookie` and is tested
+// there. What is Pulse's own is the pair of NAMES and the host-scoping
+// promise — a stray `Domain=` here would widen the session cookie to every
+// sibling subdomain, and a renamed cookie would sign every browser out.
+
+describe("pulse_web_session", () => {
+  it("is host-scoped, HttpOnly, Lax and carries the token", () => {
+    const cookie = buildWebSessionCookie("tok_abc123", { secure: true, maxAgeSeconds: 604_800 });
+    expect(cookie).toContain("pulse_web_session=tok_abc123");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Max-Age=604800");
+    expect(cookie).toContain("Secure");
+    // Host-scoped: the API host sets it, only the API host receives it back.
+    expect(cookie).not.toContain("Domain=");
+  });
+
+  it("drops Secure on a plaintext local tier", () => {
+    const cookie = buildWebSessionCookie("tok_abc123", { secure: false, maxAgeSeconds: 60 });
+    expect(cookie).not.toContain("Secure");
+  });
+
+  it("clears with matching attributes and Max-Age=0", () => {
+    const cookie = clearWebSessionCookie({ secure: true });
+    expect(cookie).toContain("pulse_web_session=;");
+    expect(cookie).toContain("Max-Age=0");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Secure");
+    expect(cookie).not.toContain("Domain=");
+  });
+
+  it("parses its own value back out of a multi-cookie header", () => {
+    expect(parseWebSessionToken("other=1; pulse_web_session=tok_abc123; last=2")).toBe(
+      "tok_abc123",
+    );
+  });
+
+  it("returns null for no header, a missing cookie, or an emptied one", () => {
+    expect(parseWebSessionToken(null)).toBeNull();
+    expect(parseWebSessionToken("other=1")).toBeNull();
+    expect(parseWebSessionToken("pulse_web_session=")).toBeNull();
+  });
+
+  it("does not confuse a prefix-sharing cookie name for the session", () => {
+    expect(parseWebSessionToken("pulse_web_session_old=tok_abc123")).toBeNull();
+  });
+
+  it("hasWebSessionCookie is the origin guard's presence signal", () => {
+    expect(hasWebSessionCookie("pulse_web_session=tok_abc123")).toBe(true);
+    expect(hasWebSessionCookie("pulse_oidc_tx=payload.sig")).toBe(false);
+    expect(hasWebSessionCookie(null)).toBe(false);
+  });
+});
+
+describe("pulse_oidc_tx", () => {
+  it("round-trips the dotted `<payload>.<hmac>` value", () => {
+    const value = "eyJhIjoiYiJ9.c2lnbmF0dXJl";
+    const cookie = buildOidcTxCookie(value, { secure: true, maxAgeSeconds: 600 });
+    expect(cookie).toContain(`pulse_oidc_tx=${value}`);
+    expect(cookie).toContain("Max-Age=600");
+    expect(parseOidcTxCookie(cookie.split(";")[0] ?? "")).toBe(value);
+  });
+
+  it("clears independently of the session cookie", () => {
+    const cookie = clearOidcTxCookie({ secure: false });
+    expect(cookie).toContain("pulse_oidc_tx=;");
+    expect(cookie).toContain("Max-Age=0");
+    expect(cookie).not.toContain("pulse_web_session");
+  });
+
+  it("rejects a value that would corrupt the Set-Cookie header", () => {
+    expect(() =>
+      buildOidcTxCookie("evil; Domain=example.com", { secure: true, maxAgeSeconds: 60 }),
+    ).toThrow(TypeError);
+  });
+
+  it("is a different cookie from the session — neither parser reads the other", () => {
+    const header = "pulse_web_session=tok_abc123; pulse_oidc_tx=payload.sig";
+    expect(parseWebSessionToken(header)).toBe("tok_abc123");
+    expect(parseOidcTxCookie(header)).toBe("payload.sig");
+  });
+});

--- a/pulse/api/tests/lib/origin-guard.test.ts
+++ b/pulse/api/tests/lib/origin-guard.test.ts
@@ -1,0 +1,75 @@
+import { Elysia } from "elysia";
+import { describe, expect, it } from "vitest";
+
+import { originGuard } from "../../src/lib/origin-guard";
+
+const ALLOWED = ["https://pulse.example"];
+
+const makeApp = (allowed: readonly string[] = ALLOWED) =>
+  new Elysia({ aot: false })
+    .use(originGuard(allowed))
+    .get("/read", () => ({ ok: true }))
+    .post("/write", () => ({ ok: true }))
+    .delete("/write", () => ({ ok: true }));
+
+const call = (
+  app: ReturnType<typeof makeApp>,
+  method: string,
+  headers: Record<string, string> = {},
+) => app.handle(new Request("http://localhost/write", { method, headers }));
+
+const SESSION = "pulse_web_session=tok_abc123";
+
+describe("originGuard", () => {
+  it("passes a state-changing request that carries no session cookie", async () => {
+    // The iOS app sends a bearer token and no Origin header at all. Guarding it
+    // would 403 every native write.
+    const res = await call(makeApp(), "POST");
+    expect(res.status).toBe(200);
+  });
+
+  it("passes an unauthenticated share/exposure ping with an unrelated cookie", async () => {
+    const res = await call(makeApp(), "POST", { cookie: "ab_bucket=3" });
+    expect(res.status).toBe(200);
+  });
+
+  it("403s a cookie-carrying write with no Origin header", async () => {
+    const res = await call(makeApp(), "POST", { cookie: SESSION });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "forbidden" });
+  });
+
+  it("403s a cookie-carrying write from an origin outside the allowlist", async () => {
+    const res = await call(makeApp(), "POST", {
+      cookie: SESSION,
+      origin: "https://evil.example",
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ message: "Origin not allowed" });
+  });
+
+  it("passes a cookie-carrying write from an allowed origin", async () => {
+    const res = await call(makeApp(), "POST", {
+      cookie: SESSION,
+      origin: "https://pulse.example",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("guards DELETE as well as POST", async () => {
+    const res = await call(makeApp(), "DELETE", { cookie: SESSION });
+    expect(res.status).toBe(403);
+  });
+
+  it("never fires on a GET, cookie or not", async () => {
+    const res = await makeApp().handle(
+      new Request("http://localhost/read", { headers: { cookie: SESSION } }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("is disabled by an empty allowlist (local dev, no corsOrigins)", async () => {
+    const res = await call(makeApp([]), "POST", { cookie: SESSION });
+    expect(res.status).toBe(200);
+  });
+});

--- a/pulse/api/tests/routes/auth.test.ts
+++ b/pulse/api/tests/routes/auth.test.ts
@@ -1,0 +1,436 @@
+import type { Db } from "@pulse/db/service";
+import type { OidcConfig } from "@shared/osn-auth-client/oidc-rp";
+import {
+  makeOidcTestIssuer,
+  stubTokenEndpoint,
+  tokenResponse,
+  TEST_PAIRWISE_SUB,
+  TEST_PROFILE_ID,
+  type OidcTestIssuer,
+  type TokenEndpointCall,
+} from "@shared/osn-auth-client/testing/oidc-issuer";
+import type { RateLimiterBackend } from "@shared/rate-limit";
+import { Layer, ManagedRuntime } from "effect";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { createAuthRoutes } from "../../src/routes/auth";
+import { webSessionService, type WebIdentity } from "../../src/services/webSession";
+import { createTestLayer } from "../helpers/db";
+
+/**
+ * The Pulse web sign-in surface end to end. Both OIDC legs run against the
+ * shared fake issuer (`@shared/osn-auth-client/testing/oidc-issuer`) — no
+ * socket is touched: `_testKey` stands in for the JWKS fetch and `_fetch` for
+ * the back-channel exchange.
+ *
+ * Per-IP limiting keys on `x-forwarded-for` here, with `trustedProxyCount: 1`:
+ * under `app.handle(...)` there is no socket peer, and the policy is
+ * fail-closed, so a request with no forwarded IP is denied (S-M34).
+ */
+
+const RETURN_ORIGIN = "https://pulse.test.invalid";
+const RETURN_TO = `${RETURN_ORIGIN}/home`;
+const LOGIN_FALLBACK = `${RETURN_ORIGIN}/login`;
+const PROXIED = { trustedProxyCount: 1 } as const;
+const IP_HEADER = { "x-forwarded-for": "203.0.113.7" };
+
+const allow: RateLimiterBackend = { check: () => true };
+const block: RateLimiterBackend = { check: () => false };
+
+let issuer: OidcTestIssuer;
+
+beforeAll(async () => {
+  issuer = await makeOidcTestIssuer({ returnOrigin: RETURN_ORIGIN });
+});
+
+interface HarnessOptions {
+  /** `null` models a tier with no OIDC credentials configured. */
+  oidc?: OidcConfig | null;
+  startLimiter?: RateLimiterBackend;
+  sessionLimiter?: RateLimiterBackend;
+  secureCookies?: boolean;
+  respond?: (call: TokenEndpointCall) => Response | Promise<Response>;
+}
+
+/**
+ * One app plus a runtime over the SAME layer, so a test can mint sessions
+ * directly and have the routes see them (`createTestLayer` is a
+ * `Layer.succeed` over one in-memory DB).
+ */
+const harness = (options: HarnessOptions = {}) => {
+  const layer: Layer.Layer<Db> = createTestLayer();
+  // Filled in by the test before the callback leg runs — the ID token has to
+  // carry the nonce that `/oidc/start` minted, which is not known until then.
+  const idToken = { value: "" };
+  const stub = stubTokenEndpoint(options.respond ?? (() => tokenResponse(idToken.value)));
+  const oidc = options.oidc === undefined ? issuer.config({ _fetch: stub.fetch }) : options.oidc;
+
+  const app = createAuthRoutes(layer, {
+    oidc,
+    secureCookies: options.secureCookies ?? true,
+    loginFallbackUrl: LOGIN_FALLBACK,
+    startLimiter: options.startLimiter ?? allow,
+    sessionLimiter: options.sessionLimiter ?? allow,
+    clientIpConfig: PROXIED,
+  });
+
+  return { app, runtime: ManagedRuntime.make(layer), idToken, stub };
+};
+
+type App = ReturnType<typeof harness>["app"];
+
+const get = (app: App, path: string, headers: Record<string, string> = {}) =>
+  app.handle(new Request(`http://localhost${path}`, { headers: { ...IP_HEADER, ...headers } }));
+
+const post = (app: App, path: string, headers: Record<string, string> = {}) =>
+  app.handle(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { ...IP_HEADER, ...headers },
+    }),
+  );
+
+/** The `name=value` pair of one Set-Cookie on a response, ready to send back. */
+const cookieFrom = (res: Response, name: string): string | null => {
+  const header = res.headers.getSetCookie().find((c) => c.startsWith(`${name}=`));
+  return header ? (header.split(";")[0] ?? null) : null;
+};
+
+/** Run leg 1 and hand back everything leg 2 needs. */
+const startLogin = async (app: App, query = `?return_to=${encodeURIComponent(RETURN_TO)}`) => {
+  const res = await get(app, `/api/auth/oidc/start${query}`);
+  expect(res.status).toBe(302);
+  const authorizeUrl = new URL(res.headers.get("location") ?? "");
+  const cookie = cookieFrom(res, "pulse_oidc_tx");
+  expect(cookie).not.toBeNull();
+  return {
+    res,
+    authorizeUrl,
+    cookie: cookie ?? "",
+    state: authorizeUrl.searchParams.get("state") ?? "",
+    nonce: authorizeUrl.searchParams.get("nonce") ?? "",
+  };
+};
+
+const identity: WebIdentity = {
+  osnProfileId: "usr_alice",
+  osnSub: "pairwise-sub-for-pulse",
+  email: "alice@example.com",
+  handle: "alice",
+  displayName: "Alice",
+  avatarUrl: null,
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/oidc/start
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/oidc/start", () => {
+  it("redirects to the issuer with PKCE and remembers the transaction", async () => {
+    const { app } = harness();
+    const { authorizeUrl, res } = await startLogin(app);
+
+    expect(authorizeUrl.origin).toBe("https://id.test.invalid");
+    expect(authorizeUrl.pathname).toBe("/authorize");
+    expect(authorizeUrl.searchParams.get("response_type")).toBe("code");
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("cid_test");
+    expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authorizeUrl.searchParams.get("code_challenge")).toBeTruthy();
+    expect(authorizeUrl.searchParams.get("state")).toBeTruthy();
+    expect(authorizeUrl.searchParams.get("nonce")).toBeTruthy();
+    // `return_to` rides in our own transaction, never in the redirect URI —
+    // the issuer only ever sees the one registered callback.
+    expect(authorizeUrl.searchParams.get("redirect_uri")).not.toContain("return_to");
+
+    const cookie = res.headers.getSetCookie().find((c) => c.startsWith("pulse_oidc_tx="));
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Secure");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("forwards prompt=create and drops every other prompt value", async () => {
+    const { app } = harness();
+    const created = await startLogin(
+      app,
+      `?return_to=${encodeURIComponent(RETURN_TO)}&prompt=create`,
+    );
+    expect(created.authorizeUrl.searchParams.get("prompt")).toBe("create");
+
+    // `prompt=none` asks for a silent grant. The query string is
+    // attacker-reachable, so anything but `create` is dropped, not forwarded.
+    const silent = await startLogin(app, `?return_to=${encodeURIComponent(RETURN_TO)}&prompt=none`);
+    expect(silent.authorizeUrl.searchParams.get("prompt")).toBeNull();
+  });
+
+  it("400s a return_to outside the allowlist rather than starting a login", async () => {
+    const { app } = harness();
+    const res = await get(app, "/api/auth/oidc/start?return_to=https%3A%2F%2Fevil.test%2Fsteal");
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_return_to" });
+    expect(cookieFrom(res, "pulse_oidc_tx")).toBeNull();
+  });
+
+  it("bounces to the login page when the tier has no OIDC credentials", async () => {
+    const { app } = harness({ oidc: null });
+    const res = await get(app, `/api/auth/oidc/start?return_to=${encodeURIComponent(RETURN_TO)}`);
+    expect(res.status).toBe(302);
+    // A top-level navigation must land on a page, not on a JSON error body.
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin + location.pathname).toBe(LOGIN_FALLBACK);
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_unavailable");
+  });
+
+  it("429s over the per-IP ceiling, and with no resolvable IP at all", async () => {
+    const { app } = harness({ startLimiter: block });
+    const limited = await get(
+      app,
+      `/api/auth/oidc/start?return_to=${encodeURIComponent(RETURN_TO)}`,
+    );
+    expect(limited.status).toBe(429);
+    expect(await limited.json()).toMatchObject({ error: "rate_limited" });
+
+    const { app: open } = harness();
+    const unresolved = await open.handle(
+      new Request(
+        `http://localhost/api/auth/oidc/start?return_to=${encodeURIComponent(RETURN_TO)}`,
+      ),
+    );
+    expect(unresolved.status).toBe(429);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/oidc/callback
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/oidc/callback", () => {
+  it("exchanges the code and lands the browser back with a session cookie", async () => {
+    const { app, idToken, stub } = harness();
+    const { state, nonce, cookie } = await startLogin(app);
+    idToken.value = await issuer.signIdToken({ nonce });
+
+    const res = await get(app, `/api/auth/oidc/callback?code=abc&state=${state}`, { cookie });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(RETURN_TO);
+    expect(stub.calls).toHaveLength(1);
+
+    const session = cookieFrom(res, "pulse_web_session");
+    expect(session).toMatch(/^pulse_web_session=.+/);
+    const sessionHeader = res.headers
+      .getSetCookie()
+      .find((c) => c.startsWith("pulse_web_session="));
+    expect(sessionHeader).toContain("Max-Age=604800");
+    expect(sessionHeader).toContain("HttpOnly");
+    // Spent transaction: single-use by construction, so it goes with the reply.
+    expect(res.headers.getSetCookie()).toContainEqual(expect.stringContaining("pulse_oidc_tx=;"));
+
+    // The cookie it minted really signs the browser in, and on the profile id
+    // rather than the pairwise subject.
+    const probe = await get(app, "/api/auth/session", { cookie: session ?? "" });
+    expect(await probe.json()).toMatchObject({
+      signedIn: true,
+      osnProfileId: TEST_PROFILE_ID,
+      email: "person@example.test",
+      handle: "person",
+    });
+    expect(TEST_PROFILE_ID).not.toBe(TEST_PAIRWISE_SUB);
+  });
+
+  it("reports a refusal from the issuer without echoing its error string", async () => {
+    const { app } = harness();
+    const { cookie } = await startLogin(app);
+
+    const res = await get(
+      app,
+      "/api/auth/oidc/callback?error=access_denied&error_description=user%20said%20no",
+      { cookie },
+    );
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location") ?? "");
+    // Back to where the login started, since the transaction still names it.
+    expect(location.origin + location.pathname).toBe(RETURN_TO);
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_declined");
+    expect(location.search).not.toContain("access_denied");
+    expect(cookieFrom(res, "pulse_web_session")).toBeNull();
+  });
+
+  it("refuses a state that does not match the transaction cookie", async () => {
+    const { app, stub } = harness();
+    const { cookie } = await startLogin(app);
+
+    const res = await get(app, "/api/auth/oidc/callback?code=abc&state=not-the-state", { cookie });
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_failed");
+    // The code is never spent on a transaction that failed its CSRF binding.
+    expect(stub.calls).toHaveLength(0);
+    expect(cookieFrom(res, "pulse_web_session")).toBeNull();
+  });
+
+  it("falls back to the login page when there is no transaction cookie", async () => {
+    const { app } = harness();
+    const res = await get(app, "/api/auth/oidc/callback?code=abc&state=whatever");
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin + location.pathname).toBe(LOGIN_FALLBACK);
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_failed");
+  });
+
+  it("refuses an ID token with no osn_profile_id claim", async () => {
+    const { app, idToken } = harness();
+    const { state, nonce, cookie } = await startLogin(app);
+    // A pairwise subject alone names nothing in the OSN graph.
+    idToken.value = await issuer.signIdToken({ nonce, osnProfileId: null });
+
+    const res = await get(app, `/api/auth/oidc/callback?code=abc&state=${state}`, { cookie });
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_failed");
+    expect(cookieFrom(res, "pulse_web_session")).toBeNull();
+  });
+
+  it("refuses an ID token minted for a different nonce", async () => {
+    const { app, idToken } = harness();
+    const { state, cookie } = await startLogin(app);
+    idToken.value = await issuer.signIdToken({ nonce: "some-other-login" });
+
+    const res = await get(app, `/api/auth/oidc/callback?code=abc&state=${state}`, { cookie });
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_failed");
+    expect(cookieFrom(res, "pulse_web_session")).toBeNull();
+  });
+
+  it("bounces to the login page when the tier has no OIDC credentials", async () => {
+    const { app } = harness({ oidc: null });
+    const res = await get(app, "/api/auth/oidc/callback?code=abc&state=x");
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("auth_error")).toBe("sign_in_unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/session
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/session", () => {
+  it("answers 200 `signedIn: false` for a visitor, not 401", async () => {
+    // Every page load runs this probe; a signed-out visitor is the expected
+    // case, not an error.
+    const { app } = harness();
+    const res = await get(app, "/api/auth/session");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ signedIn: false });
+  });
+
+  it("returns the login-time snapshot for a live session", async () => {
+    const { app, runtime } = harness();
+    const created = await runtime.runPromise(webSessionService.create(identity));
+
+    const res = await get(app, "/api/auth/session", {
+      cookie: `pulse_web_session=${created.token}`,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      signedIn: true,
+      osnProfileId: "usr_alice",
+      email: "alice@example.com",
+      handle: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+    expect(new Date(String(body["expiresAt"])).getTime()).toBeGreaterThan(Date.now());
+    // The opaque token is never handed back to the page.
+    expect(JSON.stringify(body)).not.toContain(created.token);
+  });
+
+  it("answers `signedIn: false` for an unknown or expired cookie", async () => {
+    const { app, runtime } = harness();
+    const stale = await runtime.runPromise(webSessionService.create(identity, -1));
+
+    expect(
+      await (await get(app, "/api/auth/session", { cookie: "pulse_web_session=nope" })).json(),
+    ).toEqual({ signedIn: false });
+    expect(
+      await (
+        await get(app, "/api/auth/session", { cookie: `pulse_web_session=${stale.token}` })
+      ).json(),
+    ).toEqual({ signedIn: false });
+  });
+
+  it("429s over the per-IP ceiling", async () => {
+    const { app } = harness({ sessionLimiter: block });
+    const res = await get(app, "/api/auth/session");
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({ error: "rate_limited" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/signout
+// ---------------------------------------------------------------------------
+
+describe("POST /api/auth/signout", () => {
+  it("clears the cookie and drops the session row", async () => {
+    const { app, runtime } = harness();
+    const created = await runtime.runPromise(webSessionService.create(identity));
+    const cookie = `pulse_web_session=${created.token}`;
+
+    const res = await post(app, "/api/auth/signout", { cookie });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    const cleared = res.headers.getSetCookie().find((c) => c.startsWith("pulse_web_session="));
+    expect(cleared).toContain("pulse_web_session=;");
+    expect(cleared).toContain("Max-Age=0");
+
+    // Not just the browser's copy — the row itself is gone.
+    expect(await (await get(app, "/api/auth/session", { cookie })).json()).toEqual({
+      signedIn: false,
+    });
+  });
+
+  it("answers 200 with no cookie, and for a token that was never issued", async () => {
+    // Signing out is idempotent, and saying whether a token was live would be
+    // a free oracle.
+    const { app } = harness();
+    expect((await post(app, "/api/auth/signout")).status).toBe(200);
+
+    const unknown = await post(app, "/api/auth/signout", {
+      cookie: "pulse_web_session=never-issued",
+    });
+    expect(unknown.status).toBe(200);
+    expect(await unknown.json()).toEqual({ ok: true });
+  });
+
+  it("?all=1 signs the profile out of every browser", async () => {
+    const { app, runtime } = harness();
+    const here = await runtime.runPromise(webSessionService.create(identity));
+    const elsewhere = await runtime.runPromise(webSessionService.create(identity));
+    const other = await runtime.runPromise(
+      webSessionService.create({ ...identity, osnProfileId: "usr_bob" }),
+    );
+
+    const res = await post(app, "/api/auth/signout?all=1", {
+      cookie: `pulse_web_session=${here.token}`,
+    });
+    expect(res.status).toBe(200);
+
+    for (const token of [here.token, elsewhere.token]) {
+      expect(
+        await (
+          await get(app, "/api/auth/session", { cookie: `pulse_web_session=${token}` })
+        ).json(),
+      ).toEqual({ signedIn: false });
+    }
+    // Another profile's sessions are untouched.
+    expect(
+      await (
+        await get(app, "/api/auth/session", { cookie: `pulse_web_session=${other.token}` })
+      ).json(),
+    ).toMatchObject({ signedIn: true, osnProfileId: "usr_bob" });
+  });
+
+  it("429s over the per-IP ceiling", async () => {
+    const { app } = harness({ sessionLimiter: block });
+    const res = await post(app, "/api/auth/signout");
+    expect(res.status).toBe(429);
+  });
+});

--- a/pulse/api/tests/routes/closeFriends.test.ts
+++ b/pulse/api/tests/routes/closeFriends.test.ts
@@ -124,6 +124,41 @@ describe("close-friends routes", () => {
     expect(body.closeFriends.find((c) => c.profileId === "usr_bob")?.handle).toBe("bob");
   });
 
+  it("GET /close-friends/candidates returns the caller's connections, name-sorted", async () => {
+    vi.mocked(bridge.getConnectionIds).mockReturnValue(
+      Effect.succeed(new Set(["usr_bob", "usr_carol"])),
+    );
+    vi.mocked(bridge.getProfileDisplays).mockReturnValue(
+      Effect.succeed(
+        new Map([
+          ["usr_bob", { id: "usr_bob", handle: "bob", displayName: "Bob", avatarUrl: null }],
+          [
+            "usr_carol",
+            { id: "usr_carol", handle: "carol", displayName: "Alice C", avatarUrl: null },
+          ],
+        ]),
+      ),
+    );
+    const res = await get(app, "/close-friends/candidates", aliceToken);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      connections: Array<{ profileId: string; displayName: string | null }>;
+    };
+    expect(body.connections.map((c) => c.profileId)).toEqual(["usr_carol", "usr_bob"]);
+  });
+
+  it("GET /close-friends/candidates 502 when the graph bridge fails", async () => {
+    vi.mocked(bridge.getConnectionIds).mockReturnValue(
+      Effect.fail(new bridge.GraphBridgeError({ cause: new Error("down") })),
+    );
+    const res = await get(app, "/close-friends/candidates", aliceToken);
+    expect(res.status).toBe(502);
+  });
+
+  it("GET /close-friends/candidates 401 unauthenticated", async () => {
+    expect((await get(app, "/close-friends/candidates")).status).toBe(401);
+  });
+
   it("GET /close-friends/:friendId/check returns the boolean", async () => {
     await Effect.runPromise(seedCloseFriend("usr_alice", "usr_bob").pipe(Effect.provide(layer)));
     const yes = await get(app, "/close-friends/usr_bob/check", aliceToken);

--- a/pulse/api/tests/services/webSession.test.ts
+++ b/pulse/api/tests/services/webSession.test.ts
@@ -1,0 +1,164 @@
+import { it, expect } from "@effect/vitest";
+import { pulseWebSessions } from "@pulse/db/schema";
+import { Db } from "@pulse/db/service";
+import { hashToken } from "@shared/crypto/tokens";
+import { Effect } from "effect";
+
+import { webSessionService, type WebIdentity } from "../../src/services/webSession";
+import { createTestLayer } from "../helpers/db";
+
+const identity: WebIdentity = {
+  osnProfileId: "usr_alice",
+  osnSub: "pairwise-sub-for-pulse",
+  email: "alice@example.com",
+  handle: "alice",
+  displayName: "Alice",
+  avatarUrl: null,
+};
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+it.effect("create returns a token that is stored only as a hash", () =>
+  Effect.gen(function* () {
+    const { token } = yield* webSessionService.create(identity);
+    expect(token.length).toBeGreaterThan(20);
+
+    const { db } = yield* Db;
+    const rows = yield* Effect.promise(() => db.select().from(pulseWebSessions));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.token).not.toBe(token);
+    expect(rows[0]?.token).toBe(yield* hashToken(token));
+    expect(rows[0]?.osnProfileId).toBe("usr_alice");
+    expect(rows[0]?.osnSub).toBe("pairwise-sub-for-pulse");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("create honours the TTL it is given", () =>
+  Effect.gen(function* () {
+    const before = Date.now();
+    const { expiresAt } = yield* webSessionService.create(identity, 60);
+    // Bounded either side rather than exact — the clock moves between the two reads.
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+    expect(expiresAt.getTime()).toBeLessThan(before + 60_000 + 5_000);
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// validate
+// ---------------------------------------------------------------------------
+
+it.effect("validate resolves a live token to its login-time identity snapshot", () =>
+  Effect.gen(function* () {
+    const { token } = yield* webSessionService.create(identity);
+    const session = yield* webSessionService.validate(token);
+    expect(session.osnProfileId).toBe("usr_alice");
+    expect(session.osnSub).toBe("pairwise-sub-for-pulse");
+    expect(session.email).toBe("alice@example.com");
+    expect(session.handle).toBe("alice");
+    expect(session.displayName).toBe("Alice");
+    expect(session.avatarUrl).toBeNull();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("validate fails `missing` for an unknown token", () =>
+  Effect.gen(function* () {
+    const err = yield* Effect.flip(webSessionService.validate("not-a-real-token"));
+    expect(err._tag).toBe("WebSessionInvalid");
+    expect(err.reason).toBe("missing");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("validate fails `missing` for an empty token without touching the DB", () =>
+  Effect.gen(function* () {
+    const err = yield* Effect.flip(webSessionService.validate(""));
+    expect(err.reason).toBe("missing");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("validate fails `expired` for a lapsed token and leaves the row in place", () =>
+  Effect.gen(function* () {
+    // Negative TTL puts `expiresAt` in the past without waiting on a clock.
+    const { token } = yield* webSessionService.create(identity, -1);
+    const err = yield* Effect.flip(webSessionService.validate(token));
+    expect(err.reason).toBe("expired");
+
+    // Expiry is reported, never deleted — `sweepExpired` owns removal, so a
+    // read path stays a read path.
+    const { db } = yield* Db;
+    const rows = yield* Effect.promise(() => db.select().from(pulseWebSessions));
+    expect(rows).toHaveLength(1);
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// revoke / revokeAllForProfile
+// ---------------------------------------------------------------------------
+
+it.effect("revoke drops only the session it names", () =>
+  Effect.gen(function* () {
+    const first = yield* webSessionService.create(identity);
+    const second = yield* webSessionService.create(identity);
+
+    yield* webSessionService.revoke(first.token);
+
+    const err = yield* Effect.flip(webSessionService.validate(first.token));
+    expect(err.reason).toBe("missing");
+    const survivor = yield* webSessionService.validate(second.token);
+    expect(survivor.osnProfileId).toBe("usr_alice");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("revoke of an unknown token succeeds — sign-out is idempotent", () =>
+  Effect.gen(function* () {
+    const live = yield* webSessionService.create(identity);
+    yield* webSessionService.revoke("never-issued");
+
+    // No error, and nothing else went with it.
+    const survivor = yield* webSessionService.validate(live.token);
+    expect(survivor.osnProfileId).toBe("usr_alice");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("revokeAllForProfile drops every session of that profile and no other's", () =>
+  Effect.gen(function* () {
+    const a1 = yield* webSessionService.create(identity);
+    const a2 = yield* webSessionService.create(identity);
+    const b = yield* webSessionService.create({ ...identity, osnProfileId: "usr_bob" });
+
+    yield* webSessionService.revokeAllForProfile("usr_alice");
+
+    expect((yield* Effect.flip(webSessionService.validate(a1.token))).reason).toBe("missing");
+    expect((yield* Effect.flip(webSessionService.validate(a2.token))).reason).toBe("missing");
+    expect((yield* webSessionService.validate(b.token)).osnProfileId).toBe("usr_bob");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+// ---------------------------------------------------------------------------
+// sweepExpired
+// ---------------------------------------------------------------------------
+
+it.effect("sweepExpired deletes lapsed rows, counts them, and spares live ones", () =>
+  Effect.gen(function* () {
+    yield* webSessionService.create(identity, -1);
+    yield* webSessionService.create(identity, -1);
+    const live = yield* webSessionService.create(identity);
+
+    const deleted = yield* webSessionService.sweepExpired();
+    expect(deleted).toBe(2);
+
+    const { db } = yield* Db;
+    const rows = yield* Effect.promise(() => db.select().from(pulseWebSessions));
+    expect(rows).toHaveLength(1);
+    expect((yield* webSessionService.validate(live.token)).osnProfileId).toBe("usr_alice");
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+it.effect("sweepExpired at an earlier `now` leaves a not-yet-expired row alone", () =>
+  Effect.gen(function* () {
+    yield* webSessionService.create(identity, 60);
+    const deleted = yield* webSessionService.sweepExpired(new Date(Date.now() - 60_000));
+    expect(deleted).toBe(0);
+  }).pipe(Effect.provide(createTestLayer())),
+);

--- a/pulse/api/wrangler.toml
+++ b/pulse/api/wrangler.toml
@@ -17,6 +17,12 @@ migrations_dir = "../db/drizzle"
 
 [env.dev.vars]
 OSN_JWKS_URL = "http://localhost:4000/.well-known/jwks.json"
+OSN_ISSUER_URL = "http://localhost:4000"
+PULSE_API_ORIGIN = "http://localhost:3001"
+PULSE_LOGIN_URL = "http://localhost:1420/"
+# OSN_OIDC_CLIENT_ID / OSN_OIDC_CLIENT_SECRET come from a client registered with
+# osn-api. Until both are set, /api/auth/oidc/* answers `sign_in_unavailable`
+# and the rest of the API is unaffected.
 
 # ── staging ──────────────────────────────────────────────────────────────────
 [[env.staging.d1_databases]]
@@ -28,6 +34,14 @@ migrations_dir = "../db/drizzle"
 [env.staging.vars]
 # TODO: real OSN issuer origin before staging deploy
 OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://osn-api.example.com"
+# TODO: set once the Pulse domain is chosen. Must be same-site with the Pulse
+# web origin (`api.<pulse-domain>`) — the session cookie is host-scoped and
+# `SameSite=Lax`, so a cross-site API host is never sent one.
+PULSE_API_ORIGIN = "https://api.pulse.example.com"
+PULSE_LOGIN_URL = "https://pulse.example.com/"
+# OSN_OIDC_CLIENT_ID is a var; OSN_OIDC_CLIENT_SECRET is a secret
+# (`wrangler secret put OSN_OIDC_CLIENT_SECRET --env staging`).
 
 # ── production ───────────────────────────────────────────────────────────────
 [[env.production.d1_databases]]
@@ -39,6 +53,14 @@ migrations_dir = "../db/drizzle"
 [env.production.vars]
 # TODO: real OSN issuer origin before prod deploy
 OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://osn-api.example.com"
+# TODO: set once the Pulse domain is chosen. Must be same-site with the Pulse
+# web origin (`api.<pulse-domain>`) — the session cookie is host-scoped and
+# `SameSite=Lax`, so a cross-site API host is never sent one.
+PULSE_API_ORIGIN = "https://api.pulse.example.com"
+PULSE_LOGIN_URL = "https://pulse.example.com/"
+# OSN_OIDC_CLIENT_ID is a var; OSN_OIDC_CLIENT_SECRET is a secret
+# (`wrangler secret put OSN_OIDC_CLIENT_SECRET --env production`).
 
 # The leave-app deletion sweepers run on the long-lived `local` host today. On
 # Workers they belong on a Cron Trigger — add a [triggers] crons entry + a

--- a/pulse/db/drizzle/0010_pulse_web_sessions.sql
+++ b/pulse/db/drizzle/0010_pulse_web_sessions.sql
@@ -1,0 +1,49 @@
+-- Browser sessions for the Pulse web app, minted by the OSN OIDC login flow.
+--
+-- Why Pulse needs its own session at all: the iOS app holds an OSN refresh
+-- token and presents a bearer access JWT on every call, and `extractClaims`
+-- verifies it. A browser cannot do that. The OSN issuer lives on
+-- `musubi.social`, a different site from Pulse web, so OSN's HttpOnly session
+-- cookie is never sent to the Pulse API and there is nothing to silent-refresh
+-- against. Pulse web signs in by redirect instead — `/api/auth/oidc/start` →
+-- the OSN authorize endpoint → back to `/api/auth/oidc/callback` — and the API
+-- mints this row and sets its own host-scoped cookie.
+--
+-- Same shape and reasoning as cire's `organiser_sessions` (cire migration
+-- 0047): an opaque random token, SHA-256 hashed at rest so a database read
+-- cannot mint a session, carried in a host-scoped HttpOnly cookie.
+--
+-- `osn_profile_id` is the real `usr_*` id from the first-party-only
+-- `osn_profile_id` ID-token claim, not the OIDC pairwise `sub`. It has to be:
+-- every Pulse row keys on the profile id (`events.organiser_profile_id`,
+-- `event_rsvps.profile_id`, `pulse_users.profile_id`), and the access JWT the
+-- iOS clients present resolves to the same value — the two callers must land on
+-- one identifier or a user's web session would see none of their own data.
+-- `osn_sub` keeps the pairwise subject for audit and for matching a revoked
+-- OIDC connection.
+--
+-- `email`/`handle`/`display_name`/`avatar_url` are a login-time snapshot of the
+-- ID token's profile claims, not a profile record. The web chrome needs a name
+-- to render and cannot read one from an OSN session cross-site. They expire
+-- with the row and are re-taken on every sign-in.
+--
+-- No foreign key: OSN identities live in a different D1 database.
+CREATE TABLE `pulse_web_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token` text NOT NULL,
+	`osn_profile_id` text NOT NULL,
+	`osn_sub` text NOT NULL,
+	`email` text,
+	`handle` text,
+	`display_name` text,
+	`avatar_url` text,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `pulse_web_sessions_token_unique` ON `pulse_web_sessions` (`token`);--> statement-breakpoint
+-- Sign-out-everywhere, the OIDC connection-revocation hook and account erasure
+-- all delete by profile id.
+CREATE INDEX `pulse_web_sessions_profile_idx` ON `pulse_web_sessions` (`osn_profile_id`);--> statement-breakpoint
+-- The sweep deletes every row past its expiry.
+CREATE INDEX `pulse_web_sessions_expires_idx` ON `pulse_web_sessions` (`expires_at`);

--- a/pulse/db/drizzle/meta/_journal.json
+++ b/pulse/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785974400000,
       "tag": "0009_events_chat_and_price",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1786406400000,
+      "tag": "0010_pulse_web_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/pulse/db/src/schema/index.ts
+++ b/pulse/db/src/schema/index.ts
@@ -8,3 +8,4 @@ export * from "./deletionJobs";
 export * from "./onboarding";
 export * from "./venues";
 export * from "./eventLineup";
+export * from "./webSessions";

--- a/pulse/db/src/schema/webSessions.ts
+++ b/pulse/db/src/schema/webSessions.ts
@@ -1,0 +1,48 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * Browser sessions for the Pulse web app, minted by the OSN OIDC login flow.
+ *
+ * The iOS app holds an OSN refresh token and calls this API with a bearer
+ * access JWT. A browser cannot: the OSN issuer lives on `musubi.social`, a
+ * different site from Pulse web, so its session cookie never rides along. Pulse
+ * web therefore signs in by redirect through the OSN authorize endpoint and
+ * comes back with an ID token; `pulse/api` mints this row and sets its own
+ * host-scoped cookie. Same shape as cire's `organiser_sessions` — the token
+ * column stores the SHA-256 hash, never the token itself.
+ *
+ * `osnProfileId` is the real `usr_*` id from the first-party-only
+ * `osn_profile_id` claim, NOT the OIDC pairwise `sub`: every row Pulse owns
+ * keys on profile ids, and so does the access JWT the iOS clients present, so
+ * the two callers must resolve to the same identifier. `osnSub` keeps the
+ * pairwise subject for audit and connection-revocation matching. Both are
+ * opaque cross-database ids, deliberately not foreign keys.
+ *
+ * The four profile columns are a login-time snapshot of the ID token's claims
+ * so the web chrome has a name to render without a round trip to OSN; they
+ * expire with the row and are re-taken on every sign-in.
+ */
+export const pulseWebSessions = sqliteTable(
+  "pulse_web_sessions",
+  {
+    id: text("id").primaryKey(), // pws_<uuid>
+    token: text("token").notNull().unique(), // SHA-256 of the opaque cookie value
+    osnProfileId: text("osn_profile_id").notNull(),
+    osnSub: text("osn_sub").notNull(),
+    email: text("email"),
+    handle: text("handle"),
+    displayName: text("display_name"),
+    avatarUrl: text("avatar_url"),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  // profile_id serves sign-out-everywhere and the OIDC connection-revocation
+  // hook; expires_at serves the sweep. Both would be full scans otherwise.
+  (t) => [
+    index("pulse_web_sessions_profile_idx").on(t.osnProfileId),
+    index("pulse_web_sessions_expires_idx").on(t.expiresAt),
+  ],
+);
+
+export type PulseWebSession = typeof pulseWebSessions.$inferSelect;
+export type NewPulseWebSession = typeof pulseWebSessions.$inferInsert;

--- a/pulse/db/tests/testing.test.ts
+++ b/pulse/db/tests/testing.test.ts
@@ -56,6 +56,7 @@ describe("applySchema", () => {
       "pulse_deletion_jobs",
       "pulse_profile_accounts",
       "pulse_users",
+      "pulse_web_sessions",
       "venues",
     ]);
   });

--- a/shared/openapi/pulse.json
+++ b/shared/openapi/pulse.json
@@ -861,6 +861,26 @@
         ]
       }
     },
+    "/api/auth/oidc/callback": {
+      "get": {
+        "operationId": "getApiAuthOidcCallback"
+      }
+    },
+    "/api/auth/oidc/start": {
+      "get": {
+        "operationId": "getApiAuthOidcStart"
+      }
+    },
+    "/api/auth/session": {
+      "get": {
+        "operationId": "getApiAuthSession"
+      }
+    },
+    "/api/auth/signout": {
+      "post": {
+        "operationId": "postApiAuthSignout"
+      }
+    },
     "/close-friends/": {
       "get": {
         "operationId": "listCloseFriends",
@@ -932,6 +952,101 @@
               }
             },
             "description": "Response for status 401"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/close-friends/candidates": {
+      "get": {
+        "operationId": "listCloseFriendCandidates",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "connections": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "profileId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "profileId",
+                          "handle",
+                          "displayName",
+                          "avatarUrl"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "connections"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 502"
           }
         },
         "security": [

--- a/shared/openapi/pulse.json
+++ b/shared/openapi/pulse.json
@@ -863,22 +863,188 @@
     },
     "/api/auth/oidc/callback": {
       "get": {
-        "operationId": "getApiAuthOidcCallback"
+        "operationId": "completeOidcSignIn",
+        "responses": {
+          "302": {
+            "description": "Redirect back to `return_to`, setting the Pulse session cookie and clearing the transaction cookie. Every failure path redirects to the same place with an `?auth_error=` marker instead."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Per-IP rate limit exceeded."
+          }
+        },
+        "summary": "Complete OSN OIDC sign-in"
       }
     },
     "/api/auth/oidc/start": {
       "get": {
-        "operationId": "getApiAuthOidcStart"
+        "operationId": "startOidcSignIn",
+        "responses": {
+          "302": {
+            "description": "Redirect to the OSN authorize endpoint, carrying the transaction cookie. On a misconfigured issuer, a redirect back to the app with an `?auth_error=` marker instead."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "`return_to` is missing or not an allowlisted origin."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Per-IP rate limit exceeded."
+          }
+        },
+        "summary": "Begin OSN OIDC sign-in"
       }
     },
     "/api/auth/session": {
       "get": {
-        "operationId": "getApiAuthSession"
+        "operationId": "getWebSession",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "avatarUrl": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "handle": {
+                      "type": "string"
+                    },
+                    "osnProfileId": {
+                      "type": "string"
+                    },
+                    "signedIn": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "signedIn"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The viewer's session. The identity fields are present only when `signedIn` is true."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Per-IP rate limit exceeded."
+          }
+        },
+        "summary": "Who is signed in"
       }
     },
     "/api/auth/signout": {
       "post": {
-        "operationId": "postApiAuthSignout"
+        "operationId": "signOutWebSession",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Signed out. Always 200, with or without a live session."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Per-IP rate limit exceeded."
+          }
+        },
+        "summary": "Drop the Pulse session cookie"
       }
     },
     "/close-friends/": {


### PR DESCRIPTION
Stacked on #416 (`refactor/rp-auth-server`) — **review the diff against that base, not `main`**.

## Why

Pulse web cannot sign anyone in today. A WebAuthn ceremony only runs on an origin same-site with the RP ID, which is now `musubi.social`, so no Pulse origin can mint or use an OSN credential. Pulse becomes a plain OIDC relying party instead, on top of the server half extracted in the parent PR.

## What

- **`pulse_web_sessions`** (migration `0010`) — opaque tokens, SHA-256 hashed at rest, seven-day TTL, keyed on the `usr_*` profile id and never on the pairwise `sub`.
- **Four routes** under `/api/auth`:
  - `GET /oidc/start` — mints the PKCE verifier + state + nonce into a short-lived signed tx cookie and redirects to the issuer. `return_to` is validated against an allowlist; a disallowed one is a 400, not a redirect.
  - `GET /oidc/callback` — state check before the code is ever spent, back-channel exchange, ID-token verification, session mint, redirect home.
  - `GET /session` — 200 `{ signedIn: false }` for a visitor, **not a 401**: the probe runs on every page load.
  - `POST /signout` — idempotent; `?all=1` clears every browser.
- **`makeCallerResolver`** now accepts either credential at every authenticated route. A bearer token is checked first and decides the request outright — present-but-invalid is a rejection, never a fall back to whoever the cookie names. The iOS app is untouched and never pays for the cookie lookup.
- **Cookie + CSRF.** The session cookie is host-scoped, `HttpOnly`, `SameSite=Lax`, no `Domain=`. Cookie credentials make Pulse writes CSRF-eligible for the first time, so an origin guard covers state-changing requests — it fires only when the session cookie is present, because the native app sends no `Origin` header at all.

## Tests

Both OIDC legs run end to end against the shared fake issuer (`@shared/osn-auth-client/testing/oidc-issuer`) — no socket is touched: `_testKey` stands in for the JWKS fetch, `_fetch` for the back-channel exchange. Pinned invariants include:

- a state mismatch fails **and never spends the code** (`stub.calls` stays empty);
- an ID token with no `osn_profile_id` is refused;
- an ID token minted for another nonce is refused;
- the issuer's own error string is never echoed back to the browser;
- the `/session` body never contains the opaque token;
- `/signout?all=1` spares another profile's sessions.

`pulse/api`: 42 files, 607 tests pass. Monorepo `check` 25/25, `test` 31/31, lint clean.

## Deploy constraint

The API must be served from a host **same-site with the web origin** (`api.<pulse-domain>`), or the browser will not send the session cookie back. Recorded in `shared/osn-auth-client/src/cookie.ts`, `pulse/api/src/lib/cookie.ts`, the `Env` type in `pulse/api/src/index.ts`, the changeset, and as TODOs in `pulse/api/wrangler.toml` — the staging/prod `PULSE_API_ORIGIN` and `PULSE_LOGIN_URL` values stay placeholders until the Pulse domain is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
