### PR TITLE
refactor(swift): extract OSNSession + shared PasskeySignInView

### DIFF
--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .library(name: "OSNKit", targets: ["OSNKit"]),
         .library(name: "OSNAuth", targets: ["OSNAuth"]),
         .library(name: "OSNUI", targets: ["OSNUI"]),
+        .library(name: "OSNAuthUI", targets: ["OSNAuthUI"]),
         .library(name: "OSNTesting", targets: ["OSNTesting"]),
         .library(name: "PulseAPI", targets: ["PulseAPI"]),
         .library(name: "PulseFeature", targets: ["PulseFeature"]),
@@ -30,6 +31,7 @@ let package = Package(
         .target(name: "OSNKit"),
         .target(name: "OSNAuth", dependencies: ["OSNKit"]),
         .target(name: "OSNUI"),
+        .target(name: "OSNAuthUI", dependencies: ["OSNAuth", "OSNUI"]),
         .target(name: "OSNTesting", dependencies: ["OSNKit"]),
         .testTarget(name: "OSNKitTests", dependencies: ["OSNKit", "OSNTesting"]),
         .testTarget(name: "OSNAuthTests", dependencies: ["OSNAuth", "OSNTesting"]),
@@ -44,7 +46,7 @@ let package = Package(
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
         ),
         .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI", "OSNKit", "OSNTesting"]),
-        .target(name: "PulseFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "PulseAPI"]),
+        .target(name: "PulseFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAuthUI", "PulseAPI"]),
         .testTarget(name: "PulseFeatureTests", dependencies: ["PulseFeature", "OSNTesting"]),
     ]
 )

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Observation
+import OSNKit
+
+/// Owns the app-agnostic half of passkey sign-in — restore, sign in, sign
+/// out — shared across every OSN app. Builds the shared cookie-jar-backed
+/// `URLSession`/`TokenRefresher` once and exposes both so an app-specific
+/// session (e.g. `PulseFeature.PulseSession`) can build its own API client
+/// on top without duplicating cookie-jar/token-refresh plumbing.
+@MainActor
+@Observable
+public final class OSNSession {
+    /// `.signedIn` carries an *optional* profile, not the non-optional one
+    /// the brief describes. A silent restore only round-trips
+    /// `TokenRefresher.refresh()`, which returns a `TokenGrant` — never a
+    /// `PasskeyProfile` — and no OSNAuth endpoint exposes "fetch current
+    /// profile" (`PasskeyManagementClient` only lists/renames/deletes
+    /// passkeys). So a restored session starts as `.signedIn(nil)`; an
+    /// interactive `signIn(...)` populates the profile from
+    /// `PasskeyLoginCompleteResponse.profile`.
+    public enum SessionState: Equatable, Sendable {
+        case restoring
+        case signedOut
+        case signedIn(PasskeyProfile?)
+        case failed(String)
+    }
+
+    public private(set) var state: SessionState = .restoring
+
+    /// Shared cookie-jar-backed session and token refresher — every
+    /// app-specific API client (e.g. `makePulseClient`) is built from these
+    /// so it shares the same cookie jar and refresh-in-flight coalescing.
+    public let urlSession: URLSession
+    public let tokenRefresher: TokenRefresher
+
+    private let loginClient: PasskeyLoginClient
+
+    /// Test-only injection seam, mirroring `SharedCookieJar.makeConfiguration`'s
+    /// `containerURLProvider` parameter: the public initializer always builds
+    /// real dependencies from `environment`, and there is no way to swap in
+    /// a mock `URLSession` through it. This lets `OSNAuthTests` construct an
+    /// `OSNSession` wired to `LoginMockURLProtocol` and assert deterministically
+    /// on its behaviour instead of depending on a real network call failing.
+    init(urlSession: URLSession, tokenRefresher: TokenRefresher, loginClient: PasskeyLoginClient) {
+        self.urlSession = urlSession
+        self.tokenRefresher = tokenRefresher
+        self.loginClient = loginClient
+    }
+
+    /// - Parameter environment: identity host for passkey ceremonies + token
+    ///   refresh. Defaults to `.local` — no deployed Pulse API host exists
+    ///   yet, so this is development-oriented, not a hardcoded prod value.
+    /// - Throws: whatever `SharedCookieJar.makeSession()` throws
+    ///   (`OSNKitError.appGroupContainerUnavailable` when the App Group
+    ///   container doesn't resolve — the group is registered, so this means
+    ///   the target is missing the entitlement or is signed by another team;
+    ///   see `pulse/ios/project.yml`). That is an infrastructure/build-config
+    ///   failure, not a session state — there is no working `URLSession` to
+    ///   hand out if it happens, so it isn't folded into `SessionState`.
+    public convenience init(environment: Environment = .local) throws {
+        let session = try SharedCookieJar.makeSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+        let loginClient = PasskeyLoginClient(session: session, environment: environment)
+        self.init(urlSession: session, tokenRefresher: tokenRefresher, loginClient: loginClient)
+    }
+
+    /// Silent restore on launch. A throw from `TokenRefresher.refresh()`
+    /// (no session cookie, expired session, etc. — see `OSNKitError`) means
+    /// "signed out", not an error banner, per the brief.
+    public func restore() async {
+        state = .restoring
+        do {
+            try await tokenRefresher.refresh()
+            state = .signedIn(nil)
+        } catch {
+            state = .signedOut
+        }
+    }
+
+    /// Runs the passkey ceremony (`identifier: nil` for discoverable UI, a
+    /// typed identifier for the account-bound flow) and, on success, moves
+    /// to `.signedIn(profile)`. Never branches on whether the `begin` step
+    /// found an account — `PasskeyLoginClient.signIn` already keeps that
+    /// opaque.
+    public func signIn(
+        identifier: String?,
+        anchorProvider: @escaping PresentationAnchorProvider
+    ) async throws {
+        let response = try await loginClient.signIn(identifier: identifier, anchorProvider: anchorProvider)
+        state = .signedIn(response.profile)
+    }
+
+    /// `TokenRefresher.logout()` already deletes the Keychain access token
+    /// internally on every path (even a failed network call). The explicit
+    /// `KeychainAccessTokenStore.delete()` here is defensive — `delete()`
+    /// treats "already gone" as success (`errSecItemNotFound`), so calling
+    /// it after `logout()` is a no-op, not a race.
+    public func signOut() async {
+        try? await tokenRefresher.logout()
+        try? KeychainAccessTokenStore.delete()
+        state = .signedOut
+    }
+
+    /// Loads the Keychain-stored access token and refreshes it if it's
+    /// missing or expires within the next 30 seconds; otherwise does
+    /// nothing. `RequestHelpers.applyBearerAccessToken` pastes whatever
+    /// token is currently in the Keychain onto a request with no expiry
+    /// check and no 401-retry, so a caller that skips this and waits out
+    /// the 5-minute access-token TTL (`wiki/systems/identity-model.md`)
+    /// 401s on its next request — e.g. the Musubi account screen's
+    /// `PasskeyManagementClient.list()`. `TokenRefresher.refresh()` already
+    /// persists the refreshed token to the Keychain; this method never
+    /// writes to it directly.
+    public func ensureFreshAccessToken() async throws {
+        let stored = try KeychainAccessTokenStore.load()
+        let isFresh = stored.map { $0.expiresAt.timeIntervalSinceNow > 30 } ?? false
+        guard !isFresh else { return }
+        try await tokenRefresher.refresh()
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNAuthUI/PasskeySignInView.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuthUI/PasskeySignInView.swift
@@ -6,22 +6,24 @@ import SwiftUI
 /// (`identifier: nil`) and a typed-identifier flow; never branches on
 /// whether the server recognised the identifier, since it deliberately
 /// fabricates `allowCredentials` for unknown ones.
-public struct SignInView: View {
-    private let session: PulseSession
+public struct PasskeySignInView: View {
+    private let appName: String
+    private let session: OSNSession
     private let anchorProvider: PresentationAnchorProvider
 
     @State private var identifier = ""
     @State private var isSigningIn = false
     @State private var errorMessage: String?
 
-    public init(session: PulseSession, anchorProvider: @escaping PresentationAnchorProvider) {
+    public init(appName: String, session: OSNSession, anchorProvider: @escaping PresentationAnchorProvider) {
+        self.appName = appName
         self.session = session
         self.anchorProvider = anchorProvider
     }
 
     public var body: some View {
         VStack(spacing: 24) {
-            Text("Pulse")
+            Text(appName)
                 .font(.osn(.display, size: 40))
 
             TextField("Handle or email", text: $identifier)

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
@@ -1,4 +1,5 @@
 import OSNAuth
+import OSNAuthUI
 import OSNUI
 import SwiftUI
 
@@ -30,7 +31,7 @@ public struct PulseRootView: View {
         case .restoring:
             ProgressView()
         case .signedOut, .failed:
-            SignInView(session: session, anchorProvider: anchorProvider)
+            PasskeySignInView(appName: "Pulse", session: session.auth, anchorProvider: anchorProvider)
         case .signedIn:
             PulseTabView(session: session)
         }

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
@@ -4,36 +4,27 @@ import OSNAuth
 import OSNKit
 import PulseAPI
 
-/// Owns Pulse auth state for the whole app shell. Builds the shared
-/// `URLSession`/`TokenRefresher`/Pulse `Client` once and holds them
-/// internally — no feature view ever sees an access token, only this
-/// object's `api` (an `APIProtocol`, generated from `shared/openapi/pulse.json`
-/// at build time and produced only by `makePulseClient`).
+/// Owns Pulse auth state for the whole app shell. Forwards restore/sign-in/
+/// sign-out to the shared `OSNSession` (`auth`) and additionally builds the
+/// Pulse `Client` once and holds it internally — no feature view ever sees
+/// an access token, only this object's `api` (an `APIProtocol`, generated
+/// from `shared/openapi/pulse.json` at build time and produced only by
+/// `makePulseClient`).
 @MainActor
 @Observable
 public final class PulseSession {
-    /// `.signedIn` carries an *optional* profile, not the non-optional one
-    /// the brief describes. A silent restore only round-trips
-    /// `TokenRefresher.refresh()`, which returns a `TokenGrant` — never a
-    /// `PasskeyProfile` — and no OSNAuth endpoint exposes "fetch current
-    /// profile" (`PasskeyManagementClient` only lists/renames/deletes
-    /// passkeys). So a restored session starts as `.signedIn(nil)`; an
-    /// interactive `signIn(...)` populates the profile from
-    /// `PasskeyLoginCompleteResponse.profile`.
-    public enum SessionState: Equatable {
-        case restoring
-        case signedOut
-        case signedIn(PasskeyProfile?)
-        case failed(String)
-    }
+    public typealias SessionState = OSNSession.SessionState
 
-    public private(set) var state: SessionState = .restoring
+    /// Computed, not a stored copy synced on events — a stored copy would
+    /// break `@Observable` change tracking, since observers would be
+    /// tracking this property instead of `auth.state`.
+    public var state: SessionState { auth.state }
+
+    /// The app-agnostic half of sign-in, shared with other OSN apps.
+    public let auth: OSNSession
 
     /// Every Pulse call in this feature goes through this client.
     public let api: any APIProtocol
-
-    private let tokenRefresher: TokenRefresher
-    private let loginClient: PasskeyLoginClient
 
     /// - Parameters:
     ///   - environment: identity host for passkey ceremonies + token
@@ -41,56 +32,24 @@ public final class PulseSession {
     ///     yet, so this is development-oriented, not a hardcoded prod value.
     ///   - pulseEnvironment: Pulse API host for `api`. Defaults to `.local`
     ///     for the same reason.
-    /// - Throws: whatever `SharedCookieJar.makeSession()` throws
-    ///   (`OSNKitError.appGroupContainerUnavailable` when the App Group
-    ///   container doesn't resolve — the group is registered, so this means
-    ///   the target is missing the entitlement or is signed by another team;
-    ///   see `pulse/ios/project.yml`). That is an infrastructure/build-config
-    ///   failure, not a session state — there is no working `URLSession` to
-    ///   hand out if it happens, so it isn't folded into `SessionState`.
     public init(environment: Environment = .local, pulseEnvironment: PulseEnvironment = .local) throws {
-        let session = try SharedCookieJar.makeSession()
-        let tokenRefresher = TokenRefresher(session: session, environment: environment)
-        self.tokenRefresher = tokenRefresher
-        self.loginClient = PasskeyLoginClient(session: session, environment: environment)
-        self.api = makePulseClient(environment: pulseEnvironment, session: session, tokenRefresher: tokenRefresher)
+        let auth = try OSNSession(environment: environment)
+        self.auth = auth
+        self.api = makePulseClient(environment: pulseEnvironment, session: auth.urlSession, tokenRefresher: auth.tokenRefresher)
     }
 
-    /// Silent restore on launch. A throw from `TokenRefresher.refresh()`
-    /// (no session cookie, expired session, etc. — see `OSNKitError`) means
-    /// "signed out", not an error banner, per the brief.
     public func restore() async {
-        state = .restoring
-        do {
-            try await tokenRefresher.refresh()
-            state = .signedIn(nil)
-        } catch {
-            state = .signedOut
-        }
+        await auth.restore()
     }
 
-    /// Runs the passkey ceremony (`identifier: nil` for discoverable UI, a
-    /// typed identifier for the account-bound flow) and, on success, moves
-    /// to `.signedIn(profile)`. Never branches on whether the `begin` step
-    /// found an account — `PasskeyLoginClient.signIn` already keeps that
-    /// opaque.
     public func signIn(
         identifier: String?,
         anchorProvider: @escaping PresentationAnchorProvider
     ) async throws {
-        let response = try await loginClient.signIn(identifier: identifier, anchorProvider: anchorProvider)
-        state = .signedIn(response.profile)
+        try await auth.signIn(identifier: identifier, anchorProvider: anchorProvider)
     }
 
-    /// `TokenRefresher.logout()` already deletes the Keychain access token
-    /// internally on every path (even a failed network call). The explicit
-    /// `KeychainAccessTokenStore.delete()` here is defensive, per the
-    /// brief's deliverable 2 — `delete()` treats "already gone" as success
-    /// (`errSecItemNotFound`), so calling it after `logout()` is a no-op,
-    /// not a race.
     public func signOut() async {
-        try? await tokenRefresher.logout()
-        try? KeychainAccessTokenStore.delete()
-        state = .signedOut
+        await auth.signOut()
     }
 }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import OSNKit
+import OSNTesting
+import Testing
+@testable import OSNAuth
+
+private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [LoginMockURLProtocol.self]
+    configuration.httpShouldSetCookies = true
+    configuration.httpCookieAcceptPolicy = .always
+    LoginMockURLProtocol.cookieStorage = configuration.httpCookieStorage
+    return URLSession(configuration: configuration)
+}
+
+@MainActor
+private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
+    OSNSession(
+        urlSession: session,
+        tokenRefresher: tokenRefresher,
+        loginClient: PasskeyLoginClient(session: session, environment: environment)
+    )
+}
+
+/// Touches the real Keychain via `KeychainAccessTokenStore`/`TokenRefresher`,
+/// so shares the cross-target serialized lock with
+/// `OSNKitTests/KeychainAccessTokenStoreTests.swift` and
+/// `PasskeyLoginClientTests.swift` rather than running independently.
+@Suite(.serialized, .keychainSerializing)
+@MainActor
+struct OSNSessionTests {
+    @Test func failingRefreshLeavesStateSignedOutNeverFailed() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        LoginMockURLProtocol.handler = { _ in
+            let body = #"{"error":"invalid_grant","message":"session expired"}"#
+            return (400, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        #expect(osnSession.state == .signedOut)
+    }
+
+    @Test func signOutClearsKeychainAccessToken() async throws {
+        try KeychainAccessTokenStore.save("token-to-clear", expiresIn: 300)
+        #expect(try KeychainAccessTokenStore.load() != nil)
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        LoginMockURLProtocol.handler = { _ in
+            (200, [:], Data())
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.signOut()
+
+        #expect(try KeychainAccessTokenStore.load() == nil)
+        #expect(osnSession.state == .signedOut)
+    }
+
+    @Test func ensureFreshAccessTokenRefreshesWhenMissingOrExpiring() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let requestCount = Counter()
+        LoginMockURLProtocol.handler = { _ in
+            await requestCount.increment()
+            let body = """
+            {"access_token":"at-fresh-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-fresh-1; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+
+        // Missing token: must refresh.
+        try await osnSession.ensureFreshAccessToken()
+        #expect(await requestCount.value == 1)
+
+        // Expiring inside the next 30 seconds: must refresh again.
+        try KeychainAccessTokenStore.save("token-about-to-expire", expiresIn: 5)
+        try await osnSession.ensureFreshAccessToken()
+        #expect(await requestCount.value == 2)
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func ensureFreshAccessTokenDoesNotRefreshWhenFresh() async throws {
+        try KeychainAccessTokenStore.save("token-still-fresh", expiresIn: 300)
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let requestCount = Counter()
+        LoginMockURLProtocol.handler = { _ in
+            await requestCount.increment()
+            return (200, [:], Data())
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        try await osnSession.ensureFreshAccessToken()
+        #expect(await requestCount.value == 0)
+
+        try KeychainAccessTokenStore.delete()
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -48,6 +48,19 @@
 - Every OSNAuth request runs through the shared `URLSession` /
   `SharedCookieJar` — no client constructs its own session or cookie
   storage.
+- `OSNSession` (new, `OSNAuth`) extracted as the app-agnostic sign-in owner;
+  `PulseFeature.PulseSession` now forwards to it (`state` is computed from
+  `auth.state`, never a synced stored copy — that would break `@Observable`
+  tracking). Covered by `OSNSessionTests`: a failing `TokenRefresher.refresh()`
+  during `restore()` lands on `.signedOut`, never `.failed`; `signOut()`
+  clears the Keychain access token; `ensureFreshAccessToken()` refreshes
+  when the stored token is missing or expires within 30s and is a no-op
+  (asserted via request count against `LoginMockURLProtocol`) when the
+  token is still fresh.
+- New `OSNAuthUI` target (`OSNAuth` + `OSNUI`) holds `PasskeySignInView`,
+  the app-name-parameterized, `OSNSession`-driven successor to
+  `PulseFeature`'s old `SignInView`. `PulseRootView` renders it against
+  `session.auth`; no other view changed.
 
 ## Not verified
 


### PR DESCRIPTION
## What

Splits the app-agnostic half of Pulse's sign-in out of `PulseFeature` so a second app can reuse it.

- **New `OSNSession` (`OSNAuth`)** — owns `restore()` / `signIn()` / `signOut()` and the shared cookie-jar `URLSession` + `TokenRefresher`. `PulseSession` keeps its exact public signatures and forwards to it, gaining one property (`auth`) and losing nothing.
- **New `OSNAuthUI` target** (`OSNAuth` + `OSNUI`) holding `PasskeySignInView` — the old `SignInView` with the hardcoded `Text("Pulse")` replaced by an `appName` parameter. `OSNUI` has no dependencies and `OSNAuth` has no SwiftUI, so the shared view needs a target of its own rather than a folder in either.
- **New `OSNSession.ensureFreshAccessToken()`** — refreshes when the stored token is missing or expires within 30s. `RequestHelpers.applyBearerAccessToken` pastes whatever is in the Keychain with no expiry check and no 401-retry, and access tokens live 5 minutes, so any Bearer-authed OSNAuth client called from a long-lived screen needs this first. The next PR's Musubi account screen is the first caller.

`PulseSession.state` is a computed forward to `auth.state`, not a synced stored copy — a copy would leave observers tracking the wrong property and break `@Observable` updates.

## Why

Musubi is the second app on the same shared cookie jar. Without this split it would either duplicate session plumbing or import `PulseFeature`.

## Behaviour change

None. Pulse renders the same screen against the same state machine.

## Verified

Run in the worktree, not taken from the implementing agent:

- `swift build` clean
- `swift test` — 80 tests, 10 suites, 0 failures, including 4 new `OSNSessionTests`
- `xcodegen generate` + `xcodebuild -scheme Pulse -destination 'generic/platform=iOS Simulator' … build` — exit 0
- repo gates: `check`, `lint`, `fmt:check`, `test`, changeset check

## Changeset

None, deliberately. Every path here (`shared/swift/`) is on the allowlist in `scripts/changeset-required.sh` — no versioned package ships from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rtirhHZfmxZrJXCBxXF9s