### PR TITLE
feat(osn-api): describe the organisation route group's responses

### DIFF
--- a/.changeset/osn-api-organisation-response-schemas.md
+++ b/.changeset/osn-api-organisation-response-schemas.md
@@ -1,0 +1,47 @@
+---
+"@osn/api": patch
+---
+
+Organisation route group — response schemas and stable operation ids (PR 6 of
+the `shared/openapi/osn.json` series). All nine routes in
+`routes/organisation.ts` — create, list mine, read, update, delete, add member,
+remove member, change role, list members — previously generated with an empty
+`responses` object. Nine of the eighteen remaining empty operations; the last
+nine are account erasure/export, profiles and recommendations.
+
+Two consts in `routes/response-schemas.ts` were named after the graph but are
+not specific to it, so they are renamed rather than duplicated per group:
+`graphErrorResponse` → `errorResponse` and `graphOkResponse` → `okResponse`.
+Both are internal to `osn/api` and the generated spec is unchanged by the
+rename. Four groups still to come would each have needed its own copy.
+
+Points where the described behaviour is not what the endpoint looks like:
+
+- **`POST /organisations/` cannot 500.** Its catch maps every service failure
+  to 400, so a taken handle and a database fault are reported identically. The
+  schema says so rather than declaring a 500 that never arrives.
+- **Authorisation refusals are 400, not 403,** everywhere a check lives in the
+  service: "only admins can update", "only the owner can delete", "only the
+  owner can grant admin". The single real 403 is `GET
+  /organisations/:handle/members`, whose membership check runs in the route.
+- **404 on the member routes covers two different misses** — no such
+  organisation and no such profile — told apart by the message, since both
+  handles are in the path.
+- `resolveOrg` sets **500** when the lookup itself throws and returns null
+  either way, so every handle-resolving route can emit a 500 carrying the same
+  `{ error: "Organisation not found" }` body.
+
+One behaviour change, and it is a fix: in `GET /organisations/:handle/members`
+the `getMemberRole` call sat outside the `try`, so a database fault during the
+membership check escaped to Elysia's default handler and answered with a body
+unlike every other error in the group. It now runs inside the `try` and reports
+`{ error }` at 500 like its neighbours. The 200 and 403 paths are untouched.
+
+`listMembers` also had its return type narrowed from `role: string` to the
+column's own `"admin" | "member"`. The roster is what a client reads before
+PATCHing a role back, and both request bodies accept exactly those two values,
+so the wider type was wrong at the source — and a `t.String()` in the response
+schema would have propagated it into every generated client.
+
+Route set unchanged: 62 paths, 73 operations before and after.
+`shared/openapi/pulse.json` regenerates byte-identical.

--- a/osn/api/src/routes/graph.ts
+++ b/osn/api/src/routes/graph.ts
@@ -11,8 +11,8 @@ import { createGraphService } from "../services/graph";
 import {
   graphConnectionStatus,
   graphConnectionSummary,
-  graphErrorResponse,
-  graphOkResponse,
+  errorResponse,
+  okResponse,
   graphProfileSummary,
   graphRequestSummary,
 } from "./response-schemas";
@@ -193,20 +193,20 @@ export function createGraphRoutes(
           response: {
             // 201 rather than 200: a request row now exists, and the sender
             // sees it in `/connections/sent`.
-            201: graphOkResponse,
+            201: okResponse,
             // Every refusal the service raises — already connected, request
             // already pending, blocked in either direction, self-connect —
             // arrives here through `safeError`, which keeps a tagged
             // `GraphError` message and swallows anything else.
-            400: graphErrorResponse,
-            401: graphErrorResponse,
+            400: errorResponse,
+            401: errorResponse,
             // No profile with that handle. Note the block cases do NOT land
             // here: a blocked target still resolves, and the refusal is a 400.
-            404: graphErrorResponse,
-            429: graphErrorResponse,
+            404: errorResponse,
+            429: errorResponse,
             // Only from `resolveHandle`'s catch — the mutation's own failures
             // are already 400s.
-            500: graphErrorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "sendConnectionRequest", security: [{ bearerAuth: [] }] },
         },
@@ -241,14 +241,14 @@ export function createGraphRoutes(
             // Accept and reject both answer `{ ok: true }` — the caller
             // already knows which it asked for, and neither leaves anything
             // to report.
-            200: graphOkResponse,
+            200: okResponse,
             // Includes "there was no pending request from that profile",
             // which is what a double-accept looks like.
-            400: graphErrorResponse,
-            401: graphErrorResponse,
-            404: graphErrorResponse,
-            429: graphErrorResponse,
-            500: graphErrorResponse,
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "respondToConnectionRequest", security: [{ bearerAuth: [] }] },
         },
@@ -277,14 +277,14 @@ export function createGraphRoutes(
           response: {
             // Removal is symmetric — it deletes the edge, not the caller's
             // half of it, so the other profile loses the connection too.
-            200: graphOkResponse,
+            200: okResponse,
             // "Not connected" is a 400, not a 404: the profile exists, the
             // edge doesn't.
-            400: graphErrorResponse,
-            401: graphErrorResponse,
-            404: graphErrorResponse,
-            429: graphErrorResponse,
-            500: graphErrorResponse,
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "removeConnection", security: [{ bearerAuth: [] }] },
         },
@@ -315,8 +315,8 @@ export function createGraphRoutes(
             // Reads aren't rate limited and take no handle, so this route
             // cannot 404 or 429 — the only two failures are "no token" and
             // "the query blew up".
-            401: graphErrorResponse,
-            500: graphErrorResponse,
+            401: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "listConnections", security: [{ bearerAuth: [] }] },
         },
@@ -347,8 +347,8 @@ export function createGraphRoutes(
           response: {
             // Requests waiting on the caller to accept or reject.
             200: t.Object({ pending: t.Array(graphRequestSummary) }),
-            401: graphErrorResponse,
-            500: graphErrorResponse,
+            401: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "listPendingConnectionRequests", security: [{ bearerAuth: [] }] },
         },
@@ -380,8 +380,8 @@ export function createGraphRoutes(
             // The mirror of `pending` — requests the caller sent and nobody
             // has answered yet. Same row shape, different direction.
             200: t.Object({ sent: t.Array(graphRequestSummary) }),
-            401: graphErrorResponse,
-            500: graphErrorResponse,
+            401: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "listSentConnectionRequests", security: [{ bearerAuth: [] }] },
         },
@@ -408,9 +408,9 @@ export function createGraphRoutes(
             // row read from opposite ends, so a client can label the button
             // "Cancel" or "Accept" without a second call.
             200: t.Object({ status: graphConnectionStatus }),
-            401: graphErrorResponse,
-            404: graphErrorResponse,
-            500: graphErrorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "getConnectionStatus", security: [{ bearerAuth: [] }] },
         },
@@ -445,12 +445,12 @@ export function createGraphRoutes(
             // exists. Blocking also tears down any connection or pending
             // request between the two, which the empty body doesn't report —
             // clients refetch rather than patch state from this.
-            201: graphOkResponse,
-            400: graphErrorResponse,
-            401: graphErrorResponse,
-            404: graphErrorResponse,
-            429: graphErrorResponse,
-            500: graphErrorResponse,
+            201: okResponse,
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "blockProfile", security: [{ bearerAuth: [] }] },
         },
@@ -480,14 +480,14 @@ export function createGraphRoutes(
             // 200, not 201: unblocking deletes a row rather than creating one.
             // Note it does NOT restore the connection the block tore down —
             // that has to be requested again.
-            200: graphOkResponse,
+            200: okResponse,
             // `unblockProfile` fails with NotFoundError when no block exists,
             // and the handler maps every service failure here to 400.
-            400: graphErrorResponse,
-            401: graphErrorResponse,
-            404: graphErrorResponse,
-            429: graphErrorResponse,
-            500: graphErrorResponse,
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "unblockProfile", security: [{ bearerAuth: [] }] },
         },
@@ -514,8 +514,8 @@ export function createGraphRoutes(
             200: t.Object({ blocks: t.Array(graphProfileSummary) }),
             // A read: no rate limiter, and no handle to resolve, so 429 and
             // 404 can't happen here.
-            401: graphErrorResponse,
-            500: graphErrorResponse,
+            401: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "listBlocks", security: [{ bearerAuth: [] }] },
         },
@@ -547,11 +547,11 @@ export function createGraphRoutes(
             // the CALLER has blocked the target. A client can't learn from this
             // that it has been blocked.
             200: t.Object({ blocked: t.Boolean() }),
-            401: graphErrorResponse,
+            401: errorResponse,
             // `resolveHandle` runs inside the try here, so a miss still sets
             // 404 and a lookup failure still sets 500.
-            404: graphErrorResponse,
-            500: graphErrorResponse,
+            404: errorResponse,
+            500: errorResponse,
           },
           detail: { operationId: "isProfileBlocked", security: [{ bearerAuth: [] }] },
         },

--- a/osn/api/src/routes/organisation.ts
+++ b/osn/api/src/routes/organisation.ts
@@ -8,6 +8,12 @@ import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { makeSafeError } from "../lib/safe-error";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createOrganisationService } from "../services/organisation";
+import {
+  errorResponse,
+  okResponse,
+  organisationMemberSummary,
+  organisationSummary,
+} from "./response-schemas";
 
 // ---------------------------------------------------------------------------
 // Rate limiter
@@ -198,6 +204,18 @@ export function createOrganisationRoutes(
             name: t.String({ minLength: 1, maxLength: 100 }),
             description: t.Optional(t.String({ maxLength: 500 })),
           }),
+          response: {
+            // 201 with the created organisation, so a client can route to it
+            // without a follow-up GET.
+            201: t.Object({ ok: t.Boolean(), organisation: organisationSummary }),
+            // A taken handle and a DB failure both land here: the catch maps
+            // every service failure to 400, and nothing in this handler sets
+            // 500. That is the existing behaviour, faithfully described.
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+          },
+          detail: { operationId: "createOrganisation", security: [{ bearerAuth: [] }] },
         },
       )
       .get(
@@ -216,7 +234,18 @@ export function createOrganisationRoutes(
             return { error: safeError(e) };
           }
         },
-        { query: PaginationQuery },
+        {
+          query: PaginationQuery,
+          response: {
+            // The caller's own organisations, not a directory — there is no
+            // handle to resolve and no rate limiter on a read, so 404 and 429
+            // can't happen.
+            200: t.Object({ organisations: t.Array(organisationSummary) }),
+            401: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "listMyOrganisations", security: [{ bearerAuth: [] }] },
+        },
       )
       .get(
         "/:handle",
@@ -229,7 +258,21 @@ export function createOrganisationRoutes(
 
           return { organisation: orgProjection(organisation) };
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            // Readable by any authenticated caller, member or not. Only the
+            // roster below is member-only.
+            200: t.Object({ organisation: organisationSummary }),
+            401: errorResponse,
+            // `resolveOrg` owns both: 404 on a miss, 500 when the lookup
+            // itself throws. It returns null either way, so the body is the
+            // same "Organisation not found" string at both statuses.
+            404: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "getOrganisation", security: [{ bearerAuth: [] }] },
+        },
       )
       .patch(
         "/:handle",
@@ -258,6 +301,19 @@ export function createOrganisationRoutes(
             name: t.Optional(t.String({ minLength: 1, maxLength: 100 })),
             description: t.Optional(t.String({ maxLength: 500 })),
           }),
+          response: {
+            // Returns the organisation after the update, so a client never has
+            // to guess what the server made of a partial body.
+            200: t.Object({ ok: t.Boolean(), organisation: organisationSummary }),
+            // Not an admin is a 400 here, not a 403: the authorisation check
+            // lives in the service and surfaces as an OrgError like any other.
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "updateOrganisation", security: [{ bearerAuth: [] }] },
         },
       )
       .delete(
@@ -279,7 +335,21 @@ export function createOrganisationRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam },
+        {
+          params: HandleParam,
+          response: {
+            200: okResponse,
+            // Owner-only, and "only the owner can delete the organisation"
+            // arrives as an OrgError — so an admin who is not the owner gets a
+            // 400, same as any other refusal in this group.
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "deleteOrganisation", security: [{ bearerAuth: [] }] },
+        },
       )
       // -----------------------------------------------------------------------
       // Member management
@@ -314,6 +384,22 @@ export function createOrganisationRoutes(
           body: t.Object({
             role: t.Union([t.Literal("admin"), t.Literal("member")]),
           }),
+          response: {
+            // 201: a membership row now exists. The body is bare — a client
+            // that wants the new roster refetches it.
+            201: okResponse,
+            // Already a member, not an admin, and granting admin without being
+            // the owner all arrive here.
+            400: errorResponse,
+            401: errorResponse,
+            // Two different misses share this status: no such organisation and
+            // no such profile. They are told apart by the message, since both
+            // handles live in the path.
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "addOrganisationMember", security: [{ bearerAuth: [] }] },
         },
       )
       .delete(
@@ -340,7 +426,20 @@ export function createOrganisationRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: MemberHandleParams },
+        {
+          params: MemberHandleParams,
+          response: {
+            200: okResponse,
+            // Removing the owner is refused outright; removing an admin is
+            // owner-only. Both are OrgErrors, so both are 400.
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "removeOrganisationMember", security: [{ bearerAuth: [] }] },
+        },
       )
       .patch(
         "/:handle/members/:profileHandle",
@@ -373,6 +472,17 @@ export function createOrganisationRoutes(
           body: t.Object({
             role: t.Union([t.Literal("admin"), t.Literal("member")]),
           }),
+          response: {
+            200: okResponse,
+            // Owner-only, and the owner's own role can't be changed at all —
+            // there is no way to hand the organisation over through this route.
+            400: errorResponse,
+            401: errorResponse,
+            404: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "updateOrganisationMemberRole", security: [{ bearerAuth: [] }] },
         },
       )
       .get(
@@ -384,17 +494,18 @@ export function createOrganisationRoutes(
           const organisation = await resolveOrg(params.handle, set);
           if (!organisation) return { error: "Organisation not found" };
 
-          // Least-privilege: the full roster (handles, display names, roles) is
-          // visible only to members of the org, not to any authenticated user.
-          // If public org pages are ever wanted, gate this on an explicit
-          // `organisations.visibility` flag rather than dropping the check.
-          const callerRole = await run(org.getMemberRole(organisation.id, caller.profileId));
-          if (!callerRole) {
-            set.status = 403;
-            return { error: "Forbidden" };
-          }
-
           try {
+            // Least-privilege: the full roster (handles, display names, roles)
+            // is visible only to members of the org, not to any authenticated
+            // user. If public org pages are ever wanted, gate this on an
+            // explicit `organisations.visibility` flag rather than dropping the
+            // check.
+            const callerRole = await run(org.getMemberRole(organisation.id, caller.profileId));
+            if (!callerRole) {
+              set.status = 403;
+              return { error: "Forbidden" };
+            }
+
             const list = await run(org.listMembers(organisation.id, parsePagination(query)));
             return {
               members: list.map((m) =>
@@ -409,7 +520,22 @@ export function createOrganisationRoutes(
             return { error: safeError(e) };
           }
         },
-        { params: HandleParam, query: PaginationQuery },
+        {
+          params: HandleParam,
+          query: PaginationQuery,
+          response: {
+            200: t.Object({ members: t.Array(organisationMemberSummary) }),
+            401: errorResponse,
+            // The only 403 in the group. Membership, not admin, is what it
+            // asks for — and it is a real 403 rather than the 400 the write
+            // routes use, because the check runs in the route, not the service.
+            403: errorResponse,
+            404: errorResponse,
+            // A read: no rate limiter, so no 429.
+            500: errorResponse,
+          },
+          detail: { operationId: "listOrganisationMembers", security: [{ bearerAuth: [] }] },
+        },
       )
   );
 }

--- a/osn/api/src/routes/response-schemas.ts
+++ b/osn/api/src/routes/response-schemas.ts
@@ -25,21 +25,21 @@
 import { t } from "elysia";
 
 /**
- * The graph error envelope. Unlike the auth surface's `{ error, message }`,
- * `error` here IS the message: the routes pass the caller either a fixed
- * string ("Unauthorized", "Profile not found", "Too many requests") or the
- * output of `makeSafeError`, which surfaces a tagged `GraphError` /
- * `NotFoundError` message and swallows everything else.
+ * The error envelope shared by every group in this file. Unlike the auth
+ * surface's `{ error, message }`, `error` here IS the message: the routes pass
+ * the caller either a fixed string ("Unauthorized", "Profile not found",
+ * "Forbidden", "Too many requests") or the output of `makeSafeError`, which
+ * surfaces a tagged domain-error message and swallows everything else.
  *
- * Every status in the group uses it, including 500 — `resolveHandle`'s catch
- * sets 500 and the handler then returns the same shape.
+ * Every status uses it, including 500 — `resolveHandle` / `resolveOrg` catch
+ * their own failures, set 500, and the handler returns the same shape.
  */
-export const graphErrorResponse = t.Object({
+export const errorResponse = t.Object({
   error: t.String(),
 });
 
-/** `{ ok: true }` — what every graph mutation returns on success. */
-export const graphOkResponse = t.Object({
+/** `{ ok: true }` — what a mutation with nothing to report returns. */
+export const okResponse = t.Object({
   ok: t.Boolean(),
 });
 
@@ -86,3 +86,33 @@ export const graphConnectionStatus = t.Union([
   t.Literal("pending_received"),
   t.Literal("connected"),
 ]);
+
+/**
+ * `orgProjection` in `routes/organisation.ts`. The organisation's own id is
+ * deliberately absent — every organisation route addresses it by handle, so
+ * publishing the internal id would invite clients to key on something the
+ * public surface never accepts back.
+ */
+export const organisationSummary = t.Object({
+  handle: t.String(),
+  name: t.String(),
+  description: t.Union([t.String(), t.Null()]),
+  avatarUrl: t.Union([t.String(), t.Null()]),
+  createdAt: t.String({ format: "date-time" }),
+  updatedAt: t.String({ format: "date-time" }),
+});
+
+/**
+ * A row of the member roster. Narrower than the graph's profile summary: no
+ * profile id, because membership is managed by handle throughout.
+ *
+ * `role` is the same closed union the `organisation_members.role` column
+ * declares, and the same one the add/update-role request bodies accept — a
+ * client can round-trip a value it read here straight back into a PATCH.
+ */
+export const organisationMemberSummary = t.Object({
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  role: t.Union([t.Literal("admin"), t.Literal("member")]),
+  joinedAt: t.String({ format: "date-time" }),
+});

--- a/osn/api/src/services/organisation.ts
+++ b/osn/api/src/services/organisation.ts
@@ -540,7 +540,10 @@ export function createOrganisationService() {
         createdAt: Date;
         updatedAt: Date;
       };
-      role: string;
+      // The column's own enum, not a bare string: the roster is what a client
+      // reads before PATCHing a role back, and both request bodies accept
+      // exactly these two values.
+      role: "admin" | "member";
       joinedAt: Date;
     }[],
     NotFoundError | DatabaseError,

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -5470,7 +5470,7 @@
     },
     "/organisations/": {
       "get": {
-        "operationId": "getOrganisations",
+        "operationId": "listMyOrganisations",
         "parameters": [
           {
             "in": "query",
@@ -5488,10 +5488,110 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "organisations": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "createdAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "handle",
+                          "name",
+                          "description",
+                          "avatarUrl",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "organisations"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       },
       "post": {
-        "operationId": "postOrganisations",
+        "operationId": "createOrganisation",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5574,12 +5674,131 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "organisation": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "handle",
+                        "name",
+                        "description",
+                        "avatarUrl",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "organisation"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/organisations/{handle}": {
       "delete": {
-        "operationId": "deleteOrganisationsByHandle",
+        "operationId": "deleteOrganisation",
         "parameters": [
           {
             "in": "path",
@@ -5591,11 +5810,126 @@
               "pattern": "^[a-z0-9_]+$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       },
       "get": {
-        "operationId": "getOrganisationsByHandle",
+        "operationId": "getOrganisation",
         "parameters": [
           {
             "in": "path",
@@ -5608,10 +5942,125 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "organisation": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "handle",
+                        "name",
+                        "description",
+                        "avatarUrl",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "organisation"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       },
       "patch": {
-        "operationId": "patchOrganisationsByHandle",
+        "operationId": "updateOrganisation",
         "parameters": [
           {
             "in": "path",
@@ -5677,12 +6126,167 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "organisation": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "handle",
+                        "name",
+                        "description",
+                        "avatarUrl",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "organisation"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/organisations/{handle}/members": {
       "get": {
-        "operationId": "getOrganisationsByHandleMembers",
+        "operationId": "listOrganisationMembers",
         "parameters": [
           {
             "in": "path",
@@ -5710,13 +6314,141 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "members": {
+                      "items": {
+                        "properties": {
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "joinedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "role": {
+                            "enum": [
+                              "admin",
+                              "member"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "handle",
+                          "displayName",
+                          "role",
+                          "joinedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "members"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 403"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }
     },
     "/organisations/{handle}/members/{profileHandle}": {
       "delete": {
-        "operationId": "deleteOrganisationsByHandleMembersByProfileHandle",
+        "operationId": "removeOrganisationMember",
         "parameters": [
           {
             "in": "path",
@@ -5739,11 +6471,126 @@
               "pattern": "^[a-z0-9_]+$",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       },
       "patch": {
-        "operationId": "patchOrganisationsByHandleMembersByProfileHandle",
+        "operationId": "updateOrganisationMemberRole",
         "parameters": [
           {
             "in": "path",
@@ -5823,10 +6670,125 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
-        "operationId": "postOrganisationsByHandleMembersByProfileHandle",
+        "operationId": "addOrganisationMember",
         "parameters": [
           {
             "in": "path",
@@ -5906,7 +6868,122 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 404"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/passkey/register/begin": {


### PR DESCRIPTION
Sixth in the stack. Stacked on #425 — review that first; this diff is only the organisation group.

**Stack:** #421 → #422 → #423 → #424 → #425 → **this**

## What this covers

All nine routes in `osn/api/src/routes/organisation.ts`. That leaves **nine** empty operations in the whole spec: account erasure/export (4), profiles (3), recommendations (2).

| Operation | Method + path | Statuses |
|---|---|---|
| `createOrganisation` | `POST /organisations/` | 201, 400, 401, 429 |
| `listMyOrganisations` | `GET /organisations/` | 200, 401, 500 |
| `getOrganisation` | `GET /organisations/:handle` | 200, 401, 404, 500 |
| `updateOrganisation` | `PATCH /organisations/:handle` | 200, 400, 401, 404, 429, 500 |
| `deleteOrganisation` | `DELETE /organisations/:handle` | 200, 400, 401, 404, 429, 500 |
| `addOrganisationMember` | `POST /organisations/:handle/members/:profileHandle` | 201, 400, 401, 404, 429, 500 |
| `removeOrganisationMember` | `DELETE /organisations/:handle/members/:profileHandle` | 200, 400, 401, 404, 429, 500 |
| `updateOrganisationMemberRole` | `PATCH /organisations/:handle/members/:profileHandle` | 200, 400, 401, 404, 429, 500 |
| `listOrganisationMembers` | `GET /organisations/:handle/members` | 200, 401, 403, 404, 500 |

## Two renames

`graphErrorResponse` → `errorResponse`, `graphOkResponse` → `okResponse`. Both were named after the group that happened to need them first, and neither is graph-specific — the bare `{ error }` envelope and `{ ok: true }` are what the whole non-auth surface uses. Renaming now, while graph is the only consumer, beats four more copies as the remaining groups land. Internal to `osn/api`; the generated spec is byte-for-byte unaffected by the rename itself.

## Where the schemas disagree with the endpoint's appearance

- **`POST /organisations/` cannot 500.** Its catch maps *every* service failure to 400, so a taken handle and a database fault are reported identically. Rather than declare a 500 that never arrives, the schema says what happens. (Worth a follow-up decision — it means a client can't distinguish "pick another handle" from "try again later" — but changing it is a behaviour change, not a docs one.)
- **Authorisation refusals are 400, not 403,** wherever the check lives in the service: *only admins can update the organisation*, *only the owner can delete*, *only the owner can grant admin*, *only the owner can change roles*. They arrive as `OrgError` and go through the same catch as everything else. The one genuine 403 in the group is `listOrganisationMembers`, whose membership check runs in the route.
- **404 on the three member routes covers two different misses** — no such organisation, and no such profile. Both handles are in the path, so they are told apart by the message.
- **`resolveOrg` sets 500 when the lookup itself throws**, returning null either way, so every handle-resolving route emits `{ error: "Organisation not found" }` at whichever status it set. Same shape as its 404.

The roster is member-only by design and the existing comment says why; the schema now records that it is a 403 and not a 404, so a client can tell "you're not in this org" from "no such org".

## The one behaviour change

In `GET /organisations/:handle/members`, the `getMemberRole` call sat *outside* the `try`. A database fault during the membership check therefore escaped to Elysia's default error handler and answered with a body unlike every other error in the group — which a `500: errorResponse` declaration would have documented incorrectly. It now runs inside the `try` and reports `{ error }` at 500 like its neighbours. The 200 and 403 paths are untouched.

Related: `listMembers` had its return type narrowed from `role: string` to the column's own `"admin" | "member"`. A client reads the roster before PATCHing a role back, and both request bodies accept exactly those two values, so the wide type was wrong at the source — declaring `t.String()` in the response schema would have propagated it into every generated client. This is what forced the change: `tsc` rejected the narrow schema against the wide service type, which is the type system doing its job.

## Verification

- `bun run --cwd osn/api check` — clean
- `bun run --cwd osn/api test:run` — 61 files, 1003 tests, all passing
- `shared/openapi/pulse.json` regenerates **byte-identical** (md5 unchanged)
- route set unchanged: **62 paths / 73 operations**, set-diff of `METHOD path` keys against `HEAD` empty both ways
- all nine operation ids present with exactly the status sets above — 0 mismatches
- operations with an empty `responses` object: **18 → 9**

## Still unanswered, from #421

The openapi plugin is mounted on `osn/api` unconditionally, so the deployed `id.musubi.social` Worker serves a Scalar docs UI at `/openapi` enumerating the whole public surface. If it should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`; one line, happy to do it here or separately.

Next and last in the stack: profiles (3), recommendations (2), erasure and export (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
