### PR TITLE
feat(musubi-ios): Musubi as second OSNSession client, sharing Pulse's cookie jar

### DIFF
--- a/.changeset/musubi-app-aasa.md
+++ b/.changeset/musubi-app-aasa.md
@@ -1,0 +1,5 @@
+---
+"@osn/social": patch
+---
+
+Add `social.musubi.app` (the Musubi iOS app) to the `apple-app-site-association` webcredentials list, alongside Pulse, so passkey autofill associates with the new app.

--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -62,7 +62,7 @@ jobs:
             # it at build time — so a spec-only change can break the iOS build
             # while touching no file under `shared/swift/`. This very PR is that
             # case: it rewrites every nullable field's spelling and nothing else.
-            if echo "$changed" | grep -qE '^(shared/swift/|shared/openapi/|pulse/ios/|\.github/workflows/ci-swift\.yml$)'; then
+            if echo "$changed" | grep -qE '^(shared/swift/|shared/openapi/|pulse/ios/|osn/ios/|\.github/workflows/ci-swift\.yml$)'; then
               echo "ios=true" >> "$GITHUB_OUTPUT"
             else
               echo "ios=false" >> "$GITHUB_OUTPUT"
@@ -73,6 +73,8 @@ jobs:
             echo "ios=true" >> "$GITHUB_OUTPUT"
           fi
 
+  # Name kept as-is even though this job now also builds Musubi — a required
+  # status check may pin the exact string "swift test + xcodebuild (Pulse)".
   swift:
     name: swift test + xcodebuild (Pulse)
     needs: changes
@@ -113,10 +115,25 @@ jobs:
       # "OpenAPIGenerator" in package "swift-openapi-generator"`. The flag is
       # how you consent on a runner. The package and its version are pinned in
       # `Package.resolved`, so this doesn't widen what code can run.
-      - name: xcodebuild
+      - name: xcodebuild (Pulse)
         working-directory: pulse/ios
         run: |
           xcodebuild -scheme Pulse \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            -quiet \
+            CODE_SIGNING_ALLOWED=NO \
+            EXCLUDED_ARCHS=x86_64 \
+            build
+
+      - name: xcodegen generate (Musubi)
+        working-directory: osn/ios
+        run: xcodegen generate
+
+      - name: xcodebuild (Musubi)
+        working-directory: osn/ios
+        run: |
+          xcodebuild -scheme Musubi \
             -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation \
             -quiet \

--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -115,11 +115,16 @@ jobs:
       # "OpenAPIGenerator" in package "swift-openapi-generator"`. The flag is
       # how you consent on a runner. The package and its version are pinned in
       # `Package.resolved`, so this doesn't widen what code can run.
+      # Both apps consume the same `OSNShared` products (`OSNKit`, `OSNAuth`,
+      # `OSNUI`). DerivedData is keyed per project by default, so without a
+      # shared path the second xcodebuild recompiles all three from scratch
+      # inside the same job. One path, one compile.
       - name: xcodebuild (Pulse)
         working-directory: pulse/ios
         run: |
           xcodebuild -scheme Pulse \
             -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
             -skipPackagePluginValidation \
             -quiet \
             CODE_SIGNING_ALLOWED=NO \
@@ -135,6 +140,7 @@ jobs:
         run: |
           xcodebuild -scheme Musubi \
             -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
             -skipPackagePluginValidation \
             -quiet \
             CODE_SIGNING_ALLOWED=NO \

