### PR TITLE
feat(passkey): conditional UI autofill sign-in

### DIFF
--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -82,12 +82,29 @@ public final class OSNSession {
     /// to `.signedIn(profile)`. Never branches on whether the `begin` step
     /// found an account — `PasskeyLoginClient.signIn` already keeps that
     /// opaque.
+    ///
+    /// Brief T3 §4 modal collision: only one `ASAuthorizationController`
+    /// request can be live at a time. Cancels a still-armed autofill
+    /// request before starting the modal ceremony, and re-arms autofill
+    /// (same `anchorProvider`) if the modal flow throws or is cancelled —
+    /// a failed/cancelled button tap should not leave the QuickType
+    /// suggestion gone too.
     public func signIn(
         identifier: String?,
         anchorProvider: @escaping PresentationAnchorProvider
     ) async throws {
-        let response = try await loginClient.signIn(identifier: identifier, anchorProvider: anchorProvider)
-        state = .signedIn(response.profile)
+        #if os(iOS)
+        cancelAutoFillSignIn()
+        #endif
+        do {
+            let response = try await loginClient.signIn(identifier: identifier, anchorProvider: anchorProvider)
+            state = .signedIn(response.profile)
+        } catch {
+            #if os(iOS)
+            await startAutoFillSignIn(anchorProvider: anchorProvider)
+            #endif
+            throw error
+        }
     }
 
     /// `TokenRefresher.logout()` already deletes the Keychain access token
@@ -117,4 +134,66 @@ public final class OSNSession {
         guard !isFresh else { return }
         try await tokenRefresher.refresh()
     }
+
+    #if os(iOS)
+    private var autoFillHandle: PasskeyCeremonyHandle?
+
+    /// Conditional UI (brief T3 §4): arms `performAutoFillAssistedRequests()`
+    /// so the account's passkey shows up in the QuickType bar, letting a
+    /// returning user sign in with a tap instead of "Sign in with passkey".
+    /// Never throws and never lands on `.failed` — see
+    /// `attemptAutoFillSignIn` for why.
+    public func startAutoFillSignIn(anchorProvider: @escaping PresentationAnchorProvider) async {
+        await attemptAutoFillSignIn(anchorProvider: anchorProvider, isRetry: false)
+    }
+
+    public func cancelAutoFillSignIn() {
+        autoFillHandle?.cancel()
+        autoFillHandle = nil
+    }
+
+    /// The server's passkey challenge lives 120 seconds
+    /// (`osn/api/src/services/auth/constants.ts` `CHALLENGE_TTL_MS`). An
+    /// autofill request typically sits armed in the QuickType bar far
+    /// longer than that before the user taps it, so a non-cancellation
+    /// failure here is almost always an expired challenge, not a bad
+    /// credential — surfacing `.failed` for it would blame the user for
+    /// waiting. On such a failure this re-arms once with a fresh challenge
+    /// and stays silent; if the retry also fails it gives up and stays
+    /// `.signedOut`. Deliberately does not loop on a timer under the 120s
+    /// TTL instead: cancelling and re-issuing the request flickers the
+    /// QuickType suggestion, which is worse than leaving a slightly stale
+    /// one armed until the user acts or the view disappears.
+    private func attemptAutoFillSignIn(anchorProvider: @escaping PresentationAnchorProvider, isRetry: Bool) async {
+        do {
+            let begun = try await loginClient.beginLogin(identifier: nil, turnstileToken: nil)
+            let assertionRequest = try loginClient.makeAssertionRequest(from: begun)
+            let handle = PasskeyCeremonyHandle(
+                requests: [assertionRequest],
+                autoFill: true,
+                anchorProvider: anchorProvider
+            )
+            autoFillHandle = handle
+            let authorization = try await handle.result()
+            autoFillHandle = nil
+            let target = try loginClient.loginTarget(identifier: nil, begun: begun)
+            let assertion = try loginClient.packageAssertion(authorization)
+            let response = try await loginClient.complete(target: target, assertion: assertion)
+            state = .signedIn(response.profile)
+        } catch is CancellationError {
+            autoFillHandle = nil
+        } catch let error as PasskeyCeremonyError {
+            autoFillHandle = nil
+            if case .cancelled = error { return }
+            if !isRetry {
+                await attemptAutoFillSignIn(anchorProvider: anchorProvider, isRetry: true)
+            }
+        } catch {
+            autoFillHandle = nil
+            if !isRetry {
+                await attemptAutoFillSignIn(anchorProvider: anchorProvider, isRetry: true)
+            }
+        }
+    }
+    #endif
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -101,13 +101,14 @@ public final class OSNSession {
             state = .signedIn(response.profile)
         } catch {
             #if os(iOS)
-            // Detached, never awaited: `startAutoFillSignIn` does not return
+            // Detached and never awaited, but *tracked* — see
+            // `autoFillReArmTask`. `startAutoFillSignIn` does not return
             // until the ceremony it arms completes, which for a QuickType
             // suggestion means "when the user taps it", i.e. usually never.
             // Awaiting it here would hold `signIn` open past the modal
             // failure, and `PasskeySignInView` leaves its button disabled and
             // its error unshown for exactly as long as `signIn` runs.
-            Task { [weak self] in
+            autoFillReArmTask = Task { [weak self] in
                 await self?.startAutoFillSignIn(anchorProvider: anchorProvider)
             }
             #endif
@@ -146,6 +147,26 @@ public final class OSNSession {
     #if os(iOS)
     private var autoFillHandle: PasskeyCeremonyHandle?
 
+    /// The re-arm `Task` `signIn`'s catch spawns. Held so
+    /// `cancelAutoFillSignIn()` can cancel it as well as the armed handle:
+    /// the Task does not reach `autoFillHandle = handle` until a
+    /// `beginLogin` round trip has finished, so a view that disappears
+    /// inside that window would otherwise call `cancelAutoFillSignIn()`
+    /// against a `nil` handle, cancel nothing, and let the Task go on to
+    /// arm a ceremony no later call can reach.
+    private var autoFillReArmTask: Task<Void, Never>?
+
+    /// Clears `autoFillHandle` only if it still points at the caller's own
+    /// handle. Two autofill attempts can overlap — the first suspended in
+    /// `handle.result()` while the second arms — and the first one waking
+    /// up to an unconditional `autoFillHandle = nil` would drop the second's
+    /// handle on the floor, leaving it armed and uncancellable.
+    private func clearAutoFillHandle(_ handle: PasskeyCeremonyHandle) {
+        if autoFillHandle === handle {
+            autoFillHandle = nil
+        }
+    }
+
     /// Conditional UI (brief T3 §4): arms `performAutoFillAssistedRequests()`
     /// so the account's passkey shows up in the QuickType bar, letting a
     /// returning user sign in with a tap instead of "Sign in with passkey".
@@ -156,6 +177,8 @@ public final class OSNSession {
     }
 
     public func cancelAutoFillSignIn() {
+        autoFillReArmTask?.cancel()
+        autoFillReArmTask = nil
         autoFillHandle?.cancel()
         autoFillHandle = nil
     }
@@ -173,31 +196,44 @@ public final class OSNSession {
     /// QuickType suggestion, which is worse than leaving a slightly stale
     /// one armed until the user acts or the view disappears.
     private func attemptAutoFillSignIn(anchorProvider: @escaping PresentationAnchorProvider, isRetry: Bool) async {
+        guard !Task.isCancelled else { return }
+        var armed: PasskeyCeremonyHandle?
         do {
             let begun = try await loginClient.beginLogin(identifier: nil, turnstileToken: nil)
             let assertionRequest = try loginClient.makeAssertionRequest(from: begun)
+            guard !Task.isCancelled else { return }
             let handle = PasskeyCeremonyHandle(
                 requests: [assertionRequest],
                 autoFill: true,
                 anchorProvider: anchorProvider
             )
+            armed = handle
+            // Cancel-before-arm. Only one `ASAuthorizationController` request
+            // can be live, and `cancelAutoFillSignIn()` can only reach the one
+            // handle this property holds — so overwriting a live handle would
+            // strand a second live controller with no way to cancel it.
+            autoFillHandle?.cancel()
             autoFillHandle = handle
             let authorization = try await handle.result()
-            autoFillHandle = nil
+            clearAutoFillHandle(handle)
             let target = try loginClient.loginTarget(identifier: nil, begun: begun)
             let assertion = try loginClient.packageAssertion(authorization)
             let response = try await loginClient.complete(target: target, assertion: assertion)
+            // Deliberately not gated on `Task.isCancelled`: the ceremony and
+            // the `complete` call both succeeded, so the session *is* signed
+            // in server-side. Dropping the state here because the view went
+            // away would leave the app showing signed-out over a live session.
             state = .signedIn(response.profile)
         } catch is CancellationError {
-            autoFillHandle = nil
+            if let armed { clearAutoFillHandle(armed) }
         } catch let error as PasskeyCeremonyError {
-            autoFillHandle = nil
+            if let armed { clearAutoFillHandle(armed) }
             if case .cancelled = error { return }
             if !isRetry {
                 await attemptAutoFillSignIn(anchorProvider: anchorProvider, isRetry: true)
             }
         } catch {
-            autoFillHandle = nil
+            if let armed { clearAutoFillHandle(armed) }
             if !isRetry {
                 await attemptAutoFillSignIn(anchorProvider: anchorProvider, isRetry: true)
             }

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -101,7 +101,15 @@ public final class OSNSession {
             state = .signedIn(response.profile)
         } catch {
             #if os(iOS)
-            await startAutoFillSignIn(anchorProvider: anchorProvider)
+            // Detached, never awaited: `startAutoFillSignIn` does not return
+            // until the ceremony it arms completes, which for a QuickType
+            // suggestion means "when the user taps it", i.e. usually never.
+            // Awaiting it here would hold `signIn` open past the modal
+            // failure, and `PasskeySignInView` leaves its button disabled and
+            // its error unshown for exactly as long as `signIn` runs.
+            Task { [weak self] in
+                await self?.startAutoFillSignIn(anchorProvider: anchorProvider)
+            }
             #endif
             throw error
         }

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyCeremonyRunner.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyCeremonyRunner.swift
@@ -42,7 +42,32 @@ enum PasskeyCeremony {
 ///   closure returns, before the ceremony completes. Both the controller and
 ///   this runner are held as strong properties/locals for the whole async
 ///   call so neither disappears mid-ceremony.
-final class PasskeyCeremonyRunner: NSObject, ASAuthorizationControllerDelegate,
+/// Brief T3 §2 — the handle a caller keeps to cancel a still-running
+/// ceremony. `PasskeyCeremony.perform` above is untouched: the modal path
+/// is fire-and-forget and has never needed cancellation. Autofill does,
+/// since a `.task`-armed request can outlive the view that started it.
+@MainActor
+final class PasskeyCeremonyHandle {
+    private let runner: PasskeyCeremonyRunner
+    private let requests: [ASAuthorizationRequest]
+    private let autoFill: Bool
+
+    init(requests: [ASAuthorizationRequest], autoFill: Bool = false, anchorProvider: @escaping PresentationAnchorProvider) {
+        runner = PasskeyCeremonyRunner(anchorProvider: anchorProvider)
+        self.requests = requests
+        self.autoFill = autoFill
+    }
+
+    func result() async throws -> ASAuthorization {
+        try await runner.run(requests: requests, autoFill: autoFill)
+    }
+
+    func cancel() {
+        runner.cancel()
+    }
+}
+
+final class PasskeyCeremonyRunner: NSObject, @unchecked Sendable, ASAuthorizationControllerDelegate,
     ASAuthorizationControllerPresentationContextProviding
 {
     private let anchorProvider: PresentationAnchorProvider
@@ -53,16 +78,45 @@ final class PasskeyCeremonyRunner: NSObject, ASAuthorizationControllerDelegate,
         self.anchorProvider = anchorProvider
     }
 
-    func run(requests: [ASAuthorizationRequest]) async throws -> ASAuthorization {
-        try await withCheckedThrowingContinuation { continuation in
-            let guarded = SingleResumeContinuation(continuation)
-            self.guarded = guarded
-            let controller = ASAuthorizationController(authorizationRequests: requests)
-            controller.delegate = self
-            controller.presentationContextProvider = self
-            self.controller = controller
-            controller.performRequests()
+    /// `autoFill` arms `performAutoFillAssistedRequests()` (conditional UI,
+    /// iOS-only — brief T3 §3) instead of the modal `performRequests()`.
+    /// Default keeps `PasskeyCeremony.perform`'s existing call site
+    /// (`runner.run(requests: requests)`) compiling unchanged.
+    func run(requests: [ASAuthorizationRequest], autoFill: Bool = false) async throws -> ASAuthorization {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let guarded = SingleResumeContinuation(continuation)
+                self.guarded = guarded
+                let controller = ASAuthorizationController(authorizationRequests: requests)
+                controller.delegate = self
+                controller.presentationContextProvider = self
+                self.controller = controller
+                if autoFill {
+                    #if os(iOS)
+                    controller.performAutoFillAssistedRequests()
+                    #else
+                    preconditionFailure("performAutoFillAssistedRequests() does not exist on macOS")
+                    #endif
+                } else {
+                    controller.performRequests()
+                }
+            }
+        } onCancel: {
+            // Brief T3 §2 — without this, a `.task`-started autofill whose
+            // Task is cancelled on disappear awaits a continuation nothing
+            // resumes and hangs forever. `SingleResumeContinuation` guards
+            // double-resume, not never-resume. `onCancel` is `@Sendable` and
+            // can run off the main actor, so hop back to call `cancel()`.
+            Task { @MainActor in
+                self.cancel()
+            }
         }
+    }
+
+    /// Shared by `PasskeyCeremonyHandle.cancel()` (explicit) and the
+    /// `onCancel` handler above (implicit Task cancellation).
+    func cancel() {
+        controller?.cancel()
     }
 
     func authorizationController(

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyCeremonyRunner.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyCeremonyRunner.swift
@@ -67,7 +67,7 @@ final class PasskeyCeremonyHandle {
     }
 }
 
-final class PasskeyCeremonyRunner: NSObject, @unchecked Sendable, ASAuthorizationControllerDelegate,
+final class PasskeyCeremonyRunner: NSObject, ASAuthorizationControllerDelegate,
     ASAuthorizationControllerPresentationContextProviding
 {
     private let anchorProvider: PresentationAnchorProvider

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyLoginClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyLoginClient.swift
@@ -26,58 +26,24 @@ public final class PasskeyLoginClient: Sendable {
         turnstileToken: String? = nil,
         anchorProvider: @escaping PresentationAnchorProvider
     ) async throws -> PasskeyLoginCompleteResponse {
-        let begun = try await begin(identifier: identifier, turnstileToken: turnstileToken)
-        let options = begun.options
-
-        // RP ID always comes off the response (DoD 4) — never hardcoded.
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.rpId)
-        guard let challenge = Base64URL.decode(options.challenge) else {
-            throw OSNAuthError.responseMalformed(status: 200)
-        }
-        let assertionRequest = provider.createCredentialAssertionRequest(challenge: challenge)
-        assertionRequest.allowedCredentials = try options.allowCredentials.map { credential in
-            guard let id = Base64URL.decode(credential.id) else {
-                throw OSNAuthError.responseMalformed(status: 200)
-            }
-            return ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: id)
-        }
-        if let preference = RequestHelpers.userVerificationPreference(from: options.userVerification) {
-            assertionRequest.userVerificationPreference = preference
-        }
-
-        let target: PasskeyLoginTarget
-        if let identifier {
-            target = .identifier(identifier)
-        } else if let challengeId = begun.challengeId {
-            target = .challengeId(challengeId)
-        } else {
-            throw OSNAuthError.responseMalformed(status: 200)
-        }
+        let begun = try await beginLogin(identifier: identifier, turnstileToken: turnstileToken)
+        let assertionRequest = try makeAssertionRequest(from: begun)
+        let target = try loginTarget(identifier: identifier, begun: begun)
 
         let authorization = try await PasskeyCeremony.perform(
             requests: [assertionRequest],
             anchorProvider: anchorProvider
         )
-        guard let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
-            throw OSNAuthError.unexpectedCredentialType
-        }
-
-        let assertion = AuthenticationResponseJSON(
-            id: Base64URL.encode(credential.credentialID),
-            rawId: Base64URL.encode(credential.credentialID),
-            authenticatorAttachment: "platform",
-            response: AuthenticatorAssertionResponseJSON(
-                clientDataJSON: Base64URL.encode(credential.rawClientDataJSON),
-                authenticatorData: Base64URL.encode(credential.rawAuthenticatorData),
-                signature: Base64URL.encode(credential.signature),
-                userHandle: credential.userID.map(Base64URL.encode)
-            )
-        )
+        let assertion = try packageAssertion(authorization)
 
         return try await complete(target: target, assertion: assertion)
     }
 
-    private func begin(identifier: String?, turnstileToken: String?) async throws -> PasskeyLoginBeginResponse {
+    /// Autofill (brief T3 §4) reuses each step individually: `beginLogin` with
+    /// `identifier: nil` to get a discoverable challenge, `makeAssertionRequest`
+    /// to arm `performAutoFillAssistedRequests()`, then `loginTarget` +
+    /// `packageAssertion` once the QuickType suggestion resolves.
+    func beginLogin(identifier: String?, turnstileToken: String?) async throws -> PasskeyLoginBeginResponse {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("login/passkey/begin"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -94,6 +60,57 @@ public final class PasskeyLoginClient: Sendable {
             throw OSNAuthError.responseMalformed(status: http.statusCode)
         }
         return decoded
+    }
+
+    /// RP ID always comes off the response (DoD 4) — never hardcoded.
+    func makeAssertionRequest(
+        from begun: PasskeyLoginBeginResponse
+    ) throws -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
+        let options = begun.options
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.rpId)
+        guard let challenge = Base64URL.decode(options.challenge) else {
+            throw OSNAuthError.responseMalformed(status: 200)
+        }
+        let assertionRequest = provider.createCredentialAssertionRequest(challenge: challenge)
+        assertionRequest.allowedCredentials = try options.allowCredentials.map { credential in
+            guard let id = Base64URL.decode(credential.id) else {
+                throw OSNAuthError.responseMalformed(status: 200)
+            }
+            return ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: id)
+        }
+        if let preference = RequestHelpers.userVerificationPreference(from: options.userVerification) {
+            assertionRequest.userVerificationPreference = preference
+        }
+        return assertionRequest
+    }
+
+    /// A typed `identifier` always wins; a discoverable/conditional-UI begin
+    /// (`identifier == nil`) falls back to the server-issued `challengeId`.
+    func loginTarget(identifier: String?, begun: PasskeyLoginBeginResponse) throws -> PasskeyLoginTarget {
+        if let identifier {
+            return .identifier(identifier)
+        } else if let challengeId = begun.challengeId {
+            return .challengeId(challengeId)
+        } else {
+            throw OSNAuthError.responseMalformed(status: 200)
+        }
+    }
+
+    func packageAssertion(_ authorization: ASAuthorization) throws -> AuthenticationResponseJSON {
+        guard let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            throw OSNAuthError.unexpectedCredentialType
+        }
+        return AuthenticationResponseJSON(
+            id: Base64URL.encode(credential.credentialID),
+            rawId: Base64URL.encode(credential.credentialID),
+            authenticatorAttachment: "platform",
+            response: AuthenticatorAssertionResponseJSON(
+                clientDataJSON: Base64URL.encode(credential.rawClientDataJSON),
+                authenticatorData: Base64URL.encode(credential.rawAuthenticatorData),
+                signature: Base64URL.encode(credential.signature),
+                userHandle: credential.userID.map(Base64URL.encode)
+            )
+        )
     }
 
     /// Internal, not private: lets `OSNAuthTests` exercise the

--- a/shared/swift/OSNShared/Sources/OSNAuthUI/PasskeySignInView.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuthUI/PasskeySignInView.swift
@@ -52,6 +52,14 @@ public struct PasskeySignInView: View {
             .disabled(isSigningIn)
         }
         .padding()
+        #if os(iOS)
+        .task {
+            await session.startAutoFillSignIn(anchorProvider: anchorProvider)
+        }
+        .onDisappear {
+            session.cancelAutoFillSignIn()
+        }
+        #endif
     }
 
     private func signIn(identifier: String?) {

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/PasskeyLoginClientHelpersTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/PasskeyLoginClientHelpersTests.swift
@@ -1,0 +1,180 @@
+import AuthenticationServices
+import Foundation
+import Testing
+@testable import OSNAuth
+
+/// Brief T3 §6 — direct coverage of the helpers `PasskeyLoginClient.signIn`
+/// used to run inline: request building (`makeAssertionRequest`) and target
+/// selection (`loginTarget`). Both are platform-neutral (no
+/// `ASAuthorizationController` involved), so they run on the macOS host same
+/// as every other target in this package.
+///
+/// `packageAssertion(_:)` — the third helper the brief names — is not
+/// covered here. It takes an `ASAuthorization` whose credential is an
+/// `ASAuthorizationPlatformPublicKeyCredentialAssertion`; Apple vends that
+/// type only from a real ceremony completion and exposes no public
+/// initializer, so no fixture can be constructed in-process. That line of
+/// the autofill path (and the modal path, which shares this same helper)
+/// has never been machine-tested, before or after this brief — it ships
+/// human-reviewed only.
+private func makeClient() -> PasskeyLoginClient {
+    PasskeyLoginClient(session: URLSession(configuration: .ephemeral), environment: .local)
+}
+
+private func fixtureBegin(
+    challenge: String = "Y2hhbGxlbmdl",
+    rpId: String = "musubi.social",
+    allowCredentials: [AllowCredentialJSON] = [],
+    userVerification: String = "preferred",
+    challengeId: String? = "challenge-id-1"
+) -> PasskeyLoginBeginResponse {
+    PasskeyLoginBeginResponse(
+        options: PublicKeyCredentialRequestOptionsJSON(
+            challenge: challenge,
+            timeout: nil,
+            rpId: rpId,
+            allowCredentials: allowCredentials,
+            userVerification: userVerification
+        ),
+        challengeId: challengeId
+    )
+}
+
+struct PasskeyLoginClientMakeAssertionRequestTests {
+    @Test func usesRpIdAndDecodedChallengeFromResponse() throws {
+        let client = makeClient()
+        let begun = fixtureBegin(challenge: "Y2hhbGxlbmdl", rpId: "musubi.social")
+
+        let request = try client.makeAssertionRequest(from: begun)
+
+        #expect(request.relyingPartyIdentifier == "musubi.social")
+        #expect(request.challenge == Base64URL.decode("Y2hhbGxlbmdl"))
+    }
+
+    @Test func mapsAllowCredentialsToDecodedDescriptors() throws {
+        let client = makeClient()
+        let credentialId = Base64URL.encode(Data([1, 2, 3, 4]))
+        let begun = fixtureBegin(allowCredentials: [
+            AllowCredentialJSON(id: credentialId, type: "public-key", transports: nil),
+        ])
+
+        let request = try client.makeAssertionRequest(from: begun)
+
+        #expect(request.allowedCredentials.count == 1)
+        #expect(request.allowedCredentials.first?.credentialID == Data([1, 2, 3, 4]))
+    }
+
+    @Test func emptyAllowCredentialsStaysEmpty() throws {
+        // Discoverable / conditional-UI begin: server sends `allowCredentials: []`.
+        let client = makeClient()
+        let begun = fixtureBegin(allowCredentials: [])
+
+        let request = try client.makeAssertionRequest(from: begun)
+
+        #expect(request.allowedCredentials.isEmpty)
+    }
+
+    @Test func recognizedUserVerificationValueIsApplied() throws {
+        let client = makeClient()
+        let begun = fixtureBegin(userVerification: "required")
+
+        let request = try client.makeAssertionRequest(from: begun)
+
+        #expect(request.userVerificationPreference == .required)
+    }
+
+    @Test func unrecognizedUserVerificationValueLeavesSDKDefaultInEffect() throws {
+        // RequestHelpers.userVerificationPreference returns nil for an
+        // unrecognized string rather than guessing — verify that leaves
+        // Apple's own default (`.preferred`) untouched instead of e.g. nil.
+        let client = makeClient()
+        let begun = fixtureBegin(userVerification: "bogus-value")
+
+        let request = try client.makeAssertionRequest(from: begun)
+
+        #expect(request.userVerificationPreference == .preferred)
+    }
+
+    @Test func malformedChallengeThrows() {
+        let client = makeClient()
+        let begun = fixtureBegin(challenge: "not valid base64url!!!")
+
+        #expect(throws: OSNAuthError.responseMalformed(status: 200)) {
+            try client.makeAssertionRequest(from: begun)
+        }
+    }
+
+    @Test func malformedCredentialIdThrows() {
+        let client = makeClient()
+        let begun = fixtureBegin(allowCredentials: [
+            AllowCredentialJSON(id: "not valid base64url!!!", type: "public-key", transports: nil),
+        ])
+
+        #expect(throws: OSNAuthError.responseMalformed(status: 200)) {
+            try client.makeAssertionRequest(from: begun)
+        }
+    }
+}
+
+struct PasskeyLoginClientLoginTargetTests {
+    @Test func typedIdentifierAlwaysWins() throws {
+        let client = makeClient()
+        let begun = fixtureBegin(challengeId: "should-be-ignored")
+
+        let target = try client.loginTarget(identifier: "someone", begun: begun)
+
+        #expect(target == .identifier("someone"))
+    }
+
+    @Test func nilIdentifierFallsBackToChallengeId() throws {
+        let client = makeClient()
+        let begun = fixtureBegin(challengeId: "challenge-id-1")
+
+        let target = try client.loginTarget(identifier: nil, begun: begun)
+
+        #expect(target == .challengeId("challenge-id-1"))
+    }
+
+    @Test func nilIdentifierAndNilChallengeIdThrows() {
+        let client = makeClient()
+        let begun = fixtureBegin(challengeId: nil)
+
+        #expect(throws: OSNAuthError.responseMalformed(status: 200)) {
+            try client.loginTarget(identifier: nil, begun: begun)
+        }
+    }
+}
+
+/// Brief T3 §6 — "`SingleResumeContinuation` still resumes exactly once when
+/// a cancel races a completion." `SingleResumeContinuationTests` already
+/// covers double-resume in general (two sequential calls on the same
+/// thread); this covers the specific race the runner's
+/// `withTaskCancellationHandler` introduces — an `onCancel`-triggered resume
+/// and a delegate-triggered resume firing concurrently from different
+/// threads, mirroring `PasskeyCeremonyRunner.run`'s real shape (`onCancel`
+/// resumes via `cancel()` -> the delegate's `didCompleteWithError`, while
+/// `didCompleteWithAuthorization` can already be in flight). Both outcomes
+/// (the cancel error or the real result) are individually valid — what this
+/// guards is that exactly one wins and the process never crashes on a
+/// double-resume.
+struct SingleResumeContinuationCancelRaceTests {
+    @Test func concurrentCancelAndCompletionResumeExactlyOnce() async throws {
+        struct CancelMarker: Error {}
+
+        for _ in 0..<200 {
+            let outcome = try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+                let guarded = SingleResumeContinuation(continuation)
+                DispatchQueue.global().async {
+                    guarded.resume(throwing: CancelMarker())
+                }
+                DispatchQueue.global().async {
+                    guarded.resume(returning: 42)
+                }
+            }
+            // Either resume could win the race; either outcome is legitimate,
+            // but a nil (i.e. a resume that never happened, or a second
+            // resume that crashed instead of no-op'ing) is not.
+            #expect(outcome == nil || outcome == 42)
+        }
+    }
+}

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -72,9 +72,28 @@
 - No confirmation against a live `osn-api` deployment. The shapes are now
   read off the server source rather than the brief (see Verified), but
   nothing has been checked against a captured production payload.
