### PR TITLE
perf(cire): give each invite image slot its own cache-key version

### DIFF
--- a/.changeset/proud-images-version.md
+++ b/.changeset/proud-images-version.md
@@ -1,0 +1,14 @@
+---
+"@cire/api": patch
+---
+
+Give each invite image slot its own cache-key version.
+
+The `?v=` version for the hero, story and footer slots came from one
+per-wedding `images_updated_at` column, so re-uploading a single slot moved
+every slot's URL — guests re-fetched images whose bytes had not changed, and
+the whole wedding's transform cache was orphaned at once. Each slot's version
+is now an FNV-1a digest of its own R2 key, which moves exactly when the bytes
+move. The hero digest also folds in the backdrop blur radius, because that blur
+is applied server-side to the `hero-bg` variant and the response is cached
+`immutable` for a year.

--- a/cire/api/src/routes/invite.test.ts
+++ b/cire/api/src/routes/invite.test.ts
@@ -13,7 +13,6 @@ import { DESIGNS } from "@cire/invite-designs";
 import type { DesignMeta } from "@cire/invite-designs";
 import { createRateLimiter } from "@shared/rate-limit";
 import type { RateLimiterBackend } from "@shared/rate-limit";
-import { eq } from "drizzle-orm";
 
 import { createApp } from "../app";
 import { createDb, seedDb } from "../db/setup";
@@ -97,13 +96,20 @@ function createImagesStub(opts?: { fail?: boolean }): ImagesBindingLike & {
   };
 }
 