--- a/osn/ios/Sources/App.swift
+++ b/osn/ios/Sources/App.swift
@@ -1,0 +1,46 @@
+import AuthenticationServices
+import MusubiFeature
+import OSNAuth
+import SwiftUI
+import UIKit
+
+@main
+struct MusubiApp: App {
+    @State private var session: OSNSession?
+    @State private var sessionError: String?
+
+    var body: some Scene {
+        WindowGroup {
+            Group {
+                if let session {
+                    MusubiRootView(session: session, anchorProvider: MusubiApp.keyWindowAnchor)
+                } else if let sessionError {
+                    Text(sessionError)
+                } else {
+                    ProgressView()
+                }
+            }
+            .task {
+                guard session == nil, sessionError == nil else { return }
+                do {
+                    session = try OSNSession()
+                } catch {
+                    sessionError = String(describing: error)
+                }
+            }
+        }
+    }
+
+    /// This package can't `import MusubiFeature`'s dependency `OSNAuth`'s
+    /// `PresentationAnchorProvider` without also supplying the key
+    /// `UIWindow` itself — `MusubiFeature` can't `import UIKit` (must build
+    /// on the macOS host), so this one lookup stays in the app target.
+    @MainActor
+    private static func keyWindowAnchor() -> ASPresentationAnchor {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+        let window = scene?.windows.first(where: \.isKeyWindow) ?? scene?.windows.first
+        return window ?? ASPresentationAnchor()
+    }
+}

--- a/osn/ios/project.yml
+++ b/osn/ios/project.yml
@@ -1,0 +1,56 @@
+name: Musubi
+options:
+  bundleIdPrefix: social.musubi
+  deploymentTarget:
+    iOS: "26.0"
+packages:
+  OSNShared:
+    path: ../../shared/swift/OSNShared
+targets:
+  Musubi:
+    type: application
+    platform: iOS
+    deploymentTarget: "26.0"
+    sources:
+      - path: Sources
+    dependencies:
+      - package: OSNShared
+        product: OSNKit
+      - package: OSNShared
+        product: OSNAuth
+      - package: OSNShared
+        product: OSNUI
+      - package: OSNShared
+        product: OSNAuthUI
+      - package: OSNShared
+        product: MusubiFeature
+    settings:
+      base:
+        # Changing this means changing `osn/social/public/.well-known/
+        # apple-app-site-association` in the same commit — it names
+        # `<TEAMID>.<bundle id>`, and a stale entry there means the
+        # associated domain silently never forms and passkeys never appear.
+        PRODUCT_BUNDLE_IDENTIFIER: social.musubi.app
+        DEVELOPMENT_TEAM: FV59Y8RSUH
+        CODE_SIGN_STYLE: Automatic
+        TARGETED_DEVICE_FAMILY: "1"
+        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+        GENERATE_INFOPLIST_FILE: "YES"
+        SWIFT_VERSION: "6.2"
+    # The App Group `group.social.musubi.session` is registered under team
+    # FV59Y8RSUH, so the shared cookie jar resolves and every OSN app signs in
+    # once. The string must stay in step with
+    # OSNKit/SharedCookieJar.swift:10 (osnSessionAppGroupIdentifier) — change
+    # one and the jar silently splits in two.
+    #
+    # Both capabilities are on the App ID: App Groups (with this group
+    # assigned) and Associated Domains. Adding or removing a capability there
+    # invalidates every provisioning profile carrying this App ID, so they
+    # have to be regenerated afterwards.
+    entitlements:
+      path: Musubi.entitlements
+      properties:
+        com.apple.developer.associated-domains:
+          - webcredentials:musubi.social
+        com.apple.security.application-groups:
+          - group.social.musubi.session

--- a/osn/social/public/.well-known/apple-app-site-association
+++ b/osn/social/public/.well-known/apple-app-site-association
@@ -1,5 +1,5 @@
 {
   "webcredentials": {
-    "apps": ["FV59Y8RSUH.social.musubi.pulse"]
+    "apps": ["FV59Y8RSUH.social.musubi.pulse", "FV59Y8RSUH.social.musubi.app"]
   }
 }

--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .library(name: "OSNTesting", targets: ["OSNTesting"]),
         .library(name: "PulseAPI", targets: ["PulseAPI"]),
         .library(name: "PulseFeature", targets: ["PulseFeature"]),
