### PR TITLE
feat(osn-api): describe the OIDC route group's responses

### DIFF
--- a/.changeset/osn-api-oidc-response-schemas.md
+++ b/.changeset/osn-api-oidc-response-schemas.md
@@ -1,0 +1,43 @@
+---
+"@osn/api": patch
+---
+
+OIDC route group — response schemas and stable operation ids (PR 4 of the
+`shared/openapi/osn.json` series). Covers `routes/auth/oidc-clients.ts` (client
+registration, list, disable) and `routes/auth/oidc.ts` (`/authorize`,
+`/authorize/context`, `/authorize/decision`, `/oidc/token`,
+`/oidc/connections`). Nine operations that previously generated with an empty
+`responses` object — and so a `Void` return in any generated client — now
+describe every status they can emit.
+
+Two things about this group are unlike the ones before it.
+
+The OIDC routes emit **two different error envelopes at the same status**.
+Their own refusals use the RFC 6749 §5.2 `{ error, error_description }` shape;
+the shared rate-limit gate and `handleError` use the house
+`{ error, message }`. Elysia's `response:` schemas clean as well as validate —
+an undeclared key is deleted from the body before it is sent — so a schema
+carrying only the RFC pair would silently blank the message on a 429 or a 500.
+`oidcErrorResponse` is therefore a superset of both, with `error_description`
+and `message` each optional, rather than a union.
+
+`GET /authorize` is the only route in the auth surface whose body is sometimes
+a string. It answers a browser navigation, not a fetch, and has three shapes:
+an empty body at 302 (every success and every post-validation error, which
+travels back to the relying party as query parameters); a rendered HTML page at
+400/401/429, because RFC 6749 §4.1.2.1 forbids redirecting before the client
+and redirect URI are trusted, so the user is stranded and gets a real page; and
+a JSON error at 400/500 when a non-OIDC failure falls through `handleError`.
+Its 400 is a `t.Union([t.String(), oidcErrorResponse])` for that reason —
+declaring only the object would have made Elysia reject the error page it was
+rendering.
+
+Four new schema consts in `routes/auth/response-schemas.ts`
+(`oidcErrorResponse`, `ownedClientSummary`, `oidcConnectionSummary`,
+`oidcTokenResponse`), each modelled on the service's literal return type rather
+than the endpoint's apparent intent. Routes authenticated by session cookie or
+client credentials get an `operationId` but no `security: [{ bearerAuth: [] }]`,
+since a bearer token is not what authenticates them.
+
+No behaviour change: the route set in `shared/openapi/osn.json` is identical
+before and after, and `shared/openapi/pulse.json` regenerates byte-identical.

--- a/osn/api/src/routes/auth/oidc-clients.ts
+++ b/osn/api/src/routes/auth/oidc-clients.ts
@@ -18,6 +18,7 @@ import { Elysia, t } from "elysia";
 import { resolveAccessTokenPrincipal } from "../../lib/auth-derive";
 import { validateClientRegistration } from "../../services/auth";
 import type { AuthRouteContext } from "./context";
+import { oidcErrorResponse, ownedClientSummary } from "./response-schemas";
 
 export function createOidcClientRoutes(ctx: AuthRouteContext) {
   const { auth, run, handleError, rateLimit, socketIpOf, rl } = ctx;
@@ -110,38 +111,72 @@ export function createOidcClientRoutes(ctx: AuthRouteContext) {
             logo_url: t.Optional(t.String({ maxLength: 1024 })),
             confidential: t.Optional(t.Boolean()),
           }),
+          response: {
+            // 201, not 200 — the only route in the auth surface that creates a
+            // durable record the caller then addresses by id.
+            201: t.Object({
+              client: ownedClientSummary,
+              // Shown exactly once, and null for a public client. The server
+              // keeps only the SHA-256, so a client that loses this must
+              // register again.
+              client_secret: t.Union([t.String(), t.Null()]),
+            }),
+            // Both envelopes land here: `validateClientRegistration` and the
+            // `OidcError` catch emit `error_description`, the rate-limit gate
+            // and `handleError` emit `message`.
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "registerOidcClient", security: [{ bearerAuth: [] }] },
         },
       )
       // -----------------------------------------------------------------------
       // GET /oidc/clients — the caller's registered clients.
       // -----------------------------------------------------------------------
