### PR TITLE
chore: type-check gates for pulse/web tests and three cire packages

### DIFF
--- a/.changeset/cire-typecheck-gates.md
+++ b/.changeset/cire-typecheck-gates.md
@@ -1,0 +1,35 @@
+---
+"@cire/db": patch
+"@cire/theme": patch
+"@cire/landing": patch
+"@cire/api": patch
+---
+
+Add `check` scripts to the cire packages that had none, and fix what they
+caught.
+
+`@cire/db`, `@cire/theme` and `@cire/landing` shipped with no type-check gate,
+so nothing in CI read their types — `astro build` and the drizzle tooling both
+strip types without checking them. All three now run `tsc --noEmit` (or
+`astro check` for the Astro package) and all three pass.
+
+`@cire/landing` caught a real bug on the way in.
+`src/components/demo/Modal.motion.ts` passed `easing:` to all four of its
+animations. That is the Motion **v10** key; the package is on `motion@^12.42.2`,
+where it is `ease:`. Every animation had been silently running with default
+easing. All four call sites now use `ease:` with v12 value names. Same v10 → v12
+drift class as the invite-reveal fix in #296.
+
+Two `TS2769`s in `@cire/theme` tests fixed without assertions: one `toEqual`
+receiver flipped, one `readonly string[]` annotation added.
+
+`cire/api/tsconfig.json` is fixed here too — it overrode the shared base's
+`lib`/`types` with ES2022 and workers-types only, which made `bun:test` and
+`bun:sqlite` unresolvable and `toSorted` undefined, on its own about 150 errors.
+It now extends `@shared/typescript-config/node.json` and keeps `bun-types`
+alongside the workers types. The `check` script itself is not added yet: the
+package still has 608 errors behind an Elysia `.guard()` inference collapse,
+tracked in #707. `@cire/invites` is deferred the same way with 103 errors, in
+#708.
+
+Part of #705.

--- a/.changeset/pulse-web-typecheck-tests.md
+++ b/.changeset/pulse-web-typecheck-tests.md
@@ -1,0 +1,42 @@
+---
+"@pulse/web": patch
+---
+
+Type-check `pulse/web/tests/` and fix the 85 errors it had been hiding.
+
+`tsconfig.json` had `"include": ["src"]`, so `tsc --noEmit` never read a line
+of the test suite — matching the `osn/ui` and `osn/client` precedent, it is now
+`["src/**/*", "tests/**/*"]`.
+
+What that surfaced:
+
+- Every event fixture was a partial literal. `EventItem` is derived from the
+  Eden treaty response type and carries all 31 columns of the events table, so
+  each fixture was missing about 25 fields. Replaced with one shared
+  `tests/helpers/events.ts` exporting `makeEvent(overrides)` over a complete
+  base, so a test names only the fields it asserts on.
+- `@testing-library/jest-dom` was a declared devDep that nothing imported. The
+  matchers worked at runtime but had no types, so `toHaveAttribute` was a
+  `TS2339`. Added `tests/setup.ts` importing
+  `@testing-library/jest-dom/vitest`, wired through `setupFiles`.
+- Two files wrote `render(() => wrapRouter(factory))`. `wrapRouter` already
+  returns `() => JSX.Element`, so this built `() => () => JSX.Element` and only
+  worked because Solid's insert calls a function child as an accessor. The
+  other eleven call sites already had it right.
+- Three `vi.fn(() => X)` mocks were re-exposed through
+  `(...args: unknown[]) => mock(...args)` wrappers. Under vitest 4 a bare
+  `vi.fn()` accepts any args but `vi.fn(() => X)` infers a zero-parameter
+  signature, so the spread was a `TS2556`. Widened each implementation to
+  `(..._args: unknown[])`.
+- Exported bare `vi.fn()` consts tripped `TS2883` — their inferred type cannot
+  be named without referencing `Procedure` from `@vitest/spy`. Annotated as
+  `Mock`.
+- `createdByName: undefined` / `location: undefined` in `ExploreCard.test.tsx`:
+  both fields are `string | null`, not optional.
+- An `as const` onboarding fixture typed `interests` as `readonly ["music"]`,
+  which is not an `InterestCategory[]`. Annotated with
+  `CompleteOnboardingPayload` instead.
+
+462 tests across 40 files still pass; `tsc --noEmit` is clean.
+
+Closes #706.

