### PR TITLE
feat(osn-api): response schemas for the core auth routes

### DIFF
--- a/.changeset/osn-api-auth-response-schemas.md
+++ b/.changeset/osn-api-auth-response-schemas.md
@@ -1,0 +1,13 @@
+---
+"@osn/api": minor
+---
+
+Declare `response:` schemas for the core session-lifecycle auth routes, and stop the OpenAPI document dropping `/.well-known/*`.
+
+Fourteen operations — handle availability, registration, `/token`, logout, passkey login, session introspection and revocation, profile list and switch, OIDC discovery and JWKS — now declare TypeBox `response:` schemas and an `operationId`. Shared shapes (`errorResponse`, `tokenResponse`, `publicProfile`, `sessionSummary`, the WebAuthn request options) live in a new `routes/auth/response-schemas.ts`.
+
+These schemas are not documentation. Elysia validates and *cleans* every response against them at runtime: an undeclared key is deleted from the body before it is sent, and a value that fails its type check turns the route into a 500. Each schema here was written against the handler's actual return value and the service's return type rather than the endpoint's intent. The JWK object carries `additionalProperties: true` for exactly that reason — a JWK field the schema forgot would be silently stripped from the document every relying party verifies signatures against.
+
+`jwtPublicKeyJwk` on `AuthConfig` is now typed as jose's `JWK` rather than `Record<string, unknown>`, because a property of type `unknown` satisfies no TypeBox schema. The three `as Record<string, unknown>` casts at its call sites are gone.
+
+The generated document also gains `/.well-known/openid-configuration` and `/.well-known/jwks.json`, which had never appeared in it: `@elysiajs/openapi` decides a route serves a static file when its path contains a dot, and dropped both. No route in `@osn/api` serves a file, so the heuristic is now off.

--- a/osn/api/src/app.ts
+++ b/osn/api/src/app.ts
@@ -188,7 +188,13 @@ export function createApp(deps: AppDeps) {
         // as well, but the plugin matches with `excludePaths.includes(path)`, so
         // a pattern silently matches nothing. The ARC-gated internal prefixes
         // are therefore dropped in `scripts/generate-openapi.ts` instead.
-        exclude: { paths: ["/", "/health", "/ready"] },
+        //
+        // `staticFile: false` because the plugin's static-asset heuristic is
+        // "the path contains a dot", which silently drops
+        // `/.well-known/openid-configuration` and `/.well-known/jwks.json` —
+        // the two endpoints every relying party reads first. No route here
+        // serves a file, so nothing else changes.
+        exclude: { paths: ["/", "/health", "/ready"], staticFile: false },
       }),
     )
     .use(

--- a/osn/api/src/build-deps.ts
+++ b/osn/api/src/build-deps.ts
@@ -75,14 +75,14 @@ export async function loadJwtKeyPair(env: EnvRecord) {
     }
     const publicKey = await importKeyFromJwk(JSON.parse(atob(rawPub)) as Record<string, unknown>);
     const kid = await thumbprintKid(publicKey);
-    const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+    const jwtPublicKeyJwk = await exportJWK(publicKey);
     return { privateKey, publicKey, kid, jwtPublicKeyJwk };
   }
 
   // Ephemeral dev pair — warn via Effect logger after observability is ready.
   const { privateKey, publicKey } = await generateArcKeyPair();
   const kid = await thumbprintKid(publicKey);
-  const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+  const jwtPublicKeyJwk = await exportJWK(publicKey);
   return { privateKey, publicKey, kid, jwtPublicKeyJwk, ephemeral: true };
 }
 

--- a/osn/api/src/routes/auth/context.ts
+++ b/osn/api/src/routes/auth/context.ts
@@ -77,6 +77,11 @@ export function createAuthRouteContext(deps: AuthRouteDeps) {
   // The key does not change during the server's lifetime — no need to allocate
   // a new object (and spread-copy all JWK fields) on every request.
   // S-L2: include key_ops alongside use for RFC 7517 compliance.
+  //
+  // Deliberately not `as const`: that widens to a readonly tuple, which no
+  // TypeBox `t.Array` accepts, and the JWKS route now declares a response
+  // schema. The prebuild-once win comes from the shared object, not the
+  // literal type.
   const jwksResponse = {
     keys: [
       {
@@ -87,7 +92,7 @@ export function createAuthRouteContext(deps: AuthRouteDeps) {
         key_ops: ["verify"],
       },
     ],
-  } as const;
+  };
 
   const auth = createAuthService(authConfig);
 

--- a/osn/api/src/routes/auth/login.ts
+++ b/osn/api/src/routes/auth/login.ts
@@ -3,6 +3,12 @@ import { Elysia, t } from "elysia";
 import { buildSessionCookie } from "../../lib/cookie-session";
 import type { AuthRouteContext } from "./context";
 import { toTokenResponseCookieOnly } from "./context";
+import {
+  errorResponse,
+  publicKeyCredentialRequestOptions,
+  publicProfile,
+  tokenResponse,
+} from "./response-schemas";
 
 export function createPasskeyLoginRoutes(ctx: AuthRouteContext) {
   const {
@@ -80,6 +86,18 @@ export function createPasskeyLoginRoutes(ctx: AuthRouteContext) {
             // schema; enforced by `turnstileGate` only when configured.
             turnstileToken: t.Optional(t.String()),
           }),
+          response: {
+            200: t.Object({
+              options: publicKeyCredentialRequestOptions,
+              // Present only on the discoverable-credential path; the client
+              // must round-trip it to /login/passkey/complete.
+              challengeId: t.Optional(t.String()),
+            }),
+            400: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "beginPasskeyLogin" },
         },
       )
       .post(
@@ -134,6 +152,13 @@ export function createPasskeyLoginRoutes(ctx: AuthRouteContext) {
             challengeId: t.Optional(t.String()),
             assertion: t.Any(),
           }),
