### PR TITLE
fix(cire): chunk RSVP batch commits under D1's per-batch ceiling

### DIFF
--- a/.changeset/cire-rsvp-batch-ceiling.md
+++ b/.changeset/cire-rsvp-batch-ceiling.md
@@ -1,0 +1,14 @@
+---
+"@cire/api": patch
+---
+
+Chunk the RSVP write set under D1's per-batch statement ceiling.
+
+`submitRsvps` built one write set and committed it unchunked, but the endpoint
+accepts up to 200 RSVPs and D1 rejects a batch over 50 statements — so a large
+household submit answered 500. It now commits through `commitGroupedBatches`
+with one singleton group per upsert: each upsert is independent and idempotent
+on `(guestId, eventId)`, so giving up whole-set atomicity beyond the ceiling
+costs nothing a retry can't fix. The 200 cap is unchanged. Covered by a
+Miniflare (`test:d1`) case submitting 51 pairs — one over the ceiling — since
+the bun:sqlite fallback commits sequentially and cannot fail this way. P-W2.

--- a/cire/api/src/db/d1-integration.test.ts
+++ b/cire/api/src/db/d1-integration.test.ts
@@ -280,6 +280,44 @@ describe("cire/api over real D1 (Miniflare)", () => {
     expect(await db.select().from(families).where(eq(families.id, "fam_y"))).toHaveLength(0);
   });
 
