### PR TITLE
feat(ios): add the Musubi Account tab

### DIFF
--- a/shared/swift/OSNShared/Sources/MusubiFeature/AccountAPI.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/AccountAPI.swift
@@ -1,0 +1,149 @@
+import Foundation
+import OSNAPI
+import OSNAuth
+import OSNKit
+
+/// The nine calls the account screen makes, named in its own terms.
+///
+/// Same seam as `DevicesAPI`, `PasskeysAPI` and `SecurityAPI`: the view
+/// model never sees `APIProtocol`'s 73 methods, never sees a generated
+/// request shape, and never mints a step-up token. Four of these nine run a
+/// passkey ceremony inside `OSNAccountAPI` and are `@MainActor` for it,
+/// because `ASAuthorizationController` is.
+public protocol AccountAPI: Sendable {
+    /// Every profile on the signed-in account. The server says nothing
+    /// about which is current or which is default — see `MusubiProfile`.
+    func listProfiles() async throws -> [MusubiProfile]
+    func deletionStatus() async throws -> MusubiDeletionStatus
+    /// Signs the app in as another profile on the same account.
+    ///
+    /// - Returns: the profile now in force. The new access token is stored
+    ///   as part of the call, not handed back — see `OSNAccountAPI`.
+    func switchProfile(id: String) async throws -> MusubiProfile
+    /// Marks a profile the one to land on at next sign-in. Does **not**
+    /// switch to it.
+    func setDefaultProfile(id: String) async throws -> MusubiProfile
+    /// Sends a code to the **new** address. Nothing changes until the code
+    /// comes back.
+    /// - Returns: the server's `sent`.
+    func beginEmailChange(to newEmail: String) async throws -> Bool
+    /// - Returns: the address now on the account.
+    @MainActor func completeEmailChange(code: String) async throws -> String
+    /// - Parameter confirmHandle: must equal the profile's handle verbatim
+    ///   or the server answers 400 `handle_mismatch`. It is there to make
+    ///   the press deliberate.
+    @MainActor func requestDeletion(confirmHandle: String) async throws -> MusubiDeletionSchedule
+    /// Cancels a pending deletion inside the grace window.
+    ///
+    /// No step-up: the session itself is a fresh-enough authenticator for
+    /// *un*-deleting, and a user who has lost their passkey mid-window is
+    /// exactly who this is for.
+    /// - Returns: the server's `cancelled`. `false` is a 200, not an error —
+    ///   it means nothing was pending.
+    func restore() async throws -> Bool
+    /// Runs the export and writes the bundle somewhere the share sheet can
+    /// reach it.
+    /// - Returns: a file URL the caller owns and is expected to delete.
+    @MainActor func exportAccount() async throws -> URL
+}
+
+/// `AccountAPI` over the generated osn-api client, `OSNAuth`'s step-up
+/// client, and one hand-written client for the export — which the spec
+/// cannot describe (see `AccountExportClient`).
+public struct OSNAccountAPI: AccountAPI {
+    private let client: any APIProtocol
+    private let stepUp: StepUpPasskeyClient
+    private let export: AccountExportClient
+    private let anchorProvider: PresentationAnchorProvider
+
+    public init(
+        client: any APIProtocol,
+        stepUp: StepUpPasskeyClient,
+        export: AccountExportClient,
+        anchorProvider: @escaping PresentationAnchorProvider
+    ) {
+        self.client = client
+        self.stepUp = stepUp
+        self.export = export
+        self.anchorProvider = anchorProvider
+    }
+
+    public func listProfiles() async throws -> [MusubiProfile] {
+        try await client.listAccountProfiles(.init()).ok.body.json.profiles.map(MusubiProfile.init)
+    }
+
+    public func deletionStatus() async throws -> MusubiDeletionStatus {
+        try await MusubiDeletionStatus(client.getAccountDeletionStatus(.init()).ok.body.json)
+    }
+
+    /// The one call on this screen with a trap in it: a switch re-issues the
+    /// **access token**, and every later request that keeps sending the old
+    /// one keeps authenticating as the old profile. So the new token is
+    /// written to the Keychain here, before the profile is handed back, and
+    /// no caller is trusted to remember.
+    ///
+    /// The session and its cookie are untouched — a switch is a new token on
+    /// the same session, which is why there's no `TokenRefresher` work here.
+    public func switchProfile(id: String) async throws -> MusubiProfile {
+        let grant = try await client.switchProfile(.init(body: .json(.init(profileId: id)))).ok.body.json
+        try KeychainAccessTokenStore.save(grant.accessToken, expiresIn: TimeInterval(grant.expiresIn))
+        return MusubiProfile(grant.profile)
+    }
+
+    public func setDefaultProfile(id: String) async throws -> MusubiProfile {
+        try await MusubiProfile(
+            client.setDefaultProfile(.init(path: .init(profileId: id))).ok.body.json.profile
+        )
+    }
+
+    public func beginEmailChange(to newEmail: String) async throws -> Bool {
+        try await client.beginEmailChange(.init(body: .json(.init(newEmail: newEmail)))).ok.body.json.sent
+    }
+
+    /// Both halves are required together: the code proves the new address,
+    /// the step-up proves the person. Neither alone changes anything.
+    @MainActor
+    public func completeEmailChange(code: String) async throws -> String {
+        let token = try await mint(.emailChange)
+        return try await client.completeEmailChange(
+            .init(body: .json(.init(code: code, stepUpToken: token)))
+        ).ok.body.json.email
+    }
+
+    /// A 202, not a 200: nothing is erased yet.
+    @MainActor
+    public func requestDeletion(confirmHandle: String) async throws -> MusubiDeletionSchedule {
+        let token = try await mint(.accountDelete)
+        return try await MusubiDeletionSchedule(
+            client.requestAccountDeletion(
+                .init(body: .json(.init(confirmHandle: confirmHandle, stepUpToken: token)))
+            ).accepted.body.json
+        )
+    }
+
+    public func restore() async throws -> Bool {
+        try await client.restoreAccount(.init()).ok.body.json.cancelled
+    }
+
+    /// Writes the bundle to the caches directory rather than returning it,
+    /// because `ShareLink` shares a file and a `Data` in memory is not one.
+    ///
+    /// Caches and not Documents: this is a copy of data the server already
+    /// holds, it is somebody's whole account in plaintext, and the caller
+    /// deletes it as soon as the share sheet closes. Caches is the directory
+    /// the system will also reap on its own if we somehow don't.
+    @MainActor
+    public func exportAccount() async throws -> URL {
+        let token = try await mint(.accountExport)
+        let data = try await export.download(stepUpToken: token)
+        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(AccountExportClient.filename)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    @MainActor
+    private func mint(_ purpose: StepUpPurpose) async throws -> String {
+        try await stepUp.mintStepUpToken(purpose: purpose, anchorProvider: anchorProvider).stepUpToken
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/AccountView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/AccountView.swift
@@ -1,0 +1,405 @@
+import OSNAuth
+import OSNUI
+import SwiftUI
+
+/// Account screen: the profiles on the account, the address it answers to, a
+/// copy of everything it holds, and the button that ends it.
+///
+/// Everything here that can't be undone by pressing it again runs a passkey
+/// ceremony first — changing the email, exporting, deleting. Restoring
+/// doesn't, deliberately: see `AccountAPI.restore()`.
+public struct AccountView: View {
+    @State private var viewModel: AccountViewModel
+    @State private var newEmail = ""
+    @State private var code = ""
+    @State private var confirmHandle = ""
+
+    public init(
+        session: MusubiSession,
+        anchorProvider: @escaping PresentationAnchorProvider,
+        currentProfileID: String? = nil,
+        onSwitch: @escaping (MusubiProfile) -> Void = { _ in }
+    ) {
+        _viewModel = State(
+            wrappedValue: AccountViewModel(
+                api: session.makeAccountAPI(anchorProvider: anchorProvider),
+                currentProfileID: currentProfileID,
+                onSwitch: onSwitch
+            )
+        )
+    }
+
+    /// For previews and for a caller that already has an API of its own.
+    public init(viewModel: AccountViewModel) {
+        _viewModel = State(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        ScrollView {
+            GlassEffectContainer {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    if let mutationError = viewModel.mutationError {
+                        Text(mutationError)
+                            .font(.osn(.body, size: 14))
+                            .foregroundStyle(.red)
+                    }
+
+                    // First, because it outranks everything else on the
+                    // screen: there's a clock running.
+                    if let deletion = viewModel.deletion, deletion.isScheduled {
+                        RestoreCard(
+                            scheduledFor: deletion.scheduledFor,
+                            isRestoring: viewModel.isRestoring,
+                            restore: { Task { await viewModel.restore() } }
+                        )
+                    }
+
+                    profiles
+
+                    EmailCard(
+                        currentEmail: viewModel.profiles.first?.email,
+                        pendingEmail: viewModel.pendingEmail,
+                        newEmail: $newEmail,
+                        code: $code,
+                        isSendingCode: viewModel.isSendingCode,
+                        isConfirming: viewModel.isConfirmingEmail,
+                        send: {
+                            Task {
+                                await viewModel.beginEmailChange(to: newEmail)
+                                if viewModel.pendingEmail != nil { newEmail = "" }
+                            }
+                        },
+                        confirm: {
+                            Task {
+                                await viewModel.confirmEmailChange(code: code)
+                                if viewModel.pendingEmail == nil { code = "" }
+                            }
+                        },
+                        cancel: {
+                            viewModel.cancelEmailChange()
+                            code = ""
+                        }
+                    )
+
+                    ExportCard(
+                        isExporting: viewModel.isExporting,
+                        export: { Task { await viewModel.exportAccount() } }
+                    )
+
+                    DeleteCard(
+                        handle: viewModel.currentProfile?.handle,
+                        confirmHandle: $confirmHandle,
+                        isScheduled: viewModel.deletion?.isScheduled ?? false,
+                        isRequesting: viewModel.isRequestingDeletion,
+                        delete: {
+                            Task {
+                                await viewModel.requestDeletion(confirmHandle: confirmHandle)
+                                confirmHandle = ""
+                            }
+                        }
+                    )
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("Account")
+        .refreshable {
+            await viewModel.load()
+        }
+        .task {
+            if viewModel.state == .idle {
+                await viewModel.load()
+            }
+        }
+        .sheet(isPresented: exportIsPresented) {
+            if let url = viewModel.exportURL {
+                ExportSheet(url: url)
+            }
+        }
+    }
+
+    /// Driven off `exportURL` and clearing it on dismissal, so the file on
+    /// disk lives exactly as long as the sheet does.
+    private var exportIsPresented: Binding<Bool> {
+        Binding(
+            get: { viewModel.exportURL != nil },
+            set: { if !$0 { viewModel.dismissExport() } }
+        )
+    }
+
+    @ViewBuilder
+    private var profiles: some View {
+        switch viewModel.state {
+        case .idle:
+            ProgressView()
+        // A reload with rows already on screen keeps them: the refresh
+        // control is the progress indicator there.
+        case .loading where viewModel.profiles.isEmpty:
+            ProgressView()
+        case .failed(let message):
+            ContentUnavailableView(
+                "Couldn't load your account",
+                systemImage: "exclamationmark.triangle",
+                description: Text(message)
+            )
+        default:
+            ForEach(viewModel.profiles) { profile in
+                ProfileRow(
+                    profile: profile,
+                    isCurrent: profile.id == viewModel.currentProfileID,
+                    canSwitch: viewModel.canSwitch,
+                    isSwitching: viewModel.switchingID == profile.id,
+                    isMakingDefault: viewModel.makingDefaultID == profile.id,
+                    switchTo: { Task { await viewModel.switchProfile(id: profile.id) } },
+                    makeDefault: { Task { await viewModel.makeDefault(id: profile.id) } }
+                )
+            }
+        }
+    }
+}
+
+private struct ProfileRow: View {
+    let profile: MusubiProfile
+    let isCurrent: Bool
+    let canSwitch: Bool
+    let isSwitching: Bool
+    let isMakingDefault: Bool
+    let switchTo: () -> Void
+    let makeDefault: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(profile.title)
+                        .font(.osn(.body, size: 18))
+                    Spacer()
+                    // Only shown when the app actually knows — a restored
+                    // session doesn't, and marking a row on a guess would be
+                    // worse than marking none.
+                    if isCurrent {
+                        Pill("Signed in", tint: OSNColor.badgeLive)
+                    }
+                }
+
+                Text(profile.subtitle)
+                    .font(.osn(.body, size: 14))
+                    .foregroundStyle(.secondary)
+
+                if canSwitch, !isCurrent {
+                    GlassButton(isSwitching ? "Working…" : "Switch to this", action: switchTo)
+                        .disabled(isSwitching)
+                }
+
+                // Where the next sign-in lands, on this device and any other.
+                GlassButton(
+                    isMakingDefault ? "Working…" : "Sign in as this by default",
+                    kind: .secondary,
+                    action: makeDefault
+                )
+                .disabled(isMakingDefault)
+            }
+        }
+    }
+}
+
+/// The banner for an account on its way out. Restoring takes it back whole,
+/// and only until `scheduledFor`.
+private struct RestoreCard: View {
+    let scheduledFor: Date?
+    let isRestoring: Bool
+    let restore: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("This account is being deleted", systemImage: "clock.badge.exclamationmark")
+                    .font(.osn(.body, size: 18))
+
+                if let scheduledFor {
+                    Text("Everything goes \(scheduledFor, format: .relative(presentation: .named)). Until then you can take it back.")
+                        .font(.osn(.body, size: 14))
+                } else {
+                    Text("You can still take it back.")
+                        .font(.osn(.body, size: 14))
+                }
+
+                GlassButton(isRestoring ? "Working…" : "Keep my account", action: restore)
+                    .disabled(isRestoring)
+            }
+        }
+    }
+}
+
+/// Two steps in one card, because they are one job: the address only changes
+/// when a code sent to it comes back.
+private struct EmailCard: View {
+    let currentEmail: String?
+    let pendingEmail: String?
+    @Binding var newEmail: String
+    @Binding var code: String
+    let isSendingCode: Bool
+    let isConfirming: Bool
+    let send: () -> Void
+    let confirm: () -> Void
+    let cancel: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Email")
+                    .font(.osn(.body, size: 18))
+
+                if let currentEmail {
+                    Text(currentEmail)
+                        .font(.osn(.body, size: 14))
+                }
+
+                if let pendingEmail {
+                    Text("We sent a code to \(pendingEmail). Nothing has changed yet.")
+                        .font(.osn(.body, size: 14))
+                        .foregroundStyle(.secondary)
+
+                    TextField("Code", text: $code)
+                        .textContentType(.oneTimeCode)
+                        .font(.system(.body, design: .monospaced))
+
+                    GlassButton(isConfirming ? "Working…" : "Confirm the change", action: confirm)
+                        .disabled(isConfirming || code.isEmpty)
+
+                    GlassButton("Cancel", kind: .secondary, action: cancel)
+                        .disabled(isConfirming)
+
+                    // Worth saying before they press it, not after they find
+                    // themselves signed out of their laptop.
+                    Text("Changing your email signs out everywhere except this device.")
+                        .font(.osn(.body, size: 12))
+                        .foregroundStyle(.secondary)
+                } else {
+                    TextField("New email", text: $newEmail)
+                        .textContentType(.emailAddress)
+                        #if canImport(UIKit)
+                            .keyboardType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                        #endif
+                        .autocorrectionDisabled()
+
+                    GlassButton(isSendingCode ? "Working…" : "Send a code", action: send)
+                        .disabled(isSendingCode || newEmail.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+private struct ExportCard: View {
+    let isExporting: Bool
+    let export: () -> Void
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Your data")
+                    .font(.osn(.body, size: 18))
+
+                Text("A copy of everything this account holds, as a file you can keep or take elsewhere.")
+                    .font(.osn(.body, size: 14))
+
+                GlassButton(isExporting ? "Working…" : "Download a copy", action: export)
+                    .disabled(isExporting)
+
+                Text("Once a day.")
+                    .font(.osn(.body, size: 12))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// `ShareLink` and not a save button: the file is already on disk, the share
+/// sheet is how iOS puts it anywhere the user actually wants it, and
+/// `UIPasteboard` is UIKit-only (this package builds against macOS too).
+private struct ExportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let url: URL
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Your copy is ready. It holds everything on your account in plain text, so put it somewhere you trust.")
+                    .font(.osn(.body, size: 14))
+
+                ShareLink(item: url) {
+                    Text("Save or send it")
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .navigationTitle("Your data")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+/// Typing the handle is the confirmation — no alert, because an alert is one
+/// tap away from a tap you didn't mean and this isn't.
+private struct DeleteCard: View {
+    let handle: String?
+    @Binding var confirmHandle: String
+    let isScheduled: Bool
+    let isRequesting: Bool
+    let delete: () -> Void
+
+    /// When the app knows the handle it checks the typing here, so the user
+    /// isn't told about a mismatch by a round trip. When it doesn't, the
+    /// server checks — and answers 400 `handle_mismatch`.
+    private var matches: Bool {
+        guard let handle else { return !confirmHandle.isEmpty }
+        return confirmHandle == handle
+    }
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Delete this account")
+                    .font(.osn(.body, size: 18))
+
+                Text("Your profiles, your connections and everything you've posted. There's a grace period, and after it there isn't.")
+                    .font(.osn(.body, size: 14))
+
+                if isScheduled {
+                    Text("Already on its way out — see the top of this screen.")
+                        .font(.osn(.body, size: 14))
+                        .foregroundStyle(.secondary)
+                } else {
+                    if let handle {
+                        Text("Type @\(handle) to confirm.")
+                            .font(.osn(.body, size: 12))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Type your handle to confirm.")
+                            .font(.osn(.body, size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    TextField("Handle", text: $confirmHandle)
+                        #if canImport(UIKit)
+                            .textInputAutocapitalization(.never)
+                        #endif
+                        .autocorrectionDisabled()
+                        .font(.system(.body, design: .monospaced))
+
+                    GlassButton(isRequesting ? "Working…" : "Delete my account", kind: .secondary, action: delete)
+                        .disabled(isRequesting || !matches)
+                        .tint(.red)
+                }
+            }
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/AccountViewModel.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/AccountViewModel.swift
@@ -1,0 +1,245 @@
+import Foundation
+import Observation
+
+/// Drives the account screen: the profiles on the account, the email on it,
+/// a copy of everything it holds, and the two buttons that end it.
+///
+/// Owns no client and no token — everything goes through `AccountAPI`.
+@MainActor
+@Observable
+public final class AccountViewModel {
+    public enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    public private(set) var profiles: [MusubiProfile] = []
+    /// `nil` until the first load answers, and after a load where the
+    /// profiles came back but the status call didn't.
+    public private(set) var deletion: MusubiDeletionStatus?
+    public private(set) var state: LoadState = .idle
+
+    /// Which profile the app is signed in as, when it knows.
+    ///
+    /// It knows after a fresh sign-in (the login response names the profile)
+    /// and after a switch it made itself. It does **not** know after a
+    /// silent restore on launch: the restore round-trips a token, not a
+    /// profile, and `/profiles/list` says nothing about which of them is the
+    /// caller. `nil` means unknown, and the screen marks no row rather than
+    /// guessing at the first one.
+    public private(set) var currentProfileID: String?
+
+    public private(set) var switchingID: String?
+    public private(set) var makingDefaultID: String?
+    /// A failed mutation, shown above the cards. Kept apart from
+    /// `LoadState.failed` because the screen is still good — including when
+    /// the user cancelled the Face ID sheet, which arrives here as an error
+    /// like any other.
+    public private(set) var mutationError: String?
+
+    /// The address a code was sent to, held while waiting for the code back.
+    /// Non-`nil` is what puts the screen in its second step.
+    public private(set) var pendingEmail: String?
+    public private(set) var isSendingCode = false
+    public private(set) var isConfirmingEmail = false
+
+    public private(set) var isRequestingDeletion = false
+    public private(set) var isRestoring = false
+
+    public private(set) var isExporting = false
+    /// The bundle on disk, held only until the share sheet closes — see
+    /// `dismissExport()`.
+    public private(set) var exportURL: URL?
+
+    public var currentProfile: MusubiProfile? {
+        profiles.first { $0.id == currentProfileID }
+    }
+
+    /// One profile is the ordinary case, and switching is meaningless then.
+    public var canSwitch: Bool { profiles.count > 1 }
+
+    private let api: any AccountAPI
+    /// Told when the app is now a different profile, so the rest of the shell
+    /// stops showing the old one. Nothing to do with the API call, which has
+    /// already stored the new token by the time this runs.
+    private let onSwitch: (MusubiProfile) -> Void
+    private var loadGeneration = 0
+
+    public init(
+        api: any AccountAPI,
+        currentProfileID: String? = nil,
+        onSwitch: @escaping (MusubiProfile) -> Void = { _ in }
+    ) {
+        self.api = api
+        self.currentProfileID = currentProfileID
+        self.onSwitch = onSwitch
+    }
+
+    /// Both reads at once: they are separate routes with nothing to say to
+    /// each other.
+    ///
+    /// A failed deletion-status call does **not** fail the screen — the
+    /// profiles are the screen, the banner is a banner. It does mean the
+    /// banner stays down, which is the honest reading of "we don't know".
+    public func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        state = .loading
+        async let profiles = api.listProfiles()
+        async let deletion = api.deletionStatus()
+        do {
+            let loadedProfiles = try await profiles
+            let loadedDeletion = try? await deletion
+            guard generation == loadGeneration else { return }
+            self.profiles = loadedProfiles
+            self.deletion = loadedDeletion
+            state = .loaded
+        } catch {
+            // A view that goes away cancels its load. That is the screen
+            // closing, not a failure worth showing.
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            state = .failed(String(describing: error))
+        }
+    }
+
+    /// Switching re-issues the access token, which `AccountAPI` stores. The
+    /// list itself doesn't change — same account, same profiles — so this
+    /// moves the marker and tells the shell, and doesn't re-read.
+    public func switchProfile(id: String) async {
+        guard id != currentProfileID else { return }
+        switchingID = id
+        mutationError = nil
+        defer { switchingID = nil }
+        do {
+            let profile = try await api.switchProfile(id: id)
+            currentProfileID = profile.id
+            onSwitch(profile)
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Where the next sign-in lands. Deliberately not a switch: pressing it
+    /// on the profile you aren't using should not move you there.
+    public func makeDefault(id: String) async {
+        makingDefaultID = id
+        mutationError = nil
+        defer { makingDefaultID = nil }
+        do {
+            _ = try await api.setDefaultProfile(id: id)
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Sends a code to the new address. Nothing on the account changes yet,
+    /// and the screen says so — the swap happens in `confirmEmailChange`.
+    ///
+    /// A `sent: false` is not treated as success: no code arrived, so
+    /// putting the user on the code screen would be a lie.
+    public func beginEmailChange(to newEmail: String) async {
+        isSendingCode = true
+        mutationError = nil
+        defer { isSendingCode = false }
+        do {
+            if try await api.beginEmailChange(to: newEmail) {
+                pendingEmail = newEmail
+            } else {
+                mutationError = "The code didn't go out. Try again."
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// The code proves the new address; the passkey ceremony inside the API
+    /// proves the person. The swap also revokes the account's other
+    /// sessions, so this device is the only one still signed in afterwards.
+    public func confirmEmailChange(code: String) async {
+        isConfirmingEmail = true
+        mutationError = nil
+        defer { isConfirmingEmail = false }
+        do {
+            _ = try await api.completeEmailChange(code: code)
+            pendingEmail = nil
+            // The address lives on the profile rows, so they are now stale.
+            await load()
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Backs out of the code step without changing anything. The code the
+    /// server sent simply goes unused.
+    public func cancelEmailChange() {
+        pendingEmail = nil
+    }
+
+    /// - Parameter confirmHandle: what the user typed. Sent verbatim; the
+    ///   server compares it to the profile's handle and answers 400
+    ///   `handle_mismatch` if it differs.
+    public func requestDeletion(confirmHandle: String) async {
+        isRequestingDeletion = true
+        mutationError = nil
+        defer { isRequestingDeletion = false }
+        do {
+            let schedule = try await api.requestDeletion(confirmHandle: confirmHandle)
+            // Nothing is erased yet, so the screen stays and grows a banner
+            // counting down to the moment it would be.
+            deletion = .scheduled(scheduledFor: schedule.scheduledFor, softDeletedAt: Date())
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// `false` means nothing was pending — the window closed, or another
+    /// device already restored. Either way this screen's idea of the state
+    /// is stale, so it re-reads instead of claiming a rescue that didn't
+    /// happen.
+    public func restore() async {
+        isRestoring = true
+        mutationError = nil
+        defer { isRestoring = false }
+        do {
+            if try await api.restore() {
+                deletion = MusubiDeletionStatus.none
+            } else {
+                await load()
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// One export per day per account, and the cap is only spent on a
+    /// ceremony that succeeded — so a cancelled Face ID sheet costs nothing.
+    public func exportAccount() async {
+        isExporting = true
+        mutationError = nil
+        defer { isExporting = false }
+        do {
+            exportURL = try await api.exportAccount()
+        } catch {
+            guard !Task.isCancelled else { return }
+            mutationError = String(describing: error)
+        }
+    }
+
+    /// Deletes the bundle off disk. Called when the share sheet closes: the
+    /// file is somebody's whole account in plaintext and has no business
+    /// outliving the sheet that shared it.
+    public func dismissExport() {
+        if let exportURL {
+            try? FileManager.default.removeItem(at: exportURL)
+        }
+        exportURL = nil
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiDeletionStatus.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiDeletionStatus.swift
@@ -1,0 +1,68 @@
+import Foundation
+import OSNAPI
+
+/// Whether this account is on its way out, and when it stops being
+/// recoverable.
+///
+/// `GET /account/deletion-status` answers for a live account too —
+/// `{ scheduled: false }`, not a 404 — because this backs a banner that is
+/// polled, and "nothing pending" has to be an ordinary success
+/// (`osn/api/src/routes/account-erasure.ts`).
+public enum MusubiDeletionStatus: Equatable, Sendable {
+    case none
+    /// `scheduledFor` is when the hard delete becomes eligible; until then a
+    /// restore takes the account back whole.
+    case scheduled(scheduledFor: Date, softDeletedAt: Date)
+
+    public var isScheduled: Bool {
+        if case .scheduled = self { return true }
+        return false
+    }
+
+    public var scheduledFor: Date? {
+        if case .scheduled(let date, _) = self { return date }
+        return nil
+    }
+}
+
+/// What `DELETE /account` answers with: a 202, because nothing is erased
+/// yet. The account is tombstoned and the hard delete becomes eligible when
+/// the grace window closes at `scheduledFor`.
+public struct MusubiDeletionSchedule: Equatable, Sendable {
+    public let scheduledFor: Date
+    /// `true` when a deletion was already pending — the call is idempotent
+    /// and this is the second press, not a failure.
+    public let alreadyPending: Bool
+
+    public init(scheduledFor: Date, alreadyPending: Bool) {
+        self.scheduledFor = scheduledFor
+        self.alreadyPending = alreadyPending
+    }
+}
+
+extension MusubiDeletionStatus {
+    /// The 200 body is an `anyOf` of two closed shapes, and `anyOf` means
+    /// *at least* one branch matched, not exactly one: a scheduled payload
+    /// satisfies the un-scheduled branch too, since that branch requires
+    /// only `scheduled`. So the richer branch is read first and the poorer
+    /// one is the fallback — never the other way round.
+    public init(_ payload: Operations.GetAccountDeletionStatus.Output.Ok.Body.JsonPayload) {
+        if let scheduled = payload.value2, scheduled.scheduled {
+            self = .scheduled(
+                scheduledFor: Date(timeIntervalSince1970: scheduled.scheduledFor),
+                softDeletedAt: Date(timeIntervalSince1970: scheduled.softDeletedAt)
+            )
+        } else {
+            self = .none
+        }
+    }
+}
+
+extension MusubiDeletionSchedule {
+    public init(_ payload: Operations.RequestAccountDeletion.Output.Accepted.Body.JsonPayload) {
+        self.init(
+            scheduledFor: Date(timeIntervalSince1970: payload.scheduledFor),
+            alreadyPending: payload.alreadyPending
+        )
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiProfile.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiProfile.swift
@@ -1,0 +1,74 @@
+import Foundation
+import OSNAPI
+
+/// One profile on the signed-in account, as the account screen shows it.
+///
+/// An OSN *account* is the thing that holds the passkeys, the email and the
+/// sessions; a *profile* is a handle under it, and an account may hold
+/// several (`[[wiki/systems/identity-model]]`). Every other screen in this
+/// app works on the account; this is the only one that names the profiles.
+///
+/// The server's `publicProfile` shape carries no "is this the default" and
+/// no "is this the one you're signed in as"
+/// (`osn/api/src/routes/auth/response-schemas.ts`), so neither is inferred
+/// here. What the app knows about the current profile it learned from the
+/// sign-in response or from its own switch — see `AccountViewModel`.
+public struct MusubiProfile: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let handle: String
+    public let email: String
+    public let displayName: String?
+    public let avatarUrl: String?
+
+    public init(id: String, handle: String, email: String, displayName: String?, avatarUrl: String?) {
+        self.id = id
+        self.handle = handle
+        self.email = email
+        self.displayName = displayName
+        self.avatarUrl = avatarUrl
+    }
+
+    /// What to put on the row. A profile always has a handle; a display name
+    /// is optional and often absent on the profiles nobody has dressed up.
+    public var title: String { displayName ?? "@\(handle)" }
+
+    /// The line under it, never a repeat of the line above it.
+    public var subtitle: String { displayName == nil ? email : "@\(handle)" }
+}
+
+// The same five fields arrive under three different generated types, because
+// the spec inlines the profile object at each route rather than naming it
+// once under `components`. One init per shape is the price of that; the
+// alternative is a `$ref` in `osn/api`, which is a server change and doesn't
+// belong in an iOS branch.
+extension MusubiProfile {
+    public init(_ payload: Operations.ListAccountProfiles.Output.Ok.Body.JsonPayload.ProfilesPayloadPayload) {
+        self.init(
+            id: payload.id,
+            handle: payload.handle,
+            email: payload.email,
+            displayName: payload.displayName,
+            avatarUrl: payload.avatarUrl
+        )
+    }
+
+    public init(_ payload: Operations.SwitchProfile.Output.Ok.Body.JsonPayload.ProfilePayload) {
+        self.init(
+            id: payload.id,
+            handle: payload.handle,
+            email: payload.email,
+            displayName: payload.displayName,
+            avatarUrl: payload.avatarUrl
+        )
+    }
+
+    public init(_ payload: Operations.SetDefaultProfile.Output.Ok.Body.JsonPayload.ProfilePayload) {
+        self.init(
+            id: payload.id,
+            handle: payload.handle,
+            email: payload.email,
+            displayName: payload.displayName,
+            avatarUrl: payload.avatarUrl
+        )
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// iOS anchor provider in from `App.swift` (this package can't import
 /// UIKit).
 ///
-/// Three signed-in screens now. Sign out sits in each tab's own toolbar
+/// Four signed-in screens now. Sign out sits in each tab's own toolbar
 /// rather than a tab of its own: it is an action, not a place.
 public struct MusubiRootView: View {
     private let session: MusubiSession
@@ -52,6 +52,17 @@ public struct MusubiRootView: View {
                     NavigationStack {
                         SecurityView(session: session, anchorProvider: anchorProvider)
                             .toolbar { signOutButton }
+                    }
+                }
+                Tab("Account", systemImage: "person.crop.circle") {
+                    NavigationStack {
+                        AccountView(
+                            session: session,
+                            anchorProvider: anchorProvider,
+                            currentProfileID: session.currentProfileID,
+                            onSwitch: { session.adopt(profile: $0) }
+                        )
+                        .toolbar { signOutButton }
                     }
                 }
             }

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiSession.swift
@@ -30,6 +30,15 @@ public final class MusubiSession {
 
     public private(set) var state: SessionState = .restoring
 
+    /// The profile the app is signed in as, when it knows — which is after a
+    /// sign-in, and after a profile switch it made itself.
+    ///
+    /// `nil` after a silent restore: the restore round-trips a token, and no
+    /// route on osn-api answers "which profile is this token". Kept beside
+    /// `state` rather than inside it because `state`'s payload is what the
+    /// login response said, and a switch doesn't produce one of those.
+    public private(set) var currentProfileID: String?
+
     /// Every osn-api call in this feature goes through this client. The
     /// bearer middleware inside it consults `OSNAuthenticatedOperations`,
     /// so the sign-in and `/token` calls go out with no `Authorization`
@@ -41,6 +50,7 @@ public final class MusubiSession {
     private let passkeyManagementClient: PasskeyManagementClient
     private let stepUpClient: StepUpPasskeyClient
     private let passkeyEnrollmentClient: PasskeyEnrollmentClient
+    private let accountExportClient: AccountExportClient
 
     /// - Parameter environment: identity host for passkey ceremonies, token
     ///   refresh *and* the API. Defaults to `.local`; the app target picks
@@ -58,6 +68,7 @@ public final class MusubiSession {
         self.passkeyManagementClient = PasskeyManagementClient(session: session, environment: environment)
         self.stepUpClient = StepUpPasskeyClient(session: session, environment: environment)
         self.passkeyEnrollmentClient = PasskeyEnrollmentClient(session: session, environment: environment)
+        self.accountExportClient = AccountExportClient(session: session, environment: environment)
         self.api = makeOSNClient(environment: environment, session: session, tokenRefresher: tokenRefresher)
     }
 
@@ -94,6 +105,28 @@ public final class MusubiSession {
         )
     }
 
+    /// The account screen's API. Nine calls, four of which run a ceremony,
+    /// and one of which — the export — can't go through the generated client
+    /// at all (`AccountExportClient` says why).
+    ///
+    /// - Parameter anchorProvider: the app target's key-window lookup, for
+    ///   the ceremonies behind the email change, the export and the delete.
+    public func makeAccountAPI(anchorProvider: @escaping PresentationAnchorProvider) -> OSNAccountAPI {
+        OSNAccountAPI(
+            client: api,
+            stepUp: stepUpClient,
+            export: accountExportClient,
+            anchorProvider: anchorProvider
+        )
+    }
+
+    /// Told by the account screen after a switch. The access token has
+    /// already been swapped by then — this only keeps the shell's idea of
+    /// who's signed in from going stale.
+    public func adopt(profile: MusubiProfile) {
+        currentProfileID = profile.id
+    }
+
     /// Silent restore on launch. A throw from `TokenRefresher.refresh()`
     /// means "signed out", not an error banner.
     public func restore() async {
@@ -111,6 +144,7 @@ public final class MusubiSession {
         anchorProvider: @escaping PresentationAnchorProvider
     ) async throws {
         let response = try await loginClient.signIn(identifier: identifier, anchorProvider: anchorProvider)
+        currentProfileID = response.profile.id
         state = .signedIn(response.profile)
     }
 
@@ -121,6 +155,7 @@ public final class MusubiSession {
     public func signOut() async {
         try? await tokenRefresher.logout()
         try? KeychainAccessTokenStore.delete()
+        currentProfileID = nil
         state = .signedOut
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/AccountExportClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/AccountExportClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+import OSNKit
+
+/// `GET /account/export` — the DSAR bundle (Art. 15 access / Art. 20
+/// portability), streamed as NDJSON.
+///
+/// Hand-written rather than generated, and not because generating it would
+/// be awkward: the spec **can't** describe it. The route returns a raw
+/// streamed `Response`, so `osn/api` deliberately documents no 200 schema
+/// ("a `response` schema is a runtime validator as much as a document —
+/// putting one on 200 would make Elysia try to validate a stream it cannot
+/// read without consuming it", `osn/api/src/routes/account-export.ts`), and
+/// the step-up token rides the `x-step-up-token` header because a GET has
+/// no body. The generated client can send neither a header the spec never
+/// declares nor decode a body the spec never types.
+///
+/// Two limits sit in front of it: a pre-auth per-IP throttle, and a
+/// per-account cap of one export per 24 hours that is consumed only after a
+/// successful step-up — so a cancelled Face ID sheet never burns the day's
+/// allowance. Both answer 429.
+public final class AccountExportClient: Sendable {
+    /// What the server calls the file, taken from its own
+    /// `content-disposition`. Kept as a constant rather than parsed back out
+    /// of the header: it is a fixed string on the server, and a header parse
+    /// would be a second place for it to go wrong.
+    public static let filename = "osn-account-export.ndjson"
+
+    private let session: URLSession
+    private let environment: Environment
+
+    public init(session: URLSession, environment: Environment) {
+        self.session = session
+        self.environment = environment
+    }
+
+    /// - Parameter stepUpToken: minted via `StepUpPasskeyClient` with
+    ///   `purpose: .accountExport`. Anything else is a 403 the server reads
+    ///   as `step_up_required`.
+    /// - Returns: the whole NDJSON bundle. Held in memory rather than
+    ///   streamed to disk line by line: this is one person's account, not a
+    ///   dataset, and the caller writes it out in one go.
+    public func download(stepUpToken: String) async throws -> Data {
+        var request = URLRequest(url: environment.baseURL.appendingPathComponent("account/export"))
+        request.httpMethod = "GET"
+        request.setValue(stepUpToken, forHTTPHeaderField: "X-Step-Up-Token")
+        try RequestHelpers.applyBearerAccessToken(to: &request)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw OSNAuthError.responseMalformed(status: -1)
+        }
+        guard http.statusCode == 200 else {
+            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
+        }
+        // An empty body would mean the stream died after the headers went
+        // out — a 200 that isn't one. Better to say so than to hand the user
+        // an empty file and call it their data.
+        guard !data.isEmpty else {
+            throw OSNAuthError.responseMalformed(status: http.statusCode)
+        }
+        return data
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/AccountViewModelTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/AccountViewModelTests.swift
@@ -1,0 +1,391 @@
+import Foundation
+import OSNAPI
+import Testing
+@testable import MusubiFeature
+
+private func makeProfile(id: String, handle: String = "ada", email: String = "ada@example.com") -> MusubiProfile {
+    MusubiProfile(id: id, handle: handle, email: email, displayName: nil, avatarUrl: nil)
+}
+
+private struct StubError: Error, CustomStringConvertible {
+    let description = "stub failed"
+}
+
+/// Scripted `AccountAPI`. `@MainActor` because four of the nine methods run
+/// a passkey ceremony in the real conformance and are declared on the main
+/// actor there.
+@MainActor
+private final class StubAccountAPI: AccountAPI {
+    var listResults: [Result<[MusubiProfile], Error>]
+    var statusResults: [Result<MusubiDeletionStatus, Error>]
+    var switchResults: [Result<MusubiProfile, Error>]
+    var defaultResults: [Result<MusubiProfile, Error>]
+    var beginEmailResults: [Result<Bool, Error>]
+    var completeEmailResults: [Result<String, Error>]
+    var deletionResults: [Result<MusubiDeletionSchedule, Error>]
+    var restoreResults: [Result<Bool, Error>]
+    var exportResults: [Result<URL, Error>]
+    private(set) var listCount = 0
+    private(set) var switchedIDs: [String] = []
+    private(set) var defaultedIDs: [String] = []
+    private(set) var begunEmails: [String] = []
+    private(set) var submittedCodes: [String] = []
+    private(set) var confirmedHandles: [String] = []
+    private(set) var restoreCount = 0
+    private(set) var exportCount = 0
+
+    init(
+        listResults: [Result<[MusubiProfile], Error>] = [.success([])],
+        statusResults: [Result<MusubiDeletionStatus, Error>] = [.success(.none)],
+        switchResults: [Result<MusubiProfile, Error>] = [.success(makeProfile(id: "usr_000000000002"))],
+        defaultResults: [Result<MusubiProfile, Error>] = [.success(makeProfile(id: "usr_000000000002"))],
+        beginEmailResults: [Result<Bool, Error>] = [.success(true)],
+        completeEmailResults: [Result<String, Error>] = [.success("new@example.com")],
+        deletionResults: [Result<MusubiDeletionSchedule, Error>] = [
+            .success(MusubiDeletionSchedule(scheduledFor: Date(timeIntervalSince1970: 900), alreadyPending: false)),
+        ],
+        restoreResults: [Result<Bool, Error>] = [.success(true)],
+        exportResults: [Result<URL, Error>] = [.success(URL(fileURLWithPath: "/dev/null"))]
+    ) {
+        self.listResults = listResults
+        self.statusResults = statusResults
+        self.switchResults = switchResults
+        self.defaultResults = defaultResults
+        self.beginEmailResults = beginEmailResults
+        self.completeEmailResults = completeEmailResults
+        self.deletionResults = deletionResults
+        self.restoreResults = restoreResults
+        self.exportResults = exportResults
+    }
+
+    /// Each call consumes the next scripted result; the last one repeats, so
+    /// a test needn't script the reload a mutation does.
+    private func next<T>(_ results: inout [Result<T, Error>]) throws -> T {
+        let result = results.count > 1 ? results.removeFirst() : results[0]
+        return try result.get()
+    }
+
+    func listProfiles() async throws -> [MusubiProfile] {
+        listCount += 1
+        return try next(&listResults)
+    }
+
+    func deletionStatus() async throws -> MusubiDeletionStatus {
+        try next(&statusResults)
+    }
+
+    func switchProfile(id: String) async throws -> MusubiProfile {
+        switchedIDs.append(id)
+        return try next(&switchResults)
+    }
+
+    func setDefaultProfile(id: String) async throws -> MusubiProfile {
+        defaultedIDs.append(id)
+        return try next(&defaultResults)
+    }
+
+    func beginEmailChange(to newEmail: String) async throws -> Bool {
+        begunEmails.append(newEmail)
+        return try next(&beginEmailResults)
+    }
+
+    func completeEmailChange(code: String) async throws -> String {
+        submittedCodes.append(code)
+        return try next(&completeEmailResults)
+    }
+
+    func requestDeletion(confirmHandle: String) async throws -> MusubiDeletionSchedule {
+        confirmedHandles.append(confirmHandle)
+        return try next(&deletionResults)
+    }
+
+    func restore() async throws -> Bool {
+        restoreCount += 1
+        return try next(&restoreResults)
+    }
+
+    func exportAccount() async throws -> URL {
+        exportCount += 1
+        return try next(&exportResults)
+    }
+}
+
+@MainActor
+@Suite struct AccountViewModelTests {
+    @Test func loadFetchesBothAndKeepsTheServerOrder() async {
+        let api = StubAccountAPI(
+            listResults: [.success([makeProfile(id: "usr_a"), makeProfile(id: "usr_b")])],
+            statusResults: [.success(.scheduled(
+                scheduledFor: Date(timeIntervalSince1970: 900),
+                softDeletedAt: Date(timeIntervalSince1970: 100)
+            ))]
+        )
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.profiles.map(\.id) == ["usr_a", "usr_b"])
+        #expect(viewModel.deletion?.isScheduled == true)
+    }
+
+    /// The profiles are the screen; the banner is a banner. A dead status
+    /// call must not blank the rows the user came to read.
+    @Test func aFailedStatusStillLoadsTheProfiles() async {
+        let api = StubAccountAPI(
+            listResults: [.success([makeProfile(id: "usr_a")])],
+            statusResults: [.failure(StubError())]
+        )
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.profiles.map(\.id) == ["usr_a"])
+        #expect(viewModel.deletion == nil)
+    }
+
+    @Test func aFailedListFailsTheScreen() async {
+        let viewModel = AccountViewModel(api: StubAccountAPI(listResults: [.failure(StubError())]))
+
+        await viewModel.load()
+
+        #expect(viewModel.profiles.isEmpty)
+        #expect(viewModel.state == .failed("stub failed"))
+    }
+
+    /// A switch changes the token, not the list. Re-reading would cost a
+    /// round trip to learn nothing.
+    @Test func switchingMovesTheMarkerAndTellsTheShell() async {
+        let api = StubAccountAPI(
+            listResults: [.success([makeProfile(id: "usr_a"), makeProfile(id: "usr_b")])],
+            switchResults: [.success(makeProfile(id: "usr_b", handle: "grace"))]
+        )
+        var adopted: [String] = []
+        let viewModel = AccountViewModel(api: api, currentProfileID: "usr_a", onSwitch: { adopted.append($0.id) })
+        await viewModel.load()
+
+        await viewModel.switchProfile(id: "usr_b")
+
+        #expect(api.switchedIDs == ["usr_b"])
+        #expect(viewModel.currentProfileID == "usr_b")
+        #expect(adopted == ["usr_b"])
+        #expect(api.listCount == 1)
+        #expect(viewModel.switchingID == nil)
+    }
+
+    @Test func switchingToTheProfileAlreadyInForceDoesNothing() async {
+        let api = StubAccountAPI()
+        let viewModel = AccountViewModel(api: api, currentProfileID: "usr_a")
+
+        await viewModel.switchProfile(id: "usr_a")
+
+        #expect(api.switchedIDs.isEmpty)
+    }
+
+    /// The token was never re-issued, so the marker must not move — the app
+    /// is still the profile it was.
+    @Test func aFailedSwitchKeepsTheOldMarker() async {
+        let api = StubAccountAPI(switchResults: [.failure(StubError())])
+        var adopted: [String] = []
+        let viewModel = AccountViewModel(api: api, currentProfileID: "usr_a", onSwitch: { adopted.append($0.id) })
+
+        await viewModel.switchProfile(id: "usr_b")
+
+        #expect(viewModel.currentProfileID == "usr_a")
+        #expect(adopted.isEmpty)
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(viewModel.switchingID == nil)
+    }
+
+    /// Setting the default is about the *next* sign-in. Pressing it must not
+    /// move the user now.
+    @Test func makingADefaultDoesNotSwitch() async {
+        let api = StubAccountAPI()
+        let viewModel = AccountViewModel(api: api, currentProfileID: "usr_a")
+
+        await viewModel.makeDefault(id: "usr_b")
+
+        #expect(api.defaultedIDs == ["usr_b"])
+        #expect(api.switchedIDs.isEmpty)
+        #expect(viewModel.currentProfileID == "usr_a")
+        #expect(viewModel.makingDefaultID == nil)
+    }
+
+    @Test func beginningAnEmailChangeWaitsForTheCode() async {
+        let api = StubAccountAPI()
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.beginEmailChange(to: "new@example.com")
+
+        #expect(api.begunEmails == ["new@example.com"])
+        #expect(viewModel.pendingEmail == "new@example.com")
+        #expect(!viewModel.isSendingCode)
+    }
+
+    /// `sent: false` is a 200 with nothing in the inbox. Putting the user on
+    /// the code step would be a lie.
+    @Test func anUnsentCodeIsNotProgress() async {
+        let api = StubAccountAPI(beginEmailResults: [.success(false)])
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.beginEmailChange(to: "new@example.com")
+
+        #expect(viewModel.pendingEmail == nil)
+        #expect(viewModel.mutationError != nil)
+    }
+
+    /// The address is on every profile row, so the rows are stale the moment
+    /// it changes.
+    @Test func confirmingTheChangeClearsTheStepAndReloads() async {
+        let api = StubAccountAPI(
+            listResults: [
+                .success([makeProfile(id: "usr_a", email: "old@example.com")]),
+                .success([makeProfile(id: "usr_a", email: "new@example.com")]),
+            ]
+        )
+        let viewModel = AccountViewModel(api: api)
+        await viewModel.load()
+        await viewModel.beginEmailChange(to: "new@example.com")
+
+        await viewModel.confirmEmailChange(code: "123456")
+
+        #expect(api.submittedCodes == ["123456"])
+        #expect(viewModel.pendingEmail == nil)
+        #expect(api.listCount == 2)
+        #expect(viewModel.profiles.first?.email == "new@example.com")
+    }
+
+    /// A cancelled Face ID sheet arrives as a thrown error. The user keeps
+    /// the code step and can try again.
+    @Test func aFailedConfirmationKeepsTheCodeStep() async {
+        let api = StubAccountAPI(completeEmailResults: [.failure(StubError())])
+        let viewModel = AccountViewModel(api: api)
+        await viewModel.beginEmailChange(to: "new@example.com")
+
+        await viewModel.confirmEmailChange(code: "123456")
+
+        #expect(viewModel.pendingEmail == "new@example.com")
+        #expect(viewModel.mutationError == "stub failed")
+        #expect(!viewModel.isConfirmingEmail)
+    }
+
+    @Test func cancellingTheEmailChangeChangesNothingElse() async {
+        let api = StubAccountAPI()
+        let viewModel = AccountViewModel(api: api)
+        await viewModel.beginEmailChange(to: "new@example.com")
+
+        viewModel.cancelEmailChange()
+
+        #expect(viewModel.pendingEmail == nil)
+        #expect(api.submittedCodes.isEmpty)
+    }
+
+    @Test func requestingDeletionRaisesTheBanner() async {
+        let api = StubAccountAPI(
+            deletionResults: [
+                .success(MusubiDeletionSchedule(scheduledFor: Date(timeIntervalSince1970: 900), alreadyPending: false)),
+            ]
+        )
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.requestDeletion(confirmHandle: "ada")
+
+        #expect(api.confirmedHandles == ["ada"])
+        #expect(viewModel.deletion?.scheduledFor == Date(timeIntervalSince1970: 900))
+        #expect(!viewModel.isRequestingDeletion)
+    }
+
+    /// A handle the server rejects, or a cancelled ceremony — either way
+    /// nothing is scheduled and the banner must stay down.
+    @Test func aFailedDeletionRaisesNoBanner() async {
+        let api = StubAccountAPI(deletionResults: [.failure(StubError())])
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.requestDeletion(confirmHandle: "wrong")
+
+        #expect(viewModel.deletion == nil)
+        #expect(viewModel.mutationError == "stub failed")
+    }
+
+    @Test func restoringLowersTheBanner() async {
+        let api = StubAccountAPI(restoreResults: [.success(true)])
+        let viewModel = AccountViewModel(api: api)
+        await viewModel.requestDeletion(confirmHandle: "ada")
+
+        await viewModel.restore()
+
+        #expect(api.restoreCount == 1)
+        #expect(viewModel.deletion == MusubiDeletionStatus.none)
+        #expect(!viewModel.isRestoring)
+    }
+
+    /// `cancelled: false` means nothing was pending — another device got
+    /// there first, or the window closed. This screen's copy is stale, so it
+    /// re-reads instead of claiming a rescue that didn't happen.
+    @Test func aRestoreThatCancelledNothingReloads() async {
+        let api = StubAccountAPI(restoreResults: [.success(false)])
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.restore()
+
+        #expect(api.listCount == 1)
+    }
+
+    @Test func exportingHoldsTheFileForTheSheet() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("account-export-test-\(UUID().uuidString).ndjson")
+        try Data("{}\n".utf8).write(to: url)
+        let api = StubAccountAPI(exportResults: [.success(url)])
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.exportAccount()
+
+        #expect(viewModel.exportURL == url)
+        #expect(!viewModel.isExporting)
+
+        // Somebody's whole account in plaintext has no business outliving
+        // the sheet that shared it.
+        viewModel.dismissExport()
+
+        #expect(viewModel.exportURL == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test func aFailedExportShowsNoSheet() async {
+        let api = StubAccountAPI(exportResults: [.failure(StubError())])
+        let viewModel = AccountViewModel(api: api)
+
+        await viewModel.exportAccount()
+
+        #expect(viewModel.exportURL == nil)
+        #expect(viewModel.mutationError == "stub failed")
+    }
+}
+
+@Suite struct MusubiDeletionStatusTests {
+    private func decode(_ json: String) throws -> MusubiDeletionStatus {
+        let payload = try JSONDecoder().decode(
+            Operations.GetAccountDeletionStatus.Output.Ok.Body.JsonPayload.self,
+            from: Data(json.utf8)
+        )
+        return MusubiDeletionStatus(payload)
+    }
+
+    @Test func anUnscheduledAccountReadsAsNone() throws {
+        #expect(try decode(#"{"scheduled":false}"#) == MusubiDeletionStatus.none)
+    }
+
+    /// The trap this type exists for. `anyOf` means *at least* one branch
+    /// matched: a scheduled body satisfies the `{ scheduled }` branch too,
+    /// so the decoder fills **both** `value1` and `value2`. Reading `value1`
+    /// first would quietly report a live account and hide the countdown.
+    @Test func aScheduledAccountFillsBothBranchesAndReadsAsScheduled() throws {
+        let status = try decode(#"{"scheduled":true,"scheduledFor":900,"softDeletedAt":100}"#)
+
+        #expect(status == .scheduled(
+            scheduledFor: Date(timeIntervalSince1970: 900),
+            softDeletedAt: Date(timeIntervalSince1970: 100)
+        ))
+    }
+}

--- a/wiki/apps/ios.md
+++ b/wiki/apps/ios.md
@@ -59,7 +59,7 @@ Refresh failure is **HTTP 400 with an `error` string, never 401**. A client that
 
 ## Musubi's screens
 
-Three tabs so far.
+Four tabs so far.
 
 **Devices** — every live session on the account, with per-row revoke and "sign out everywhere else": `listSessions` / `revokeSession` / `revokeAllOtherSessions` ([[sessions]]). Built first because it needs no new API work and it is the screen that *shows* the shared jar: sign in on Pulse, and the session appears in Musubi's list.
 
@@ -89,7 +89,21 @@ Two contract details worth keeping:
 - Generating writes a `recovery_code_generate` event of its own, so the screen reloads afterwards for two reasons, not one: the counts moved *and* the feed is a row short.
 - `GET /recovery/status` deliberately has **no** step-up. It carries counts, never a code, and it is what tells a user whether starting a ceremony is worth it. A failed status call therefore does not fail the screen — the feed is the point, the counts are a header.
 
-View models take a narrow protocol (`DevicesAPI`, three methods; `PasskeysAPI`, four; `SecurityAPI`, five), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI`, `OSNPasskeysAPI` and `OSNSecurityAPI` are the only places generated shapes and ceremonies are unwrapped — which is also why the mutating methods on `PasskeysAPI` and `SecurityAPI` are `@MainActor`: `ASAuthorizationController` is.
+**Account** — the profiles on the account, the address it answers to, an export of everything it holds, and the button that ends it. Contract details:
+
+- **`email` is account-level, not profile-level.** `toPublicProfile(u, email)` takes the address off the linked `accounts` row (`osn/api/src/services/auth/types.ts`), so every profile on an account carries the same one. The Email card reads it off the first row and labels it as the account's, rather than the current profile's — which it may not know.
+- **The app can't always know which profile it is.** A silent restore round-trips a token, and no route answers "which profile is this token". So `MusubiSession.currentProfileID` is seeded by sign-in and updated by a switch this app made, and is `nil` otherwise — the list marks no row rather than guessing at the first. It sits beside `state` and not inside it because `state`'s `PasskeyProfile` payload is what *login* returned, and a switch produces no such payload.
+- **A switch re-issues the access token**, which `OSNAccountAPI` writes to the Keychain before returning. The list itself doesn't change — same account, same profiles — so the screen moves the marker and does not re-read.
+- **Setting a default is not a switch.** It says where the *next* sign-in lands, on this device and any other. Pressing it on a profile you aren't using must not move you there.
+- **`GET /account/deletion-status` answers `{ scheduled: false }` for a live account, not a 404** — it backs a polled banner, so "nothing pending" has to be an ordinary success. Its 200 body is an `anyOf`, and `anyOf` means *at least* one branch matched: a scheduled payload also satisfies the `{ scheduled }` branch, so the generated decoder fills **both** `value1` and `value2`. `MusubiDeletionStatus` reads the richer branch first; reading `value1` first would report a live account and hide the countdown.
+- **The export can't go through the generated client.** The spec documents no 2xx for it and never declares `x-step-up-token`, so `AccountExportClient` is hand-written on the shared-jar `URLSession`. The bundle lands in caches, is handed to `ShareLink`, and is deleted when the sheet closes — it is somebody's whole account in plaintext and has no business outliving the sheet.
+- **`begin` answering `sent: false` is not progress.** No code arrived, so the screen stays on step one rather than asking for a code that doesn't exist. Completing the change also revokes the account's other sessions, and the card says so before the tap, not after.
+- **Restoring is deliberately not step-up gated.** Deleting is; taking it back isn't. A `cancelled: false` means nothing was pending — another device got there first, or the window closed — so the screen re-reads instead of claiming a rescue that didn't happen.
+- Deletion is confirmed by typing the handle, not by an alert: an alert is one tap away from a tap you didn't mean, and this isn't.
+
+`POST /profiles/create` and `POST /profiles/delete` are deliberately not on this screen yet — making a second profile is a bigger design question than switching between the ones you have.
+
+View models take a narrow protocol (`DevicesAPI`, three methods; `PasskeysAPI`, four; `SecurityAPI`, five; `AccountAPI`, nine), not the generated `APIProtocol` (73). A test double for the latter would be 70 stubs of nothing. `OSNDevicesAPI`, `OSNPasskeysAPI`, `OSNSecurityAPI` and `OSNAccountAPI` are the only places generated shapes and ceremonies are unwrapped — which is also why the ceremony-running methods on `PasskeysAPI`, `SecurityAPI` and `AccountAPI` are `@MainActor`: `ASAuthorizationController` is.
 
 ## macOS purity rule
 


### PR DESCRIPTION
Stacked on #432 (`feat/osn-ios-security`). **Do not merge without approval.**

The fourth signed-in screen in Musubi: the profiles on the account, the address it answers to, an export of everything it holds, and the button that ends it.

## What's here

- **`AccountAPI`** — nine methods, the fourth narrow protocol beside `DevicesAPI` (3), `PasskeysAPI` (4) and `SecurityAPI` (5), rather than the generated `APIProtocol` (73). `OSNAccountAPI` is the only place generated shapes and step-up ceremonies are unwrapped; its ceremony-running methods are `@MainActor` because `ASAuthorizationController` is.
- **`MusubiProfile`, `MusubiDeletionStatus`, `MusubiDeletionSchedule`** — domain types over the generated payloads.
- **`AccountExportClient`** (in `OSNAuth`) — hand-written on the shared-jar `URLSession`.
- **`AccountViewModel` + `AccountView`** — profiles, email change, export, delete, restore.
- **`MusubiSession`** gains `currentProfileID` and `adopt(profile:)`.
- 20 new tests; the suite is 150 and green. Both apps build under `xcodebuild`.

## Contract details worth reviewing

- **`email` is account-level, not profile-level.** `toPublicProfile(u, email)` takes the address off the linked `accounts` row (`osn/api/src/services/auth/types.ts`), so every profile on an account carries the same one. The Email card reads it off the first row and labels it as the account's.
- **The app can't always know which profile it is.** A silent restore round-trips a token, and no route answers "which profile is this token". So `currentProfileID` is seeded by sign-in and updated by a switch this app made, and is `nil` otherwise — the list marks no row rather than guessing at the first. It sits beside `state`, not inside it, because `state`'s `PasskeyProfile` payload is what *login* returned and a switch produces no such payload.
- **The `anyOf` trap in `GET /account/deletion-status`.** `anyOf` means *at least* one branch matched: a scheduled payload also satisfies the `{ scheduled }` branch, so the generated decoder fills **both** `value1` and `value2`. `MusubiDeletionStatus` reads the richer branch first — reading `value1` first would report a live account and hide the countdown. There is a test that decodes the real JSON and asserts this.
- **The export can't go through the generated client.** The spec documents no 2xx for it and never declares `x-step-up-token`. The bundle lands in caches, is handed to `ShareLink`, and is deleted when the sheet closes — it is somebody's whole account in plaintext and has no business outliving the sheet.
- **`begin` answering `sent: false` is not progress.** No code arrived, so the screen stays on step one. Completing the change revokes the account's other sessions, and the card says so before the tap.
- **Restoring is deliberately not step-up gated.** Deleting is; taking it back isn't. A `cancelled: false` means nothing was pending, so the screen re-reads rather than claiming a rescue that didn't happen.

## Deferred

`POST /profiles/create` and `POST /profiles/delete` are not on this screen. Making a second profile is a bigger design question than switching between the ones you have.

## Optional follow-up (carried from #427)

Move the idempotency check ahead of the `confirm_handle` check in `DELETE /account`.

## Standing questions for you

1. **`/openapi` is served in production.** The openapi plugin is mounted on `osn/api` unconditionally, so the deployed `id.musubi.social` Worker serves a Scalar docs UI enumerating the whole public surface. If it should be dev-only it belongs next to `includeObservabilityPlugin` in `AppDeps`.
2. **Apple portal, still blocking a real device run:** register App Group `group.social.musubi.session` and associated domain `webcredentials:musubi.social` under team `FV59Y8RSUH`, and confirm bundle ids `com.osn.pulse` and `social.musubi.app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