+          response: {
+            200: t.Object({ session: tokenResponse, profile: publicProfile }),
+            400: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "completePasskeyLogin" },
         },
       )
   );

--- a/osn/api/src/routes/auth/profile-switch.ts
+++ b/osn/api/src/routes/auth/profile-switch.ts
@@ -3,6 +3,7 @@ import { Elysia, t } from "elysia";
 import { resolveAccessTokenPrincipal } from "../../lib/auth-derive";
 import { readSessionCookie } from "../../lib/cookie-session";
 import type { AuthRouteContext } from "./context";
+import { errorResponse, publicProfile } from "./response-schemas";
 
 export function createProfileSwitchRoutes(ctx: AuthRouteContext) {
   const { auth, run, handleError, rateLimit, socketIpOf, rl, cookieConfig } = ctx;
@@ -15,35 +16,48 @@ export function createProfileSwitchRoutes(ctx: AuthRouteContext) {
       // refresh token in body). The access token's `sub` is `profileId`;
       // we resolve `accountId` via DB lookup.
       // -------------------------------------------------------------------------
-      .get("/profiles/list", async ({ headers, set, server, request }) => {
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "profile_list",
-          rl.profileList,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+      .get(
+        "/profiles/list",
+        async ({ headers, set, server, request }) => {
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "profile_list",
+            rl.profileList,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileById(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileById(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            return await run(auth.listAccountProfiles(profile.accountId));
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          return await run(auth.listAccountProfiles(profile.accountId));
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            200: t.Object({ profiles: t.Array(publicProfile) }),
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "listAccountProfiles", security: [{ bearerAuth: [] }] },
+        },
+      )
       .post(
         "/profiles/switch",
         async ({ body, headers, set, server, request }) => {
@@ -95,6 +109,20 @@ export function createProfileSwitchRoutes(ctx: AuthRouteContext) {
           body: t.Object({
             profile_id: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
           }),
+          response: {
+            // No `token_type`/`scope` here — a switch re-issues only the
+            // access token; the session (and its cookie) is unchanged.
+            200: t.Object({
+              access_token: t.String(),
+              expires_in: t.Number(),
+              profile: publicProfile,
+            }),
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "switchProfile", security: [{ bearerAuth: [] }] },
         },
       )
   );

--- a/osn/api/src/routes/auth/registration.ts
+++ b/osn/api/src/routes/auth/registration.ts
@@ -3,6 +3,7 @@ import { Elysia, t } from "elysia";
 import { buildSessionCookie } from "../../lib/cookie-session";
 import type { AuthRouteContext } from "./context";
 import { toTokenResponseCookieOnly } from "./context";
+import { errorResponse, tokenResponse } from "./response-schemas";
 
 export function createRegistrationRoutes(ctx: AuthRouteContext) {
   const {
@@ -44,6 +45,12 @@ export function createRegistrationRoutes(ctx: AuthRouteContext) {
         },
         {
           params: t.Object({ handle: t.String() }),
+          response: {
+            200: t.Object({ available: t.Boolean() }),
+            400: errorResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "checkHandleAvailability" },
         },
       )
       // -------------------------------------------------------------------------
@@ -96,6 +103,15 @@ export function createRegistrationRoutes(ctx: AuthRouteContext) {
             // when configured, `turnstileGate` rejects a missing/invalid value.
             turnstileToken: t.Optional(t.String()),
           }),
+          response: {
+            200: t.Object({ sent: t.Boolean() }),
+            400: errorResponse,
+            // C-H8 (COPPA): `age_restricted`, raised before the OTP is sent.
+            422: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "beginRegistration" },
         },
       )
       // -------------------------------------------------------------------------
@@ -146,6 +162,18 @@ export function createRegistrationRoutes(ctx: AuthRouteContext) {
             email: t.String(),
             code: t.String(),
           }),
+          response: {
+            201: t.Object({
+              profileId: t.String(),
+              handle: t.String(),
+              email: t.String(),
+              session: tokenResponse,
+            }),
+            400: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "completeRegistration" },
         },
       )
   );

