### PR TITLE
feat(osn-api): describe the last nine operations' responses

### DIFF
--- a/.changeset/osn-api-final-response-schemas.md
+++ b/.changeset/osn-api-final-response-schemas.md
@@ -1,0 +1,7 @@
+---
+"@osn/api": patch
+---
+
+Describe the response bodies of the last nine operations: profiles, recommendations, account erasure and account export. Every operation in the OpenAPI document now declares its success and error shapes, so a generated client no longer has to guess.
+
+Account export keeps its 200 out of the `response` map on purpose — the success path streams a raw NDJSON `Response`, and an Elysia response schema is a runtime validator as much as a document. It is described through `detail.responses` instead.

--- a/osn/api/src/routes/account-erasure.ts
+++ b/osn/api/src/routes/account-erasure.ts
@@ -17,6 +17,13 @@ import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { metricAccountDeletionRequested, metricAuthRateLimited } from "../metrics";
 import * as accountErasure from "../services/account-erasure";
 import { createAuthService, type AuthConfig } from "../services/auth";
+import {
+  accountDeletionScheduledResponse,
+  accountDeletionStatusResponse,
+  accountRestoreResponse,
+  errorResponse,
+  stepUpRequiredResponse,
+} from "./auth/response-schemas";
 
 /**
  * Per-account rate limits for the deletion endpoints. Tighter than the
@@ -196,6 +203,22 @@ export function createAccountErasureRoutes(
             confirm_handle: t.String({ minLength: 1, maxLength: 64 }),
             step_up_token: t.Optional(t.String()),
           }),
+          response: {
+            // 202, not 200: nothing is erased yet. The account is tombstoned
+            // and the hard delete becomes eligible when the grace window
+            // closes at `scheduled_for`.
+            202: accountDeletionScheduledResponse,
+            // `handle_mismatch` — the typed confirmation did not match — plus
+            // whatever `publicError` maps a service failure to.
+            400: errorResponse,
+            401: errorResponse,
+            // Missing or rejected step-up. The only status in this group that
+            // carries a `detail`; see `stepUpRequiredResponse`.
+            403: stepUpRequiredResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "requestAccountDeletion", security: [{ bearerAuth: [] }] },
         },
       )
       // ---------------------------------------------------------------------
@@ -206,68 +229,100 @@ export function createAccountErasureRoutes(
       // this account). We don't require step-up here — the session itself
       // is a fresh-enough authenticator within the 7-day window.
       // ---------------------------------------------------------------------
-      .post("/restore", async ({ headers, set, server, request }) => {
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "account_restore",
-          rl.accountRestore,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+      .post(
+        "/restore",
+        async ({ headers, set, server, request }) => {
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "account_restore",
+            rl.accountRestore,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileByIdIncludingTombstoned(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileByIdIncludingTombstoned(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const result = await run(accountErasure.cancelErasure(profile.accountId));
+            return { cancelled: result.cancelled };
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          const result = await run(accountErasure.cancelErasure(profile.accountId));
-          return { cancelled: result.cancelled };
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            // `cancelled: false` is a 200, not an error — read the flag. No
+            // step-up here: the surviving cancellation session is itself a
+            // fresh-enough authenticator inside the grace window.
+            200: accountRestoreResponse,
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "restoreAccount", security: [{ bearerAuth: [] }] },
+        },
+      )
       // ---------------------------------------------------------------------
       // GET /account/deletion-status — UI banner support.
       // ---------------------------------------------------------------------
-      .get("/deletion-status", async ({ headers, set, server, request }) => {
-        const rlErr = await rateLimit(
-          headers,
-          socketIpOf({ server, request }),
-          "account_deletion_status",
-          rl.accountDeletionStatus,
-        );
-        if (rlErr) {
-          set.status = 429;
-          return rlErr;
-        }
-        try {
-          const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
-          if (!claims) {
-            set.status = 401;
-            return { error: "unauthorized" };
+      .get(
+        "/deletion-status",
+        async ({ headers, set, server, request }) => {
+          const rlErr = await rateLimit(
+            headers,
+            socketIpOf({ server, request }),
+            "account_deletion_status",
+            rl.accountDeletionStatus,
+          );
+          if (rlErr) {
+            set.status = 429;
+            return rlErr;
           }
-          const profile = await run(auth.findProfileByIdIncludingTombstoned(claims.profileId));
-          if (!profile) {
-            set.status = 401;
-            return { error: "unauthorized" };
+          try {
+            const claims = await resolveAccessTokenPrincipal(auth, headers.authorization);
+            if (!claims) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const profile = await run(auth.findProfileByIdIncludingTombstoned(claims.profileId));
+            if (!profile) {
+              set.status = 401;
+              return { error: "unauthorized" };
+            }
+            const status = await run(accountErasure.getDeletionStatus(profile.accountId));
+            return status;
+          } catch (e) {
+            const { status, body: errBody } = handleError(e);
+            set.status = status;
+            return errBody;
           }
-          const status = await run(accountErasure.getDeletionStatus(profile.accountId));
-          return status;
-        } catch (e) {
-          const { status, body: errBody } = handleError(e);
-          set.status = status;
-          return errBody;
-        }
-      })
+        },
+        {
+          response: {
+            // Answers for a live account too — `{ scheduled: false }`, not a 404.
+            // This backs a banner that is polled, so "nothing pending" has to be
+            // an ordinary success.
+            200: accountDeletionStatusResponse,
+            400: errorResponse,
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "getAccountDeletionStatus", security: [{ bearerAuth: [] }] },
+        },
+      )
   );
 }

--- a/osn/api/src/routes/account-export.ts
+++ b/osn/api/src/routes/account-export.ts
@@ -21,6 +21,7 @@ import {
   type ExportDownstream,
 } from "../services/account-export";
 import { createAuthService, type AuthConfig } from "../services/auth";
+import { errorResponse, stepUpRequiredResponse } from "./auth/response-schemas";
 
 /**
  * C-H1 — `GET /account/export` (DSAR Art. 15 access / Art. 20 portability).
@@ -162,6 +163,36 @@ export function createAccountExportRoutes(
         set.status = status;
         return errBody;
       }
+    },
+    {
+      // No 200 in this map, and that is on purpose. The success path returns a
+      // raw `Response` wrapping an NDJSON stream, and a `response` schema is a
+      // runtime validator as much as a document — putting one on 200 would
+      // make Elysia try to validate a stream it cannot read without consuming
+      // it. The 200 is described in `detail.responses` below instead, which
+      // reaches the spec without touching the wire.
+      response: {
+        400: errorResponse,
+        401: errorResponse,
+        403: stepUpRequiredResponse,
+        // Two different limits, same status: the pre-auth per-IP throttle, and
+        // the per-account 1-per-24h cap. The second is consumed only AFTER a
+        // successful step-up, so a fumbled ceremony never burns the day's
+        // allowance.
+        429: errorResponse,
+        500: errorResponse,
+      },
+      detail: {
+        operationId: "exportAccount",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": {
+            description:
+              "The export bundle as newline-delimited JSON, streamed. Sent as an attachment; each line is one record and the set of record types is the DSAR contract in `services/account-export.ts`.",
+            content: { "application/x-ndjson": { schema: { type: "string" } } },
+          },
+        },
+      },
     },
   );
 }

--- a/osn/api/src/routes/auth/response-schemas.ts
+++ b/osn/api/src/routes/auth/response-schemas.ts
@@ -1,5 +1,10 @@
 /**
- * Shared TypeBox response schemas for the auth route groups.
+ * Shared TypeBox response schemas for every route that funnels its failures
+ * through `publicError` — the auth groups, and also account erasure, account
+ * export and profiles, which sit outside `routes/auth/` but answer with the
+ * same envelope. The split against `routes/response-schemas.ts` is by envelope,
+ * not by folder: that file serves the groups whose `error` field IS the
+ * human-readable message.
  *
  * These exist for one reason: `@elysiajs/openapi` can only describe a
  * response it has a schema for. Without them every operation in
@@ -234,4 +239,72 @@ export const oidcTokenResponse = t.Object({
   token_type: t.Literal("Bearer"),
   expires_in: t.Number(),
   scope: t.String(),
+});
+
+/**
+ * The 403 from a failed step-up gate on `DELETE /account` and
+ * `GET /account/export`.
+ *
+ * `error` is always the literal `step_up_required`. `detail` appears only when
+ * a step-up token WAS supplied and the verifier rejected it, and carries
+ * `publicError`'s own envelope — so a client can tell "you need to re-auth"
+ * from "the token you sent was expired or minted for another purpose". Absent
+ * when no token was supplied at all.
+ *
+ * Declared as its own const rather than reusing `errorResponse`, because
+ * Elysia deletes any key the schema omits: an `errorResponse` here would
+ * silently drop `detail` on the wire.
+ */
+export const stepUpRequiredResponse = t.Object({
+  error: t.String(),
+  message: t.Optional(t.String()),
+  detail: t.Optional(
+    t.Object({
+      error: t.String(),
+      message: t.Optional(t.String()),
+    }),
+  ),
+});
+
+/**
+ * `DELETE /account` at 202. `scheduled_for` is Unix seconds — the moment the
+ * grace window closes and the hard delete becomes eligible, not the moment of
+ * the request.
+ *
+ * `already_pending` is what makes the endpoint idempotent: a second call inside
+ * the window returns the FIRST call's schedule with the flag set, rather than
+ * moving the date or erroring.
+ */
+export const accountDeletionScheduledResponse = t.Object({
+  scheduled_for: t.Number(),
+  already_pending: t.Boolean(),
+});
+
+/**
+ * `GET /account/deletion-status`. A closed union, not one object with optional
+ * fields: `scheduledFor` and `softDeletedAt` exist together or not at all, and
+ * a client that switches on `scheduled` can never read a half-populated row.
+ *
+ * Both timestamps are Unix seconds. Note the camelCase — this body comes
+ * straight off the service's return type, unlike the snake_case `scheduled_for`
+ * of the deletion request above. Inconsistent, and worth settling before an
+ * external client depends on either; the schema records what ships today.
+ */
+export const accountDeletionStatusResponse = t.Union([
+  t.Object({ scheduled: t.Literal(false) }),
+  t.Object({
+    scheduled: t.Literal(true),
+    scheduledFor: t.Number(),
+    softDeletedAt: t.Number(),
+  }),
+]);
+
+/**
+ * `POST /account/restore`. A 200 with `cancelled: false` is a real outcome, not
+ * an error: there was no pending deletion, or — the case that matters — the
+ * grace window had already closed, so the downstream purge may be under way and
+ * the account is past resurrecting. A client must read the flag, not the status.
+ */
+export const accountRestoreResponse = t.Object({
+  cancelled: t.Boolean(),
 });

