### PR TITLE
fix(cire-host): apply the review gate to the RSVP search and filter

### DIFF
--- a/.changeset/cire-host-rsvp-filter-review.md
+++ b/.changeset/cire-host-rsvp-filter-review.md
@@ -1,0 +1,5 @@
+---
+"@cire/host": patch
+---
+
+Apply the review gate to the host RSVP search and filter. Each row now carries the lower-cased text it matches on, built once at merge time instead of per keystroke; the merge and the filter each run once per render rather than four times per event; the status tallies count the merged rows the list already holds. Each row's Edit or Record button names the guest it belongs to, the match count is announced to screen readers on a short delay instead of on every keystroke, and an open editor closes when a filter hides its row.

--- a/cire/host/src/components/RsvpView.test.tsx
+++ b/cire/host/src/components/RsvpView.test.tsx
@@ -31,24 +31,48 @@ function json(body: unknown, status = 200) {
   });
 }
 
+const ADA = {
+  guestId: "g1",
+  firstName: "Ada",
+  lastName: "Sharma",
+  familyName: "Sharma",
+  familyCode: "SHARMA-WIDGET-AB3K9",
+};
+const CLEO = {
+  guestId: "g3",
+  firstName: "Cleo",
+  lastName: "Jones",
+  familyName: "Jones",
+  familyCode: "JONES-KITE-77Q2",
+};
+const DEV = {
+  guestId: "g4",
+  firstName: "Dev",
+  lastName: "Rao",
+  familyName: "Rao",
+  familyCode: "RAO-EMBER-51X8",
+};
+
+/**
+ * Three events, and the tallies match the lists: `noResponse` is exactly the
+ * length of `unresponded`, because that is the contract the API upholds. Ada is
+ * invited to two of them, so a row count and a guest count differ — which is
+ * what the status line has to get right.
+ */
 const VIEW = {
   events: [
     {
       id: "evt_1",
       name: "Ceremony",
       invited: 4,
-      attending: 2,
+      attending: 1,
       declined: 1,
-      maybe: 0,
+      maybe: 1,
       responded: 3,
       noResponse: 1,
       guests: [
         {
-          guestId: "g1",
-          firstName: "Ada",
-          lastName: "Sharma",
-          familyName: "Sharma",
-          familyCode: "SHARMA-WIDGET-AB3K9",
+          ...ADA,
           status: "attending" as const,
           dietary: "Gluten free",
           consentSource: "guest" as const,
@@ -63,16 +87,14 @@ const VIEW = {
           dietary: "",
           consentSource: "organiser_attested" as const,
         },
-      ],
-      unresponded: [
         {
-          guestId: "g3",
-          firstName: "Cleo",
-          lastName: "Jones",
-          familyName: "Jones",
-          familyCode: "JONES-KITE-77Q2",
+          ...DEV,
+          status: "maybe" as const,
+          dietary: "Nut allergy",
+          consentSource: "guest" as const,
         },
       ],
+      unresponded: [CLEO],
     },
     {
       id: "evt_2",
@@ -84,10 +106,34 @@ const VIEW = {
       responded: 0,
       noResponse: 2,
       guests: [],
+      unresponded: [ADA, DEV],
+    },
+    {
+      id: "evt_3",
+      name: "Welcome drinks",
+      invited: 0,
+      attending: 0,
+      declined: 0,
+      maybe: 0,
+      responded: 0,
+      noResponse: 0,
+      guests: [],
       unresponded: [],
     },
   ],
 };
+
+// Six rows over three events: 1 attending, 1 declined, 1 maybe, 3 no-reply.
+
+/** The `dd` beside a tally's `dt`, so "Attending 1" is read as a pair. */
+function tally(section: HTMLElement, label: string) {
+  const dt = within(section).getByText(label, { selector: "dt" });
+  return dt.parentElement?.querySelector("dd")?.textContent;
+}
+
+const chips = () => screen.getByRole("group", { name: "Filter by reply" });
+const chip = (name: RegExp) => within(chips()).getByRole("button", { name });
+const searchBox = () => screen.getByLabelText("Search guests");
 
 describe("RsvpView", () => {
   afterEach(() => {
@@ -114,19 +160,28 @@ describe("RsvpView", () => {
     expect(within(tbody as HTMLElement).getByText("Attending")).toBeTruthy();
     expect(within(tbody as HTMLElement).getByText("Declined")).toBeTruthy();
 
-    // The tally numbers are present (attending 2, no-reply 1, invited 4).
-    const dl = ceremony.querySelector("dl")!;
-    expect(dl.textContent).toContain("2");
-    expect(dl.textContent).toContain("4");
+    // Each tally reads as its own pair, not as digits loose in the header.
+    expect(tally(ceremony, "Attending")).toBe("1");
+    expect(tally(ceremony, "Declined")).toBe("1");
+    expect(tally(ceremony, "Maybe")).toBe("1");
+    expect(tally(ceremony, "No reply")).toBe("1");
+    expect(tally(ceremony, "Invited")).toBe("4");
   });
 
   it("shows a per-event empty note when the event has no guests at all", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
 
-    await waitFor(() => expect(screen.getByText("Reception")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Welcome drinks")).toBeTruthy());
+    // Nobody is invited to this one — distinct from an event whose guests are
+    // all silent, which lists them as "No reply" rows.
+    const drinks = screen.getByText("Welcome drinks").closest("section")!;
+    expect(within(drinks).getByText(/No guests to show/i)).toBeTruthy();
+
     const reception = screen.getByText("Reception").closest("section")!;
-    expect(within(reception).getByText(/No guests to show/i)).toBeTruthy();
+    expect(within(reception).queryByText(/No guests to show/i)).toBeNull();
+    expect(within(reception).getAllByText("No reply", { selector: "span" })).toHaveLength(2);
+    expect(tally(reception, "No reply")).toBe("2");
   });
 
   it("lists a guest who has not replied in the same table, badged No reply", async () => {
@@ -156,6 +211,27 @@ describe("RsvpView", () => {
     await waitFor(() => expect(screen.getByText(/Could not load RSVPs/i)).toBeTruthy());
   });
 
+  it("keeps one live region mounted, silent until it has something to say", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    // Mounted from the start: a region created at the moment it fills is not
+    // announced by most screen readers.
+    const live = screen.getByRole("status");
+    expect(live.textContent).toBe("");
+
+    fireEvent.input(searchBox(), { target: { value: "jones" } });
+    // The printed count is immediate; the announcement waits for the typing to
+    // stop, so it never reads a number the host has already typed past.
+    expect(screen.getByText(/Showing 2 of 6 guest rows/i)).toBeTruthy();
+    expect(live.textContent).toBe("");
+    await waitFor(() => expect(live.textContent).toMatch(/Showing 2 of 6 guest rows/i));
+
+    fireEvent.input(searchBox(), { target: { value: "" } });
+    await waitFor(() => expect(live.textContent).toBe(""));
+  });
+
   it("badges a host-entered reply distinctly from a guest-submitted one", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
@@ -169,64 +245,122 @@ describe("RsvpView", () => {
   it("does not show record/edit controls for a viewer (canEdit falsy)", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
-    expect(screen.queryByRole("button", { name: /^Edit$/i })).toBeNull();
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /^Edit reply for/i })).toBeNull();
     // The no-reply row is still listed — a viewer may read it, not act on it.
     expect(screen.getByText("Cleo Jones")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^Record$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Record reply for/i })).toBeNull();
+  });
+
+  it("names each row's control after the guest it acts on", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" canEdit />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    // A screen reader lands on six identical "Edit"/"Record" buttons otherwise.
+    expect(screen.getByRole("button", { name: "Edit reply for Ada Sharma" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Record reply for Cleo Jones" })).toBeTruthy();
+    // Ada is invited to two events and silent on one: two rows, two names.
+    expect(screen.getByRole("button", { name: "Record reply for Ada Sharma" })).toBeTruthy();
   });
 
   it("filters every event by a status chip", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
 
-    // The chip carries its count: 1 guest owes a reply across both events.
-    const noReply = screen.getByRole("button", { name: /^No reply/i });
-    expect(noReply.textContent).toContain("1");
+    // The chip carries its count: three rows owe a reply across the events.
+    const noReply = chip(/^No reply/i);
+    expect(noReply.textContent).toContain("3");
+    // "All" is the pressed one until a host picks another.
+    expect(chip(/^All/i).getAttribute("aria-pressed")).toBe("true");
 
     fireEvent.click(noReply);
     expect(noReply.getAttribute("aria-pressed")).toBe("true");
-    expect(screen.getByText("Cleo Jones")).toBeTruthy();
-    expect(screen.queryByText("Ada Sharma")).toBeNull();
-    expect(screen.getByText(/Showing 1 of 3 guests/i)).toBeTruthy();
+    expect(chip(/^All/i).getAttribute("aria-pressed")).toBe("false");
+    expect(
+      within(chips())
+        .getAllByRole("button")
+        .filter((b) => b.getAttribute("aria-pressed") === "true"),
+    ).toHaveLength(1);
+
+    const ceremony = screen.getByText("Ceremony").closest("section")!;
+    expect(within(ceremony).getByText("Cleo Jones")).toBeTruthy();
+    expect(within(ceremony).queryByText("Ada Sharma")).toBeNull();
+    expect(screen.getByText(/Showing 3 of 6 guest rows/i)).toBeTruthy();
 
     // The event sections stay put, with their tallies, and say why they're bare.
     expect(screen.getByText("Reception")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: /^Attending/i }));
-    const ceremony = screen.getByText("Ceremony").closest("section")!;
+    fireEvent.click(chip(/^Attending/i));
     expect(within(ceremony).getByText("Ada Sharma")).toBeTruthy();
     expect(within(ceremony).queryByText("Cleo Jones")).toBeNull();
+    const reception = screen.getByText("Reception").closest("section")!;
+    expect(within(reception).getByText(/No guests match this filter/i)).toBeTruthy();
+    expect(tally(reception, "No reply")).toBe("2");
+
+    // Back to All restores every row.
+    fireEvent.click(chip(/^All/i));
+    expect(within(ceremony).getByText("Cleo Jones")).toBeTruthy();
+    expect(screen.queryByText(/Showing \d+ of/i)).toBeNull();
+  });
+
+  it("counts on the chips describe the whole wedding, not the search", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    fireEvent.input(searchBox(), { target: { value: "jones" } });
+    // Narrowing to the Joneses must not renumber the chips — they are the map
+    // out of the current search, not a description of it.
+    expect(chip(/^All/i).textContent).toContain("6");
+    expect(chip(/^Attending/i).textContent).toContain("1");
+    expect(chip(/^No reply/i).textContent).toContain("3");
   });
 
   it("searches across name, household and dietary text", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
 
-    const search = screen.getByPlaceholderText(/Search a name/i);
-    fireEvent.input(search, { target: { value: "jones" } });
+    fireEvent.input(searchBox(), { target: { value: "jones" } });
     expect(screen.getByText("Bo Jones")).toBeTruthy();
     expect(screen.getByText("Cleo Jones")).toBeTruthy();
-    expect(screen.queryByText("Ada Sharma")).toBeNull();
+    expect(screen.queryAllByText("Ada Sharma")).toHaveLength(0);
 
-    // Dietary text is searchable — the caterer's question.
-    fireEvent.input(search, { target: { value: "gluten" } });
+    // Dietary text is searchable — the caterer's question. Ada is invited to
+    // two events; only the row that carries the note matches.
+    fireEvent.input(searchBox(), { target: { value: "gluten" } });
     expect(screen.getByText("Ada Sharma")).toBeTruthy();
     expect(screen.queryByText("Bo Jones")).toBeNull();
+
+    // Clearing the box puts every row back and drops the status line.
+    fireEvent.input(searchBox(), { target: { value: "" } });
+    expect(screen.getAllByText("Ada Sharma")).toHaveLength(2);
+    expect(screen.getByText("Bo Jones")).toBeTruthy();
+    expect(screen.queryByText(/Showing \d+ of/i)).toBeNull();
+  });
+
+  it("applies the search and the chip together", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    fireEvent.input(searchBox(), { target: { value: "jones" } });
+    fireEvent.click(chip(/^No reply/i));
+    expect(screen.getByText("Cleo Jones")).toBeTruthy();
+    expect(screen.queryByText("Bo Jones")).toBeNull();
+    expect(screen.getByText(/Showing 1 of 6 guest rows/i)).toBeTruthy();
   });
 
   it("says so when a filter matches nobody", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" />);
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
 
-    fireEvent.input(screen.getByPlaceholderText(/Search a name/i), {
-      target: { value: "nobody" },
-    });
+    fireEvent.input(searchBox(), { target: { value: "nobody" } });
     const ceremony = screen.getByText("Ceremony").closest("section")!;
     expect(within(ceremony).getByText(/No guests match this filter/i)).toBeTruthy();
-    expect(screen.getByText(/Showing 0 of 3 guests/i)).toBeTruthy();
+    expect(screen.getByText(/Showing 0 of 6 guest rows/i)).toBeTruthy();
   });
 
   it("editor records a phone RSVP: PUTs consent-attested body and reloads", async () => {
@@ -238,10 +372,10 @@ describe("RsvpView", () => {
       .mockResolvedValueOnce(json(VIEW)); // reload after save
     render(() => <RsvpView weddingId="wed_a" canEdit />);
 
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
 
     // Cleo hasn't replied; her row carries the Record button.
-    fireEvent.click(screen.getByRole("button", { name: /^Record$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Record reply for Cleo Jones" }));
 
     // Enter dietary text → the consent checkbox appears + gates submit.
     const dietary = await screen.findByLabelText(/Dietary requirements/i);
@@ -280,9 +414,9 @@ describe("RsvpView", () => {
       .mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" canEdit />);
 
-    await waitFor(() => expect(screen.getByText("Ada Sharma")).toBeTruthy());
-    // Edit Ada's existing reply (first Edit button in the responded table).
-    fireEvent.click(screen.getAllByRole("button", { name: /^Edit$/i })[0]!);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+    // Edit Ada's existing reply.
+    fireEvent.click(screen.getByRole("button", { name: "Edit reply for Ada Sharma" }));
     // The status select is prefilled to her current status ("attending").
     const status = (await screen.findByLabelText(/Status/i)) as HTMLSelectElement;
     expect(status.value).toBe("attending");
@@ -294,5 +428,24 @@ describe("RsvpView", () => {
     expect(putCall[0]).toContain("/api/organiser/weddings/wed_a/guests/g1/rsvps/evt_1");
     const body = JSON.parse(putCall[1]?.body as string) as { status: string };
     expect(body.status).toBe("declined");
+  });
+
+  it("closes the open editor when a filter hides the row it belongs to", async () => {
+    authFetchMock.mockResolvedValueOnce(json(VIEW));
+    render(() => <RsvpView weddingId="wed_a" canEdit />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit reply for Ada Sharma" }));
+    expect(await screen.findByLabelText(/Status/i)).toBeTruthy();
+
+    // Ada is attending, so "Declined" takes her row away. Leaving the form open
+    // under a row that is gone invites a save the host cannot see land.
+    fireEvent.click(chip(/^Declined/i));
+    expect(screen.queryByLabelText(/Status/i)).toBeNull();
+
+    // Reopening after the filter is cleared still works.
+    fireEvent.click(chip(/^All/i));
+    fireEvent.click(screen.getByRole("button", { name: "Edit reply for Ada Sharma" }));
+    expect(await screen.findByLabelText(/Status/i)).toBeTruthy();
   });
 });

--- a/cire/host/src/components/RsvpView.tsx
+++ b/cire/host/src/components/RsvpView.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "@shared/rp-auth/solid";
-import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { haptic } from "../lib/haptics";
@@ -110,13 +110,26 @@ export default function RsvpView(props: RsvpViewProps) {
   onMount(load);
 
   const hasEvents = () => events().length > 0;
-  /** Every guest invited to this event, replied or not, before filtering. */
-  const rowsFor = (event: RsvpViewEvent) => mergeRows(event);
-  const shownFor = (event: RsvpViewEvent) => filterRows(rowsFor(event), query(), filter());
 
-  const counts = createMemo(() => statusCounts(events()));
+  // Two memos, both keyed by event id. Without them the merge and the filter
+  // ran once per read — and the markup reads them four times per event, on
+  // every keystroke. The rows also keep their identity between reads, which is
+  // what lets <For> patch the table instead of rebuilding it.
+  /** Every guest invited to each event, replied or not, before filtering. */
+  const merged = createMemo(
+    () => new Map(events().map((event) => [event.id, mergeRows(event)] as const)),
+  );
+  const shown = createMemo(() => {
+    const q = query();
+    const f = filter();
+    return new Map([...merged()].map(([id, rows]) => [id, filterRows(rows, q, f)] as const));
+  });
+  const rowsFor = (event: RsvpViewEvent) => merged().get(event.id) ?? [];
+  const shownFor = (event: RsvpViewEvent) => shown().get(event.id) ?? [];
+
+  const counts = createMemo(() => statusCounts(merged().values()));
   const shownCount = createMemo(() =>
-    events().reduce((total, event) => total + shownFor(event).length, 0),
+    [...shown().values()].reduce((total, rows) => total + rows.length, 0),
   );
   const filtering = () => query().trim().length > 0 || filter() !== "all";
 
@@ -160,6 +173,27 @@ export default function RsvpView(props: RsvpViewProps) {
     const e = edit();
     return e !== null && e.eventId === eventId && e.guestId === guestId;
   };
+
+  // A filter that hides the row an editor is open on would otherwise leave the
+  // form floating under a row that is no longer there — and a Save would write
+  // an RSVP the host can't see. Close it instead.
+  createEffect(() => {
+    const target = edit();
+    if (!target) return;
+    const rows = shown().get(target.eventId);
+    if (!rows?.some((row) => row.guestId === target.guestId)) closeEditor();
+  });
+
+  // The count a screen reader hears, held back until the typing stops. Read
+  // live, a status region interrupts on every keystroke and says a number the
+  // host is already halfway past; the printed line beside it stays immediate,
+  // because a sighted host reading a stale number is the worse failure.
+  const [announcement, setAnnouncement] = createSignal("");
+  createEffect(() => {
+    const message = filtering() ? `Showing ${shownCount()} of ${counts().all} guest rows.` : "";
+    const timer = setTimeout(() => setAnnouncement(message), 450);
+    onCleanup(() => clearTimeout(timer));
+  });
 
   const save = async () => {
     const target = edit();
@@ -277,11 +311,15 @@ export default function RsvpView(props: RsvpViewProps) {
               </For>
             </div>
           </div>
-          {/* Announced, because narrowing to nothing is otherwise silent. */}
-          <p role="status" class="font-body text-text-muted text-[0.78rem]">
+          {/* Two readings of one fact: the printed count updates as you type,
+              the announced one waits for you to stop. */}
+          <p class="font-body text-text-muted text-[0.78rem]">
             <Show when={filtering()}>
-              Showing {shownCount()} of {counts().all} guests.
+              Showing {shownCount()} of {counts().all} guest rows.
             </Show>
+          </p>
+          <p role="status" class="sr-only">
+            {announcement()}
           </p>
         </div>
 
@@ -386,6 +424,7 @@ export default function RsvpView(props: RsvpViewProps) {
                                     <button
                                       type="button"
                                       class="border-border text-text-muted hover:text-text hover:border-gold/40 rounded-sm border px-2.5 py-1 text-[0.7rem] tracking-[0.08em] uppercase"
+                                      aria-label={`${row.responded ? "Edit" : "Record"} reply for ${row.firstName} ${row.lastName}`}
                                       onClick={() => openRow(event.id, row)}
                                     >
                                       {row.responded ? "Edit" : "Record"}

--- a/cire/host/src/lib/rsvp-filter.test.ts
+++ b/cire/host/src/lib/rsvp-filter.test.ts
@@ -44,7 +44,7 @@ const CEREMONY: RsvpFilterEvent = {
       familyName: "Rao",
       familyCode: "RAO-EMBER-51X8",
       status: "maybe",
-      dietary: "Nut allergy",
+      dietary: "Nut allergy (severe)",
       consentSource: "guest",
     },
   ],
@@ -87,6 +87,13 @@ describe("mergeRows", () => {
       dietary: "",
       responded: false,
     });
+  });
+
+  it("builds each row's search text once, lower-cased, over every matchable field", () => {
+    const rows = mergeRows(CEREMONY);
+    expect(rows[0]?.search).toBe("ada sharma sharma sharma-widget-ab3k9 gluten free");
+    // A silent guest has no dietary text, but is still searchable by household.
+    expect(rows[3]?.search).toBe("cleo jones jones jones-kite-77q2 ");
   });
 
   it("keeps the provenance of a reply and leaves it off a non-reply", () => {
@@ -136,6 +143,16 @@ describe("filterRows", () => {
     expect(ids(filterRows(rows, "nut", "all"))).toEqual(["g4"]);
   });
 
+  it("matches punctuation inside a dietary note as typed", () => {
+    expect(ids(filterRows(rows, "(severe)", "all"))).toEqual(["g4"]);
+    expect(ids(filterRows(rows, "allergy (severe)", "all"))).toEqual(["g4"]);
+  });
+
+  it("treats a whitespace-only query as no query at all", () => {
+    expect(ids(filterRows(rows, "   ", "all"))).toEqual(["g1", "g2", "g4", "g3"]);
+    expect(ids(filterRows(rows, " \t ", "attending"))).toEqual(["g1"]);
+  });
+
   it("applies the query and the status together", () => {
     expect(ids(filterRows(rows, "jones", "none"))).toEqual(["g3"]);
     expect(ids(filterRows(rows, "jones", "attending"))).toEqual([]);
@@ -148,7 +165,7 @@ describe("filterRows", () => {
 
 describe("statusCounts", () => {
   it("sums each status across every event, with 'all' as the total", () => {
-    expect(statusCounts([CEREMONY, RECEPTION])).toEqual({
+    expect(statusCounts([mergeRows(CEREMONY), mergeRows(RECEPTION)])).toEqual({
       all: 5,
       attending: 2,
       declined: 1,
@@ -159,6 +176,16 @@ describe("statusCounts", () => {
 
   it("counts nothing for a wedding with no events", () => {
     expect(statusCounts([])).toEqual({ all: 0, attending: 0, declined: 0, maybe: 0, none: 0 });
+  });
+
+  it("counts the same rows the list renders, taking any iterable of groups", () => {
+    const groups = new Map([
+      ["evt_1", mergeRows(CEREMONY)],
+      ["evt_2", mergeRows(RECEPTION)],
+    ]);
+    expect(statusCounts(groups.values())).toEqual(
+      statusCounts([mergeRows(CEREMONY), mergeRows(RECEPTION)]),
+    );
   });
 
   it("names every filter the chips render", () => {

--- a/cire/host/src/lib/rsvp-filter.ts
+++ b/cire/host/src/lib/rsvp-filter.ts
@@ -19,6 +19,13 @@
  *
  * Dietary text is part of what a word can match on purpose. "Search nut" is the
  * caterer's question, and it has no other home in the portal.
+ *
+ * ## Why a row carries its own search text
+ *
+ * Every keystroke re-tests every row. Building the lower-cased haystack inside
+ * the predicate meant one string concatenation per row per keystroke, for text
+ * that never changes between loads. `mergeRows` builds it once instead, and
+ * `filterRows` only reads it.
  */
 
 export type RsvpStatus = "attending" | "declined" | "maybe";
@@ -63,6 +70,8 @@ export interface RsvpRow {
   /** Null on a row nobody has answered for — there is no reply to attribute. */
   consentSource: ConsentSource | null;
   responded: boolean;
+  /** Everything a typed word can land on, lower-cased once at merge time. */
+  search: string;
 }
 
 export const RSVP_FILTERS: readonly { key: RsvpFilterKey; label: string }[] = [
@@ -72,6 +81,17 @@ export const RSVP_FILTERS: readonly { key: RsvpFilterKey; label: string }[] = [
   { key: "maybe", label: "Maybe" },
   { key: "none", label: "No reply" },
 ];
+
+/** Everything about a row a word can land on, lower-cased once. */
+function haystack(guest: {
+  firstName: string;
+  lastName: string;
+  familyName: string;
+  familyCode: string;
+  dietary?: string;
+}): string {
+  return `${guest.firstName} ${guest.lastName} ${guest.familyName} ${guest.familyCode} ${guest.dietary ?? ""}`.toLowerCase();
+}
 
 /** Replies in the order the API gave them, then the guests who owe one. */
 export function mergeRows(event: RsvpFilterEvent): RsvpRow[] {
@@ -85,6 +105,7 @@ export function mergeRows(event: RsvpFilterEvent): RsvpRow[] {
     dietary: guest.dietary,
     consentSource: guest.consentSource,
     responded: true,
+    search: haystack(guest),
   }));
   const silent: RsvpRow[] = event.unresponded.map((guest) => ({
     guestId: guest.guestId,
@@ -96,13 +117,9 @@ export function mergeRows(event: RsvpFilterEvent): RsvpRow[] {
     dietary: "",
     consentSource: null,
     responded: false,
+    search: haystack(guest),
   }));
   return [...replied, ...silent];
-}
-
-/** Everything about a row a word can land on, lower-cased once per test. */
-function haystack(row: RsvpRow): string {
-  return `${row.firstName} ${row.lastName} ${row.familyName} ${row.familyCode} ${row.dietary}`.toLowerCase();
 }
 
 function terms(query: string): string[] {
@@ -112,11 +129,10 @@ function terms(query: string): string[] {
 /** Rows matching both the typed words and the chosen status. */
 export function filterRows(rows: RsvpRow[], query: string, filter: RsvpFilterKey): RsvpRow[] {
   const words = terms(query);
+  if (words.length === 0 && filter === "all") return rows;
   return rows.filter((row) => {
     if (filter !== "all" && row.status !== filter) return false;
-    if (words.length === 0) return true;
-    const text = haystack(row);
-    return words.every((word) => text.includes(word));
+    return words.every((word) => row.search.includes(word));
   });
 }
 
@@ -124,8 +140,12 @@ export function filterRows(rows: RsvpRow[], query: string, filter: RsvpFilterKey
  * How many rows each chip would show, summed over every event. A guest invited
  * to three events counts three times — the chips label rows, and rows are what
  * the list shows.
+ *
+ * Takes the merged rows rather than the raw events so the caller can hand over
+ * a merge it already holds; re-merging here would do the same work twice on
+ * every load.
  */
-export function statusCounts(events: RsvpFilterEvent[]): Record<RsvpFilterKey, number> {
+export function statusCounts(rowGroups: Iterable<RsvpRow[]>): Record<RsvpFilterKey, number> {
   const counts: Record<RsvpFilterKey, number> = {
     all: 0,
     attending: 0,
@@ -133,8 +153,8 @@ export function statusCounts(events: RsvpFilterEvent[]): Record<RsvpFilterKey, n
     maybe: 0,
     none: 0,
   };
-  for (const event of events) {
-    for (const row of mergeRows(event)) {
+  for (const rows of rowGroups) {
+    for (const row of rows) {
       counts.all += 1;
       counts[row.status] += 1;
     }

--- a/cire/wiki/todo/perf.md
+++ b/cire/wiki/todo/perf.md
@@ -5,10 +5,21 @@ related:
   - "[[index]]"
   - "[[review-findings]]"
   - "[[host-portal-layout]]"
-last-reviewed: 2026-08-08
+last-reviewed: 2026-08-15
 ---
 
 # Performance Backlog
+
+### Host RSVP search + status filter (`fix/cire-rsvp-filter-review`, 2026-08-15)
+
+Post-merge review of PR #445 (the gate was skipped when it merged). Everything below was found on the merged code; the fixes ship on the follow-up branch.
+
+- [x] **P-C1** (FIXED on the follow-up branch) — **the merge and the filter ran once per read, and the markup reads them four times per event.** `RsvpView` called `mergeRows(event)` / `filterRows(...)` from plain accessors inside the `<For>` body — the row count, the empty-state test, the table body and the tally each triggered a fresh pass. Every keystroke therefore re-merged and re-filtered every event, times four. **Fixed** by two `createMemo`s keyed by event id: `merged` (all rows per event, recomputed only when the payload changes) and `shown` (the filtered subset, recomputed only when the query or the chip changes). Reads are now map lookups.
+- [x] **P-W1** (FIXED) — **the search haystack was rebuilt per row per keystroke.** `filterRows` concatenated five fields and lower-cased them inside the predicate, for text that never changes between loads. `mergeRows` now builds `row.search` once and `filterRows` only reads it. `filterRows` also short-circuits to the input array when there is no query and the chip is `all`, so the common case allocates nothing.
+- [x] **P-I1** (FIXED) — **`statusCounts` re-merged every event to count rows the component had already merged.** Its signature is now `statusCounts(rowGroups: Iterable<RsvpRow[]>)`, fed straight from `merged().values()`.
+- [x] **P-I2** (FIXED) — **`<For>` rebuilt the whole table on every keystroke.** Solid reconciles by referential equality, and a per-read merge handed it new row objects every time, so a narrowing search discarded and recreated every remaining `<tr>` instead of removing the ones that stopped matching. The memos keep row identity stable across reads, so `<For>` patches.
+- [ ] **P-W2** (open, deliberately not attempted) — **the RSVP table has no `table-layout: fixed`, so every filter change re-runs auto table layout over the surviving rows.** Auto layout measures every cell in every row before it can size a column, which is the one layout cost that grows with row count on a change that only ever removes rows. Setting `table-layout: fixed` would make column widths a function of the header alone and take the measure pass off the filter path. **Not done here** because the column widths are currently content-derived — a household code is much wider than a status badge — and switching would need explicit widths chosen against real guest lists, plus a browser-tier measurement to prove the change is a win rather than a re-flow of the same work. File it, measure it, then do it.
+- [ ] **P-W3** (open, pre-existing) — **a saved RSVP reloads the whole wedding's payload and replaces every row object.** `load()` re-fetches `/rsvps` and `setEvents(body.events)` swaps the array wholesale, so one guest's saved reply re-merges every event and hands `<For>` an entirely new row set — the table rebuild the memos otherwise avoid, paid on every save. **Fix:** hold the payload in a `createStore` and apply the reload with `reconcile(body.events, { key: "id" })`, so only the rows whose fields actually changed are written. Left out of this branch on purpose: it changes how the component owns its state, which is a wider diff than a review follow-up should carry, and the memos make the steady-state cost (typing) cheap already — this is the save path only.
 
 ### Guest sign-out control (claude/cire-invites-claim-code-button-sn5br8, 2026-08-08)
 

--- a/cire/wiki/todo/security.md
+++ b/cire/wiki/todo/security.md
@@ -5,12 +5,21 @@ related:
   - "[[index]]"
   - "[[overview]]"
   - "[[review-findings]]"
-last-reviewed: 2026-08-08
+last-reviewed: 2026-08-15
 ---
 
 # Security Backlog
 
 See [[overview]] for observability rules that apply to all security-sensitive code paths. See [[review-findings]] for severity prefix conventions.
+
+### Host RSVP search + status filter (`fix/cire-rsvp-filter-review`, 2026-08-15)
+
+Post-merge review of PR #445 (the gate was skipped when it merged). **No Critical, High or Medium findings.** The diff is one new pure module and one component in `cire/host` — no route, no gate, no token, no query construction, no outbound `fetch`, no dependency, no logging. Two things were checked rather than assumed: the non-repliers a viewer can now see were **already** in the `GET …/rsvps` payload this component has always fetched (the old build hid them behind an editor-only `<details>` — presentation, never authorisation, and the route is `weddingMember()`-gated for reads either way), so no recipient class widened; and search runs entirely client-side over data already in the browser, so no query text reaches the API and none is logged.
+
+- [ ] **S-L1** (open, no code change here) — **the RSVP search matches the household claim CODE, which sharpens the already-open `S-M2`.** `families.public_id` is a credential (see the claim-code row in root `[[wiki/compliance/data-map]]`) and the payload has always carried it; what is new is that any co-host, **read-only `viewer` included**, can now type a fragment and pull up the household it belongs to. On its own that is not a capability — the codes are printed on the dashboard for the same roles. It matters because the recipient set can widen **without the owner acting**: an `editor` may create a co-host seat, and owner notification is the open **S-M2** in the co-host-seats section below ("a new co-host seat is a silent, immediate grant"). Search makes a seat granted that way more useful against the codes than a scroll through a table was. Two mitigations were considered and **not** taken: a minimum query length (say 4 characters) before a code fragment is matched at all, which costs the caterer nothing and blunts fragment-probing; and dropping `familyCode` from the searchable text entirely, which would break the organiser's real workflow of pasting a code from a message to find the household. **Do S-M2 first** — it is the finding that actually bounds who is holding the codes; a length floor on top of an unnotified seat is decoration. Revisit the floor once notification lands.
+- [x] **C-L1** (FIXED on the follow-up branch) — **the Article 30 record under-listed which organiser reads disclose the claim code.** The claim-code row named `/guests`, `/households`, `/guests.csv` and `/export/guests.csv?fidelity=full`, but `rsvp-export.ts` also selects `families.public_id` as `familyCode` for the dashboard RSVP view. A record that under-reports a credential's recipients is exactly the kind that gets relied on when scoping a new gate. **Fixed:** `/rsvps` added to that cell in root `[[wiki/compliance/data-map]]`, with a note that the portal holds the code in memory and now searches it, `last-reviewed` bumped.
+- [x] **C-L2** (FIXED) — **the row action was a bare "Record" / "Edit" with nothing naming the guest.** In a table of near-identical rows, a screen-reader user tabbing the action column heard the same two words over and over with no way to tell which household they were about to write an RSVP for — and this button writes special-category dietary data under an organiser attestation. WCAG 2.2 SC 2.4.6 / 4.1.2, in scope under the EAA. **Fixed:** each button carries `aria-label="Record reply for Cleo Jones"` / `"Edit reply for Ada Sharma"`, pinned by a test naming all three.
+- [x] **C-L3** (FIXED) — **the live region announced on every keystroke.** One `role="status"` carried the visible count, so a screen reader interrupted itself on each letter with a number the host had already typed past. **Fixed** by splitting it: the printed line updates immediately (a sighted host reading a stale count is the worse failure), and a separate `sr-only role="status"` is written 450ms after typing stops. WCAG 2.2 SC 4.1.3.
 
 ### RSVP sheet close delay (`claude/rsvp-modal-close-delay-d8sqnd`, 2026-08-08)
 

--- a/wiki/compliance/data-map.md
+++ b/wiki/compliance/data-map.md
@@ -9,7 +9,7 @@ related:
   - "[[cire]]"
   - "[[cire-auth]]"
   - "[[dpia/cire-guest-data]]"
-last-reviewed: 2026-08-07
+last-reviewed: 2026-08-15
 ---
 
 # Data Map
@@ -113,7 +113,7 @@ organiser-initiated wedding administration.
 | Field | Purpose | Lawful basis | Retention | Recipients | System page |
 |---|---|---|---|---|---|
 | `families.family_name` | Guest household label on the invite + organiser guest table | Art. 6(1)(f) — legit interest in wedding administration (organiser-controlled) | Tied to wedding lifecycle — no automated purge yet (C-H1) | `@cire/api` + the wedding owner (organiser) | [[cire-auth]] |
-| `families.public_id` (claim CODE, e.g. `SHARMA-IVY-QM42`) | **Credential** — exchanged at `POST /api/claim` for a guest session; not a public identifier | Art. 6(1)(b) — contract (the access mechanism for the guest's RSVP) | Tied to wedding lifecycle (C-H1) | `@cire/api` + the wedding owner **and every co-host, viewers included** — the code is shown on the dashboard and returned by the organiser roster reads `/guests`, `/households`, `/guests.csv` and `/export/guests.csv?fidelity=full`. Treated as a secret elsewhere: redacted in logs (C-M2), and every response carrying it is `Cache-Control: no-store` | [[cire-auth]] |
+| `families.public_id` (claim CODE, e.g. `SHARMA-IVY-QM42`) | **Credential** — exchanged at `POST /api/claim` for a guest session; not a public identifier | Art. 6(1)(b) — contract (the access mechanism for the guest's RSVP) | Tied to wedding lifecycle (C-H1) | `@cire/api` + the wedding owner **and every co-host, viewers included** — the code is shown on the dashboard and returned by the organiser roster reads `/guests`, `/households`, `/guests.csv`, `/export/guests.csv?fidelity=full` and `/rsvps` (the dashboard RSVP view — `rsvp-export.ts` selects `families.public_id` as `familyCode` for every replied and unresponded guest; the portal does not print it, but it holds it in memory and, since 2026-08-15, the RSVP search matches on it). Treated as a secret elsewhere: redacted in logs (C-M2), and every response carrying it is `Cache-Control: no-store` | [[cire-auth]] |
 | `families.public_id` where `kind = 'host'` (host preview CODE, `HOST-*`) | **Credential** — organiser-provisioned code that opens the guest invite to see every event ("Preview invite"). Synthetic host family carries no real guest personal data (one placeholder member "Wedding Host"); preview-only, cannot RSVP | Art. 6(1)(f) — wedding administration (organiser self-service preview) | Tied to wedding lifecycle (C-H1) | `@cire/api` only (treated as a secret — redacted via the `publicId`/`public_id` deny-list) | [[cire-auth]] |
 | `guests.first_name`, `last_name` | Per-guest identity on the invite + RSVP attribution | Art. 6(1)(f) — wedding administration (organiser-controlled) | Tied to wedding lifecycle (C-H1) | `@cire/api` + wedding owner | [[cire-auth]] |
 | `families.code_shared_at`, `first_opened_at`, `deactivated_at` (invite-tracking timestamps) | Organiser invite-delivery tracking — drives the dashboard's Sent/Opened badges + Deactivated state and the `guests.csv` roster export. `first_opened_at` is behavioural (when a guest household first opened the invite; host-preview claims excluded) | Art. 6(1)(f) — wedding administration (organiser-controlled) | Tied to wedding lifecycle — covered by the 1-year `sweepExpiredGuestData` families sweep, see [[retention]] (C-H1 for the R2 side) | `@cire/api` + wedding owner/co-hosts (dashboard + CSV export) | [[cire-auth]] |


### PR DESCRIPTION
## Summary

PR #445 (host RSVP search + status filter) merged before the `/prep-pr` gate ran. This is that gate, run against merge commit `bd0c484f`, with every fix it produced. Nothing the organiser sees changes except the three accessibility items below — the list still filters exactly as designed.

Reviewed for security, performance, accessibility/compliance and test coverage. **No Critical, High or Medium security findings.** Two facts checked rather than assumed: the non-repliers the merged table shows were already in the `weddingMember()`-gated `/rsvps` payload, so the old `<details>` disclosure was presentation and never authorisation; and the search runs entirely in the browser, so no typed guest name or code reaches or is logged by the API.

## Workspaces affected

- `@cire/host` — `src/lib/rsvp-filter.ts`, `src/components/RsvpView.tsx` and both test files
- Docs only: `cire/wiki/todo/perf.md`, `cire/wiki/todo/security.md`, `wiki/compliance/data-map.md`

## Decisions & issues

### P-C1 — the merge and the filter ran once per read, and the markup read them four times per event (fixed)

- **Issue:** `RsvpView` called `mergeRows(event)` and `filterRows(...)` inline wherever it needed rows — the count line, the empty-state test, the `<For>` and the tally each re-ran the whole pipeline for every event on every render.
- **Why:** with three events and a few hundred guests that is thousands of allocations per keystroke, and every `<For>` read produced fresh row objects, so Solid's referential reconciliation rebuilt every `<tr>` rather than reordering.
- **Solution:** two memos — `merged()` returns a `Map<eventId, RsvpRow[]>`, `shown()` filters that map — and `rowsFor`/`shownFor` read the maps.
- **Rationale:** a `Map` keyed by event id keeps row identity stable across reads, which is what makes `<For>` cheap; a fresh array per call cannot.

### P-W1 — the search haystack was rebuilt per row per keystroke (fixed)

- **Issue:** `filterRows` concatenated and lower-cased five fields inside the predicate, for every row, on every keystroke.
- **Why:** that text never changes between loads. Typing an 8-character name over 300 rows did 2,400 string builds for nothing.
- **Solution:** `RsvpRow` carries `search: string`, built once in `mergeRows`; `filterRows` only reads it, and short-circuits when the query is empty and the filter is `all`.
- **Rationale:** the cost belongs where the data is shaped, not where it is queried.

### P-I1 — `statusCounts` re-merged the events it was counting (fixed)

- **Issue:** it took the raw events and merged them again, duplicating work the caller had already done.
- **Solution:** it now takes `Iterable<RsvpRow[]>`, so the caller hands over the merge it holds. A test proves a `Map#values()` and an array of arrays count identically.
- **Rationale:** counting the rows the list renders also removes the chance of the tallies and the table disagreeing.

### C-L2 — every row button was called "Edit" or "Record" and nothing else (fixed)

- **Issue:** a screen reader's list-of-buttons view read as a column of identical labels with no guest attached.
- **Why:** WCAG 2.2 SC 2.4.6 (Headings and Labels) and 4.1.2 (Name, Role, Value) — the accessible name has to identify what the control acts on.
- **Solution:** ``aria-label={`${row.responded ? "Edit" : "Record"} reply for ${first} ${last}`}``. Visible text is unchanged.
- **Rationale:** the short visible label is right for scanning a dense table; the accessible name carries the row context instead.

### C-L3 — the live region announced on every keystroke (fixed)

- **Issue:** one `role="status"` element held the visible count, so a screen reader interrupted itself once per character typed.
- **Why:** SC 4.1.3 (Status Messages) — a status that fires faster than it can be read is noise.
- **Solution:** split in two. The visible line updates immediately; a separate `sr-only` `role="status"` waits 450 ms of quiet.
- **Rationale:** **the input itself is deliberately not debounced.** Debouncing the filter would make the table lag behind the keyboard for everyone, to fix a problem only assistive tech has. Delay the announcement, not the result.

### T-S1 — an open editor survived a filter that hid its row (fixed)

- **Issue:** open the inline reply editor, then click a status chip that excludes that guest, and the editor stayed open over a row no longer in the table.
- **Solution:** an effect closes the editor when its `(eventId, guestId)` is no longer in `shown()`. Covered by a test.
- **Rationale:** closing loses at most an unsaved keystroke; leaving it open lets a save land on a row the organiser can no longer see.

### C-L1 — the data map under-listed where the claim code goes (fixed, docs)

- **Issue:** `wiki/compliance/data-map.md` (the Article 30 record) listed the claim code's recipients as the roster and export reads, not `/rsvps`.
- **Why:** `rsvp-export.ts:191/211/488` selects `families.public_id` as `familyCode` for every replied *and* unresponded guest, so the dashboard payload has always carried it — and since #445 the search matches on it. The code is classed as a credential, so its recipient list has to be right.
- **Solution:** the row now names `/rsvps` and the mechanism; `last-reviewed` bumped.
- **Rationale:** verified against source before writing it into the record.

### S-L1 — the search matches the claim code (open, not fixed here)

- **Issue:** an organiser with any role, including read-only `viewer`, can now find a household by typing a fragment of its claim code.
- **Why:** the code is a credential. Two mitigations were considered and rejected: a 4-character minimum before code fragments match (a `viewer` can already read whole codes elsewhere in the same payload, so the floor buys nothing), and dropping `familyCode` from the searchable text (organisers do paste a code from a printed list to find a household — that is the feature working).
- **Solution:** logged in `cire/wiki/todo/security.md` as Low, tied to the open **S-M2** on co-host seats — an `editor` can add a co-host, and a new seat is a silent, immediate grant of guest credentials.
- **Rationale:** the real exposure is who holds a seat, not how fast a seat-holder can search. Fix S-M2 first; this Low collapses into it.

### P-W2, P-W3 — deferred with documentation

- **P-W2:** the table has no `table-layout: fixed`, so filtering to a short set can reflow column widths. Needs explicit widths plus a browser-tier measurement to confirm — out of scope for a review fix.
- **P-W3:** saving a reply reloads the whole `/rsvps` payload and replaces every row object. The fix is `createStore` + `reconcile(body.events, { key: "id" })`, which changes who owns the view's state — a wider change than this PR should carry.

## Test plan

- `bun run --cwd cire/host test:run` → **80 files, 1065 tests passed**
- `bun run --cwd cire/host check` (astro check, 185 files) → **0 errors, 0 warnings**, 2 pre-existing hints in unrelated files
- `bunx --bun oxlint cire/host/src` → passes; 2 advisory `prefer-tag-over-role` warnings on `RsvpView.tsx`, both deliberate — `role="status"` on a `<p>` is announced more reliably across screen readers than `<output>`, and `role="group"` labels a set of toggle buttons that is not a `<fieldset>`
- `scripts/validate-changesets.sh` → passes
- New tests: `search` text built once and lower-cased over every matchable field; punctuation inside a dietary note matches as typed; a whitespace-only query counts as no query; `statusCounts` agrees across any iterable of groups; per-guest button names; the immediate visible count and the debounced `sr-only` announcement; chip counts unaffected by search; combined query + chip; zero-match; editor closes when a filter hides its row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