-      .get("/oidc/clients", async ({ headers, set, server, request }) => {
-        set.headers["cache-control"] = "no-store";
+      .get(
+        "/oidc/clients",
+        async ({ headers, set, server, request }) => {
+          set.headers["cache-control"] = "no-store";
 
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "oidc_client_list",
-          rl.oidcClientList,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const accountId = await resolveOwner(headers.authorization);
-          if (accountId === null) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "oidc_client_list",
+            rl.oidcClientList,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const clients = await run(auth.listOwnedOidcClients(accountId));
-          return { clients };
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+          try {
+            const accountId = await resolveOwner(headers.authorization);
+            if (accountId === null) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const clients = await run(auth.listOwnedOidcClients(accountId));
+            return { clients };
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
+          }
+        },
+        {
+          response: {
+            // Disabled clients stay in the list — the owner needs to see that
+            // the id is spent, not have it vanish.
+            200: t.Object({ clients: t.Array(ownedClientSummary) }),
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "listOidcClients", security: [{ bearerAuth: [] }] },
+        },
+      )
       // -----------------------------------------------------------------------
       // DELETE /oidc/clients/:clientId — disable an owned client.
       //
@@ -182,7 +217,20 @@ export function createOidcClientRoutes(ctx: AuthRouteContext) {
             return errBody;
           }
         },
-        { params: t.Object({ clientId: t.String({ minLength: 1, maxLength: 128 }) }) },
+        {
+          params: t.Object({ clientId: t.String({ minLength: 1, maxLength: 128 }) }),
+          response: {
+            200: t.Object({ success: t.Boolean() }),
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            // Covers "not yours" as well as "no such client" — deliberately
+            // one status, so the route is not an existence oracle.
+            404: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "disableOidcClient", security: [{ bearerAuth: [] }] },
+        },
       )
   );
 }