--- a/osn/api/src/routes/profile.ts
+++ b/osn/api/src/routes/profile.ts
@@ -16,6 +16,7 @@ import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { metricAuthRateLimited } from "../metrics";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createProfileService } from "../services/profile";
+import { errorResponse, publicProfile } from "./auth/response-schemas";
 
 // ---------------------------------------------------------------------------
 // Rate limiter types
@@ -139,6 +140,19 @@ export function createProfileRoutes(
           handle: t.String(),
           display_name: t.Optional(t.String()),
         }),
+        response: {
+          201: t.Object({ profile: publicProfile }),
+          // A taken handle, a malformed one and a breached per-account profile
+          // cap all arrive here as `invalid_request`. `publicError` maps
+          // `ValidationError` and `AuthError` to the same opaque 400 on
+          // purpose — a create endpoint that distinguished them would be a
+          // handle-enumeration oracle.
+          400: errorResponse,
+          401: errorResponse,
+          429: errorResponse,
+          500: errorResponse,
+        },
+        detail: { operationId: "createProfile", security: [{ bearerAuth: [] }] },
       },
     )
     .post(
@@ -172,6 +186,19 @@ export function createProfileRoutes(
         body: t.Object({
           profile_id: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
         }),
+        response: {
+          200: t.Object({ deleted: t.Boolean() }),
+          // Four refusals share this status: no such profile, a profile
+          // belonging to another account, the account's last profile, and a
+          // profile that still owns an organisation. All are `AuthError`, so
+          // all read `invalid_request` — deliberately, since telling "not
+          // yours" from "does not exist" would confirm a stranger's id.
+          400: errorResponse,
+          401: errorResponse,
+          429: errorResponse,
+          500: errorResponse,
+        },
+        detail: { operationId: "deleteProfile", security: [{ bearerAuth: [] }] },
       },
     )
     .post(
@@ -207,6 +234,16 @@ export function createProfileRoutes(
         params: t.Object({
           profileId: t.String({ pattern: "^usr_[a-f0-9]{12}$" }),
         }),
+        response: {
+          // Returns the profile that is now default, so a client can render
+          // the switch without re-reading the list.
+          200: t.Object({ profile: publicProfile }),
+          400: errorResponse,
+          401: errorResponse,
+          429: errorResponse,
+          500: errorResponse,
+        },
+        detail: { operationId: "setDefaultProfile", security: [{ bearerAuth: [] }] },
       },
     );
 }

