### PR TITLE
fix(swift): derive displayed identity from the live access token, not a cached profile (S-H1)

### DIFF
--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiRootView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 public struct MusubiRootView: View {
     private let session: OSNSession
     private let anchorProvider: PresentationAnchorProvider
+    @Environment(\.scenePhase) private var scenePhase
 
     public init(session: OSNSession, anchorProvider: @escaping PresentationAnchorProvider) {
         self.session = session
@@ -20,6 +21,15 @@ public struct MusubiRootView: View {
             .task {
                 if shouldRestore(session.state) {
                     await session.restore()
+                }
+            }
+            // S-H1: Pulse and Musubi share one cookie jar and one Keychain
+            // slot, so coming back to the foreground is the moment a sibling
+            // app's sign-in swap needs to be noticed — `revalidate()` is a
+            // no-op unless `session.state` is already `.signedIn`.
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    Task { await session.revalidate() }
                 }
             }
     }

--- a/shared/swift/OSNShared/Sources/OSNAuth/AccessTokenClaims.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/AccessTokenClaims.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The subset of an access-token JWT's payload claims this package reads —
+/// `osn/api/src/services/auth/tokens.ts` `issueAccessToken` mints `sub`,
+/// `aud`, `email`, `handle`, and an optional `displayName` (`accountId` is
+/// deliberately absent, the P6 invariant). `aud` and `scope` aren't decoded
+/// here because nothing on this side branches on them.
+///
+/// **This does not verify the signature and is not a trust boundary.** It
+/// exists only to notice that the token now sitting in the Keychain belongs
+/// to someone else, so a stale cached profile can be dropped — see
+/// `reconciledProfile(cached:claims:)`. Every authorisation decision still
+/// happens server-side, which verifies the ES256 signature
+/// (`verifyAccessToken`). A forged token gets a caller nothing here: it is
+/// rejected by the API on the next request that actually needs it.
+public struct AccessTokenClaims: Sendable, Equatable, Decodable {
+    public let sub: String
+    public let email: String
+    public let handle: String
+    public let displayName: String?
+
+    /// Splits `jwt` on `"."`, requiring exactly 3 segments, base64url-decodes
+    /// the middle one, and `JSONDecoder`s it. Any failure — wrong segment
+    /// count, non-base64url text, valid base64url that isn't JSON, JSON
+    /// missing a required claim — returns `nil`. Never throws, never traps.
+    /// Unknown claims (`aud`, `scope`, `osn_sid`, …) are ignored by
+    /// `Decodable`'s default behaviour.
+    public init?(jwt: String) {
+        let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3,
+            let payloadData = Base64URL.decode(String(segments[1])),
+            let claims = try? JSONDecoder().decode(AccessTokenClaims.self, from: payloadData)
+        else {
+            return nil
+        }
+        self = claims
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -2,6 +2,37 @@ import Foundation
 import Observation
 import OSNKit
 
+/// Reconciliation between a cached profile and the claims of the access
+/// token actually in the Keychain right now (S-H1: two apps share one
+/// cookie jar and one Keychain slot but each keeps its own `OSNSession`,
+/// so a stale cached profile can silently belong to a different signed-in
+/// user than the live token). The token is the truth; the cache is only
+/// trusted when it still names the same subject.
+///
+/// Pure, no Keychain access, no state — the testable seam for this fix,
+/// same spirit as `MusubiFeature.shouldRestore(_:)`.
+///
+/// - `claims == nil` → `nil`. Fail closed: no decodable token means no
+///   identity to show, never guess.
+/// - `claims != nil` and `cached?.id == claims.sub` → `cached` unchanged,
+///   which keeps `avatarUrl` (a field claims cannot supply).
+/// - otherwise → a fresh `PasskeyProfile` built from the claims, with
+///   `avatarUrl: nil` — the token now names someone the cache doesn't
+///   already know.
+func reconciledProfile(cached: PasskeyProfile?, claims: AccessTokenClaims?) -> PasskeyProfile? {
+    guard let claims else { return nil }
+    if let cached, cached.id == claims.sub {
+        return cached
+    }
+    return PasskeyProfile(
+        id: claims.sub,
+        handle: claims.handle,
+        email: claims.email,
+        displayName: claims.displayName,
+        avatarUrl: nil
+    )
+}
+
 /// Owns the app-agnostic half of passkey sign-in — restore, sign in, sign
 /// out — shared across every OSN app. Builds the shared cookie-jar-backed
 /// `URLSession`/`TokenRefresher` once and exposes both so an app-specific
@@ -17,7 +48,9 @@ public final class OSNSession {
     /// profile" (`PasskeyManagementClient` only lists/renames/deletes
     /// passkeys). So a restored session starts as `.signedIn(nil)`; an
     /// interactive `signIn(...)` populates the profile from
-    /// `PasskeyLoginCompleteResponse.profile`.
+    /// `PasskeyLoginCompleteResponse.profile`, and `reconcileIdentity()`
+    /// fills it in afterward from the access token's own claims (S-H1) —
+    /// see `reconciledProfile(cached:claims:)`.
     public enum SessionState: Equatable, Sendable {
         case restoring
         case signedOut
@@ -66,12 +99,16 @@ public final class OSNSession {
 
     /// Silent restore on launch. A throw from `TokenRefresher.refresh()`
     /// (no session cookie, expired session, etc. — see `OSNKitError`) means
-    /// "signed out", not an error banner, per the brief.
+    /// "signed out", not an error banner, per the brief. `reconcileIdentity()`
+    /// immediately supplies the profile the freshly refreshed token names
+    /// (S-H1) — `.signedIn(nil)` is a transient inner state, not the
+    /// steady-state result.
     public func restore() async {
         state = .restoring
         do {
             try await tokenRefresher.refresh()
             state = .signedIn(nil)
+            reconcileIdentity()
         } catch {
             state = .signedOut
         }
@@ -140,8 +177,61 @@ public final class OSNSession {
     public func ensureFreshAccessToken() async throws {
         let stored = try KeychainAccessTokenStore.load()
         let isFresh = stored.map { $0.expiresAt.timeIntervalSinceNow > 30 } ?? false
-        guard !isFresh else { return }
+        guard !isFresh else {
+            reconcileIdentity()
+            return
+        }
         try await tokenRefresher.refresh()
+        reconcileIdentity()
+    }
+
+    /// S-H1: every authenticated call goes through `ensureFreshAccessToken()`,
+    /// so reconciling here on both the already-fresh and just-refreshed paths
+    /// closes the hole — a sibling app rotating the shared Keychain token to a
+    /// different user's is caught on the very next call this app makes, not
+    /// just at launch.
+    ///
+    /// Loads whatever access token is in the Keychain right now, decodes its
+    /// claims (`AccessTokenClaims`, not signature-verified — see its doc),
+    /// and — only when `state` is already `.signedIn` — replaces the profile
+    /// with `reconciledProfile(cached:claims:)`'s result. Never touches
+    /// `.signedOut`/`.restoring`/`.failed`. A `Keychain` read failure is
+    /// treated the same as "no token": `reconciledProfile` then returns `nil`,
+    /// which is the fail-closed behaviour the brief asks for. Skips the write
+    /// when the reconciled profile equals the cached one, so `@Observable`
+    /// doesn't churn on every call.
+    private func reconcileIdentity() {
+        guard case .signedIn(let cached) = state else { return }
+        let stored = try? KeychainAccessTokenStore.load()
+        let claims = stored.flatMap { AccessTokenClaims(jwt: $0.token) }
+        let reconciled = reconciledProfile(cached: cached, claims: claims)
+        guard reconciled != cached else { return }
+        state = .signedIn(reconciled)
+    }
+
+    /// Foreground entry point (S-H1): call when the app becomes active so a
+    /// profile cached while backgrounded is checked against whatever token a
+    /// sibling app (same cookie jar, same Keychain slot) may have rotated in
+    /// while this app was away.
+    ///
+    /// No-ops outside `.signedIn` — reviving a signed-out session because a
+    /// sibling app is signed in is out of scope here (that is `restore()`'s
+    /// job, run at launch, not at every foreground).
+    public func revalidate() async {
+        guard case .signedIn = state else { return }
+        do {
+            try await ensureFreshAccessToken()
+        } catch OSNKitError.refreshSessionInvalid {
+            // The shared session is genuinely dead — this is not a case
+            // `reconcileIdentity()` can paper over with a different profile.
+            state = .signedOut
+        } catch {
+            // Network hiccup, malformed response, etc. Leave the sign-in
+            // state alone, but still reconcile against whatever token is
+            // already in the Keychain — a wrong name must never linger on
+            // screen just because a refresh attempt failed.
+            reconcileIdentity()
+        }
     }
 
     #if os(iOS)

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyLoginTypes.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyLoginTypes.swift
@@ -109,6 +109,18 @@ public struct PasskeyProfile: Sendable, Equatable, Decodable {
     public let email: String
     public let displayName: String?
     public let avatarUrl: String?
+
+    /// Decodable's synthesized init is memberwise but internal (this type has
+    /// no other explicit initializer, so Swift still generates one — just not
+    /// a public one). `reconciledProfile(cached:claims:)` needs to build a
+    /// `PasskeyProfile` from JWT claims rather than a decoded response body.
+    public init(id: String, handle: String, email: String, displayName: String?, avatarUrl: String?) {
+        self.id = id
+        self.handle = handle
+        self.email = email
+        self.displayName = displayName
+        self.avatarUrl = avatarUrl
+    }
 }
 
 /// `osn/api/src/routes/auth/context.ts:34` success body of

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseRootView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public struct PulseRootView: View {
     private let session: PulseSession
     private let anchorProvider: PresentationAnchorProvider
+    @Environment(\.scenePhase) private var scenePhase
 
     public init(session: PulseSession, anchorProvider: @escaping PresentationAnchorProvider) {
         self.session = session
@@ -21,6 +22,15 @@ public struct PulseRootView: View {
             .task {
                 if session.state == .restoring {
                     await session.restore()
+                }
+            }
+            // S-H1: Pulse and Musubi share one cookie jar and one Keychain
+            // slot, so coming back to the foreground is the moment a sibling
+            // app's sign-in swap needs to be noticed — `revalidate()` is a
+            // no-op unless `session.state` is already `.signedIn`.
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    Task { await session.revalidate() }
                 }
             }
     }

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
@@ -42,6 +42,14 @@ public final class PulseSession {
         await auth.restore()
     }
 
+    /// S-H1 foreground hook — forwarded to `OSNSession.revalidate()` so a
+    /// profile cached while backgrounded is checked against whatever token a
+    /// sibling app (Musubi; same cookie jar, same Keychain slot) may have
+    /// rotated in while Pulse was away.
+    public func revalidate() async {
+        await auth.revalidate()
+    }
+
     public func signIn(
         identifier: String?,
         anchorProvider: @escaping PresentationAnchorProvider

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/AccessTokenClaimsTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/AccessTokenClaimsTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import OSNAuth
+
+/// Builds a JWT-shaped string from real header/payload JSON via
+/// `Base64URL.encode` — never an opaque literal blob — so a reader can see
+/// exactly what each test decodes. The signature segment is arbitrary bytes:
+/// `AccessTokenClaims.init?(jwt:)` never verifies it (see that type's doc).
+private func makeJWT(payloadObject: [String: String]) -> String {
+    let header = Base64URL.encode(Data(#"{"alg":"ES256","typ":"JWT"}"#.utf8))
+    let payloadData = try! JSONSerialization.data(withJSONObject: payloadObject)
+    let payload = Base64URL.encode(payloadData)
+    let signature = Base64URL.encode(Data([0x01, 0x02, 0x03]))
+    return "\(header).\(payload).\(signature)"
+}
+
+struct AccessTokenClaimsTests {
+    @Test func validThreeSegmentJWTDecodesAllFourFields() {
+        let jwt = makeJWT(payloadObject: [
+            "sub": "profile-a",
+            "email": "a@example.com",
+            "handle": "alice",
+            "displayName": "Alice A.",
+            // Unknown claim, present on every real token — must not break decoding.
+            "aud": "osn-access",
+        ])
+
+        let claims = AccessTokenClaims(jwt: jwt)
+        #expect(claims?.sub == "profile-a")
+        #expect(claims?.email == "a@example.com")
+        #expect(claims?.handle == "alice")
+        #expect(claims?.displayName == "Alice A.")
+    }
+
+    @Test func missingDisplayNameDecodesToNil() {
+        let jwt = makeJWT(payloadObject: [
+            "sub": "profile-a",
+            "email": "a@example.com",
+            "handle": "alice",
+        ])
+
+        let claims = AccessTokenClaims(jwt: jwt)
+        #expect(claims != nil)
+        #expect(claims?.displayName == nil)
+    }
+
+    @Test func unknownExtraClaimsAreIgnored() {
+        let jwt = makeJWT(payloadObject: [
+            "sub": "profile-a",
+            "email": "a@example.com",
+            "handle": "alice",
+            "osn_sid": "session-abc",
+            "scope": "openid profile",
+        ])
+
+        let claims = AccessTokenClaims(jwt: jwt)
+        #expect(claims?.sub == "profile-a")
+    }
+
+    @Test func twoSegmentStringReturnsNil() {
+        #expect(AccessTokenClaims(jwt: "onlyheader.onlypayload") == nil)
+    }
+
+    @Test func segmentThatIsNotBase64URLReturnsNil() {
+        let header = Base64URL.encode(Data(#"{"alg":"ES256","typ":"JWT"}"#.utf8))
+        let signature = Base64URL.encode(Data([0x01, 0x02, 0x03]))
+        // "!" and " " are outside the base64url alphabet, so decoding the
+        // middle segment must fail before JSON ever gets involved.
+        let jwt = "\(header).not valid base64!!!.\(signature)"
+
+        #expect(AccessTokenClaims(jwt: jwt) == nil)
+    }
+
+    @Test func segmentThatIsValidBase64URLButNotJSONReturnsNil() {
+        let header = Base64URL.encode(Data(#"{"alg":"ES256","typ":"JWT"}"#.utf8))
+        let signature = Base64URL.encode(Data([0x01, 0x02, 0x03]))
+        let payload = Base64URL.encode(Data("hello world, not json".utf8))
+        let jwt = "\(header).\(payload).\(signature)"
+
+        #expect(AccessTokenClaims(jwt: jwt) == nil)
+    }
+
+    @Test func jsonMissingSubReturnsNil() {
+        let jwt = makeJWT(payloadObject: [
+            "email": "a@example.com",
+            "handle": "alice",
+        ])
+
+        #expect(AccessTokenClaims(jwt: jwt) == nil)
+    }
+
+    @Test func emptyStringReturnsNil() {
+        #expect(AccessTokenClaims(jwt: "") == nil)
+    }
+}

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -4,6 +4,20 @@ import OSNTesting
 import Testing
 @testable import OSNAuth
 
+/// Same fixture-building approach as `AccessTokenClaimsTests` — real header/
+/// payload JSON through `Base64URL.encode`, not an opaque literal blob.
+private func makeJWT(sub: String, email: String, handle: String, displayName: String?) -> String {
+    let header = Base64URL.encode(Data(#"{"alg":"ES256","typ":"JWT"}"#.utf8))
+    var payloadObject = ["sub": sub, "email": email, "handle": handle]
+    if let displayName {
+        payloadObject["displayName"] = displayName
+    }
+    let payloadData = try! JSONSerialization.data(withJSONObject: payloadObject)
+    let payload = Base64URL.encode(payloadData)
+    let signature = Base64URL.encode(Data([0x01, 0x02, 0x03]))
+    return "\(header).\(payload).\(signature)"
+}
+
 private func makeMockSession() -> URLSession {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [LoginMockURLProtocol.self]
@@ -112,6 +126,97 @@ struct OSNSessionTests {
         let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
         try await osnSession.ensureFreshAccessToken()
         #expect(await requestCount.value == 0)
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// S-H1 end to end: session is showing A's profile, then the Keychain
+    /// token it shares with a sibling app (same cookie jar, same slot) is
+    /// swapped out from under it to one whose `sub` is B — without this app
+    /// ever calling `signIn`/`signOut`/`restore` again. `ensureFreshAccessToken()`
+    /// is the seam every authenticated call goes through, so it must be what
+    /// catches this: state ends at `.signedIn(B)`, never `.signedIn(A)`.
+    @Test func ensureFreshAccessTokenReflectsKeychainTokenSwapToADifferentUser() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let jwtA = makeJWT(sub: "profile-a", email: "a@example.com", handle: "alice", displayName: "Alice")
+        LoginMockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"\(jwtA)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-a; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        guard case .signedIn(let profileA) = osnSession.state, profileA?.id == "profile-a" else {
+            Issue.record("expected .signedIn(profile-a) after restore, got \(osnSession.state)")
+            try KeychainAccessTokenStore.delete()
+            return
+        }
+
+        // A sibling app (Pulse) rotates the shared Keychain slot to B's token
+        // — this session is never told directly, and never calls signIn/
+        // signOut/restore again.
+        let jwtB = makeJWT(sub: "profile-b", email: "b@example.com", handle: "bob", displayName: "Bob")
+        try KeychainAccessTokenStore.save(jwtB, expiresIn: 300)
+
+        try await osnSession.ensureFreshAccessToken()
+
+        guard case .signedIn(let profileB) = osnSession.state else {
+            Issue.record("expected .signedIn after ensureFreshAccessToken, got \(osnSession.state)")
+            try KeychainAccessTokenStore.delete()
+            return
+        }
+        #expect(profileB?.id == "profile-b")
+        #expect(osnSession.state != .signedIn(profileA))
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// Second half of the S-H1 fix: the Keychain token is not a JWT at all
+    /// (corrupted, or some future non-JWT credential). `reconciledProfile`
+    /// fails closed on undecodable claims, so state must drop to
+    /// `.signedIn(nil)` rather than keep showing A's now-untrustworthy
+    /// cached profile.
+    @Test func ensureFreshAccessTokenDropsToNilProfileWhenKeychainTokenIsNotAJWT() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let jwtA = makeJWT(sub: "profile-a", email: "a@example.com", handle: "alice", displayName: "Alice")
+        LoginMockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"\(jwtA)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-a2; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        guard case .signedIn(let profileA) = osnSession.state, profileA?.id == "profile-a" else {
+            Issue.record("expected .signedIn(profile-a) after restore, got \(osnSession.state)")
+            try KeychainAccessTokenStore.delete()
+            return
+        }
+
+        try KeychainAccessTokenStore.save("not-a-jwt-token", expiresIn: 300)
+
+        try await osnSession.ensureFreshAccessToken()
+
+        #expect(osnSession.state == .signedIn(nil))
 
         try KeychainAccessTokenStore.delete()
     }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/ReconciledProfileTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/ReconciledProfileTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import OSNAuth
+
+/// Same fixture-building approach as `AccessTokenClaimsTests` — real JSON
+/// through `Base64URL.encode`, decoded back via `AccessTokenClaims.init?(jwt:)`,
+/// rather than constructing `AccessTokenClaims` any other way (it has no
+/// other initializer).
+private func makeClaims(sub: String, email: String = "a@example.com", handle: String = "alice", displayName: String? = nil) -> AccessTokenClaims {
+    let header = Base64URL.encode(Data(#"{"alg":"ES256","typ":"JWT"}"#.utf8))
+    var payloadObject = ["sub": sub, "email": email, "handle": handle]
+    if let displayName {
+        payloadObject["displayName"] = displayName
+    }
+    let payloadData = try! JSONSerialization.data(withJSONObject: payloadObject)
+    let payload = Base64URL.encode(payloadData)
+    let signature = Base64URL.encode(Data([0x01, 0x02, 0x03]))
+    let jwt = "\(header).\(payload).\(signature)"
+    return AccessTokenClaims(jwt: jwt)!
+}
+
+/// Covers the four branches of `reconciledProfile(cached:claims:)` — the
+/// pure reconciliation seam S-H1 hangs everything else off.
+struct ReconciledProfileTests {
+    @Test func nilClaimsAlwaysReturnsNilEvenWithACachedProfile() {
+        let cached = PasskeyProfile(id: "profile-a", handle: "alice", email: "a@example.com", displayName: nil, avatarUrl: "https://example.com/a.png")
+
+        #expect(reconciledProfile(cached: cached, claims: nil) == nil)
+        #expect(reconciledProfile(cached: nil, claims: nil) == nil)
+    }
+
+    @Test func matchingIdPreservesCachedProfileIncludingAvatarUrl() {
+        let cached = PasskeyProfile(id: "profile-a", handle: "alice", email: "a@example.com", displayName: "Alice", avatarUrl: "https://example.com/a.png")
+        let claims = makeClaims(sub: "profile-a", email: "a-new@example.com", handle: "alice-new", displayName: "Alice New")
+
+        let reconciled = reconciledProfile(cached: cached, claims: claims)
+
+        // The cached value wins verbatim — including fields the token
+        // disagrees with, and `avatarUrl`, which claims cannot supply.
+        #expect(reconciled == cached)
+        #expect(reconciled?.avatarUrl == "https://example.com/a.png")
+    }
+
+    @Test func differingIdReplacesCachedProfileAndClearsAvatarUrl() {
+        let cached = PasskeyProfile(id: "profile-a", handle: "alice", email: "a@example.com", displayName: "Alice", avatarUrl: "https://example.com/a.png")
+        let claims = makeClaims(sub: "profile-b", email: "b@example.com", handle: "bob", displayName: "Bob")
+
+        let reconciled = reconciledProfile(cached: cached, claims: claims)
+
+        #expect(reconciled?.id == "profile-b")
+        #expect(reconciled?.handle == "bob")
+        #expect(reconciled?.email == "b@example.com")
+        #expect(reconciled?.displayName == "Bob")
+        #expect(reconciled?.avatarUrl == nil)
+    }
+
+    @Test func noCachedProfileBuildsFreshOneFromClaims() {
+        let claims = makeClaims(sub: "profile-b", email: "b@example.com", handle: "bob", displayName: nil)
+
+        let reconciled = reconciledProfile(cached: nil, claims: claims)
+
+        #expect(reconciled?.id == "profile-b")
+        #expect(reconciled?.displayName == nil)
+        #expect(reconciled?.avatarUrl == nil)
+    }
+}

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -176,3 +176,82 @@ which now names `FV59Y8RSUH.social.musubi.pulse`. iOS reads that file through
 Apple's CDN and caches it up to ~24h; during development append
 `?mode=developer` to the entitlement and turn on Settings → Developer →
 Associated Domains Development to skip the cache. Strip it before TestFlight.
+
+## S-H1 — cached `PasskeyProfile` outliving the Keychain token it was read from (2026-08-17)
+
+Pulse and Musubi share one cookie jar (App Group `group.social.musubi.session`)
+and one Keychain access-token slot, but each holds its own `OSNSession` with
+its own cached `PasskeyProfile`. Sign into Musubi as A, switch Pulse to B,
+come back to Musubi: the cached profile still named A while `loadPasskeys()`
+— which authenticates with the now-refreshed, now-B token — listed B's
+passkeys, and "Sign out" would have ended B's session under A's label. The
+token was always the truth; the cached profile was the only thing that could
+lie.
+
+- `AccessTokenClaims` (`Sources/OSNAuth/AccessTokenClaims.swift`) decodes the
+  four claims `issueAccessToken` (`osn/api/src/services/auth/tokens.ts`)
+  actually mints that this package cares about — `sub`, `email`, `handle`,
+  `displayName?` — off whatever JWT is in the Keychain right now, via
+  `Base64URL.decode(_:)`. It does not verify the signature and says so in its
+  own doc: it exists only to notice *whose* token this is, not to authorize
+  anything. A forged token still gets rejected server-side on the next call
+  that needs one.
+- `reconciledProfile(cached:claims:)` (file-scope in `OSNSession.swift`, not
+  a method — it has to be callable as a bare identifier from tests, and a
+  function declared inside a Swift class body isn't reachable that way even
+  under `@testable import`) is the pure decision: no claims → `nil` (fail
+  closed, never guess an identity); `cached.id == claims.sub` → keep `cached`
+  verbatim, which is the only way `avatarUrl` survives (claims can't supply
+  it); otherwise → a fresh `PasskeyProfile` from the claims with
+  `avatarUrl: nil`, because the token now names someone the cache doesn't
+  already know.
+- `OSNSession.reconcileIdentity()` is `private`, runs only when `state` is
+  already `.signedIn`, loads the Keychain token, and calls the above.
+  `restore()` calls it right after a successful silent refresh; the public
+  `ensureFreshAccessToken()` — the seam every authenticated call already goes
+  through — calls it on **both** the already-fresh and the just-refreshed
+  path, so a sibling app rotating the shared slot to a different user is
+  caught on this app's very next authenticated call, not just at the next
+  launch. `revalidate()` is the new public foreground entry point:
+  no-op outside `.signedIn`; on `OSNKitError.refreshSessionInvalid` the
+  shared session really is dead, so it drops to `.signedOut`; on any other
+  error (network hiccup, malformed response) it leaves the sign-in state
+  alone but still reconciles against whatever token is already sitting in
+  the Keychain, so a failed refresh attempt can never let a wrong name linger
+  on screen. `PulseSession.revalidate()` forwards to it. `MusubiRootView` and
+  `PulseRootView` both call it from `.onChange(of: scenePhase)` on
+  `.active`.
+- The `restore()` doc comment now explains why `.signedIn(nil)` is a real
+  (if transient) state rather than a bug: a silent restore only round-trips
+  `TokenRefresher.refresh()`, which returns a `TokenGrant`, never a profile,
+  and no OSNAuth endpoint exposes "fetch current profile". `reconcileIdentity()`
+  fills the profile in immediately afterward from the token's own claims —
+  the gap between the two calls is not externally observable.
+- Tests: `AccessTokenClaimsTests` (8 cases — valid decode, missing optional
+  claim, unknown-claims-ignored, 2-segment string, non-base64url segment,
+  base64url-but-not-JSON segment, JSON missing `sub`, empty string — all nil
+  or fully decoded, nothing in between). `ReconciledProfileTests` (4 cases,
+  one per branch of the pure function). `OSNSessionTests` gained two
+  end-to-end cases driven entirely through the public API (`state` is
+  `private(set)`, so even `@testable import` can't set it directly):
+  `ensureFreshAccessTokenReflectsKeychainTokenSwapToADifferentUser` signs in
+  as A via `restore()`, swaps the Keychain token to a B JWT directly (no
+  `signIn`/`signOut`/`restore` call), then asserts `ensureFreshAccessToken()`
+  alone flips the visible profile to B. The sibling case,
+  `ensureFreshAccessTokenDropsToNilProfileWhenKeychainTokenIsNotAJWT`, swaps
+  in a non-JWT string and asserts the state drops to `.signedIn(nil)` rather
+  than keep showing A.
+- Not exercised anywhere in this branch: the real two-app ceremony — Pulse
+  and Musubi actually installed side by side, sharing the real App Group
+  Keychain slot, one switching users while the other is foregrounded. Every
+  test above drives the same code path through a mocked `URLSession` and a
+  directly-written Keychain entry, which is the honest ceiling of what
+  `swift test` on a single package can do; nothing here has been checked
+  against two real app processes touching one physical Keychain.
+- Deliberately out of scope, left for their own findings: `kSecAttrAccessGroup`
+  itself (S-M1 — whether the Keychain entry is even scoped to the shared
+  App Group correctly is a separate question from what this app does with
+  whatever it reads), per-app request attribution (S-L1), the 30s-skew
+  literal and 401-retry behaviour (P-W2), the hard-coded `Environment.local`
+  in the test helpers above, and moving the mock `URLProtocol` into
+  `OSNTesting`.

--- a/wiki/changelog/security-fixes.md
+++ b/wiki/changelog/security-fixes.md
@@ -8,12 +8,16 @@ related:
   - "[[redis]]"
   - "[[identity-model]]"
   - "[[event-access]]"
-last-reviewed: 2026-08-13
+last-reviewed: 2026-08-17
 ---
 
 # Security Fixes — Completed
 
 Archived completed security findings from [[TODO]]. Finding IDs follow the [[review-findings]] format. For open findings see the Security Backlog in [[TODO]].
+
+## Stale cached profile survived a shared-Keychain sign-in swap (2026-08-17)
+
+- [x] **S-H1 (session-identity-cache)** — **Pulse and Musubi could show one signed-in user's name and email while acting as another.** **Issue:** Pulse and Musubi share one cookie jar (App Group `group.social.musubi.session`) and one Keychain access-token slot, but each app keeps its own `OSNSession` with its own cached `PasskeyProfile`. Sign into Musubi as A, switch Pulse to B, come back to Musubi: the cached profile still rendered A's name and email, while `loadPasskeys()` — which authenticates with the now-refreshed, now-B access token — listed B's passkeys, and "Sign out" would have ended B's session under A's label. The live access token was always the truth; only the cached profile could lie, and nothing in either app ever checked the two against each other. **Why:** one app displaying another signed-in user's identity is a direct trust failure on a shared device, not a cosmetic bug — the mismatch reaches destructive actions (sign-out) and account-management surfaces (passkey list) that a user reasonably expects to be scoped to the name on screen. **Solution:** a new `AccessTokenClaims` type decodes the `sub`/`email`/`handle`/`displayName` claims already present in every access token `issueAccessToken` mints (no new server contract; the signature is not verified client-side and this is documented as not a trust boundary — every authorization decision still happens server-side). A pure function, `reconciledProfile(cached:claims:)`, is the seam: no claims → `nil` (fail closed, never guess an identity); the cached profile's `id` matches the token's `sub` → keep the cache verbatim (the only source for `avatarUrl`, which claims can't supply); otherwise → replace it with a fresh profile built from the claims. `OSNSession` calls this from `restore()` after every silent relaunch refresh and from `ensureFreshAccessToken()` — the seam every authenticated call already goes through — on both its already-fresh and just-refreshed paths, so a sibling app rotating the shared Keychain slot to a different user is caught on this app's very next authenticated call. A new `revalidate()`, wired to `.onChange(of: scenePhase)` on `.active` in both `MusubiRootView` and `PulseRootView`, re-checks on every foreground too. **Rationale:** deriving displayed identity from the live token rather than trusting a per-app cache means the two apps can never again disagree about who is signed in, without requiring either app to know the other exists — the shared Keychain slot is the only coordination point needed. Not exercised: the real two-app ceremony (both apps installed side by side, one switching users while the other is foregrounded) — every test drives the same code paths through a mocked `URLSession` and a directly-written Keychain entry, the ceiling of what a single-package `swift test` run can cover. See [[identity-model]], [[sessions]].
 
 ## OTP codes written to the production log sink (2026-08-13)
 


### PR DESCRIPTION
Fixes **S-H1** (High, OWASP A07), disclosed but deliberately not fixed on #679: Pulse and Musubi could display one signed-in user's name and email while acting as another.

## Summary

Pulse and Musubi share one cookie jar (App Group `group.social.musubi.session`) and one Keychain access-token slot, but each app keeps its own `OSNSession` with its own cached `PasskeyProfile`. Sign into Musubi as A, switch Pulse to B, come back to Musubi: the cached profile still rendered A's name and email, while `loadPasskeys()` — which authenticates with the now-refreshed, now-B access token — listed **B's** passkeys, and "Sign out" would have ended B's session under A's label.

The live access token was always the truth. Only the cached profile could lie, and nothing checked the two against each other.

The fix derives displayed identity from the claims of the token that is actually in the Keychain, and re-derives it whenever that token is (re)issued or the app comes to the foreground.

- **`AccessTokenClaims`** decodes `sub`/`email`/`handle`/`displayName` — claims `issueAccessToken` already mints, so no new server contract. It does **not** verify the signature and says so in its own doc comment: it exists only to notice *whose* token this is. Every authorization decision still happens server-side (`verifyAccessToken`, ES256), so a forged token gets a caller nothing here.
- **`reconciledProfile(cached:claims:)`** is the pure seam. No claims → `nil` (fail closed; never guess an identity, never throw, never force a sign-out). `cached.id == claims.sub` → keep the cache verbatim, the only way `avatarUrl` survives. Otherwise → a fresh profile from the claims.
- **`OSNSession`** calls it from `restore()` after the silent relaunch refresh, and from `ensureFreshAccessToken()` — the seam every authenticated call already goes through — on **both** the already-fresh and just-refreshed paths. So a sibling app rotating the shared slot is caught on this app's very next authenticated call, not at the next launch.
- **`revalidate()`** is the new foreground entry point, wired to `.onChange(of: scenePhase)` on `.active` in both root views (neither had any foreground hook before). No-op outside `.signedIn`. On `OSNKitError.refreshSessionInvalid` the shared session is genuinely dead → `.signedOut`. On any other error (network, malformed) it leaves the sign-in state alone but still reconciles, so a wrong name can never linger because a refresh attempt failed.

## Workspaces affected

`shared/swift/OSNShared` (`OSNAuth`, `MusubiFeature`, `PulseFeature`) and `wiki/`. No changeset — `scripts/changeset-required.sh` allowlists both, and no versioned package ships any of this.

## Decisions & issues

**Issue:** the cached `PasskeyProfile` outlives the token it was read from, and the two apps share the token slot. **Why:** one app showing another signed-in user's identity is a trust failure on a shared device, not a cosmetic bug — the mismatch reaches a destructive action (sign-out) and an account-management surface (passkey list) that a user reasonably expects to be scoped to the name on screen. **Solution:** the token's own claims become the source of displayed identity; the cache is kept only while its `id` still matches `sub`. **Rationale:** neither app has to know the other exists — the shared Keychain slot is the only coordination point needed, and it is one both apps already read.

**Decision — decode without verifying.** Verifying ES256 client-side would mean shipping JWKS fetch, cache and rotation into the app for a decision that is display-only. The token is not being trusted here; it is being *identified*. Documented as not a trust boundary at the type, in `a3-notes.md`, and in the changelog entry.

**Not exercised:** the real two-app ceremony — both apps installed side by side, sharing the physical App Group Keychain slot, one switching users while the other is foregrounded. Every test drives the same code paths through a mocked `URLSession` and a directly-written Keychain entry, which is the ceiling of what a single-package `swift test` run can cover. Recorded in `a3-notes.md` rather than left implied.

**Deliberately out of scope**, each already tracked as its own finding: `kSecAttrAccessGroup` on the Keychain item (S-M1 — whether the entry is scoped to the App Group at all is a separate question from what this app does with what it reads), per-app request attribution (S-L1), the duplicated 30s skew literal and 401-retry (P-W2), the hard-coded `Environment.local` in test helpers, and moving the mock `URLProtocol` into `OSNTesting`.

## Test plan

All gates re-run by hand in the worktree:

- `swift build` — exit 0.
- `swift test` — 112 tests / 17 suites, 0 failures. New: `AccessTokenClaimsTests` (8 — valid decode, absent optional claim, unknown claims ignored, 2-segment string, non-base64url segment, base64url-but-not-JSON, JSON missing `sub`, empty string), `ReconciledProfileTests` (4, one per branch, including that a same-`id` match preserves `avatarUrl` and a different-`id` replacement clears it), and two end-to-end cases in `OSNSessionTests` driving the actual S-H1 scenario through the public API: swap the Keychain token to a JWT whose `sub` is B and `ensureFreshAccessToken()` alone flips the visible profile to B; swap in a non-JWT and the state drops to `.signedIn(nil)` rather than keeping A. Fixtures are built with `Base64URL.encode` over real JSON, not opaque literal blobs.
- `xcodegen generate` — exit 0 in both `pulse/ios` and `osn/ios`.
- `xcodebuild` for both the `Pulse` and `Musubi` schemes — `BUILD SUCCEEDED`. Re-run after touching both root views to confirm the `#if os(iOS)`-only `scenePhase` code genuinely recompiled rather than hitting a cached no-op; `swift build`/`swift test` run on macOS and compile that code out, so `xcodebuild` is the only gate that typechecks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj5a3sj7iR79Xvpg5yrfX8