--- a/bun.lock
+++ b/bun.lock
@@ -132,11 +132,13 @@
         "three": "^0.185.1",
       },
       "devDependencies": {
+        "@astrojs/check": "0.9.10",
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
         "@testing-library/jest-dom": "^6.10.0",
         "@types/three": "^0.185.1",
         "jsdom": "^29.1.1",
+        "typescript": "^6.0.3",
         "vite-plugin-solid": "^2.11.14",
         "vitest": "^4.1.10",
       },
@@ -175,7 +177,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.20.3",
+      "version": "3.20.4",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/openapi": "1.4.15",
@@ -264,7 +266,7 @@
     },
     "osn/social": {
       "name": "@osn/social",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -316,7 +318,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -387,7 +389,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@pulse/api": "workspace:*",
@@ -417,7 +419,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -448,7 +450,7 @@
     },
     "shared/email": {
       "name": "@shared/email",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@shared/observability": "workspace:*",
         "effect": "^3.22.0",
@@ -461,7 +463,7 @@
     },
     "shared/feature-flags": {
       "name": "@shared/feature-flags",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@growthbook/growthbook": "^1.6.5",
         "@shared/observability": "workspace:*",
@@ -473,7 +475,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "dependencies": {
         "@effect/opentelemetry": "^0.64.0",
         "@effect/platform": "^0.97.0",
@@ -506,7 +508,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.4",
@@ -522,7 +524,7 @@
     },
     "shared/rate-limit": {
       "name": "@shared/rate-limit",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "vitest": "^4.1.10",
@@ -564,7 +566,7 @@
     },
     "shared/turnstile": {
       "name": "@shared/turnstile",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@shared/observability": "workspace:*",
       },
@@ -579,7 +581,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",

--- a/cire/api/tsconfig.json
+++ b/cire/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@shared/typescript-config/node.json",
   "compilerOptions": {
-    "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"]
+    "lib": ["ES2023"],
+    "types": ["@cloudflare/workers-types", "bun-types"]
   },
   "include": ["src/**/*", "worker-configuration.d.ts"]
 }

--- a/cire/db/package.json
+++ b/cire/db/package.json
@@ -7,6 +7,7 @@
     "./seed": "./seed/data/index.ts"
   },
   "scripts": {
+    "check": "tsc --noEmit",
     "test": "bun test",
     "seed:generate": "bun run seed/generate.ts",
     "assets:seed:dev": "bun run seed/assets.ts",

--- a/cire/landing/package.json
+++ b/cire/landing/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev --port 4323",
     "build": "astro build",
     "preview": "astro preview --port 4323",
+    "check": "bunx --bun astro check",
     "test": "vitest run",
     "test:run": "vitest run"
   },
@@ -19,11 +20,13 @@
     "three": "^0.185.1"
   },
   "devDependencies": {
+    "@astrojs/check": "0.9.10",
     "@shared/typescript-config": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.10.0",
     "@types/three": "^0.185.1",
     "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
     "vite-plugin-solid": "^2.11.14",
     "vitest": "^4.1.10"
   }

--- a/cire/landing/src/components/demo/Modal.motion.ts
+++ b/cire/landing/src/components/demo/Modal.motion.ts
@@ -4,26 +4,26 @@ import { animate } from "motion";
 // exactly like the real RSVP modal it stands in for.
 
 export function modalEnter(backdrop: HTMLElement, panel: HTMLElement) {
-  animate(backdrop, { opacity: [0, 1] }, { duration: 0.25, easing: "ease-out" });
+  animate(backdrop, { opacity: [0, 1] }, { duration: 0.25, ease: "easeOut" });
   animate(
     panel,
     {
       opacity: [0, 1],
       transform: ["translateY(40px) scale(0.97)", "translateY(0) scale(1)"],
     },
-    { duration: 0.35, easing: [0.22, 1, 0.36, 1] },
+    { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
   );
 }
 
 export async function modalExit(backdrop: HTMLElement, panel: HTMLElement) {
-  animate(backdrop, { opacity: [1, 0] }, { duration: 0.2, easing: "ease-in" });
+  animate(backdrop, { opacity: [1, 0] }, { duration: 0.2, ease: "easeIn" });
   const panelAnim = animate(
     panel,
     {
       opacity: [1, 0],
       transform: ["translateY(0) scale(1)", "translateY(24px) scale(0.97)"],
     },
-    { duration: 0.2, easing: [0.4, 0, 1, 1] },
+    { duration: 0.2, ease: [0.4, 0, 1, 1] },
   );
   await panelAnim.finished;
 }

--- a/cire/theme/package.json
+++ b/cire/theme/package.json
@@ -6,6 +6,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "check": "tsc --noEmit",
     "test": "bun test",
     "test:run": "bun test"
   },