--- a/osn/api/src/routes/auth/response-schemas.ts
+++ b/osn/api/src/routes/auth/response-schemas.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared TypeBox response schemas for the auth route groups.
+ *
+ * These exist for one reason: `@elysiajs/openapi` can only describe a
+ * response it has a schema for. Without them every operation in
+ * `shared/openapi/osn.json` generates with an empty `responses` object,
+ * and a generated client (Swift, TS, anything) gets back `Void`.
+ *
+ * Two things to know before adding one.
+ *
+ * 1. Elysia VALIDATES and CLEANS against `response:` at runtime. A key the
+ *    schema doesn't declare is deleted from the body before it is sent, and
+ *    a value that doesn't type-check 500s the route. A wrong schema here is
+ *    a silent data-loss bug, not a docs bug. Model what the handler actually
+ *    returns, not what you wish it returned.
+ * 2. The schema is checked against the PRE-serialisation value. A `Date`
+ *    never satisfies `t.String({ format: "date-time" })` — the handler has
+ *    to `.toISOString()` first.
+ */
+
+import { t } from "elysia";
+
+/**
+ * The uniform public error envelope. Every auth handler funnels failures
+ * through `publicError` (`lib/public-error.ts`), the rate-limit gate, or
+ * the Turnstile gate, and all three emit `{ error }` with an optional
+ * human-readable `message`. Covers 400, 401, 403, 404, 409, 422, 429 and
+ * 500 alike, so routes reuse this single const at every error status.
+ */
+export const errorResponse = t.Object({
+  error: t.String(),
+  message: t.Optional(t.String()),
+});
+
+/**
+ * A session envelope WITHOUT the refresh token — the return shape of
+ * `toTokenResponseCookieOnly`. The refresh token lives only in the
+ * HttpOnly cookie (S-M2), which is why it is absent here and must stay
+ * absent: adding it to the schema would not leak it (Elysia only strips,
+ * never invents), but it would document a field first-party clients must
+ * never look for.
+ */
+export const tokenResponse = t.Object({
+  access_token: t.String(),
+  token_type: t.Literal("Bearer"),
+  expires_in: t.Number(),
+  scope: t.String(),
+});
+
+/** `PublicProfile` from `services/auth/types.ts`. */
+export const publicProfile = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  email: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  avatarUrl: t.Union([t.String(), t.Null()]),
+});
+
+/** `SessionSummary` from `services/auth/types.ts`. Timestamps are Unix seconds. */
+export const sessionSummary = t.Object({
+  id: t.String(),
+  uaLabel: t.Union([t.String(), t.Null()]),
+  createdAt: t.Number(),
+  lastUsedAt: t.Union([t.Number(), t.Null()]),
+  expiresAt: t.Number(),
+  isCurrent: t.Boolean(),
+});
+
+/**
+ * `PublicKeyCredentialDescriptorJSON` — one entry of `allowCredentials`.
+ * `transports` is whatever the authenticator reported at registration, so
+ * it is a plain string array rather than an enum: the WebAuthn transport
+ * list grows (`hybrid` post-dates `internal`), and an enum here would make
+ * a future browser's value fail response validation and 500 the ceremony.
+ */
+export const publicKeyCredentialDescriptor = t.Object({
+  id: t.String(),
+  type: t.Literal("public-key"),
+  transports: t.Optional(t.Array(t.String())),
+});
+
+/**
+ * `PublicKeyCredentialRequestOptionsJSON` — the assertion ceremony options
+ * handed to `navigator.credentials.get()` on the web and to
+ * `ASAuthorizationPlatformPublicKeyCredentialProvider` on iOS.
+ *
+ * Modelled field by field rather than as `t.Any()` on purpose: `t.Any()`
+ * generates an opaque JSON blob in the client, and the iOS client needs
+ * `challenge`, `rpId`, `allowCredentials` and `userVerification` as typed
+ * values to build a request at all. Only `challenge` is required — the
+ * others are optional in the spec, and `@simplewebauthn/server` omits any
+ * it wasn't asked for.
+ */
+export const publicKeyCredentialRequestOptions = t.Object({
+  challenge: t.String(),
+  timeout: t.Optional(t.Number()),
+  rpId: t.Optional(t.String()),
+  allowCredentials: t.Optional(t.Array(publicKeyCredentialDescriptor)),
+  userVerification: t.Optional(t.String()),
+});

--- a/osn/api/src/routes/auth/sessions.ts
+++ b/osn/api/src/routes/auth/sessions.ts
@@ -3,6 +3,7 @@ import { Elysia, t } from "elysia";
 import { resolveAccessTokenPrincipal } from "../../lib/auth-derive";
 import { buildClearSessionCookie, readSessionCookie } from "../../lib/cookie-session";
 import type { AuthRouteContext } from "./context";