+        .library(name: "MusubiFeature", targets: ["MusubiFeature"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
@@ -48,5 +49,6 @@ let package = Package(
         .testTarget(name: "PulseAPITests", dependencies: ["PulseAPI", "OSNKit", "OSNTesting"]),
         .target(name: "PulseFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAuthUI", "PulseAPI"]),
         .testTarget(name: "PulseFeatureTests", dependencies: ["PulseFeature", "OSNTesting"]),
+        .target(name: "MusubiFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAuthUI"]),
     ]
 )

--- a/shared/swift/OSNShared/Package.swift
+++ b/shared/swift/OSNShared/Package.swift
@@ -50,5 +50,6 @@ let package = Package(
         .target(name: "PulseFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAuthUI", "PulseAPI"]),
         .testTarget(name: "PulseFeatureTests", dependencies: ["PulseFeature", "OSNTesting"]),
         .target(name: "MusubiFeature", dependencies: ["OSNKit", "OSNAuth", "OSNUI", "OSNAuthUI"]),
+        .testTarget(name: "MusubiFeatureTests", dependencies: ["MusubiFeature", "OSNTesting"]),
     ]
 )

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
@@ -1,0 +1,75 @@
+import OSNAuth
+import SwiftUI
+
+/// Read-only account screen: the signed-in profile (when the session carries
+/// one — a restored session doesn't, and there is no "fetch current profile"
+/// endpoint to fill that in) plus the account's passkeys. Rename and delete
+/// need a step-up ceremony (`wiki/systems/step-up.md`) and are out of scope
+/// here — no buttons for either.
+public struct MusubiAccountView: View {
+    private let session: OSNSession
+
+    @State private var passkeys: [PasskeySummary] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    public init(session: OSNSession) {
+        self.session = session
+    }
+
+    public var body: some View {
+        List {
+            Section("Profile") {
+                if case .signedIn(let profile?) = session.state {
+                    Text(profile.displayName ?? profile.handle)
+                    Text(profile.email)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Signed in")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Passkeys") {
+                if isLoading {
+                    ProgressView()
+                } else if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                    Button("Retry") {
+                        Task { await loadPasskeys() }
+                    }
+                } else if passkeys.isEmpty {
+                    Text("No passkeys")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(passkeys, id: \.id) { passkey in
+                        Text(passkey.label ?? passkey.id)
+                    }
+                }
+            }
+
+            Section {
+                Button("Sign out", role: .destructive) {
+                    Task { await session.signOut() }
+                }
+            }
+        }
+        .task {
+            await loadPasskeys()
+        }
+    }
+
+    private func loadPasskeys() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            try await session.ensureFreshAccessToken()
+            let client = PasskeyManagementClient(session: session.urlSession, environment: .local)
+            passkeys = try await client.list()
+        } catch {
+            errorMessage = String(describing: error)
+        }
+    }
+}

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
@@ -65,11 +65,24 @@ public struct MusubiAccountView: View {
         errorMessage = nil
         defer { isLoading = false }
         do {
-            try await session.ensureFreshAccessToken()
-            let client = PasskeyManagementClient(session: session.urlSession, environment: .local)
-            passkeys = try await client.list()
+            passkeys = try await fetchPasskeys(session: session)
         } catch {
             errorMessage = String(describing: error)
         }
     }
