### PR TITLE
feat(cire-api): guest-facing registry read, claim and release

### DIFF
--- a/.changeset/cire-registry-guest-surface.md
+++ b/.changeset/cire-registry-guest-surface.md
@@ -1,0 +1,36 @@
+---
+"@cire/api": patch
+---
+
+Guest-facing registry surface. A published registry is now readable from the
+invite site, and a household can reserve, mark purchased and release a gift
+against its claim-code cookie.
+
+`GET /api/invite/:slug/registry` returns the couple's copy and the item list;
+`GET .../registry/image/:name` serves a gift photo through the same transform
+pipeline as the rest of the invite; `GET .../registry/mine` returns the calling
+household's own claims, plus the shipping address once it has earned it;
+`POST`/`DELETE .../items/:itemId/claim` delegate to the existing
+`registryService.claim` / `releaseClaim`, so the guest-side business logic has
+one home.
+
+Three things worth knowing:
+
+- **Every failure on the public routes is one 404 with one body.** Unknown
+  slug, wedding without the `registry` entitlement, and registry not yet
+  published are three different facts, and a guest URL is public, so all three
+  answer identically. Organisers still get a 402 on their own routes; guests
+  must not be able to tell a drafted list from a wedding that does not exist.
+- **The slug decides the wedding, never the cookie.** Every write resolves the
+  wedding from the URL and hands that id to the service, so a session minted
+  for one wedding does nothing on another.
+- **The shipping address is earned.** It ships only to a household holding a
+  live claim, only when the couple has set one, and only once
+  `shippingVisibleFrom` has passed.
+
+Also adds the registry section copy (`registryEyebrow` / `registryHeading` /
+`registryBody` / `registryTone`, columns that existed but were never read) to
+the public invite payload, alongside the other section copy.
+
+Everything here stays behind the `registry` entitlement, which no wedding
+holds.

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -49,6 +49,11 @@ import {
   createRegistryReadRoutes,
   createRegistryWriteRoutes,
 } from "./routes/registry";