--- a/osn/api/src/routes/recommendations.ts
+++ b/osn/api/src/routes/recommendations.ts
@@ -6,6 +6,12 @@ import { Elysia, t } from "elysia";
 import { makeAppRunner, type AppRuntime } from "../lib/route-runtime";
 import { createAuthService, type AuthConfig } from "../services/auth";
 import { createRecommendationService } from "../services/recommendations";
+import {
+  errorResponse,
+  organisationSearchResult,
+  profileSearchResult,
+  suggestionSummary,
+} from "./response-schemas";
 
 // ---------------------------------------------------------------------------
 // Rate limiters — per-user fixed window
@@ -150,6 +156,17 @@ export function createRecommendationRoutes(
             // validates bounds at the HTTP boundary (S-M1 / P-W1).
             limit: t.Optional(t.Numeric({ minimum: 1, maximum: 50 })),
           }),
+          response: {
+            // An empty list is the normal answer for a new account with no
+            // connections and no organisation — not a 404.
+            200: t.Object({ suggestions: t.Array(suggestionSummary) }),
+            401: errorResponse,
+            429: errorResponse,
+            // The fan-out is several queries deep; anything it throws is
+            // swallowed and reported as one opaque "Request failed".
+            500: errorResponse,
+          },
+          detail: { operationId: "suggestConnections", security: [{ bearerAuth: [] }] },
         },
       )
       // -----------------------------------------------------------------------
