### PR TITLE
feat(api): serve the OpenAPI docs on local and dev only

### DIFF
--- a/.changeset/tidy-lions-repeat.md
+++ b/.changeset/tidy-lions-repeat.md
@@ -1,0 +1,27 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+---
+
+Serve the OpenAPI docs on `local` and `dev` only
+
+The Scalar UI at `/openapi` and the document at `/openapi/json` are now mounted
+on the `local` and `dev` tiers only; on `staging` and `production` the plugin is
+never mounted and both paths 404.
+
+The document maps every route, parameter and error shape, and nothing reads it
+at runtime — `shared/openapi/{osn,pulse}.json` are committed, the generated
+clients are built from those files, and each generator boots its own app to
+produce one. A deployed public host gains nothing by serving it.
+
+Both gates take the tier from the request-scoped `env.OSN_ENV` binding rather
+than `process.env`, which workerd leaves empty during module evaluation; a
+decision made at import time would read `local` on every deployed tier. They
+fail closed, so an unrecognised tier string leaves the docs off.
+
+`pulse/api/wrangler.toml` now sets `OSN_ENV` on `staging` and `production`. That
+var also drives the cookie `Secure` flag, the plaintext-JWKS refusal and the
+fail-closed CORS check, all of which were inert on those tiers because the var
+was never set. Neither tier has ever deployed (both still carry placeholder D1
+ids), and both will now refuse to boot until their CORS and issuer vars are
+real — which is the intended posture.