--- a/osn/api/src/routes/auth/oidc.ts
+++ b/osn/api/src/routes/auth/oidc.ts
@@ -35,6 +35,12 @@ import {
 import { metricOidcAuthorize, metricOidcConsentGranted, metricOidcToken } from "../../metrics";
 import type { AuthorizeSession, OidcErrorCode } from "../../services/auth";
 import type { AuthRouteContext } from "./context";
+import {
+  oidcConnectionSummary,
+  oidcErrorResponse,
+  oidcTokenResponse,
+  publicProfile,
+} from "./response-schemas";
 
 /** The wire codes that map onto their own authorize metric bucket. */
 const AUTHORIZE_RESULTS = new Set<string>([
@@ -230,126 +236,163 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
       // relying party with a code, off to the consent UI, or back to the
       // relying party with an error.
       // -----------------------------------------------------------------------
-      .get("/authorize", async ({ query, set, headers, server, request }) => {
-        set.headers["cache-control"] = "no-store";
-        // The interaction redirect carries the parked-request id in its query
-        // string, and the whole endpoint carries the relying party's OAuth
-        // parameters. Neither may ride a `Referer` header onto the next page.
-        set.headers["referrer-policy"] = "no-referrer";
+      .get(
+        "/authorize",
+        async ({ query, set, headers, server, request }) => {
+          set.headers["cache-control"] = "no-store";
+          // The interaction redirect carries the parked-request id in its query
+          // string, and the whole endpoint carries the relying party's OAuth
+          // parameters. Neither may ride a `Referer` header onto the next page.
+          set.headers["referrer-policy"] = "no-referrer";
 
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "oidc_authorize",
-          rl.oidcAuthorize,
-        );
-        if (rlErr) {
-          // Top-level navigation: a JSON blob would strand the user. Render the
-          // branded error page instead (the XHR context/decision routes below
-          // keep returning JSON).
-          set.status = 429;
-          set.headers["content-type"] = "text/html; charset=utf-8";
-          return renderAuthorizeErrorPage("rate_limited");
-        }
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "oidc_authorize",
+            rl.oidcAuthorize,
+          );
+          if (rlErr) {
+            // Top-level navigation: a JSON blob would strand the user. Render the
+            // branded error page instead (the XHR context/decision routes below
+            // keep returning JSON).
+            set.status = 429;
+            set.headers["content-type"] = "text/html; charset=utf-8";
+            return renderAuthorizeErrorPage("rate_limited");
+          }
 
-        const q = query as Record<string, string | undefined>;
-        const params = {
-          clientId: q["client_id"] ?? "",
-          redirectUri: q["redirect_uri"] ?? "",
-          responseType: q["response_type"] ?? "",
-          scope: q["scope"] ?? null,
-          state: q["state"] ?? null,
-          nonce: q["nonce"] ?? null,
-          codeChallenge: q["code_challenge"] ?? null,
-          codeChallengeMethod: q["code_challenge_method"] ?? "",
-          prompt: q["prompt"] ?? null,
-          maxAge: q["max_age"] ?? null,
-        };
+          const q = query as Record<string, string | undefined>;
+          const params = {
+            clientId: q["client_id"] ?? "",
+            redirectUri: q["redirect_uri"] ?? "",
+            responseType: q["response_type"] ?? "",
+            scope: q["scope"] ?? null,
+            state: q["state"] ?? null,
+            nonce: q["nonce"] ?? null,
+            codeChallenge: q["code_challenge"] ?? null,
+            codeChallengeMethod: q["code_challenge_method"] ?? "",
+            prompt: q["prompt"] ?? null,
+            maxAge: q["max_age"] ?? null,
+          };
 
-        const validated = await run(Effect.either(auth.validateAuthorizeRequest(params)));
+          const validated = await run(Effect.either(auth.validateAuthorizeRequest(params)));
 
-        if (Either.isLeft(validated)) {
-          const oidc = asOidcError(validated.left);
-          if (!oidc) {
-            metricOidcAuthorize({ result: "server_error", clientKind: "third_party" });
-            const { status, body } = handleError(validated.left);
+          if (Either.isLeft(validated)) {
+            const oidc = asOidcError(validated.left);
+            if (!oidc) {
+              metricOidcAuthorize({ result: "server_error", clientKind: "third_party" });
+              const { status, body } = handleError(validated.left);
+              set.status = status;
+              return body;
+            }
+            // No trusted redirect URI exists yet, so this is rendered — never
+            // redirected (open-redirect guard). The client kind is unknowable for
+            // the same reason. This is a top-level browser navigation, so render
+            // a branded HTML page (keyed only off our own error code, never any
+            // RP-supplied value) rather than stranding the user on raw JSON.
+            metricOidcAuthorize({
+              result: authorizeResultOf(oidc.code),
+              clientKind: "third_party",
+            });
+            set.status = oidc.code === "invalid_client" ? 401 : 400;
+            set.headers["content-type"] = "text/html; charset=utf-8";
+            return renderAuthorizeErrorPage(oidc.code);
+          }
+
+          const outcome = validated.right;
+
+          if (outcome.kind === "error") {
+            metricOidcAuthorize({
+              result: authorizeResultOf(outcome.code),
+              clientKind: clientKindOf(outcome.client),
+            });
+            set.status = 302;
+            set.headers["location"] = auth.buildOidcErrorRedirect(
+              outcome.redirectUri,
+              outcome.code,
+              outcome.description,
+              outcome.state,
+            );
+            return "";
+          }
+
+          const { request: authorizeRequest, prompts } = outcome;
+          const clientKind = clientKindOf(authorizeRequest.client);
+          const session = await resolveSession(headers.cookie);
+
+          let prepared;
+          try {
+            prepared = await run(auth.prepareAuthorization(authorizeRequest, prompts, session));
+          } catch (e) {
+            metricOidcAuthorize({ result: "server_error", clientKind });
+            const { status, body } = handleError(e);
             set.status = status;
             return body;
           }
-          // No trusted redirect URI exists yet, so this is rendered — never
-          // redirected (open-redirect guard). The client kind is unknowable for
-          // the same reason. This is a top-level browser navigation, so render
-          // a branded HTML page (keyed only off our own error code, never any
-          // RP-supplied value) rather than stranding the user on raw JSON.
-          metricOidcAuthorize({ result: authorizeResultOf(oidc.code), clientKind: "third_party" });
-          set.status = oidc.code === "invalid_client" ? 401 : 400;
-          set.headers["content-type"] = "text/html; charset=utf-8";
-          return renderAuthorizeErrorPage(oidc.code);
-        }
 
-        const outcome = validated.right;
-
-        if (outcome.kind === "error") {
-          metricOidcAuthorize({
-            result: authorizeResultOf(outcome.code),
-            clientKind: clientKindOf(outcome.client),
-          });
           set.status = 302;
+          if (prepared.kind === "code") {
+            metricOidcAuthorize({ result: "redirected", clientKind });
+            set.headers["location"] = auth.buildOidcCodeRedirect(
+              authorizeRequest.redirectUri,
+              prepared.code,
+              authorizeRequest.state,
+            );
+            return "";
+          }
+          if (prepared.kind === "interaction") {
+            metricOidcAuthorize({ result: "interaction", clientKind });
+            // S-M1: bind the parked request to this browser. The consent screen's
+            // context + decision calls must arrive with this cookie, so a leaked
+            // or guessed request id approves nothing anywhere else.
+            set.headers["set-cookie"] = buildBindingCookie(
+              prepared.requestId,
+              prepared.bindingSecret,
+              cookieConfig,
+            );
+            set.headers["location"] = buildInteractionRedirect(prepared.requestId, prepared.reason);
+            return "";
+          }
+          metricOidcAuthorize({ result: authorizeResultOf(prepared.code), clientKind });
           set.headers["location"] = auth.buildOidcErrorRedirect(
-            outcome.redirectUri,
-            outcome.code,
-            outcome.description,
-            outcome.state,
-          );
-          return "";
-        }
-
-        const { request: authorizeRequest, prompts } = outcome;
-        const clientKind = clientKindOf(authorizeRequest.client);
-        const session = await resolveSession(headers.cookie);
-
-        let prepared;
-        try {
-          prepared = await run(auth.prepareAuthorization(authorizeRequest, prompts, session));
-        } catch (e) {
-          metricOidcAuthorize({ result: "server_error", clientKind });
-          const { status, body } = handleError(e);
-          set.status = status;
-          return body;
-        }
-
-        set.status = 302;
-        if (prepared.kind === "code") {
-          metricOidcAuthorize({ result: "redirected", clientKind });
-          set.headers["location"] = auth.buildOidcCodeRedirect(
             authorizeRequest.redirectUri,
             prepared.code,
+            prepared.description,
             authorizeRequest.state,
           );
           return "";
-        }
-        if (prepared.kind === "interaction") {
-          metricOidcAuthorize({ result: "interaction", clientKind });
-          // S-M1: bind the parked request to this browser. The consent screen's
-          // context + decision calls must arrive with this cookie, so a leaked
-          // or guessed request id approves nothing anywhere else.
-          set.headers["set-cookie"] = buildBindingCookie(
-            prepared.requestId,
-            prepared.bindingSecret,
-            cookieConfig,
-          );
-          set.headers["location"] = buildInteractionRedirect(prepared.requestId, prepared.reason);
-          return "";
-        }
-        metricOidcAuthorize({ result: authorizeResultOf(prepared.code), clientKind });
-        set.headers["location"] = auth.buildOidcErrorRedirect(
-          authorizeRequest.redirectUri,
-          prepared.code,
-          prepared.description,
-          authorizeRequest.state,
-        );
-        return "";
-      })
+        },
+        {
+          // The only route in this file that answers a browser navigation
+          // rather than a fetch, so it is the only one whose body is sometimes
+          // a string. Three shapes, not two:
+          //
+          //   302 + empty body   — every success and every post-validation
+          //                        error, which goes back to the relying party
+          //                        as query parameters, never as a body.
+          //   HTML page          — an error raised BEFORE the redirect URI is
+          //                        trusted. RFC 6749 §4.1.2.1 forbids
+          //                        redirecting there, so the user is stranded
+          //                        and gets a real page.
+          //   JSON error         — a non-OIDC failure falling through
+          //                        `handleError` (a DatabaseError is the only
+          //                        realistic one).
+          //
+          // 400 carries both of the latter two, hence the union. Declaring
+          // only the object would have made Elysia reject the HTML string.
+          response: {
+            302: t.String(),
+            400: t.Union([t.String(), oidcErrorResponse]),
+            // `invalid_client` alone — an unrecognised or disabled relying
+            // party, rendered for the same reason.
+            401: t.String(),
+            429: t.String(),
+            500: oidcErrorResponse,
+          },
+          // Unauthenticated by design: an unsigned-in browser is the normal
+          // case here, and the answer to it is the sign-in screen.
+          detail: { operationId: "oidcAuthorize" },
+        },
+      )
       // -----------------------------------------------------------------------
       // GET /authorize/context — what the consent screen needs to draw itself.
       //
@@ -424,7 +467,37 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
             return body;
           }
         },