@@ -194,6 +211,19 @@ export function createRecommendationRoutes(
             limit: t.Optional(t.Numeric({ minimum: 1, maximum: 20 })),
             orgLimit: t.Optional(t.Numeric({ minimum: 1, maximum: 20 })),
           }),
+          response: {
+            // Both halves always present, both possibly empty. A query below
+            // the service's minimum length comes back as two empty lists at
+            // 200 — a half-typed word is not a client error.
+            200: t.Object({
+              people: t.Array(profileSearchResult),
+              organisations: t.Array(organisationSearchResult),
+            }),
+            401: errorResponse,
+            429: errorResponse,
+            500: errorResponse,
+          },
+          detail: { operationId: "searchProfilesAndOrganisations", security: [{ bearerAuth: [] }] },
         },
       )
   );

--- a/osn/api/src/routes/response-schemas.ts
+++ b/osn/api/src/routes/response-schemas.ts
@@ -1,12 +1,13 @@
 /**
- * Shared TypeBox response schemas for the non-auth route groups (graph,
- * organisations, profiles, recommendations, erasure, export).
+ * Shared TypeBox response schemas for the route groups that answer with a bare
+ * `{ error }`: graph, organisations and recommendations.
  *
- * The auth groups have their own file, `routes/auth/response-schemas.ts`, and
- * the two are deliberately not merged: the auth surface funnels every failure
- * through `publicError`, so its envelope carries an optional human-readable
- * `message`, while these routes answer with a bare `{ error }` whose value is
- * already the human-readable string. One shared const would have had to be a
+ * The other file, `routes/auth/response-schemas.ts`, serves everything that
+ * funnels failures through `publicError`. The split is by envelope, not by
+ * folder — account erasure, account export and profiles live outside
+ * `routes/auth/` and still belong there, because `publicError`'s envelope
+ * carries an optional human-readable `message` while these routes' `error`
+ * field IS the human-readable string. One shared const would have had to be a
  * superset of both, which would document a `message` field that half the API
  * never sends.
  *
@@ -115,4 +116,51 @@ export const organisationMemberSummary = t.Object({
   displayName: t.Union([t.String(), t.Null()]),
   role: t.Union([t.Literal("admin"), t.Literal("member")]),
   joinedAt: t.String({ format: "date-time" }),
+});
+
+/**
+ * `Suggestion` from `services/recommendations.ts` — one card in "people you may
+ * know". Addressed by handle, not id, like the organisation surface.
+ *
+ * `reason` names the STRONGEST signal, not the only one: `sharedOrganisation`
+ * can be present alongside `reason: "mutual_connections"`, because the card
+ * shows both lines. Read them independently.
+ *
+ * `mutualCount` is a count, never a list. The connection graph is not
+ * enumerable through this endpoint — that is the whole reason the suggestion
+ * carries a number instead of the names behind it.
+ */
+export const suggestionSummary = t.Object({
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  avatarUrl: t.Union([t.String(), t.Null()]),
+  mutualCount: t.Number(),
+  reason: t.Union([t.Literal("mutual_connections"), t.Literal("shared_organisation")]),
+  sharedOrganisation: t.Union([t.Object({ handle: t.String(), name: t.String() }), t.Null()]),
+});
+
+/**
+ * `ProfileSearchResult` — one person in the typeahead. `connectionStatus` is
+ * the same closed union as `graphConnectionStatus`, deliberately: it lets the
+ * result row render Connect / Pending / Connected without a second request per
+ * result, and a client can hand the value straight to the graph code it
+ * already has.
+ */
+export const profileSearchResult = t.Object({
+  handle: t.String(),
+  displayName: t.Union([t.String(), t.Null()]),
+  avatarUrl: t.Union([t.String(), t.Null()]),
+  connectionStatus: graphConnectionStatus,
+});
+
+/**
+ * `OrganisationSearchResult` — one organisation in the typeahead. No id, for
+ * the same reason `organisationSummary` has none: every organisation route
+ * addresses it by handle.
+ */
+export const organisationSearchResult = t.Object({
+  handle: t.String(),
+  name: t.String(),
+  avatarUrl: t.Union([t.String(), t.Null()]),
+  isMember: t.Boolean(),
 });