+}
+
+/// The network half of `MusubiAccountView.loadPasskeys()`, pulled out so a
+/// test can reach it: refreshes the access token if it's missing or about
+/// to expire, then lists passkeys. Contract this exists to protect — a
+/// failing `list()` must throw without ever mutating `session.state`, i.e.
+/// a passkey-list failure must not sign the user out. `session.state` is
+/// `private(set)`; nothing below this call has any way to write to it, and
+/// that's what makes the contract checkable from a test rather than merely
+/// asserted in a comment.
+@MainActor
+func fetchPasskeys(session: OSNSession) async throws -> [PasskeySummary] {
+    try await session.ensureFreshAccessToken()
+    let client = PasskeyManagementClient(session: session.urlSession, environment: .local)
+    return try await client.list()
 }

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -18,7 +18,7 @@ public struct MusubiRootView: View {
     public var body: some View {
         content
             .task {
-                if session.state == .restoring {
+                if shouldRestore(session.state) {
                     await session.restore()
                 }
             }
@@ -35,4 +35,14 @@ public struct MusubiRootView: View {
             MusubiAccountView(session: session)
         }
     }
+}
+
+/// The gate `MusubiRootView`'s `.task` runs on: restore only fires while the
+/// session is still in its initial `.restoring` state, so it runs at most
+/// once per launch and a signed-in/signed-out/failed session is never
+/// re-restored. Pulled out of the view body so it's reachable from a test —
+/// `swift test` can't render SwiftUI, and a test that reimplements this
+/// switch against its own copy would stay green after the real gate broke.
+func shouldRestore(_ state: OSNSession.SessionState) -> Bool {
+    state == .restoring
 }

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -1,0 +1,38 @@
+import OSNAuth
+import OSNAuthUI
+import SwiftUI
+
+/// App shell root: gates on `OSNSession.state` directly — Musubi has no
+/// feature-specific session wrapper, nothing to add on top of sign-in.
+/// Construct once per app launch and pass the iOS anchor provider in from
+/// `App.swift` (this package can't import UIKit).
+public struct MusubiRootView: View {
+    private let session: OSNSession
+    private let anchorProvider: PresentationAnchorProvider
+
+    public init(session: OSNSession, anchorProvider: @escaping PresentationAnchorProvider) {
+        self.session = session
+        self.anchorProvider = anchorProvider
+    }
+
+    public var body: some View {
+        content
+            .task {
+                if session.state == .restoring {
+                    await session.restore()
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch session.state {
+        case .restoring:
+            ProgressView()
+        case .signedOut, .failed:
+            PasskeySignInView(appName: "Musubi", session: session, anchorProvider: anchorProvider)
+        case .signedIn:
+            MusubiAccountView(session: session)
+        }
+    }
+}

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import OSNKit
+import OSNTesting
+import Testing
+@testable import MusubiFeature
+@testable import OSNAuth
+
+/// Intercepts requests for one `URLSession` at a time — mirrors
+/// `OSNAuthTests/PasskeyLoginClientTests.swift`'s `LoginMockURLProtocol`.
+/// Each test target needs its own copy since `URLProtocol` subclasses
+/// aren't shared across SPM targets (see the comment there).
+final class MusubiMockURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
+    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        Task {
+            do {
+                let (status, headers, data) = try await handler(request)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                if let url = request.url {
+                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
+                    if !cookies.isEmpty {
+                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
+                    }
+                }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MusubiMockURLProtocol.self]
+    configuration.httpShouldSetCookies = true
+    configuration.httpCookieAcceptPolicy = .always
+    MusubiMockURLProtocol.cookieStorage = configuration.httpCookieStorage
+    return URLSession(configuration: configuration)
+}
+
+@MainActor
+private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
+    OSNSession(
+        urlSession: session,
+        tokenRefresher: tokenRefresher,
+        loginClient: PasskeyLoginClient(session: session, environment: environment)
+    )
+}
+
+/// T-U2: `MusubiRootView` gates `session.restore()` on `shouldRestore(_:)`.
+/// No Keychain/network access, so no serialising trait needed.
+@Suite
+struct ShouldRestoreTests {
+    @Test func restoringIsTrue() {
+        #expect(shouldRestore(.restoring))
+    }
+
+    @Test func signedOutIsFalse() {
+        #expect(!shouldRestore(.signedOut))
+    }
+
+    @Test func signedInWithNoProfileIsFalse() {
+        #expect(!shouldRestore(.signedIn(nil)))
+    }
+
+    @Test func signedInWithProfileIsFalse() {
+        let profile = PasskeyProfile(
+            id: "user-1",
+            handle: "aniket",
+            email: "aniket@example.com",
+            displayName: "Aniket",
+            avatarUrl: nil
+        )
+        #expect(!shouldRestore(.signedIn(profile)))
+    }
+
+    @Test func failedIsFalse() {
+        #expect(!shouldRestore(.failed("session expired")))
+    }
+}
+
+/// T-U1: `fetchPasskeys(session:)` — the network half of
+/// `MusubiAccountView.loadPasskeys()`. Touches the real Keychain via
+/// `ensureFreshAccessToken()`/`TokenRefresher`, so it shares the
+/// cross-target serialized lock with every other Keychain-touching suite
+/// (`OSNSessionTests.swift:29`).
+@Suite(.serialized, .keychainSerializing)
+@MainActor
+struct FetchPasskeysTests {
+    @Test func successReturnsSummariesAndLeavesStateUnchanged() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        MusubiMockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"at-fresh-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-1; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        #expect(osnSession.state == .signedIn(nil))
+
+        MusubiMockURLProtocol.handler = { _ in
+            let body = """
+            {"passkeys":[{"id":"pk-1","label":"iPhone","aaguid":null,"transports":null,"backupEligible":null,"backupState":null,"createdAt":1,"lastUsedAt":null}]}
+            """
+            return (200, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+
+        let stateBefore = osnSession.state
+        let passkeys = try await fetchPasskeys(session: osnSession)
+
+        #expect(passkeys.map(\.id) == ["pk-1"])
+        #expect(osnSession.state == stateBefore)
+        #expect(osnSession.state == .signedIn(nil))
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func listFailureThrowsAndLeavesStateUnchanged() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        MusubiMockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"at-fresh-2","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-2; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        #expect(osnSession.state == .signedIn(nil))
+
+        MusubiMockURLProtocol.handler = { _ in
+            let body = #"{"error":"server_error","message":"boom"}"#
+            return (500, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+
+        let stateBefore = osnSession.state
+        await #expect(throws: (any Error).self) {
+            try await fetchPasskeys(session: osnSession)
+        }
+        #expect(osnSession.state == stateBefore)
+        #expect(osnSession.state == .signedIn(nil))
+
+        try KeychainAccessTokenStore.delete()
+    }
+}

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -85,10 +85,29 @@
   `ci-swift.yml`'s path filter and `swift` job now also generate/build the
   `Musubi` scheme; the job's `name:` string is untouched (may be pinned by a
   required status check).
-- This branch did not run the two-app shared-cookie-jar check (signing in
-  on Pulse, confirming Musubi restores signed-in via the App Group jar) —
-  that is a simulator-level check outside this task, tracked below in §Not
-  verified, and is not closed by adding the second client.
+- **App Group container verified on simulator, 2026-08-17.** Both apps were
+  built signed for `iPhone 17 Pro` (iOS 26.3, `C9C6D823-…`), installed, and
+  launched. Three things came out of it:
+  - The entitlement reaches the bundle. A simulator build is
+    `adhoc, linker-signed`, so `codesign -d --entitlements` shows nothing and
+    is the wrong probe; the entitlements live in a `__TEXT,__entitlements`
+    section and in `<Scheme>.build/<App>.app-Simulated.xcent`. `plutil -p` on
+    those prints `com.apple.security.application-groups =>
+    ["group.social.musubi.session"]` for both, under
+    `FV59Y8RSUH.social.musubi.pulse` and `FV59Y8RSUH.social.musubi.app`.
+  - Both apps resolve the **same** container:
+    `xcrun simctl get_app_container … group.social.musubi.session` returns
+    `…/Containers/Shared/AppGroup/DBBDABDC-4232-4719-BAB3-A65F87FF9FA7` for
+    each bundle id.
+  - `SharedCookieJar.makeSession()` does not throw in either app. Both
+    render `PasskeySignInView`; neither shows `MusubiApp`/`PulseApp`'s
+    `Text(sessionError)` fallback, which is the only thing an
+    `OSNKitError.appGroupContainerUnavailable` would produce. A live process
+    alone proves nothing here — the throw is caught, not fatal — so this was
+    checked by screenshot, not by exit status.
+- What that check does **not** close: signing in on Pulse and confirming
+  Musubi restores signed-in through the shared jar. That needs a real passkey
+  ceremony, which is blocked — see §Not verified.
 
 ## Not verified
 

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -62,6 +62,34 @@
   `PulseFeature`'s old `SignInView`. `PulseRootView` renders it against
   `session.auth`; no other view changed.
 
+## Musubi (second client)
+
+- New `MusubiFeature` target (`OSNKit`/`OSNAuth`/`OSNUI`/`OSNAuthUI`, no API
+  client — Musubi talks to OSNAuth's clients only). `MusubiRootView` gates
+  directly on `OSNSession.state` (no `PulseSession`-style wrapper) and
+  reuses `PasskeySignInView` unmodified. `MusubiAccountView` is read-only:
+  lists passkeys, shows the profile when `.signedIn` carries one (`nil` on a
+  restored session — handled, not force-unwrapped), and a sign-out button.
+  No rename/delete UI — both need a step-up ceremony
+  (`wiki/systems/step-up.md`), out of scope.
+- `ensureFreshAccessToken()` runs immediately before every
+  `PasskeyManagementClient.list()` call in `MusubiAccountView`, per
+  `RequestHelpers.applyBearerAccessToken`'s no-expiry-check/no-401-retry
+  behavior. A load failure surfaces inline in the view (error text + Retry
+  button) and never touches `session.state`.
+- `osn/ios/` mirrors `pulse/ios/` (`project.yml`, `Sources/App.swift`):
+  bundle id `social.musubi.app`, same team/App-Group/associated-domain
+  entitlements. AASA
+  (`osn/social/public/.well-known/apple-app-site-association`) now lists
+  both `FV59Y8RSUH.social.musubi.pulse` and `FV59Y8RSUH.social.musubi.app`.
+  `ci-swift.yml`'s path filter and `swift` job now also generate/build the
+  `Musubi` scheme; the job's `name:` string is untouched (may be pinned by a
+  required status check).
+- This branch did not run the two-app shared-cookie-jar check (signing in
+  on Pulse, confirming Musubi restores signed-in via the App Group jar) —
+  that is a simulator-level check outside this task, tracked below in §Not
+  verified, and is not closed by adding the second client.
+
 ## Not verified
 
 - No device/simulator run of an actual passkey ceremony (`ASAuthorizationController`


### PR DESCRIPTION
## Summary

Adds **Musubi** as the second iOS client of the shared `OSNSession` / `PasskeySignInView` layer, proving the shared-session design with a real second consumer rather than an argument.

Musubi ships as `osn/ios/` mirroring `pulse/ios/`: bundle id `social.musubi.app`, same team, same `group.social.musubi.session` App Group, same `webcredentials:musubi.social` associated domain. `MusubiRootView` gates directly on `OSNSession.state` — no `PulseSession`-style wrapper — and reuses `PasskeySignInView` unmodified. `MusubiAccountView` is read-only: passkey list, profile when `.signedIn` carries one, sign-out.

Both apps therefore share one cookie jar in one App Group container, which is the point of the branch.

## Workspaces affected

- `shared/swift/OSNShared` — new `MusubiFeature` target + `MusubiFeatureTests`, `Package.swift`
- `osn/ios` — new Xcode project inputs (`project.yml`, `Sources/App.swift`)
- `osn/social` — AASA now lists `FV59Y8RSUH.social.musubi.app` alongside Pulse (changeset `musubi-app-aasa`, `@osn/social` patch)
- `.github/workflows/ci-swift.yml` — path filter and build job extended to the `Musubi` scheme

Base is `main`. The `refactor/osn-session-shared` base PR (#535) was squash-merged, so this branch was rebased `--onto origin/main` and is no longer stacked.

## Decisions & issues

**Issue: S-H1 (High) — shared cookie jar plus un-synced `OSNSession.state` lets one app display another user's identity.**
**Why:** each app holds its own `OSNSession` instance with its own cached `PasskeyProfile`, but they share the cookie jar. Sign into Musubi as A, switch Pulse to B, return to Musubi: Profile still shows A's name and email while `loadPasskeys()` lists **B's** passkeys, and "Sign out" kills B's session under A's label. OWASP A07.
**Solution:** disclosed, **not fixed on this branch**. Deferred to the follow-up PR.
**Rationale:** the fix is a cross-cutting change to `OSNSession` — compare a stable `PasskeyProfile.id` on every authenticated call and/or re-run `restore()` on foreground — and it belongs with the other session-identity work rather than buried in the branch that introduces the second client. It is not reachable today without two real passkey sign-ins, which the AASA blocker (below) prevents. Ship gated on that, or hold this branch — the call is the reviewer's, and it is called out here rather than in a footnote for exactly that reason.

**Issue: S-M1 — `KeychainAccessTokenStore.baseQuery()` sets no `kSecAttrAccessGroup`.**
**Why:** each app's Keychain item is its own. `TokenRefresher.logout()` deletes only the calling app's access token; the sibling app's bearer keeps working for the rest of its ≤5-minute TTL.
**Solution:** disclosed, deferred to the follow-up PR.
**Rationale:** adding an access group changes where existing items live and needs a migration path thought through once, for both apps, in one change.

**Issue: S-L1 — no per-app request attribution.**
**Why:** no UA suffix and no `X-Client-App` header, so `GET /sessions` cannot tell a Musubi session from a Pulse one.
**Solution:** disclosed, deferred.
**Rationale:** it is a server-visible product decision (what the sessions list should *show*), not a client bug to slip in here.

**Issue: P-W1 — two synchronous main-actor `SecItemCopyMatching` calls per list request.**
**Why:** `ensureFreshAccessToken()` reads the Keychain, then `RequestHelpers.applyBearerAccessToken` reads it again.
**Solution:** disclosed, deferred.
**Rationale:** real, but it is two Keychain reads on a user-initiated action, not a hot loop. It merges with the P-W2 work below.

**Issue: P-W2 — the 30 s clock-skew allowance is duplicated.**
**Why:** the literal appears in both `OSNSession.swift` and `BearerTokenMiddleware.swift`'s `expirySkew`, and there is still no 401 → refresh → retry on the `RequestHelpers` path.
**Solution:** disclosed, deferred.
**Rationale:** the right fix is a single retrying transport used by both paths, which subsumes P-W1 as well. Doing half of it here would leave two seams instead of one.

**Issue: P-W3 — the two iOS builds each rebuilt the whole package from scratch in CI.**
**Why:** separate `xcodebuild` invocations with no shared build products.
**Solution:** **fixed** — both schemes now build in one job against a shared `-derivedDataPath "$RUNNER_TEMP/DerivedData"`. Commit `7b3e3cad`.
**Rationale:** adding a second app should not double the CI bill.

**Issue: T-M1 / T-U1 / T-U2 — `MusubiRootView`'s restore gate and `MusubiAccountView`'s passkey fetch had no tests, because both were closures inside view bodies.**
**Why:** untestable shape, not missing intent.
**Solution:** **fixed** — extracted `shouldRestore(_:)` and `fetchPasskeys(session:)` as testable seams and added `MusubiFeatureTests` (7 tests). Commit `b45a4713`. The fetch tests assert `session.state` is unchanged on **both** a 200 and a 500, which is the property `MusubiAccountView` relies on to surface load failures inline instead of signing the user out.
**Rationale:** extracting the seam is the whole fix; a test that drove the view would have tested SwiftUI, not the gate.

**Issue: `MusubiMockURLProtocol` duplicates `OSNAuthTests`' `LoginMockURLProtocol` almost line for line.**
**Why:** `URLProtocol` subclasses are not shared across SPM test targets.
**Solution:** duplicated on purpose, with a comment in each pointing at the other.
**Rationale:** the shared home is `Sources/OSNTesting`, which is still an A0 stub. Consolidating there while two branches are in flight over the same package invites a merge conflict for no functional gain — it is on the follow-up list, once the collision risk is gone.

**Issue: the Musubi app hard-codes `Environment.local`.**
**Why:** there is no scheme-driven environment selection yet.
**Solution:** deliberately left, deferred to the follow-up PR.
**Rationale:** it matches what `pulse/ios` already does. Fixing it for one app and not the other is worse than fixing it for both later.

**Issue: `MusubiFeature` takes no API client dependency.**
**Why:** it would have been the obvious symmetry with `PulseFeature`.
**Solution:** deliberately omitted — Musubi depends on `OSNKit`/`OSNAuth`/`OSNUI`/`OSNAuthUI` only.
**Rationale:** Musubi talks to OSNAuth's clients and nothing else today. `PulseAPI` drags in the swift-openapi-generator build plugin; taking it on for nothing would slow every Musubi build.

**Issue: no rename/delete UI in `MusubiAccountView`.**
**Why:** an account screen that lists passkeys usually lets you manage them.
**Solution:** deliberately out of scope.
**Rationale:** both operations require a step-up ceremony (`wiki/systems/step-up.md`). That is its own task.

**Issue:** the `swift` CI job's `name:` string was left untouched while its body changed.
**Why:** it may be pinned by a required status check on the repo.
**Solution:** body extended, name kept.
**Rationale:** renaming it would quietly drop a required check.

## Test plan

Gates re-run by hand after the rebase, all exit 0:

- `swift build` → `Build complete!`
- `swift test` → **87 tests in 12 suites passed**; confirmed `ShouldRestoreTests` and `FetchPasskeysTests` both *started and passed* rather than being silently skipped
- `xcodegen generate` + `xcodebuild build` for **both** `Pulse` and `Musubi` against `generic/platform=iOS Simulator` → exit 0 each

**Shared App Group container, verified on simulator (2026-08-17).** Both apps built signed from this tree, installed on `iPhone 17 Pro` (iOS 26.3), launched:

1. The entitlement reaches both bundles — `plutil -p <Scheme>.build/<App>.app-Simulated.xcent` prints `com.apple.security.application-groups => ["group.social.musubi.session"]` under `FV59Y8RSUH.social.musubi.pulse` and `FV59Y8RSUH.social.musubi.app`. (`codesign -d --entitlements` is the *wrong* probe for a simulator build — it is `adhoc, linker-signed` and prints nothing.)
2. Both resolve the **same** container — `xcrun simctl get_app_container <udid> <bundle-id> group.social.musubi.session` returns `…/AppGroup/DBBDABDC-4232-4719-BAB3-A65F87FF9FA7` for each.
3. `SharedCookieJar.makeSession()` throws in neither — both render `PasskeySignInView`, neither shows the `Text(sessionError)` fallback that an `appGroupContainerUnavailable` would produce. Checked by **screenshot**: `MusubiApp`/`PulseApp` catch that throw, so a live process alone proves nothing.

**Not covered:** signing in on Pulse and confirming Musubi restores signed-in through the shared jar. Blocked, not skipped — it needs a real passkey ceremony, and production `musubi.social` still serves the pre-rename `{"webcredentials":{"apps":["FV59Y8RSUH.com.osn.pulse"]}}`; the merged #441 rename has never been deployed. Local `osn-api` defaults to `rpId: "localhost"` (`osn/api/src/build-deps.ts:254`), which no iOS app can claim via `webcredentials:`. Deploying `@osn/social` sits behind the manual `production` environment approval.

## Merge order

This branch and `feat/passkey-autofill` both touch `shared/swift/OSNShared/a3-notes.md`, and this one also touches `Package.swift`. They collide in the tree — merge one, rebase the other, do not merge by whichever is green first.