-        { query: t.Object({ request: t.String({ pattern: "^oar_[a-f0-9]{12}$" }) }) },
+        {
+          query: t.Object({ request: t.String({ pattern: "^oar_[a-f0-9]{12}$" }) }),
+          response: {
+            200: t.Object({
+              client: t.Object({
+                clientId: t.String(),
+                name: t.String(),
+                logoUrl: t.Union([t.String(), t.Null()]),
+                firstParty: t.Boolean(),
+                // The host the code is actually delivered to for THIS request.
+                // The consent screen shows it beside the self-asserted (and so
+                // spoofable) name, so dropping it would remove the one signal
+                // that separates a genuine first-party app from a look-alike.
+                redirectDomain: t.String(),
+              }),
+              scopes: t.Array(t.String()),
+              signedIn: t.Boolean(),
+              // Empty when the browser holds no session — the screen then
+              // sends the user to sign in and retries the same request id.
+              profiles: t.Array(publicProfile),
+              linkedProfileId: t.Union([t.String(), t.Null()]),
+            }),
+            400: oidcErrorResponse,
+            // Unknown id, expired id, and a right id in the wrong browser all
+            // answer identically: a leaked request id learns nothing here.
+            404: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "getOidcAuthorizeContext" },
+        },
       )
       // -----------------------------------------------------------------------
       // POST /authorize/decision — the user's answer.
