### PR TITLE
feat(cire-host): search and filter the RSVP list

### DIFF
--- a/.changeset/cire-host-rsvp-filter.md
+++ b/.changeset/cire-host-rsvp-filter.md
@@ -1,0 +1,26 @@
+---
+"@cire/host": patch
+---
+
+Search and status filtering on the organiser RSVP list, over one merged list per
+event.
+
+The list used to show only the guests who had replied, with everyone still
+silent tucked into an editor-only `<details>` disclosure below the table. Both
+now render as rows in the same table: a guest who has not answered carries a
+muted "No reply" badge, and — for an editor — a `Record` button in the same
+column that `Edit` sits in. The disclosure is gone. A viewer now sees who owes a
+reply too, read-only.
+
+Above the events sits one control bar, not one per event: a search box and a set
+of status chips (All / Attending / Declined / Maybe / No reply), each with a
+count summed across every event. Search matches a name, the household name, the
+household code and the dietary note, and every typed word must match, so "jones
+cleo" and "sharma gluten" both work. Filtering never hides an event section — the
+header and its tallies stay as the unfiltered truth, and a section with nothing
+left says "No guests match this filter". A live region reports how many of the
+total are showing.
+
+The merge and the predicate live in a new pure `src/lib/rsvp-filter.ts`
+(`mergeRows` / `filterRows` / `statusCounts`) with its own unit tests. No API
+change: the RSVP payload already carried both lists.