-async function uploadHero(app: ReturnType<typeof buildApp>["app"]): Promise<void> {
-  const up = await appRequest(app, `${orgBase}/image/hero`, {
+async function uploadSlot(
+  app: ReturnType<typeof buildApp>["app"],
+  slot: "hero" | "story" | "footer",
+): Promise<void> {
+  const up = await appRequest(app, `${orgBase}/image/${slot}`, {
     method: "POST",
     headers: await authHeaders(BOOTSTRAP_OWNER),
     body: PNG,
   });
   expect(up.status).toBe(200);
+}
+
+async function uploadHero(app: ReturnType<typeof buildApp>["app"]): Promise<void> {
+  await uploadSlot(app, "hero");
 }
 
 const emptyText = JSON.stringify({
@@ -1229,7 +1235,7 @@ describe("invite image transforms — Cache API short-circuit", () => {
     });
   });
 
-  it("a re-upload (bumped updatedAt) creates a second cache entry and re-runs the binding (T-S1)", async () => {
+  it("a re-upload (fresh R2 key) creates a second cache entry and re-runs the binding (T-S1)", async () => {
     const cache = createCacheStub();
     await withCaches(cache.caches, async () => {
       const images = createImagesStub();
@@ -1240,7 +1246,7 @@ describe("invite image transforms — Cache API short-circuit", () => {
       const accept = { accept: "image/avif,image/webp,*/*" };
 
       // First request → miss → binding runs once, one cache entry written under
-      // the current server `updatedAt`.
+      // the current server-derived version.
       const first = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
         headers: accept,
       });
@@ -1248,16 +1254,10 @@ describe("invite image transforms — Cache API short-circuit", () => {
       expect(images.widths).toEqual([1600]); // binding ran once
       expect(cache.store.size).toBe(1);
 
-      // Simulate a re-upload by advancing the wedding's stored `imagesUpdatedAt`
-      // (what setImage bumps; migration 0029 made it the image cache version).
-      // After the S-M1 fix the cache version is derived from this DB value (NOT
-      // the client ?v=), so a bump must mint a fresh key — the new image can't
-      // be served the stale cached transform.
-      built.db
-        .update(weddingInviteCustomisations)
-        .set({ imagesUpdatedAt: new Date(Date.now() + 60_000) })
-        .where(eq(weddingInviteCustomisations.weddingId, BOOTSTRAP_WEDDING_ID))
-        .run();
+      // A real re-upload: `storeAsset` mints a fresh uuid-suffixed R2 key, and
+      // the cache version is a digest of that key (NOT the client ?v=, S-M1), so
+      // the new bytes can never be served the stale cached transform.
+      await uploadHero(app);
 
       // Same request URL (same ?variant, same Accept) → because the server
       // version changed, this is a MISS against a new key → binding re-runs and a
@@ -1771,7 +1771,7 @@ describe("hero display sliders (migration 0018)", () => {
       expect(images.widths.length).toBe(1);
       expect(cache.store.size).toBe(1);
 
-      // A copy-only save (bumps `updatedAt`, NOT `imagesUpdatedAt`)…
+      // A copy-only save — it writes no image key, so no slot's version moves…
       const put = await appRequest(app, `${orgBase}/text`, {
         method: "PUT",
         headers: { "Content-Type": "application/json", ...(await authHeaders(BOOTSTRAP_OWNER)) },
@@ -1792,6 +1792,53 @@ describe("hero display sliders (migration 0018)", () => {
       expect(second.status).toBe(200);
       expect(images.widths.length).toBe(1); // still exactly one transform
       expect(cache.store.size).toBe(1); // no new cache entry
+    });
+  });
+
+  it("re-uploading one slot leaves the other slots' versions and caches untouched (P-I1)", async () => {
+    const cache = createCacheStub();
+    await withCaches(cache.caches, async () => {
+      const images = createImagesStub();
+      const { app } = buildApp({ images });
+      await uploadSlot(app, "hero");
+      await uploadSlot(app, "story");
+      await uploadSlot(app, "footer");
+      const accept = { accept: "image/webp,*/*" };
+
+      type Urls = {
+        hero: { imageUrl: string };
+        story: { imageUrl: string };
+        footer: { imageUrl: string };
+      };
+      const before = (await (await appRequest(app, `/api/invite/${SLUG}`)).json()) as Urls;
+
+      // Prime the hero transform cache.
+      const primed = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(primed.status).toBe(200);
+      expect(images.widths.length).toBe(1);
+      expect(cache.store.size).toBe(1);
+
+      // Re-upload the STORY slot only. Under the old per-wedding
+      // `images_updated_at` this bumped the version every slot shared, throwing
+      // away hero (including the preloaded `hero-bg` LCP variant) and footer in
+      // every colo and format.
+      await uploadSlot(app, "story");
+
+      const after = (await (await appRequest(app, `/api/invite/${SLUG}`)).json()) as Urls;
+      expect(after.story.imageUrl).not.toBe(before.story.imageUrl);
+      expect(after.hero.imageUrl).toBe(before.hero.imageUrl);
+      expect(after.footer.imageUrl).toBe(before.footer.imageUrl);
+
+      // …and the hero's primed transform is still a HIT: no re-billed transform,
+      // no second cache entry.
+      const heroAgain = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero`, {
+        headers: accept,
+      });
+      expect(heroAgain.status).toBe(200);
+      expect(images.widths.length).toBe(1);
+      expect(cache.store.size).toBe(1);
     });
   });
 
@@ -1873,7 +1920,10 @@ describe("hero display sliders (migration 0018)", () => {
       await uploadHero(app);
       const accept = { accept: "image/webp,*/*" };
 
-      // Prime the cache at the default blur.
+      // Prime the cache at the default blur, and capture the guest-facing URL.
+      const beforeBlur = (await (await appRequest(app, `/api/invite/${SLUG}`)).json()) as {
+        hero: { imageUrl: string };
+      };
       const first = await appRequest(app, `/api/invite/${SLUG}/image/hero?variant=hero-bg`, {
         headers: accept,
       });
@@ -1896,6 +1946,17 @@ describe("hero display sliders (migration 0018)", () => {
       // Binding re-ran with the new blur; a distinct cache entry was minted.
       expect(images.blurs).toEqual([VARIANT_BLUR["hero-bg"], 5]);
       expect(cache.store.size).toBe(2);
+
+      // …and the GUEST-facing ?v= moved too. The edge cache folds `blur` into
+      // its own key, but the response is `max-age=31536000, immutable`, so a
+      // browser that already holds the old backdrop would keep it forever unless
+      // the URL changes. The hero slot folds the radius into its version for
+      // exactly this (`heroVersionFromKey`) — the R2 key alone does not move on
+      // a blur-only save.
+      const afterBlur = (await (await appRequest(app, `/api/invite/${SLUG}`)).json()) as {
+        hero: { imageUrl: string };
+      };
+      expect(afterBlur.hero.imageUrl).not.toBe(beforeBlur.hero.imageUrl);
     });
   });
 });

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -98,7 +98,7 @@ export const createInvitePublicRoutes = (
       // cardinality per slot is capped (3 variants × 3 formats) — keeps the edge
       // cache hot and denies an attacker unbounded distinct transform URLs.
       // (The client's `?v=` is intentionally NOT read here — the cache version is
-      // derived server-side from the wedding row's `updatedAt` below, S-M1.)
+      // derived server-side from the SLOT's own R2 key below, S-M1.)
       const variant = resolveVariant((query as Record<string, string | undefined>).variant);
       const format = negotiateFormat(request.headers.get("accept"));
       return runCire(
@@ -106,15 +106,16 @@ export const createInvitePublicRoutes = (
           // Resolve the slug → image key + authoritative content version FIRST.
           // This is a cheap, indexed D1 read and it's required before we can key
           // the cache: the cache-key version is derived SERVER-SIDE from the
-          // row's `updatedAt` (NOT the client `?v=`). Slugs are public, so if we
-          // keyed on the raw `?v=` an attacker could loop ?v=1,2,3… on a valid
-          // slug to force unbounded cache-missing, per-call-billed transforms,
-          // defeating the bounded-cardinality cost guarantee (S-M1). The client
-          // may still SEND `?v=` (the frontend uses it for browser-cache busting
-          // and it equals `updatedAt` anyway) but it MUST NOT influence this key.
-          // By design this DB read now runs on EVERY request — it's cheap and is
-          // the source of the authoritative version; the expensive work (R2 read
-          // + Images binding call) is still skipped on a cache hit below.
+          // SLOT's own R2 key (`versionFromKey`, NOT the client `?v=`). Slugs are
+          // public, so if we keyed on the raw `?v=` an attacker could loop
+          // ?v=1,2,3… on a valid slug to force unbounded cache-missing, per-call-
+          // billed transforms, defeating the bounded-cardinality cost guarantee
+          // (S-M1). The client may still SEND `?v=` (the frontend uses it for
+          // browser-cache busting and it equals the key-derived version anyway)
+          // but it MUST NOT influence this key. By design this DB read now runs
+          // on EVERY request — it's cheap and is the source of the authoritative
+          // version; the expensive work (R2 read + Images binding call) is still
+          // skipped on a cache hit below.
           const { key, imageVersion, heroBlur } = yield* inviteService.imageKeyForSlug(
             params.slug,
             slot,
@@ -149,11 +150,13 @@ export const createInvitePublicRoutes = (
               return { error: "Not found" };
             }
           }
-          // Server-derived IMAGE version (`imagesUpdatedAt`, migration 0029):
-          // a re-upload / crop / hero-blur change mints a new cache key (fresh
-          // entry) so the new image is never served stale — while copy/colour
-          // saves leave it untouched, keeping the transform cache warm (WT-P-I1).
-          const version = imageVersion ? String(imageVersion.getTime()) : undefined;
+          // Server-derived IMAGE version (a digest of the slot's own R2 key,
+          // `versionFromKey`): a re-upload mints a fresh key ⇒ a fresh version ⇒
+          // a fresh cache entry, so the new image is never served stale — while
+          // copy/colour saves (same key) and another slot's changes (different
+          // column) both leave it untouched, keeping the transform cache warm
+          // (WT-P-I1 / P-I1).
+          const version = imageVersion ?? undefined;
 
           // Per-wedding hero backdrop blur (migration 0018). It applies ONLY to
           // the blurred `hero-bg` variant of the `hero` slot; every other
@@ -166,9 +169,9 @@ export const createInvitePublicRoutes = (
           // Identical Cache-API-short-circuit + Images-binding transform + raw-
           // original fallback pipeline as the per-event serve route — see
           // `serveTransformedImage`. The cache version is ALWAYS the server-
-          // derived one (here `updatedAt`, NEVER the client `?v=`), so an attacker
-          // can't loop arbitrary `?v=` to mint unbounded per-call-billed
-          // transforms (S-M1).
+          // derived one (here the slot's key-derived version, NEVER the client
+          // `?v=`), so an attacker can't loop arbitrary `?v=` to mint unbounded
+          // per-call-billed transforms (S-M1).
           return yield* serveTransformedImage({
             request,
             key,

--- a/cire/api/src/services/claim.ts
+++ b/cire/api/src/services/claim.ts
@@ -278,9 +278,13 @@ function buildClaimResponse(family: FamilyRow): Effect.Effect<ClaimResponse, nev
     }
     eventList.sort((a, b) => a.sortOrder - b.sortOrder);
 
-    // The image URL's `?v=` tracks the IMAGE version like every other slot's
-    // (WT-P-I1), coalescing to `updatedAt` for rows that predate migration 0029.
-    const closingVersion = (closing?.imagesUpdatedAt ?? closing?.updatedAt)?.getTime() ?? 0;
+    // The image URL's `?v=` is derived from the closing image's own R2 key
+    // (WT-P-I1 / P-I1) — a digest of the key, not the row's `updatedAt` — so
+    // bumping the hero or story slot never busts this one, and a byte-neutral
+    // crop save (same key) never busts it either.
+    const closingImageUrl = closing?.imageKey
+      ? `/api/invite/${encodeURIComponent(slug)}/image/footer?v=${versionFromKey(closing.imageKey)}`
+      : null;
     return {
       familyId: family.id,
       publicId: family.publicId,
@@ -299,9 +303,7 @@ function buildClaimResponse(family: FamilyRow): Effect.Effect<ClaimResponse, nev
       ),
       closing: {
         message: closing?.message ?? null,
-        imageUrl: closing?.imageKey
-          ? `/api/invite/${encodeURIComponent(slug)}/image/footer?v=${closingVersion}`
-          : null,
+        imageUrl: closingImageUrl,
         // Only surface a rectangle when there is an image to crop; `decodeCrop`
         // drops a malformed/legacy value so a bad rect never reaches a style.
         imageCrop: closing?.imageKey ? decodeCrop(closing.imageCrop) : null,

--- a/cire/api/src/services/invite-image-transform.ts
+++ b/cire/api/src/services/invite-image-transform.ts
@@ -116,16 +116,19 @@ export function negotiateFormat(accept: string | null | undefined): OutputFormat
  *    is NOT in the request URL (it comes from the `Accept` header), so baking it
  *    into the key is what keeps AVIF/WebP/JPEG as separate entries — otherwise a
  *    WebP-only client could be served an AVIF cached for an AVIF-capable one.
- *  - `v` — the content version, derived SERVER-SIDE from the wedding row's
- *    `updatedAt` (NOT the client `?v=`, which is ignored for keying — S-M1), so a
- *    re-upload bumps `updatedAt` → a new key → the new image isn't served stale,
- *    while an attacker can't loop arbitrary `?v=` values to mint fresh transforms.
+ *  - `v` — the content version, derived SERVER-SIDE from the slot's own R2 key
+ *    (`versionFromKey`, NOT the client `?v=`, which is ignored for keying — S-M1),
+ *    so a re-upload mints a fresh key → a new `v` → the new image isn't served
+ *    stale, while an attacker can't loop arbitrary `?v=` values to mint fresh
+ *    transforms, and bumping one slot never busts another slot's cached entry.
  *  - `blur` — the server-derived hero backdrop blur radius (per-wedding
- *    `hero_blur`, migration 0018), present only for the `hero-bg` variant. Saving
- *    a new blur already bumps `updatedAt` (so `v` busts the cache on its own),
- *    but we ALSO fold `blur` into the key defensively so the cached bytes can
- *    never disagree with the requested radius. It stays bounded: exactly one
- *    server-derived value per wedding, not a client-swept param.
+ *    `hero_blur`, migration 0018), present only for the `hero-bg` variant. A
+ *    blur-only save touches no image key, so the hero slot's version folds the
+ *    radius into its digest as well (`heroVersionFromKey`, `invite.ts`) — `v`
+ *    busts the cache on its own. We ALSO fold `blur` in here defensively so the
+ *    cached bytes can never disagree with the requested radius. It stays
+ *    bounded: exactly one server-derived value per wedding, not a client-swept
+ *    param.
  *
  * The format slug strips the `image/` prefix to keep the key tidy. We use a
  * synthetic host so the key never collides with a real inbound request URL and
@@ -295,9 +298,10 @@ export function imageResponseHeaders(
  * it", not "any proxy may"; nothing between us and the browser ever sees this
  * header.
  *
- * NOT VERIFIED against a live Worker. The 413-on-`private` behaviour is from
- * Cloudflare's docs; confirm with `wrangler tail` and a second identical request
- * (see `[[wiki/todo/perf]]`).
+ * VERIFIED against the deployed dev Worker on 2026-08-19: a repeat request showed
+ * a Cache API HIT with `age` advancing, `cache-control: private, max-age=31536000,
+ * immutable` on the way out to the client, and zero `image cache put failed`
+ * events in the tail.
  */
 const STORABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 

--- a/cire/api/src/services/invite.ts
+++ b/cire/api/src/services/invite.ts
@@ -21,6 +21,7 @@ import {
   type InviteTextBody,
   type InviteThemeBody,
 } from "../schemas/invite";
+import { versionFromKey } from "./event-image";
 import { deleteAsset, storeAsset } from "./invite-assets";
 import type { AssetR2Error, AssetsR2Service } from "./invite-assets";
 
@@ -32,8 +33,9 @@ export class WeddingNotFound extends Data.TaggedError("WeddingNotFound")<{
  * The customisation as the invite renders it. Text fields are the raw stored
  * overrides (`null` ⇒ the guest site / organiser preview falls back to the
  * built-in default copy). Image fields are ready-to-use URL *paths* — clients
- * prepend their API origin — carrying a `?v=` cache-buster keyed to the row's
- * `updatedAt` so a re-uploaded image isn't served stale.
+ * prepend their API origin — carrying a `?v=` cache-buster derived from that
+ * SLOT's own R2 key (`versionFromKey`), so a re-uploaded image isn't served
+ * stale and bumping one slot never busts another's cache.
  */
 /**
  * Per-section theme as the invite renders it. Every field is nullable; `null`
@@ -203,8 +205,24 @@ const EMPTY: InviteCustomisation = {
 };
 
 /** Public path the invite image is served from. Clients prepend the API origin. */
-function imagePath(slug: string, slot: InviteImageSlot, version: number): string {
+function imagePath(slug: string, slot: InviteImageSlot, version: string): string {
   return `/api/invite/${encodeURIComponent(slug)}/image/${slot}?v=${version}`;
+}
+
+/**
+ * Version for the HERO slot's URLs. The hero backdrop blur is applied
+ * server-side to the `hero-bg` variant, so a blur-only save changes the bytes we
+ * serve WITHOUT changing the R2 key — and the served image carries
+ * `max-age=31536000, immutable`, so a guest's browser would hold the old radius
+ * forever. Folding the radius into the digest moves the URL when either the
+ * bytes or the radius move. The edge cache already keys `blur` separately
+ * (`buildTransformCacheKey`); this is the browser's half of the same guarantee.
+ * The sharp `hero` variant ignores blur, so it takes one needless re-transform
+ * per blur-only save — a rare organiser action, and the alternative (a
+ * per-variant version) would leak the variant into a shared URL.
+ */
+function heroVersionFromKey(key: string, heroBlur: number | null): string {
+  return versionFromKey(`${key}#blur=${heroBlur ?? HERO_BLUR_DEFAULT}`);
 }
 
 /**
@@ -302,17 +320,20 @@ function toCustomisation(
     imagesUpdatedAt: Date | null;
   },
 ): InviteCustomisation {
-  // The image URLs' ?v= cache-buster tracks the IMAGE version, not the row
-  // version — a copy/colour save must not bust the guest image caches
-  // (WT-P-I1). `imagesUpdatedAt` is null only for rows that predate any image
-  // write; coalesce to `updatedAt` as a safety net.
-  const imageVersion = c.imagesUpdatedAt ?? c.updatedAt;
-  const version = imageVersion ? imageVersion.getTime() : 0;
+  // Each slot's ?v= cache-buster is derived from THAT slot's own R2 key
+  // (versionFromKey — mirrors the per-event image path in event-image.ts) —
+  // never the row's `updatedAt`/`imagesUpdatedAt`. A copy/colour save must not
+  // bust the guest image caches (WT-P-I1), and bumping one slot must not bust
+  // another's (P-I1): a per-row version broke both, since it moved on every
+  // slot's write. Deriving from the key alone fixes both — the key only
+  // changes when THAT slot's bytes change.
   return {
     hero: {
       title: c.heroTitle,
       subtitle: c.heroSubtitle,
-      imageUrl: c.heroImageKey ? imagePath(slug, "hero", version) : null,
+      imageUrl: c.heroImageKey
+        ? imagePath(slug, "hero", heroVersionFromKey(c.heroImageKey, c.heroBlur))
+        : null,
       // Only surface a crop when there's an image to crop — a stored rectangle on
       // a since-removed image is inert. `decodeCrop` drops a malformed/legacy
       // value to null so a bad rectangle never reaches the guest-facing style.
@@ -323,7 +344,7 @@ function toCustomisation(
       eyebrow: c.storyEyebrow,
       heading: c.storyHeading,
       body: c.storyBody,
-      imageUrl: c.storyImageKey ? imagePath(slug, "story", version) : null,
+      imageUrl: c.storyImageKey ? imagePath(slug, "story", versionFromKey(c.storyImageKey)) : null,
       imageCrop: c.storyImageKey ? decodeCrop(c.storyImageCrop) : null,
     },
     details: { eyebrow: c.detailsEyebrow, heading: c.detailsHeading },
@@ -335,7 +356,9 @@ function toCustomisation(
     },
     footer: {
       message: c.footerMessage,
-      imageUrl: c.footerImageKey ? imagePath(slug, "footer", version) : null,
+      imageUrl: c.footerImageKey
+        ? imagePath(slug, "footer", versionFromKey(c.footerImageKey))
+        : null,
       imageCrop: c.footerImageKey ? decodeCrop(c.footerImageCrop) : null,
     },
     heroDisplay: {
@@ -533,29 +556,34 @@ export const inviteService = {
   },
 
   /**
-   * Resolve the R2 key backing a slug's image slot (for serving) PLUS the row's
-   * IMAGE version (`imagesUpdatedAt`, coalesced to `updatedAt` for legacy rows;
-   * migration 0029) — the authoritative content version — and the per-wedding
-   * `heroBlur`. The serve route derives its edge-cache key from this server-side
-   * version (not the client `?v=`), so an attacker can't loop distinct `?v=`
-   * values to force unbounded, per-call-billed transforms (S-M1); and because
-   * the version only moves on image upload/remove/crop + hero-blur changes,
-   * copy/colour saves leave the transform cache warm (WT-P-I1). The version is
-   * null when the wedding exists but has no customisation row yet (LEFT JOIN
-   * miss) — the slot key is then null too, so the route 404s before it ever
-   * builds a cache key.
+   * Resolve the R2 key backing a slug's image slot (for serving) PLUS that
+   * slot's key-derived content version (`versionFromKey` — mirrors the
+   * per-event image path in `event-image.ts`) and the per-wedding `heroBlur`.
+   * The serve route derives its edge-cache key from this server-side version
+   * (not the client `?v=`), so an attacker can't loop distinct `?v=` values to
+   * force unbounded, per-call-billed transforms (S-M1). Deriving the version
+   * from the SLOT's own key rather than the row's `updatedAt`/`imagesUpdatedAt`
+   * fixes two over-invalidation bugs at once (P-I1): a copy/colour save never
+   * bumps it (the key is unchanged — WT-P-I1), and bumping one slot never
+   * busts another slot's cache (each slot's version comes from its own
+   * column). The version is null when there is no key — either the wedding has
+   * no customisation row yet (LEFT JOIN miss) or that slot has no image — so
+   * the route 404s before it ever builds a cache key.
    *
    * `heroBlur` is the per-wedding override of the hero backdrop's server-side
    * blur (migration 0018). It is resolved here alongside the key so the serve
    * route can apply it to the `hero-bg` transform WITHOUT a client query param
    * (preserving the no-arbitrary-cache-minting invariant) and fold it into the
-   * cache key. A LEFT JOIN miss coalesces to the today's-look default.
+   * cache key. A LEFT JOIN miss coalesces to the today's-look default. It is
+   * ALSO folded into the hero slot's version (`heroVersionFromKey`), because a
+   * blur-only save changes the bytes we serve without changing the R2 key and
+   * the response is `immutable` for a year — see that function.
    */
   imageKeyForSlug(
     slug: string,
     slot: InviteImageSlot,
   ): Effect.Effect<
-    { key: string | null; imageVersion: Date | null; heroBlur: number },
+    { key: string | null; imageVersion: string | null; heroBlur: number },
     WeddingNotFound,
     DbService
   > {
@@ -572,8 +600,6 @@ export const inviteService = {
             storyImageKey: weddingInviteCustomisations.storyImageKey,
             footerImageKey: weddingInviteCustomisations.footerImageKey,
             heroBlur: weddingInviteCustomisations.heroBlur,
-            updatedAt: weddingInviteCustomisations.updatedAt,
-            imagesUpdatedAt: weddingInviteCustomisations.imagesUpdatedAt,
           })
           .from(weddings)
           .leftJoin(
@@ -585,10 +611,15 @@ export const inviteService = {
       );
       if (!row) return yield* Effect.fail(new WeddingNotFound({ slug }));
       const key = row[SLOT_COLUMNS[slot].key];
+      const heroBlur = row.heroBlur ?? HERO_BLUR_DEFAULT;
       return {
         key,
-        imageVersion: row.imagesUpdatedAt ?? row.updatedAt,
-        heroBlur: row.heroBlur ?? HERO_BLUR_DEFAULT,
+        imageVersion: key
+          ? slot === "hero"
+            ? heroVersionFromKey(key, heroBlur)
+            : versionFromKey(key)
+          : null,
+        heroBlur,
       };
     }).pipe(Effect.withSpan("cire.invite.imageKeyForSlug"));
   },


### PR DESCRIPTION
## Summary

The three invite image slots (hero, story, footer) shared **one** cache-key version, so re-uploading any one of them moved every slot's URL and orphaned every transform-cache entry for that wedding at once. Each slot's `?v=` is now the FNV-1a digest of that slot's **own** R2 key, via the existing `versionFromKey` (`cire/api/src/services/event-image.ts`). No new column, no migration.

- The hero slot folds its server-side backdrop-blur radius into the same digest, because a blur-only save changes the bytes we serve without changing the key.
- Consumers converted in the same PR: the client-facing URLs in `services/invite.ts`, the server-derived version in `imageKeyForSlug`, and the closing-image URL in `services/claim.ts`.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/proud-images-version.md` (`@cire/*` are version-less, so the changeset is named but carries no bump) |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#95 | P-W2 — one per-wedding version column keyed three independent images |

Closes xchromo/osn-tracker#95

**Opened**

None. Tracker #422 (the stale docstring's `NOT VERIFIED` caveat) was already closed by the 2026-08-19 verification this PR records.

## Decisions

### Derive each slot's version from its own R2 key — `P-W2`

- **Issue** — `images_updated_at` is a single column, and it was the `?v=` for hero, story and footer alike. Changing the footer moved the hero URL — including the preloaded `hero-bg` LCP variant — in every colo and every output format.
- **Why** — guests re-fetched bytes that had not changed, on the one image the page's LCP waits for.
- **Solution** — derive each slot's version from that slot's own R2 key with `versionFromKey`.
- **Rationale** — upload keys carry a fresh `crypto.randomUUID()`, so the digest moves exactly when the bytes move — and never on a byte-neutral copy-only save, which the old column could not distinguish.

### Hero blur folds into the hero digest — `correctness`

- **Issue** — the hero backdrop blur is applied **server-side** to the `hero-bg` variant. Under a purely key-derived version, a blur-only save would leave the URL unchanged.
- **Why** — the image response carries `Cache-Control: private, max-age=31536000, immutable`, so a guest's browser would hold the old radius for a year. Silent, guest-facing, and unreachable by any cache purge we control. The old `images_updated_at` bump was covering this; removing it without a replacement would have introduced a regression the finding never mentioned.
- **Solution** — `heroVersionFromKey(key, heroBlur)` digests the key **and** the radius, and is used on both sides: the client-facing `?v=` in `toCustomisation` and the server-derived version in `imageKeyForSlug`.
- **Rationale** — folding it on both sides preserves the S-M1 invariant that the version is always server-derived and the client's `?v=` is never read for keying. The edge cache was already safe (`buildTransformCacheKey` keys `blur` separately); this is the browser's half of the same guarantee. Cost is one needless re-transform of the sharp `hero` variant per blur-only save — a rare organiser action, and the alternative, a per-variant version, would leak the variant into a shared URL.

### Folded on both sides rather than client-only — `approach`

- **Issue** — folding blur into the client `?v=` alone would have been a smaller diff.
- **Why** — `routes/invite.ts` asserts, in a comment, that the client's `?v=` equals the key-derived version anyway. A client-only fold would silently falsify that.
- **Solution** — both sides.
- **Rationale** — an invariant a comment claims and the code no longer holds is worse than the extra line.

### Two existing tests asserted the mechanism, not the property — `test debt`

- **Issue** — the re-upload test faked an upload by writing `imagesUpdatedAt` directly, and another asserted a copy-only save does not bump that column. Both became meaningless.
- **Why** — a test that pokes the implementation passes after the implementation is replaced, proving nothing.
- **Solution** — the re-upload test now performs a real second upload. The blur test additionally asserts the **guest-facing** hero URL moves. A new test asserts that re-uploading one slot leaves the other slots' versions and their transform-cache entries untouched.
- **Rationale** — that last test is the property the finding exists for, and nothing was asserting it before.

### Stale docstring in `invite-image-transform.ts` — `cosmetic`

- **Issue** — the `blur` cache-key note carried a `NOT VERIFIED against a live Worker` caveat pointing at `wiki/todo/perf`, a page the 2026-08-15 issues migration deleted.
- **Why** — a caveat nobody can follow up is noise, and the pointer resolved to nothing.
- **Solution** — replaced with the 2026-08-19 verification against the deployed dev Worker (tracker #422, closed), and rewritten to describe the new two-layer arrangement.
- **Rationale** — in scope because the same paragraph had to change anyway.

**Out of scope** — `images_updated_at` itself is left in place; dropping the column is a migration and belongs in its own PR. Per-variant versions were considered and rejected above.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd cire/api test` | pass — 1690 pass |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Manual steps for the dev tier once this deploys:

- Re-upload one slot on a wedding with all three set — only that slot's `?v=` moves.
- Save a hero blur change with no new upload — the hero `?v=` moves, story and footer do not.
- A copy-only save moves no slot's `?v=`.

The three manual steps above are covered by unit tests against the service; they are listed because the browser-cache half of the blur decision can only be observed on a real deployed origin.