--- a/osn/api/tests/routes/account-erasure.test.ts
+++ b/osn/api/tests/routes/account-erasure.test.ts
@@ -1,10 +1,12 @@
 import type { RateLimiterBackend } from "@shared/rate-limit";
+import { Effect } from "effect";
 import { describe, it, expect, beforeAll } from "vitest";
 
 import {
   createAccountErasureRoutes,
   type AccountErasureRateLimiters,
 } from "../../src/routes/account-erasure";
+import { createAuthService } from "../../src/services/auth";
 import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayer } from "../helpers/db";
 
@@ -115,5 +117,196 @@ describe("account-erasure routes — client-IP keying (S-M5)", () => {
     );
     expect(res.status).toBe(429);
     expect(((await res.json()) as { error: string }).error).toBe("rate_limited");
+  });
+});
+
+/**
+ * The wire shapes of the success paths.
+ *
+ * Elysia validates AND CLEANS every body against the route's `response`
+ * schema before it goes out: a key the schema omits is deleted, and a value
+ * that fails its type 500s the route. So these are not documentation tests —
+ * each one asserts that a real handler's body survives the schema intact.
+ */
+describe("account-erasure routes — response bodies", () => {
+  const allowAll = (): AccountErasureRateLimiters => {
+    const backend = { check: async () => true } as RateLimiterBackend;
+    return {
+      accountDelete: backend,
+      accountRestore: backend,
+      accountDeletionStatus: backend,
+    };
+  };
+
+  /** Direct-mode client-IP resolution needs a trusted XFF hop under app.handle. */
+  const IP_HEADERS = { "x-forwarded-for": "1.2.3.4" };
+
+  async function seed(layer: ReturnType<typeof createTestLayer>) {
+    const auth = createAuthService(config);
+    const profile = await Effect.runPromise(
+      auth.registerProfile("eraser@example.com", "eraser", "Erase Me").pipe(Effect.provide(layer)),
+    );
+    const tokens = await Effect.runPromise(
+      auth
+        .issueTokens(
+          profile.id,
+          profile.accountId,
+          profile.email,
+          profile.handle,
+          profile.displayName,
+        )
+        .pipe(Effect.provide(layer)),
+    );
+    const app = createAccountErasureRoutes(
+      config,
+      layer,
+      undefined,
+      allowAll(),
+      { secure: false },
+      { trustedProxyCount: 1 },
+    );
+    const authed = { ...IP_HEADERS, Authorization: `Bearer ${tokens.accessToken}` };
+    return { auth, profile, app, authed };
+  }
+
+  const requestDeletion = (
+    app: Awaited<ReturnType<typeof seed>>["app"],
+    authed: Record<string, string>,
+    body: Record<string, unknown>,
+  ) =>
+    app.handle(
+      new Request("http://localhost/account", {
+        method: "DELETE",
+        headers: { ...authed, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  it("DELETE /account returns 202 with both scheduling fields, and is idempotent", async () => {
+    const layer = createTestLayer();
+    const { auth, profile, app, authed } = await seed(layer);
+
+    const first = await requestDeletion(app, authed, {
+      confirm_handle: profile.handle,
+      step_up_token: await Effect.runPromise(
+        auth.issueStepUpToken(profile.accountId, "otp", "account_delete"),
+      ),
+    });
+    expect(first.status).toBe(202);
+    const firstBody = (await first.json()) as { scheduled_for: number; already_pending: boolean };
+    expect(typeof firstBody.scheduled_for).toBe("number");
+    // Unix SECONDS, not milliseconds — a schema of `t.Number()` would pass
+    // either, so pin the magnitude here instead.
+    expect(firstBody.scheduled_for).toBeLessThan(1e12);
+    expect(firstBody.already_pending).toBe(false);
+
+    // Second call inside the window: same schedule, flag flipped. The date
+    // must not move — that is what makes the endpoint safe to retry.
+    //
+    // Note the handle: soft-delete redacts every profile handle to
+    // `deleted_<usr-suffix>`, and the route checks the confirmation BEFORE it
+    // reaches the idempotent service path. So a client retrying with the
+    // handle the user actually typed gets 400 `handle_mismatch`, not the
+    // `already_pending` body below. Worth settling, but it is a behaviour
+    // change, not a schema one — recorded here rather than fixed in this PR.
+    const second = await requestDeletion(app, authed, {
+      confirm_handle: `deleted_${profile.id.replace("usr_", "")}`,
+      step_up_token: await Effect.runPromise(
+        auth.issueStepUpToken(profile.accountId, "otp", "account_delete"),
+      ),
+    });
+    expect(second.status).toBe(202);
+    expect(await second.json()).toEqual({
+      scheduled_for: firstBody.scheduled_for,
+      already_pending: true,
+    });
+  });
+
+  it("a rejected step-up 403s with its `detail` envelope intact", async () => {
+    const layer = createTestLayer();
+    const { auth, profile, app, authed } = await seed(layer);
+    // An export-purpose token must not authorise a deletion.
+    const wrongPurpose = await Effect.runPromise(
+      auth.issueStepUpToken(profile.accountId, "otp", "account_export"),
+    );
+    const res = await requestDeletion(app, authed, {
+      confirm_handle: profile.handle,
+      step_up_token: wrongPurpose,
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; detail?: { error: string } };
+    expect(body.error).toBe("step_up_required");
+    // `detail` only exists on the rejected-token branch, and only survives
+    // because the route declares `stepUpRequiredResponse` rather than the
+    // shared `errorResponse` — see the schema's own note.
+    expect(typeof body.detail?.error).toBe("string");
+  });
+
+  it("GET /account/deletion-status answers both arms of the union", async () => {
+    const layer = createTestLayer();
+    const { auth, profile, app, authed } = await seed(layer);
+
+    const before = await app.handle(
+      new Request("http://localhost/account/deletion-status", { headers: authed }),
+    );
+    expect(before.status).toBe(200);
+    // A live account is `{ scheduled: false }` and nothing else — the union's
+    // false arm declares no timestamps, so any that leaked would be cleaned.
+    expect(await before.json()).toEqual({ scheduled: false });
+
+    await requestDeletion(app, authed, {
+      confirm_handle: profile.handle,
+      step_up_token: await Effect.runPromise(
+        auth.issueStepUpToken(profile.accountId, "otp", "account_delete"),
+      ),
+    });
+
+    const after = await app.handle(
+      new Request("http://localhost/account/deletion-status", { headers: authed }),
+    );
+    expect(after.status).toBe(200);
+    const status = (await after.json()) as {
+      scheduled: boolean;
+      scheduledFor?: number;
+      softDeletedAt?: number;
+    };
+    // The true arm carries both timestamps or the client cannot render a
+    // countdown. Note the camelCase, against `scheduled_for` above.
+    expect(status.scheduled).toBe(true);
+    expect(typeof status.scheduledFor).toBe("number");
+    expect(typeof status.softDeletedAt).toBe("number");
+    expect(status.softDeletedAt!).toBeLessThanOrEqual(status.scheduledFor!);
+  });
+
+  it("POST /account/restore returns the `cancelled` flag, and cancels for real", async () => {
+    const layer = createTestLayer();
+    const { auth, profile, app, authed } = await seed(layer);
+    await requestDeletion(app, authed, {
+      confirm_handle: profile.handle,
+      step_up_token: await Effect.runPromise(
+        auth.issueStepUpToken(profile.accountId, "otp", "account_delete"),
+      ),
+    });
+
+    const restored = await app.handle(
+      new Request("http://localhost/account/restore", { method: "POST", headers: authed }),
+    );
+    expect(restored.status).toBe(200);
+    expect(await restored.json()).toEqual({ cancelled: true });
+
+    // The status endpoint agrees — restore isn't just a 200.
+    const status = await app.handle(
+      new Request("http://localhost/account/deletion-status", { headers: authed }),
+    );
+    expect(await status.json()).toEqual({ scheduled: false });
+
+    // Nothing pending → `cancelled: false` at 200, not an error status. A
+    // client must read the flag; the same body reports a grace window that
+    // has already closed, which is past resurrecting.
+    const again = await app.handle(
+      new Request("http://localhost/account/restore", { method: "POST", headers: authed }),
+    );
+    expect(again.status).toBe(200);
+    expect(await again.json()).toEqual({ cancelled: false });
   });
 });

--- a/osn/api/tests/routes/account-export.test.ts
+++ b/osn/api/tests/routes/account-export.test.ts
@@ -103,6 +103,14 @@ describe("GET /account/export — gating", () => {
       }),
     );
     expect(res.status).toBe(403);
+    // The rejected-token case carries `publicError`'s envelope under `detail`,
+    // so a client can tell "you need to re-auth" from "the token you sent was
+    // minted for another ceremony". Elysia CLEANS the body against the route's
+    // `response` schema — an `errorResponse` on 403 would delete this key on
+    // the wire, silently, which is why the route declares its own schema.
+    const body = (await res.json()) as { error: string; detail?: { error: string } };
+    expect(body.error).toBe("step_up_required");
+    expect(typeof body.detail?.error).toBe("string");
   });
 
   it("a failed step-up (403) does not consume the 1/24h allowance", async () => {

--- a/osn/api/tests/routes/recommendations.test.ts
+++ b/osn/api/tests/routes/recommendations.test.ts
@@ -111,11 +111,25 @@ describe("recommendations routes", () => {
     );
     expect(res.status).toBe(200);
     const json = (await res.json()) as {
-      suggestions: Array<{ handle: string; mutualCount: number }>;
+      suggestions: Array<Record<string, unknown>>;
     };
     expect(json.suggestions).toHaveLength(1);
+    // The whole card, key for key. Elysia cleans the body against the route's
+    // `response` schema, so a field the schema forgot would vanish here and
+    // nowhere else — assert the shape, not just the two fields the UI reads
+    // first.
+    expect(Object.keys(json.suggestions[0]!).toSorted()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "handle",
+      "mutualCount",
+      "reason",
+      "sharedOrganisation",
+    ]);
     expect(json.suggestions[0]!.handle).toBe("dana");
     expect(json.suggestions[0]!.mutualCount).toBe(1);
+    expect(json.suggestions[0]!.reason).toBe("mutual_connections");
+    expect(json.suggestions[0]!.sharedOrganisation).toBeNull();
   });
 
   // -------------------------------------------------------------------------

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -186,7 +186,7 @@
     },
     "/account": {
       "delete": {
-        "operationId": "deleteAccount",
+        "operationId": "requestAccountDeletion",
         "requestBody": {
           "content": {
             "application/json": {
@@ -245,12 +245,294 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "already_pending": {
+                      "type": "boolean"
+                    },
+                    "scheduled_for": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "scheduled_for",
+                    "already_pending"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 202"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 403"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/account/deletion-status": {
       "get": {
-        "operationId": "getAccountDeletion-status"
+        "operationId": "getAccountDeletionStatus",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "scheduled": {
+                          "const": false,
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "scheduled"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "scheduled": {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        "scheduledFor": {
+                          "type": "number"
+                        },
+                        "softDeletedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "scheduled",
+                        "scheduledFor",
+                        "softDeletedAt"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/account/email/begin": {
@@ -583,12 +865,247 @@
     },
     "/account/export": {
       "get": {
-        "operationId": "getAccountExport"
+        "operationId": "exportAccount",
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 403"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/account/restore": {
       "post": {
-        "operationId": "postAccountRestore"
+        "operationId": "restoreAccount",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cancelled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "cancelled"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/account/security-events": {
@@ -8041,7 +8558,7 @@
     },
     "/profiles/create": {
       "post": {
-        "operationId": "postProfilesCreate",
+        "operationId": "createProfile",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8094,12 +8611,151 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "profile": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "displayName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "handle",
+                        "email",
+                        "displayName",
+                        "avatarUrl"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "profile"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/profiles/delete": {
       "post": {
-        "operationId": "postProfilesDelete",
+        "operationId": "deleteProfile",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8146,7 +8802,116 @@
             }
           },
           "required": true
-        }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "deleted"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/profiles/list": {
@@ -8497,7 +9262,7 @@
     },
     "/profiles/{profileId}/default": {
       "post": {
-        "operationId": "postProfilesByProfileIdDefault",
+        "operationId": "setDefaultProfile",
         "parameters": [
           {
             "in": "path",
@@ -8508,12 +9273,151 @@
               "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "profile": {
+                      "properties": {
+                        "avatarUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "displayName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "handle",
+                        "email",
+                        "displayName",
+                        "avatarUrl"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "profile"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
     "/recommendations/connections": {
       "get": {
-        "operationId": "getRecommendationsConnections",
+        "operationId": "suggestConnections",
         "parameters": [
           {
             "in": "query",
@@ -8536,12 +9440,147 @@
               "minimum": 1
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "suggestions": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "mutualCount": {
+                            "type": "number"
+                          },
+                          "reason": {
+                            "enum": [
+                              "mutual_connections",
+                              "shared_organisation"
+                            ],
+                            "type": "string"
+                          },
+                          "sharedOrganisation": {
+                            "properties": {
+                              "handle": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "handle",
+                              "name"
+                            ],
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "handle",
+                          "displayName",
+                          "avatarUrl",
+                          "mutualCount",
+                          "reason",
+                          "sharedOrganisation"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "suggestions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
     "/recommendations/search": {
       "get": {
-        "operationId": "getRecommendationsSearch",
+        "operationId": "searchProfilesAndOrganisations",
         "parameters": [
           {
             "in": "query",
@@ -8593,6 +9632,150 @@
               "maximum": 20,
               "minimum": 1
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "organisations": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "isMember": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "handle",
+                          "name",
+                          "avatarUrl",
+                          "isMember"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "people": {
+                      "items": {
+                        "properties": {
+                          "avatarUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "connectionStatus": {
+                            "enum": [
+                              "none",
+                              "pending_sent",
+                              "pending_received",
+                              "connected"
+                            ],
+                            "type": "string"
+                          },
+                          "displayName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "handle",
+                          "displayName",
+                          "avatarUrl",
+                          "connectionStatus"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "people",
+                    "organisations"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 200"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 401"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 429"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 500"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
           }
         ]
       }


### PR DESCRIPTION
Last of the stack. Profiles (3 operations), recommendations (2), account erasure (3) and account export (1) now declare their response bodies. **Every operation in `shared/openapi/osn.json` now has a `responses` map** — the count went 9 → 0 this PR, 29 → 0 across the seven.

Stacked on #426 (`feat/osn-api-response-schemas-5`). Review that one first; this diff is only its own commit.

## Three things worth reading in the diff

**`GET /account/export` has no 200 in its `response` map, on purpose.** The success path returns a raw `Response` wrapping an NDJSON stream. An Elysia response schema is a runtime validator as much as a document, so declaring a 200 would make it try to validate a stream it cannot read without consuming it. The 200 is described through `detail.responses` instead, which reaches the spec without touching the wire.

**The 403 from a failed step-up gets its own schema.** `stepUpRequiredResponse` carries an optional `detail` object holding `publicError`'s envelope, so a client can tell "you need to re-authenticate" from "the token you sent was minted for another ceremony". Elysia deletes any key a schema omits — the shared `errorResponse` would have dropped `detail` on the wire, silently. Both `DELETE /account` and `GET /account/export` use it.

**`GET /account/deletion-status` is a union, not an object with optional fields.** Discriminated on the `scheduled` literal: the two timestamps exist together or not at all, and a client switching on the flag can never read a half-populated row.

## The split between the two schema files is by envelope, not by folder

Account erasure, account export and profiles sit outside `routes/auth/` and still import from `routes/auth/response-schemas.ts`, because they funnel failures through `publicError` and answer `{ error, message? }`. The other file serves the groups whose `error` field **is** the human-readable message. Both doc headers now say this, since the folder layout implies the opposite.

## Tests

Covering the three bodies where a cleaning bug would otherwise be invisible — no existing test drove a success body through these routes at all:

- the deletion-status union, both arms, including that the false arm carries nothing else
- the `cancelled` flag on `POST /account/restore`, and that a second call returns `cancelled: false` at 200 rather than an error status
- the `detail` key surviving on a rejected step-up, on both erasure and export
- the suggestion card asserted key for key, so a forgotten field in `suggestionSummary` fails here

1007 tests pass. `check`, oxlint and oxfmt clean. `shared/openapi/pulse.json` is byte-identical (md5 unchanged); the path and operation sets in `osn.json` are unchanged — 62 paths, 73 operations, same `METHOD path` set as the base.

## Found while testing, not changed here

Soft delete redacts every profile handle to `deleted_<suffix>`, and `DELETE /account` checks the typed confirmation **before** it reaches the idempotent service path. So a client retrying with the handle the user actually typed gets 400 `handle_mismatch`, not the `already_pending: true` body. The schema is right about what the route can return; the route's ordering is the question. Fixing it is a behaviour change, so it stays out of a response-schema PR — say the word and it's a two-line move.

## Still unanswered, from all seven PR bodies

The openapi plugin is mounted on `osn/api` unconditionally, so the deployed `id.musubi.social` Worker serves a Scalar docs UI at `/openapi` enumerating the whole public surface. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps` — one line.