+import {
+  createRegistryGuestClaimRoutes,
+  createRegistryGuestMineRoutes,
+  createRegistryGuestRoutes,
+} from "./routes/registry-guest";
 import { createRsvpRoutes } from "./routes/rsvp";
 import { createTaskReadRoutes, createTaskWriteRoutes } from "./routes/tasks";
 import {
@@ -198,6 +203,22 @@ const defaultRegistryPreviewLimiter = createRateLimiter({ maxRequests: 10, windo
  * organiser has to preview before they can pick.
  */
 const defaultRegistryImageLimiter = createRateLimiter({ maxRequests: 10, windowMs: 60_000 });
+/**
+ * Default per-IP limiter for the two GUEST registry writes (claim / release).
+ *
+ * Per-IP, not per-user: a guest has no user, only a household cookie — the same
+ * shape as `defaultClaimLimiter` and for the same reason. The budget is 20/min,
+ * sized like the account-link writes: a household picking gifts claims a few
+ * things, changes its mind about one, marks another purchased weeks later. It is
+ * deliberately looser than the 5/min claim-code budget (that one guards a
+ * guessable credential; this one sits BEHIND that credential) and tighter than
+ * the 60/min session probe (that one is a page load; these are writes).
+ *
+ * A NAT'd venue-wifi household shares an IP, hence 20 rather than 10 — still far
+ * below what it costs anyone else, since the conditional INSERT behind it is one
+ * indexed statement.
+ */
+const defaultRegistryGuestLimiter = createRateLimiter({ maxRequests: 20, windowMs: 60_000 });
 /**
  * Default per-IP limiter for the pre-auth OIDC redirect legs (`/oidc/start`,
  * `/oidc/callback`). Tighter than the session probe below — these are the
@@ -408,6 +429,8 @@ export interface AppOptions {
   registryPreviewLimiter?: RateLimiterBackend;
   /** Override the registry image-save rate limiter (useful for testing). */
   registryImageLimiter?: RateLimiterBackend;
+  /** Override the guest registry claim/release rate limiter (useful for testing). */
+  registryGuestLimiter?: RateLimiterBackend;
   /**
    * Test seam: injectable `fetch` + DNS resolver for the registry link-preview
    * service, so its route tests reach no network. Production passes nothing and
@@ -476,6 +499,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
     enquiryLimiter = defaultEnquiryLimiter,
     registryPreviewLimiter = defaultRegistryPreviewLimiter,
     registryImageLimiter = defaultRegistryImageLimiter,
+    registryGuestLimiter = defaultRegistryGuestLimiter,
     registryLinkPreviewOptions,
     // Key-optional default: an inert provider that serves registry defaults with
     // no network, so an app built without GrowthBook config behaves exactly as
@@ -642,6 +666,19 @@ export function createApp(db: Db, options: AppOptions = {}) {
       // cookie minted by a Turnstile-gated `/api/claim`, so a second bot check
       // here is pure friction. Claim + organiser login keep the gate.
       .use(createRsvpRoutes(db))
+      // Guest gift registry, three sibling instances by gate class: the public
+      // reads take no auth at all, `/registry/mine` needs the household cookie,
+      // and the two writes need that cookie PLUS a per-IP limiter an Elysia
+      // guard would otherwise spread over the read. Same no-Turnstile argument
+      // as RSVP above — the cookie came from a Turnstile-gated `/api/claim`.
+      //
+      // Every route here is invisible without the `registry` entitlement, which
+      // NO wedding holds: they answer 404 `registry_not_found`, not 402, because
+      // an unauthenticated caller must not learn which weddings have bought
+      // which features.
+      .use(createRegistryGuestRoutes(db, { assets, images }))
+      .use(createRegistryGuestMineRoutes(db))
+      .use(createRegistryGuestClaimRoutes(db, { limiter: registryGuestLimiter }))
       .use(createOrganiserWeddingsRoutes(db, osnAuthOptions))
       .use(createOrganiserExportRoutes(db, osnAuthOptions, exportLimiter))
       .use(createOrganiserWeddingCreateRoute(db, osnAuthOptions, weddingCreateLimiter))

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -112,6 +112,12 @@ export interface Env {
   // exists to protect the third party being fetched, not to stop a brute force.
   REGISTRY_PREVIEW_RATE_LIMITER?: WorkersRateLimitBinding;
   REGISTRY_IMAGE_RATE_LIMITER?: WorkersRateLimitBinding;
+  // The guest registry write limiter — claiming and releasing a gift. Its own
+  // namespace because guests are a different population from organisers: a
+  // guest party working through a gift list must not spend the budget the
+  // couple needs to edit it. Absent ⇒ the per-isolate in-memory default; the
+  // route is session-authenticated, so an unbound limiter degrades a throttle.
+  REGISTRY_GUEST_RATE_LIMITER?: WorkersRateLimitBinding;
   // Turnstile bot-protection secret (KEY-OPTIONAL). When set, the guest claim +
   // RSVP endpoints require a valid Turnstile token (fail-closed); unset ⇒ those
   // gates are skipped. `wrangler secret put TURNSTILE_SECRET_KEY`.
@@ -337,6 +343,13 @@ const handler: ExportedHandler<Env> = {
       const registryImageEdgeLimiter = env.REGISTRY_IMAGE_RATE_LIMITER
         ? createWorkersRateLimiter(env.REGISTRY_IMAGE_RATE_LIMITER)
         : undefined;
+      // The guest claim/release writes. Own namespace, not the two above: those
+      // budgets belong to the couple building the list, this one to every guest
+      // of every wedding, and a guest party working through the list must not
+      // spend the budget the couple needs to edit it.
+      const registryGuestEdgeLimiter = env.REGISTRY_GUEST_RATE_LIMITER
+        ? createWorkersRateLimiter(env.REGISTRY_GUEST_RATE_LIMITER)
+        : undefined;
       // Turnstile bot protection (KEY-OPTIONAL). Unset secret ⇒ null ⇒ the
       // claim + rsvp gates are skipped. The secret is read here and never
       // logged or placed anywhere but Cloudflare's siteverify endpoint.
@@ -400,6 +413,7 @@ const handler: ExportedHandler<Env> = {
             ? { registryPreviewLimiter: registryPreviewEdgeLimiter }
             : {}),
           ...(registryImageEdgeLimiter ? { registryImageLimiter: registryImageEdgeLimiter } : {}),
+          ...(registryGuestEdgeLimiter ? { registryGuestLimiter: registryGuestEdgeLimiter } : {}),
           r2: env.SHEETS,
           assets: env.ASSETS,
           images: env.IMAGES,

--- a/cire/api/src/routes/invite.test.ts
+++ b/cire/api/src/routes/invite.test.ts
@@ -274,6 +274,59 @@ describe("PUT /invite/text (organiser)", () => {
     expect(body.welcome.message).toBeNull();
   });
 
+  /**
+   * The 0057 registry copy columns. Written straight to the row because no write
+   * path exists yet — `InviteTextBody` / `InviteThemeBody` have no field for
+   * them, and adding one would change what the host portal PUTs. This pins the
+   * READ half: the columns reach the guest payload, shaped like the other
+   * section copy, and are NOT redacted (the section header is invite furniture,
+   * same as details/story — the gift list itself lives behind its own gate).
+   */
+  it("surfaces the registry section copy + tone on the public read", async () => {
+    const { app, db } = buildApp();
+    db.insert(weddingInviteCustomisations)
+      .values({
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        registryEyebrow: "Gifts",
+        registryHeading: "Our Registry",
+        registryBody: "Your presence is the present.",
+        registryTone: "card",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: weddingInviteCustomisations.weddingId,
+        set: {
+          registryEyebrow: "Gifts",
+          registryHeading: "Our Registry",
+          registryBody: "Your presence is the present.",
+          registryTone: "card",
+        },
+      })
+      .run();
+
+    const pub = await appRequest(app, `/api/invite/${SLUG}`);
+    const body = (await pub.json()) as {
+      registry: { eyebrow: string | null; heading: string | null; body: string | null };
+      theme: { tones: { registry: string | null } };
+    };
+    expect(body.registry).toEqual({
+      eyebrow: "Gifts",
+      heading: "Our Registry",
+      body: "Your presence is the present.",
+    });
+    expect(body.theme.tones.registry).toBe("card");
+  });
+
+  it("reports null registry copy for a wedding that never set it", async () => {
+    const { app } = buildApp();
+    const pub = await appRequest(app, `/api/invite/${SLUG}`);
+    const body = (await pub.json()) as {
+      registry: { eyebrow: string | null; heading: string | null; body: string | null };
+    };
+    expect(body.registry).toEqual({ eyebrow: null, heading: null, body: null });
+  });
+
   it("saves the footer note (trimmed) and surfaces it on the ORGANISER read", async () => {
     const { app } = buildApp();
     const put = await appRequest(app, `${orgBase}/text`, {
@@ -1313,6 +1366,7 @@ interface ThemeShape {
     story: string | null;
     details: string | null;
     welcome: string | null;
+    registry: string | null;
   };
 }
 
@@ -1386,6 +1440,10 @@ describe("PUT /invite/theme (organiser)", () => {
       story: "card",
       details: null,
       welcome: "raised",
+      // Not writable through `PUT /invite/theme` yet (0057's column has no
+      // field on the total `InviteThemeBody`), so it reads back null even
+      // after a full theme save.
+      registry: null,
     });
     // Typography option keys (0048) round-trip as keys — the guest site
     // resolves them to CSS values, the API never stores a raw value.
@@ -1415,6 +1473,7 @@ describe("PUT /invite/theme (organiser)", () => {
       story: null,
       details: null,
       welcome: null,
+      registry: null,
     });
     expect(body.theme.headingSize).toBeNull();
     expect(body.theme.headingWeight).toBeNull();

--- a/cire/api/src/routes/registry-guest.test.ts
+++ b/cire/api/src/routes/registry-guest.test.ts
@@ -1,0 +1,783 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  BOOTSTRAP_WEDDING_ID,
+  families,
+  registryClaims,
+  registryItems,
+  registrySettings,
+  weddingEntitlements,
+  weddings,
+} from "@cire/db";
+import { createRateLimiter } from "@shared/rate-limit";
+import { and, eq } from "drizzle-orm";
+
+import { createApp } from "../app";
+import { createDb, seedDb } from "../db/setup";
+import { createAssetsStub } from "../services/invite-assets";
+import type {
+  ImagesBindingLike,
+  ImageTransformHandle,
+  OutputFormat,
+} from "../services/invite-image-transform";
+import type { HouseholdRegistryDto, PublicRegistryDto } from "../services/registry";
+import { appRequest } from "../test-helpers";
+
+const SLUG = "cire-wedding";
+const OTHER_WEDDING_ID = "wed_other";
+const OTHER_SLUG = "other-wedding";
+
+/** Seeded households of the bootstrap wedding. */
+const FAMILY = "TESTONE-IVY-AA11";
+const OTHER_HOUSEHOLD = "TESTTWO-OAK-BB22";
+/** Minted below, on the SECOND wedding — the cross-tenant cookie. */
+const FOREIGN_FAMILY = "OTHERWD-ELM-EE55";
+
+const PAN = "reg_pan";
+const BOWL = "reg_bowl";
+const OTHER_ITEM = "reg_other_pan";
+const PAN_IMAGE = "registry-pan";
+
+/** The claim another household already holds — the identity that must never leak. */
+const FOREIGN_NOTE = "Bought it in the Boxing Day sale";
+const FOREIGN_DISPLAY_NAME = "Auntie Ros";
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01]);
+/** Distinct from `PNG` so a transformed serve is distinguishable from the original. */
+const TRANSFORMED = new Uint8Array([0xaa, 0xbb, 0xcc]);
+
+/** Stub Images binding — records the transform widths so re-billing is countable. */
+function createImagesStub(): ImagesBindingLike & { widths: (number | undefined)[] } {
+  const widths: (number | undefined)[] = [];
+  return {
+    widths,
+    input() {
+      const handle: ImageTransformHandle = {
+        transform(t) {
+          widths.push(t.width);
+          return handle;
+        },
+        output(o: { format: OutputFormat }) {
+          return Promise.resolve({
+            response: () => new Response(TRANSFORMED, { headers: { "Content-Type": o.format } }),
+            contentType: () => o.format,
+          });
+        },
+      };
+      return handle;
+    },
+  };
+}
+
+/** Stub Cache API. `caches` is undefined in bun:test unless a test installs one. */
+function createCacheStub() {
+  const store = new Map<string, Response>();
+  const calls = { match: 0, put: 0 };
+  const def = {
+    async match(req: Request | string): Promise<Response | undefined> {
+      calls.match += 1;
+      const url = typeof req === "string" ? req : req.url;
+      const hit = store.get(url);
+      return hit ? hit.clone() : undefined;
+    },
+    async put(req: Request | string, res: Response): Promise<void> {
+      calls.put += 1;
+      const url = typeof req === "string" ? req : req.url;
+      store.set(url, res);
+    },
+  };
+  return { calls, store, caches: { default: def } as unknown as CacheStorage };
+}
+
+async function withCaches<T>(stub: CacheStorage, fn: () => Promise<T>): Promise<T> {
+  const original = (globalThis as { caches?: CacheStorage }).caches;
+  (globalThis as { caches?: CacheStorage }).caches = stub;
+  try {
+    return await fn();
+  } finally {
+    (globalThis as { caches?: CacheStorage }).caches = original;
+  }
+}
+
+/**
+ * Two weddings, both with a registry, so every cross-tenant assertion has a real
+ * target rather than a fabricated id.
+ *
+ * The bootstrap wedding's gates are the knobs — `entitled` and `published` — and
+ * BOTH default to on, the opposite of `registry.test.ts`. That file's subject is
+ * the feature staying locked; this one's is what a guest sees once a couple has
+ * deliberately opened it, so the interesting fixture here is the open one and
+ * every locked case says so explicitly.
+ *
+ * The second wedding is always fully open: it exists to prove that a cookie from
+ * it buys nothing on the first, which it cannot do if it is itself invisible.
+ */
+function buildApp(
+  opts: {
+    entitled?: boolean;
+    published?: boolean;
+    shippingAddress?: string | null;
+    shippingVisibleFrom?: string | null;
+    images?: ImagesBindingLike;
+  } = {},
+) {
+  const {
+    entitled = true,
+    published = true,
+    shippingAddress = null,
+    shippingVisibleFrom = null,
+    images,
+  } = opts;
+  const db = createDb(":memory:");
+  seedDb(db);
+  const assets = createAssetsStub();
+  const now = new Date();
+
+  db.insert(weddings)
+    .values({
+      id: OTHER_WEDDING_ID,
+      slug: OTHER_SLUG,
+      displayName: "Other",
+      ownerOsnProfileId: "usr_bob",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(families)
+    .values({
+      id: "fam_other",
+      weddingId: OTHER_WEDDING_ID,
+      publicId: FOREIGN_FAMILY,
+      familyName: "Elmwood",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  for (const weddingId of entitled
+    ? [BOOTSTRAP_WEDDING_ID, OTHER_WEDDING_ID]
+    : [OTHER_WEDDING_ID]) {
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId,
+        entitlement: "registry",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: "usr_dev_bootstrap_owner",
+        providerRef: null,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
+
+  db.insert(registrySettings)
+    .values({
+      weddingId: BOOTSTRAP_WEDDING_ID,
+      published,
+      headline: "Gifts",
+      message: "Your presence is the present.",
+      cashGiftsEnabled: false,
+      shippingAddress,
+      shippingVisibleFrom,
+      // Present so a leak test has something to catch: no guest payload may
+      // carry the couple's Stripe account, published or not.
+      stripeAccountId: "acct_secret_123",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(registrySettings)
+    .values({
+      weddingId: OTHER_WEDDING_ID,
+      published: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  db.insert(registryItems)
+    .values([
+      {
+        id: PAN,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        title: "Copper pan",
+        description: "The heavy one",
+        imageKey: `assets/${BOOTSTRAP_WEDDING_ID}/${PAN_IMAGE}`,
+        imageCrop: null,
+        externalUrl: "https://shop.example/pan",
+        priceMinor: 12_000,
+        quantityWanted: 2,
+        category: "Kitchen",
+        // Deliberately NOT in insertion order — the read must sort.
+        sortOrder: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: BOWL,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        title: "Mixing bowl",
+        quantityWanted: 1,
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: OTHER_ITEM,
+        weddingId: OTHER_WEDDING_ID,
+        title: "Other pan",
+        quantityWanted: 5,
+        sortOrder: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    .run();
+
+  // One claim already on the pan, held by a DIFFERENT household of the same
+  // wedding. Everything about it — who, how many, the note, the name — is what
+  // the public read must reduce to a bare count.
+  const [neighbour] = db
+    .select({ id: families.id })
+    .from(families)
+    .where(eq(families.publicId, OTHER_HOUSEHOLD))
+    .all();
+  db.insert(registryClaims)
+    .values({
+      id: "rcl_neighbour",
+      weddingId: BOOTSTRAP_WEDDING_ID,
+      itemId: PAN,
+      familyId: (neighbour as { id: string }).id,
+      quantity: 1,
+      status: "reserved",
+      note: FOREIGN_NOTE,
+      displayName: FOREIGN_DISPLAY_NAME,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  const app = createApp(db, {
+    assets,
+    images,
+    // Fresh limiters per app: the module-level defaults are process-wide, so
+    // without these the 21st guest write in this file would 429 whichever test
+    // happened to run last (and `/api/claim`'s budget is only 5/min).
+    registryGuestLimiter: createRateLimiter({ maxRequests: 1000, windowMs: 60_000 }),
+    claimLimiter: createRateLimiter({ maxRequests: 1000, windowMs: 60_000 }),
+  });
+  return { app, assets, db };
+}
+
+type App = ReturnType<typeof buildApp>["app"];
+
+/** Claim a code and keep the `cire_session` cookie it mints. */
+async function guestCookie(app: App, publicId = FAMILY): Promise<string> {
+  const res = await appRequest(app, "/api/claim", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ publicId }),
+  });
+  expect(res.status).toBe(200);
+  const token = /cire_session=([^;]+)/.exec(res.headers.get("set-cookie") ?? "")?.[1];
+  expect(token).toBeTruthy();
+  return `cire_session=${token}`;
+}
+
+const guestBase = (slug = SLUG) => `/api/invite/${slug}/registry`;
+
+function claim(app: App, cookie: string, body: unknown, slug = SLUG, itemId = PAN) {
+  return appRequest(app, `${guestBase(slug)}/items/${itemId}/claim`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+function release(app: App, cookie: string, slug = SLUG, itemId = PAN) {
+  return appRequest(app, `${guestBase(slug)}/items/${itemId}/claim`, {
+    method: "DELETE",
+    headers: { Cookie: cookie },
+  });
+}
+
+async function mine(app: App, cookie: string, slug = SLUG): Promise<HouseholdRegistryDto> {
+  const res = await appRequest(app, `${guestBase(slug)}/mine`, { headers: { Cookie: cookie } });
+  expect(res.status).toBe(200);
+  return (await res.json()) as HouseholdRegistryDto;
+}
+
+async function publicView(app: App, slug = SLUG): Promise<PublicRegistryDto> {
+  const res = await appRequest(app, guestBase(slug));
+  expect(res.status).toBe(200);
+  return (await res.json()) as PublicRegistryDto;
+}
+
+describe("the guest registry is one 404, whatever the reason", () => {
+  // Unknown slug, feature not bought, list not published: three completely
+  // different facts, and a guest URL is public and unauthenticated, so all three
+  // must answer identically. Anything else lets a stranger enumerate which
+  // weddings exist and which of them are quietly drafting a gift list.
+  const scenarios = [
+    ["an unknown slug", () => buildApp(), "no-such-wedding"],
+    ["a wedding without the entitlement", () => buildApp({ entitled: false }), SLUG],
+    ["an unpublished registry", () => buildApp({ published: false }), SLUG],
+  ] as const;
+
+  for (const [label, make, slug] of scenarios) {
+    it(`${label} → the same 404 on every public route`, async () => {
+      const { app } = make();
+      for (const path of [guestBase(slug), `${guestBase(slug)}/image/${PAN_IMAGE}`]) {
+        const res = await appRequest(app, path);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "registry_not_found" });
+      }
+    });
+
+    it(`${label} → the same 404 on every session-gated route`, async () => {
+      const { app } = make();
+      const cookie = await guestCookie(app);
+
+      const read = await appRequest(app, `${guestBase(slug)}/mine`, {
+        headers: { Cookie: cookie },
+      });
+      expect(read.status).toBe(404);
+      expect(await read.json()).toEqual({ error: "registry_not_found" });
+
+      const claimed = await claim(app, cookie, { quantity: 1 }, slug);
+      expect(claimed.status).toBe(404);
+      expect(await claimed.json()).toEqual({ error: "registry_not_found" });
+
+      const released = await release(app, cookie, slug);
+      expect(released.status).toBe(404);
+      expect(await released.json()).toEqual({ error: "registry_not_found" });
+    });
+  }
+
+  it("401s the session-gated routes with no cookie at all, before the slug is read", async () => {
+    const { app } = buildApp();
+    expect((await appRequest(app, `${guestBase()}/mine`)).status).toBe(401);
+    const res = await appRequest(app, `${guestBase()}/items/${PAN}/claim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ quantity: 1 }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/invite/:slug/registry (public)", () => {
+  it("returns the couple's copy and the list in sort order, no auth needed", async () => {
+    const body = await publicView(buildApp().app);
+    expect(body.headline).toBe("Gifts");
+    expect(body.message).toBe("Your presence is the present.");
+    expect(body.cashGiftsEnabled).toBe(false);
+    expect(body.currency).toBe("AUD");
+    // Inserted pan-then-bowl, sortOrder 1-then-0: the read sorts.
+    expect(body.items.map((i) => i.id)).toEqual([BOWL, PAN]);
+  });
+
+  it("is never cached — a stale list has two households buying the same pan", async () => {
+    const res = await appRequest(buildApp().app, guestBase());
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("reports the claimed total as an aggregate and nothing else about it", async () => {
+    const { app } = buildApp();
+    const body = await publicView(app);
+    const pan = body.items.find((i) => i.id === PAN);
+    expect(pan?.quantityWanted).toBe(2);
+    expect(pan?.quantityClaimed).toBe(1); // the neighbour's claim, counted only
+    expect(body.items.find((i) => i.id === BOWL)?.quantityClaimed).toBe(0);
+
+    // Exhaustive key set, so a field added to the DTO later cannot slip out to
+    // guests without this failing first.
+    expect(Object.keys(pan ?? {}).toSorted()).toEqual(
+      [
+        "category",
+        "description",
+        "externalUrl",
+        "id",
+        "imageCrop",
+        "imageName",
+        "kind",
+        "priceMinor",
+        "quantityClaimed",
+        "quantityWanted",
+        "sortOrder",
+        "title",
+      ].toSorted(),
+    );
+    // The last segment of the key, never the key: the serve route rebuilds
+    // `assets/<weddingId>/<name>` itself, so the payload names no wedding.
+    expect(pan?.imageName).toBe(PAN_IMAGE);
+  });
+
+  it("leaks no claimant, note, gift log, Stripe id or shipping address", async () => {
+    const { app } = buildApp({ shippingAddress: "12 Wattle St, Fitzroy" });
+    const raw = await (await appRequest(app, guestBase())).text();
+    for (const secret of [
+      FOREIGN_NOTE,
+      FOREIGN_DISPLAY_NAME,
+      "acct_secret_123",
+      "12 Wattle St",
+      "rcl_neighbour",
+      BOOTSTRAP_WEDDING_ID,
+    ]) {
+      expect(raw).not.toContain(secret);
+    }
+    const body = JSON.parse(raw) as Record<string, unknown>;
+    expect(Object.keys(body).toSorted()).toEqual(
+      ["cashGiftsEnabled", "currency", "headline", "items", "message"].toSorted(),
+    );
+  });
+});
+
+describe("GET /api/invite/:slug/registry/mine", () => {
+  it("returns this household's own claims and nobody else's", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    expect((await mine(app, cookie)).claims).toEqual([]); // the neighbour's claim is not ours
+
+    expect((await claim(app, cookie, { quantity: 1, note: "ours" })).status).toBe(200);
+    expect((await mine(app, cookie)).claims).toEqual([
+      { itemId: PAN, quantity: 1, status: "reserved", note: "ours", displayName: null },
+    ]);
+  });
+
+  it("is never cached", async () => {
+    const { app } = buildApp();
+    const res = await appRequest(app, `${guestBase()}/mine`, {
+      headers: { Cookie: await guestCookie(app) },
+    });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});
+
+describe("the shipping address is earned, not published", () => {
+  it("ships to a household with a live claim once no embargo stands", async () => {
+    const { app } = buildApp({ shippingAddress: "12 Wattle St, Fitzroy" });
+    const cookie = await guestCookie(app);
+    expect((await mine(app, cookie)).shippingAddress).toBeUndefined(); // nothing claimed yet
+
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+    expect((await mine(app, cookie)).shippingAddress).toBe("12 Wattle St, Fitzroy");
+  });
+
+  it("withholds it until the couple's date has passed, then hands it over", async () => {
+    const future = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10);
+    const past = new Date(Date.now() - 30 * 86_400_000).toISOString().slice(0, 10);
+
+    const embargoed = buildApp({
+      shippingAddress: "12 Wattle St, Fitzroy",
+      shippingVisibleFrom: future,
+    });
+    const embargoedCookie = await guestCookie(embargoed.app);
+    expect((await claim(embargoed.app, embargoedCookie, { quantity: 1 })).status).toBe(200);
+    // Claimed, but the couple asked for nothing to arrive yet.
+    expect((await mine(embargoed.app, embargoedCookie)).shippingAddress).toBeUndefined();
+
+    const lifted = buildApp({
+      shippingAddress: "12 Wattle St, Fitzroy",
+      shippingVisibleFrom: past,
+    });
+    const liftedCookie = await guestCookie(lifted.app);
+    expect((await claim(lifted.app, liftedCookie, { quantity: 1 })).status).toBe(200);
+    expect((await mine(lifted.app, liftedCookie)).shippingAddress).toBe("12 Wattle St, Fitzroy");
+  });
+
+  it("counts the named day itself as lifted, not as one more day of waiting", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const { app } = buildApp({
+      shippingAddress: "12 Wattle St, Fitzroy",
+      shippingVisibleFrom: today,
+    });
+    const cookie = await guestCookie(app);
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+    expect((await mine(app, cookie)).shippingAddress).toBe("12 Wattle St, Fitzroy");
+  });
+
+  it("takes it back when the household releases its last claim", async () => {
+    const { app } = buildApp({ shippingAddress: "12 Wattle St, Fitzroy" });
+    const cookie = await guestCookie(app);
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+    expect((await release(app, cookie)).status).toBe(200);
+    expect((await mine(app, cookie)).shippingAddress).toBeUndefined();
+  });
+
+  it("never ships an address the couple never set", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+    expect((await mine(app, cookie)).shippingAddress).toBeUndefined();
+  });
+});
+
+describe("claim → purchased → release, over HTTP", () => {
+  it("runs the round trip, and a release is a tombstone the re-claim reuses", async () => {
+    const { app, db } = buildApp();
+    const cookie = await guestCookie(app);
+
+    expect((await claim(app, cookie, { quantity: 1, displayName: "The Testfamilys" })).status).toBe(
+      200,
+    );
+    expect((await mine(app, cookie)).claims[0]?.status).toBe("reserved");
+    expect((await publicView(app)).items.find((i) => i.id === PAN)?.quantityClaimed).toBe(2);
+
+    // "Mark purchased" is the SAME endpoint with a different status — one unique
+    // (item, family) row in two states, so there is no second write path to drift.
+    const purchased = await claim(app, cookie, { quantity: 1, status: "purchased" });
+    expect(purchased.status).toBe(200);
+    expect(await purchased.json()).toEqual({ ok: true });
+    const afterPurchase = await mine(app, cookie);
+    expect(afterPurchase.claims[0]?.status).toBe("purchased");
+    expect(afterPurchase.claims[0]?.displayName).toBeNull(); // omitted ⇒ cleared
+
+    expect((await release(app, cookie)).status).toBe(200);
+    expect((await mine(app, cookie)).claims).toEqual([]); // released ⇒ not a claim
+    expect((await publicView(app)).items.find((i) => i.id === PAN)?.quantityClaimed).toBe(1);
+
+    // The row survives as `released` rather than being deleted…
+    const [family] = db
+      .select({ id: families.id })
+      .from(families)
+      .where(eq(families.publicId, FAMILY))
+      .all();
+    const rows = db
+      .select({ id: registryClaims.id, status: registryClaims.status })
+      .from(registryClaims)
+      .where(
+        and(
+          eq(registryClaims.itemId, PAN),
+          eq(registryClaims.familyId, (family as { id: string }).id),
+        ),
+      )
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe("released");
+    const tombstoneId = rows[0]?.id;
+
+    // …and the re-claim reuses it, rather than colliding with the unique index.
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+    const after = db
+      .select({ id: registryClaims.id, status: registryClaims.status })
+      .from(registryClaims)
+      .where(
+        and(
+          eq(registryClaims.itemId, PAN),
+          eq(registryClaims.familyId, (family as { id: string }).id),
+        ),
+      )
+      .all();
+    expect(after).toHaveLength(1);
+    expect(after[0]?.id).toBe(tombstoneId as string);
+    expect(after[0]?.status).toBe("reserved");
+  });
+
+  it("409s an over-claim, counting what other households already hold", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    // Two wanted, one already spoken for by the neighbour: asking for two is one
+    // too many, and the caller may not see why (that would name the neighbour).
+    const res = await claim(app, cookie, { quantity: 2 });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "item_fully_claimed" });
+
+    expect((await claim(app, cookie, { quantity: 1 })).status).toBe(200);
+  });
+
+  it("404s an item id that belongs to no item, with the item-shaped code", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    const res = await claim(app, cookie, { quantity: 1 }, SLUG, "reg_nope");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "registry_item_not_found" });
+  });
+});
+
+describe("guest claim request bodies", () => {
+  it("400s a quantity outside 1..99, at either end", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    for (const quantity of [0, -1, 100, 1.5, "1"]) {
+      const res = await claim(app, cookie, { quantity });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Missing or invalid fields" });
+    }
+  });
+
+  it("400s a malformed body rather than surfacing a framework parse error", async () => {
+    const { app } = buildApp();
+    const res = await appRequest(app, `${guestBase()}/items/${PAN}/claim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: await guestCookie(app) },
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("defaults an empty body to one reserved, and bounds the free text", async () => {
+    const { app } = buildApp();
+    const cookie = await guestCookie(app);
+    expect((await claim(app, cookie, {})).status).toBe(200);
+    expect((await mine(app, cookie)).claims[0]).toEqual({
+      itemId: PAN,
+      quantity: 1,
+      status: "reserved",
+      note: null,
+      displayName: null,
+    });
+
+    expect((await claim(app, cookie, { note: "x".repeat(1001) })).status).toBe(400);
+    expect((await claim(app, cookie, { displayName: "x".repeat(121) })).status).toBe(400);
+    expect((await claim(app, cookie, { status: "released" })).status).toBe(400);
+  });
+});
+
+describe("a cookie for one wedding buys nothing on another", () => {
+  it("cannot claim another wedding's item", async () => {
+    const { app } = buildApp();
+    // A real, valid session — for the OTHER wedding's household.
+    const foreign = await guestCookie(app, FOREIGN_FAMILY);
+    const res = await claim(app, foreign, { quantity: 1 });
+    expect(res.status).toBe(404);
+    // Deliberately the item-shaped code, not a family-shaped one: a distinct
+    // code would confirm to the holder of any valid cookie that this item id
+    // exists on a wedding they cannot read.
+    expect(await res.json()).toEqual({ error: "registry_item_not_found" });
+  });
+
+  it("cannot release another wedding's claim", async () => {
+    const { app } = buildApp();
+    const local = await guestCookie(app);
+    expect((await claim(app, local, { quantity: 1 })).status).toBe(200);
+
+    const foreign = await guestCookie(app, FOREIGN_FAMILY);
+    const res = await release(app, foreign);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "registry_item_not_found" });
+    // The local household's claim is untouched.
+    expect((await mine(app, local)).claims).toHaveLength(1);
+  });
+
+  it("reads an empty household on another wedding's slug, never its claims", async () => {
+    const { app } = buildApp({ shippingAddress: "12 Wattle St, Fitzroy" });
+    const local = await guestCookie(app);
+    expect((await claim(app, local, { quantity: 1 })).status).toBe(200);
+
+    const foreign = await guestCookie(app, FOREIGN_FAMILY);
+    const view = await mine(app, foreign);
+    expect(view.claims).toEqual([]);
+    // No claim on this wedding ⇒ no address, even though a household of this
+    // wedding would see one.
+    expect(view.shippingAddress).toBeUndefined();
+  });
+
+  it("works the other way round too — the bootstrap cookie is useless next door", async () => {
+    const { app } = buildApp();
+    const local = await guestCookie(app);
+    const res = await claim(app, local, { quantity: 1 }, OTHER_SLUG, OTHER_ITEM);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "registry_item_not_found" });
+  });
+});
+
+describe("GET /api/invite/:slug/registry/image/:name", () => {
+  function plant(assets: ReturnType<typeof createAssetsStub>, key: string) {
+    assets._store.set(key, { bytes: PNG.buffer.slice(0) as ArrayBuffer, contentType: "image/png" });
+  }
+
+  it("serves a published registry's image to anyone, no cookie", async () => {
+    const { app, assets } = buildApp();
+    plant(assets, `assets/${BOOTSTRAP_WEDDING_ID}/${PAN_IMAGE}`);
+    const res = await appRequest(app, `${guestBase()}/image/${PAN_IMAGE}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    // Public bytes: a published registry's images are as public as its slug.
+    expect(res.headers.get("cache-control")).toContain("public");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PNG);
+  });
+
+  it("refuses every name that is not a registry key, and never leaves the prefix", async () => {
+    const { app, assets } = buildApp();
+    plant(assets, `assets/${BOOTSTRAP_WEDDING_ID}/${PAN_IMAGE}`);
+    plant(assets, `assets/${OTHER_WEDDING_ID}/registry-secret`);
+    // These reach the handler as one path segment and are refused by name.
+    for (const name of [
+      "..%2Fwed_other%2Fregistry-secret",
+      "hero-1234",
+      "registry-",
+      "registry-abc.jpg",
+    ]) {
+      const res = await appRequest(app, `${guestBase()}/image/${name}`);
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "registry_not_found" });
+    }
+    // These collapse in the URL parser before routing, so they match no route
+    // at all — still 404, but the framework's, not ours.
+    for (const name of [
+      "../wed_other/registry-secret",
+      "registry-secret/../../wed_other/registry-secret",
+    ]) {
+      expect((await appRequest(app, `${guestBase()}/image/${name}`)).status).toBe(404);
+    }
+    // Not simply refusing everything.
+    expect((await appRequest(app, `${guestBase()}/image/${PAN_IMAGE}`)).status).toBe(200);
+  });
+
+  it("404s a well-formed name with no object behind it, same body as everything else", async () => {
+    const { app } = buildApp();
+    const res = await appRequest(app, `${guestBase()}/image/registry-missing`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "registry_not_found" });
+  });
+
+  it("ignores the client ?v= for cache keying — looping ?v= re-bills nothing (S-M1)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const { app, assets } = buildApp({ images });
+      plant(assets, `assets/${BOOTSTRAP_WEDDING_ID}/${PAN_IMAGE}`);
+
+      const accept = { accept: "image/avif,image/webp,*/*" };
+      const first = await appRequest(app, `${guestBase()}/image/${PAN_IMAGE}?v=1`, {
+        headers: accept,
+      });
+      expect(first.status).toBe(200);
+      expect(new Uint8Array(await first.arrayBuffer())).toEqual(TRANSFORMED);
+      expect(images.widths).toHaveLength(1);
+      expect(cache.store.size).toBe(1);
+
+      // The slug is public, so anyone can loop `?v=`. The version is derived from
+      // the server-built key, so every one of these hits the SAME entry: the
+      // Images binding — billed per call — never runs again.
+      for (const v of [2, 3, 4, 5]) {
+        const res = await appRequest(app, `${guestBase()}/image/${PAN_IMAGE}?v=${v}`, {
+          headers: accept,
+        });
+        expect(res.status).toBe(200);
+        expect(new Uint8Array(await res.arrayBuffer())).toEqual(TRANSFORMED);
+      }
+      expect(images.widths).toHaveLength(1);
+      expect(cache.store.size).toBe(1);
+    });
+  });
+
+  it("keys the cache per image name, so two gifts never share one entry", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const { app, assets, db } = buildApp({ images });
+      db.update(registryItems)
+        .set({ imageKey: `assets/${BOOTSTRAP_WEDDING_ID}/registry-bowl` })
+        .where(eq(registryItems.id, BOWL))
+        .run();
+      plant(assets, `assets/${BOOTSTRAP_WEDDING_ID}/${PAN_IMAGE}`);
+      plant(assets, `assets/${BOOTSTRAP_WEDDING_ID}/registry-bowl`);
+
+      await appRequest(app, `${guestBase()}/image/${PAN_IMAGE}`);
+      await appRequest(app, `${guestBase()}/image/registry-bowl`);
+      expect(cache.store.size).toBe(2);
+    });
+  });
+});

--- a/cire/api/src/routes/registry-guest.ts
+++ b/cire/api/src/routes/registry-guest.ts
@@ -1,0 +1,314 @@
+import type { RateLimiterBackend } from "@shared/rate-limit";
+import { Effect, Schema } from "effect";
+import { Elysia } from "elysia";
+
+import { DbService } from "../db";
+import type { Db } from "../db";
+import { sessionAuth } from "../middleware/auth";
+import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { runCire } from "../observability";
+import { ClaimItemBody } from "../schemas/registry";
+import { versionFromKey } from "../services/event-image";
+import { AssetsR2Service, REGISTRY_IMAGE_NAME } from "../services/invite-assets";
+import type { AssetsBucket } from "../services/invite-assets";
+import {
+  negotiateFormat,
+  resolveVariant,
+  serveTransformedImage,
+} from "../services/invite-image-transform";
+import type { ImagesBindingLike } from "../services/invite-image-transform";
+import { registryGuestService, registryService } from "../services/registry";
+
+// Sentinel parse hook — the handler parses by hand so a malformed payload
+// degrades to the schema's 400 (same idiom as every other cire write route).
+const manualParse = { parse: () => ({}) };
+
+/**
+ * The ONE 404 the whole guest surface answers with.
+ *
+ * Unknown slug, wedding without the `registry` entitlement, registry never
+ * opened, registry unpublished, image name that doesn't match the registry
+ * prefix, object missing from R2 — all of them, on every route here, produce
+ * this exact body. A guest URL is public and unauthenticated, so any answer that
+ * told these apart would let anyone enumerate which weddings exist and which of
+ * them are quietly drafting a gift list.
+ */
+const notVisible = (set: { status?: number | string }) =>
+  Effect.sync(() => {
+    set.status = 404;
+    return { error: "registry_not_found" };
+  });
+
+function notVisibleSync(set: { status?: number | string }) {
+  set.status = 404;
+  return { error: "registry_not_found" };
+}
+
+const itemNotFound = (set: { status?: number | string }) =>
+  Effect.sync(() => {
+    set.status = 404;
+    return { error: "registry_item_not_found" };
+  });
+
+const badRequest = (set: { status?: number | string }) =>
+  Effect.sync(() => {
+    set.status = 400;
+    return { error: "Missing or invalid fields" };
+  });
+
+const internal = (set: { status?: number | string }) =>
+  Effect.sync(() => {
+    set.status = 500;
+    return { error: "Internal error" };
+  });
+
+function unauthorisedSync(set: { status?: number | string }) {
+  set.status = 401;
+  return { error: "Unauthorized" };
+}
+
+/**
+ * Log a defect before it becomes an anonymous 500.
+ *
+ * Annotated with NOTHING. The organiser routes annotate `weddingId`, which these
+ * handlers don't have until after the read that may be the very thing failing;
+ * the identifier they DO have is the slug, and a slug is the couple's names
+ * (`anna-and-ben`) — squarely the PII the logging rules keep out of log lines.
+ * `runCire` still stamps the trace/span, which is what correlates the line.
+ */
+const logDefect = (cause: unknown) => Effect.logError("registry guest handler defect", cause);
+
+/**
+ * Guest registry — PUBLIC READS (no auth), mounted under /api/invite:
+ *
+ *   GET /api/invite/:slug/registry             → the published list
+ *   GET /api/invite/:slug/registry/image/:name → a gift's image bytes
+ *
+ * A sibling Elysia instance to `createInvitePublicRoutes` rather than more
+ * routes on it: this pair is the only part of the invite surface that must
+ * disappear when the `registry` entitlement is absent, and keeping it separate
+ * means that gate can never leak onto the invite's own routes (or fail to cover
+ * one of these two).
+ *
+ * The gate itself lives in `registryGuestService`, not here, so the read routes
+ * and the write routes below cannot drift into different ideas of "visible".
+ */
+export const createRegistryGuestRoutes = (
+  db: Db,
+  deps: { readonly assets?: AssetsBucket; readonly images?: ImagesBindingLike } = {},
+) =>
+  new Elysia({ prefix: "/api/invite" })
+    .get("/:slug/registry", ({ params, set }) => {
+      // Same reasoning as the invite payload it sits beside: this JSON carries
+      // live claim totals and the couple's copy, and a guest revalidates it on
+      // mount. Served stale it would show a gift as available that someone
+      // claimed an hour ago — two households buying the same pan.
+      set.headers["cache-control"] = "no-store";
+      return runCire(
+        registryGuestService.publicView(params.slug).pipe(
+          Effect.provideService(DbService, db),
+          Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
+          Effect.tapDefect(logDefect),
+          Effect.catchAllDefect(() => internal(set)),
+        ),
+      );
+    })
+    .get("/:slug/registry/image/:name", ({ params, query, request, set }) => {
+      if (!REGISTRY_IMAGE_NAME.test(params.name)) return notVisibleSync(set);
+      // Bounded, allowlisted variant (?variant=) + Accept-negotiated format,
+      // both collapsing to a fixed value, so the transform-URL cardinality per
+      // image stays capped (3 variants × 3 formats) — the same cost guarantee
+      // the invite image routes make.
+      const variant = resolveVariant((query as Record<string, string | undefined>).variant);
+      const format = negotiateFormat(request.headers.get("accept"));
+      return runCire(
+        Effect.gen(function* () {
+          // The gate runs BEFORE any R2 or Images work: an unpublished or
+          // unentitled wedding must not be able to spend a transform call, and
+          // its image bytes must not be reachable by anyone who guesses a name.
+          const weddingId = yield* registryGuestService.visibleWeddingId(params.slug);
+          // The key is rebuilt server-side from the resolved wedding id and a
+          // `:name` that must match `registry-<uuid>` — so no request can name
+          // another wedding's object, climb out of the prefix, or reach the
+          // invite builder's slots, however it spells the path.
+          const key = `assets/${weddingId}/${params.name}`;
+          return yield* serveTransformedImage({
+            request,
+            key,
+            // Server-derived version, NEVER the client's `?v=` (S-M1). Every
+            // save mints a fresh uuid, so the key IS the content version; keying
+            // on `?v=` would let anyone loop ?v=1,2,3… on a public slug to mint
+            // unbounded per-call-billed transforms.
+            version: versionFromKey(key),
+            // Slug-namespaced, and including the image name. The name is what
+            // stops every gift in a wedding sharing one cache path (told apart
+            // only by a 32-bit hash); the slug prefix is what stops this PUBLIC
+            // entry ever colliding with the organiser route's PRIVATE one for
+            // the same bytes — `serveTransformedImage` folds `visibility` into
+            // the response header, not into the cache key.
+            cacheSlot: `${params.slug}:registry:${params.name}`,
+            variant,
+            format,
+            // Public: a published registry's images are as public as its slug.
+            visibility: "public",
+            images: deps.images,
+          });
+        }).pipe(
+          Effect.provideService(DbService, db),
+          Effect.provideService(AssetsR2Service, deps.assets as AssetsBucket),
+          Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
+          // A key absent from R2 is a stale reference, not a fault: the item's
+          // row outlived its object (or never had one).
+          Effect.catchTag("AssetR2Error", () => notVisible(set)),
+          Effect.tapDefect(logDefect),
+          Effect.catchAllDefect(() => internal(set)),
+        ),
+      );
+    });
+
+/**
+ * Guest registry — THIS HOUSEHOLD'S READ:
+ *
+ *   GET /api/invite/:slug/registry/mine  (sessionAuth)
+ *
+ * Split from the writes below because the gate differs by one plugin: reading
+ * your own claims is what the gift page does on every mount, and putting it
+ * behind the write limiter would 429 a NAT'd household for browsing.
+ */
+export const createRegistryGuestMineRoutes = (db: Db) =>
+  new Elysia({ prefix: "/api/invite" })
+    .use(sessionAuth(db))
+    .get("/:slug/registry/mine", ({ params, familyId, set }) => {
+      // The sessionAuth plugin guarantees this; the check is a runtime net.
+      if (!familyId) return unauthorisedSync(set);
+      set.headers["cache-control"] = "no-store";
+      return runCire(
+        registryGuestService.householdView({ slug: params.slug, familyId }).pipe(
+          Effect.provideService(DbService, db),
+          Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
+          Effect.tapDefect(logDefect),
+          Effect.catchAllDefect(() => internal(set)),
+        ),
+      );
+    });
+
+/** Options for {@link createRegistryGuestClaimRoutes}. */
+export interface RegistryGuestClaimDeps {
+  /** Per-IP limiter for the two guest writes. Required. */
+  readonly limiter: RateLimiterBackend;
+}
+
+/**
+ * Guest registry — WRITES:
+ *
+ *   POST   /api/invite/:slug/registry/items/:itemId/claim   (sessionAuth + limiter)
+ *   DELETE /api/invite/:slug/registry/items/:itemId/claim   (sessionAuth + limiter)
+ *
+ * Gate order: `sessionAuth` (401) → limiter (429). The limiter is LAST of the
+ * two so an anonymous caller cannot spend a household's budget by hammering the
+ * route. The visible-registry gate necessarily runs inside the handler — it
+ * needs a slug→wedding read the middleware chain has no place for — so an
+ * authenticated guest of an unpublished wedding does spend their OWN per-IP
+ * budget on a 404. That is the intended shape: the budget is per-IP, so the only
+ * caller they can exhaust is themselves.
+ *
+ * Per-IP, unlike the organiser registry writes, which are per-user: a guest has
+ * no user. Sized for a household deciding on gifts, not for a form submit.
+ *
+ * No Turnstile. The `cire_session` cookie these routes require was minted by
+ * `POST /api/claim`, which IS Turnstile-gated — the same argument `app.ts`
+ * already records for the RSVP writes.
+ *
+ * There is deliberately NO "mark purchased" endpoint. A claim and a purchase are
+ * the same unique `(item_id, family_id)` row in two states, so marking one
+ * purchased is a POST with `status: "purchased"` — a second endpoint would be a
+ * second way to write one row, and the two would drift.
+ *
+ * Error mapping, all as machine-readable codes (the `rsvp_closed` precedent):
+ *
+ *   RegistryNotVisible      → 404 `registry_not_found`
+ *   RegistryItemNotInWedding→ 404 `registry_item_not_found`
+ *   FamilyNotInWedding      → 404 `registry_item_not_found`  (see below)
+ *   ItemFullyClaimed        → 409 `item_fully_claimed`
+ *   InvalidQuantity         → 400 `invalid_quantity`
+ *
+ * `FamilyNotInWedding` answers as a missing ITEM on purpose. It fires when a
+ * cookie for wedding A is used on wedding B's slug, and a distinct code there
+ * would confirm to the holder of any valid cookie that a given item id exists on
+ * a wedding they have no business reading.
+ */
+export const createRegistryGuestClaimRoutes = (db: Db, deps: RegistryGuestClaimDeps) =>
+  new Elysia({ prefix: "/api/invite" })
+    .use(sessionAuth(db))
+    .use(rateLimitMiddleware(deps.limiter))
+    .post(
+      "/:slug/registry/items/:itemId/claim",
+      async ({ params, familyId, request, set }) => {
+        if (!familyId) return unauthorisedSync(set);
+        const raw: unknown = await request.json().catch(() => null);
+        return runCire(
+          Effect.gen(function* () {
+            const body = yield* Schema.decodeUnknown(ClaimItemBody)(raw);
+            // Resolve the wedding from the SLUG and hand THAT id to the service.
+            // The cookie names a household, not a wedding, so this is what stops
+            // a family of wedding A acting on wedding B: `claim` proves the
+            // family belongs to the wedding it was given, and fails
+            // `FamilyNotInWedding` when it doesn't.
+            const weddingId = yield* registryGuestService.visibleWeddingId(params.slug);
+            yield* registryService.claim({
+              weddingId,
+              itemId: params.itemId,
+              familyId,
+              quantity: body.quantity,
+              status: body.status,
+              note: body.note,
+              displayName: body.displayName,
+            });
+            return { ok: true };
+          }).pipe(
+            Effect.provideService(DbService, db),
+            Effect.catchTag("ParseError", () => badRequest(set)),
+            Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
+            Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
+            Effect.catchTag("FamilyNotInWedding", () => itemNotFound(set)),
+            Effect.catchTag("ItemFullyClaimed", () =>
+              Effect.sync(() => {
+                set.status = 409;
+                return { error: "item_fully_claimed" };
+              }),
+            ),
+            // Unreachable through this route — the schema bounds quantity to
+            // 1..99 before the service sees it — but mapped rather than cast, so
+            // a future schema change can only widen the 400, never 500.
+            Effect.catchTag("InvalidQuantity", () =>
+              Effect.sync(() => {
+                set.status = 400;
+                return { error: "invalid_quantity" };
+              }),
+            ),
+            Effect.tapDefect(logDefect),
+            Effect.catchAllDefect(() => internal(set)),
+          ),
+        );
+      },
+      manualParse,
+    )
+    .delete("/:slug/registry/items/:itemId/claim", ({ params, familyId, set }) => {
+      if (!familyId) return unauthorisedSync(set);
+      return runCire(
+        Effect.gen(function* () {
+          const weddingId = yield* registryGuestService.visibleWeddingId(params.slug);
+          // A release is a tombstone, not a delete: the row survives as
+          // `released` so a re-claim reuses it under the unique index. Scoped by
+          // all three ids, so releasing is as cross-tenant-safe as claiming.
+          yield* registryService.releaseClaim({ weddingId, itemId: params.itemId, familyId });
+          return { ok: true };
+        }).pipe(
+          Effect.provideService(DbService, db),
+          Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
+          Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
+          Effect.tapDefect(logDefect),
+          Effect.catchAllDefect(() => internal(set)),
+        ),
+      );
+    });

--- a/cire/api/src/services/invite.ts
+++ b/cire/api/src/services/invite.ts
@@ -78,6 +78,12 @@ export interface InviteTheme {
     story: SectionTone | null;
     details: SectionTone | null;
     welcome: SectionTone | null;
+    // Gift-registry section (migration 0057). Read-only for now: the theme WRITE
+    // body (`InviteThemeBody`) is total, so adding a key there would 400 every
+    // save the host portal already sends. The column exists and is emitted so
+    // the guest site can paint the section; the builder control that sets it is
+    // a separate change.
+    registry: SectionTone | null;
   };
 }
 
@@ -130,6 +136,18 @@ export interface InviteCustomisation {
   welcome: {
     message: string | null;
   };
+  // Gift-registry section copy (migration 0057). Same nullable-means-built-in-
+  // default contract as `details` / `story`, and public for the same reason:
+  // it is section furniture on the invite shell, not household-addressed prose
+  // like the closing note. Whether the section RENDERS at all is decided by the
+  // registry's own endpoint (entitlement + `published`), never by this copy —
+  // so a wedding that never opened a registry may still carry a heading here,
+  // and no guest ever sees it.
+  registry: {
+    eyebrow: string | null;
+    heading: string | null;
+    body: string | null;
+  };
   // Footer closing note (0049) + its optional image (0050) — a small centred
   // monogram / motif / signature above the note. Both `null` ⇒ the guest site
   // renders NEITHER; there is no built-in default here, unlike
@@ -160,7 +178,7 @@ const EMPTY_THEME: InviteTheme = {
   bodyStyle: null,
   palettePreset: null,
   palette: { ground: null, card: null, ink: null, gilt: null, bloom: null },
-  tones: { hero: null, story: null, details: null, welcome: null },
+  tones: { hero: null, story: null, details: null, welcome: null, registry: null },
 };
 
 // The defaults a wedding with no customisation row reports — identical to the
@@ -176,6 +194,7 @@ const EMPTY: InviteCustomisation = {
   story: { eyebrow: null, heading: null, body: null, imageUrl: null, imageCrop: null },
   details: { eyebrow: null, heading: null },
   welcome: { message: null },
+  registry: { eyebrow: null, heading: null, body: null },
   footer: { message: null, imageUrl: null, imageCrop: null },
   heroDisplay: DEFAULT_HERO_DISPLAY,
   theme: EMPTY_THEME,
@@ -242,6 +261,9 @@ function toCustomisation(
     detailsEyebrow: string | null;
     detailsHeading: string | null;
     welcomeMessage: string | null;
+    registryEyebrow: string | null;
+    registryHeading: string | null;
+    registryBody: string | null;
     footerMessage: string | null;
     heroImageKey: string | null;
     storyImageKey: string | null;
@@ -272,6 +294,7 @@ function toCustomisation(
     storyTone: string | null;
     detailsTone: string | null;
     welcomeTone: string | null;
+    registryTone: string | null;
     inviteMessage: string | null;
     // NOT NULL column, but a LEFT JOIN miss (no customisation row) yields null.
     designId: string | null;
@@ -305,6 +328,11 @@ function toCustomisation(
     },
     details: { eyebrow: c.detailsEyebrow, heading: c.detailsHeading },
     welcome: { message: c.welcomeMessage },
+    registry: {
+      eyebrow: c.registryEyebrow,
+      heading: c.registryHeading,
+      body: c.registryBody,
+    },
     footer: {
       message: c.footerMessage,
       imageUrl: c.footerImageKey ? imagePath(slug, "footer", version) : null,
@@ -343,6 +371,7 @@ function toCustomisation(
         story: c.storyTone as SectionTone | null,
         details: c.detailsTone as SectionTone | null,
         welcome: c.welcomeTone as SectionTone | null,
+        registry: c.registryTone as SectionTone | null,
       },
     },
     inviteMessage: c.inviteMessage,
@@ -402,6 +431,9 @@ export const inviteService = {
             detailsEyebrow: weddingInviteCustomisations.detailsEyebrow,
             detailsHeading: weddingInviteCustomisations.detailsHeading,
             welcomeMessage: weddingInviteCustomisations.welcomeMessage,
+            registryEyebrow: weddingInviteCustomisations.registryEyebrow,
+            registryHeading: weddingInviteCustomisations.registryHeading,
+            registryBody: weddingInviteCustomisations.registryBody,
             footerMessage: weddingInviteCustomisations.footerMessage,
             heroImageKey: weddingInviteCustomisations.heroImageKey,
             storyImageKey: weddingInviteCustomisations.storyImageKey,
@@ -430,6 +462,7 @@ export const inviteService = {
             storyTone: weddingInviteCustomisations.storyTone,
             detailsTone: weddingInviteCustomisations.detailsTone,
             welcomeTone: weddingInviteCustomisations.welcomeTone,
+            registryTone: weddingInviteCustomisations.registryTone,
             inviteMessage: weddingInviteCustomisations.inviteMessage,
             designId: weddingInviteCustomisations.designId,
             updatedAt: weddingInviteCustomisations.updatedAt,

--- a/cire/api/src/services/registry.ts
+++ b/cire/api/src/services/registry.ts
@@ -29,6 +29,7 @@ import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
 import { commitGroupedBatches, DbService, dbQuery } from "../db";
+import { entitlementService } from "./entitlements";
 import { REGISTRY_IMAGE_NAME } from "./invite-assets";
 
 /** No item with this id under this wedding (missing or another wedding's). 404-class. */
@@ -51,6 +52,17 @@ export class RegistryItemLimitReached extends Data.TaggedError("RegistryItemLimi
  * throw, which surfaces as a 500 and says nothing useful.
  */
 export class InvalidQuantity extends Data.TaggedError("InvalidQuantity") {}
+/**
+ * No registry a guest may see at this slug. 404-class, and DELIBERATELY one error
+ * for four different causes: unknown slug, wedding without the `registry`
+ * entitlement, registry never opened, registry opened but unpublished.
+ *
+ * Telling them apart would tell an unauthenticated caller which weddings exist
+ * and which of them are drafting a gift list — so the guest surface answers all
+ * four the same way, the same posture the session-gated invite image slots take
+ * (404, not 401/403).
+ */
+export class RegistryNotVisible extends Data.TaggedError("RegistryNotVisible") {}
 
 /** One page of the gift log. A wedding's log is unbounded; a snapshot is not. */
 const GIFT_LOG_PAGE = 50;
@@ -1082,5 +1094,286 @@ export const registryService = {
       );
       return itemRows.length > 0 || contributionRows.length > 0;
     }).pipe(Effect.withSpan("cire.registry.hasRows"));
+  },
+};
+
+// ── Guest surface ─────────────────────────────────────────────────────────────
+//
+// Everything below serves the GUEST site, off a wedding slug rather than a
+// `:weddingId` path segment, behind no organiser role gate. It is a separate
+// export rather than more methods on `registryService` because the audience —
+// and therefore what may leave the process — is different: `registryService.get`
+// returns the gift log, Stripe account state and the shipping address to a
+// caller the route already proved owns the wedding, and none of that may reach a
+// guest. Two objects means the narrow DTOs cannot be widened by accident.
+
+/**
+ * One item as a guest sees it.
+ *
+ * `imageName` is the LAST SEGMENT of the R2 key, not the key — the guest image
+ * route rebuilds `assets/<weddingId>/<name>` server-side, so the payload has no
+ * reason to carry the wedding id, and a key shaped wrongly (or naming another
+ * wedding's object) resolves to null rather than a URL the serve route would
+ * refuse anyway.
+ *
+ * No `weddingId`, no `imageKey`, no timestamps: nothing a guest renders needs
+ * them, and every field here is public bytes the moment the registry publishes.
+ */
+export interface PublicRegistryItemDto {
+  id: string;
+  kind: RegistryItemKind;
+  title: string;
+  description: string | null;
+  imageName: string | null;
+  imageCrop: string | null;
+  externalUrl: string | null;
+  priceMinor: number | null;
+  quantityWanted: number;
+  /** Everyone's non-released claims, summed. An aggregate — never who claimed. */
+  quantityClaimed: number;
+  category: string | null;
+  sortOrder: number;
+}
+
+/**
+ * The published registry as a guest sees it: the couple's copy and the list.
+ *
+ * What is ABSENT is the point — no gift log, no Stripe identifiers, no
+ * `familyId`, no claimant name or note, no shipping address. A guest may learn
+ * that two of three pans are spoken for; never by whom.
+ */
+export interface PublicRegistryDto {
+  headline: string | null;
+  message: string | null;
+  cashGiftsEnabled: boolean;
+  /** The wedding's primary currency — what every `priceMinor` is denominated in. */
+  currency: string;
+  items: PublicRegistryItemDto[];
+}
+
+/** One of THIS household's live claims. */
+export interface HouseholdClaimDto {
+  itemId: string;
+  quantity: number;
+  status: Exclude<RegistryClaimStatus, "released">;
+  note: string | null;
+  displayName: string | null;
+}
+
+/**
+ * What a signed-in household may see beyond the public list.
+ *
+ * `shippingAddress` is OPTIONAL rather than nullable: absent means "you may not
+ * see it", and there is no second field saying why. A household that has claimed
+ * nothing, or one reading before the couple's embargo date, gets the same shape
+ * as a couple who set no address at all.
+ */
+export interface HouseholdRegistryDto {
+  claims: HouseholdClaimDto[];
+  shippingAddress?: string;
+}
+
+/** Today in the same `YYYY-MM-DD` shape `shipping_visible_from` is stored in. */
+const todayIso = (): string => new Date().toISOString().slice(0, 10);
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Has the couple's shipping-address embargo lifted?
+ *
+ * A NULL date means no embargo, and so does an unparseable one — the write
+ * schema validates the shape (S-M2), so a value that got past it is corruption,
+ * and failing open here matches what `schemas/registry.ts` documents. Comparing
+ * `YYYY-MM-DD` strings lexicographically IS a date comparison for that shape, and
+ * avoids inventing a timezone the couple never chose.
+ */
+function embargoLifted(visibleFrom: string | null): boolean {
+  if (!visibleFrom || !ISO_DATE.test(visibleFrom)) return true;
+  return visibleFrom <= todayIso();
+}
+
+const toPublicItemDto = (
+  weddingId: string,
+  r: ItemRow,
+  quantityClaimed: number,
+): PublicRegistryItemDto => ({
+  id: r.id,
+  kind: r.kind,
+  title: r.title,
+  description: r.description,
+  imageName:
+    r.imageKey && imageKeyBelongsTo(weddingId, r.imageKey)
+      ? (r.imageKey.split("/")[2] ?? null)
+      : null,
+  imageCrop: r.imageCrop,
+  externalUrl: r.externalUrl,
+  priceMinor: r.priceMinor,
+  quantityWanted: r.quantityWanted,
+  quantityClaimed,
+  category: r.category,
+  sortOrder: r.sortOrder,
+});
+
+/**
+ * Slug → wedding id, but ONLY when a guest may see this wedding's registry.
+ *
+ * Two independent gates, both of which must hold: the wedding carries the
+ * `registry` entitlement, and `registry_settings.published` is 1. Either one
+ * missing fails `RegistryNotVisible`, which every guest route turns into the
+ * same 404 — so an unentitled wedding, an unpublished one and a slug nobody
+ * registered are indistinguishable from outside.
+ *
+ * The settings row travels back with the id because every caller that needs the
+ * gate also needs the settings, and re-reading it per route would be a second
+ * round trip for a row already in hand.
+ */
+function resolveVisibleRegistry(
+  slug: string,
+): Effect.Effect<
+  { weddingId: string; settings: RegistrySettingsDto },
+  RegistryNotVisible,
+  DbService
+> {
+  return Effect.gen(function* () {
+    const db = yield* DbService;
+    const [weddingRow] = yield* dbQuery(() =>
+      db.select({ id: weddings.id }).from(weddings).where(eq(weddings.slug, slug)).all(),
+    );
+    const weddingId = (weddingRow as { id: string } | undefined)?.id;
+    if (!weddingId) return yield* Effect.fail(new RegistryNotVisible());
+
+    // Both gates read together: neither answer depends on the other, and the
+    // common case (locked feature, no settings row) pays one round trip's
+    // latency rather than two.
+    const { entitled, settingsRows } = yield* Effect.all(
+      {
+        entitled: entitlementService.has(weddingId, "registry"),
+        settingsRows: dbQuery(() =>
+          db.select().from(registrySettings).where(eq(registrySettings.weddingId, weddingId)).all(),
+        ),
+      },
+      { concurrency: "unbounded" },
+    );
+    const settings = settingsRows[0]
+      ? toSettingsDto(settingsRows[0] as SettingsRow)
+      : defaultSettings(weddingId);
+    if (!entitled || !settings.published) return yield* Effect.fail(new RegistryNotVisible());
+    return { weddingId, settings };
+  });
+}
+
+export const registryGuestService = {
+  /**
+   * The wedding a guest route may act on, or `RegistryNotVisible`.
+   *
+   * The write routes resolve the wedding from the SLUG and hand the id to
+   * `registryService.claim` / `releaseClaim`, so a `cire_session` cookie minted
+   * for wedding A carries no authority on wedding B's slug: the claim statement
+   * proves the household belongs to the wedding it names (S-H2) and fails
+   * `FamilyNotInWedding` when it does not.
+   */
+  visibleWeddingId(slug: string): Effect.Effect<string, RegistryNotVisible, DbService> {
+    return resolveVisibleRegistry(slug).pipe(
+      Effect.map((r) => r.weddingId),
+      Effect.withSpan("cire.registry.visibleWeddingId"),
+    );
+  },
+
+  /** The published list, with per-item claimed totals. No identities, ever. */
+  publicView(slug: string): Effect.Effect<PublicRegistryDto, RegistryNotVisible, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const { settings, weddingId } = yield* resolveVisibleRegistry(slug);
+      const { claimed, currency, itemRows } = yield* Effect.all(
+        {
+          itemRows: dbQuery(() =>
+            db
+              .select()
+              .from(registryItems)
+              .where(eq(registryItems.weddingId, weddingId))
+              .orderBy(asc(registryItems.sortOrder), asc(registryItems.id))
+              .all(),
+          ),
+          claimed: claimedByItem(weddingId),
+          currency: primaryCurrency(weddingId),
+        },
+        { concurrency: "unbounded" },
+      );
+      return {
+        headline: settings.headline,
+        message: settings.message,
+        cashGiftsEnabled: settings.cashGiftsEnabled,
+        currency,
+        items: (itemRows as ItemRow[]).map((r) =>
+          toPublicItemDto(weddingId, r, claimed.get(r.id) ?? 0),
+        ),
+      };
+    }).pipe(Effect.withSpan("cire.registry.publicView"));
+  },
+
+  /**
+   * This household's own claims, plus the shipping address when it has earned it.
+   *
+   * RELEASED claims are left out. The row survives release as a tombstone so a
+   * re-claim can reuse it (the unique `(item_id, family_id)` index), but to a
+   * guest a released claim means "you have not claimed this" — returning it would
+   * have the UI show a claim that is not one.
+   *
+   * The address ships only to a household with something live on the list, and
+   * only once the couple's date has passed. It is the one piece of the couple's
+   * own PII this surface hands out, so both conditions are checked here rather
+   * than in the route: every caller gets them.
+   */
+  householdView(input: {
+    slug: string;
+    familyId: string;
+  }): Effect.Effect<HouseholdRegistryDto, RegistryNotVisible, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+      const { settings, weddingId } = yield* resolveVisibleRegistry(input.slug);
+      const rows = yield* dbQuery(() =>
+        db
+          .select({
+            itemId: registryClaims.itemId,
+            quantity: registryClaims.quantity,
+            status: registryClaims.status,
+            note: registryClaims.note,
+            displayName: registryClaims.displayName,
+          })
+          .from(registryClaims)
+          .where(
+            and(
+              eq(registryClaims.weddingId, weddingId),
+              eq(registryClaims.familyId, input.familyId),
+              sql`${registryClaims.status} <> 'released'`,
+            ),
+          )
+          .orderBy(asc(registryClaims.itemId))
+          .all(),
+      );
+      const claims = (
+        rows as Array<{
+          itemId: string;
+          quantity: number;
+          status: Exclude<RegistryClaimStatus, "released">;
+          note: string | null;
+          displayName: string | null;
+        }>
+      ).map((r) => ({
+        itemId: r.itemId,
+        quantity: r.quantity,
+        status: r.status,
+        note: r.note,
+        displayName: r.displayName,
+      }));
+
+      const showAddress =
+        settings.shippingAddress !== null &&
+        claims.length > 0 &&
+        embargoLifted(settings.shippingVisibleFrom);
+      return showAddress
+        ? { claims, shippingAddress: settings.shippingAddress as string }
+        : { claims };
+    }).pipe(Effect.withSpan("cire.registry.householdView"));
   },
 };

--- a/cire/api/wrangler.toml
+++ b/cire/api/wrangler.toml
@@ -132,6 +132,18 @@ type = "ratelimit"
 namespace_id = "1004"
 simple = { limit = 10, period = 60 }
 
+# The guest registry write limiter — claiming and releasing a gift. Its own
+# namespace because it belongs to a different population: the two above are the
+# organiser building a list, this one is every guest of every wedding, and a
+# guest party hitting the ceiling must not stop the couple editing. Wider at
+# 20/60 because claiming several gifts in one sitting is the honest path.
+# 20/60 mirrors `defaultRegistryGuestLimiter` in src/app.ts.
+[[unsafe.bindings]]
+name = "REGISTRY_GUEST_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1005"
+simple = { limit = 20, period = 60 }
+
 [[d1_databases]]
 binding = "DB"
 database_name = "cire-db"
@@ -260,6 +272,12 @@ type = "ratelimit"
 namespace_id = "1104"
 simple = { limit = 10, period = 60 }
 
+[[env.dev.unsafe.bindings]]
+name = "REGISTRY_GUEST_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1105"
+simple = { limit = 20, period = 60 }
+
 # Created 2026-08-13 (`wrangler d1 create cire-db-dev`, primary location OC to
 # match prod). Reset + re-migrated + re-seeded on every dev deploy, so each
 # deploy also replays the migration chain from zero — a free migration test.
@@ -377,6 +395,12 @@ name = "REGISTRY_IMAGE_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1004"
 simple = { limit = 10, period = 60 }
+
+[[env.production.unsafe.bindings]]
+name = "REGISTRY_GUEST_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1005"
+simple = { limit = 20, period = 60 }
 
 [[env.production.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
Fourth PR in the registry stack. Based on `feat/cire-registry-preview` (#438) — review that first.

The couple can now build a gift list; this PR lets a household read it and claim from it.

## What lands

- `GET /api/invite/:slug/registry` — the published list: couple's copy, items, and a per-item claimed count. No claimant identity is ever selected on this path.
- `GET /api/invite/:slug/registry/image/:name` — gift photos through the same transform pipeline as the rest of the invite. `:name` must match `registry-<uuid>`; format is Accept-negotiated.
- `GET /api/invite/:slug/registry/mine` — the calling household's own claims, plus the shipping address once it has earned it.
- `POST`/`DELETE /api/invite/:slug/registry/items/:itemId/claim` — reserve, mark purchased, release. Both delegate to `registryService.claim` / `releaseClaim`, so the claim logic keeps one home.
- The registry section copy (`registryEyebrow` / `registryHeading` / `registryBody` / `registryTone`) joins the public invite payload. The columns existed; nothing read them until now.
- A per-IP rate limiter binding for the guest claim routes, declared on `Env` and in `wrangler.toml` for every environment.

## Three decisions worth reviewing

**Every failure on the public read is one 404 with one body.** Unknown slug, wedding without the `registry` entitlement, and registry not yet published are three different facts. A guest URL is public and unauthenticated, so all three answer identically. Organisers still get a 402 on their own routes — but a guest must not be able to tell a drafted list from a wedding that does not exist.

**The slug decides the wedding, never the cookie.** Every write resolves the wedding from the URL and hands that id to the service. A session minted against one wedding's claim code does nothing on another.

**The shipping address is earned.** It ships only to a household holding a live claim, only when the couple has set one, and only once `shippingVisibleFrom` has passed. When it is not permitted it is simply absent — there is no reason field to read.

## Concurrency

Two guests clicking the last item at the same moment is the ordinary case, not the edge case. Claims go through the existing single `INSERT … SELECT` with the remaining-quantity check in the `WHERE` and success decided by `RETURNING`; the loser gets a 409 `item_fully_claimed`. This PR adds no new path around that.

## Tests

783 lines of route tests covering the privacy property (no claimant identity on the public read), the 404-for-everything shape, the shipping-address gate, the claim race, and the signed-out path. Full suite: 1689 pass, 0 fail. `bun run check` clean.

## Not in this PR

The guest-facing UI — the invite section, the claim modal, the household view. That is the next branch in the stack. Stripe Connect for cash gifts is later still.

Everything here stays behind the `registry` entitlement, which no wedding holds.
