### PR TITLE
Pulse iOS: bundle id social.musubi.pulse, App ID registered with both capabilities

### DIFF
--- a/.changeset/plenty-hounds-shave.md
+++ b/.changeset/plenty-hounds-shave.md
@@ -1,0 +1,16 @@
+---
+"@osn/social": patch
+---
+
+Point the App Site Association file at the renamed Pulse bundle id
+
+`/.well-known/apple-app-site-association` named `FV59Y8RSUH.com.osn.pulse`. The
+Pulse bundle id is now `social.musubi.pulse`, so the entry is
+`FV59Y8RSUH.social.musubi.pulse`.
+
+The file is the domain half of the `webcredentials:musubi.social` associated
+domain: iOS reads it to decide whether an app may use passkeys saved for this
+site. A stale app id there fails silently — no error, no prompt, the
+association simply never forms and passkeys never appear in the app. The two
+values have to move together, which `pulse/ios/project.yml` now says next to
+the bundle id itself.

--- a/osn/social/public/.well-known/apple-app-site-association
+++ b/osn/social/public/.well-known/apple-app-site-association
@@ -1,5 +1,5 @@
 {
   "webcredentials": {
-    "apps": ["FV59Y8RSUH.com.osn.pulse"]
+    "apps": ["FV59Y8RSUH.social.musubi.pulse"]
   }
 }

--- a/pulse/ios/project.yml
+++ b/pulse/ios/project.yml
@@ -43,9 +43,10 @@ targets:
     # OSNKit/SharedCookieJar.swift:10 (osnSessionAppGroupIdentifier) — change
     # one and the jar silently splits in two.
     #
-    # BLOCKED: the associated domain is not registered yet. No App ID carries
-    # webcredentials:musubi.social, so codesigning fails until it is added in
-    # the developer portal. Passkeys won't autofill from the app before then.
+    # Both capabilities are on the App ID: App Groups (with this group
+    # assigned) and Associated Domains. Adding or removing a capability there
+    # invalidates every provisioning profile carrying this App ID, so they
+    # have to be regenerated afterwards.
     entitlements:
       path: Pulse.entitlements
       properties:

--- a/pulse/ios/project.yml
+++ b/pulse/ios/project.yml
@@ -1,6 +1,6 @@
 name: Pulse
 options:
-  bundleIdPrefix: com.osn
+  bundleIdPrefix: social.musubi
   deploymentTarget:
     iOS: "26.0"
 packages:
@@ -26,19 +26,22 @@ targets:
         product: PulseFeature
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.osn.pulse
+        PRODUCT_BUNDLE_IDENTIFIER: social.musubi.pulse
         DEVELOPMENT_TEAM: FV59Y8RSUH
         CODE_SIGN_STYLE: Automatic
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
         GENERATE_INFOPLIST_FILE: "YES"
         SWIFT_VERSION: "6.2"
-    # BLOCKED: neither capability is registered in the Apple developer portal
-    # yet (no App ID configured for webcredentials:musubi.social or for the
-    # group.social.musubi.session App Group). Xcode codesigning will fail
-    # until both are added there. RP ID/App Group string sourced from
-    # brief-a3.md and OSNKit/SharedCookieJar.swift:10 (osnSessionAppGroupIdentifier)
-    # — not invented here.
+    # The App Group `group.social.musubi.session` is registered under team
+    # FV59Y8RSUH, so the shared cookie jar resolves and every OSN app signs in
+    # once. The string must stay in step with
+    # OSNKit/SharedCookieJar.swift:10 (osnSessionAppGroupIdentifier) — change
+    # one and the jar silently splits in two.
+    #
+    # BLOCKED: the associated domain is not registered yet. No App ID carries
+    # webcredentials:musubi.social, so codesigning fails until it is added in
+    # the developer portal. Passkeys won't autofill from the app before then.
     entitlements:
       path: Pulse.entitlements
       properties:

--- a/pulse/ios/project.yml
+++ b/pulse/ios/project.yml
@@ -26,6 +26,10 @@ targets:
         product: PulseFeature
     settings:
       base:
+        # Changing this means changing `osn/social/public/.well-known/
+        # apple-app-site-association` in the same commit — it names
+        # `<TEAMID>.<bundle id>`, and a stale entry there means the
+        # associated domain silently never forms and passkeys never appear.
         PRODUCT_BUNDLE_IDENTIFIER: social.musubi.pulse
         DEVELOPMENT_TEAM: FV59Y8RSUH
         CODE_SIGN_STYLE: Automatic

