### PR TITLE
docs: confirm a registered stack with gh stack checkout, not gh stack view

### DIFF
--- a/.claude/commands/prep-pr.md
+++ b/.claude/commands/prep-pr.md
@@ -332,10 +332,10 @@ Only when `$BASE` is not `main`, i.e. this PR sits on top of another:
 ```bash
 gh stack --help >/dev/null 2>&1 || gh extension install github/gh-stack
 gh stack link <bottom-pr> [<middle-pr> …] <this-pr>      # bottom to top, PR numbers or branches
-gh stack view                                            # confirm
+gh stack checkout <stack-number>                         # confirm — number that link printed
 ```
 
-`gh stack link` needs no local stack state, which is what makes it the right command in a worktree layout. It reuses PRs that already exist and never drops one. Two arguments minimum, so the bottom PR of a stack has nothing to register until the second PR opens.
+`gh stack link` needs no local stack state, which is what makes it the right command in a worktree layout — and is also why `gh stack view` on its own is not the confirmation. `view` reads local tracking that `link` never writes, so it reports "not part of a stack" on a stack that exists. `gh stack checkout <stack-number>` imports the tracking, fails loudly if the stack is not there, and prints the chain. It reuses PRs that already exist and never drops one. Two arguments minimum, so the bottom PR of a stack has nothing to register until the second PR opens.
 
 If the extension is missing and cannot be installed (a remote environment with no network), say so and stop there. The base chain is already correct, so the diffs and merge order hold; the stack can be registered later from any machine.
 

--- a/wiki/conventions/stacked-prs.md
+++ b/wiki/conventions/stacked-prs.md
@@ -6,7 +6,7 @@ related:
   - "[[contributing]]"
   - "[[review-findings]]"
   - "[[commands]]"
-last-reviewed: 2026-08-19
+last-reviewed: 2026-08-20
 ---
 
 # Stacked PRs
@@ -52,7 +52,18 @@ It pushes any branch that is not on the remote, opens a PR for any branch that h
 
 Run it once the second PR of a stack exists, and again with the new PR appended each time the stack grows.
 
-Everything else the extension offers — `gh stack init/add/submit/sync/rebase`, the navigation verbs — assumes local stack tracking in one checkout. Reach for them only in a single-checkout clone. `gh stack view` reports the current branch's stack and is safe anywhere.
+Everything else the extension offers — `gh stack init/add/submit/sync/rebase`, the navigation verbs — assumes local stack tracking in one checkout. Reach for them only in a single-checkout clone.
+
+`gh stack view` is in that group too, which is easy to miss: `link` registers the stack on GitHub and writes **no local state**, so `view` reports `current branch "<name>" is not part of a stack` on a stack that exists and renders fine on GitHub. It is not a failure. To read the stack locally, import the tracking first — `gh stack checkout <stack-number>` (the number `link` printed) is a no-op on the branch you are already on, and prints the chain:
+
+```
+$ gh stack link 713 716
+✓ Created stack with 2 PRs (stack #717)
+
+$ gh stack checkout 717
+✓ Imported stack with 2 branches from GitHub (stack #717)
+Stack: (main) <- fix/cire-rsvp-batch-ceiling <- perf/cire-rsvp-roundtrips
+```
 
 ## The base branch
 
@@ -93,10 +104,12 @@ Never assume. Two checks, one per half:
 
 ```bash
 gh pr list --repo xchromo/osn --state open --json number,headRefName,baseRefName
-gh stack view                    # from any branch in the stack
+gh stack checkout <stack-number> # then: gh stack view, from any branch in it
 ```
 
-Every PR but the bottom one must show its parent's branch in `baseRefName`. A PR showing `main` is not stacked. And if `gh stack view` says the branch is not part of a stack, the chain exists in base branches only — GitHub will render no stack. Run `gh stack link`.
+Every PR but the bottom one must show its parent's branch in `baseRefName`. A PR showing `main` is not stacked — fix the base.
+
+For the other half, check the number `gh stack link` printed. `gh stack view` alone is not the check: it reads local tracking, which `link` never writes, so it says "not part of a stack" whether the stack is missing or merely unimported. Run `gh stack checkout <stack-number>` first — it fails loudly on a stack that does not exist, and prints the chain on one that does.
 
 ## Merge order
 


### PR DESCRIPTION
## Summary

Our stacked-PR docs told you to confirm a registered stack with `gh stack view`. That command reads **local** tracking state which `gh stack link` never writes, so it reports no stack for a stack that exists — and the last two stacks I registered were both re-checked by hand in the web UI because of it. The confirmation command is `gh stack checkout <stack-number>`, which imports the stack from GitHub and prints it.

- `wiki/conventions/stacked-prs.md` — corrects the verify step and says why `view` false-negatives.
- `.claude/commands/prep-pr.md` — same correction where the command tells you to confirm the stack.

## Workspaces affected

| Package | Changeset |
|---|---|
| — | None. Docs only: `wiki/` and `.claude/` are both on the allowlist in `scripts/changeset-required.sh`, so `Require changeset` reports `skip`. |

## Issues

**Closes**

None — this is a documentation fix arising from the stacked-PR work, with no issue behind it.

**Opened**

None.

## Decisions

### `gh stack checkout <n>`, not `gh stack view`, is the confirmation — `approach`

- **Issue** — `gh stack view` returns nothing for a stack that GitHub has, so a correctly registered stack reads as unregistered.
- **Why** — `link` writes the stack on the server; `view` reads a local tracking file that only `checkout` populates. The two are not talking about the same state.
- **Solution** — documented `gh stack checkout <stack-number>` as the verify step, with a line explaining the false negative so the next person does not re-derive it.
- **Rationale** — verified live against stack #717: `gh stack link 713 716` created stack #717, `gh stack view` failed to see it, and `gh stack checkout 717` imported it and printed `(main) <- fix/cire-rsvp-batch-ceiling <- perf/cire-rsvp-roundtrips`. The docs now match what the tool does rather than what its name suggests.

**Out of scope** — the `--base` half of stacking, which was already documented and already correct. Registering the stack is a separate object from setting the base; the page keeps saying so.

## Test plan

| Gate | Result |
|---|---|
| `scripts/changeset-required.sh` | `skip` — every changed path is on the allowlist |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts / Build & Test | pass |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Verified against a live stack rather than by reading docs — the transcript in the Decisions section above is what the commands actually printed against stack #717. No unit test is possible here: the subject is a third-party CLI extension's behaviour.
