### PR TITLE
feat(ios): Musubi passkeys screen — list, rename, delete, add

### DIFF
--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -79,6 +79,6 @@ let package = Package(
         // shared cookie jar and passkey ceremonies are one implementation,
         // not one per app.
         .target(name: "MusubiFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAPI"]),
-        .testTarget(name: "MusubiFeatureTests", dependencies: ["MusubiFeature", "OSNAPI"]),
+        .testTarget(name: "MusubiFeatureTests", dependencies: ["MusubiFeature", "OSNAPI", "OSNAuth"]),
     ]
 )

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiPasskey.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiPasskey.swift
@@ -1,0 +1,80 @@
+import Foundation
+import OSNAuth
+
+/// One registered passkey, as the passkeys screen shows it.
+///
+/// `PasskeySummary` carries Unix **seconds** as `Int` (the management route
+/// hands back integers, unlike the session routes' `Double`), so the
+/// conversion happens here and no view does date arithmetic on a bare
+/// number.
+public struct MusubiPasskey: Identifiable, Equatable, Sendable {
+    public let id: String
+    /// User-set name. `nil` for a passkey enrolled before labelling, or one
+    /// the user never named.
+    public let label: String?
+    public let createdAt: Date
+    /// `nil` until the passkey is used to sign in.
+    public let lastUsedAt: Date?
+    /// The authenticator says the credential *can* be backed up (iCloud
+    /// Keychain, a password manager) — not that it has been.
+    public let backupEligible: Bool
+    /// The authenticator says the credential *is* backed up. A passkey that
+    /// is eligible but not backed up lives on one device only, which is the
+    /// one worth warning about: lose the device, lose the account.
+    public let backupState: Bool
+
+    public init(
+        id: String,
+        label: String?,
+        createdAt: Date,
+        lastUsedAt: Date?,
+        backupEligible: Bool,
+        backupState: Bool
+    ) {
+        self.id = id
+        self.label = label
+        self.createdAt = createdAt
+        self.lastUsedAt = lastUsedAt
+        self.backupEligible = backupEligible
+        self.backupState = backupState
+    }
+
+    public var displayLabel: String { label ?? "Unnamed passkey" }
+
+    /// Falls back to `createdAt`: a passkey never used again was last used
+    /// when it was enrolled.
+    public var lastActive: Date { lastUsedAt ?? createdAt }
+
+    /// Synced to the user's keychain, so it survives losing this device.
+    public var isSynced: Bool { backupState }
+
+    /// Eligible for sync but not synced — the only state that costs the user
+    /// their account if the device goes in a river.
+    public var isDeviceBound: Bool { backupEligible && !backupState }
+}
+
+extension MusubiPasskey {
+    /// The server sends `backupEligible`/`backupState` as optional: a
+    /// credential enrolled by an authenticator that reported no backup flags
+    /// has neither. Absent is read as false — claiming a passkey is synced
+    /// when nobody said so is the one wrong answer here.
+    public init(_ summary: PasskeySummary) {
+        self.init(
+            id: summary.id,
+            label: summary.label,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(summary.createdAt)),
+            lastUsedAt: summary.lastUsedAt.map { Date(timeIntervalSince1970: TimeInterval($0)) },
+            backupEligible: summary.backupEligible ?? false,
+            backupState: summary.backupState ?? false
+        )
+    }
+}
+
+extension Array where Element == MusubiPasskey {
+    /// Most recently used first. Unlike the devices list there is no "this
+    /// one" to pin: the screen can't know which credential the current
+    /// session was signed in with, and the server doesn't say.
+    public func sortedForDisplay() -> [MusubiPasskey] {
+        sorted { $0.lastActive > $1.lastActive }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -7,9 +7,9 @@ import SwiftUI
 /// iOS anchor provider in from `App.swift` (this package can't import
 /// UIKit).
 ///
-/// There is one signed-in screen so far, so this is a `NavigationStack`
-/// rather than a `TabView` — a tab bar with one tab is a tab bar that lies
-/// about what is built. Tabs arrive with the second surface.
+/// Two signed-in screens now, so the tab bar arrives as promised. Sign out
+/// sits in each tab's own toolbar rather than a third tab: it is an action,
+/// not a place.
 public struct MusubiRootView: View {
     private let session: MusubiSession
     private let anchorProvider: PresentationAnchorProvider
@@ -36,15 +36,28 @@ public struct MusubiRootView: View {
         case .signedOut, .failed:
             MusubiSignInView(session: session, anchorProvider: anchorProvider)
         case .signedIn:
-            NavigationStack {
-                DevicesView(session: session)
-                    .toolbar {
-                        ToolbarItem(placement: .primaryAction) {
-                            Button("Sign out") {
-                                Task { await session.signOut() }
-                            }
-                        }
+            TabView {
+                Tab("Devices", systemImage: "laptopcomputer.and.iphone") {
+                    NavigationStack {
+                        DevicesView(session: session)
+                            .toolbar { signOutButton }
                     }
+                }
+                Tab("Passkeys", systemImage: "person.badge.key") {
+                    NavigationStack {
+                        PasskeysView(session: session, anchorProvider: anchorProvider)
+                            .toolbar { signOutButton }
+                    }
+                }
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var signOutButton: some ToolbarContent {
+        ToolbarItem(placement: .secondaryAction) {
+            Button("Sign out") {
+                Task { await session.signOut() }
             }
         }
     }

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
@@ -38,6 +38,9 @@ public final class MusubiSession {
 
     private let tokenRefresher: TokenRefresher
     private let loginClient: PasskeyLoginClient
+    private let passkeyManagementClient: PasskeyManagementClient
+    private let stepUpClient: StepUpPasskeyClient
+    private let passkeyEnrollmentClient: PasskeyEnrollmentClient
 
     /// - Parameter environment: identity host for passkey ceremonies, token
     ///   refresh *and* the API. Defaults to `.local`; the app target picks
@@ -52,7 +55,28 @@ public final class MusubiSession {
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
         self.tokenRefresher = tokenRefresher
         self.loginClient = PasskeyLoginClient(session: session, environment: environment)
+        self.passkeyManagementClient = PasskeyManagementClient(session: session, environment: environment)
+        self.stepUpClient = StepUpPasskeyClient(session: session, environment: environment)
+        self.passkeyEnrollmentClient = PasskeyEnrollmentClient(session: session, environment: environment)
         self.api = makeOSNClient(environment: environment, session: session, tokenRefresher: tokenRefresher)
+    }
+
+    /// The passkeys screen's API, assembled from the three `OSNAuth` clients
+    /// this session already owns. Built here rather than in the view because
+    /// the clients are built off the shared-jar `URLSession`, which nothing
+    /// outside this type holds.
+    ///
+    /// - Parameter anchorProvider: the app target's key-window lookup —
+    ///   every call on the returned API runs a passkey ceremony that needs
+    ///   somewhere to present.
+    public func makePasskeysAPI(anchorProvider: @escaping PresentationAnchorProvider) -> OSNPasskeysAPI {
+        OSNPasskeysAPI(
+            management: passkeyManagementClient,
+            stepUp: stepUpClient,
+            enrollment: passkeyEnrollmentClient,
+            client: api,
+            anchorProvider: anchorProvider
+        )
     }
 
     /// Silent restore on launch. A throw from `TokenRefresher.refresh()`

--- a/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysAPI.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysAPI.swift
@@ -1,0 +1,111 @@
+import Foundation
+import OSNAPI
+import OSNAuth
+
+/// The four things the passkeys screen does, named in its own terms.
+///
+/// Same seam as `DevicesAPI`, and for a second reason on top of the test
+/// double: three of these four calls run a live WebAuthn ceremony first, and
+/// the step-up dance is exactly what a view model must not know about. The
+/// real conformance below is the only place `StepUpPasskeyClient` appears.
+///
+/// The mutating calls are `@MainActor` because
+/// `ASAuthorizationController` is: the ceremony has to be started from the
+/// main actor with a live presentation anchor.
+public protocol PasskeysAPI: Sendable {
+    func listPasskeys() async throws -> [MusubiPasskey]
+    @MainActor func renamePasskey(id: String, label: String) async throws
+    /// - Returns: the server's `remaining` count after the delete.
+    @MainActor func deletePasskey(id: String) async throws -> Int
+    @MainActor func addPasskey() async throws
+}
+
+public enum PasskeysAPIError: Error, Equatable, CustomStringConvertible {
+    /// `/profiles/list` came back empty. Every account has a profile, so
+    /// this means the call was made without a usable session rather than
+    /// that the user has none.
+    case noProfile
+
+    public var description: String {
+        switch self {
+        case .noProfile:
+            "Couldn't work out which profile to enrol the passkey under."
+        }
+    }
+}
+
+/// `PasskeysAPI` over the `OSNAuth` clients.
+///
+/// Every mutation mints its own step-up token first. They are single-use and
+/// short-lived, so there is nothing to cache: one ceremony per action is the
+/// contract, and it is also what makes the action safe.
+public struct OSNPasskeysAPI: PasskeysAPI {
+    private let management: PasskeyManagementClient
+    private let stepUp: StepUpPasskeyClient
+    private let enrollment: PasskeyEnrollmentClient
+    private let client: any APIProtocol
+    private let anchorProvider: PresentationAnchorProvider
+
+    public init(
+        management: PasskeyManagementClient,
+        stepUp: StepUpPasskeyClient,
+        enrollment: PasskeyEnrollmentClient,
+        client: any APIProtocol,
+        anchorProvider: @escaping PresentationAnchorProvider
+    ) {
+        self.management = management
+        self.stepUp = stepUp
+        self.enrollment = enrollment
+        self.client = client
+        self.anchorProvider = anchorProvider
+    }
+
+    public func listPasskeys() async throws -> [MusubiPasskey] {
+        try await management.list().map(MusubiPasskey.init)
+    }
+
+    /// Rename mints `passkey_delete`, not a `passkey_rename` that doesn't
+    /// exist: the server shares one verifier for both
+    /// (`osn/api/src/services/auth/step-up.ts:398-400`). Mirroring that is
+    /// deliberate — a `passkey_rename` purpose would simply be rejected.
+    @MainActor
+    public func renamePasskey(id: String, label: String) async throws {
+        let token = try await stepUp.mintStepUpToken(purpose: .passkeyDelete, anchorProvider: anchorProvider)
+        try await management.rename(id: id, label: label, stepUpToken: token.stepUpToken)
+    }
+
+    @MainActor
+    public func deletePasskey(id: String) async throws -> Int {
+        let token = try await stepUp.mintStepUpToken(purpose: .passkeyDelete, anchorProvider: anchorProvider)
+        return try await management.delete(id: id, stepUpToken: token.stepUpToken).remaining
+    }
+
+    /// Enrolling from a signed-in account always steps up — the "first
+    /// passkey, no ceremony available" case `PasskeyEnrollmentClient`
+    /// documents is registration, where there is no account to step up
+    /// against yet. Here there is one, by definition: the screen is behind a
+    /// sign-in.
+    @MainActor
+    public func addPasskey() async throws {
+        let profileId = try await resolveProfileId()
+        let token = try await stepUp.mintStepUpToken(purpose: .passkeyRegister, anchorProvider: anchorProvider)
+        _ = try await enrollment.register(
+            profileId: profileId,
+            stepUpToken: token.stepUpToken,
+            anchorProvider: anchorProvider
+        )
+    }
+
+    /// A restored session is `signedIn(nil)` — `PasskeyProfile` only ever
+    /// arrives from a live `/login/passkey/complete`, so the profile id has
+    /// to come off the wire. First profile: passkeys are held by the
+    /// account, and the id only names the WebAuthn user the ceremony is run
+    /// as.
+    private func resolveProfileId() async throws -> String {
+        let profiles = try await client.listAccountProfiles(.init()).ok.body.json.profiles
+        guard let first = profiles.first else {
+            throw PasskeysAPIError.noProfile
+        }
+        return first.id
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysView.swift
@@ -1,0 +1,173 @@
+import OSNAuth
+import OSNUI
+import SwiftUI
+
+/// Passkeys screen: every credential that can sign in to this account, with
+/// rename, delete and add.
+///
+/// This is the surface `OSNAuth`'s management, step-up and enrolment clients
+/// were built for and until now had no consumer. Everything on it except the
+/// list runs a passkey ceremony first, which is why there are no
+/// "are you sure?" sheets: Face ID *is* the confirmation, and a dialog in
+/// front of it would only train the user to tap through both.
+public struct PasskeysView: View {
+    @State private var viewModel: PasskeysViewModel
+    @State private var renameTarget: MusubiPasskey?
+    @State private var renameLabel = ""
+
+    public init(session: MusubiSession, anchorProvider: @escaping PresentationAnchorProvider) {
+        _viewModel = State(
+            wrappedValue: PasskeysViewModel(api: session.makePasskeysAPI(anchorProvider: anchorProvider))
+        )
+    }
+
+    /// For previews and for a caller that already has an API of its own.
+    public init(viewModel: PasskeysViewModel) {
+        _viewModel = State(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        content
+            .navigationTitle("Passkeys")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Add", systemImage: "plus") {
+                        Task { await viewModel.add() }
+                    }
+                    .disabled(viewModel.isAdding)
+                }
+            }
+            .task {
+                if viewModel.isEmpty {
+                    await viewModel.load()
+                }
+            }
+            .alert("Rename passkey", isPresented: renameIsPresented, presenting: renameTarget) { passkey in
+                TextField("Name", text: $renameLabel)
+                Button("Cancel", role: .cancel) {}
+                Button("Rename") {
+                    Task { await viewModel.rename(id: passkey.id, label: renameLabel) }
+                }
+            } message: { _ in
+                Text("Names are only for you — they help you tell your devices apart.")
+            }
+    }
+
+    private var renameIsPresented: Binding<Bool> {
+        Binding(
+            get: { renameTarget != nil },
+            set: { if !$0 { renameTarget = nil } }
+        )
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isEmpty {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView()
+            case .failed(let message):
+                ContentUnavailableView(
+                    "Couldn't load your passkeys",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(message)
+                )
+            case .loaded:
+                // An account always has at least one passkey, so this is
+                // unreachable in practice. Kept rather than force-unwrapped:
+                // a list is a list.
+                ContentUnavailableView(
+                    "No passkeys",
+                    systemImage: "person.badge.key",
+                    description: Text("Passkeys you add show up here.")
+                )
+            }
+        } else {
+            list
+        }
+    }
+
+    private var list: some View {
+        ScrollView {
+            GlassEffectContainer {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    if let mutationError = viewModel.mutationError {
+                        Text(mutationError)
+                            .font(.osn(.body, size: 14))
+                            .foregroundStyle(.red)
+                    }
+
+                    ForEach(viewModel.passkeys) { passkey in
+                        PasskeyRow(
+                            passkey: passkey,
+                            isMutating: viewModel.mutatingID == passkey.id,
+                            canDelete: viewModel.canDelete,
+                            rename: {
+                                renameLabel = passkey.label ?? ""
+                                renameTarget = passkey
+                            },
+                            delete: { Task { await viewModel.delete(id: passkey.id) } }
+                        )
+                    }
+
+                    GlassButton(viewModel.isAdding ? "Adding…" : "Add a passkey") {
+                        Task { await viewModel.add() }
+                    }
+                    .disabled(viewModel.isAdding)
+                }
+                .padding()
+            }
+        }
+        .refreshable {
+            await viewModel.load()
+        }
+    }
+}
+
+private struct PasskeyRow: View {
+    let passkey: MusubiPasskey
+    let isMutating: Bool
+    let canDelete: Bool
+    let rename: () -> Void
+    let delete: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(passkey.displayLabel)
+                        .font(.osn(.body, size: 18))
+                    Spacer()
+                    if passkey.isSynced {
+                        Pill("Synced", tint: OSNColor.accent)
+                    }
+                }
+
+                // The one state worth saying out loud: a passkey that could
+                // be backed up but isn't lives on one device, and losing
+                // that device loses the account.
+                if passkey.isDeviceBound {
+                    Text("On this device only — it won't survive losing it.")
+                        .font(.osn(.body, size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Last used \(passkey.lastActive, format: .relative(presentation: .named))")
+                    .font(.osn(.body, size: 14))
+                Text("Added \(passkey.createdAt, format: .relative(presentation: .named))")
+                    .font(.osn(.body, size: 12))
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    GlassButton(isMutating ? "Working…" : "Rename", kind: .secondary, action: rename)
+                        .disabled(isMutating)
+
+                    if canDelete {
+                        GlassButton("Remove", kind: .secondary, action: delete)
+                            .disabled(isMutating)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysViewModel.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/PasskeysViewModel.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Observation
+
+/// Drives the passkeys screen: lists the account's credentials, renames,
+/// deletes and enrols. Owns no client and no token — everything goes through
+/// `PasskeysAPI`.
+///
+/// Each mutation re-lists rather than patching the array. That is the
+/// opposite of `DevicesViewModel`, on purpose: a rename changes a field the
+/// server owns, an enrolment adds a row the client can't describe (it never
+/// sees the new credential's flags), and both have just cost the user a
+/// biometric prompt — a round trip is cheap next to that, and guessing is
+/// how a list starts lying.
+@MainActor
+@Observable
+public final class PasskeysViewModel {
+    public enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    public private(set) var passkeys: [MusubiPasskey] = []
+    public private(set) var state: LoadState = .idle
+    /// The row being renamed or deleted, so only its own controls spin.
+    public private(set) var mutatingID: String?
+    /// True while an enrolment ceremony is in flight.
+    public private(set) var isAdding = false
+    /// A failed mutation, shown above the list. Kept apart from
+    /// `LoadState.failed` because the list is still good — including when
+    /// the user simply cancelled the passkey sheet, which arrives here as an
+    /// error like any other.
+    public private(set) var mutationError: String?
+
+    public var isEmpty: Bool { passkeys.isEmpty }
+
+    /// The account invariant is at least one passkey, and the server
+    /// enforces it. The screen shows the last one as undeletable rather than
+    /// letting the user spend a biometric prompt on a call that will be
+    /// refused.
+    public var canDelete: Bool { passkeys.count > 1 }
+
+    private let api: any PasskeysAPI
+    private var loadGeneration = 0
+
+    public init(api: any PasskeysAPI) {
+        self.api = api
+    }
+
+    public func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        state = .loading
+        do {
+            let passkeys = try await api.listPasskeys()
+            // A pull-to-refresh landing mid-request starts a newer load;
+            // that one owns the list from here.
+            guard generation == loadGeneration else { return }
+            self.passkeys = passkeys.sortedForDisplay()
+            state = .loaded
+        } catch {
+            // A view that goes away cancels its load. That is the screen
+            // closing, not a failure worth showing.
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            state = .failed(String(describing: error))
+        }
+    }
+
+    public func rename(id: String, label: String) async {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        await mutate(id: id) {
+            try await self.api.renamePasskey(id: id, label: trimmed)
+            // `PATCH /passkeys/:id` answers `{ "success": true }` and not the
+            // updated summary, so the new label comes back the only way it
+            // can.
+            await self.load()
+        }
+    }
+
+    /// Drops the row on success and trusts `remaining` over its own count:
+    /// the server has just told us how many are left, and a passkey enrolled
+    /// on another device since the last list would make a local count wrong.
+    public func delete(id: String) async {
+        await mutate(id: id) {
+            let remaining = try await self.api.deletePasskey(id: id)
+            self.passkeys.removeAll { $0.id == id }
+            // Only worth re-listing when the two disagree — something
+            // changed elsewhere and this list is already stale.
+            if remaining != self.passkeys.count {
+                await self.load()
+            }
+        }
+    }
+
+    public func add() async {
+        isAdding = true
+        mutationError = nil
+        defer { isAdding = false }
+        do {
+            try await api.addPasskey()
+            await load()
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    private func mutate(id: String, _ body: () async throws -> Void) async {
+        mutatingID = id
+        mutationError = nil
+        defer { mutatingID = nil }
+        do {
+            try await body()
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiPasskeyTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiPasskeyTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import OSNAuth
+import Testing
+@testable import MusubiFeature
+
+private let nowSeconds = 1_700_000_000
+
+/// `PasskeySummary` has no public memberwise init — it is a wire type, so
+/// the tests build it the way the app does, off JSON. That the decode is
+/// exercised too is a bonus, not the point.
+private func makeSummary(_ json: String) throws -> PasskeySummary {
+    try JSONDecoder().decode(PasskeySummary.self, from: Data(json.utf8))
+}
+
+@Suite struct MusubiPasskeyTests {
+    @Test func decodesUnixSecondsAsSeconds() throws {
+        let summary = try makeSummary(
+            """
+            {
+              "id": "pk_1",
+              "label": "iPhone",
+              "createdAt": \(nowSeconds),
+              "lastUsedAt": \(nowSeconds + 60),
+              "backupEligible": true,
+              "backupState": true
+            }
+            """
+        )
+
+        let passkey = MusubiPasskey(summary)
+
+        #expect(passkey.createdAt == Date(timeIntervalSince1970: TimeInterval(nowSeconds)))
+        #expect(passkey.lastUsedAt == Date(timeIntervalSince1970: TimeInterval(nowSeconds + 60)))
+        #expect(passkey.displayLabel == "iPhone")
+        #expect(passkey.isSynced)
+        #expect(!passkey.isDeviceBound)
+    }
+
+    /// Absent backup flags read as false. Saying "synced" when the
+    /// authenticator never claimed it is the one answer that could cost
+    /// someone their account.
+    @Test func missingBackupFlagsAreNotSynced() throws {
+        let summary = try makeSummary(
+            """
+            { "id": "pk_1", "createdAt": \(nowSeconds) }
+            """
+        )
+
+        let passkey = MusubiPasskey(summary)
+
+        #expect(!passkey.isSynced)
+        #expect(!passkey.isDeviceBound)
+        #expect(passkey.displayLabel == "Unnamed passkey")
+    }
+
+    /// Eligible but not backed up: the state the row warns about.
+    @Test func eligibleButUnbackedIsDeviceBound() throws {
+        let summary = try makeSummary(
+            """
+            { "id": "pk_1", "createdAt": \(nowSeconds), "backupEligible": true, "backupState": false }
+            """
+        )
+
+        #expect(MusubiPasskey(summary).isDeviceBound)
+    }
+
+    /// Never used again → last active is when it was added, so a fresh
+    /// passkey doesn't sink to the bottom of the list.
+    @Test func lastActiveFallsBackToCreatedAt() throws {
+        let summary = try makeSummary(
+            """
+            { "id": "pk_1", "createdAt": \(nowSeconds) }
+            """
+        )
+
+        #expect(MusubiPasskey(summary).lastActive == Date(timeIntervalSince1970: TimeInterval(nowSeconds)))
+    }
+
+    @Test func sortsMostRecentlyUsedFirst() {
+        let old = MusubiPasskey(
+            id: "old",
+            label: nil,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastUsedAt: Date(timeIntervalSince1970: 100),
+            backupEligible: false,
+            backupState: false
+        )
+        let recent = MusubiPasskey(
+            id: "recent",
+            label: nil,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastUsedAt: Date(timeIntervalSince1970: 500),
+            backupEligible: false,
+            backupState: false
+        )
+
+        #expect([old, recent].sortedForDisplay().map(\.id) == ["recent", "old"])
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/PasskeysViewModelTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/PasskeysViewModelTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+@testable import MusubiFeature
+
+private func makePasskey(id: String, label: String? = "iPhone", lastUsedAt: TimeInterval = 500) -> MusubiPasskey {
+    MusubiPasskey(
+        id: id,
+        label: label,
+        createdAt: Date(timeIntervalSince1970: 0),
+        lastUsedAt: Date(timeIntervalSince1970: lastUsedAt),
+        backupEligible: true,
+        backupState: true
+    )
+}
+
+private struct StubError: Error, CustomStringConvertible {
+    let description = "stub failed"
+}
+
+/// Scripted `PasskeysAPI`. `@MainActor` rather than an actor because three
+/// of the four protocol methods are main-actor-bound — the real ones run
+/// `ASAuthorizationController`, which is.
+@MainActor
+private final class StubPasskeysAPI: PasskeysAPI {
+    var listResults: [Result<[MusubiPasskey], Error>]
+    var renameResult: Result<Void, Error>
+    var deleteResults: [Result<Int, Error>]
+    var addResult: Result<Void, Error>
+    private(set) var listCount = 0
+    private(set) var renamed: [(id: String, label: String)] = []
+    private(set) var deletedIDs: [String] = []
+    private(set) var addCount = 0
+
+    init(
+        listResults: [Result<[MusubiPasskey], Error>] = [.success([])],
+        renameResult: Result<Void, Error> = .success(()),
+        deleteResults: [Result<Int, Error>] = [.success(1)],
+        addResult: Result<Void, Error> = .success(())
+    ) {
+        self.listResults = listResults
+        self.renameResult = renameResult
+        self.deleteResults = deleteResults
+        self.addResult = addResult
+    }
+
+    /// Each call consumes the next scripted result; the last one repeats, so
+    /// a test that only cares about the first answer needn't script the
+    /// re-list every mutation does.
+    func listPasskeys() async throws -> [MusubiPasskey] {
+        listCount += 1
+        let result = listResults.count > 1 ? listResults.removeFirst() : listResults[0]
+        return try result.get()
+    }
+
+    func renamePasskey(id: String, label: String) async throws {
+        renamed.append((id: id, label: label))
+        try renameResult.get()
+    }
+
+    func deletePasskey(id: String) async throws -> Int {
+        deletedIDs.append(id)
+        let result = deleteResults.count > 1 ? deleteResults.removeFirst() : deleteResults[0]
+        return try result.get()
+    }
+
+    func addPasskey() async throws {
+        addCount += 1
+        try addResult.get()
+    }
+}
+
+@MainActor
+@Suite struct PasskeysViewModelTests {
+    @Test func loadSortsMostRecentlyUsedFirst() async {
+        let api = StubPasskeysAPI(
+            listResults: [.success([makePasskey(id: "old", lastUsedAt: 100), makePasskey(id: "recent", lastUsedAt: 900)])]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.passkeys.map(\.id) == ["recent", "old"])
+    }
+
+    @Test func loadFailureIsReported() async {
+        let viewModel = PasskeysViewModel(api: StubPasskeysAPI(listResults: [.failure(StubError())]))
+
+        await viewModel.load()
+
+        #expect(viewModel.isEmpty)
+        #expect(viewModel.state == .failed("stub failed"))
+    }
+
+    /// The rename endpoint answers `{ "success": true }` and not the updated
+    /// summary, so the new label can only come from a re-list.
+    @Test func renameRefreshesFromTheServer() async {
+        let api = StubPasskeysAPI(
+            listResults: [
+                .success([makePasskey(id: "pk_1", label: "iPhone")]),
+                .success([makePasskey(id: "pk_1", label: "Work phone")]),
+            ]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.rename(id: "pk_1", label: "  Work phone  ")
+
+        #expect(api.renamed.map(\.label) == ["Work phone"])
+        #expect(api.listCount == 2)
+        #expect(viewModel.passkeys.map(\.displayLabel) == ["Work phone"])
+        #expect(viewModel.mutatingID == nil)
+        #expect(viewModel.mutationError == nil)
+    }
+
+    /// A whitespace-only name is not a rename. Caught before the ceremony,
+    /// so the user isn't asked for Face ID to do nothing.
+    @Test func blankRenameIsNotSent() async {
+        let api = StubPasskeysAPI(listResults: [.success([makePasskey(id: "pk_1")])])
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.rename(id: "pk_1", label: "   ")
+
+        #expect(api.renamed.isEmpty)
+        #expect(api.listCount == 1)
+    }
+
+    /// Cancelling the passkey sheet arrives as a thrown error, and it must
+    /// not take the list with it.
+    @Test func renameFailureKeepsTheList() async {
+        let api = StubPasskeysAPI(
+            listResults: [.success([makePasskey(id: "pk_1")])],
+            renameResult: .failure(StubError())
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.rename(id: "pk_1", label: "Work phone")
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.passkeys.map(\.id) == ["pk_1"])
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(viewModel.mutatingID == nil)
+    }
+
+    /// `remaining` agrees with the local count, so no re-list.
+    @Test func deleteDropsTheRowWithoutReloading() async {
+        let api = StubPasskeysAPI(
+            listResults: [.success([makePasskey(id: "pk_1"), makePasskey(id: "pk_2")])],
+            deleteResults: [.success(1)]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.delete(id: "pk_2")
+
+        #expect(viewModel.passkeys.map(\.id) == ["pk_1"])
+        #expect(api.listCount == 1)
+    }
+
+    /// The server counts one more than we do — a passkey was enrolled
+    /// somewhere else. Its answer wins, and the list catches up.
+    @Test func deleteReloadsWhenTheServerCountDisagrees() async {
+        let api = StubPasskeysAPI(
+            listResults: [
+                .success([makePasskey(id: "pk_1"), makePasskey(id: "pk_2")]),
+                .success([makePasskey(id: "pk_1"), makePasskey(id: "pk_3")]),
+            ],
+            deleteResults: [.success(2)]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.delete(id: "pk_2")
+
+        #expect(api.listCount == 2)
+        #expect(viewModel.passkeys.map(\.id) == ["pk_1", "pk_3"])
+    }
+
+    @Test func deleteFailureKeepsTheRow() async {
+        let api = StubPasskeysAPI(
+            listResults: [.success([makePasskey(id: "pk_1"), makePasskey(id: "pk_2")])],
+            deleteResults: [.failure(StubError())]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.delete(id: "pk_2")
+
+        #expect(viewModel.passkeys.map(\.id) == ["pk_1", "pk_2"])
+        #expect(viewModel.mutationError == "stub failed")
+    }
+
+    /// The account invariant is at least one passkey. The last row offers no
+    /// remove button rather than spending a biometric prompt on a call the
+    /// server will refuse.
+    @Test func theLastPasskeyCannotBeDeleted() async {
+        let api = StubPasskeysAPI(listResults: [.success([makePasskey(id: "pk_1")])])
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        #expect(!viewModel.canDelete)
+    }
+
+    /// Enrolment returns only an id; the new row's flags are the server's to
+    /// describe, so the list comes back from it.
+    @Test func addReloadsAndClearsItsFlag() async {
+        let api = StubPasskeysAPI(
+            listResults: [
+                .success([makePasskey(id: "pk_1")]),
+                .success([makePasskey(id: "pk_1"), makePasskey(id: "pk_2")]),
+            ]
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.add()
+
+        #expect(api.addCount == 1)
+        #expect(viewModel.passkeys.map(\.id) == ["pk_1", "pk_2"])
+        #expect(!viewModel.isAdding)
+    }
+
+    @Test func addFailureIsReportedAndDoesNotReload() async {
+        let api = StubPasskeysAPI(
+            listResults: [.success([makePasskey(id: "pk_1")])],
+            addResult: .failure(StubError())
+        )
+        let viewModel = PasskeysViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.add()
+
+        #expect(api.listCount == 1)
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(!viewModel.isAdding)
+    }
+}

--- a/wiki/apps/ios.md
+++ b/wiki/apps/ios.md
@@ -6,6 +6,7 @@ related:
   - "[[sessions]]"
   - "[[identity-model]]"
   - "[[passkey-primary]]"
+  - "[[step-up]]"
   - "[[pulse]]"
   - "[[osn-core]]"
 packages:
@@ -55,16 +56,28 @@ Access tokens are the 5-minute ES256 JWTs from [[identity-model]], cached in the
 
 Refresh failure is **HTTP 400 with an `error` string, never 401**. A client that branches on 401 retries a dead session forever.
 
-## Musubi's first screen
+## Musubi's screens
 
-Devices: every live session on the account, with per-row revoke and "sign out everywhere else" — `listSessions` / `revokeSession` / `revokeAllOtherSessions` ([[sessions]]). Chosen because it needs no new API work and it is the screen that *shows* the shared jar: sign in on Pulse, and the session appears in Musubi's list.
+Two tabs so far.
+
+**Devices** — every live session on the account, with per-row revoke and "sign out everywhere else": `listSessions` / `revokeSession` / `revokeAllOtherSessions` ([[sessions]]). Built first because it needs no new API work and it is the screen that *shows* the shared jar: sign in on Pulse, and the session appears in Musubi's list.
 
 Two contract details worth keeping:
 
 - Session timestamps are **Unix seconds** (`osn/api/src/routes/auth/response-schemas.ts`), so the generated types are `Double`; conversion to `Date` happens once, in `MusubiDevice`.
 - Whether a revoke killed *this* session is read from the server's `revokedSelf`, never inferred from the row's `isCurrent`.
 
-View models take a narrow protocol (`DevicesAPI`, three methods), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI` is the only place generated shapes are unwrapped.
+**Passkeys** — list, rename, delete, add. The consumer `OSNAuth`'s `PasskeyManagementClient`, `StepUpPasskeyClient` and `PasskeyEnrollmentClient` were written for and had until now gone without. Contract details:
+
+- Every mutation mints its **own** step-up token first ([[step-up]]) — they are single-use and short-lived, so there is nothing to cache, and one ceremony per action is what makes the action safe. Face ID *is* the confirmation; the screen adds no "are you sure?" sheet in front of it.
+- **Rename mints `passkey_delete`.** The server shares one verifier for rename and delete (`osn/api/src/services/auth/step-up.ts:398-400`). A `passkey_rename` purpose does not exist and would be rejected.
+- `PATCH /passkeys/:id` answers a bare `{ "success": true }`, not the updated summary, so a rename can only get its new label back by re-listing. Enrolment likewise returns just an id.
+- `PasskeySummary` timestamps are Unix seconds as **`Int`** — the management routes hand back integers where the session routes hand back `Double`.
+- Absent `backupEligible`/`backupState` read as **false**. Calling a passkey synced when no authenticator said so is the one wrong answer: eligible-but-unbacked means it dies with the device.
+- The account invariant is ≥1 passkey ([[passkey-primary]]) and the server enforces it, so the last row offers no Remove rather than spending a biometric prompt on a refusal.
+- Enrolment needs a `profileId`, and a *restored* session is `signedIn(nil)` — `PasskeyProfile` only ever arrives from a live `/login/passkey/complete`. So it comes off the wire, via `listAccountProfiles`.
+
+View models take a narrow protocol (`DevicesAPI`, three methods; `PasskeysAPI`, four), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI` and `OSNPasskeysAPI` are the only places generated shapes and ceremonies are unwrapped — which is also why `PasskeysAPI`'s three mutating methods are `@MainActor`: `ASAuthorizationController` is.
 
 ## macOS purity rule
 


### PR DESCRIPTION
Stacked on #430 (`feat/osn-ios-app`). Review the [diff against that base](https://github.com/xchromo/osn/compare/feat/osn-ios-app...feat/osn-ios-passkeys) rather than against `main`.

Musubi's second screen. It is the first consumer of `OSNAuth`'s `PasskeyManagementClient`, `StepUpPasskeyClient` and `PasskeyEnrollmentClient`, which until now shipped without one.

## What's here

| File | Role |
|---|---|
| `MusubiFeature/MusubiPasskey.swift` | Domain model + `PasskeySummary` conversion |
| `MusubiFeature/PasskeysAPI.swift` | Four-method protocol + `OSNPasskeysAPI`, the only place ceremonies appear |
| `MusubiFeature/PasskeysViewModel.swift` | `@Observable` state: load, rename, delete, add |
| `MusubiFeature/PasskeysView.swift` | The screen |
| `MusubiFeature/MusubiRootView.swift` | `NavigationStack` → `TabView`, now there are two screens |
| `MusubiFeature/MusubiSession.swift` | Holds the three clients; `makePasskeysAPI(anchorProvider:)` |
| `Tests/MusubiFeatureTests/` | 16 new tests |
| `wiki/apps/ios.md` | The contract details below, written down |

## Contract details that shaped the code

- **Rename mints purpose `passkey_delete`.** The server deliberately shares one verifier for rename and delete (`osn/api/src/services/auth/step-up.ts:398-400`); a `passkey_rename` purpose does not exist and would be rejected. The client mirrors the server rather than inventing a purpose it would have to strip later.
- **Every mutation re-lists.** `PATCH /passkeys/:id` answers a bare `{ "success": true }`, not the updated summary, and enrolment answers only a `passkeyId` — so the client cannot describe the result it just caused. Delete is the exception that proves it: it drops the row locally and re-lists only when the server's `remaining` disagrees with the local count, because a disagreement means a passkey moved somewhere else.
- **Absent `backupEligible` / `backupState` read as `false`.** Showing "synced" when no authenticator claimed it is the one wrong answer here: eligible-but-unbacked means the credential dies with the device, and the row says so.
- **`PasskeySummary` timestamps are `Int` seconds** where the session routes' are `Double`. Converted once, in `MusubiPasskey`.
- **The last passkey has no Remove button.** The account invariant is ≥1 credential and the server enforces it, so the alternative is spending a biometric prompt to earn a refusal.
- **No confirmation sheets.** Face ID *is* the confirmation; a second "are you sure?" in front of it teaches people to dismiss both.
- **Enrolment resolves `profileId` from `listAccountProfiles`.** A restored session is `signedIn(nil)` — `PasskeyProfile` only ever arrives from a live `/login/passkey/complete`.

`PasskeysAPI` is four methods against `APIProtocol`'s 73, matching `DevicesAPI`'s three. Its three mutating methods are `@MainActor` because `ASAuthorizationController` is.

## Verification

- `swift test` — **109 tests in 14 suites pass** (was 93 in 12).
- `xcodegen generate` + `xcodebuild -scheme Musubi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — **exit 0**, one pre-existing `ASPresentationAnchor()` deprecation warning at `osn/ios/Sources/App.swift:44`.
- `scripts/changeset-required.sh` — `skip` (Swift + wiki paths ship no versioned package).

## Still open, carried from the stack

- **`/openapi` is mounted unconditionally**, so the deployed `id.musubi.social` Worker serves a Scalar docs UI enumerating the whole public surface. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`. Needs a call.
- **Apple developer portal, team `FV59Y8RSUH`** — App Group `group.social.musubi.session` and associated domain `webcredentials:musubi.social` must be registered, and bundle ids `com.osn.pulse` / `social.musubi.app` confirmed, before either app codesigns. CI stays green meanwhile via `CODE_SIGNING_ALLOWED=NO`; a device build does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
