### PR TITLE
perf(cire-api): build the Effect runtime once per isolate, not once per call

### DIFF
--- a/.changeset/eighty-runtimes-rest.md
+++ b/.changeset/eighty-runtimes-rest.md
@@ -1,0 +1,11 @@
+---
+"@cire/api": patch
+---
+
+Build the Effect runtime once per isolate instead of once per call.
+
+`runCire` / `runCireSync` each constructed a fresh `FiberRuntime` and rebuilt
+the logger layer through `Effect.provide` on every invocation. Both now delegate
+to a single module-scope `ManagedRuntime`. `Layer.suspend` stays on
+`cireLoggerLayer`, so config loading is still deferred to first call — on
+workerd `process.env` is unpopulated at module-eval time.

--- a/cire/api/src/observability.ts
+++ b/cire/api/src/observability.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "@shared/observability/config";
 import { makeLoggerLayer } from "@shared/observability/logger";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 
 /**
  * Redacting structured-logger layer for cire/api.
@@ -39,6 +39,24 @@ export const cireLoggerLayer: Layer.Layer<never> = Layer.suspend(
 );
 
 /**
+ * Module-scope runtime for `cireLoggerLayer`, built once per isolate instead
+ * of once per `runCire`/`runCireSync` call — each call used to pay for a
+ * fresh `FiberRuntime` plus `Layer.buildWithScope`, twice over on routes that
+ * called either helper more than once.
+ *
+ * This is safe with the `Layer.suspend` above left intact: `ManagedRuntime.make`
+ * only runs `scopeMake` at construction (pure, no env access) — it does not
+ * force the layer. The layer itself still builds lazily, on the first
+ * `runPromise`/`runSync` below, so `loadConfig` still never runs during module
+ * evaluation. Do NOT "simplify" this by inlining `loadConfig` or dropping
+ * `Layer.suspend`: on workerd, `nodejs_compat_populate_process_env` only fills
+ * `process.env` on first access, and a config read during module load would
+ * silently pin every deployed tier to `local` (pretty logs, debug level) with
+ * no error at all.
+ */
+const cireRuntime = ManagedRuntime.make(cireLoggerLayer);
+
+/**
  * Run a fully-resolved cire effect to a Promise with the redacting logger
  * installed. The effect must already have its services (`DbService`,
  * `R2Service`, `AssetsR2Service`, …) provided and its typed errors handled —
@@ -46,11 +64,11 @@ export const cireLoggerLayer: Layer.Layer<never> = Layer.suspend(
  * `Effect.runPromise` so no log line escapes redaction.
  */
 export const runCire = <A, E>(effect: Effect.Effect<A, E, never>): Promise<A> =>
-  Effect.runPromise(Effect.provide(effect, cireLoggerLayer));
+  cireRuntime.runPromise(effect);
 
 /**
  * Synchronous counterpart for the framework error boundary (`app.ts` onError)
  * and the local dev-server banners, where there is no Promise to await.
  */
 export const runCireSync = <A, E>(effect: Effect.Effect<A, E, never>): A =>
-  Effect.runSync(Effect.provide(effect, cireLoggerLayer));
+  cireRuntime.runSync(effect);

--- a/wiki/architecture/backend-patterns.md
+++ b/wiki/architecture/backend-patterns.md
@@ -19,7 +19,8 @@ packages:
   - "@pulse/api"
   - "@osn/api"
   - "@zap/api"
-last-reviewed: 2026-08-02
+  - "@cire/api"
+last-reviewed: 2026-08-19
 ---
 
 # Backend Code Patterns
@@ -74,6 +75,8 @@ const result = await run(createEvent(body));
 Route factories keep accepting `dbLayer` / `loggerLayer` for tests (where `makeAppRunner` wraps the test layer in a one-time `ManagedRuntime`); production threads the single shared `appRuntime` through every factory so there is exactly one OTel SDK + one DB connection process-wide. Cheap, stateless effects that need no services (e.g. JWT verification) can still use a bare `Effect.runPromise` — the rule is: do not re-provide `DbLive` or the observability layer inside a hot request path.
 
 As of 2026-07-03, `pulse/api` and `zap/api` route factories comply too: each factory builds `const runtime = ManagedRuntime.make(dbLayer)` once at construction time and handlers call `runtime.runPromise(eff)` — the per-request `Effect.provide(dbLayer)` pattern was removed monorepo-wide. (They build one runtime per route group rather than threading a single shared `AppRuntime` like `osn/api`; consolidating to one runtime per process is a follow-up if those services grow an observability layer.)