+import { errorResponse, sessionSummary } from "./response-schemas";
 
 export function createSessionRoutes(ctx: AuthRouteContext) {
   const { auth, run, handleError, rateLimit, socketIpOf, rl, cookieConfig } = ctx;
@@ -18,37 +19,50 @@ export function createSessionRoutes(ctx: AuthRouteContext) {
       // `POST /sessions/revoke-all-other` is the "sign out everywhere else"
       // button — it preserves the caller's current session.
       // -------------------------------------------------------------------------
-      .get("/sessions", async ({ headers, set, server, request }) => {
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "session_list",
-          rl.sessionList,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+      .get(
+        "/sessions",
+        async ({ headers, set, server, request }) => {
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "session_list",
+            rl.sessionList,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileById(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileById(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
+            const currentHash = cookieToken ? auth.hashSessionToken(cookieToken) : null;
+            return await run(auth.listAccountSessions(profile.accountId, currentHash));
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
-          const currentHash = cookieToken ? auth.hashSessionToken(cookieToken) : null;
-          return await run(auth.listAccountSessions(profile.accountId, currentHash));
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            200: t.Object({ sessions: t.Array(sessionSummary) }),
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "listSessions", security: [{ bearerAuth: [] }] },
+        },
+      )
       .delete(
         "/sessions/:id",
         async ({ params, headers, set, server, request }) => {
@@ -90,43 +104,64 @@ export function createSessionRoutes(ctx: AuthRouteContext) {
         },
         {
           params: t.Object({ id: t.String({ pattern: "^[0-9a-f]{16}$" }) }),
+          response: {
+            200: t.Object({ success: t.Boolean(), revokedSelf: t.Boolean() }),
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "revokeSession", security: [{ bearerAuth: [] }] },
         },
       )
-      .post("/sessions/revoke-all-other", async ({ headers, set, server, request }) => {
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "session_revoke",
-          rl.sessionRevoke,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+      .post(
+        "/sessions/revoke-all-other",
+        async ({ headers, set, server, request }) => {
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "session_revoke",
+            rl.sessionRevoke,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileById(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileById(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
+            if (!cookieToken) {
+              set.status = 400;
+              return { error: "invalid_request", message: "No current session" };
+            }
+            const currentHash = auth.hashSessionToken(cookieToken);
+            await run(auth.revokeAllOtherAccountSessions(profile.accountId, currentHash));
+            return { success: true };
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
-          if (!cookieToken) {
-            set.status = 400;
-            return { error: "invalid_request", message: "No current session" };
-          }
-          const currentHash = auth.hashSessionToken(cookieToken);
-          await run(auth.revokeAllOtherAccountSessions(profile.accountId, currentHash));
-          return { success: true };
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            200: t.Object({ success: t.Boolean() }),
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "revokeAllOtherSessions", security: [{ bearerAuth: [] }] },
+        },
+      )
   );
 }

--- a/osn/api/src/routes/auth/tokens.ts
+++ b/osn/api/src/routes/auth/tokens.ts
@@ -7,6 +7,7 @@ import {
 } from "../../lib/cookie-session";
 import type { AuthRouteContext } from "./context";
 import { toTokenResponseCookieOnly } from "./context";
+import { errorResponse, tokenResponse } from "./response-schemas";
 
 export function createTokenRoutes(ctx: AuthRouteContext) {
   const { auth, run, cookieConfig } = ctx;
@@ -47,6 +48,13 @@ export function createTokenRoutes(ctx: AuthRouteContext) {
           body: t.Object({
             grant_type: t.String(),
           }),
+          response: {
+            200: tokenResponse,
+            // `unsupported_grant_type`, `invalid_request` (no session cookie)
+            // and `invalid_grant` (rotation/expiry) all land here.
+            400: errorResponse,
+          },
+          detail: { operationId: "refreshSession" },
         },
       )
       // -------------------------------------------------------------------------
@@ -57,17 +65,24 @@ export function createTokenRoutes(ctx: AuthRouteContext) {
       // accepting it here kept the server one accidental-logging incident
       // away from a credential leak. Idempotent — always returns 200.
       // -------------------------------------------------------------------------
-      .post("/logout", async ({ set, headers }) => {
-        const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
-        if (cookieToken) {
-          try {
-            await run(auth.invalidateSession(cookieToken));
-          } catch {
-            // Swallow — don't leak whether the session existed.
+      .post(
+        "/logout",
+        async ({ set, headers }) => {
+          const cookieToken = readSessionCookie(headers.cookie, cookieConfig);
+          if (cookieToken) {
+            try {
+              await run(auth.invalidateSession(cookieToken));
+            } catch {
+              // Swallow — don't leak whether the session existed.
+            }
           }
-        }
-        set.headers["set-cookie"] = buildClearSessionCookie(cookieConfig);
-        return { success: true };
-      })
+          set.headers["set-cookie"] = buildClearSessionCookie(cookieConfig);
+          return { success: true };
+        },
+        {
+          response: { 200: t.Object({ success: t.Boolean() }) },
+          detail: { operationId: "logout" },
+        },
+      )
   );
 }

--- a/osn/api/src/routes/auth/well-known.ts
+++ b/osn/api/src/routes/auth/well-known.ts
@@ -1,7 +1,53 @@
-import { Elysia } from "elysia";
+import { Elysia, t } from "elysia";
 
 import { metricAuthJwksServed } from "../../metrics";
 import type { AuthRouteContext } from "./context";
+
+/** OIDC Discovery 1.0 §3 — every field below is advertised, so every field is built. */
+const openidConfiguration = t.Object({
+  issuer: t.String(),
+  authorization_endpoint: t.String(),
+  token_endpoint: t.String(),
+  jwks_uri: t.String(),
+  response_types_supported: t.Array(t.String()),
+  response_modes_supported: t.Array(t.String()),
+  grant_types_supported: t.Array(t.String()),
+  scopes_supported: t.Array(t.String()),
+  subject_types_supported: t.Array(t.String()),
+  id_token_signing_alg_values_supported: t.Array(t.String()),
+  code_challenge_methods_supported: t.Array(t.String()),
+  authorization_response_iss_parameter_supported: t.Boolean(),
+  token_endpoint_auth_methods_supported: t.Array(t.String()),
+  claims_supported: t.Array(t.String()),
+});
+
+/**
+ * RFC 7517 JWK Set. `additionalProperties: true` is deliberate: the key
+ * object is built by spreading `authConfig.jwtPublicKeyJwk`, and Elysia
+ * DELETES undeclared keys from a response before sending it. A JWK field
+ * this schema forgot would be silently dropped from the document every
+ * relying party verifies signatures against — so the schema documents the
+ * ES256 fields and passes the rest through untouched.
+ */
+const jwkSet = t.Object({
+  keys: t.Array(
+    t.Object(
+      {
+        // Optional to match jose's `JWK`, where every member is optional —
+        // `exportJWK` always emits `kty`, but the type can't say so.
+        kty: t.Optional(t.String()),
+        crv: t.Optional(t.String()),
+        x: t.Optional(t.String()),
+        y: t.Optional(t.String()),
+        use: t.String(),
+        alg: t.String(),
+        kid: t.String(),
+        key_ops: t.Array(t.String()),
+      },
+      { additionalProperties: true },
+    ),
+  ),
+});
 
 export function createWellKnownRoutes(ctx: AuthRouteContext) {
   const { authConfig, jwksResponse } = ctx;
@@ -20,45 +66,59 @@ export function createWellKnownRoutes(ctx: AuthRouteContext) {
       // at `/token`; relying parties get no refresh token, which is why
       // `offline_access` is absent from the scopes.
       // -------------------------------------------------------------------------
-      .get("/.well-known/openid-configuration", () => ({
-        issuer: authConfig.issuerUrl,
-        authorization_endpoint: `${authConfig.issuerUrl}/authorize`,
-        token_endpoint: `${authConfig.issuerUrl}/oidc/token`,
-        jwks_uri: `${authConfig.issuerUrl}/.well-known/jwks.json`,
-        response_types_supported: ["code"],
-        response_modes_supported: ["query"],
-        grant_types_supported: ["authorization_code", "refresh_token"],
-        scopes_supported: ["openid", "profile", "email"],
-        subject_types_supported: ["pairwise"],
-        id_token_signing_alg_values_supported: ["ES256"],
-        code_challenge_methods_supported: ["S256"],
-        // RFC 9207: authorization responses carry an `iss` parameter.
-        authorization_response_iss_parameter_supported: true,
-        token_endpoint_auth_methods_supported: [
-          "client_secret_basic",
-          "client_secret_post",
-          "none",
-        ],
-        claims_supported: [
-          "sub",
-          "iss",
-          "aud",
-          "exp",
-          "iat",
-          "auth_time",
-          "nonce",
-          "name",
-          "preferred_username",
-          "picture",
-          "email",
-          "email_verified",
-        ],
-      }))
-      .get("/.well-known/jwks.json", ({ set }) => {
-        // S-H1: explicit caching contract — aligns with pulse-side JWKS_CACHE_TTL_MS (5 min).
-        set.headers["cache-control"] = "public, max-age=300, stale-while-revalidate=60";
-        metricAuthJwksServed();
-        return jwksResponse;
-      })
+      .get(
+        "/.well-known/openid-configuration",
+        () => ({
+          issuer: authConfig.issuerUrl,
+          authorization_endpoint: `${authConfig.issuerUrl}/authorize`,
+          token_endpoint: `${authConfig.issuerUrl}/oidc/token`,
+          jwks_uri: `${authConfig.issuerUrl}/.well-known/jwks.json`,
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          scopes_supported: ["openid", "profile", "email"],
+          subject_types_supported: ["pairwise"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          code_challenge_methods_supported: ["S256"],
+          // RFC 9207: authorization responses carry an `iss` parameter.
+          authorization_response_iss_parameter_supported: true,
+          token_endpoint_auth_methods_supported: [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+          ],
+          claims_supported: [
+            "sub",
+            "iss",
+            "aud",
+            "exp",
+            "iat",
+            "auth_time",
+            "nonce",
+            "name",
+            "preferred_username",
+            "picture",
+            "email",
+            "email_verified",
+          ],
+        }),
+        {
+          response: { 200: openidConfiguration },
+          detail: { operationId: "getOpenIdConfiguration" },
+        },
+      )
+      .get(
+        "/.well-known/jwks.json",
+        ({ set }) => {
+          // S-H1: explicit caching contract — aligns with pulse-side JWKS_CACHE_TTL_MS (5 min).
+          set.headers["cache-control"] = "public, max-age=300, stale-while-revalidate=60";
+          metricAuthJwksServed();
+          return jwksResponse;
+        },
+        {
+          response: { 200: jwkSet },
+          detail: { operationId: "getJwks" },
+        },
+      )
   );
 }

--- a/osn/api/src/services/auth/config.ts
+++ b/osn/api/src/services/auth/config.ts
@@ -1,3 +1,5 @@
+import type { JWK } from "jose";
+
 import type { RecoveryLockoutStore } from "../../lib/recovery-lockout-store";
 import type { RotatedSessionStore } from "../../lib/rotated-session-store";
 import type { AccountCapLimiter, CeremonyStores, StepUpJtiStore } from "./stores";
@@ -21,8 +23,12 @@ export interface AuthConfig {
   jwtPublicKey: CryptoKey;
   /** Key ID (RFC 7638 thumbprint) — included in JWT headers and JWKS */
   jwtKid: string;
-  /** Public key as JWK object — served at /.well-known/jwks.json */
-  jwtPublicKeyJwk: Record<string, unknown>;
+  /**
+   * Public key as JWK object — served at /.well-known/jwks.json. Typed as
+   * jose's `JWK` rather than `Record<string, unknown>` so the JWKS route can
+   * declare a response schema: an `unknown` value satisfies no TypeBox type.
+   */
+  jwtPublicKeyJwk: JWK;
   /**
    * Access token TTL in seconds. Default: 300 (5 minutes).
    *

--- a/osn/api/tests/helpers/auth-config.ts
+++ b/osn/api/tests/helpers/auth-config.ts
@@ -20,7 +20,7 @@ const BASE_CONFIG = {
 export async function makeTestAuthConfig(): Promise<AuthConfig> {
   const { privateKey, publicKey } = await generateArcKeyPair();
   const kid = await thumbprintKid(publicKey);
-  const jwtPublicKeyJwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+  const jwtPublicKeyJwk = await exportJWK(publicKey);
   return {
     ...BASE_CONFIG,
     jwtPrivateKey: privateKey,

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -16,6 +16,174 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/.well-known/jwks.json": {
+      "get": {
+        "operationId": "getJwks",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "keys": {
+                      "items": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "alg": {
+                            "type": "string"
+                          },
+                          "crv": {
+                            "type": "string"
+                          },
+                          "key_ops": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "kid": {
+                            "type": "string"
+                          },
+                          "kty": {
+                            "type": "string"
+                          },
+                          "use": {
+                            "type": "string"
+                          },
+                          "x": {
+                            "type": "string"
+                          },
+                          "y": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "use",
+                          "alg",
+                          "kid",
+                          "key_ops"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "keys"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          }
+        }
+      }
+    },
+    "/.well-known/openid-configuration": {
+      "get": {
+        "operationId": "getOpenIdConfiguration",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "authorization_endpoint": {
+                      "type": "string"
+                    },
+                    "authorization_response_iss_parameter_supported": {
+                      "type": "boolean"
+                    },
+                    "claims_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "code_challenge_methods_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "grant_types_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "id_token_signing_alg_values_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "issuer": {
+                      "type": "string"
+                    },
+                    "jwks_uri": {
+                      "type": "string"
+                    },
+                    "response_modes_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "response_types_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "scopes_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "subject_types_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "token_endpoint": {
+                      "type": "string"
+                    },
+                    "token_endpoint_auth_methods_supported": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "issuer",
+                    "authorization_endpoint",
+                    "token_endpoint",
+                    "jwks_uri",
+                    "response_types_supported",
+                    "response_modes_supported",
+                    "grant_types_supported",
+                    "scopes_supported",
+                    "subject_types_supported",
+                    "id_token_signing_alg_values_supported",
+                    "code_challenge_methods_supported",
+                    "authorization_response_iss_parameter_supported",
+                    "token_endpoint_auth_methods_supported",
+                    "claims_supported"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          }
+        }
+      }
+    },
     "/account": {
       "delete": {
         "operationId": "deleteAccount",
@@ -666,7 +834,7 @@
     },
     "/handle/{handle}": {
       "get": {
-        "operationId": "getHandleByHandle",
+        "operationId": "checkHandleAvailability",
         "parameters": [
           {
             "in": "path",
@@ -676,7 +844,69 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "available"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          }
+        }
       }
     },
     "/login/cross-device/begin": {
@@ -866,7 +1096,7 @@
     },
     "/login/passkey/begin": {
       "post": {
-        "operationId": "postLoginPasskeyBegin",
+        "operationId": "beginPasskeyLogin",
         "requestBody": {
           "content": {
             "application/json": {
@@ -910,12 +1140,140 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "challengeId": {
+                      "type": "string"
+                    },
+                    "options": {
+                      "properties": {
+                        "allowCredentials": {
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "transports": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "type": {
+                                "const": "public-key",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "challenge": {
+                          "type": "string"
+                        },
+                        "rpId": {
+                          "type": "string"
+                        },
+                        "timeout": {
+                          "type": "number"
+                        },
+                        "userVerification": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "challenge"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "options"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },
     "/login/passkey/complete": {
       "post": {
-        "operationId": "postLoginPasskeyComplete",
+        "operationId": "completePasskeyLogin",
         "requestBody": {
           "content": {
             "application/json": {
@@ -971,6 +1329,144 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "profile": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "displayName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "handle",
+                        "email",
+                        "displayName",
+                        "avatarUrl"
+                      ],
+                      "type": "object"
+                    },
+                    "session": {
+                      "properties": {
+                        "access_token": {
+                          "type": "string"
+                        },
+                        "expires_in": {
+                          "type": "number"
+                        },
+                        "scope": {
+                          "type": "string"
+                        },
+                        "token_type": {
+                          "const": "Bearer",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "access_token",
+                        "token_type",
+                        "expires_in",
+                        "scope"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "session",
+                    "profile"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },
@@ -1037,7 +1533,27 @@
     },
     "/logout": {
       "post": {
-        "operationId": "postLogout"
+        "operationId": "logout",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          }
+        }
       }
     },
     "/oidc/clients": {
@@ -2074,12 +2590,154 @@
     },
     "/profiles/list": {
       "get": {
-        "operationId": "getProfilesList"
+        "operationId": "listAccountProfiles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "profiles": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "email",
+                          "displayName",
+                          "avatarUrl"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "profiles"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/profiles/switch": {
       "post": {
-        "operationId": "postProfilesSwitch",
+        "operationId": "switchProfile",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2126,7 +2784,154 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "access_token": {
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "type": "number"
+                    },
+                    "profile": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "displayName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "handle",
+                        "email",
+                        "displayName",
+                        "avatarUrl"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "access_token",
+                    "expires_in",
+                    "profile"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/profiles/{profileId}/default": {
@@ -2278,7 +3083,7 @@
     },
     "/register/begin": {
       "post": {
-        "operationId": "postRegisterBegin",
+        "operationId": "beginRegistration",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2364,12 +3169,116 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "sent": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "sent"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 422"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },
     "/register/complete": {
       "post": {
-        "operationId": "postRegisterComplete",
+        "operationId": "completeRegistration",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2425,22 +3334,393 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "email": {
+                      "type": "string"
+                    },
+                    "handle": {
+                      "type": "string"
+                    },
+                    "profileId": {
+                      "type": "string"
+                    },
+                    "session": {
+                      "properties": {
+                        "access_token": {
+                          "type": "string"
+                        },
+                        "expires_in": {
+                          "type": "number"
+                        },
+                        "scope": {
+                          "type": "string"
+                        },
+                        "token_type": {
+                          "const": "Bearer",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "access_token",
+                        "token_type",
+                        "expires_in",
+                        "scope"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "profileId",
+                    "handle",
+                    "email",
+                    "session"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },
     "/sessions": {
       "get": {
-        "operationId": "getSessions"
+        "operationId": "listSessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "sessions": {
+                      "items": {
+                        "properties": {
+                          "createdAt": {
+                            "type": "number"
+                          },
+                          "expiresAt": {
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isCurrent": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "uaLabel": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "uaLabel",
+                          "createdAt",
+                          "lastUsedAt",
+                          "expiresAt",
+                          "isCurrent"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "sessions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/sessions/revoke-all-other": {
       "post": {
-        "operationId": "postSessionsRevoke-all-other"
+        "operationId": "revokeAllOtherSessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/sessions/{id}": {
       "delete": {
-        "operationId": "deleteSessionsById",
+        "operationId": "revokeSession",
         "parameters": [
           {
             "in": "path",
@@ -2450,6 +3730,119 @@
               "pattern": "^[0-9a-f]{16}$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "revokedSelf": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "revokedSelf"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
@@ -2642,7 +4035,7 @@
     },
     "/token": {
       "post": {
-        "operationId": "postToken",
+        "operationId": "refreshSession",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2686,6 +4079,60 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "access_token": {
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "type": "number"
+                    },
+                    "scope": {
+                      "type": "string"
+                    },
+                    "token_type": {
+                      "const": "Bearer",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "access_token",
+                    "token_type",
+                    "expires_in",
+                    "scope"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          }
         }
       }
     }


### PR DESCRIPTION
Stacked on #421 (`feat/osn-api-openapi`) — review that one first; this diff is only the second commit.

#421 landed the generator and said the follow-up was to declare `response:` schemas route group by route group. This is the first of those groups: the core session lifecycle.

## What now has a schema

Fourteen operations, each with an `operationId` and (where the route is bearer-authed) `security: [{ bearerAuth: [] }]`:

| Route group | Operations |
|---|---|
| `registration.ts` | `checkHandleAvailability`, `beginRegistration`, `completeRegistration` |
| `tokens.ts` | `refreshSession`, `logout` |
| `login.ts` | `beginPasskeyLogin`, `completePasskeyLogin` |
| `sessions.ts` | `listSessions`, `revokeSession`, `revokeAllOtherSessions` |
| `profile-switch.ts` | `listAccountProfiles`, `switchProfile` |
| `well-known.ts` | `getOpenIdConfiguration`, `getJwks` |

Shared shapes live in a new `routes/auth/response-schemas.ts`: `errorResponse`, `tokenResponse`, `publicProfile`, `sessionSummary`, and the two WebAuthn request-options objects.

The error contract is uniform across `@osn/api`, which is what makes annotating 71 operations tractable at all — `publicError` maps to 422 `age_restricted` / 400 `invalid_request` / 500 `internal_error`, `rateLimit` to 429 `rate_limited`, `turnstileGate` to 400 `turnstile_failed`. One `errorResponse` covers every non-2xx here.

## The part worth reviewing carefully

**These schemas are not documentation.** Elysia validates and *cleans* every response against its schema at runtime. An undeclared key is deleted from the body before it goes out; a value that fails its type check turns the route into a 500. A wrong schema here is a silent data-loss bug, not a stale doc.

Two consequences shaped the diff:

- Every schema was written against the handler's actual return value and the service's declared return type, not against what the endpoint is supposed to mean. `switchProfile` gets `{ access_token, expires_in, profile }` with no `token_type`/`scope`, because a switch re-issues only the access token and leaves the session cookie alone.
- The JWK object carries `additionalProperties: true` on purpose. It is built by spreading `authConfig.jwtPublicKeyJwk`, so a JWK field this schema forgot would be silently stripped from the document every relying party verifies signatures against. The schema names the ES256 fields and passes the rest through.

`PublicKeyCredentialRequestOptionsJSON` is modelled field by field rather than `t.Any()`. Safe because `generateAuthenticationOptions` is called without `extensions` (`passkeys.ts:356-416`), so nothing gets stripped — and the iOS `ASAuthorizationPlatformPublicKeyCredentialProvider` needs `challenge`/`rpId`/`allowCredentials`/`userVerification` as typed values, not as `any`. `transports` is `t.Array(t.String())` rather than an enum: the registry keeps adding members (`hybrid` post-dates `internal`), and an enum would strip a transport an authenticator legitimately reports.

## Two supporting changes

`AuthConfig.jwtPublicKeyJwk` is now typed as jose's `JWK` instead of `Record<string, unknown>` — a property of type `unknown` satisfies no TypeBox schema, so the JWKS route could not declare one. The three `as Record<string, unknown>` casts at its call sites are gone. The prebuilt `jwksResponse` also loses its `as const`, which had widened it to a readonly tuple that no `t.Array` accepts; the prebuild-once win comes from sharing the object, not from the literal type.

## `/.well-known/*` was missing from the document entirely

Neither `/.well-known/openid-configuration` nor `/.well-known/jwks.json` had ever appeared in `osn.json` — the two endpoints every relying party reads first. `@elysiajs/openapi` decides a route serves a static file when its path contains a dot (`openapi.mjs:411`), and dropped both. No route in `@osn/api` serves a file, so `exclude.staticFile` is now `false`. The document goes from 71 operations to 73.

## Verification

- `bun run --cwd osn/api check` — clean
- `bun run --cwd osn/api test:run` — 61 files, 1001 tests, all pass
- `bun run --cwd pulse/api openapi:generate` — `shared/openapi/pulse.json` byte-identical, so the shared post-processing is untouched
- `shared/openapi/osn.json`: 73 operations, 14 carrying `responses`

## Still open from #421

The openapi plugin is mounted unconditionally, matching pulse, so the deployed `id.musubi.social` Worker serves a Scalar docs UI at `/openapi` enumerating the whole public auth surface. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`. Not decided yet.

## Next in the stack

`passkey-enroll`, `passkey-management`, `step-up`, `recovery`, `cross-device`, `email-change`, `security-events`, then the OIDC group; after that graph and organisations. The generated `OSNAPI` Swift target is worth cutting only once the operations a client actually calls carry responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)