### PR TITLE
feat(ios): add the Musubi Security tab

### DIFF
--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRecoveryStatus.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRecoveryStatus.swift
@@ -1,0 +1,47 @@
+import Foundation
+import OSNAPI
+
+/// How many recovery codes the account has left, as the security screen
+/// shows it.
+///
+/// `GET /recovery/status` is the one route on this screen with **no**
+/// step-up gate, deliberately: the answer is what tells a user whether a
+/// ceremony is worth starting, and it carries counts, never a code.
+///
+/// The counts arrive as `Double` because the spec types them as plain
+/// numbers. They are whole codes, so they are narrowed here once rather
+/// than in every view.
+public struct MusubiRecoveryStatus: Equatable, Sendable {
+    /// Codes still unspent.
+    public let active: Int
+    /// Codes in the current set. A set is replaced whole, so this is 10
+    /// after any generate.
+    public let total: Int
+    /// When the current set was made. `nil` when the account has never
+    /// generated one.
+    public let generatedAt: Date?
+
+    public init(active: Int, total: Int, generatedAt: Date?) {
+        self.active = active
+        self.total = total
+        self.generatedAt = generatedAt
+    }
+
+    public var hasCodes: Bool { total > 0 }
+
+    public var used: Int { Swift.max(0, total - active) }
+
+    /// Few enough left that the user should make a new set before they are
+    /// locked out of their own fallback.
+    public var isRunningLow: Bool { hasCodes && active <= 3 }
+}
+
+extension MusubiRecoveryStatus {
+    public init(_ payload: Operations.GetRecoveryStatus.Output.Ok.Body.JsonPayload) {
+        self.init(
+            active: Int(payload.active),
+            total: Int(payload.total),
+            generatedAt: payload.generatedAt.map(Date.init(timeIntervalSince1970:))
+        )
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -7,9 +7,8 @@ import SwiftUI
 /// iOS anchor provider in from `App.swift` (this package can't import
 /// UIKit).
 ///
-/// Two signed-in screens now, so the tab bar arrives as promised. Sign out
-/// sits in each tab's own toolbar rather than a third tab: it is an action,
-/// not a place.
+/// Three signed-in screens now. Sign out sits in each tab's own toolbar
+/// rather than a tab of its own: it is an action, not a place.
 public struct MusubiRootView: View {
     private let session: MusubiSession
     private let anchorProvider: PresentationAnchorProvider
@@ -46,6 +45,12 @@ public struct MusubiRootView: View {
                 Tab("Passkeys", systemImage: "person.badge.key") {
                     NavigationStack {
                         PasskeysView(session: session, anchorProvider: anchorProvider)
+                            .toolbar { signOutButton }
+                    }
+                }
+                Tab("Security", systemImage: "shield") {
+                    NavigationStack {
+                        SecurityView(session: session, anchorProvider: anchorProvider)
                             .toolbar { signOutButton }
                     }
                 }

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSecurityEvent.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSecurityEvent.swift
@@ -1,0 +1,172 @@
+import Foundation
+import OSNAPI
+
+/// One thing that happened to the account which the user is owed a look at:
+/// a passkey added, a recovery code spent, a sign-in approved from another
+/// device.
+///
+/// `GET /account/security-events` returns **unacknowledged events only**
+/// (`osn/api/src/routes/auth/security-events.ts`), so this is a to-read
+/// list, not a history. Acknowledging is what removes a row, and there is no
+/// way back to it from the app.
+///
+/// Timestamps are Unix **seconds** typed as `Double`, like the session
+/// routes and unlike the passkey routes' `Int`.
+public struct MusubiSecurityEvent: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let kind: SecurityEventKind
+    public let createdAt: Date
+    /// The server's coarse user-agent label for the device that caused the
+    /// event. `nil` when the request carried no user-agent.
+    public let deviceLabel: String?
+    /// An HMAC-peppered hash of the source IP, never the IP. Shown only as
+    /// a short prefix — two events from the same place match, and that is
+    /// the whole question a user can answer with it.
+    public let ipHash: String?
+
+    public init(
+        id: String,
+        kind: SecurityEventKind,
+        createdAt: Date,
+        deviceLabel: String?,
+        ipHash: String?
+    ) {
+        self.id = id
+        self.kind = kind
+        self.createdAt = createdAt
+        self.deviceLabel = deviceLabel
+        self.ipHash = ipHash
+    }
+
+    public var title: String { kind.title }
+
+    public var systemImage: String { kind.systemImage }
+
+    public var displayDevice: String { deviceLabel ?? "Unknown device" }
+
+    /// First 8 characters of the hash. The full 64 says nothing more to a
+    /// human and reads as a wall.
+    public var displayLocation: String? {
+        guard let ipHash, !ipHash.isEmpty else { return nil }
+        return String(ipHash.prefix(8))
+    }
+}
+
+/// The server's `SecurityEventKind` union
+/// (`shared/observability/src/metrics/attrs.ts:137-151`), with an `other`
+/// case.
+///
+/// The wire type is a plain string, and a new kind on the server must not
+/// make the feed unreadable on an old client — the whole point of the screen
+/// is that the user sees everything. So an unrecognised kind is shown with
+/// its own name tidied up rather than dropped.
+public enum SecurityEventKind: Equatable, Sendable {
+    case recoveryCodeGenerate
+    case recoveryCodeConsume
+    case recoveryCodeLockout
+    case passkeyRegister
+    case passkeyDelete
+    case crossDeviceLogin
+    case accountDeletionScheduled
+    case accountDeletionCancelled
+    case accountDeletionCompleted
+    case appDeletionScheduled
+    case appDeletionCancelled
+    case appDeletionCompleted
+    case other(String)
+
+    public init(wire: String) {
+        switch wire {
+        case "recovery_code_generate": self = .recoveryCodeGenerate
+        case "recovery_code_consume": self = .recoveryCodeConsume
+        case "recovery_code_lockout": self = .recoveryCodeLockout
+        case "passkey_register": self = .passkeyRegister
+        case "passkey_delete": self = .passkeyDelete
+        case "cross_device_login": self = .crossDeviceLogin
+        case "account_deletion_scheduled": self = .accountDeletionScheduled
+        case "account_deletion_cancelled": self = .accountDeletionCancelled
+        case "account_deletion_completed": self = .accountDeletionCompleted
+        case "app_deletion_scheduled": self = .appDeletionScheduled
+        case "app_deletion_cancelled": self = .appDeletionCancelled
+        case "app_deletion_completed": self = .appDeletionCompleted
+        default: self = .other(wire)
+        }
+    }
+
+    public var wire: String {
+        switch self {
+        case .recoveryCodeGenerate: "recovery_code_generate"
+        case .recoveryCodeConsume: "recovery_code_consume"
+        case .recoveryCodeLockout: "recovery_code_lockout"
+        case .passkeyRegister: "passkey_register"
+        case .passkeyDelete: "passkey_delete"
+        case .crossDeviceLogin: "cross_device_login"
+        case .accountDeletionScheduled: "account_deletion_scheduled"
+        case .accountDeletionCancelled: "account_deletion_cancelled"
+        case .accountDeletionCompleted: "account_deletion_completed"
+        case .appDeletionScheduled: "app_deletion_scheduled"
+        case .appDeletionCancelled: "app_deletion_cancelled"
+        case .appDeletionCompleted: "app_deletion_completed"
+        case .other(let wire): wire
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .recoveryCodeGenerate: "New recovery codes made"
+        case .recoveryCodeConsume: "A recovery code was used"
+        case .recoveryCodeLockout: "Too many wrong recovery codes"
+        case .passkeyRegister: "Passkey added"
+        case .passkeyDelete: "Passkey removed"
+        case .crossDeviceLogin: "Signed in from another device"
+        case .accountDeletionScheduled: "Account deletion scheduled"
+        case .accountDeletionCancelled: "Account deletion called off"
+        case .accountDeletionCompleted: "Account deleted"
+        case .appDeletionScheduled: "App data deletion scheduled"
+        case .appDeletionCancelled: "App data deletion called off"
+        case .appDeletionCompleted: "App data deleted"
+        // `recovery_code_consume` -> "Recovery code consume". Not English,
+        // but it names the thing, which beats hiding it.
+        case .other(let wire): Self.humanise(wire)
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .recoveryCodeGenerate, .recoveryCodeConsume: "key.horizontal"
+        case .recoveryCodeLockout: "lock.trianglebadge.exclamationmark"
+        case .passkeyRegister: "person.badge.key"
+        case .passkeyDelete: "person.badge.minus"
+        case .crossDeviceLogin: "qrcode"
+        case .accountDeletionScheduled, .appDeletionScheduled: "clock.badge.exclamationmark"
+        case .accountDeletionCancelled, .appDeletionCancelled: "arrow.uturn.backward"
+        case .accountDeletionCompleted, .appDeletionCompleted: "trash"
+        case .other: "exclamationmark.circle"
+        }
+    }
+
+    private static func humanise(_ wire: String) -> String {
+        let words = wire.split(separator: "_").joined(separator: " ")
+        return words.prefix(1).uppercased() + words.dropFirst()
+    }
+}
+
+extension MusubiSecurityEvent {
+    public init(_ payload: Operations.ListSecurityEvents.Output.Ok.Body.JsonPayload.EventsPayloadPayload) {
+        self.init(
+            id: payload.id,
+            kind: SecurityEventKind(wire: payload.kind),
+            createdAt: Date(timeIntervalSince1970: payload.createdAt),
+            deviceLabel: payload.uaLabel,
+            ipHash: payload.ipHash
+        )
+    }
+}
+
+extension Array where Element == MusubiSecurityEvent {
+    /// Newest first. The server already sorts this way; re-sorting costs
+    /// nothing and means the screen doesn't depend on it.
+    public func sortedForDisplay() -> [MusubiSecurityEvent] {
+        sorted { $0.createdAt > $1.createdAt }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
@@ -79,6 +79,21 @@ public final class MusubiSession {
         )
     }
 
+    /// The security screen's API. Only two of its five calls are `OSNAuth`
+    /// work — the ack routes and the generate route each need a step-up
+    /// token first — so it takes the same step-up client the passkeys screen
+    /// uses, plus the generated osn-api client for the routes themselves.
+    ///
+    /// - Parameter anchorProvider: the app target's key-window lookup, for
+    ///   the ceremonies the writes run.
+    public func makeSecurityAPI(anchorProvider: @escaping PresentationAnchorProvider) -> OSNSecurityAPI {
+        OSNSecurityAPI(
+            client: api,
+            stepUp: stepUpClient,
+            anchorProvider: anchorProvider
+        )
+    }
+
     /// Silent restore on launch. A throw from `TokenRefresher.refresh()`
     /// means "signed out", not an error banner.
     public func restore() async {

--- a/shared/swift/OSNShared/Sources/MusubiFeature/SecurityAPI.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/SecurityAPI.swift
@@ -1,0 +1,93 @@
+import Foundation
+import OSNAPI
+import OSNAuth
+
+/// The five calls the security screen makes, named in its own terms.
+///
+/// Same seam as `DevicesAPI` and `PasskeysAPI`: `APIProtocol` has 73
+/// methods, and three of these five run a passkey ceremony first, which is
+/// the part a view model must not know about. `OSNSecurityAPI` below is the
+/// only place `StepUpPasskeyClient` appears.
+///
+/// Reads are plain; writes are `@MainActor` because
+/// `ASAuthorizationController` is.
+public protocol SecurityAPI: Sendable {
+    func listSecurityEvents() async throws -> [MusubiSecurityEvent]
+    func recoveryStatus() async throws -> MusubiRecoveryStatus
+    /// - Returns: the server's `acknowledged` — `false` when the id matched
+    ///   nothing unacknowledged. Not an error: both "already acked" and
+    ///   "never existed" answer the same way, and both are idempotent.
+    @MainActor func acknowledgeEvent(id: String) async throws -> Bool
+    /// - Returns: how many events the call acknowledged.
+    @MainActor func acknowledgeAllEvents() async throws -> Int
+    /// - Returns: the new codes, in plaintext, **once**. The server keeps
+    ///   only hashes, so nothing can show them again.
+    @MainActor func generateRecoveryCodes() async throws -> [String]
+}
+
+/// `SecurityAPI` over the generated osn-api client plus `OSNAuth`'s step-up
+/// client.
+///
+/// No bespoke `OSNAuth` client is needed here: every one of these routes
+/// takes an access token and, where gated, a step-up token in the JSON body
+/// — both of which the generated client and `StepUpPasskeyClient` already
+/// supply between them.
+public struct OSNSecurityAPI: SecurityAPI {
+    private let client: any APIProtocol
+    private let stepUp: StepUpPasskeyClient
+    private let anchorProvider: PresentationAnchorProvider
+
+    public init(
+        client: any APIProtocol,
+        stepUp: StepUpPasskeyClient,
+        anchorProvider: @escaping PresentationAnchorProvider
+    ) {
+        self.client = client
+        self.stepUp = stepUp
+        self.anchorProvider = anchorProvider
+    }
+
+    public func listSecurityEvents() async throws -> [MusubiSecurityEvent] {
+        try await client.listSecurityEvents(.init()).ok.body.json.events.map(MusubiSecurityEvent.init)
+    }
+
+    public func recoveryStatus() async throws -> MusubiRecoveryStatus {
+        try await MusubiRecoveryStatus(client.getRecoveryStatus(.init()).ok.body.json)
+    }
+
+    /// Acknowledging is step-up gated on purpose: an XSS-captured access
+    /// token must not be able to silently dismiss the banner that exists
+    /// precisely to notice that compromise.
+    @MainActor
+    public func acknowledgeEvent(id: String) async throws -> Bool {
+        let token = try await mintAckToken()
+        return try await client.acknowledgeSecurityEvent(
+            .init(path: .init(id: id), body: .json(.init(stepUpToken: token)))
+        ).ok.body.json.acknowledged
+    }
+
+    /// One ceremony for the lot. The alternative — a prompt per row — would
+    /// train the user to tap through Face ID without reading, which is the
+    /// habit this screen is trying not to build.
+    @MainActor
+    public func acknowledgeAllEvents() async throws -> Int {
+        let token = try await mintAckToken()
+        let acknowledged = try await client.acknowledgeAllSecurityEvents(
+            .init(body: .json(.init(stepUpToken: token)))
+        ).ok.body.json.acknowledged
+        return Int(acknowledged)
+    }
+
+    @MainActor
+    public func generateRecoveryCodes() async throws -> [String] {
+        let token = try await stepUp.mintStepUpToken(purpose: .recoveryGenerate, anchorProvider: anchorProvider)
+        return try await client.generateRecoveryCodes(
+            .init(body: .json(.init(stepUpToken: token.stepUpToken)))
+        ).ok.body.json.recoveryCodes
+    }
+
+    @MainActor
+    private func mintAckToken() async throws -> String {
+        try await stepUp.mintStepUpToken(purpose: .securityEventAck, anchorProvider: anchorProvider).stepUpToken
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/SecurityView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/SecurityView.swift
@@ -1,0 +1,242 @@
+import OSNAuth
+import OSNUI
+import SwiftUI
+
+/// Security screen: everything that happened to the account and hasn't been
+/// looked at, plus the recovery codes that get the user back in when the
+/// passkey is gone.
+///
+/// The feed is unacknowledged-only, so an empty screen is the good outcome
+/// and says so. Acknowledging runs a passkey ceremony — the point of the
+/// gate is that an attacker holding a stolen access token cannot quietly
+/// clear the evidence of themselves.
+public struct SecurityView: View {
+    @State private var viewModel: SecurityViewModel
+
+    public init(session: MusubiSession, anchorProvider: @escaping PresentationAnchorProvider) {
+        _viewModel = State(
+            wrappedValue: SecurityViewModel(api: session.makeSecurityAPI(anchorProvider: anchorProvider))
+        )
+    }
+
+    /// For previews and for a caller that already has an API of its own.
+    public init(viewModel: SecurityViewModel) {
+        _viewModel = State(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        ScrollView {
+            GlassEffectContainer {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    if let mutationError = viewModel.mutationError {
+                        Text(mutationError)
+                            .font(.osn(.body, size: 14))
+                            .foregroundStyle(.red)
+                    }
+
+                    RecoveryCard(
+                        status: viewModel.recovery,
+                        isGenerating: viewModel.isGenerating,
+                        generate: { Task { await viewModel.generateRecoveryCodes() } }
+                    )
+
+                    feed
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("Security")
+        .refreshable {
+            await viewModel.load()
+        }
+        .task {
+            if viewModel.state == .idle {
+                await viewModel.load()
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Clear all") {
+                    Task { await viewModel.acknowledgeAll() }
+                }
+                .disabled(viewModel.isEmpty || viewModel.isAcknowledgingAll)
+            }
+        }
+        .sheet(isPresented: codesArePresented) {
+            RecoveryCodesSheet(codes: viewModel.freshCodes ?? [])
+        }
+    }
+
+    /// The sheet is driven off `freshCodes` and clears it on dismissal, so
+    /// the plaintext lives exactly as long as the sheet does.
+    private var codesArePresented: Binding<Bool> {
+        Binding(
+            get: { viewModel.freshCodes != nil },
+            set: { if !$0 { viewModel.dismissCodes() } }
+        )
+    }
+
+    @ViewBuilder
+    private var feed: some View {
+        switch viewModel.state {
+        case .idle:
+            ProgressView()
+        // A reload with rows already on screen keeps them: the refresh
+        // control is the progress indicator there.
+        case .loading where viewModel.isEmpty:
+            ProgressView()
+        case .failed(let message):
+            ContentUnavailableView(
+                "Couldn't load your security events",
+                systemImage: "exclamationmark.triangle",
+                description: Text(message)
+            )
+        default:
+            if viewModel.isEmpty {
+                // Nothing to read is the good answer here, so it reads as
+                // one rather than as an empty list.
+                ContentUnavailableView(
+                    "Nothing to review",
+                    systemImage: "checkmark.shield",
+                    description: Text("Anything worth knowing about your account shows up here.")
+                )
+            } else {
+                ForEach(viewModel.events) { event in
+                    SecurityEventRow(
+                        event: event,
+                        isAcknowledging: viewModel.acknowledgingID == event.id,
+                        acknowledge: { Task { await viewModel.acknowledge(id: event.id) } }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct RecoveryCard: View {
+    let status: MusubiRecoveryStatus?
+    let isGenerating: Bool
+    let generate: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Recovery codes")
+                        .font(.osn(.body, size: 18))
+                    Spacer()
+                    if let status, status.isRunningLow {
+                        Pill("Running low", tint: OSNColor.badgeLive)
+                    }
+                }
+
+                if let status {
+                    if status.hasCodes {
+                        Text("\(status.active) of \(status.total) left")
+                            .font(.osn(.body, size: 14))
+                        if let generatedAt = status.generatedAt {
+                            Text("Made \(generatedAt, format: .relative(presentation: .named))")
+                                .font(.osn(.body, size: 12))
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text("You have none. Without a passkey and without codes, nobody can let you back in.")
+                            .font(.osn(.body, size: 14))
+                    }
+                } else {
+                    Text("Couldn't read your code count.")
+                        .font(.osn(.body, size: 14))
+                        .foregroundStyle(.secondary)
+                }
+
+                // "New codes" and not "Generate": a new set replaces the old
+                // one whole, and the button should say so before the sheet
+                // does.
+                GlassButton(isGenerating ? "Working…" : "Make new codes", action: generate)
+                    .disabled(isGenerating)
+
+                Text("Making a new set cancels every code you have now.")
+                    .font(.osn(.body, size: 12))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct SecurityEventRow: View {
+    let event: MusubiSecurityEvent
+    let isAcknowledging: Bool
+    let acknowledge: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Label(event.title, systemImage: event.systemImage)
+                    .font(.osn(.body, size: 18))
+
+                Text(event.createdAt, format: .relative(presentation: .named))
+                    .font(.osn(.body, size: 14))
+
+                Text(event.displayDevice)
+                    .font(.osn(.body, size: 12))
+                    .foregroundStyle(.secondary)
+
+                if let location = event.displayLocation {
+                    // A hash, not an address. Same prefix on two rows means
+                    // the same place, which is the only question it answers.
+                    Text("From \(location)")
+                        .font(.osn(.body, size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                GlassButton(
+                    isAcknowledging ? "Working…" : "I know about this",
+                    kind: .secondary,
+                    action: acknowledge
+                )
+                .disabled(isAcknowledging)
+            }
+        }
+    }
+}
+
+/// The one and only sighting of a set of codes.
+///
+/// `ShareLink` rather than a copy button: `UIPasteboard` is UIKit, this
+/// package must build against macOS too, and the share sheet already offers
+/// copy alongside every other way of keeping them.
+private struct RecoveryCodesSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let codes: [String]
+
+    private var joined: String { codes.joined(separator: "\n") }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Save these somewhere safe. They won't be shown again, and each one works once.")
+                        .font(.osn(.body, size: 14))
+
+                    ForEach(codes, id: \.self) { code in
+                        Text(code)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                    }
+
+                    ShareLink(item: joined) {
+                        Text("Share or copy")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle("Your recovery codes")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/SecurityViewModel.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/SecurityViewModel.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Observation
+
+/// Drives the security screen: the unacknowledged event feed, and the
+/// recovery-code counts sitting above it. Owns no client and no token —
+/// everything goes through `SecurityAPI`.
+@MainActor
+@Observable
+public final class SecurityViewModel {
+    public enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    public private(set) var events: [MusubiSecurityEvent] = []
+    /// `nil` until the first load answers, and after a load where the events
+    /// came back but the status call didn't.
+    public private(set) var recovery: MusubiRecoveryStatus?
+    public private(set) var state: LoadState = .idle
+    /// The row being acknowledged, so only its own button spins.
+    public private(set) var acknowledgingID: String?
+    public private(set) var isAcknowledgingAll = false
+    public private(set) var isGenerating = false
+    /// A failed mutation, shown above the feed. Kept apart from
+    /// `LoadState.failed` because the feed is still good — including when
+    /// the user simply cancelled the Face ID sheet, which arrives here as an
+    /// error like any other.
+    public private(set) var mutationError: String?
+    /// A set of codes just minted, held only until the user dismisses them.
+    /// The server keeps hashes, so this is the one and only time they exist
+    /// anywhere the user can read them — and the reason they are never
+    /// written to disk.
+    public private(set) var freshCodes: [String]?
+
+    public var isEmpty: Bool { events.isEmpty }
+
+    private let api: any SecurityAPI
+    private var loadGeneration = 0
+
+    public init(api: any SecurityAPI) {
+        self.api = api
+    }
+
+    /// Both reads at once: they are separate routes with nothing to say to
+    /// each other, and the screen shows them together.
+    ///
+    /// A failed status call does **not** fail the screen. The feed is the
+    /// point, the counts are a header, and blanking the first because the
+    /// second timed out would hide exactly what the user came to read.
+    public func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        state = .loading
+        async let events = api.listSecurityEvents()
+        async let recovery = api.recoveryStatus()
+        do {
+            let loadedEvents = try await events
+            let loadedRecovery = try? await recovery
+            // A pull-to-refresh landing mid-request starts a newer load;
+            // that one owns the screen from here.
+            guard generation == loadGeneration else { return }
+            self.events = loadedEvents.sortedForDisplay()
+            self.recovery = loadedRecovery
+            state = .loaded
+        } catch {
+            // A view that goes away cancels its load. That is the screen
+            // closing, not a failure worth showing.
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            state = .failed(String(describing: error))
+        }
+    }
+
+    /// Drops the row on a `true`. A `false` means the server had nothing
+    /// unacknowledged under that id — someone acknowledged it on another
+    /// device — so the list is stale and re-listing is the honest fix.
+    public func acknowledge(id: String) async {
+        acknowledgingID = id
+        mutationError = nil
+        defer { acknowledgingID = nil }
+        do {
+            if try await api.acknowledgeEvent(id: id) {
+                events.removeAll { $0.id == id }
+            } else {
+                await load()
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// One ceremony clears the feed. The server acknowledges everything
+    /// unacknowledged *at that moment*, so its count is trusted over the
+    /// local one: if they disagree, an event arrived or left while the
+    /// ceremony was on screen and this list is already behind.
+    public func acknowledgeAll() async {
+        isAcknowledgingAll = true
+        mutationError = nil
+        defer { isAcknowledgingAll = false }
+        do {
+            let acknowledged = try await api.acknowledgeAllEvents()
+            if acknowledged == events.count {
+                events.removeAll()
+            } else {
+                await load()
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Makes a new set of ten and holds them for the sheet.
+    ///
+    /// Reloads afterwards for two reasons, not one: the counts change, and
+    /// generating **writes a security event of its own**
+    /// (`recovery_code_generate`), so the feed the user is looking at is now
+    /// short a row.
+    public func generateRecoveryCodes() async {
+        isGenerating = true
+        mutationError = nil
+        defer { isGenerating = false }
+        do {
+            freshCodes = try await api.generateRecoveryCodes()
+            await load()
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Forgets the plaintext codes. Called when the sheet closes — after
+    /// this nothing can show them again, which is the contract, not a bug.
+    public func dismissCodes() {
+        freshCodes = nil
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiSecurityEventTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiSecurityEventTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import MusubiFeature
+
+@Suite struct SecurityEventKindTests {
+    @Test func everyKnownKindRoundTripsThroughTheWire() {
+        let kinds: [SecurityEventKind] = [
+            .recoveryCodeGenerate, .recoveryCodeConsume, .recoveryCodeLockout,
+            .passkeyRegister, .passkeyDelete, .crossDeviceLogin,
+            .accountDeletionScheduled, .accountDeletionCancelled, .accountDeletionCompleted,
+            .appDeletionScheduled, .appDeletionCancelled, .appDeletionCompleted,
+        ]
+
+        for kind in kinds {
+            #expect(SecurityEventKind(wire: kind.wire) == kind)
+        }
+    }
+
+    /// A kind the server grew after this build shipped. Dropping it would
+    /// hide the one thing the screen exists to show, so it survives as
+    /// `other` and round-trips unchanged.
+    @Test func anUnknownKindIsKeptRatherThanDropped() {
+        let kind = SecurityEventKind(wire: "password_reset_requested")
+
+        #expect(kind == .other("password_reset_requested"))
+        #expect(kind.wire == "password_reset_requested")
+        #expect(kind.title == "Password reset requested")
+        #expect(!kind.systemImage.isEmpty)
+    }
+
+    @Test func everyKnownKindHasATitleAndAnIcon() {
+        for wire in ["recovery_code_consume", "passkey_delete", "cross_device_login", "app_deletion_completed"] {
+            let kind = SecurityEventKind(wire: wire)
+            #expect(!kind.title.isEmpty)
+            #expect(!kind.systemImage.isEmpty)
+        }
+    }
+}
+
+@Suite struct MusubiSecurityEventTests {
+    private func event(id: String, createdAt: TimeInterval, ipHash: String? = nil, label: String? = nil) -> MusubiSecurityEvent {
+        MusubiSecurityEvent(
+            id: id,
+            kind: .passkeyRegister,
+            createdAt: Date(timeIntervalSince1970: createdAt),
+            deviceLabel: label,
+            ipHash: ipHash
+        )
+    }
+
+    @Test func displayLocationIsAShortPrefixOfTheHash() {
+        let hashed = event(id: "sev_1", createdAt: 0, ipHash: "0123456789abcdef0123456789abcdef")
+
+        #expect(hashed.displayLocation == "01234567")
+    }
+
+    /// No user-agent on the request means no label and no hash. Neither is
+    /// an error, and neither should render as an empty line.
+    @Test func missingDeviceAndLocationDegradeQuietly() {
+        let bare = event(id: "sev_1", createdAt: 0, ipHash: nil, label: nil)
+
+        #expect(bare.displayDevice == "Unknown device")
+        #expect(bare.displayLocation == nil)
+        #expect(event(id: "sev_2", createdAt: 0, ipHash: "").displayLocation == nil)
+    }
+
+    @Test func sortingPutsTheNewestFirst() {
+        let sorted = [
+            event(id: "old", createdAt: 100),
+            event(id: "newest", createdAt: 900),
+            event(id: "middle", createdAt: 500),
+        ].sortedForDisplay()
+
+        #expect(sorted.map(\.id) == ["newest", "middle", "old"])
+    }
+}
+
+@Suite struct MusubiRecoveryStatusTests {
+    @Test func usedIsWhatTheSetHasSpent() {
+        let status = MusubiRecoveryStatus(active: 4, total: 10, generatedAt: nil)
+
+        #expect(status.hasCodes)
+        #expect(status.used == 6)
+    }
+
+    /// An account that has never generated a set. `hasCodes` false is what
+    /// drives the "you have none" copy, and `isRunningLow` must not also
+    /// fire — one warning, not two contradictory ones.
+    @Test func anAccountWithNoCodesIsNotAlsoRunningLow() {
+        let status = MusubiRecoveryStatus(active: 0, total: 0, generatedAt: nil)
+
+        #expect(!status.hasCodes)
+        #expect(!status.isRunningLow)
+        #expect(status.used == 0)
+    }
+
+    @Test func runningLowStartsAtThreeLeft() {
+        #expect(MusubiRecoveryStatus(active: 4, total: 10, generatedAt: nil).isRunningLow == false)
+        #expect(MusubiRecoveryStatus(active: 3, total: 10, generatedAt: nil).isRunningLow)
+        #expect(MusubiRecoveryStatus(active: 0, total: 10, generatedAt: nil).isRunningLow)
+    }
+
+    /// Counts can only disagree in one direction honestly, but a server that
+    /// reported more active than total must not produce a negative "used".
+    @Test func usedNeverGoesNegative() {
+        #expect(MusubiRecoveryStatus(active: 12, total: 10, generatedAt: nil).used == 0)
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/SecurityViewModelTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/SecurityViewModelTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+import Testing
+@testable import MusubiFeature
+
+private func makeEvent(
+    id: String,
+    kind: SecurityEventKind = .passkeyRegister,
+    createdAt: TimeInterval = 500
+) -> MusubiSecurityEvent {
+    MusubiSecurityEvent(
+        id: id,
+        kind: kind,
+        createdAt: Date(timeIntervalSince1970: createdAt),
+        deviceLabel: "iPhone",
+        ipHash: "0123456789abcdef"
+    )
+}
+
+private struct StubError: Error, CustomStringConvertible {
+    let description = "stub failed"
+}
+
+/// Scripted `SecurityAPI`. `@MainActor` for the same reason the passkeys
+/// stub is: three of the five methods run a passkey ceremony in the real
+/// conformance, and `ASAuthorizationController` is main-actor-bound.
+@MainActor
+private final class StubSecurityAPI: SecurityAPI {
+    var listResults: [Result<[MusubiSecurityEvent], Error>]
+    var statusResults: [Result<MusubiRecoveryStatus, Error>]
+    var ackResults: [Result<Bool, Error>]
+    var ackAllResults: [Result<Int, Error>]
+    var generateResult: Result<[String], Error>
+    private(set) var listCount = 0
+    private(set) var statusCount = 0
+    private(set) var ackedIDs: [String] = []
+    private(set) var ackAllCount = 0
+    private(set) var generateCount = 0
+
+    init(
+        listResults: [Result<[MusubiSecurityEvent], Error>] = [.success([])],
+        statusResults: [Result<MusubiRecoveryStatus, Error>] = [
+            .success(MusubiRecoveryStatus(active: 10, total: 10, generatedAt: nil)),
+        ],
+        ackResults: [Result<Bool, Error>] = [.success(true)],
+        ackAllResults: [Result<Int, Error>] = [.success(0)],
+        generateResult: Result<[String], Error> = .success([])
+    ) {
+        self.listResults = listResults
+        self.statusResults = statusResults
+        self.ackResults = ackResults
+        self.ackAllResults = ackAllResults
+        self.generateResult = generateResult
+    }
+
+    /// Each call consumes the next scripted result; the last one repeats, so
+    /// a test needn't script the reload every mutation does.
+    private func next<T>(_ results: inout [Result<T, Error>]) throws -> T {
+        let result = results.count > 1 ? results.removeFirst() : results[0]
+        return try result.get()
+    }
+
+    func listSecurityEvents() async throws -> [MusubiSecurityEvent] {
+        listCount += 1
+        return try next(&listResults)
+    }
+
+    func recoveryStatus() async throws -> MusubiRecoveryStatus {
+        statusCount += 1
+        return try next(&statusResults)
+    }
+
+    func acknowledgeEvent(id: String) async throws -> Bool {
+        ackedIDs.append(id)
+        return try next(&ackResults)
+    }
+
+    func acknowledgeAllEvents() async throws -> Int {
+        ackAllCount += 1
+        return try next(&ackAllResults)
+    }
+
+    func generateRecoveryCodes() async throws -> [String] {
+        generateCount += 1
+        return try generateResult.get()
+    }
+}
+
+@MainActor
+@Suite struct SecurityViewModelTests {
+    @Test func loadFetchesBothAndSortsNewestFirst() async {
+        let api = StubSecurityAPI(
+            listResults: [.success([makeEvent(id: "old", createdAt: 100), makeEvent(id: "new", createdAt: 900)])],
+            statusResults: [.success(MusubiRecoveryStatus(active: 7, total: 10, generatedAt: nil))]
+        )
+        let viewModel = SecurityViewModel(api: api)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.events.map(\.id) == ["new", "old"])
+        #expect(viewModel.recovery?.active == 7)
+    }
+
+    /// The feed is the screen; the counts are a header. A dead status call
+    /// must not blank the rows the user came to read.
+    @Test func aFailedStatusStillLoadsTheFeed() async {
+        let api = StubSecurityAPI(
+            listResults: [.success([makeEvent(id: "sev_1")])],
+            statusResults: [.failure(StubError())]
+        )
+        let viewModel = SecurityViewModel(api: api)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.events.map(\.id) == ["sev_1"])
+        #expect(viewModel.recovery == nil)
+    }
+
+    @Test func aFailedListFailsTheScreen() async {
+        let viewModel = SecurityViewModel(api: StubSecurityAPI(listResults: [.failure(StubError())]))
+
+        await viewModel.load()
+
+        #expect(viewModel.isEmpty)
+        #expect(viewModel.state == .failed("stub failed"))
+    }
+
+    @Test func acknowledgingDropsTheRowWithoutReloading() async {
+        let api = StubSecurityAPI(
+            listResults: [.success([makeEvent(id: "sev_1"), makeEvent(id: "sev_2")])],
+            ackResults: [.success(true)]
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.acknowledge(id: "sev_2")
+
+        #expect(api.ackedIDs == ["sev_2"])
+        #expect(viewModel.events.map(\.id) == ["sev_1"])
+        #expect(api.listCount == 1)
+        #expect(viewModel.acknowledgingID == nil)
+    }
+
+    /// `false` means the server had nothing unacknowledged under that id —
+    /// another device cleared it. The list is stale, so it re-reads rather
+    /// than guessing which rows also went.
+    @Test func aFalseAcknowledgementReloads() async {
+        let api = StubSecurityAPI(
+            listResults: [
+                .success([makeEvent(id: "sev_1"), makeEvent(id: "sev_2")]),
+                .success([makeEvent(id: "sev_3")]),
+            ],
+            ackResults: [.success(false)]
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.acknowledge(id: "sev_2")
+
+        #expect(api.listCount == 2)
+        #expect(viewModel.events.map(\.id) == ["sev_3"])
+    }
+
+    /// Cancelling Face ID arrives as a thrown error. It reports, and the
+    /// feed stays exactly as it was.
+    @Test func aFailedAcknowledgementKeepsTheRow() async {
+        let api = StubSecurityAPI(
+            listResults: [.success([makeEvent(id: "sev_1")])],
+            ackResults: [.failure(StubError())]
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.acknowledge(id: "sev_1")
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.events.map(\.id) == ["sev_1"])
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(viewModel.acknowledgingID == nil)
+    }
+
+    @Test func acknowledgeAllClearsTheFeedWhenTheCountsAgree() async {
+        let api = StubSecurityAPI(
+            listResults: [.success([makeEvent(id: "sev_1"), makeEvent(id: "sev_2")])],
+            ackAllResults: [.success(2)]
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.acknowledgeAll()
+
+        #expect(api.ackAllCount == 1)
+        #expect(viewModel.isEmpty)
+        #expect(api.listCount == 1)
+        #expect(!viewModel.isAcknowledgingAll)
+    }
+
+    /// The server cleared three while this screen knew of two — an event
+    /// landed during the ceremony. Its count wins and the feed re-reads.
+    @Test func acknowledgeAllReloadsWhenTheCountsDisagree() async {
+        let api = StubSecurityAPI(
+            listResults: [
+                .success([makeEvent(id: "sev_1"), makeEvent(id: "sev_2")]),
+                .success([makeEvent(id: "sev_4")]),
+            ],
+            ackAllResults: [.success(3)]
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.acknowledgeAll()
+
+        #expect(api.listCount == 2)
+        #expect(viewModel.events.map(\.id) == ["sev_4"])
+    }
+
+    /// Generating writes a `recovery_code_generate` event of its own, so the
+    /// feed the user is looking at is short a row until it re-reads — and
+    /// the counts have changed too.
+    @Test func generatingHoldsTheCodesAndReloadsBoth() async {
+        let api = StubSecurityAPI(
+            listResults: [
+                .success([]),
+                .success([makeEvent(id: "sev_gen", kind: .recoveryCodeGenerate)]),
+            ],
+            statusResults: [
+                .success(MusubiRecoveryStatus(active: 0, total: 0, generatedAt: nil)),
+                .success(MusubiRecoveryStatus(active: 10, total: 10, generatedAt: Date(timeIntervalSince1970: 900))),
+            ],
+            generateResult: .success(["code-1", "code-2"])
+        )
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.generateRecoveryCodes()
+
+        #expect(api.generateCount == 1)
+        #expect(viewModel.freshCodes == ["code-1", "code-2"])
+        #expect(viewModel.events.map(\.id) == ["sev_gen"])
+        #expect(viewModel.recovery?.active == 10)
+        #expect(!viewModel.isGenerating)
+    }
+
+    /// Dismissing the sheet is the only exit, and after it nothing can show
+    /// the plaintext again. That is the contract, not a lost value.
+    @Test func dismissingForgetsTheCodes() async {
+        let api = StubSecurityAPI(generateResult: .success(["code-1"]))
+        let viewModel = SecurityViewModel(api: api)
+
+        await viewModel.generateRecoveryCodes()
+        #expect(viewModel.freshCodes != nil)
+
+        viewModel.dismissCodes()
+
+        #expect(viewModel.freshCodes == nil)
+    }
+
+    @Test func aFailedGenerateReportsAndShowsNoSheet() async {
+        let api = StubSecurityAPI(generateResult: .failure(StubError()))
+        let viewModel = SecurityViewModel(api: api)
+        await viewModel.load()
+
+        await viewModel.generateRecoveryCodes()
+
+        #expect(viewModel.freshCodes == nil)
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(api.listCount == 1)
+        #expect(!viewModel.isGenerating)
+    }
+}

--- a/wiki/apps/ios.md
+++ b/wiki/apps/ios.md
@@ -7,6 +7,7 @@ related:
   - "[[identity-model]]"
   - "[[passkey-primary]]"
   - "[[step-up]]"
+  - "[[recovery-codes]]"
   - "[[pulse]]"
   - "[[osn-core]]"
 packages:
@@ -58,7 +59,7 @@ Refresh failure is **HTTP 400 with an `error` string, never 401**. A client that
 
 ## Musubi's screens
 
-Two tabs so far.
+Three tabs so far.
 
 **Devices** — every live session on the account, with per-row revoke and "sign out everywhere else": `listSessions` / `revokeSession` / `revokeAllOtherSessions` ([[sessions]]). Built first because it needs no new API work and it is the screen that *shows* the shared jar: sign in on Pulse, and the session appears in Musubi's list.
 
@@ -77,7 +78,18 @@ Two contract details worth keeping:
 - The account invariant is ≥1 passkey ([[passkey-primary]]) and the server enforces it, so the last row offers no Remove rather than spending a biometric prompt on a refusal.
 - Enrolment needs a `profileId`, and a *restored* session is `signedIn(nil)` — `PasskeyProfile` only ever arrives from a live `/login/passkey/complete`. So it comes off the wire, via `listAccountProfiles`.
 
-View models take a narrow protocol (`DevicesAPI`, three methods; `PasskeysAPI`, four), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI` and `OSNPasskeysAPI` are the only places generated shapes and ceremonies are unwrapped — which is also why `PasskeysAPI`'s three mutating methods are `@MainActor`: `ASAuthorizationController` is.
+**Security** — the unacknowledged security-event feed ([[recovery-codes]], [[step-up]]) with the recovery-code counts above it. Contract details:
+
+- `GET /account/security-events` returns **unacknowledged events only**, newest first. So this is a to-read list, not a history: acknowledging removes a row and the app has no way back to it.
+- Both ack routes are **step-up gated** with `security_event_ack`. That is the point of them: an XSS-captured access token must not be able to silently dismiss the banner that exists to notice that compromise. "Clear all" runs **one** ceremony for the lot — a prompt per row would train the user to tap through Face ID without reading.
+- Ack-one answers `{ acknowledged: Boolean }`, ack-all answers `{ acknowledged: Number }` — same key, different type, so the two routes cannot share a schema. A `false` means the id matched nothing unacknowledged (another device got there first); it is idempotent, not an error, and the honest response is to re-list.
+- `kind` is a bare string on the wire. `SecurityEventKind` keeps an `other(String)` case and renders the raw name tidied up: a kind added on the server after a build shipped must still appear, since seeing everything is the entire job of the screen.
+- Event timestamps are Unix seconds as **`Double`**, like the session routes and unlike the passkey routes' `Int`.
+- `POST /recovery/generate` is step-up gated (`recovery_generate`), replaces any existing set whole, and hands back 10 plaintext codes **once** — the server keeps only hashes. They live in `SecurityViewModel.freshCodes` until the sheet closes and are never written to disk. Copying uses `ShareLink`, not `UIPasteboard`, which is UIKit (see the purity rule below).
+- Generating writes a `recovery_code_generate` event of its own, so the screen reloads afterwards for two reasons, not one: the counts moved *and* the feed is a row short.
+- `GET /recovery/status` deliberately has **no** step-up. It carries counts, never a code, and it is what tells a user whether starting a ceremony is worth it. A failed status call therefore does not fail the screen — the feed is the point, the counts are a header.
+
+View models take a narrow protocol (`DevicesAPI`, three methods; `PasskeysAPI`, four; `SecurityAPI`, five), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI`, `OSNPasskeysAPI` and `OSNSecurityAPI` are the only places generated shapes and ceremonies are unwrapped — which is also why the mutating methods on `PasskeysAPI` and `SecurityAPI` are `@MainActor`: `ASAuthorizationController` is.
 
 ## macOS purity rule
 


### PR DESCRIPTION
Stacked on #431 (`feat/osn-ios-passkeys`). Third signed-in screen in Musubi: the unacknowledged security-event feed, with the recovery-code counts above it.

## What it does

- Lists everything on the account the user hasn't looked at yet, newest first, with per-row "I know about this" and a "Clear all" in the toolbar.
- Shows how many recovery codes are left, warns when the set is running low, and makes a new set on demand — shown once, in a sheet.

## Why it is shaped this way

- **`GET /account/security-events` returns unacknowledged events only.** So this is a to-read list, not a history: acknowledging removes a row and the app offers no way back to it.
- **Both ack routes are step-up gated (`security_event_ack`).** That is the point of the gate — an XSS-captured access token must not be able to silently dismiss the banner that exists precisely to notice that compromise. "Clear all" runs **one** ceremony for the lot; a prompt per row would train the user to tap through Face ID without reading it.
- **Ack-one answers `{ acknowledged: Boolean }`, ack-all answers `{ acknowledged: Number }`.** Same key, different type, so the two routes can't share a schema. A `false` means the id matched nothing unacknowledged — another device got there first — which is idempotent rather than an error, so the view model re-lists instead of guessing what else went.
- **`kind` is a bare string on the wire.** `SecurityEventKind` keeps an `other(String)` case and renders the raw name tidied up. A kind added server-side after a build ships must still appear: seeing everything is the whole job of this screen.
- **`POST /recovery/generate` returns 10 plaintext codes once** and replaces any existing set whole. They live in `SecurityViewModel.freshCodes` until the sheet closes and are never written to disk — the server keeps only hashes. Copying uses `ShareLink`, not `UIPasteboard`, which is UIKit and would break the macOS build (see the purity rule in `wiki/apps/ios.md`).
- **Generating reloads for two reasons, not one:** the counts move, *and* generating writes a `recovery_code_generate` event of its own, so the feed is a row short until it re-reads.
- **`GET /recovery/status` has no step-up by design** — it carries counts, never a code, and it is what tells a user whether starting a ceremony is worth it. A failed status call therefore doesn't fail the screen: the feed is the point, the counts are a header.

## Seam

Same as the previous two screens. `SecurityAPI` is five methods; the generated `APIProtocol` is 73, and a test double for that would be 70 stubs of nothing. `OSNSecurityAPI` is the only place generated shapes and step-up ceremonies are unwrapped, which is why its three mutating methods are `@MainActor` — `ASAuthorizationController` is.

## Checks

- `swift test` — 130 tests, 18 suites, green. 24 of them new (`MusubiSecurityEventTests`, `SecurityViewModelTests`).
- `xcodegen generate` + `xcodebuild` for **both** apps (Pulse and Musubi), green.
- `scripts/changeset-required.sh` → `skip` (Swift + wiki paths only; no versioned package ships).

## Standing question, still unanswered

The openapi plugin is mounted on `osn/api` unconditionally, so the deployed `id.musubi.social` Worker serves a Scalar docs UI at `/openapi` enumerating the whole public surface. If that should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`.

## Still blocked on the Apple portal

Unchanged from the phases below: App Group `group.social.musubi.session` and associated domain `webcredentials:musubi.social` need registering under team `FV59Y8RSUH`, and the bundle ids `com.osn.pulse` / `social.musubi.app` need confirming. Until then `SharedCookieJar.makeSession()` throws on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)