+
+`cire/api` (`cire/api/src/observability.ts`) builds its `ManagedRuntime` at **module scope**, not per route factory: one `const cireRuntime = ManagedRuntime.make(cireLoggerLayer)` for the whole file, and both `runCire`/`runCireSync` delegate to it. The layer it wraps (`cireLoggerLayer`) stays behind `Layer.suspend` even though the runtime is now built eagerly at module load — `ManagedRuntime.make` only allocates a scope at construction (pure, no env access), it does not force the layer, so the suspended `loadConfig` still only runs on the first `runPromise`/`runSync`, inside a request or cron handler. That deferral is load-bearing on workerd: `nodejs_compat_populate_process_env` fills `process.env` from wrangler `[vars]`/secrets only on first access, so a config read during module evaluation would silently pin every deployed tier to `local` (pretty logs, debug level) with no error. Do not drop `Layer.suspend` to "simplify" this.
 
 **Catching errors from `runPromise`:** the promise rejects with a `FiberFailure` *wrapping* the typed failure — never the tagged error itself — so `catch (e) { if ("_tag" in e) … }` never matches. Unwrap with `Runtime.isFiberFailure(e)` → `Cause.failureOption(e[Runtime.FiberFailureCauseId])`, or use `makeSafeError` (`osn/api/src/lib/safe-error.ts`) when the goal is a client-safe error message. This bit the graph/organisation routes for weeks: every business-rule message collapsed to a generic "Request failed" — see [[social-graph]] §Error Handling.
 


### PR DESCRIPTION
## Summary

`runCire` / `runCireSync` built a fresh `FiberRuntime` and ran `Layer.buildWithScope` on **every call** — twice over on any route that called a helper more than once. Both now delegate to one module-scope `ManagedRuntime.make(cireLoggerLayer)`, which memoises the built layer for the life of the isolate.

- `cireLoggerLayer` keeps its `Layer.suspend` wrapper, and the comment above the runtime says why in full, so the next reader does not "simplify" it away.
- `wiki/architecture/backend-patterns.md` records that cire's runtime is module-scope rather than route-factory-scope, and adds `@cire/api` to the page's `packages` list.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/eighty-runtimes-rest.md` (`@cire/*` are version-less, so the changeset is named but carries no bump) |
| `wiki/` (docs) | — allowlisted, no changeset needed |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#79 | P-W1 — per-call `FiberRuntime` + `Layer.buildWithScope` in cire's Effect runners |

Closes xchromo/osn-tracker#79

**Opened**

None.

## Decisions

### One module-scope runtime instead of a per-call one — `P-W1`

- **Issue** — every call to `runCire` / `runCireSync` allocated a `FiberRuntime` and ran `Layer.buildWithScope`.
- **Why** — those helpers wrap cire's whole error boundary and every logging path, so the cost is paid on requests that do nothing else.
- **Solution** — one `const cireRuntime = ManagedRuntime.make(cireLoggerLayer)` at module scope; both helpers call `cireRuntime.runPromise` / `cireRuntime.runSync`.
- **Rationale** — `ManagedRuntime` memoises the built layer for the life of the isolate, which is exactly the lifetime the logger layer wants.

### This is not the layer-rebuild hazard CLAUDE.md warns about — `approach`

- **Issue** — the house rule against per-request `Effect.provide` exists because rebuilding a layer restarts the OTel SDK and opens a new DB connection. Neither applies here.
- **Why** — reaching for the rule's stated justification where it does not hold would make the change look riskier than it is, and invite a larger fix.
- **Solution** — kept the change to the runtime and scope only. `cireLoggerLayer` was already memoised behind `builtLayer ??=`, and `makeLoggerLayer` is two `FiberRef` layers with no finalizer.
- **Rationale** — the win here is the per-call `FiberRuntime` plus `Layer.buildWithScope`, and nothing else. Stating that plainly beats borrowing a scarier rationale.

### `Layer.suspend` is load-bearing on workerd and must stay — `hazard`

- **Issue** — building the runtime at module scope looks like an invitation to also drop `Layer.suspend` and parse the config eagerly.
- **Why** — on workerd, `nodejs_compat_populate_process_env` fills `process.env` only on first access. A config read during module evaluation would silently pin **every deployed tier to `local`** — pretty logs, debug level — with no error anywhere.
- **Solution** — `Layer.suspend` stays. `ManagedRuntime.make` only runs `scopeMake` at construction, which is pure and touches no env, so the layer still builds lazily on the first `runPromise` / `runSync` inside a request. Both the code comment and the wiki page spell this out and say not to remove it.
- **Rationale** — the failure mode is silent and tier-wide. A comment that only says "keep this" gets removed by the next person; one that names the mechanism will not.

**Out of scope** — `@osn/api`'s `makeAppRunner` already threads one runtime through its route factories and is untouched. No change to what the logger layer contains.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run test` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Read by hand in `cire/api/src/observability.ts`: `Layer.suspend` still wraps `cireLoggerLayer`, and nothing calls `loadConfig` at module scope.

Not verified: a real `wrangler deploy` against a tier. Module-eval crashes of this shape only surface on a live deploy, and `--dry-run` does not catch them — the dev-tier deploy on merge is the first place this is proven end to end.