--- a/cire/theme/src/palette.test.ts
+++ b/cire/theme/src/palette.test.ts
@@ -629,8 +629,8 @@ describe("fonts", () => {
       expect(fontChoiceHasStack(choice), choice).toBe(true);
       if (choice !== "default") expect(fontStack(choice), choice).not.toBeNull();
     }
-    expect(FONT_CHOICES.filter((c) => c !== "default").toSorted()).toEqual(
-      Object.keys(FONT_STACKS).toSorted(),
+    expect(Object.keys(FONT_STACKS).toSorted()).toEqual(
+      FONT_CHOICES.filter((c) => c !== "default").toSorted(),
     );
   });
 

--- a/cire/theme/src/typography.test.ts
+++ b/cire/theme/src/typography.test.ts
@@ -81,8 +81,9 @@ describe("typographyVars", () => {
       "--invite-body-weight": "300",
       "--invite-body-style": "italic",
     });
+    const knownKeys: readonly string[] = TYPOGRAPHY_VAR_KEYS;
     for (const key of Object.keys(vars)) {
-      expect(TYPOGRAPHY_VAR_KEYS).toContain(key);
+      expect(knownKeys).toContain(key);
     }
   });
 

--- a/osn/api/src/build-deps.ts
+++ b/osn/api/src/build-deps.ts
@@ -57,6 +57,9 @@ export type EnvVars = {
   readonly OSN_PAIRWISE_SALT?: string;
   readonly INTERNAL_SERVICE_SECRET?: string;
   readonly TURNSTILE_SECRET_KEY?: string;
+  // Read by the dev sign-in gate below. Unset ⇒ the routes are never mounted.
+  readonly DEV_LOGIN_SECRET?: string;
+  readonly DEV_LOGIN_RETURN_ORIGINS?: string;
 };
 
 const isNonLocal = (env: EnvVars): boolean => !!env.OSN_ENV && env.OSN_ENV !== "local";
@@ -91,7 +94,7 @@ const servesOpenapiDocs = (env: EnvVars): boolean =>
  * `routes/auth/dev-login.ts` for why the route exists at all.
  */
 const DEV_LOGIN_TIERS = new Set<string | undefined>([undefined, "local", "dev", "development"]);