@@ -497,6 +570,22 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
             profileId: t.String(),
             approved: t.Boolean(),
           }),
+          response: {
+            // A refusal is a 200 too: `approved: false` still produces a URL,
+            // one carrying `error=access_denied` back to the relying party.
+            // The screen navigates there itself, which is why this is JSON and
+            // not a 302 — a fetch would follow a redirect instead of handing
+            // it to the page.
+            200: t.Object({ redirectTo: t.String() }),
+            // Includes `login_required`, which leaves the parked request alive
+            // so the screen can re-authenticate and retry the same id.
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          // The session cookie authenticates this, not a bearer token.
+          detail: { operationId: "submitOidcAuthorizeDecision" },
         },
       )
       // -----------------------------------------------------------------------
@@ -604,6 +693,18 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
             client_id: t.Optional(t.String()),
             client_secret: t.Optional(t.String()),
           }),
+          response: {
+            200: oidcTokenResponse,
+            400: oidcErrorResponse,
+            // `invalid_client`. Paired with a `WWW-Authenticate: Basic` header
+            // when the credentials came in over HTTP Basic.
+            401: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          // Client authentication, not user authentication — HTTP Basic or
+          // form credentials, so no `bearerAuth`.
+          detail: { operationId: "exchangeOidcAuthorizationCode" },
         },
       )
       // -----------------------------------------------------------------------
@@ -613,38 +714,52 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
       // settings surface lists, and the record Art. 15 says the person may
       // see. Access-token authed like every other settings read.
       // -----------------------------------------------------------------------
-      .get("/oidc/connections", async ({ headers, set, server, request }) => {
-        set.headers["cache-control"] = "no-store";
+      .get(
+        "/oidc/connections",
+        async ({ headers, set, server, request }) => {
+          set.headers["cache-control"] = "no-store";
 
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "oidc_connections_list",
-          rl.oidcConnectionsList,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "oidc_connections_list",
+            rl.oidcConnectionsList,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileById(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileById(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const connections = await run(auth.listOidcConsents(profile.accountId));
+            return { connections };
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          const connections = await run(auth.listOidcConsents(profile.accountId));
-          return { connections };
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            // Live consents only — a revoked row never comes back here.
+            200: t.Object({ connections: t.Array(oidcConnectionSummary) }),
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "listOidcConnections", security: [{ bearerAuth: [] }] },
+        },
+      )
       // -----------------------------------------------------------------------
       // DELETE /oidc/connections/:clientId — withdraw an app's authorization.
       //
@@ -692,7 +807,20 @@ export function createOidcRoutes(ctx: AuthRouteContext) {
             return errBody;
           }
         },
-        { params: t.Object({ clientId: t.String({ minLength: 1, maxLength: 128 }) }) },
+        {
+          params: t.Object({ clientId: t.String({ minLength: 1, maxLength: 128 }) }),
+          response: {
+            200: t.Object({ success: t.Boolean() }),
+            400: oidcErrorResponse,
+            401: oidcErrorResponse,
+            // No live consent for that pair — already revoked, or never
+            // granted. The two are not told apart.
+            404: oidcErrorResponse,
+            429: oidcErrorResponse,
+            500: oidcErrorResponse,
+          },
+          detail: { operationId: "revokeOidcConnection", security: [{ bearerAuth: [] }] },
+        },
       )
   );
 }

