### PR TITLE
feat(osn-api): describe the graph route group's responses

### DIFF
--- a/.changeset/osn-api-graph-response-schemas.md
+++ b/.changeset/osn-api-graph-response-schemas.md
@@ -1,0 +1,47 @@
+---
+"@osn/api": patch
+---
+
+Graph route group — response schemas and stable operation ids (PR 5 of the
+`shared/openapi/osn.json` series). All eleven user-facing routes in
+`routes/graph.ts` — connection request, respond, remove, the three connection
+lists, connection status, block, unblock, block list and the block check —
+previously generated with an empty `responses` object, and so a `Void` return
+in any generated client. Each now describes every status it can emit.
+
+The schemas live in a new `routes/response-schemas.ts`, deliberately separate
+from `routes/auth/response-schemas.ts`. The two groups do not share an error
+envelope: the auth surface funnels failures through `publicError`, whose body
+carries an optional human-readable `message` alongside `error`, while these
+routes answer with a bare `{ error }` whose value already IS the message —
+either a fixed string ("Unauthorized", "Profile not found", "Too many
+requests") or `makeSafeError`'s output. A single shared const would have had to
+be a superset of both, documenting a `message` field that half the API never
+sends.
+
+Each status set is taken from the handler's literal control flow rather than
+from what the endpoint looks like it should do. Three consequences worth
+naming:
+
+- The three list endpoints and `GET /blocks` declare only 200/401/500. They are
+  reads, so no rate limiter runs, and they take no handle, so nothing can 404.
+- Both mutations that create a row (`POST /connections/:handle`,
+  `POST /blocks/:handle`) answer 201; every other mutation answers 200.
+- "Not connected", "no pending request" and "no block to remove" are all 400,
+  not 404. The profile in the path exists in each case — it is the edge that
+  doesn't, and `resolveHandle` is what owns 404.
+
+`resolveHandle` also sets **500** when the lookup itself throws, returning null
+either way, so every route that resolves a handle can emit a 500 carrying the
+same `{ error: "Profile not found" }` shape. That is why 500 is declared with
+the error envelope throughout rather than left off the read paths.
+
+`getConnectionStatus` returns a closed union (`none` / `pending_sent` /
+`pending_received` / `connected`) rather than a plain string, matching the
+service's own return type, so a generated client gets an enum it can switch
+over. It is directional on purpose: a client can label the button "Cancel" or
+"Accept" without a second call.
+
+No behaviour change: the route set in `shared/openapi/osn.json` is identical
+before and after (62 paths, 73 operations), and `shared/openapi/pulse.json`
+regenerates byte-identical.

--- a/osn/api/src/routes/graph.ts
+++ b/osn/api/src/routes/graph.ts
@@ -8,6 +8,14 @@ import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { makeSafeError } from "../lib/safe-error";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createGraphService } from "../services/graph";
+import {
+  graphConnectionStatus,
+  graphConnectionSummary,
+  graphErrorResponse,
+  graphOkResponse,
+  graphProfileSummary,
+  graphRequestSummary,
+} from "./response-schemas";
 
 // ---------------------------------------------------------------------------
 // Rate limiter — per-user fixed window (write operations only)