-- No conditional UI / passkey autofill: `PasskeyCeremonyRunner` never calls
-  `performAutoFillAssistedRequests()`. The discoverable-credential flow the
-  brief asked for works; the QuickType-bar suggestion does not exist yet.
+- Conditional UI / passkey autofill (brief T3): `OSNSession.startAutoFillSignIn`
+  arms `performAutoFillAssistedRequests()` via a new `PasskeyCeremonyHandle`
+  (cancellable, `#if os(iOS)`-gated), and `PasskeySignInView` starts/cancels it
+  in `.task`/`.onDisappear`. The three `PasskeyLoginClient` helpers it reuses —
+  `beginLogin`, `makeAssertionRequest`, `loginTarget` — are machine-tested
+  (`PasskeyLoginClientHelpersTests`), as is `SingleResumeContinuation`'s
+  behaviour under a cancel/completion race. What is **not** machine-tested,
+  anywhere: `packageAssertion(_:)` (needs an `ASAuthorizationPlatformPublicKeyCredentialAssertion`,
+  which Apple vends only from a real ceremony and exposes no public
+  initializer for), and the full autofill runtime path end to end
+  (`performAutoFillAssistedRequests()` itself, the QuickType suggestion
+  appearing, the one-shot silent re-arm on a 120s-TTL-expired challenge, the
+  modal/autofill collision handling in `signIn`). CI never executes any of
+  that — see the note below. It ships human-reviewed only.
+- CI coverage gap, stated plainly: the macOS host runs `swift test`, which
+  compiles and runs every `#if os(iOS)` block's *non*-iOS-only siblings but
+  cannot execute iOS-only code (`performAutoFillAssistedRequests()` doesn't
+  exist on macOS) or drive a real `ASAuthorizationController` ceremony either
+  way. The iOS lane runs `xcodebuild ... build`, not `test` — a typecheck, not
+  a run. So no line of the autofill path executes in CI on either platform.
+  A simulator test lane that could exercise it is a separate task, not
+  started here.
 - Xcode build of the Pulse target with the new entitlements has not been
   run — `swift build`/`swift test` only exercise the SPM package, not the
   Xcode project XcodeGen would generate. Nothing blocks that build now (see

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -85,7 +85,14 @@
   (`performAutoFillAssistedRequests()` itself, the QuickType suggestion
   appearing, the one-shot silent re-arm on a 120s-TTL-expired challenge, the
   modal/autofill collision handling in `signIn`). CI never executes any of
-  that — see the note below. It ships human-reviewed only.
+  that — see the note below. It ships human-reviewed only. That includes the
+  cancellation invariant two independent reviews landed on: at most one live
+  `ASAuthorizationController` request, always reachable from
+  `cancelAutoFillSignIn()`. It is held by three things — cancel-before-arm in
+  `attemptAutoFillSignIn`, an identity-checked `clearAutoFillHandle` so an
+  overlapping attempt cannot drop a newer handle, and `autoFillReArmTask`
+  making the re-arm `signIn` spawns cancellable before it reaches the arm.
+  Reading is the only check any of that gets today.
 - CI coverage gap, stated plainly: the macOS host runs `swift test`, which
   compiles and runs every `#if os(iOS)` block's *non*-iOS-only siblings but
   cannot execute iOS-only code (`performAutoFillAssistedRequests()` doesn't

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -101,10 +101,17 @@
   a run. So no line of the autofill path executes in CI on either platform.
   A simulator test lane that could exercise it is a separate task, not
   started here.
-- Xcode build of the Pulse target with the new entitlements has not been
-  run — `swift build`/`swift test` only exercise the SPM package, not the
-  Xcode project XcodeGen would generate. Nothing blocks that build now (see
-  BLOCKED below); it just hasn't been done.
+- The Xcode build of the Pulse target with the new entitlements has now been
+  run (`xcodegen generate` + `xcodebuild -scheme Pulse` against a concrete
+  iOS Simulator destination, signed, exit 0), and the resulting bundle
+  carries `com.apple.security.application-groups =>
+  ["group.social.musubi.session"]` under `FV59Y8RSUH.social.musubi.pulse`.
+  Probe it with `plutil -p <DerivedData>/Build/Intermediates.noindex/Pulse.build/Debug-iphonesimulator/Pulse.build/Pulse.app-Simulated.xcent`
+  — a simulator build is `adhoc, linker-signed`, so `codesign -d
+  --entitlements` prints nothing and proves nothing.
+  What that build does **not** cover: it typechecks the `#if os(iOS)`
+  autofill code that `swift build` compiles out, but it still never *runs*
+  it. See the CI coverage gap above — that stands.
 
 ## BLOCKED
 


### PR DESCRIPTION
## Summary

Adds passkey **conditional UI (autofill)** sign-in to the shared `OSNAuth` layer, so the QuickType bar offers a passkey the moment the sign-in screen appears rather than only after the user taps "Sign in".

`OSNSession.startAutoFillSignIn()` arms `ASAuthorizationController.performAutoFillAssistedRequests()` behind a new cancellable `PasskeyCeremonyHandle`; `PasskeySignInView` arms it in `.task` and cancels it in `.onDisappear`. Autofill always calls `beginLogin(identifier: nil)` — the discoverable-credential path — and the RP ID always comes from the server's begin-response, never a literal.

The whole iOS-only surface is `#if os(iOS)`-gated: `performAutoFillAssistedRequests()` does not exist on macOS, which is where `swift test` runs.

## Workspaces affected

- `shared/swift/OSNShared` — `OSNAuth` (`OSNSession`, `PasskeyLoginClient` helpers, `PasskeyCeremonyHandle`), `OSNAuthUI` (`PasskeySignInView`), `Tests/OSNAuthTests`
- `pulse/ios` — no source change beyond the regenerated project inputs
- `shared/swift/OSNShared/a3-notes.md` — verification record

Base is `main`. The `refactor/osn-session-shared` base PR (#535) was squash-merged, so this branch was rebased `--onto origin/main` and is no longer stacked.

## Decisions & issues

**Issue:** the armed autofill ceremony was only sometimes reachable from `cancelAutoFillSignIn()`, so a stale `ASAuthorizationController` request could outlive the view. Found independently by both reviews (security **S-M1**, performance **P-W2**).
**Why:** an overlapping `attemptAutoFillSignIn` could overwrite the stored handle, and the re-arm `signIn` spawns was not cancellable before it reached the arm.
**Solution:** cancel-before-arm in `attemptAutoFillSignIn`; an identity-checked `clearAutoFillHandle(_:)` so an overlapping attempt cannot drop a newer handle; and an `autoFillReArmTask` that makes the re-arm cancellable. Commit `1a4becac`.
**Rationale:** the invariant worth holding is "at most one live request, always reachable from cancel". Identity-checking the handle is what makes that true under a race rather than only in the happy path.

**Issue:** `signIn` awaited the autofill re-arm inline, deadlocking the modal ceremony behind the arm it had just spawned.
**Why:** the re-arm is a long-lived awaiting call; awaiting it inside `signIn` never returns while autofill sits armed.
**Solution:** spawn it as `autoFillReArmTask` and return. Commit `fd0bad24`.
**Rationale:** the re-arm is fire-and-forget by nature — nothing in `signIn`'s result depends on it.

**Issue:** performance review **P-W1** asked to skip the re-arm when the modal ceremony throws `PasskeyCeremonyError.cancelled`.
**Why:** it reads as wasted work on a user cancel.
**Solution:** rejected, deliberately.
**Rationale:** brief T3 §4 asks for the re-arm on throw *or* cancel on purpose — a user who dismisses the modal should still get the QuickType suggestion back. Leaving the screen without an armed request is the worse outcome.

**Issue:** should `state = .signedIn(response.profile)` be gated on `Task.isCancelled`?
**Why:** the surrounding task can be cancelled between the server accepting the assertion and the state write.
**Solution:** deliberately not done.
**Rationale:** the session is signed in *server-side* by that point. Dropping the state write would render signed-out over a live session — strictly worse than a late write.

**Issue:** performance **P-I1** — the ceremony path allocates a fresh request object per attempt.
**Why:** flagged as avoidable churn.
**Solution:** accepted as-is, no change.
**Rationale:** `ASAuthorization*Request` objects are single-use by API contract; reusing one is not supported.

**Issue:** tests **T-M1** — zero machine coverage of the autofill/retry/re-arm state machine.
**Why:** the state machine is the risky part of this diff and CI never runs it (macOS compiles it out; the iOS lane is `xcodebuild build`, a typecheck, not a run).
**Solution:** disclosed, not closed. `PasskeyLoginClientHelpersTests` covers `beginLogin`/`makeAssertionRequest`/`loginTarget`, and `SingleResumeContinuationTests` covers the cancel/completion race, but the machine itself ships human-reviewed.
**Rationale:** closing it needs a simulator *test* lane, which is a separate task, not a rider on this PR. It is written into `a3-notes.md` §Not verified so it is not silently forgotten.

**Issue:** tests **T-S1** — `beginLogin`'s non-200 and malformed-JSON paths are untested.
**Why:** gap found by the tests review.
**Solution:** disclosed; deferred to the follow-up PR.
**Rationale:** both paths are shared with the already-covered modal flow; the marginal risk is low next to T-M1.

**Issue:** tests **T-S2** — `packageAssertion(_:)` cannot be tested in-process.
**Why:** Apple exposes no public initializer for `ASAuthorizationPlatformPublicKeyCredentialAssertion`; it is vended only by a real ceremony.
**Solution:** accepted and documented, no workaround attempted.
**Rationale:** the alternatives are a protocol-shim over an Apple type purely for tests, or a mock that proves nothing about the real type. Neither buys real safety.

**Issue:** `osn/api/src/routes/auth/login.ts:38-66` skips Turnstile for the identifier-less login path, which is exactly the path autofill uses.
**Why:** it looks like a bypass at first read.
**Solution:** no change — verified as designed.
**Rationale:** per-IP rate limiting still applies to that path, and the client genuinely cannot present a Turnstile token from a QuickType interaction. The client sends `turnstileToken: nil` to match.

## Test plan

Gates re-run by hand after the rebase, all exit 0:

- `swift build` → `Build complete!`
- `swift test` → **91 tests in 13 suites passed**
- `xcodegen generate` + `xcodebuild -scheme Pulse -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64 build` → exit 0

The `xcodebuild` run is the only gate that typechecks the `#if os(iOS)` autofill code at all — `swift build`/`swift test` compile it out entirely. It still never *runs* it.

Signed simulator build (from the sibling Musubi branch, same tree): the Pulse bundle carries `com.apple.security.application-groups => ["group.social.musubi.session"]` under `FV59Y8RSUH.social.musubi.pulse`. Probe with `plutil -p <DerivedData>/Build/Intermediates.noindex/Pulse.build/Debug-iphonesimulator/Pulse.build/Pulse.app-Simulated.xcent` — a simulator build is `adhoc, linker-signed`, so `codesign -d --entitlements` prints nothing and proves nothing.

**Not covered:** a real `ASAuthorizationController` ceremony end to end. Blocked, not skipped — production `musubi.social` still serves the pre-rename `FV59Y8RSUH.com.osn.pulse` in its AASA, and local `osn-api` defaults to `rpId: "localhost"` (`osn/api/src/build-deps.ts:254`), which no iOS app can claim via `webcredentials:`.

## Merge order

This branch and `feat/musubi-ios-app` both touch `shared/swift/OSNShared/a3-notes.md` and will collide in the tree. Merge one, rebase the other. The Musubi branch additionally touches `Package.swift`.