--- a/cire/host/src/components/RsvpView.test.tsx
+++ b/cire/host/src/components/RsvpView.test.tsx
@@ -3,11 +3,12 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@solidjs/te
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
- * RsvpView is the in-dashboard RSVP summary: per event, a status tally and the
- * guests who responded (status + dietary + provenance badge). Editors also get a
- * record/edit affordance. The OSN auth + api helpers are stubbed; this asserts
- * the grouped render, the counts, the empty state, provenance badging, and the
- * organiser-record flow.
+ * RsvpView is the in-dashboard RSVP summary: per event, a status tally and every
+ * invited guest — replies (status + dietary + provenance badge) and the silent
+ * ones as "No reply" rows — under one search box and one set of status chips.
+ * Editors also get a record/edit affordance. The OSN auth + api helpers are
+ * stubbed; this asserts the grouped render, the counts, the empty state,
+ * provenance badging, the filtering, and the organiser-record flow.
  */
 
 vi.mock("@shared/rp-auth/solid", async () => {
@@ -119,13 +120,22 @@ describe("RsvpView", () => {
     expect(dl.textContent).toContain("4");
   });
 
-  it("shows a per-event empty note when no one has replied", async () => {
+  it("shows a per-event empty note when the event has no guests at all", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
 
     await waitFor(() => expect(screen.getByText("Reception")).toBeTruthy());
     const reception = screen.getByText("Reception").closest("section")!;
-    expect(within(reception).getByText(/No replies yet/i)).toBeTruthy();
+    expect(within(reception).getByText(/No guests to show/i)).toBeTruthy();
+  });
+
+  it("lists a guest who has not replied in the same table, badged No reply", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+
+    await waitFor(() => expect(screen.getByText("Cleo Jones")).toBeTruthy());
+    const row = screen.getByText("Cleo Jones").closest("tr")!;
+    expect(within(row).getByText("No reply")).toBeTruthy();
   });
 
   it("shows the no-events empty state when the wedding has no events", async () => {
@@ -161,7 +171,62 @@ describe("RsvpView", () => {
     render(() => <RsvpView weddingId="wed_a" />);
     await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
     expect(screen.queryByRole("button", { name: /^Edit$/i })).toBeNull();
-    expect(screen.queryByText(/Record a reply for another guest/i)).toBeNull();
+    // The no-reply row is still listed — a viewer may read it, not act on it.
+    expect(screen.getByText("Cleo Jones")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Record$/i })).toBeNull();
+  });
+
+  it("filters every event by a status chip", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+
+    // The chip carries its count: 1 guest owes a reply across both events.
+    const noReply = screen.getByRole("button", { name: /^No reply/i });
+    expect(noReply.textContent).toContain("1");
+
+    fireEvent.click(noReply);
+    expect(noReply.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText("Cleo Jones")).toBeTruthy();
+    expect(screen.queryByText("Ada Sharma")).toBeNull();
+    expect(screen.getByText(/Showing 1 of 3 guests/i)).toBeTruthy();
+
+    // The event sections stay put, with their tallies, and say why they're bare.
+    expect(screen.getByText("Reception")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^Attending/i }));
+    const ceremony = screen.getByText("Ceremony").closest("section")!;
+    expect(within(ceremony).getByText("Ada Sharma")).toBeTruthy();
+    expect(within(ceremony).queryByText("Cleo Jones")).toBeNull();
+  });
+
+  it("searches across name, household and dietary text", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+
+    const search = screen.getByPlaceholderText(/Search a name/i);
+    fireEvent.input(search, { target: { value: "jones" } });
+    expect(screen.getByText("Bo Jones")).toBeTruthy();
+    expect(screen.getByText("Cleo Jones")).toBeTruthy();
+    expect(screen.queryByText("Ada Sharma")).toBeNull();
+
+    // Dietary text is searchable — the caterer's question.
+    fireEvent.input(search, { target: { value: "gluten" } });
+    expect(screen.getByText("Ada Sharma")).toBeTruthy();
+    expect(screen.queryByText("Bo Jones")).toBeNull();
+  });
+
+  it("says so when a filter matches nobody", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+
+    fireEvent.input(screen.getByPlaceholderText(/Search a name/i), {
+      target: { value: "nobody" },
+    });
+    const ceremony = screen.getByText("Ceremony").closest("section")!;
+    expect(within(ceremony).getByText(/No guests match this filter/i)).toBeTruthy();
+    expect(screen.getByText(/Showing 0 of 3 guests/i)).toBeTruthy();
   });
 
   it("editor records a phone RSVP: PUTs consent-attested body and reloads", async () => {
@@ -175,9 +240,8 @@ describe("RsvpView", () => {
 
     await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
 
-    // Open the record list for an unresponded guest.
-    fireEvent.click(screen.getByText(/Record a reply for another guest/i));
-    fireEvent.click(screen.getByRole("button", { name: /Record/i }));
+    // Cleo hasn't replied; her row carries the Record button.
+    fireEvent.click(screen.getByRole("button", { name: /^Record$/i }));
 
     // Enter dietary text → the consent checkbox appears + gates submit.
     const dietary = await screen.findByLabelText(/Dietary requirements/i);

--- a/cire/host/src/components/RsvpView.tsx
+++ b/cire/host/src/components/RsvpView.tsx
@@ -1,10 +1,22 @@
 import { useAuth } from "@shared/rp-auth/solid";
-import { createSignal, For, onMount, Show } from "solid-js";
+import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { haptic } from "../lib/haptics";
+import {
+  filterRows,
+  mergeRows,
+  RSVP_FILTERS,
+  type RsvpFilterEvent,
+  type RsvpFilterKey,
+  type RsvpRow,
+  type RsvpRowStatus,
+  type RsvpStatus,
+  statusCounts,
+} from "../lib/rsvp-filter";
 import SectionIntro from "./SectionIntro";
 import EmptyState from "./ui/EmptyState";
+import Field, { Input } from "./ui/Field";
 import Notice from "./ui/Notice";
 import { Table, Td, Th } from "./ui/Table";
 
@@ -14,29 +26,7 @@ interface RsvpViewProps {
   canEdit?: boolean;
 }
 
-type RsvpStatus = "attending" | "declined" | "maybe";
-type ConsentSource = "guest" | "organiser_attested";
-
-interface RsvpViewGuest {
-  guestId: string;
-  firstName: string;
-  lastName: string;
-  familyName: string;
-  familyCode: string;
-  status: RsvpStatus;
-  dietary: string;
-  consentSource: ConsentSource;
-}
-
-interface RsvpViewInvitedGuest {
-  guestId: string;
-  firstName: string;
-  lastName: string;
-  familyName: string;
-  familyCode: string;
-}
-
-interface RsvpViewEvent {
+interface RsvpViewEvent extends RsvpFilterEvent {
   id: string;
   name: string;
   invited: number;
@@ -45,16 +35,23 @@ interface RsvpViewEvent {
   maybe: number;
   responded: number;
   noResponse: number;
-  guests: RsvpViewGuest[];
-  unresponded: RsvpViewInvitedGuest[];
 }
 
-/** Human label + badge styling per RSVP status. */
-const STATUS_META: Record<RsvpStatus, { label: string; class: string }> = {
+/** Human label + badge styling per row status. "No reply" is deliberately the
+ *  quiet one: it is the most common state early on, and a loud badge on every
+ *  second row would drown the answers that did come in. */
+const STATUS_META: Record<RsvpRowStatus, { label: string; class: string }> = {
   attending: { label: "Attending", class: "bg-gold text-bg" },
   declined: { label: "Declined", class: "border-error/40 text-error border" },
   maybe: { label: "Maybe", class: "border-gold/40 text-gold border" },
+  none: { label: "No reply", class: "border-border text-text-muted border" },
 };
+
+const CHIP_CLASS =
+  "border-border hover:border-gold focus-visible:border-gold focus-visible:ring-gold/40 " +
+  "font-body text-text-muted aria-pressed:border-gold aria-pressed:text-gold " +
+  "flex items-center gap-1.5 rounded-sm border px-3 py-1.5 text-[0.75rem] tracking-[0.06em] " +
+  "uppercase transition outline-none focus-visible:ring-2";
 
 /** Identifies the row being edited (event + guest) so only one form is open. */
 interface EditTarget {
@@ -66,18 +63,26 @@ interface EditTarget {
 }
 
 /**
- * In-dashboard RSVP summary. Per event: a status tally and the guests who
- * responded, with status + dietary + a provenance badge (organiser-entered vs
- * guest-submitted). Editors additionally get a "Record / edit" affordance to
- * enter a phone/paper RSVP on a guest's behalf — the API stamps such rows
+ * In-dashboard RSVP summary. Per event: a status tally and every guest invited
+ * to it — those who replied, with status + dietary + a provenance badge
+ * (organiser-entered vs guest-submitted), and those who have not, as "No reply"
+ * rows in the same list. Above them sits one search box and one set of status
+ * chips, applied to every event at once.
+ *
+ * Editors get a "Record / Edit" button in each row to enter a phone/paper RSVP
+ * on a guest's behalf — the API stamps such rows
  * `consent_source='organiser_attested'` and they VISIBLY OVERWRITE a prior
- * guest reply (platform-plan §3.3). Viewers see the read-only view.
+ * guest reply (platform-plan §3.3). Viewers see the same list, read-only.
  */
 export default function RsvpView(props: RsvpViewProps) {
   const { authFetch } = useAuth();
   const [events, setEvents] = createSignal<RsvpViewEvent[]>([]);
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
+
+  // The control bar: a search box and one status chip, applied to every event.
+  const [query, setQuery] = createSignal("");
+  const [filter, setFilter] = createSignal<RsvpFilterKey>("all");
 
   // The open editor form (one at a time), plus its transient field state.
   const [edit, setEdit] = createSignal<EditTarget | null>(null);
@@ -105,7 +110,15 @@ export default function RsvpView(props: RsvpViewProps) {
   onMount(load);
 
   const hasEvents = () => events().length > 0;
-  const hasReplies = (event: RsvpViewEvent) => event.guests.length > 0;
+  /** Every guest invited to this event, replied or not, before filtering. */
+  const rowsFor = (event: RsvpViewEvent) => mergeRows(event);
+  const shownFor = (event: RsvpViewEvent) => filterRows(rowsFor(event), query(), filter());
+
+  const counts = createMemo(() => statusCounts(events()));
+  const shownCount = createMemo(() =>
+    events().reduce((total, event) => total + shownFor(event).length, 0),
+  );
+  const filtering = () => query().trim().length > 0 || filter() !== "all";
 
   const openEditor = (
     eventId: string,
@@ -125,6 +138,16 @@ export default function RsvpView(props: RsvpViewProps) {
       status: existing?.status ?? "attending",
       dietary: existing?.dietary ?? "",
     });
+  };
+
+  /** Open the editor on a list row: prefilled when there is a reply to edit,
+   *  blank when the guest has said nothing yet. */
+  const openRow = (eventId: string, row: RsvpRow) => {
+    if (row.responded && row.status !== "none") {
+      openEditor(eventId, row, { status: row.status, dietary: row.dietary });
+      return;
+    }
+    openEditor(eventId, row);
   };
 
   const closeEditor = () => {
@@ -197,8 +220,8 @@ export default function RsvpView(props: RsvpViewProps) {
         title="Replies at a glance"
         description={
           props.canEdit
-            ? "Who's coming to each event, with dietary notes. Record a phone or paper reply on a guest's behalf — it overwrites any earlier answer and is marked as host-entered."
-            : "Who's coming to each event, with dietary notes — updated as guests reply. Read-only; download the full sheet from the Guests tab."
+            ? "Who's coming to each event, with dietary notes and who still owes a reply. Search or filter to find a guest, then record a phone or paper reply on their behalf — it overwrites any earlier answer and is marked as host-entered."
+            : "Who's coming to each event, with dietary notes and who still owes a reply — updated as guests reply. Read-only; download the full sheet from the Guests tab."
         }
       />
 
@@ -222,6 +245,46 @@ export default function RsvpView(props: RsvpViewProps) {
       </Show>
 
       <Show when={!loading() && !error() && hasEvents()}>
+        {/* One bar for the whole page, not one per event: the question a host
+            asks — who still owes a reply, who has an allergy — is asked of the
+            wedding, and each section keeps its own tallies below regardless. */}
+        <div class="flex flex-col gap-2">
+          <div class="border-border bg-surface/20 flex flex-wrap items-center gap-3 rounded-sm border p-4">
+            <Field label="Search guests" labelHidden class="min-w-[12rem] flex-1">
+              {(field) => (
+                <Input
+                  {...field}
+                  type="search"
+                  value={query()}
+                  onInput={(e) => setQuery(e.currentTarget.value)}
+                  placeholder="Search a name, household, code or dietary note…"
+                />
+              )}
+            </Field>
+            <div class="flex flex-wrap gap-2" role="group" aria-label="Filter by reply">
+              <For each={RSVP_FILTERS}>
+                {(chip) => (
+                  <button
+                    type="button"
+                    class={CHIP_CLASS}
+                    aria-pressed={filter() === chip.key}
+                    onClick={() => setFilter(chip.key)}
+                  >
+                    {chip.label}
+                    <span class="text-text font-mono text-[0.72rem]">{counts()[chip.key]}</span>
+                  </button>
+                )}
+              </For>
+            </div>
+          </div>
+          {/* Announced, because narrowing to nothing is otherwise silent. */}
+          <p role="status" class="font-body text-text-muted text-[0.78rem]">
+            <Show when={filtering()}>
+              Showing {shownCount()} of {counts().all} guests.
+            </Show>
+          </p>
+        </div>
+
         <div class="flex flex-col gap-10">
           <For each={events()}>
             {(event) => (
@@ -255,123 +318,90 @@ export default function RsvpView(props: RsvpViewProps) {
                 </header>
 
                 <Show
-                  when={hasReplies(event)}
+                  when={rowsFor(event).length > 0}
                   fallback={
                     <p class="font-body text-text-muted text-[0.82rem] italic">
-                      No replies yet for this event.
+                      No guests to show for this event.
                     </p>
                   }
                 >
-                  <Table label={`Replies for ${event.name}`} class="font-body">
-                    <caption class="sr-only">RSVPs for {event.name}</caption>
-                    <thead>
-                      <tr>
-                        <Th>Guest</Th>
-                        <Th>Household</Th>
-                        <Th>Status</Th>
-                        <Th>Dietary</Th>
-                        <Show when={props.canEdit}>
-                          <Th class="text-right">
-                            <span class="sr-only">Actions</span>
-                          </Th>
-                        </Show>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <For each={event.guests}>
-                        {(guest) => (
-                          <>
-                            <tr class="hover:[&>td]:bg-surface">
-                              <Td class="align-middle">
-                                {guest.firstName} {guest.lastName}
-                                <Show when={guest.consentSource === "organiser_attested"}>
-                                  {" "}
-                                  <span
-                                    class="border-gold/40 text-gold ml-1 inline-block rounded-sm border px-1.5 py-0.5 text-[0.55rem] tracking-[0.12em] uppercase"
-                                    title="Recorded by a host (phone/paper RSVP)"
-                                  >
-                                    Host-entered
-                                  </span>
-                                </Show>
-                              </Td>
-                              <Td class="text-text-muted align-middle">{guest.familyName}</Td>
-                              <Td class="align-middle">
-                                <span
-                                  class={`font-body inline-block rounded-sm px-1.5 py-0.5 text-[0.6rem] tracking-[0.14em] uppercase ${STATUS_META[guest.status].class}`}
-                                >
-                                  {STATUS_META[guest.status].label}
-                                </span>
-                              </Td>
-                              <Td class="text-text-muted align-middle">
-                                <Show
-                                  when={guest.dietary.trim().length > 0}
-                                  fallback={<span class="text-text-muted">--</span>}
-                                >
-                                  {guest.dietary}
-                                </Show>
-                              </Td>
-                              <Show when={props.canEdit}>
-                                <Td class="text-right align-middle">
-                                  <button
-                                    type="button"
-                                    class="border-border text-text-muted hover:text-text hover:border-gold/40 rounded-sm border px-2.5 py-1 text-[0.7rem] tracking-[0.08em] uppercase"
-                                    onClick={() =>
-                                      openEditor(event.id, guest, {
-                                        status: guest.status,
-                                        dietary: guest.dietary,
-                                      })
-                                    }
-                                  >
-                                    Edit
-                                  </button>
+                  <Show
+                    when={shownFor(event).length > 0}
+                    fallback={
+                      <p class="font-body text-text-muted text-[0.82rem] italic">
+                        No guests match this filter.
+                      </p>
+                    }
+                  >
+                    <Table label={`Replies for ${event.name}`} class="font-body">
+                      <caption class="sr-only">RSVPs for {event.name}</caption>
+                      <thead>
+                        <tr>
+                          <Th>Guest</Th>
+                          <Th>Household</Th>
+                          <Th>Status</Th>
+                          <Th>Dietary</Th>
+                          <Show when={props.canEdit}>
+                            <Th class="text-right">
+                              <span class="sr-only">Actions</span>
+                            </Th>
+                          </Show>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <For each={shownFor(event)}>
+                          {(row) => (
+                            <>
+                              <tr class="hover:[&>td]:bg-surface">
+                                <Td class="align-middle">
+                                  {row.firstName} {row.lastName}
+                                  <Show when={row.consentSource === "organiser_attested"}>
+                                    {" "}
+                                    <span
+                                      class="border-gold/40 text-gold ml-1 inline-block rounded-sm border px-1.5 py-0.5 text-[0.55rem] tracking-[0.12em] uppercase"
+                                      title="Recorded by a host (phone/paper RSVP)"
+                                    >
+                                      Host-entered
+                                    </span>
+                                  </Show>
                                 </Td>
+                                <Td class="text-text-muted align-middle">{row.familyName}</Td>
+                                <Td class="align-middle">
+                                  <span
+                                    class={`font-body inline-block rounded-sm px-1.5 py-0.5 text-[0.6rem] tracking-[0.14em] uppercase ${STATUS_META[row.status].class}`}
+                                  >
+                                    {STATUS_META[row.status].label}
+                                  </span>
+                                </Td>
+                                <Td class="text-text-muted align-middle">
+                                  <Show
+                                    when={row.dietary.trim().length > 0}
+                                    fallback={<span class="text-text-muted">--</span>}
+                                  >
+                                    {row.dietary}
+                                  </Show>
+                                </Td>
+                                <Show when={props.canEdit}>
+                                  <Td class="text-right align-middle">
+                                    <button
+                                      type="button"
+                                      class="border-border text-text-muted hover:text-text hover:border-gold/40 rounded-sm border px-2.5 py-1 text-[0.7rem] tracking-[0.08em] uppercase"
+                                      onClick={() => openRow(event.id, row)}
+                                    >
+                                      {row.responded ? "Edit" : "Record"}
+                                    </button>
+                                  </Td>
+                                </Show>
+                              </tr>
+                              <Show when={props.canEdit && isEditing(event.id, row.guestId)}>
+                                {renderEditorRow()}
                               </Show>
-                            </tr>
-                            <Show when={props.canEdit && isEditing(event.id, guest.guestId)}>
-                              {renderEditorRow()}
-                            </Show>
-                          </>
-                        )}
-                      </For>
-                    </tbody>
-                  </Table>
-                </Show>
-
-                {/* Record a reply for an invited guest who hasn't responded. */}
-                <Show when={props.canEdit && event.unresponded.length > 0}>
-                  <details class="border-border bg-surface/40 rounded-sm border">
-                    <summary class="font-body text-text-muted hover:text-text cursor-pointer px-4 py-2.5 text-[0.78rem]">
-                      Record a reply for another guest ({event.unresponded.length} awaiting)
-                    </summary>
-                    <ul class="flex flex-col gap-1 px-4 pb-3">
-                      <For each={event.unresponded}>
-                        {(guest) => (
-                          <li>
-                            <Show
-                              when={isEditing(event.id, guest.guestId)}
-                              fallback={
-                                <button
-                                  type="button"
-                                  class="text-text-muted hover:text-gold flex w-full items-center justify-between gap-3 py-1.5 text-left text-[0.84rem]"
-                                  onClick={() => openEditor(event.id, guest)}
-                                >
-                                  <span>
-                                    {guest.firstName} {guest.lastName}
-                                    <span class="text-text-muted"> — {guest.familyName}</span>
-                                  </span>
-                                  <span class="text-gold text-[0.72rem] tracking-[0.08em] uppercase">
-                                    Record
-                                  </span>
-                                </button>
-                              }
-                            >
-                              <div class="py-2">{renderEditorForm(guest)}</div>
-                            </Show>
-                          </li>
-                        )}
-                      </For>
-                    </ul>
-                  </details>
+                            </>
+                          )}
+                        </For>
+                      </tbody>
+                    </Table>
+                  </Show>
                 </Show>
               </section>
             )}
@@ -381,8 +411,8 @@ export default function RsvpView(props: RsvpViewProps) {
     </div>
   );
 
-  /** The editor form body, shared by the responded-row and unresponded-list
-   *  entry points. `label` names the guest being edited. */
+  /** The editor form body. `guest` names whoever the reply is being recorded
+   *  for — the form reads the same whether or not they answered before. */
   function renderEditorForm(guest: { firstName: string; lastName: string }) {
     return (
       <form
@@ -466,14 +496,14 @@ export default function RsvpView(props: RsvpViewProps) {
     );
   }
 
-  /** The editor form wrapped in a full-width table row (for the responded table). */
+  /** The editor form wrapped in a full-width row, opened under the row it edits. */
   function renderEditorRow() {
     const target = edit();
     if (!target) return null;
     const [firstName, ...rest] = target.guestName.split(" ");
     return (
       <tr>
-        <td colSpan={5} class="border-border border-b px-4 py-3">
+        <td colSpan={props.canEdit ? 5 : 4} class="border-border border-b px-4 py-3">
           {renderEditorForm({ firstName: firstName ?? "", lastName: rest.join(" ") })}
         </td>
       </tr>

--- a/cire/host/src/lib/rsvp-filter.test.ts
+++ b/cire/host/src/lib/rsvp-filter.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterRows,
+  mergeRows,
+  type RsvpFilterEvent,
+  RSVP_FILTERS,
+  statusCounts,
+} from "./rsvp-filter";
+
+/**
+ * The RSVP list's search + status filter. The payload arrives split in two —
+ * `guests` (replied) and `unresponded` (invited, silent) — and the view shows
+ * them as one list, so the merge and the predicate live here rather than in the
+ * component.
+ */
+
+const CEREMONY: RsvpFilterEvent = {
+  guests: [
+    {
+      guestId: "g1",
+      firstName: "Ada",
+      lastName: "Sharma",
+      familyName: "Sharma",
+      familyCode: "SHARMA-WIDGET-AB3K9",
+      status: "attending",
+      dietary: "Gluten free",
+      consentSource: "guest",
+    },
+    {
+      guestId: "g2",
+      firstName: "Bo",
+      lastName: "Jones",
+      familyName: "Jones",
+      familyCode: "JONES-KITE-77Q2",
+      status: "declined",
+      dietary: "",
+      consentSource: "organiser_attested",
+    },
+    {
+      guestId: "g4",
+      firstName: "Dev",
+      lastName: "Rao",
+      familyName: "Rao",
+      familyCode: "RAO-EMBER-51X8",
+      status: "maybe",
+      dietary: "Nut allergy",
+      consentSource: "guest",
+    },
+  ],
+  unresponded: [
+    {
+      guestId: "g3",
+      firstName: "Cleo",
+      lastName: "Jones",
+      familyName: "Jones",
+      familyCode: "JONES-KITE-77Q2",
+    },
+  ],
+};
+
+const RECEPTION: RsvpFilterEvent = {
+  guests: [
+    {
+      guestId: "g1",
+      firstName: "Ada",
+      lastName: "Sharma",
+      familyName: "Sharma",
+      familyCode: "SHARMA-WIDGET-AB3K9",
+      status: "attending",
+      dietary: "Gluten free",
+      consentSource: "guest",
+    },
+  ],
+  unresponded: [],
+};
+
+const ids = (rows: ReturnType<typeof mergeRows>) => rows.map((r) => r.guestId);
+
+describe("mergeRows", () => {
+  it("puts replies first, then the silent guests as status 'none'", () => {
+    const rows = mergeRows(CEREMONY);
+    expect(ids(rows)).toEqual(["g1", "g2", "g4", "g3"]);
+    expect(rows.at(-1)).toMatchObject({
+      guestId: "g3",
+      status: "none",
+      dietary: "",
+      responded: false,
+    });
+  });
+
+  it("keeps the provenance of a reply and leaves it off a non-reply", () => {
+    const rows = mergeRows(CEREMONY);
+    expect(rows[1]).toMatchObject({ consentSource: "organiser_attested", responded: true });
+    expect(rows[3]?.consentSource).toBeNull();
+  });
+
+  it("handles an event nobody has replied to", () => {
+    expect(mergeRows({ guests: [], unresponded: [] })).toEqual([]);
+  });
+});
+
+describe("filterRows", () => {
+  const rows = mergeRows(CEREMONY);
+
+  it("returns everything for the default filter and an empty query", () => {
+    expect(ids(filterRows(rows, "", "all"))).toEqual(["g1", "g2", "g4", "g3"]);
+  });
+
+  it("narrows to one status, no-reply included", () => {
+    expect(ids(filterRows(rows, "", "attending"))).toEqual(["g1"]);
+    expect(ids(filterRows(rows, "", "declined"))).toEqual(["g2"]);
+    expect(ids(filterRows(rows, "", "maybe"))).toEqual(["g4"]);
+    expect(ids(filterRows(rows, "", "none"))).toEqual(["g3"]);
+  });
+
+  it("matches a name case-insensitively, first or last", () => {
+    expect(ids(filterRows(rows, "ADA", "all"))).toEqual(["g1"]);
+    expect(ids(filterRows(rows, "sharma", "all"))).toEqual(["g1"]);
+  });
+
+  it("matches a full name across the gap, however it is spaced", () => {
+    expect(ids(filterRows(rows, "  ada   sharma ", "all"))).toEqual(["g1"]);
+  });
+
+  it("matches every term in any order, not the typed phrase", () => {
+    expect(ids(filterRows(rows, "jones cleo", "all"))).toEqual(["g3"]);
+  });
+
+  it("matches the household name and the household code", () => {
+    expect(ids(filterRows(rows, "jones", "all"))).toEqual(["g2", "g3"]);
+    expect(ids(filterRows(rows, "kite-77q2", "all"))).toEqual(["g2", "g3"]);
+  });
+
+  it("matches dietary text, so a caterer can find an allergen", () => {
+    expect(ids(filterRows(rows, "nut", "all"))).toEqual(["g4"]);
+  });
+
+  it("applies the query and the status together", () => {
+    expect(ids(filterRows(rows, "jones", "none"))).toEqual(["g3"]);
+    expect(ids(filterRows(rows, "jones", "attending"))).toEqual([]);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(filterRows(rows, "zzzz", "all")).toEqual([]);
+  });
+});
+
+describe("statusCounts", () => {
+  it("sums each status across every event, with 'all' as the total", () => {
+    expect(statusCounts([CEREMONY, RECEPTION])).toEqual({
+      all: 5,
+      attending: 2,
+      declined: 1,
+      maybe: 1,
+      none: 1,
+    });
+  });
+
+  it("counts nothing for a wedding with no events", () => {
+    expect(statusCounts([])).toEqual({ all: 0, attending: 0, declined: 0, maybe: 0, none: 0 });
+  });
+
+  it("names every filter the chips render", () => {
+    expect(RSVP_FILTERS.map((f) => f.key)).toEqual([
+      "all",
+      "attending",
+      "declined",
+      "maybe",
+      "none",
+    ]);
+  });
+});

--- a/cire/host/src/lib/rsvp-filter.ts
+++ b/cire/host/src/lib/rsvp-filter.ts
@@ -1,0 +1,143 @@
+/**
+ * Search and status filtering for the RSVP list.
+ *
+ * ## Why the merge lives here
+ *
+ * The API hands each event two lists: `guests`, who replied, and `unresponded`,
+ * who were invited and have said nothing. The view shows one list, because the
+ * question a host actually asks — "who still hasn't answered?" — spans both, and
+ * a silent guest is the row they most want to act on. So the two collapse into
+ * one row type with a fourth status, `"none"`, and the filter treats it like any
+ * other.
+ *
+ * ## Why every term must match, not the phrase
+ *
+ * A host types what they remember, in the order they remember it: "jones cleo".
+ * A substring test on the whole phrase fails that; testing each word against the
+ * row's text does not. It also makes "sharma gluten" a way to ask a narrower
+ * question without any extra controls.
+ *
+ * Dietary text is part of what a word can match on purpose. "Search nut" is the
+ * caterer's question, and it has no other home in the portal.
+ */
+
+export type RsvpStatus = "attending" | "declined" | "maybe";
+/** A row's status, including the guests who have not replied at all. */
+export type RsvpRowStatus = RsvpStatus | "none";
+/** What the chips filter by — every status, plus the unfiltered default. */
+export type RsvpFilterKey = "all" | RsvpRowStatus;
+export type ConsentSource = "guest" | "organiser_attested";
+
+export interface RsvpFilterGuest {
+  guestId: string;
+  firstName: string;
+  lastName: string;
+  familyName: string;
+  familyCode: string;
+  status: RsvpStatus;
+  dietary: string;
+  consentSource: ConsentSource;
+}
+
+export interface RsvpFilterInvitedGuest {
+  guestId: string;
+  firstName: string;
+  lastName: string;
+  familyName: string;
+  familyCode: string;
+}
+
+export interface RsvpFilterEvent {
+  guests: RsvpFilterGuest[];
+  unresponded: RsvpFilterInvitedGuest[];
+}
+
+export interface RsvpRow {
+  guestId: string;
+  firstName: string;
+  lastName: string;
+  familyName: string;
+  familyCode: string;
+  status: RsvpRowStatus;
+  dietary: string;
+  /** Null on a row nobody has answered for — there is no reply to attribute. */
+  consentSource: ConsentSource | null;
+  responded: boolean;
+}
+
+export const RSVP_FILTERS: readonly { key: RsvpFilterKey; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "attending", label: "Attending" },
+  { key: "declined", label: "Declined" },
+  { key: "maybe", label: "Maybe" },
+  { key: "none", label: "No reply" },
+];
+
+/** Replies in the order the API gave them, then the guests who owe one. */
+export function mergeRows(event: RsvpFilterEvent): RsvpRow[] {
+  const replied: RsvpRow[] = event.guests.map((guest) => ({
+    guestId: guest.guestId,
+    firstName: guest.firstName,
+    lastName: guest.lastName,
+    familyName: guest.familyName,
+    familyCode: guest.familyCode,
+    status: guest.status,
+    dietary: guest.dietary,
+    consentSource: guest.consentSource,
+    responded: true,
+  }));
+  const silent: RsvpRow[] = event.unresponded.map((guest) => ({
+    guestId: guest.guestId,
+    firstName: guest.firstName,
+    lastName: guest.lastName,
+    familyName: guest.familyName,
+    familyCode: guest.familyCode,
+    status: "none",
+    dietary: "",
+    consentSource: null,
+    responded: false,
+  }));
+  return [...replied, ...silent];
+}
+
+/** Everything about a row a word can land on, lower-cased once per test. */
+function haystack(row: RsvpRow): string {
+  return `${row.firstName} ${row.lastName} ${row.familyName} ${row.familyCode} ${row.dietary}`.toLowerCase();
+}
+
+function terms(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/** Rows matching both the typed words and the chosen status. */
+export function filterRows(rows: RsvpRow[], query: string, filter: RsvpFilterKey): RsvpRow[] {
+  const words = terms(query);
+  return rows.filter((row) => {
+    if (filter !== "all" && row.status !== filter) return false;
+    if (words.length === 0) return true;
+    const text = haystack(row);
+    return words.every((word) => text.includes(word));
+  });
+}
+
+/**
+ * How many rows each chip would show, summed over every event. A guest invited
+ * to three events counts three times — the chips label rows, and rows are what
+ * the list shows.
+ */
+export function statusCounts(events: RsvpFilterEvent[]): Record<RsvpFilterKey, number> {
+  const counts: Record<RsvpFilterKey, number> = {
+    all: 0,
+    attending: 0,
+    declined: 0,
+    maybe: 0,
+    none: 0,
+  };
+  for (const event of events) {
+    for (const row of mergeRows(event)) {
+      counts.all += 1;
+      counts[row.status] += 1;
+    }
+  }
+  return counts;
+}


### PR DESCRIPTION
## What

The organiser RSVP list gets a search box and status chips, over one merged list of guests per event.

Before, the table held only the guests who had replied; everyone still silent sat in an editor-only `<details>` disclosure underneath it. So the question a host actually asks — who has not answered yet — had to be read out of a collapsed list, and a viewer could not see it at all.

- **One list per event.** Replies and non-replies are rows in the same table. A guest who has not answered carries a muted **No reply** badge and, for an editor, a `Record` button in the column `Edit` already used. The `<details>` disclosure is gone.
- **One control bar for the page**, not one per event: a search box plus chips — All / Attending / Declined / Maybe / No reply — each showing a count summed across every event. A host scans the whole wedding for who owes a reply; the per-event tallies still sit in each section header.
- **Search** matches a name, the household name, the household code and the dietary note. Every typed word has to match, in any order, so `jones cleo` and `sharma gluten` both work. Dietary text is searchable on purpose — "search nut" is the caterer's question and it has no other home in the portal.
- **Sections never disappear.** The header and its tallies stay as the unfiltered truth; a section left with nothing says "No guests match this filter". A live region reports how many of the total are showing.

## Where

- `cire/host/src/lib/rsvp-filter.ts` — new, pure: `mergeRows` / `filterRows` / `statusCounts`. The logic sits here rather than in the component, which was already 480 lines, and it unit-tests without a DOM.
- `cire/host/src/components/RsvpView.tsx` — control bar, unified rows, disclosure removed.
- Tests for both.

## Notes

- **No API change.** `GET /api/organiser/weddings/:id/rsvps` already returned `guests` and `unresponded`; all of this is client-side.
- **Deliberate behaviour change:** a viewer (`canEdit` falsy) now sees who has not replied, read-only. They could not before. Agreed up front.
- Chip counts are per row, so a guest invited to three events counts three times — the chips label rows, and rows are what the list shows.
- Not in scope: URL persistence of the filter, sort controls, server-side filtering.

## Testing

- `bun run --cwd cire/host test` — 1056 passed (80 files), including 15 new filter unit tests and 4 new component tests (chip filtering, search across the three fields, the no-match note, and `Record` still opening the editor for a guest who has not replied).
- `bun run check` — clean.

Worth a look on the Pages preview: the chip row's wrap behaviour on a narrow screen, and whether "No reply" is quiet enough next to the three answered states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