@@ -180,7 +188,28 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // 201 rather than 200: a request row now exists, and the sender
+            // sees it in `/connections/sent`.
+            201: graphOkResponse,
+            // Every refusal the service raises — already connected, request
+            // already pending, blocked in either direction, self-connect —
+            // arrives here through `safeError`, which keeps a tagged
+            // `GraphError` message and swallows anything else.
+            400: graphErrorResponse,
+            401: graphErrorResponse,
+            // No profile with that handle. Note the block cases do NOT land
+            // here: a blocked target still resolves, and the refusal is a 400.
+            404: graphErrorResponse,
+            429: graphErrorResponse,
+            // Only from `resolveHandle`'s catch — the mutation's own failures
+            // are already 400s.
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "sendConnectionRequest", security: [{ bearerAuth: [] }] },
+        },
       )
       .patch(
         "/connections/:handle",
@@ -208,6 +237,20 @@ export function createGraphRoutes(
         {
           params: HandleParam,
           body: t.Object({ action: t.Union([t.Literal("accept"), t.Literal("reject")]) }),
+          response: {
+            // Accept and reject both answer `{ ok: true }` — the caller
+            // already knows which it asked for, and neither leaves anything
+            // to report.
+            200: graphOkResponse,
+            // Includes "there was no pending request from that profile",
+            // which is what a double-accept looks like.
+            400: graphErrorResponse,
+            401: graphErrorResponse,
+            404: graphErrorResponse,
+            429: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "respondToConnectionRequest", security: [{ bearerAuth: [] }] },
         },
       )
       .delete(
@@ -229,7 +272,22 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // Removal is symmetric — it deletes the edge, not the caller's
+            // half of it, so the other profile loses the connection too.
+            200: graphOkResponse,
+            // "Not connected" is a 400, not a 404: the profile exists, the
+            // edge doesn't.
+            400: graphErrorResponse,
+            401: graphErrorResponse,
+            404: graphErrorResponse,
+            429: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "removeConnection", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/connections",
@@ -250,7 +308,18 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { query: PaginationQuery },
+        {
+          query: PaginationQuery,
+          response: {
+            200: t.Object({ connections: t.Array(graphConnectionSummary) }),
+            // Reads aren't rate limited and take no handle, so this route
+            // cannot 404 or 429 — the only two failures are "no token" and
+            // "the query blew up".
+            401: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "listConnections", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/connections/pending",
@@ -273,7 +342,16 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { query: PaginationQuery },
+        {
+          query: PaginationQuery,
+          response: {
+            // Requests waiting on the caller to accept or reject.
+            200: t.Object({ pending: t.Array(graphRequestSummary) }),
+            401: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "listPendingConnectionRequests", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/connections/sent",
@@ -296,7 +374,17 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { query: PaginationQuery },
+        {
+          query: PaginationQuery,
+          response: {
+            // The mirror of `pending` — requests the caller sent and nobody
+            // has answered yet. Same row shape, different direction.
+            200: t.Object({ sent: t.Array(graphRequestSummary) }),
+            401: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "listSentConnectionRequests", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/connections/:handle",
@@ -313,7 +401,19 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // Directional: `pending_sent` and `pending_received` are the same
+            // row read from opposite ends, so a client can label the button
+            // "Cancel" or "Accept" without a second call.
+            200: t.Object({ status: graphConnectionStatus }),
+            401: graphErrorResponse,
+            404: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "getConnectionStatus", security: [{ bearerAuth: [] }] },
+        },
       )
       // -------------------------------------------------------------------------
       // Blocks
@@ -338,7 +438,22 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // 201 for the same reason as a connection request: a block row now
+            // exists. Blocking also tears down any connection or pending
+            // request between the two, which the empty body doesn't report —
+            // clients refetch rather than patch state from this.
+            201: graphOkResponse,
+            400: graphErrorResponse,
+            401: graphErrorResponse,
+            404: graphErrorResponse,
+            429: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "blockProfile", security: [{ bearerAuth: [] }] },
+        },
       )
       .delete(
         "/blocks/:handle",
@@ -359,7 +474,23 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // 200, not 201: unblocking deletes a row rather than creating one.
+            // Note it does NOT restore the connection the block tore down —
+            // that has to be requested again.
+            200: graphOkResponse,
+            // `unblockProfile` fails with NotFoundError when no block exists,
+            // and the handler maps every service failure here to 400.
+            400: graphErrorResponse,
+            401: graphErrorResponse,
+            404: graphErrorResponse,
+            429: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "unblockProfile", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/blocks",
@@ -374,7 +505,20 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { query: PaginationQuery },
+        {
+          query: PaginationQuery,
+          response: {
+            // The caller's own block list, so it carries the full profile
+            // projection rather than a timestamp — there is no "blockedAt" in
+            // the service's return type.
+            200: t.Object({ blocks: t.Array(graphProfileSummary) }),
+            // A read: no rate limiter, and no handle to resolve, so 429 and
+            // 404 can't happen here.
+            401: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "listBlocks", security: [{ bearerAuth: [] }] },
+        },
       )
       // -------------------------------------------------------------------------
       // Block status check
@@ -396,7 +540,21 @@ export function createGraphRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // One direction only, per the M1 note above: `blocked` is true when
+            // the CALLER has blocked the target. A client can't learn from this
+            // that it has been blocked.
+            200: t.Object({ blocked: t.Boolean() }),
+            401: graphErrorResponse,
+            // `resolveHandle` runs inside the try here, so a miss still sets
+            // 404 and a lookup failure still sets 500.
+            404: graphErrorResponse,
+            500: graphErrorResponse,
+          },
+          detail: { operationId: "isProfileBlocked", security: [{ bearerAuth: [] }] },
+        },
       )
   );
 }