-const servesDevLogin = (env: EnvRecord): boolean => DEV_LOGIN_TIERS.has(env.OSN_ENV);
+const servesDevLogin = (env: EnvVars): boolean => DEV_LOGIN_TIERS.has(env.OSN_ENV);
 
 /**
  * `DEV_LOGIN_RETURN_ORIGINS` — comma-separated origins a dev-login `return_to`

--- a/pulse/web/tests/components/EventCard.test.tsx
+++ b/pulse/web/tests/components/EventCard.test.tsx
@@ -4,6 +4,7 @@ import type { JSX } from "solid-js";
 import { vi, describe, it, expect, afterEach } from "vitest";
 
 import { EventCard } from "../../src/components/EventCard";
+import { makeEvent } from "../helpers/events";
 import { wrapRouter } from "../helpers/router";
 
 // EventCard now uses `<A>` from @solidjs/router, which requires a Router
@@ -12,12 +13,12 @@ import { wrapRouter } from "../helpers/router";
 const render: typeof _baseRender = ((factory: () => JSX.Element) =>
   _baseRender(wrapRouter(factory))) as unknown as typeof _baseRender;
 
-const mockEvent = {
+const mockEvent = makeEvent({
   id: "evt_1",
   title: "Test Event",
-  status: "upcoming" as const,
+  status: "upcoming",
   startTime: "2030-06-01T10:00:00.000Z",
-};
+});
 
 describe("EventCard", () => {
   afterEach(() => {

--- a/pulse/web/tests/components/OnboardingGate.test.tsx
+++ b/pulse/web/tests/components/OnboardingGate.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@shared/rp-auth/solid", async () => {
 });
 
 const mockFetchStatus = vi.fn();
-const mockIsSkipped = vi.fn(() => false);
+const mockIsSkipped = vi.fn((..._a: unknown[]) => false);
 vi.mock("../../src/lib/onboarding", async () => {
   const actual = await vi.importActual<typeof import("../../src/lib/onboarding")>(
     "../../src/lib/onboarding",

--- a/pulse/web/tests/components/ShareEventButton.test.tsx
+++ b/pulse/web/tests/components/ShareEventButton.test.tsx
@@ -8,7 +8,7 @@ vi.mock("solid-toast", async () => {
 });
 import { mockToastSuccess } from "../helpers/toast";
 
-const mockRecordShareInvoked = vi.fn(() => Promise.resolve());
+const mockRecordShareInvoked = vi.fn((..._args: unknown[]) => Promise.resolve());
 vi.mock("../../src/lib/rsvps", () => ({
   recordShareInvoked: (...args: unknown[]) => mockRecordShareInvoked(...args),
 }));

--- a/pulse/web/tests/components/VenueEventCarousel.test.tsx
+++ b/pulse/web/tests/components/VenueEventCarousel.test.tsx
@@ -7,7 +7,7 @@ import { VenueEventCarousel } from "../../src/components/VenueEventCarousel";
 import type { VenueEvent } from "../../src/lib/venues";
 import { wrapRouter } from "../helpers/router";
 
-const renderWithRouter = (factory: () => JSX.Element) => render(() => wrapRouter(factory));
+const renderWithRouter = (factory: () => JSX.Element) => render(wrapRouter(factory));
 
 const evt = (overrides: Partial<VenueEvent>): VenueEvent => ({
   id: "evt_1",

--- a/pulse/web/tests/explore/ExploreCard.test.tsx
+++ b/pulse/web/tests/explore/ExploreCard.test.tsx
@@ -4,22 +4,23 @@ import type { JSX } from "solid-js";
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { ExploreCard } from "../../src/explore/ExploreCard";
+import { makeEvent } from "../helpers/events";
 import { wrapRouter } from "../helpers/router";
 
 const render: typeof _baseRender = ((factory: () => JSX.Element) =>
   _baseRender(wrapRouter(factory))) as unknown as typeof _baseRender;
 
-const baseEvent = {
+const baseEvent = makeEvent({
   id: "evt_1",
   title: "Rooftop Jazz Session",
-  status: "upcoming" as const,
+  status: "upcoming",
   startTime: "2030-06-01T19:30:00.000Z",
   category: "music",
   venue: "The Vessel",
   location: "East Village",
   createdByProfileId: "usr_host",
   createdByName: "Maya Chen",
-};
+});
 
 describe("ExploreCard", () => {
   afterEach(cleanup);
@@ -49,7 +50,7 @@ describe("ExploreCard", () => {
   });
 
   it("omits host row when createdByName is absent", () => {
-    const event = { ...baseEvent, createdByName: undefined };
+    const event = { ...baseEvent, createdByName: null };
     const { container } = render(() => <ExploreCard event={event} />);
     expect(container.textContent).not.toContain("Hosted by");
   });
@@ -192,7 +193,7 @@ describe("ExploreCard", () => {
   });
 
   it("omits separator dot when only venue or only location", () => {
-    const venueOnly = { ...baseEvent, location: undefined };
+    const venueOnly = { ...baseEvent, location: null };
     const { container } = render(() => <ExploreCard event={venueOnly} />);
     const dots = container.querySelectorAll(".rounded-full.bg-foreground\\/20");
     expect(dots.length).toBe(0);

--- a/pulse/web/tests/explore/ExploreMap.test.tsx
+++ b/pulse/web/tests/explore/ExploreMap.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { ExploreMap } from "../../src/explore/ExploreMap";
 import type { VenueSummary } from "../../src/lib/venues";
+import { makeEvent } from "../helpers/events";
 import { wrapRouter } from "../helpers/router";
 
 const venueRow = (overrides: Partial<VenueSummary>): VenueSummary => ({
@@ -28,38 +29,38 @@ const venueRow = (overrides: Partial<VenueSummary>): VenueSummary => ({
   ...overrides,
 });
 
-const renderWithRouter = (factory: () => JSX.Element) => render(() => wrapRouter(factory));
+const renderWithRouter = (factory: () => JSX.Element) => render(wrapRouter(factory));
 
 const eventsWithGeo = [
-  {
+  makeEvent({
     id: "evt_1",
     title: "Jazz Night",
-    status: "upcoming" as const,
+    status: "upcoming",
     startTime: "2030-06-01T19:30:00.000Z",
     category: "music",
     venue: "The Vessel",
     latitude: 40.725,
     longitude: -73.985,
-  },
-  {
+  }),
+  makeEvent({
     id: "evt_2",
     title: "Ceramics Studio",
-    status: "upcoming" as const,
+    status: "upcoming",
     startTime: "2030-06-01T18:00:00.000Z",
     category: "art",
     venue: "Clayroom",
     latitude: 40.676,
     longitude: -73.988,
-  },
+  }),
 ];
 
-const eventNoGeo = {
+const eventNoGeo = makeEvent({
   id: "evt_3",
   title: "Online Talk",
-  status: "upcoming" as const,
+  status: "upcoming",
   startTime: "2030-06-01T20:00:00.000Z",
   category: "talks",
-};
+});
 
 describe("ExploreMap", () => {
   afterEach(cleanup);
@@ -197,17 +198,17 @@ describe("ExploreMap", () => {
       }),
     ];
     const events = [
-      {
+      makeEvent({
         id: "evt_at_venue",
         title: "Friday Residency",
-        status: "upcoming" as const,
+        status: "upcoming",
         startTime: "2030-06-07T22:00:00.000Z",
         category: "music",
         venue: "The Factory",
         venueId: "ven_dup",
         latitude: 40.705,
         longitude: -73.93,
-      },
+      }),
     ];
     const { container } = renderWithRouter(() => <ExploreMap events={events} venues={venues} />);
     // No standalone venue diamond — event pin owns the location.
@@ -225,17 +226,17 @@ describe("ExploreMap", () => {
       }),
     ];
     const events = [
-      {
+      makeEvent({
         id: "evt_at_venue",
         title: "Friday Residency",
-        status: "upcoming" as const,
+        status: "upcoming",
         startTime: "2030-06-07T22:00:00.000Z",
         category: "music",
         venue: "The Factory",
         venueId: "ven_dup",
         latitude: 40.705,
         longitude: -73.93,
-      },
+      }),
     ];
     const { container, findByText } = renderWithRouter(() => (
       <ExploreMap events={events} venues={venues} />
@@ -267,17 +268,17 @@ describe("ExploreMap", () => {
       }),
     ],
     events: [
-      {
+      makeEvent({
         id: "evt_at_venue",
         title: "Friday Residency",
-        status: "upcoming" as const,
+        status: "upcoming",
         startTime: "2030-06-07T22:00:00.000Z",
         category: "music",
         venue: "The Factory",
         venueId: "ven_dup",
         latitude: 40.705,
         longitude: -73.93,
-      },
+      }),
     ],
   });
 

--- a/pulse/web/tests/helpers/auth.ts
+++ b/pulse/web/tests/helpers/auth.ts
@@ -1,5 +1,5 @@
 import type { RpSession } from "@shared/rp-auth";
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 /**
  * Test double for `@shared/rp-auth/solid`.
@@ -24,7 +24,7 @@ export function fakeSession(overrides: Partial<RpSession> = {}): RpSession {
 /** Mutable: set in `beforeEach` to choose the viewer. `null` is signed out. */
 export const authState: { session: RpSession | null } = { session: null };
 