--- a/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
@@ -5,9 +5,9 @@ import Foundation
 /// otherwise show up only as "the ceremony succeeded and the user is still
 /// signed out," with nothing in the logs.
 public enum OSNKitError: Error, Sendable, Equatable {
-    /// Door 2 — the App Group container is unavailable. Either the group is
-    /// not registered in the Apple developer portal yet, or the entitlement
-    /// is missing from this target. `HTTPCookieStorage
+    /// Door 2 — the App Group container is unavailable. The group is
+    /// registered, so this means the entitlement is missing from this target
+    /// or the build is signed by another team. `HTTPCookieStorage
     /// .sharedCookieStorage(forGroupContainerIdentifier:)` does not itself
     /// fail in this case — it silently hands back storage that never
     /// actually shares with another process. This error is raised from a
@@ -58,7 +58,7 @@ extension OSNKitError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .appGroupContainerUnavailable(let groupIdentifier):
-            return "App Group container unavailable for \(groupIdentifier) — not registered in the developer portal, or the entitlement is missing from this target. Cross-app session sharing does not exist until this is fixed."
+            return "App Group container unavailable for \(groupIdentifier) — the entitlement is missing from this target, or the build is signed by a team the group isn't registered under. Cross-app session sharing does not exist until this is fixed."
         case .sessionCookieNotPersisted(let name, let host):
             return "Expected cookie \(name) for \(host) to be in the shared jar after a successful /token response, but it isn't. Check the URLSession is the shared one, and that the cookie name matches this environment's `secure` setting."
         case .refreshUnsupportedGrantType:

--- a/shared/swift/OSNShared/Sources/OSNKit/SharedCookieJar.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/SharedCookieJar.swift
@@ -4,9 +4,13 @@ import Foundation
 /// and any later OSN app see the same HttpOnly session cookie. Named in
 /// exactly one place — nothing else in `OSNShared` should hardcode it.
 ///
-/// BLOCKED: this identifier is not yet registered in the Apple developer
-/// portal (brief open question 1). `SharedCookieJar.makeConfiguration`
-/// throws `OSNKitError.appGroupContainerUnavailable` until it is.
+/// Registered in the Apple developer portal under team FV59Y8RSUH, so the
+/// container resolves on device and `makeConfiguration` returns a real shared
+/// jar. It still throws `OSNKitError.appGroupContainerUnavailable` where the
+/// container is absent — an app target missing the
+/// `com.apple.security.application-groups` entitlement, or a build signed by
+/// another team. Both are the loud failure we want, not a jar that silently
+/// shares with nobody.
 public let osnSessionAppGroupIdentifier = "group.social.musubi.session"
 
 public enum SharedCookieJar {

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
@@ -43,8 +43,9 @@ public final class PulseSession {
     ///     for the same reason.
     /// - Throws: whatever `SharedCookieJar.makeSession()` throws
     ///   (`OSNKitError.appGroupContainerUnavailable` when the App Group
-    ///   entitlement isn't registered — see `pulse/ios/project.yml`'s
-    ///   `BLOCKED:` comment). That is an infrastructure/build-config
+    ///   container doesn't resolve — the group is registered, so this means
+    ///   the target is missing the entitlement or is signed by another team;
+    ///   see `pulse/ios/project.yml`). That is an infrastructure/build-config
     ///   failure, not a session state — there is no working `URLSession` to
     ///   hand out if it happens, so it isn't folded into `SessionState`.
     public init(environment: Environment = .local, pulseEnvironment: PulseEnvironment = .local) throws {

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -63,16 +63,23 @@
   `performAutoFillAssistedRequests()`. The discoverable-credential flow the
   brief asked for works; the QuickType-bar suggestion does not exist yet.
 - Xcode build of the Pulse target with the new entitlements has not been
-  run (would fail regardless — see BLOCKED below) — `swift build`/`swift test`
-  only exercise the SPM package, not the Xcode project XcodeGen would
-  generate.
+  run — `swift build`/`swift test` only exercise the SPM package, not the
+  Xcode project XcodeGen would generate. Nothing blocks that build now (see
+  BLOCKED below); it just hasn't been done.
 
 ## BLOCKED
 
-- `pulse/ios/project.yml`: `com.apple.developer.associated-domains`
-  (`webcredentials:musubi.social`) is declared in the entitlements block
-  but no App ID carries the capability in the Apple developer portal.
-  Xcode codesigning of the Pulse target will fail until it is added there.
-  Cleared 2026-08-14: the App Group `group.social.musubi.session` is now
-  registered under team FV59Y8RSUH, so `SharedCookieJar.makeSession()` no
-  longer throws on a correctly signed build.
+Nothing. Cleared 2026-08-15: App ID `social.musubi.pulse` is registered
+under team FV59Y8RSUH with both capabilities the entitlements block
+declares — **Associated Domains**, and **App Groups** with
+`group.social.musubi.session` assigned. So Xcode codesigning of the Pulse
+target no longer fails on a missing capability, and
+`SharedCookieJar.makeSession()` no longer throws on a correctly signed
+build.
+
+The portal never takes the domain string itself. `webcredentials:musubi.social`
+is matched against `osn/social/public/.well-known/apple-app-site-association`,
+which now names `FV59Y8RSUH.social.musubi.pulse`. iOS reads that file through
+Apple's CDN and caches it up to ~24h; during development append
+`?mode=developer` to the entitlement and turn on Settings → Developer →
+Associated Domains Development to skip the cache. Strip it before TestFlight.

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -70,8 +70,9 @@
 ## BLOCKED
 
 - `pulse/ios/project.yml`: `com.apple.developer.associated-domains`
-  (`webcredentials:musubi.social`) and App Group
-  `group.social.musubi.session` are declared in the entitlements block
-  but neither capability is registered in the Apple developer portal.
-  Xcode codesigning of the Pulse target will fail until both are added
-  there.
+  (`webcredentials:musubi.social`) is declared in the entitlements block
+  but no App ID carries the capability in the Apple developer portal.
+  Xcode codesigning of the Pulse target will fail until it is added there.
+  Cleared 2026-08-14: the App Group `group.social.musubi.session` is now
+  registered under team FV59Y8RSUH, so `SharedCookieJar.makeSession()` no
+  longer throws on a correctly signed build.


### PR DESCRIPTION
## What

Three follow-ups on the iOS shared-session work, all unblocked now.

**Bundle id.** `com.osn.pulse` → `social.musubi.pulse`, and `bundleIdPrefix` `com.osn` → `social.musubi`. The identity zone is `musubi.social` and the shared cookie jar lives in `group.social.musubi.session`; the bundle id now sits in the same namespace. Nothing has shipped to the App Store, so the id is still free to change — it stops being free at first release, which is the reason to do it now.

**App Site Association.** `osn/social/public/.well-known/apple-app-site-association` named `FV59Y8RSUH.com.osn.pulse`; it now names `FV59Y8RSUH.social.musubi.pulse`. That file is the domain half of `webcredentials:musubi.social` — iOS reads it to decide whether an app may use passkeys saved for this site, and a stale app id there fails silently: no error, no prompt, the association simply never forms. The bundle id and this file have to move together, which `pulse/ios/project.yml` now says next to the bundle id itself.

**App ID.** `social.musubi.pulse` is registered in the developer portal under team FV59Y8RSUH with both capabilities the entitlements block declares: **Associated Domains**, and **App Groups** with `group.social.musubi.session` assigned. So codesigning the Pulse target no longer fails on a missing capability, and `SharedCookieJar.makeSession()` no longer throws `OSNKitError.appGroupContainerUnavailable` on a correctly signed build — Pulse, Musubi and any later OSN app share one session cookie.

The error case itself stays. The container is still absent when a target is missing the `com.apple.security.application-groups` entitlement, or when the build is signed by a team the group isn't registered under — and `HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier:)` doesn't fail there, it hands back storage that shares with nobody. The container-URL check in front of it keeps that loud. Comments and the error's `description` now name those two causes rather than "not registered yet".

## Nothing blocked

The `BLOCKED` sections are cleared. Two portal facts worth keeping, both now recorded in `a3-notes.md`:

- Adding or removing a capability on an App ID invalidates every provisioning profile that includes it; they have to be regenerated.
- The portal never takes the domain string — `webcredentials:musubi.social` is matched against the app-site-association file, which Apple's CDN caches for up to ~24h. During development append `?mode=developer` to the entitlement and turn on Settings → Developer → Associated Domains Development. Strip it before TestFlight.

## Files

| File | Change |
|---|---|
| `pulse/ios/project.yml` | bundle id + prefix; entitlements comments rewritten |
| `osn/social/public/.well-known/apple-app-site-association` | app id → `FV59Y8RSUH.social.musubi.pulse` |
| `shared/swift/.../OSNKit/SharedCookieJar.swift` | doc on `osnSessionAppGroupIdentifier` |
| `shared/swift/.../OSNKit/OSNKitError.swift` | doc + `description` for `appGroupContainerUnavailable` |
| `shared/swift/.../PulseFeature/PulseSession.swift` | `init` throws-doc |
| `shared/swift/OSNShared/a3-notes.md` | BLOCKED section cleared |
| `.changeset/plenty-hounds-shave.md` | `@osn/social` patch for the association file |

## Verification

- `swift build` — clean.
- `swift test` — 76 tests, 9 suites, passed.
- `xcodegen generate` in `pulse/ios` — project written, `PRODUCT_BUNDLE_IDENTIFIER = social.musubi.pulse`, entitlements plist carries both keys. The generated `.xcodeproj` and `Pulse.entitlements` are gitignored.
- Portal state re-read after saving: App Groups enabled with `Enabled App Groups (1)`, Associated Domains enabled.
- `scripts/changeset-required.sh` → `required`, because the association file lives under `osn/social/`; the changeset above names `@osn/social`. Everything else is on the allowlist (`shared/swift/`, `pulse/ios/`).

An Xcode build of the Pulse target still hasn't been run — `swift build`/`swift test` only exercise the SPM package. Nothing blocks it now; it just hasn't been done.

No behaviour change to any deployed service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rtirhHZfmxZrJXCBxXF9s