--- a/osn/api/src/routes/response-schemas.ts
+++ b/osn/api/src/routes/response-schemas.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared TypeBox response schemas for the non-auth route groups (graph,
+ * organisations, profiles, recommendations, erasure, export).
+ *
+ * The auth groups have their own file, `routes/auth/response-schemas.ts`, and
+ * the two are deliberately not merged: the auth surface funnels every failure
+ * through `publicError`, so its envelope carries an optional human-readable
+ * `message`, while these routes answer with a bare `{ error }` whose value is
+ * already the human-readable string. One shared const would have had to be a
+ * superset of both, which would document a `message` field that half the API
+ * never sends.
+ *
+ * The same two rules apply here as there.
+ *
+ * 1. Elysia VALIDATES and CLEANS against `response:` at runtime. A key the
+ *    schema doesn't declare is deleted from the body before it is sent, and a
+ *    value that doesn't type-check 500s the route. A wrong schema here is a
+ *    silent data-loss bug, not a docs bug. Model what the handler actually
+ *    returns, not what you wish it returned.
+ * 2. The schema is checked against the PRE-serialisation value. A `Date` never
+ *    satisfies `t.String({ format: "date-time" })` — the handler has to
+ *    `.toISOString()` first.
+ */
+
+import { t } from "elysia";
+
+/**
+ * The graph error envelope. Unlike the auth surface's `{ error, message }`,
+ * `error` here IS the message: the routes pass the caller either a fixed
+ * string ("Unauthorized", "Profile not found", "Too many requests") or the
+ * output of `makeSafeError`, which surfaces a tagged `GraphError` /
+ * `NotFoundError` message and swallows everything else.
+ *
+ * Every status in the group uses it, including 500 — `resolveHandle`'s catch
+ * sets 500 and the handler then returns the same shape.
+ */
+export const graphErrorResponse = t.Object({
+  error: t.String(),
+});
+
+/** `{ ok: true }` — what every graph mutation returns on success. */
+export const graphOkResponse = t.Object({
+  ok: t.Boolean(),
+});
+
+/**
+ * `profileProjection` in `routes/graph.ts` — the three fields the graph is
+ * allowed to reveal about somebody else. Email is deliberately absent: a
+ * connection list is not an address book, and adding it here would leak it
+ * from ten endpoints at once.
+ */
+export const graphProfileSummary = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+});
+
+/** A connection: the other profile, plus when the two were connected. */
+export const graphConnectionSummary = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  connectedAt: t.String({ format: "date-time" }),
+});
+
+/**
+ * A connection request, incoming or outgoing. Both directions carry the same
+ * fields — which profile it concerns is decided by the endpoint, not the body.
+ */
+export const graphRequestSummary = t.Object({
+  id: t.String(),
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  requestedAt: t.String({ format: "date-time" }),
+});
+
+/**
+ * The return of `getConnectionStatus`. A closed union rather than a plain
+ * string, because it genuinely is closed at the service — the four values are
+ * the whole type — and a generated client is better off with an enum it can
+ * switch over than a string it has to compare.
+ */
+export const graphConnectionStatus = t.Union([
+  t.Literal("none"),
+  t.Literal("pending_sent"),
+  t.Literal("pending_received"),
+  t.Literal("connected"),
+]);

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -1589,7 +1589,7 @@
     },
     "/graph/blocks": {
       "get": {
-        "operationId": "getGraphBlocks",
+        "operationId": "listBlocks",
         "parameters": [
           {
             "in": "query",
@@ -1606,13 +1606,96 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blocks": {
+                      "items": {
+                        "properties": {
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "displayName"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "blocks"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/graph/blocks/{handle}": {
       "delete": {
-        "operationId": "deleteGraphBlocksByHandle",
+        "operationId": "unblockProfile",
         "parameters": [
           {
             "in": "path",
@@ -1625,10 +1708,125 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       },
       "post": {
-        "operationId": "postGraphBlocksByHandle",
+        "operationId": "blockProfile",
         "parameters": [
           {
             "in": "path",
@@ -1640,13 +1838,128 @@
               "pattern": "^[a-z0-9_]+$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/graph/connections": {
       "get": {
-        "operationId": "getGraphConnections",
+        "operationId": "listConnections",
         "parameters": [
           {
             "in": "query",
@@ -1663,13 +1976,101 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "connections": {
+                      "items": {
+                        "properties": {
+                          "connectedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "displayName",
+                          "connectedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "connections"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/graph/connections/pending": {
       "get": {
-        "operationId": "getGraphConnectionsPending",
+        "operationId": "listPendingConnectionRequests",
         "parameters": [
           {
             "in": "query",
@@ -1686,13 +2087,101 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "pending": {
+                      "items": {
+                        "properties": {
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "requestedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "displayName",
+                          "requestedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "pending"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/graph/connections/sent": {
       "get": {
-        "operationId": "getGraphConnectionsSent",
+        "operationId": "listSentConnectionRequests",
         "parameters": [
           {
             "in": "query",
@@ -1710,12 +2199,100 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "sent": {
+                      "items": {
+                        "properties": {
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "requestedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "handle",
+                          "displayName",
+                          "requestedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "sent"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
     "/graph/connections/{handle}": {
       "delete": {
-        "operationId": "deleteGraphConnectionsByHandle",
+        "operationId": "removeConnection",
         "parameters": [
           {
             "in": "path",
@@ -1727,11 +2304,126 @@
               "pattern": "^[a-z0-9_]+$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       },
       "get": {
-        "operationId": "getGraphConnectionsByHandle",
+        "operationId": "getConnectionStatus",
         "parameters": [
           {
             "in": "path",
@@ -1744,10 +2436,95 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "status": {
+                      "enum": [
+                        "none",
+                        "pending_sent",
+                        "pending_received",
+                        "connected"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       },
       "patch": {
-        "operationId": "patchGraphConnectionsByHandle",
+        "operationId": "respondToConnectionRequest",
         "parameters": [
           {
             "in": "path",
@@ -1816,10 +2593,125 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
-        "operationId": "postGraphConnectionsByHandle",
+        "operationId": "sendConnectionRequest",
         "parameters": [
           {
             "in": "path",
@@ -1832,12 +2724,127 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
     "/graph/is-blocked/{handle}": {
       "get": {
-        "operationId": "getGraphIs-blockedByHandle",
+        "operationId": "isProfileBlocked",
         "parameters": [
           {
             "in": "path",
@@ -1849,6 +2856,85 @@
               "pattern": "^[a-z0-9_]+$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blocked"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }


### PR DESCRIPTION
Fifth in the stack that gives `shared/openapi/osn.json` real response schemas. Stacked on #424 — review that first; this diff is only the graph group.

**Stack:** #421 → #422 → #423 → #424 → **this**

## What this covers

All eleven user-facing routes in `osn/api/src/routes/graph.ts`. Every one previously generated with an empty `responses` object, which means a generated client sees `Void` — including the three connection lists, which are the whole point of the group.

| Operation | Method + path | Statuses |
|---|---|---|
| `sendConnectionRequest` | `POST /connections/:handle` | 201, 400, 401, 404, 429, 500 |
| `respondToConnectionRequest` | `PATCH /connections/:handle` | 200, 400, 401, 404, 429, 500 |
| `removeConnection` | `DELETE /connections/:handle` | 200, 400, 401, 404, 429, 500 |
| `listConnections` | `GET /connections` | 200, 401, 500 |
| `listPendingConnectionRequests` | `GET /connections/pending` | 200, 401, 500 |
| `listSentConnectionRequests` | `GET /connections/sent` | 200, 401, 500 |
| `getConnectionStatus` | `GET /connections/:handle` | 200, 401, 404, 500 |
| `blockProfile` | `POST /blocks/:handle` | 201, 400, 401, 404, 429, 500 |
| `unblockProfile` | `DELETE /blocks/:handle` | 200, 400, 401, 404, 429, 500 |
| `listBlocks` | `GET /blocks` | 200, 401, 500 |
| `isProfileBlocked` | `GET /is-blocked/:handle` | 200, 401, 404, 500 |

## Why a second schema file

The consts live in a new `osn/api/src/routes/response-schemas.ts` rather than joining `routes/auth/response-schemas.ts`. The two surfaces do not share an error envelope:

- **auth** funnels every failure through `publicError`, so its body is `{ error, message? }` where `error` is a machine code.
- **graph** answers with a bare `{ error }` whose value already *is* the human-readable string — either a fixed one (`"Unauthorized"`, `"Profile not found"`, `"Too many requests"`) or `makeSafeError`'s output, which surfaces a tagged `GraphError`/`NotFoundError` message and swallows the rest.

One shared const would have had to be a superset of both, documenting a `message` field half the API never sends. Elysia's `response:` schemas clean as well as validate — an undeclared key is deleted from the body before it goes out — so a too-wide schema is not merely inaccurate, it is how you silently lose a field.

## Where the status sets come from

Each one is read off the handler's literal control flow, not off what the endpoint looks like it ought to do. Four things this surfaced:

- **The reads declare 200/401/500 only.** No rate limiter runs on a read, and the three lists plus `GET /blocks` resolve no handle, so 429 and 404 are unreachable on them.
- **Only the two row-creating mutations answer 201** (`POST /connections/:handle`, `POST /blocks/:handle`). Everything else answers 200 — including `unblockProfile`, which deletes.
- **"Not connected", "no pending request" and "no block to remove" are 400, not 404.** The profile named in the path exists in all three cases; it is the *edge* that doesn't. 404 belongs to `resolveHandle` alone. A double-accept therefore looks like "no pending request" → 400.
- **`resolveHandle` sets 500 when the lookup itself throws**, and returns null either way, so the handler emits `{ error: "Profile not found" }` at whichever status was set. That is why 500 carries the error envelope on every handle-resolving route rather than being left off.

Two smaller calls:

- `getConnectionStatus` keeps the service's closed union — `none` / `pending_sent` / `pending_received` / `connected` — instead of widening to `t.String()`, so a generated client gets an enum it can switch over. It is directional on purpose: a client can label the button "Cancel" or "Accept" without a second call.
- `graphProfileSummary` mirrors `profileProjection` exactly: `id`, `handle`, `displayName`. Email is deliberately absent — a connection list is not an address book, and adding it there would leak it from ten endpoints at once.

## Verification

- `bun run --cwd osn/api check` — clean
- `bun run --cwd osn/api test:run` — 61 files, 1003 tests, all passing
- both `openapi:generate` scripts re-run; `shared/openapi/pulse.json` regenerates **byte-identical** (md5 unchanged)
- route set unchanged: **62 paths / 73 operations** before and after, and a set-diff of `METHOD path` keys against `HEAD` returns empty both ways
- all eleven operation ids present with exactly the status sets in the table above — 0 mismatches

The `shared/openapi/osn.json` diff is large (1228+/142−) because the generator reorders and inlines schemas on every run. The counts and the set-diff above are the real check, not the diff size.

## Still unanswered, from #421

The openapi plugin is mounted on `osn/api` unconditionally, matching pulse. So the deployed `id.musubi.social` Worker serves a Scalar docs UI at `/openapi` enumerating the whole public auth surface — now including client registration, the consent flow and the graph. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`; one-line change, happy to make it here or separately.

Next in the stack: organisations (9 operations), then profiles, recommendations, erasure and export (~9 more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