--- a/osn/api/src/app.ts
+++ b/osn/api/src/app.ts
@@ -53,6 +53,21 @@ export interface AppDeps {
    * `healthRoutes` stay on both paths.
    */
   includeObservabilityPlugin: boolean;
+  /**
+   * Whether to mount the `@elysiajs/openapi` plugin — the Scalar UI at
+   * `/openapi` and the document at `/openapi/json`. True on `local` and on the
+   * `dev` tier; false on `staging` and `production`.
+   *
+   * The document is a complete map of every route, every parameter and every
+   * error shape, and nothing reads it at runtime: `shared/openapi/osn.json` is
+   * committed, generated clients are built from that file, and the generator
+   * boots its own app to produce it. So a deployed public host gains nothing by
+   * serving it and loses the cheapest reconnaissance step an attacker has.
+   *
+   * `buildAppDeps` derives this from `OSN_ENV` and fails closed — a tier string
+   * it doesn't recognise is not `dev`, so the docs stay off.
+   */
+  includeOpenapiPlugin: boolean;
   /** Auth config (rp id/name, origins, issuer, JWT key material, TTLs, pepper). */
   authConfig: AuthConfig;
   /** Cookie session config — drives Secure flag + `__Host-` prefix. */
@@ -129,6 +144,7 @@ export function createApp(deps: AppDeps) {
   const {
     serviceName,
     includeObservabilityPlugin,
+    includeOpenapiPlugin,
     authConfig,
     cookieConfig,
     corsOrigins,
@@ -170,33 +186,42 @@ export function createApp(deps: AppDeps) {
     ? base.use(observabilityPlugin({ serviceName }))
     : base;
 
-  return withObservability
+  const withRoot = withObservability
     .use(healthRoutes({ serviceName }))
-    .get("/", () => ({ status: "ok", service: "osn-auth" }))
-    .use(
-      openapi({
-        documentation: {
-          openapi: "3.1.0",
-          info: { title: "OSN Identity API", version: "1.0.0" },
-          components: {
-            securitySchemes: {
-              bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+    .get("/", () => ({ status: "ok", service: "osn-auth" }));
+
+  // The docs are gated the same way, and mounted in the same position in the
+  // chain either way: the plugin renders from the finished route table, so the
+  // document is identical wherever it sits, but keeping the position fixed
+  // keeps the committed spec byte-stable.
+  const withDocs = includeOpenapiPlugin
+    ? withRoot.use(
+        openapi({
+          documentation: {
+            openapi: "3.1.0",
+            info: { title: "OSN Identity API", version: "1.0.0" },
+            components: {
+              securitySchemes: {
+                bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+              },
             },
           },
-        },
-        // Only exact strings work here. The option is typed to accept a RegExp
-        // as well, but the plugin matches with `excludePaths.includes(path)`, so
-        // a pattern silently matches nothing. The ARC-gated internal prefixes
-        // are therefore dropped in `scripts/generate-openapi.ts` instead.
-        //
-        // `staticFile: false` because the plugin's static-asset heuristic is
-        // "the path contains a dot", which silently drops
-        // `/.well-known/openid-configuration` and `/.well-known/jwks.json` —
-        // the two endpoints every relying party reads first. No route here
-        // serves a file, so nothing else changes.
-        exclude: { paths: ["/", "/health", "/ready"], staticFile: false },
-      }),
-    )
+          // Only exact strings work here. The option is typed to accept a RegExp
+          // as well, but the plugin matches with `excludePaths.includes(path)`, so
+          // a pattern silently matches nothing. The ARC-gated internal prefixes
+          // are therefore dropped in `scripts/generate-openapi.ts` instead.
+          //
+          // `staticFile: false` because the plugin's static-asset heuristic is
+          // "the path contains a dot", which silently drops
+          // `/.well-known/openid-configuration` and `/.well-known/jwks.json` —
+          // the two endpoints every relying party reads first. No route here
+          // serves a file, so nothing else changes.
+          exclude: { paths: ["/", "/health", "/ready"], staticFile: false },
+        }),
+      )
+    : withRoot;
+
+  return withDocs
     .use(
       createAuthRoutes(
         // INTEGRATION: O3/O2 (W6) — ceremonyStores + recoveryLockoutStore + the

--- a/osn/api/src/build-deps.ts
+++ b/osn/api/src/build-deps.ts
@@ -1,6 +1,7 @@
 import type { Db } from "@osn/db/service";
 import { generateArcKeyPair, importKeyFromJwk, thumbprintKid } from "@shared/crypto";
 import type { EmailService } from "@shared/email";
+import { parseDeploymentEnvironment } from "@shared/observability/config";
 import type { RedisClient } from "@shared/redis";
 import { sanitizeCause } from "@shared/redis";
 import { createTurnstileVerifier } from "@shared/turnstile";
@@ -37,6 +38,26 @@ export const SERVICE_NAME = "osn-api";
 export type EnvRecord = Readonly<Record<string, string | undefined>>;
 
 const isNonLocal = (env: EnvRecord): boolean => !!env.OSN_ENV && env.OSN_ENV !== "local";
+
+/**
+ * Which tiers serve the OpenAPI docs (`/openapi` + `/openapi/json`): `local`
+ * and `dev` only. See `AppDeps.includeOpenapiPlugin` for why the deployed
+ * public tiers don't.
+ *
+ * Derived here rather than passed in by the caller because this function
+ * already takes the tier the honest way on both runtimes — the Workers entries
+ * hand it the request-scoped `env` binding, and `process.env` is empty during
+ * module evaluation on workerd, so any decision made at import time would pin
+ * every deployed tier to `local`. The generator passes `{}`, reads as `local`,
+ * and keeps its document.
+ *
+ * Fails closed on a tier string neither parser recognises: `isNonLocal` treats
+ * anything that isn't exactly `local` as deployed, while
+ * `parseDeploymentEnvironment` only answers `dev` for `dev`/`development`. A
+ * typo is therefore off, not on.
+ */
+const servesOpenapiDocs = (env: EnvRecord): boolean =>
+  !isNonLocal(env) || parseDeploymentEnvironment(env.OSN_ENV) === "dev";
 
 // ---------------------------------------------------------------------------
 // JWT key pair — ES256 (ECDSA P-256)
@@ -335,6 +356,7 @@ export async function buildAppDeps(env: EnvRecord, parts: BuildParts): Promise<B
   const deps: AppDeps = {
     serviceName: SERVICE_NAME,
     includeObservabilityPlugin,
+    includeOpenapiPlugin: servesOpenapiDocs(env),
     authConfig,
     cookieConfig,
     corsOrigins,

--- a/osn/api/tests/openapi-docs-gate.test.ts
+++ b/osn/api/tests/openapi-docs-gate.test.ts
@@ -1,0 +1,98 @@
+import { generateArcKeyPair } from "@shared/crypto";
+import { createMemoryClient } from "@shared/redis";
+import { exportJWK } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { createApp } from "../src/app";
+import { buildAppDeps } from "../src/build-deps";
+import { osnLoggerLayer } from "../src/observability";
+import { createTestLayer } from "./helpers/db";
+
+/**
+ * The OpenAPI docs are a tier-gated surface: served on `local` and on the `dev`
+ * tier, absent on `staging` and `production`. The document maps every route,
+ * parameter and error shape, nothing reads it at runtime (the committed
+ * `shared/openapi/osn.json` feeds the generated clients), so a deployed public
+ * host serving it only donates reconnaissance.
+ *
+ * The tier must come from the request-scoped `env` record, never `process.env`:
+ * on workerd that shim is empty during module evaluation, so an import-time
+ * decision reads every deployed tier as `local`. `buildAppDeps` already takes
+ * the env the honest way on both runtimes, which is why the derivation lives
+ * there — these tests drive it through the same door the Workers entry uses.
+ */
+
+let privB64 = "";
+let pubB64 = "";
+const b64 = (o: unknown): string => Buffer.from(JSON.stringify(o)).toString("base64");
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateArcKeyPair();
+  privB64 = b64(await exportJWK(privateKey));
+  pubB64 = b64(await exportJWK(publicKey));
+});
+
+const parts = () => ({
+  redisClient: createMemoryClient(),
+  dbAndEmailLayer: createTestLayer(),
+  observabilityLayer: osnLoggerLayer,
+  includeObservabilityPlugin: false,
+});
+
+/** A deployed env that satisfies every non-local guard, so the tier is what varies. */
+const deployedEnv = (osnEnv: string): Record<string, string> => ({
+  OSN_ENV: osnEnv,
+  OSN_ISSUER_URL: "https://api.osn.test",
+  OSN_ORIGIN: "https://api.osn.test",
+  OSN_CORS_ORIGIN: "https://app.osn.test",
+  OSN_RP_ID: "osn.test",
+  OSN_JWT_PRIVATE_KEY: privB64,
+  OSN_JWT_PUBLIC_KEY: pubB64,
+  OSN_SESSION_IP_PEPPER: "x".repeat(32),
+  OSN_PAIRWISE_SALT: "p".repeat(32),
+});
+
+const docsMounted = async (env: Record<string, string>): Promise<boolean> => {
+  const built = await buildAppDeps(env, parts());
+  const app = createApp(built.deps);
+  const res = await app.handle(new Request("http://localhost/openapi/json"));
+  return res.status === 200;
+};
+
+describe("OpenAPI docs tier gate", () => {
+  it("derives the flag from the env record, not process.env", async () => {
+    const local = await buildAppDeps({}, parts());
+    const prod = await buildAppDeps(deployedEnv("production"), parts());
+    expect(local.deps.includeOpenapiPlugin).toBe(true);
+    expect(prod.deps.includeOpenapiPlugin).toBe(false);
+  });
+
+  it("serves the document on local (an absent OSN_ENV reads as local)", async () => {
+    await expect(docsMounted({})).resolves.toBe(true);
+  });
+
+  it("serves the document on the dev tier", async () => {
+    await expect(docsMounted(deployedEnv("dev"))).resolves.toBe(true);
+  });
+
+  it("withholds it on staging", async () => {
+    await expect(docsMounted(deployedEnv("staging"))).resolves.toBe(false);
+  });
+
+  it("withholds it on production", async () => {
+    await expect(docsMounted(deployedEnv("production"))).resolves.toBe(false);
+  });
+
+  it("withholds the Scalar UI too, not just the document", async () => {
+    const built = await buildAppDeps(deployedEnv("production"), parts());
+    const res = await createApp(built.deps).handle(new Request("http://localhost/openapi"));
+    expect(res.status).toBe(404);
+  });
+
+  // Fails closed: `isNonLocal` counts anything that isn't exactly `local` as
+  // deployed, and `parseDeploymentEnvironment` answers `dev` only for
+  // `dev`/`development`. So a tier string neither recognises is off, not on.
+  it("withholds it on an unrecognised tier string", async () => {
+    await expect(docsMounted(deployedEnv("developement"))).resolves.toBe(false);
+  });
+});

--- a/pulse/api/src/app.ts
+++ b/pulse/api/src/app.ts
@@ -65,6 +65,21 @@ export interface AppOptions {
    * the local web app.
    */
   loginFallbackUrl?: string;
+  /**
+   * Whether to mount the `@elysiajs/openapi` plugin — the Scalar UI at
+   * `/openapi` and the document at `/openapi/json`. Defaults to `true`, which
+   * is right for tests, local dev and `scripts/generate-openapi.ts` (which
+   * boots this app to fetch its own document).
+   *
+   * The Workers entry passes `false` on every deployed tier except `dev`. The
+   * document is a complete map of every route, parameter and error shape, and
+   * nothing reads it at runtime — `shared/openapi/pulse.json` is committed and
+   * the generated clients are built from that file — so serving it from a
+   * public host only hands out reconnaissance. The entry derives the flag from
+   * the request-scoped `OSN_ENV` binding, never `process.env`, which workerd
+   * leaves empty during module evaluation.
+   */
+  includeOpenapi?: boolean;
 }
 
 /**
@@ -84,11 +99,12 @@ export function createApp(options: AppOptions = {}) {
     oidc = null,
     secureCookies = false,
     loginFallbackUrl = "http://localhost:1420/",
+    includeOpenapi = true,
   } = options;
 
   const { write, discovery, share, exposure, authStart, authSession } = rateLimiters;
 
-  return (
+  const base =
     // `aot: false` — Elysia's ahead-of-time compilation builds handlers via
     // `new Function`, which Cloudflare Workers forbid (no dynamic code eval).
     new Elysia({ aot: false })
@@ -100,8 +116,13 @@ export function createApp(options: AppOptions = {}) {
       // cannot guard every state-changing request the way cire does.
       .use(originGuard(corsOrigins ?? []))
       .use(healthRoutes({ serviceName: SERVICE_NAME }))
-      .get("/", () => ({ status: "ok", service: SERVICE_NAME }))
-      .use(
+      .get("/", () => ({ status: "ok", service: SERVICE_NAME }));
+
+  // Mounted in the same position either way: the plugin renders from the
+  // finished route table, so the document is identical wherever it sits, but a
+  // fixed position keeps the committed `shared/openapi/pulse.json` byte-stable.
+  const withDocs = includeOpenapi
+    ? base.use(
         openapi({
           documentation: {
             openapi: "3.1.0",
@@ -129,47 +150,49 @@ export function createApp(options: AppOptions = {}) {
           },
         }),
       )
-      .use(
-        createAuthRoutes(dbLayer, {
-          oidc,
-          secureCookies,
-          loginFallbackUrl,
-          startLimiter: authStart,
-          sessionLimiter: authSession,
-          clientIpConfig,
-        }),
-      )
-      .use(
-        createEventsRoutes(
-          dbLayer,
-          jwksUrl,
-          undefined,
-          discovery,
-          share,
-          exposure,
-          {
-            eventCreate: write.event_create,
-            eventUpdate: write.event_update,
-            rsvpUpsert: write.rsvp_upsert,
-            eventInvite: write.event_invite,
-            commsBlast: write.comms_blast,
-          },
-          clientIpConfig,
-        ),
-      )
-      .use(
-        createSeriesRoutes(dbLayer, jwksUrl, undefined, {
-          seriesCreate: write.series_create,
-          seriesUpdate: write.series_update,
-        }),
-      )
-      .use(createVenuesRoutes(dbLayer, jwksUrl))
-      .use(createSettingsRoutes(dbLayer, jwksUrl))
-      .use(createCloseFriendsRoutes(dbLayer, jwksUrl, undefined, write.close_friend_mutate))
-      .use(createOnboardingRoutes(dbLayer, jwksUrl))
-      .use(createAccountRoutes(dbLayer, jwksUrl))
-      .use(createInternalRoutes(dbLayer))
-  );
+    : base;
+
+  return withDocs
+    .use(
+      createAuthRoutes(dbLayer, {
+        oidc,
+        secureCookies,
+        loginFallbackUrl,
+        startLimiter: authStart,
+        sessionLimiter: authSession,
+        clientIpConfig,
+      }),
+    )
+    .use(
+      createEventsRoutes(
+        dbLayer,
+        jwksUrl,
+        undefined,
+        discovery,
+        share,
+        exposure,
+        {
+          eventCreate: write.event_create,
+          eventUpdate: write.event_update,
+          rsvpUpsert: write.rsvp_upsert,
+          eventInvite: write.event_invite,
+          commsBlast: write.comms_blast,
+        },
+        clientIpConfig,
+      ),
+    )
+    .use(
+      createSeriesRoutes(dbLayer, jwksUrl, undefined, {
+        seriesCreate: write.series_create,
+        seriesUpdate: write.series_update,
+      }),
+    )
+    .use(createVenuesRoutes(dbLayer, jwksUrl))
+    .use(createSettingsRoutes(dbLayer, jwksUrl))
+    .use(createCloseFriendsRoutes(dbLayer, jwksUrl, undefined, write.close_friend_mutate))
+    .use(createOnboardingRoutes(dbLayer, jwksUrl))
+    .use(createAccountRoutes(dbLayer, jwksUrl))
+    .use(createInternalRoutes(dbLayer));
 }
 
 export type App = ReturnType<typeof createApp>;

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { makeDbD1Live } from "@pulse/db/service";
+import { parseDeploymentEnvironment } from "@shared/observability/config";
 import type { ClientIpOptions } from "@shared/rate-limit";
 import { Effect } from "effect";
 
@@ -125,6 +126,14 @@ function buildApp(env: Env): App {
     corsOrigins,
     oidc,
     secureCookies: secure,
+    // OpenAPI docs on `local` and `dev` only — see `AppOptions.includeOpenapi`.
+    // Derived from the request-scoped binding, never `process.env`: workerd
+    // leaves that empty during module evaluation, so a decision made at import
+    // time would read every deployed tier as `local` and serve the docs
+    // everywhere. Fails closed — `secure` treats anything that isn't exactly
+    // `local` as deployed, and the parser answers `dev` only for
+    // `dev`/`development`, so an unrecognised tier string is off, not on.
+    includeOpenapi: !secure || parseDeploymentEnvironment(env.OSN_ENV) === "dev",
     ...(env.PULSE_LOGIN_URL ? { loginFallbackUrl: env.PULSE_LOGIN_URL } : {}),
   });
 }

--- a/pulse/api/tests/index.test.ts
+++ b/pulse/api/tests/index.test.ts
@@ -47,4 +47,38 @@ describe("pulse API app", () => {
     const res = await app.handle(new Request("http://localhost/health"));
     expect(res.headers.get("x-request-id")).toBeTruthy();
   });
+
+  /**
+   * The docs are a tier-gated surface — served on `local` and `dev`, absent on
+   * `staging` and `production`. The document maps every route, parameter and
+   * error shape, and nothing reads it at runtime (the committed
+   * `shared/openapi/pulse.json` feeds the generated clients), so a deployed
+   * public host serving it only donates reconnaissance. `src/index.ts` derives
+   * the flag from the request-scoped `OSN_ENV` binding; here we check the
+   * mount honours it in both directions.
+   */
+  describe("OpenAPI docs gate", () => {
+    it("mounts the document by default (local, tests, the generator)", async () => {
+      const res = await app.handle(new Request("http://localhost/openapi/json"));
+      expect(res.status).toBe(200);
+    });
+
+    it("withholds the document when includeOpenapi is false", async () => {
+      const noDocs = createApp({ includeOpenapi: false });
+      const res = await noDocs.handle(new Request("http://localhost/openapi/json"));
+      expect(res.status).toBe(404);
+    });
+
+    it("withholds the Scalar UI too, not just the document", async () => {
+      const noDocs = createApp({ includeOpenapi: false });
+      const res = await noDocs.handle(new Request("http://localhost/openapi"));
+      expect(res.status).toBe(404);
+    });
+
+    it("still serves the rest of the app with the docs off", async () => {
+      const noDocs = createApp({ includeOpenapi: false });
+      const res = await noDocs.handle(new Request("http://localhost/health"));
+      expect(res.status).toBe(200);
+    });
+  });
 });

--- a/pulse/api/wrangler.toml
+++ b/pulse/api/wrangler.toml
@@ -16,6 +16,12 @@ database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
 
 [env.dev.vars]
+# OSN_ENV is deliberately unset here. Every var below still points at localhost,
+# so this env is the `wrangler dev --env dev` config, and `OSN_ENV = "dev"` would
+# flip `secure` on in src/index.ts — which refuses a plaintext JWKS URL and
+# fail-closes CORS, breaking the local run. Unset reads as `local`: http cookies
+# allowed, and /openapi served (the docs gate is on for `local` and `dev` alike).
+# Set it to "dev" in the same commit that gives this env real https origins.
 OSN_JWKS_URL = "http://localhost:4000/.well-known/jwks.json"
 OSN_ISSUER_URL = "http://localhost:4000"
 PULSE_API_ORIGIN = "http://localhost:3001"
@@ -32,6 +38,7 @@ database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
 
 [env.staging.vars]
+OSN_ENV = "staging"
 # TODO: real OSN issuer origin before staging deploy
 OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
 OSN_ISSUER_URL = "https://osn-api.example.com"
@@ -51,6 +58,7 @@ database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
 
 [env.production.vars]
+OSN_ENV = "production"
 # TODO: real OSN issuer origin before prod deploy
 OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
 OSN_ISSUER_URL = "https://osn-api.example.com"

--- a/wiki/runbooks/dev-environment.md
+++ b/wiki/runbooks/dev-environment.md
@@ -377,6 +377,47 @@ Cloudflare Access (Zero Trust, free for 50 users), email-OTP policy, on the
 > CORS bug rather than an auth policy. Those two stay guarded by the CORS
 > allowlist and `origin-guard.ts`, exactly as production is.
 
+### The API docs are a dev-only surface
+
+`osn-api` and `pulse-api` mount `@elysiajs/openapi` — the Scalar UI at
+`/openapi`, the document at `/openapi/json` — on **`local` and `dev` only**.
+On `staging` and `production` both paths are a 404, because the plugin is never
+mounted; there is no route there to authorise or block.
+
+Why it comes off the public tiers: the document is a complete map of every
+route, every parameter and every error shape, and nothing reads it at runtime.
+`shared/openapi/osn.json` and `shared/openapi/pulse.json` are committed, the
+generated clients are built from those files, and each generator boots its own
+app to produce one. So a deployed public host gains nothing by serving it and
+saves an attacker the cheapest reconnaissance step there is.
+
+> [!important] The tier comes from the `env` binding, never `process.env`
+> On workerd `process.env` is a shim populated from `[vars]` on first access,
+> and it is **empty during module evaluation**. Any tier decision taken at
+> import time therefore reads `local` on every deployed tier and serves the
+> docs everywhere. `osn-api` derives the flag inside `buildAppDeps(env, …)`
+> (`osn/api/src/build-deps.ts`, `servesOpenapiDocs`); `pulse-api` derives it in
+> `buildApp(env)` (`pulse/api/src/index.ts`) and passes
+> `AppOptions.includeOpenapi`. Both read the request-scoped `env.OSN_ENV`.
+
+Both gates fail closed. `isNonLocal` counts anything that isn't exactly `local`
+as deployed, and `parseDeploymentEnvironment` answers `dev` only for `dev` or
+`development` — so a typo'd tier string leaves the docs **off**, not on. To read
+the docs against a deployed tier, use dev:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://id.dev.musubi.social/openapi/json  # 200
+curl -s -o /dev/null -w '%{http_code}\n' https://id.musubi.social/openapi/json      # 404
+```
+
+`pulse-api` has no deployed tier yet. Its `[env.dev.vars]` still points at
+localhost and deliberately leaves `OSN_ENV` unset, which reads as `local`, so
+`wrangler dev --env dev` keeps its docs; set `OSN_ENV = "dev"` there in the same
+commit that gives that env real https origins. `staging` and `production` do set
+it, which also switches on the cookie `Secure` flag, the plaintext-JWKS refusal
+and the fail-closed CORS check on those tiers — all three were silently off
+before, since the code keys them off the same var.
+
 ---
 
 ## 6. Verifying the dev tier


### PR DESCRIPTION
## What

`/openapi` (Scalar UI) and `/openapi/json` (the document) were mounted on every tier of both `osn-api` and `pulse-api`. They now mount on **`local` and `dev` only** — on `staging` and `production` the plugin is never mounted, so both paths 404.

## Why

The document is a complete map of every route, every parameter and every error shape, and nothing reads it at runtime:

- `shared/openapi/osn.json` and `shared/openapi/pulse.json` are committed
- the generated clients are built from those files
- each generator (`<pkg>/api/scripts/generate-openapi.ts`) boots its own app to produce one

So a deployed public host gains nothing by serving it, and saves an attacker the cheapest reconnaissance step there is. `dev` keeps it because that is where you actually read it.

## How

**The tier must come from the request-scoped `env` binding, not `process.env`.** On workerd `process.env` is a shim populated from `[vars]` on first access and is **empty during module evaluation** — a decision taken at import time reads `local` on every deployed tier and serves the docs everywhere.

- **osn-api** — derived inside `buildAppDeps(env, parts)` (`servesOpenapiDocs`), which already receives the tier correctly from all three callers: Bun passes `process.env` (native, always populated), the Workers entry passes the `env` binding, the generator passes `{}`. **No call site changed.** The flag lands on `AppDeps.includeOpenapiPlugin`, next to the existing `includeObservabilityPlugin`.
- **pulse-api** — derived in `buildApp(env)` and passed as the new `AppOptions.includeOpenapi` (defaults `true`, which is right for tests, local, and the generator).

Both compose the same rule and **fail closed**:

```ts
!isNonLocal(env) || parseDeploymentEnvironment(env.OSN_ENV) === "dev"
```

`isNonLocal` counts anything that isn't exactly `local` as deployed; `parseDeploymentEnvironment` answers `dev` only for `dev`/`development`. A typo'd tier string therefore leaves the docs **off**, not on.

The mount position in each Elysia chain is unchanged, so both committed documents regenerate byte-identical (verified: `openapi:generate` on both packages leaves `shared/openapi/` clean).

## ⚠️ Knock-on: `pulse/api/wrangler.toml` now sets `OSN_ENV`

Pulse never set `OSN_ENV` in any `[env.*.vars]` block, so the gate would have been inert. This PR sets it on `staging` and `production`.

That same var drives `const secure = !!env.OSN_ENV && env.OSN_ENV !== "local"` in `pulse/api/src/index.ts`, which gates three other things that were **silently off** on those tiers:

- the cookie `Secure` flag
- the refusal to fetch JWKS over plaintext HTTP
- `assertCorsOriginsConfigured` (fail-closed CORS)

**Consequence:** `staging` and `production` will now refuse to boot until their CORS/issuer vars are real. That is the intended posture, and nothing breaks today — neither tier has ever deployed (both still carry `database_id = "placeholder-replace-after-d1-create"` and `pulse.example.com` placeholders).

`[env.dev.vars]` deliberately leaves `OSN_ENV` unset, with a comment saying so: every var there still points at localhost, so that block is the `wrangler dev --env dev` config, and setting the tier would trip the plaintext-JWKS refusal and break the local run. Unset reads as `local` → docs on, which is the wanted behaviour either way. Set it to `"dev"` in the same commit that gives that env real https origins.

## Tests

- `osn/api/tests/openapi-docs-gate.test.ts` (new, 7 tests) — drives `buildAppDeps` → `createApp` → `fetch` for each tier: document present on `local`/`dev`, absent on `staging`/`production`, Scalar UI gone too, and an unrecognised tier string stays off.
- `pulse/api/tests/index.test.ts` (+4) — the mount honours `includeOpenapi` in both directions, and the rest of the app still serves with the docs off.

```
osn/api    62 files, 1019 tests  ✅
pulse/api  42 files,  621 tests  ✅
tsc --noEmit clean on both; shared/openapi/ unchanged after regeneration
```

## Docs

`wiki/runbooks/dev-environment.md` §5 gains "The API docs are a dev-only surface" — the rule, why `process.env` is the wrong source, the fail-closed composition, curl checks against dev vs prod, and the Pulse `OSN_ENV` caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rtirhHZfmxZrJXCBxXF9s