--- a/osn/api/src/routes/auth/response-schemas.ts
+++ b/osn/api/src/routes/auth/response-schemas.ts
@@ -33,6 +33,23 @@ export const errorResponse = t.Object({
 });
 
 /**
+ * The OAuth/OIDC error envelope — `{ error, error_description }` per RFC 6749
+ * §5.2, which is NOT the `{ error, message }` shape the rest of this API uses.
+ *
+ * Both keys of both shapes are declared here because the OIDC routes emit both
+ * envelopes at the same status. A route's own refusals carry
+ * `error_description`; the rate-limit gate and `handleError` fall through the
+ * same status with `message`. Elysia deletes any key the schema omits, so a
+ * schema carrying only the RFC pair would silently blank the message on a 429
+ * or a 500. The superset costs one optional field and cannot lose either.
+ */
+export const oidcErrorResponse = t.Object({
+  error: t.String(),
+  error_description: t.Optional(t.String()),
+  message: t.Optional(t.String()),
+});
+
+/**
  * A session envelope WITHOUT the refresh token — the return shape of
  * `toTokenResponseCookieOnly`. The refresh token lives only in the
  * HttpOnly cookie (S-M2), which is why it is absent here and must stay
@@ -173,4 +190,48 @@ export const securityEventSummary = t.Object({
 export const stepUpTokenResponse = t.Object({
   step_up_token: t.String(),
   expires_in: t.Number(),
+});
+
+/**
+ * `OwnedClientSummary` from `services/auth/oidc.ts` — a relying party as shown
+ * to the account that registered it. `confidential` is derived (a secret hash
+ * exists), never the hash itself. Timestamps are Unix seconds.
+ */
+export const ownedClientSummary = t.Object({
+  clientId: t.String(),
+  name: t.String(),
+  logoUrl: t.Union([t.String(), t.Null()]),
+  redirectUris: t.Array(t.String()),
+  sectorIdentifier: t.String(),
+  confidential: t.Boolean(),
+  createdAt: t.Number(),
+  disabledAt: t.Union([t.Number(), t.Null()]),
+});
+
+/**
+ * `OidcConnectionSummary` from `services/auth/oidc.ts` — one row of "apps you
+ * have authorised". `clientName` is nullable only for a consent whose client
+ * row was deleted underneath it.
+ */
+export const oidcConnectionSummary = t.Object({
+  clientId: t.String(),
+  clientName: t.Union([t.String(), t.Null()]),
+  logoUrl: t.Union([t.String(), t.Null()]),
+  profileId: t.String(),
+  scope: t.String(),
+  grantedAt: t.Number(),
+});
+
+/**
+ * `OidcTokenResponse` from `services/auth/oidc.ts`. Deliberately unlike
+ * `tokenResponse` above: this one carries an `id_token` and never a refresh
+ * token, and its access token never holds the `osn-access` audience, so a
+ * relying party's token cannot reach a first-party route.
+ */
+export const oidcTokenResponse = t.Object({
+  access_token: t.String(),
+  id_token: t.String(),
+  token_type: t.Literal("Bearer"),
+  expires_in: t.Number(),
+  scope: t.String(),
 });

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -1091,12 +1091,99 @@
     },
     "/authorize": {
       "get": {
-        "operationId": "getAuthorize"
+        "operationId": "oidcAuthorize",
+        "responses": {
+          "302": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Response for status 302"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        },
+                        "error_description": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        }
       }
     },
     "/authorize/context": {
       "get": {
-        "operationId": "getAuthorizeContext",
+        "operationId": "getOidcAuthorizeContext",
         "parameters": [
           {
             "in": "query",
@@ -1107,12 +1194,210 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "client": {
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "firstParty": {
+                          "type": "boolean"
+                        },
+                        "logoUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "redirectDomain": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "name",
+                        "logoUrl",
+                        "firstParty",
+                        "redirectDomain"
+                      ],
+                      "type": "object"
+                    },
+                    "linkedProfileId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "profiles": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "email",
+                          "displayName",
+                          "avatarUrl"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "signedIn": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "client",
+                    "scopes",
+                    "signedIn",
+                    "profiles",
+                    "linkedProfileId"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        }
       }
     },
     "/authorize/decision": {
       "post": {
-        "operationId": "postAuthorizeDecision",
+        "operationId": "submitOidcAuthorizeDecision",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1183,6 +1468,122 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "redirectTo": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "redirectTo"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },
@@ -2815,10 +3216,179 @@
     },
     "/oidc/clients": {
       "get": {
-        "operationId": "getOidcClients"
+        "operationId": "listOidcClients",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "clients": {
+                      "items": {
+                        "properties": {
+                          "clientId": {
+                            "type": "string"
+                          },
+                          "confidential": {
+                            "type": "boolean"
+                          },
+                          "createdAt": {
+                            "type": "number"
+                          },
+                          "disabledAt": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "logoUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "redirectUris": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sectorIdentifier": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "clientId",
+                          "name",
+                          "logoUrl",
+                          "redirectUris",
+                          "sectorIdentifier",
+                          "confidential",
+                          "createdAt",
+                          "disabledAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "clients"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
-        "operationId": "postOidcClients",
+        "operationId": "registerOidcClient",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2922,12 +3492,185 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "client": {
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "confidential": {
+                          "type": "boolean"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "disabledAt": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "logoUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "redirectUris": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "sectorIdentifier": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "name",
+                        "logoUrl",
+                        "redirectUris",
+                        "sectorIdentifier",
+                        "confidential",
+                        "createdAt",
+                        "disabledAt"
+                      ],
+                      "type": "object"
+                    },
+                    "client_secret": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "client",
+                    "client_secret"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/oidc/clients/{clientId}": {
       "delete": {
-        "operationId": "deleteOidcClientsByClientId",
+        "operationId": "disableOidcClient",
         "parameters": [
           {
             "in": "path",
@@ -2938,18 +3681,321 @@
               "minLength": 1,
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/oidc/connections": {
       "get": {
-        "operationId": "getOidcConnections"
+        "operationId": "listOidcConnections",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "connections": {
+                      "items": {
+                        "properties": {
+                          "clientId": {
+                            "type": "string"
+                          },
+                          "clientName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "grantedAt": {
+                            "type": "number"
+                          },
+                          "logoUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "profileId": {
+                            "type": "string"
+                          },
+                          "scope": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "clientId",
+                          "clientName",
+                          "logoUrl",
+                          "profileId",
+                          "scope",
+                          "grantedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "connections"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/oidc/connections/{clientId}": {
       "delete": {
-        "operationId": "deleteOidcConnectionsByClientId",
+        "operationId": "revokeOidcConnection",
         "parameters": [
           {
             "in": "path",
@@ -2961,12 +4007,157 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
     "/oidc/token": {
       "post": {
-        "operationId": "postOidcToken",
+        "operationId": "exchangeOidcAuthorizationCode",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3055,6 +4246,139 @@
             }
           },
           "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "access_token": {
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "type": "number"
+                    },
+                    "id_token": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "type": "string"
+                    },
+                    "token_type": {
+                      "const": "Bearer",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "access_token",
+                    "id_token",
+                    "token_type",
+                    "expires_in",
+                    "scope"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
         }
       }
     },


### PR DESCRIPTION
Fourth in the stack that gives `shared/openapi/osn.json` real response schemas. Stacked on #423 (`feat/osn-api-response-schemas-2`) — review that one first; this diff is only the OIDC group.

## Why

`@elysiajs/openapi` can only describe a response it has a schema for. Without one, an operation generates with an empty `responses` object and a generated client — Swift, TypeScript, anything — gets `Void` back. That was true of the entire OIDC surface, including the token exchange, which is the one route a relying party cannot do anything without.

Nine operations now describe every status they can emit, and carry a stable `operationId` so a regenerated client doesn't rename its methods when a route moves.

| Operation | Statuses |
|---|---|
| `registerOidcClient` | 201, 400, 401, 429, 500 |
| `listOidcClients` | 200, 400, 401, 429, 500 |
| `disableOidcClient` | 200, 400, 401, 404, 429, 500 |
| `oidcAuthorize` | 302, 400, 401, 429, 500 |
| `getOidcAuthorizeContext` | 200, 400, 404, 429, 500 |
| `submitOidcAuthorizeDecision` | 200, 400, 401, 429, 500 |
| `exchangeOidcAuthorizationCode` | 200, 400, 401, 429, 500 |
| `listOidcConnections` | 200, 400, 401, 429, 500 |
| `revokeOidcConnection` | 200, 400, 401, 404, 429, 500 |

## Two things make this group different

**Two error envelopes at the same status.** The OIDC routes' own refusals use RFC 6749 §5.2's `{ error, error_description }`. The shared rate-limit gate and `handleError` use the house `{ error, message }`. Both land at the same statuses on the same routes.

This matters because Elysia's `response:` schemas *clean* as well as validate: a key the schema doesn't declare is deleted from the body before it is sent. A schema carrying only the RFC pair would have silently blanked the message on every 429 and 500 — a data-loss bug shaped exactly like a docs change. `oidcErrorResponse` is a superset of both shapes rather than a union, with `error_description` and `message` each optional. One extra optional field is cheaper than either kind of loss.

**`GET /authorize` sometimes returns a string.** It answers a browser navigation, not a fetch, and has three body shapes:

- **empty at 302** — every success and every *post*-validation error, which travels back to the relying party as query parameters, never as a body;
- **a rendered HTML page at 400/401/429** — an error raised *before* the redirect URI is trusted. RFC 6749 §4.1.2.1 forbids redirecting there, so the user is stranded on our origin and gets a real page;
- **a JSON error at 400/500** — a non-OIDC failure falling through `handleError`.

400 carries both of the latter two, so it is `t.Union([t.String(), oidcErrorResponse])`. Declaring only the object would have made Elysia reject the error page the route had just rendered. `tests/routes/oidc.test.ts` already asserts `content-type: text/html` at both 400 and 401, so the union is covered by existing tests rather than by assertion.

## Schemas

Four new consts in `routes/auth/response-schemas.ts`, each modelled on the service's literal return type rather than on what the endpoint looks like it should return:

- `oidcErrorResponse` — the superset envelope above.
- `ownedClientSummary` — `OwnedClientSummary`. `confidential` is derived (a secret hash exists), never the hash.
- `oidcConnectionSummary` — `OidcConnectionSummary`. `clientName` is nullable only for a consent whose client row was deleted underneath it.
- `oidcTokenResponse` — deliberately *not* `tokenResponse`: it carries an `id_token`, never a refresh token, and its access token never holds the `osn-access` audience, so a relying party's token cannot reach a first-party route.

## Auth annotations

`/authorize`, `/authorize/decision` and `/oidc/token` get an `operationId` but no `security: [{ bearerAuth: [] }]`. They are authenticated by, respectively, an unsigned-in browser (the whole point — the answer to no session is the sign-in screen), a session cookie, and client credentials over HTTP Basic. Marking them bearer-authed would document a credential that does not open them.

## Mechanical

`GET /oidc/clients`, `GET /authorize` and `GET /oidc/connections` move from the two-arg to the three-arg Elysia form to take an options object. Their handler bodies are unchanged apart from oxfmt's reindent.

## Verification

- `bun run --cwd osn/api check` clean
- `bun run --cwd osn/api test:run` — 61 files, 1003 tests, all passing
- `shared/openapi/pulse.json` regenerates byte-identical (md5 unchanged)
- the route set in `shared/openapi/osn.json` is identical before and after — no path or method added or removed; the diff is schema bodies and generator reordering
- all nine operationIds present with exactly the status sets in the table above

## Still needs a decision

Carried from #421/#422/#423, still unanswered: the openapi plugin is mounted on `osn/api` unconditionally, matching pulse. So the deployed `id.musubi.social` Worker will serve a Scalar docs UI at `/openapi` enumerating the whole public auth surface — now including client registration and the consent flow. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`, and is a one-line change.

Next in the stack: the graph group (~21 operations), then organisations, profiles, recommendations, erasure and export (~25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