+  it("submitRsvps commits a 51-pair batch over D1's per-batch ceiling (P-W2)", async () => {
+    // MAX_STATEMENTS_PER_BATCH is 50; a 51-statement submit must be chunked by
+    // commitGroupedBatches rather than sent as one over-ceiling db.batch() call
+    // (which D1 rejects outright). bun:sqlite cannot exercise this: commitBatch
+    // feature-detects `.batch()` and falls back to a sequential loop there, so
+    // only the real (Miniflare-backed) D1 driver proves the fix.
+    const eventIds = Array.from({ length: 51 }, (_, i) => `evt_bulk_${i}`);
+    // One insert per event, not a single 51-row bulk insert — the bulk form
+    // trips D1's own bound-parameter ceiling on a single statement, a
+    // different limit than the per-batch statement ceiling this test targets.
+    for (const [i, id] of eventIds.entries()) {
+      await db.insert(events).values({
+        id,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        slug: `bulk-${i}`,
+        name: `Bulk ${i}`,
+        description: "",
+        startAt: "",
+        endAt: "",
+        timezone: "",
+        sortOrder: 10 + i,
+      });
+    }
+
+    const inputs = eventIds.map((eventId) => ({
+      guestId: GUEST_1,
+      eventId,
+      status: "attending" as const,
+      dietary: "",
+      dietaryConsent: false,
+    }));
+
+    await run(rsvpService.submitRsvps(inputs));
+
+    const rows = await db.select().from(rsvps).where(eq(rsvps.guestId, GUEST_1));
+    expect(rows).toHaveLength(51);
+  });
+
   it("tasks.reorder commits its per-row updates over the D1 batch path", async () => {
     // Regression guard: reorder used to run through db.transaction(), which the
     // D1 driver implements as literal BEGIN/COMMIT (rejected by D1) with

--- a/cire/api/src/services/rsvp.ts
+++ b/cire/api/src/services/rsvp.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { Effect } from "effect";
 
-import { DbService, dbQuery, commitBatch } from "../db";
+import { DbService, dbQuery, commitGroupedBatches } from "../db";
 import { metricRsvpUpserted } from "../metrics";
 import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import type { RsvpRecord } from "../schemas/rsvp";
@@ -48,23 +48,29 @@ export const rsvpService = {
   },
 
   /**
-   * Upsert a batch of RSVPs (one per guest×event pair) in a SINGLE D1 round-trip
-   * (P-W1). Caller MUST have validated every `guestId` belongs to the claimed
-   * family AND every (guestId, eventId) is a real invitation before invoking —
-   * this method does not re-check (the route validates the whole batch up front).
+   * Upsert a batch of RSVPs (one per guest×event pair) in as few D1 round-trips
+   * as the ceiling allows (P-W1, chunked per P-W2). Caller MUST have validated
+   * every `guestId` belongs to the claimed family AND every (guestId, eventId)
+   * is a real invitation before invoking — this method does not re-check (the
+   * route validates the whole batch up front).
    *
-   * Each pair becomes its own `INSERT … ON CONFLICT DO UPDATE`, collected into one
-   * `db.batch([...])` via {@link commitBatch} — mirroring `applyImport`'s write set
-   * and respecting the sync/async bridge:
-   *  - D1 (production): one atomic Workers↔D1 round-trip for the whole batch
-   *    (was N sequential round-trips on the guest hot path).
-   *  - bun:sqlite (tests/local, no `.batch()`): `commitBatch` awaits the statements
-   *    sequentially in-process — same per-pair upserts, no network cost.
+   * Each pair becomes its own `INSERT … ON CONFLICT DO UPDATE`, passed to
+   * {@link commitGroupedBatches} as a singleton group per statement — mirroring
+   * `applyImport`'s write set and respecting the sync/async bridge:
+   *  - D1 (production): chunked into batches of at most `MAX_STATEMENTS_PER_BATCH`
+   *    (was N sequential round-trips pre-P-W1, then one over-ceiling batch that
+   *    could 500 above 50 statements pre-P-W2).
+   *  - bun:sqlite (tests/local, no `.batch()`): statements run sequentially
+   *    in-process — same per-pair upserts, no network cost.
    * Either way the per-pair upsert semantics + dietary-consent stamping are
    * unchanged. An empty batch is a no-op (no statements, no metrics). Per-pair
    * `metricRsvpUpserted` is preserved so the observability shape is identical to
    * N single submits. The whole batch shares one `now` (a single submit always
-   * did too); a re-submit that clears dietary still nulls the consent record.
+   * did too, and it's captured before chunking so every chunk stamps the same
+   * `createdAt` / dietary-consent evidence); a re-submit that clears dietary
+   * still nulls the consent record. Whole-set atomicity is deliberately given
+   * up beyond `MAX_STATEMENTS_PER_BATCH` (each pair is an idempotent upsert on
+   * `(guestId, eventId)`, safe to re-apply on retry).
    */
   submitRsvps(inputs: readonly RsvpInput[]): Effect.Effect<void, never, DbService> {
     return Effect.gen(function* () {
@@ -104,7 +110,12 @@ export const rsvpService = {
           });
       });
 
-      yield* dbQuery(() => commitBatch(db, statements));
+      yield* dbQuery(() =>
+        commitGroupedBatches(
+          db,
+          statements.map((s) => [s]),
+        ),
+      );
       for (const input of inputs) {
         const writer = (input.consentSource ?? "guest") === "guest" ? "guest" : "organiser";
         yield* Effect.sync(() => metricRsvpUpserted(input.status, writer, "ok"));


### PR DESCRIPTION
## Summary

`submitRsvps` sent every RSVP upsert to D1 as one `commitBatch` call. `MAX_RSVP_BATCH` allows 200 statements; D1's ceiling is 50 (`MAX_STATEMENTS_PER_BATCH`). Any guest RSVPing to more than 50 events in one submit hit a rejected batch — and because `dbQuery` wraps the call in `Effect.promise`, the rejection surfaced as a **defect**, not a typed error: a 500 on the guest's one write path.

- One-line fix at the call site: `commitGroupedBatches(db, statements.map((s) => [s]))`, which chunks under the ceiling and was already the pattern used by the importer and the bulk code remint.
- A Miniflare-backed regression test that actually crosses the ceiling, because the bun:sqlite path used by the normal suite has no `.batch()` at all and so cannot fail this way.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/cire-rsvp-batch-ceiling.md` (`@cire/*` are version-less, so the changeset is named but carries no bump) |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#64 | P-W2 — RSVP submit exceeded D1's per-batch statement ceiling |

Closes xchromo/osn-tracker#64

**Opened**

None.

## Decisions

### Chunk with the existing helper, do not lower `MAX_RSVP_BATCH` — `P-W2`

- **Issue** — the two obvious fixes are to cap the request at 50 events or to chunk the writes.
- **Why** — capping is guest-visible: a wedding with 60 events would start rejecting a legitimate submit.
- **Solution** — `commitGroupedBatches(db, statements.map((s) => [s]))`, one statement per group so the chunker is free to split anywhere.
- **Rationale** — the helper already exists and is used by `services/import.ts` and the bulk code remint; this makes the RSVP path consistent with them rather than inventing a third chunking scheme.

### Give up whole-submit atomicity, deliberately — `trade-off`

- **Issue** — chunking means a submit over 50 events can commit chunk 1 and fail on chunk 2.
- **Why** — a partial commit must not leave the guest's RSVPs internally inconsistent or produce double-counted metrics.
- **Solution** — the single `now` is captured **before** any statement is built, so every row in a partial commit carries the same timestamp; the upserts are keyed on `(guestId, eventId)` and are idempotent, so a retry converges; and the `metricRsvpUpserted` loop runs **after** the commit returns, so a failed submit emits no counts.
- **Rationale** — this is the same trade `commitGroupedBatches` documents for the importer. It is safe here only because the writes are idempotent, which is why the three properties above are spelled out rather than assumed.

### The regression test has to be Miniflare-backed — `test placement`

- **Issue** — a test in the normal suite would have passed before the fix as well as after it.
- **Why** — `commitBatch` feature-detects `.batch()`. bun:sqlite does not have it, so the normal suite runs the statements in a sequential in-process loop and never touches a ceiling.
- **Solution** — the test lives in `cire/api/src/db/d1-integration.test.ts` and runs under `bun run --cwd cire/api test:d1`, against real D1 in Miniflare.
- **Rationale** — a test that cannot observe the bug is not a regression test. This one seeds 51 events and asserts the submit succeeds.

### Seeding 51 events one insert per row — `mechanics`

- **Issue** — the natural way to seed is one multi-row insert.
- **Why** — 51 rows × several columns crosses D1's **bound-parameter** ceiling, a different limit from the statement ceiling, and the seed would fail for a reason unrelated to what is being tested.
- **Solution** — seed with one insert per row.
- **Rationale** — a slower seed is worth a test that fails only for the reason it exists.

**Out of scope** — `MAX_RSVP_BATCH` keeps its 200 value; it is a request-shape guard, not a D1 limit, and conflating the two is what produced the bug. Other `commitBatch` callers were checked and none has a data-scaling write set.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd cire/api test:d1` | pass — 7 pass (includes the new ceiling test) |
| `bun run --cwd cire/api test` | pass |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts / Build & Test | pass |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Confirmed by hand that the new test fails on the pre-fix call: reverting the one-line change turns the 51-event submit into a rejected batch under Miniflare.

This is the bottom of stack #717 — `fix/cire-rsvp-batch-ceiling` → `perf/cire-rsvp-roundtrips` (#716) → `perf/cire-rsvp-readback` (#719). Merge bottom-up.