-export const mockSignIn = vi.fn();
+export const mockSignIn: Mock = vi.fn();
 export const mockLogout = vi.fn(() => Promise.resolve());
 export const mockRefresh = vi.fn(() => Promise.resolve(authState.session));
 

--- a/pulse/web/tests/helpers/events.ts
+++ b/pulse/web/tests/helpers/events.ts
@@ -1,0 +1,47 @@
+import type { EventItem } from "../../src/lib/types";
+
+/**
+ * A complete `EventItem`, so tests can name only the fields they assert on.
+ *
+ * `EventItem` is derived from the Eden treaty response type, which carries
+ * every column of the events table. A partial literal type-checks nowhere,
+ * and before `tests/` was inside `tsconfig.json`'s `include` nothing caught
+ * that — the fixtures here were missing 25 fields each.
+ */
+const BASE_EVENT: EventItem = {
+  id: "evt_1",
+  title: "Test Event",
+  description: null,
+  location: null,
+  venue: null,
+  venueId: null,
+  latitude: null,
+  longitude: null,
+  category: null,
+  startTime: "2030-06-01T10:00:00.000Z",
+  endTime: null,
+  status: "upcoming",
+  imageUrl: null,
+  priceAmount: null,
+  priceCurrency: null,
+  visibility: "public",
+  guestListVisibility: "public",
+  joinPolicy: "open",
+  allowInterested: true,
+  commsChannels: '["email"]',
+  chatId: null,
+  seriesId: null,
+  instanceOverride: false,
+  createdByProfileId: "prof_1",
+  createdByName: null,
+  createdByAvatar: null,
+  cancelledAt: null,
+  hardDeleteAt: null,
+  cancellationReason: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export function makeEvent(overrides: Partial<EventItem> = {}): EventItem {
+  return { ...BASE_EVENT, ...overrides };
+}

--- a/pulse/web/tests/helpers/toast.ts
+++ b/pulse/web/tests/helpers/toast.ts
@@ -1,11 +1,13 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
-export const mockToastError = vi.fn();
-export const mockToastSuccess = vi.fn();
+export const mockToastError: Mock = vi.fn();
+export const mockToastSuccess: Mock = vi.fn();
+
+type ToastFn = Mock & { error: Mock; success: Mock };
 
 /** Factory for `vi.mock("solid-toast", async () => solidToastMock())` */
-export function solidToastMock() {
-  const toastFn = Object.assign(vi.fn(), {
+export function solidToastMock(): { default: ToastFn; toast: ToastFn } {
+  const toastFn: ToastFn = Object.assign(vi.fn(), {
     error: mockToastError,
     success: mockToastSuccess,
   });

--- a/pulse/web/tests/lib/onboarding.test.ts
+++ b/pulse/web/tests/lib/onboarding.test.ts
@@ -9,6 +9,7 @@ import {
   requestLocationPermission,
   requestNotificationPermission,
 } from "../../src/lib/onboarding";
+import type { CompleteOnboardingPayload } from "../../src/lib/onboarding";
 
 const mockMeOnboardingGet = vi.fn();
 const mockMeOnboardingCompletePost = vi.fn();
@@ -198,12 +199,12 @@ describe("fetchOnboardingStatus", () => {
 });
 
 describe("completeOnboarding", () => {
-  const validPayload = {
-    interests: ["music"] as const,
+  const validPayload: CompleteOnboardingPayload = {
+    interests: ["music"],
     notificationsOptIn: true,
     eventRemindersOptIn: false,
-    notificationsPerm: "granted" as const,
-    locationPerm: "granted" as const,
+    notificationsPerm: "granted",
+    locationPerm: "granted",
   };
 
   beforeEach(() => {

--- a/pulse/web/tests/routes/EventDetailPage.test.tsx
+++ b/pulse/web/tests/routes/EventDetailPage.test.tsx
@@ -52,7 +52,7 @@ vi.mock("../../src/components/RsvpSection", () => ({
 vi.mock("../../src/components/ShareEventButton", () => ({
   ShareEventButton: () => <div data-testid="share-stub" />,
 }));
-const mockRecordShareExposure = vi.fn(() => Promise.resolve());
+const mockRecordShareExposure = vi.fn((..._args: unknown[]) => Promise.resolve());
 vi.mock("../../src/lib/rsvps", () => ({
   apiBaseUrl: "http://localhost:3001",
   recordShareExposure: (...args: unknown[]) => mockRecordShareExposure(...args),

--- a/pulse/web/tests/setup.ts
+++ b/pulse/web/tests/setup.ts
@@ -1,0 +1,4 @@
+// Registers the jest-dom matchers (`toHaveAttribute`, `toBeVisible`, …) and
+// their types. The dependency was already installed and the matchers already
+// worked at runtime; without this import TypeScript never saw them.
+import "@testing-library/jest-dom/vitest";

--- a/pulse/web/tsconfig.json
+++ b/pulse/web/tsconfig.json
@@ -11,6 +11,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src/**/*", "tests/**/*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/pulse/web/vitest.config.ts
+++ b/pulse/web/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [solid()],
   test: {
     environment: "node",
+    setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
     // Allow async event handlers to throw unhandled rejections without failing
     // the suite — this mirrors real browser behaviour where onSubmit rejection


### PR DESCRIPTION
Rung 8 of the anti-slop stack, and the follow-up work the stack's own reviews surfaced. Based on `refactor/anti-slop-webauthn-option-types` (#703).

Closes #706. Part of #705.

## `@pulse/web` — the tests were never type-checked

`pulse/web/tsconfig.json` had `"include": ["src"]`. `tsc --noEmit` had never read a line of `tests/`. Widened to `["src/**/*", "tests/**/*"]`, matching the `osn/ui` and `osn/client` precedent, and that surfaced **85 errors**. All 85 fixed, none with a type assertion — `no-chained-type-assertions` is at `error` as of #685.

| What | Count | Fix |
|---|---|---|
| Partial `EventItem` fixtures | ~40 | one shared `tests/helpers/events.ts` with `makeEvent(overrides)` over a complete base |
| `toHaveAttribute` etc. untyped | 3 | `tests/setup.ts` importing `@testing-library/jest-dom/vitest`, wired via `setupFiles` |
| Double-wrapped `wrapRouter` | 2 | `render(wrapRouter(factory))`, matching the other eleven call sites |
| vitest-4 zero-arity `vi.fn` | 3 | widened impls to `(..._args: unknown[])` |
| TS2883 on exported `vi.fn()` | 5 | explicit `Mock` annotations |
| `undefined` for a `\| null` field | 2 | `null` |
| `as const` making `interests` readonly | 5 | annotate with `CompleteOnboardingPayload` |

Two of these are worth calling out because they were latent runtime hazards, not bookkeeping:

- `EventItem` is derived from the Eden treaty response type, so it carries all 31 columns of the events table. Each fixture was missing about 25 fields. A component reading one of those fields in a test would have got `undefined` and the test would have asserted against it happily.
- `@testing-library/jest-dom` was a declared devDep that **nothing imported**. The matchers worked, because vitest's expect is global and jest-dom had been extended somewhere in the dependency graph, but there was no types-level guarantee of that. Now it is explicit.

Verified: `bunx tsc --noEmit -p pulse/web/tsconfig.json` silent, `bun run --cwd pulse/web test:run` → 40 files / 462 tests passed.

## `@cire/*` — three gates added, one real bug caught

`@cire/db`, `@cire/theme` and `@cire/landing` had no `check` script. `astro build` and the drizzle tooling both strip types without reading them, so nothing in CI checked these packages. All three now have a gate and all three pass.

The landing gate paid for itself immediately. `cire/landing/src/components/demo/Modal.motion.ts` passed `easing:` to all four of its animations — that is the Motion **v10** key, and the package is on `motion@^12.42.2`, where it is `ease:`. Every animation had been quietly running with default easing. Same v10 → v12 drift class as the invite-reveal bug in #296.

Two `TS2769`s in `@cire/theme` tests fixed without assertions: one `toEqual` receiver flipped, one `readonly string[]` annotation.

## What is deferred, and why

`cire/api/tsconfig.json` **is** fixed here — it overrode the shared base's `lib`/`types` with ES2022 and workers-types only, which made `bun:test` and `bun:sqlite` unresolvable and `toSorted` undefined, roughly 150 errors on its own. That is the prerequisite for the eventual gate, so it lands now.

The two `check` scripts do not:

- **`@cire/api` — 608 errors in 75 files** (after the tsconfig fix; 764 before). Not fixture drift: most of it cascades from one Elysia `.guard()` inference collapse on the auth-gated organiser routes (`TS2560: Value of type '(write: any) => any' has no properties in common with type 'GuardLocalHook<…>'`), which strips the context type off every handler inside the guard and turns its destructured params into implicit `any`. `budget.ts` 35, `registry.ts` 24, `vendors.ts` 19. Tracked in **#707**.
- **`@cire/invites` — 103 errors, 12 hints**. Includes six `Variable 'panelRef' is used before being assigned` in `AnimatedModal.tsx`, which is the modal on the live guest site, and twelve `ts(1005)`/`ts(1381)` syntax errors in `.astro` files that need confirming as parser artefacts before anyone assumes they are real. Tracked in **#708**.

Both are their own piece of work, not a line in this diff. Neither went into `wiki/TODO.md`.

## Changesets

Two, split — `@cire/*` are version-less and must never share a changeset with a versioned package. `scripts/validate-changesets.sh` passes.

## Reviews

**Security — 2 findings (0 critical, 0 high, 1 medium, 1 low).**

- **S-M1 — risk ordering of the new gates, already tracked.** `turbo check` silently skips a package that has no `check` script, so the gate this PR adds covers `@cire/db`, `@cire/theme` and `@cire/landing` while leaving `@cire/api` and `@cire/invites` — the two cire packages carrying auth code — ungated, and this PR edits one of them. The gap itself is disclosed above and tracked in #707 and #708, so no duplicate issue was filed. What is worth stating plainly and is not yet written down anywhere: after this PR, CI's type-check gate *looks* complete while excluding the auth surface. The packages left out are the higher-risk two, not the lower-risk two, and #707 should be prioritised on that basis rather than on its error count.
- **S-L4** (tracker #442) — `cire/api/tsconfig.json:5` adds `bun-types` to a workerd-only package. `bun-types` carries `/// <reference types="node" />` and depends on `@types/node`, so `process`, `Buffer`, `require`, `__dirname` and `NodeJS.Timeout` become type-legal **package-wide**, not just in tests. `cire/api/src/index.ts` and `src/observability.ts` already read `process.env`, and this repo's own notes record that top-level `process.env` reads are undefined during workerd deploy eval and are caught only by a real `wrangler deploy`, never by `--dry-run`. The fix — scoping `bun-types` to a `tsconfig.test.json` — belongs with #707, which is the work that makes the gate real.

Cleared, with reasons: no fixture leakage; **no `@ts-expect-error`, `@ts-ignore`, `: any`, `as any`, or any `as` assertion added anywhere in the diff**; the `@cire/db` and `@cire/theme` gates ran green and `@cire/theme` needed two fixes, which proves the include is live rather than vacuous; `@astrojs/check` is pinned to the same `0.9.10` five other packages already declare; the new fixture holds only `evt_1` / `prof_1` / `Test Event` and 2030 timestamps, so no secrets and no personal data; and the Motion `easing:` → `ease:` fix is correct for v12 with zero remaining call sites.

**Performance — 1 finding (0 critical, 0 warning, 1 info).**

- **P-I4** (tracker #448) — `pulse/web/vitest.config.ts:8` plus `tests/setup.ts`. Vitest runs setup files once per *test file*, not once per worker, so the jest-dom bundle executes 40 times to serve the one file that uses a matcher (`tests/explore/ExploreNav.test.tsx:133,134,148`, three `toHaveAttribute` calls). Measured `Duration 3.58s (… setup 5.96s …)` across 40 files at 20.17 s user CPU — setup was 0 before this PR, so all 5.96 s is new, about 30% of the suite's CPU. Roughly 0.9 s wall locally on 10 cores, nearer 1.5 s on the 4-vCPU runner. The fix is to drop `setupFiles` and import jest-dom in its one consumer; it is filed rather than applied because file deletion was unavailable in this session.

## Decisions

- **The added CI time is real but small, and cacheable to nothing.** Cold `turbo check --force` goes from 26 tasks / 17.14 s wall / 111.0 s CPU to 29 tasks / 20.68 s / 124.5 s — **+3.5 s wall on 10 cores, +13.5 s CPU**, about +3.4 s on a 4-vCPU runner. Individually `@cire/landing` 3.73 s, `@cire/db` 0.87 s, `@cire/theme` 0.41 s, and `astro check` is not new to CI. Steady state is roughly zero: `turbo.json`'s `"check": {}` is cacheable by default and verifiably hits — a warm run reports `29 successful, 29 cached … Time: 241ms … FULL TURBO`. Empty `outputs` is correct for `--noEmit`, `.astro/` is gitignored so it does not thrash the hash, and `.github/workflows/ci.yml:59-63` already caches `.turbo`.
- **The two individual config widenings cost almost nothing.** `pulse/web`'s wider include: 1825 files / 2.47 s check / 3.51 s total, against 1715 / 2.22 s / 3.23 s — **+0.28 s, about 8%**. `cire/api`'s `bun-types`: 1597 files / 4.31 s against 1569 / 4.25 s — **+28 files, +0.06 s**. The `bun-types` objection in #442 is about type legality, not build time.
- **The Motion fix changes how it looks, not what it costs.** Under 12.42.2 the `easing:` key was silently ignored and the animation ran on the library default. Both keys compile to a native `cubic-bezier(...)` with the same durations, so there is no per-frame difference — only the intended curve now actually applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkGAh3xGuYGhACTFfVkjuN
