### PR TITLE
perf(cire): cut two D1 round-trips off POST /api/rsvp

### DIFF
--- a/.changeset/cire-rsvp-roundtrips.md
+++ b/.changeset/cire-rsvp-roundtrips.md
@@ -1,0 +1,12 @@
+---
+"@cire/api": patch
+---
+
+Cut two D1 round-trips off `POST /api/rsvp`.
+
+The guest-ownership check and the invitation lookup were two sequential reads
+over the same rows; they are now one LEFT JOIN, still keyed only on the
+authenticated `familyId` so the endpoint's ownership guarantee is unchanged.
+That join and the family/deadline join no longer wait on each other — they run
+under `Effect.all({ concurrency: "unbounded" })`. Six round-trips down to four
+per submit. P-W1.

--- a/cire/api/src/routes/rsvp.test.ts
+++ b/cire/api/src/routes/rsvp.test.ts
@@ -226,6 +226,47 @@ describe("POST /api/rsvp", () => {
   );
 
   it(
+    "returns 403 (not-invited, not not-owned) for a guest with zero guest_events rows (P-W1 LEFT JOIN null case)",
+    eff(
+      Effect.gen(function* () {
+        // Ownership and invitation used to come off two separate queries;
+        // folding them into one LEFT JOIN must not drop a guest who has no
+        // guest_events rows at all. Insert a guest into Ada's family with no
+        // invitations, then confirm the ownership gate still passes for them
+        // — the request must fail on the INVITATION gate (403 "not invited"),
+        // not the OWNERSHIP gate (403 "do not belong to this family").
+        const noInviteGuestId = yield* Effect.sync(() => crypto.randomUUID());
+        yield* Effect.sync(() => {
+          const [ada] = db
+            .select({ familyId: guests.familyId })
+            .from(guests)
+            .where(eq(guests.id, sharmaGuestId))
+            .all();
+          db.insert(guests)
+            .values({
+              id: noInviteGuestId,
+              familyId: ada!.familyId,
+              firstName: "NoInvite",
+              lastName: "Testfamily",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .run();
+        });
+
+        const cookie = yield* claimAndCookie("TESTONE-IVY-AA11");
+        const res = yield* post(
+          { rsvps: [{ guestId: noInviteGuestId, eventId: HINDU_ID, status: "attending" }] },
+          cookie,
+        );
+        expect(res.status).toBe(403);
+        const data = yield* Effect.promise(() => res.json<{ error: string }>());
+        expect(data.error).toBe("One or more guests are not invited to that event");
+      }),
+    ),
+  );
+
+  it(
     "returns 403 when RSVPing to another wedding's event UUID (S-M1)",
     eff(
       Effect.gen(function* () {

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -1,6 +1,6 @@
 import { families, guests, guestEvents, weddings } from "@cire/db";
 import type { TurnstileVerifier } from "@shared/turnstile";
-import { eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Effect, Schema } from "effect";
 import { Elysia } from "elysia";
 
@@ -68,21 +68,53 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
 
             const dbService = yield* DbService;
 
-            // The household's own row plus its wedding's RSVP deadline — one
-            // join rather than two round-trips, since both gates below run on
-            // every submit. The FK guarantees the wedding row exists, so an
-            // inner join can only miss if the family itself is gone.
-            const [family] = yield* dbQuery(() =>
-              dbService
-                .select({
-                  kind: families.kind,
-                  rsvpDeadline: weddings.rsvpDeadline,
-                  rsvpDeadlineTimezone: weddings.rsvpDeadlineTimezone,
-                })
-                .from(families)
-                .innerJoin(weddings, eq(weddings.id, families.weddingId))
-                .where(eq(families.id, familyId))
-                .all(),
+            // P-W1: the deadline join and the guest/invitation join are both
+            // keyed ONLY on the authenticated familyId, both are reads, and
+            // neither result is returned to the caller before the gates below
+            // run — so it's safe to fire them concurrently instead of paying
+            // for two serialised round-trips. `Effect.all` is sequential by
+            // default; the concurrency option is what actually parallelises
+            // this. The trade: the guest/invitation read now runs even on a
+            // request a later gate rejects (host preview, closed deadline),
+            // where it used to be skipped. One extra index-served read on the
+            // reject path buys one fewer round-trip on every accept path. Both sides are already index-served: guests_family_id_sort_idx
+            // covers the family/guest join's WHERE, and guest_events' primary key
+            // (guest_id, event_id) covers the LEFT JOIN probe.
+            const [[family], familyGuestEvents] = yield* Effect.all(
+              [
+                // The household's own row plus its wedding's RSVP deadline — one
+                // join rather than two round-trips, since both gates below run on
+                // every submit. The FK guarantees the wedding row exists, so an
+                // inner join can only miss if the family itself is gone.
+                dbQuery(() =>
+                  dbService
+                    .select({
+                      kind: families.kind,
+                      rsvpDeadline: weddings.rsvpDeadline,
+                      rsvpDeadlineTimezone: weddings.rsvpDeadlineTimezone,
+                    })
+                    .from(families)
+                    .innerJoin(weddings, eq(weddings.id, families.weddingId))
+                    .where(eq(families.id, familyId))
+                    .all(),
+                ),
+                // Every guest owned by this family, LEFT JOINed to their event
+                // invitations (a guest with zero guest_events rows still belongs
+                // to the family — the join must not drop them). This is read 2
+                // and read 3 from before folded into one query; ownership and
+                // invitation sets are both derived from it below. Deliberately
+                // keyed on familyId alone, never on body-supplied guest/event
+                // ids — those are only validated AFTER ownership is established.
+                dbQuery(() =>
+                  dbService
+                    .select({ guestId: guests.id, eventId: guestEvents.eventId })
+                    .from(guests)
+                    .leftJoin(guestEvents, eq(guestEvents.guestId, guests.id))
+                    .where(eq(guests.familyId, familyId))
+                    .all(),
+                ),
+              ],
+              { concurrency: "unbounded" },
             );
 
             // Fail CLOSED on a missing row (S-L1). Both gates below read this
@@ -119,15 +151,10 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
               return { error: "rsvp_closed" };
             }
 
-            // Guest IDs that belong to the session's family.
-            const familyGuests = yield* dbQuery(() =>
-              dbService
-                .select({ id: guests.id })
-                .from(guests)
-                .where(eq(guests.familyId, familyId))
-                .all(),
-            );
-            const familyGuestIds = new Set(familyGuests.map((g) => g.id));
+            // Guest IDs that belong to the session's family — every distinct
+            // guestId in the joined rows, including rows whose eventId is null
+            // (a guest with no invitations still belongs to the family).
+            const familyGuestIds = new Set(familyGuestEvents.map((row) => row.guestId));
 
             // Validate every requested guestId is owned by the session's family.
             for (const rsvp of body.rsvps) {
@@ -140,18 +167,13 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
             // S-M1: every (guestId, eventId) pair must correspond to a real
             // invitation. Without this a guest could RSVP to an event they aren't
             // invited to — including another wedding's event if they learn its UUID.
-            // One scoped query over guest_events covers the whole batch; we only
-            // fetch links for THIS family's guests (already validated above), so a
-            // foreign wedding's links can never satisfy a pair.
-            const guestIds = [...new Set(body.rsvps.map((r) => r.guestId))];
-            const invitations = yield* dbQuery(() =>
-              dbService
-                .select({ guestId: guestEvents.guestId, eventId: guestEvents.eventId })
-                .from(guestEvents)
-                .where(inArray(guestEvents.guestId, guestIds))
-                .all(),
+            // Derived from the same LEFT JOIN as the ownership set above; a null
+            // eventId (no invitation) must never enter this set.
+            const invitedSet = new Set(
+              familyGuestEvents
+                .filter((row) => row.eventId !== null)
+                .map((row) => `${row.guestId}::${row.eventId}`),
             );
-            const invitedSet = new Set(invitations.map((i) => `${i.guestId}::${i.eventId}`));
             for (const rsvp of body.rsvps) {
               if (!invitedSet.has(`${rsvp.guestId}::${rsvp.eventId}`)) {
                 set.status = 403;


### PR DESCRIPTION
## Summary

The guest RSVP submit made six sequential D1 round-trips before it wrote anything: a chain of small reads, each awaiting the one before it, several of which were independent. This cuts it to four — the independent reads now run concurrently, and the guest/event membership check is one joined query instead of two.

- `Effect.all` with `{ concurrency: "unbounded" }` over the reads that do not depend on each other.
- `guests LEFT JOIN guest_events ON guest_events.guest_id = guests.id WHERE guests.family_id = ?` replaces a guest read followed by a membership read.
- Gate order, error precedence and status codes are unchanged — this is latency only.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/cire-rsvp-roundtrips.md` (`@cire/*` are version-less, so the changeset is named but carries no bump) |

## Issues

**Closes**

None — this closes the first two bullets of a three-bullet issue. It stays open until #719 lands.

| Issue | What |
|---|---|
| xchromo/osn-tracker#63 | P-W1 — RSVP submit round-trips; bullets 1–2 here, bullet 3 in #719 |

**Opened**

None.

## Decisions

### Run the independent reads concurrently — `P-W1`

- **Issue** — the reads were `yield*`-ed one after another inside `Effect.gen`, so each waited for the one before it even where there was no data dependency.
- **Why** — on D1 each of those is a network round-trip; sequencing them multiplies the guest's wait by the number of reads.
- **Solution** — `Effect.all([...], { concurrency: "unbounded" })` over the independent set.
- **Rationale** — `unbounded` rather than a fixed number because the set is small and fixed at three; a limit would be a cap with nothing to cap.

### One join instead of a guest read then a membership read — `P-W1`

- **Issue** — the code read the family's guests, then read `guest_events` to find which events each was invited to.
- **Why** — two round-trips for one question the database can answer in one.
- **Solution** — `guests LEFT JOIN guest_events ON guest_events.guest_id = guests.id WHERE guests.family_id = ?`, `LEFT` so a guest invited to nothing still comes back.
- **Rationale** — the join is index-covered on both sides: `guests_family_id_sort_idx` on the driving table, and `guest_events`' primary key `(guest_id, event_id)` on the joined one. No new index, no scan.

### The reject path pays one extra read — `trade-off`

- **Issue** — running reads concurrently means a request that is going to be rejected still issues reads it will not use.
- **Why** — worth naming rather than discovering later in a metric.
- **Solution** — accepted as-is.
- **Rationale** — the rejects are the rare path and are already cheap; sequencing every success to save a read on a failure is the wrong trade. Gate order and status codes are unchanged, so nothing observable differs — only the count of reads on a request that was going to 4xx anyway.

**Out of scope** — the write path's round-trips. That is bullet 3 of the same issue and lands in #719, immediately above this in the stack.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd cire/api test` | pass |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts / Build & Test | pass |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

The existing RSVP route tests cover the gate order and every error status; they pass unchanged, which is the point — the observable contract did not move.

Not verified: a real latency measurement against deployed D1. The claim here is six round-trips to four, counted in the code, not milliseconds measured in a colo.

Middle of stack #717 — `fix/cire-rsvp-batch-ceiling` (#713) → **`perf/cire-rsvp-roundtrips`** → `perf/cire-rsvp-readback` (#719). Merge #713 first.
