### PR TITLE
perf(cire): fold the RSVP read-back into the upsert batch

### DIFF
--- a/.changeset/cire-rsvp-readback.md
+++ b/.changeset/cire-rsvp-readback.md
@@ -1,0 +1,16 @@
+---
+"@cire/api": patch
+---
+
+Fold the `POST /api/rsvp` read-back into the write batch.
+
+The endpoint committed its upserts and then read the household's rows back in a
+second round-trip. New `commitGroupedBatchesReturning` helper carries a trailing
+select through the same chunked `db.batch()` call — riding in the final chunk
+where it fits, and shipping as its own trailing batch at the statement ceiling —
+so the write and its read-back cost one round-trip instead of two. The read-back
+is still keyed only on the authenticated `familyId`. `submitRsvps` and
+`getRsvpsForFamily` keep their existing behaviour; both paths now build their
+statements through shared helpers so they cannot drift apart. Proven over real
+D1 in `test:d1`, the only environment where a batch can order or map results
+wrongly. P-W1.

--- a/cire/api/src/db/d1-integration.test.ts
+++ b/cire/api/src/db/d1-integration.test.ts
@@ -351,6 +351,96 @@ describe("cire/api over real D1 (Miniflare)", () => {
   );
 
   it(
+    "submitRsvpsAndList folds the read-back into the write batch over D1 (P-W1)",
+    async () => {
+      // Real db.batch() is the only environment that can fail the way the fix
+      // targets — bun:sqlite's fallback just awaits each statement in order and
+      // would pass even if the tail read the wrong rows or ran before the writes.
+      const rows = await run(
+        rsvpService.submitRsvpsAndList(
+          [
+            {
+              guestId: GUEST_1,
+              eventId: EVENT_A,
+              status: "attending",
+              dietary: "",
+              dietaryConsent: false,
+            },
+            {
+              guestId: GUEST_2,
+              eventId: EVENT_A,
+              status: "declined",
+              dietary: "",
+              dietaryConsent: false,
+            },
+          ],
+          FAMILY_ID,
+        ),
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(rows.find((r) => r.guestId === GUEST_1)).toMatchObject({
+        guestId: GUEST_1,
+        eventId: EVENT_A,
+        status: "attending",
+      });
+      expect(rows.find((r) => r.guestId === GUEST_2)).toMatchObject({
+        guestId: GUEST_2,
+        eventId: EVENT_A,
+        status: "declined",
+      });
+
+      // Persisted, not just echoed back.
+      const persisted = await db.select().from(rsvps).where(eq(rsvps.guestId, GUEST_1));
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]).toMatchObject({ status: "attending" });
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "submitRsvpsAndList sends the tail as its own trailing batch at the chunk ceiling",
+    async () => {
+      // MAX_STATEMENTS_PER_BATCH is 50. 50 upsert statements exactly fill the
+      // first chunk, so commitGroupedBatchesReturning must flush it and send the
+      // tail read as its own trailing batch rather than folding it in — proving
+      // the ceiling path (not just the common under-ceiling path above) still
+      // returns the full row set.
+      const eventIds = Array.from({ length: 50 }, (_, i) => `evt_ceiling_${i}`);
+      for (const [i, id] of eventIds.entries()) {
+        await db.insert(events).values({
+          id,
+          weddingId: BOOTSTRAP_WEDDING_ID,
+          slug: `ceiling-${i}`,
+          name: `Ceiling ${i}`,
+          description: "",
+          startAt: "",
+          endAt: "",
+          timezone: "",
+          sortOrder: 20 + i,
+        });
+      }
+
+      const inputs = eventIds.map((eventId) => ({
+        guestId: GUEST_1,
+        eventId,
+        status: "attending" as const,
+        dietary: "",
+        dietaryConsent: false,
+      }));
+
+      const rows = await run(rsvpService.submitRsvpsAndList(inputs, FAMILY_ID));
+
+      expect(rows).toHaveLength(50);
+      expect(new Set(rows.map((r) => r.eventId))).toEqual(new Set(eventIds));
+
+      const persisted = await db.select().from(rsvps).where(eq(rsvps.guestId, GUEST_1));
+      expect(persisted).toHaveLength(50);
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
     "tasks.reorder commits its per-row updates over the D1 batch path",
     async () => {
       // Regression guard: reorder used to run through db.transaction(), which the

--- a/cire/api/src/db/index.ts
+++ b/cire/api/src/db/index.ts
@@ -53,16 +53,18 @@ export type BatchStatements = [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]];
  * The `.batch()` half of a Drizzle handle, as an OPTIONAL member — only the D1
  * driver has it, bun:sqlite does not, so every caller feature-detects it (see
  * {@link commitBatch}). Kept here as one named type rather than re-declared at
- * each of the three call sites (`commitBatch`, the importer's write-set commit,
- * session rotation).
+ * each call site (`commitBatch`, `commitGroupedBatchesReturning`, the importer's
+ * write-set commit, session rotation).
  *
- * The result is `Promise<void>`: D1 resolves one `D1Result` per statement, but
- * no caller in this codebase reads them — what a batch guarantees is that every
- * statement committed together, which you get by awaiting. TypeScript's
- * "return value is ignored" rule keeps D1's real, richer signature assignable.
+ * The result is one element per statement, in statement order. Write-only
+ * callers ignore it — what a batch guarantees them is that every statement
+ * committed together, which you get by awaiting. A caller that ends its batch
+ * with a SELECT reads the last element for that SELECT's rows (see
+ * {@link commitGroupedBatchesReturning}); Drizzle's D1 session maps a SELECT
+ * result to rows for us, so the element is already the row array.
  */
 export type BatchableDb = {
-  batch?: (statements: BatchStatements) => Promise<void>;
+  batch?: (statements: BatchStatements) => Promise<unknown[]>;
 };
 
 /**
@@ -115,4 +117,77 @@ export async function commitGroupedBatches(db: Db, groups: BatchItem<"sqlite">[]
     chunk.push(...group);
   }
   await commitBatch(db, chunk);
+}
+
+/**
+ * The trailing read `commitGroupedBatchesReturning` appends to the write
+ * batch. It must be batchable (rides inside `db.batch()`, same as any write
+ * statement) AND directly awaitable (the bun:sqlite fallback just awaits it
+ * in place) — a real Drizzle select builder is both.
+ */
+export type ReturningTail<T> = BatchItem<"sqlite"> & PromiseLike<T[]>;
+
+/**
+ * Commit GROUPS of statements exactly as {@link commitGroupedBatches} does,
+ * then run one trailing read and return its rows — folding a read-back into
+ * the same D1 round-trip as the write that produced it, instead of a second
+ * one after (P-W1).
+ *
+ * The tail rides in the FINAL chunk when it fits under
+ * `MAX_STATEMENTS_PER_BATCH`; if appending it would push that chunk over the
+ * ceiling, it ships as its own trailing batch instead. Either way it ends up
+ * the last statement of the last batch actually sent, so its rows are always
+ * `results.at(-1)` of that batch — D1 returns one result per statement, and
+ * `drizzle-orm@0.45.2`'s `d1/session` maps a SELECT's element to its rows via
+ * `mapResult(result, true)`. Correctness never depends on the tail sharing a
+ * batch with the writes (every earlier batch is already committed by the
+ * time the next one runs) — only the saved round-trip does.
+ *
+ * bun:sqlite has no `.batch()`: every statement, including the tail, just
+ * runs in order in-process, same as {@link commitBatch}'s fallback — chunking
+ * is a D1-only concern there. An empty `groups` list is legal: the tail still
+ * runs and still returns rows.
+ *
+ * Whole-set atomicity is given up beyond the ceiling, the same trade
+ * `commitGroupedBatches` makes — callers must tolerate a mid-run failure
+ * (each group idempotent / re-runnable).
+ */
+export async function commitGroupedBatchesReturning<T>(
+  db: Db,
+  groups: BatchItem<"sqlite">[][],
+  tail: ReturningTail<T>,
+): Promise<T[]> {
+  const batchable = db as BatchableDb;
+  if (typeof batchable.batch !== "function") {
+    for (const group of groups) {
+      for (const stmt of group) {
+        // eslint-disable-next-line no-await-in-loop
+        await stmt;
+      }
+    }
+    return await tail;
+  }
+
+  const chunks: BatchItem<"sqlite">[][] = [];
+  let chunk: BatchItem<"sqlite">[] = [];
+  for (const group of groups) {
+    if (chunk.length > 0 && chunk.length + group.length > MAX_STATEMENTS_PER_BATCH) {
+      chunks.push(chunk);
+      chunk = [];
+    }
+    chunk.push(...group);
+  }
+  if (chunk.length + 1 <= MAX_STATEMENTS_PER_BATCH) {
+    chunks.push([...chunk, tail]);
+  } else {
+    chunks.push(chunk, [tail]);
+  }
+
+  let tailRows: T[] = [];
+  for (const c of chunks) {
+    // eslint-disable-next-line no-await-in-loop
+    const results = await batchable.batch(c as BatchStatements);
+    tailRows = results[results.length - 1] as T[];
+  }
+  return tailRows;
 }

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -194,9 +194,9 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
             }
 
             // Ownership + invitation already validated above — service method does
-            // not re-check. Upsert the whole batch in ONE D1 round-trip (P-W1)
-            // instead of N sequential ones on the guest hot path.
-            yield* rsvpService.submitRsvps(
+            // not re-check. Upsert the whole batch AND read back the family's
+            // current rows in ONE D1 round-trip (P-W1) instead of two.
+            const updatedRsvps = yield* rsvpService.submitRsvpsAndList(
               body.rsvps.map((rsvp) => ({
                 guestId: rsvp.guestId,
                 eventId: rsvp.eventId,
@@ -206,11 +206,11 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
                 // data to authorise; clearing dietary clears the record too.
                 dietaryConsent: rsvp.dietary.length > 0 && rsvp.dietaryConsent,
               })),
+              familyId,
             );
 
             yield* Effect.sync(() => metricRsvpBatchSize(body.rsvps.length));
 
-            const updatedRsvps = yield* rsvpService.getRsvpsForFamily(familyId);
             return { rsvps: updatedRsvps };
           }).pipe(
             Effect.provideService(DbService, db),

--- a/cire/api/src/services/rsvp.ts
+++ b/cire/api/src/services/rsvp.ts
@@ -3,7 +3,8 @@ import { eq } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { Effect } from "effect";
 
-import { DbService, dbQuery, commitGroupedBatches } from "../db";
+import type { Db, ReturningTail } from "../db";
+import { DbService, dbQuery, commitGroupedBatches, commitGroupedBatchesReturning } from "../db";
 import { metricRsvpUpserted } from "../metrics";
 import { DIETARY_CONSENT_VERSION } from "../schemas/rsvp";
 import type { RsvpRecord } from "../schemas/rsvp";
@@ -30,6 +31,71 @@ export interface RsvpInput {
   // so the row is distinguishable and its dietary consent is attested, not
   // self-given. Stamped into `rsvps.consent_source`.
   consentSource?: ConsentSource;
+}
+
+/**
+ * Build one `INSERT … ON CONFLICT DO UPDATE` per input. The single place that
+ * knows the upsert shape — {@link rsvpService.submitRsvps} and
+ * {@link rsvpService.submitRsvpsAndList} both call this instead of building
+ * their own, so the two paths cannot drift apart.
+ */
+function buildRsvpUpsertStatements(
+  db: Db,
+  inputs: readonly RsvpInput[],
+  now: Date,
+): BatchItem<"sqlite">[] {
+  return inputs.map((input) => {
+    const dietaryConsentAt = input.dietaryConsent ? now : null;
+    const dietaryConsentVersion = input.dietaryConsent ? DIETARY_CONSENT_VERSION : null;
+    const consentSource: ConsentSource = input.consentSource ?? "guest";
+    return db
+      .insert(rsvps)
+      .values({
+        id: crypto.randomUUID(),
+        guestId: input.guestId,
+        eventId: input.eventId,
+        status: input.status,
+        dietary: input.dietary,
+        dietaryConsentAt,
+        dietaryConsentVersion,
+        consentSource,
+        createdAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [rsvps.guestId, rsvps.eventId],
+        set: {
+          status: input.status,
+          dietary: input.dietary,
+          dietaryConsentAt,
+          dietaryConsentVersion,
+          // Overwrite the writer/consent provenance too: an organiser
+          // recording over a guest's reply (or vice-versa) must repoint
+          // this so the row reflects who last wrote it.
+          consentSource,
+        },
+      });
+  });
+}
+
+/**
+ * Build the read-back select for a family's RSVPs. The single place that
+ * knows the read-back shape — {@link rsvpService.getRsvpsForFamily} and
+ * {@link rsvpService.submitRsvpsAndList} both call this instead of building
+ * their own. Deliberately unexecuted (no `.all()`): it must ride either as a
+ * `db.batch()` array element (S1: keyed only on `familyId`) or, directly
+ * awaited, resolve to the same rows on bun:sqlite.
+ */
+function buildFamilyRsvpsQuery(db: Db, familyId: string) {
+  return db
+    .select({
+      guestId: rsvps.guestId,
+      eventId: rsvps.eventId,
+      status: rsvps.status,
+      dietary: rsvps.dietary,
+    })
+    .from(rsvps)
+    .innerJoin(guests, eq(rsvps.guestId, guests.id))
+    .where(eq(guests.familyId, familyId));
 }
 
 export const rsvpService = {
@@ -78,37 +144,7 @@ export const rsvpService = {
       if (inputs.length === 0) return;
 
       const now = new Date();
-      const statements: BatchItem<"sqlite">[] = inputs.map((input) => {
-        const dietaryConsentAt = input.dietaryConsent ? now : null;
-        const dietaryConsentVersion = input.dietaryConsent ? DIETARY_CONSENT_VERSION : null;
-        const consentSource: ConsentSource = input.consentSource ?? "guest";
-        return db
-          .insert(rsvps)
-          .values({
-            id: crypto.randomUUID(),
-            guestId: input.guestId,
-            eventId: input.eventId,
-            status: input.status,
-            dietary: input.dietary,
-            dietaryConsentAt,
-            dietaryConsentVersion,
-            consentSource,
-            createdAt: now,
-          })
-          .onConflictDoUpdate({
-            target: [rsvps.guestId, rsvps.eventId],
-            set: {
-              status: input.status,
-              dietary: input.dietary,
-              dietaryConsentAt,
-              dietaryConsentVersion,
-              // Overwrite the writer/consent provenance too: an organiser
-              // recording over a guest's reply (or vice-versa) must repoint
-              // this so the row reflects who last wrote it.
-              consentSource,
-            },
-          });
-      });
+      const statements = buildRsvpUpsertStatements(db, inputs, now);
 
       yield* dbQuery(() =>
         commitGroupedBatches(
@@ -127,21 +163,50 @@ export const rsvpService = {
     return Effect.gen(function* () {
       const db = yield* DbService;
 
-      const rows = yield* dbQuery(() =>
-        db
-          .select({
-            guestId: rsvps.guestId,
-            eventId: rsvps.eventId,
-            status: rsvps.status,
-            dietary: rsvps.dietary,
-          })
-          .from(rsvps)
-          .innerJoin(guests, eq(rsvps.guestId, guests.id))
-          .where(eq(guests.familyId, familyId))
-          .all(),
-      );
+      const rows = yield* dbQuery(() => buildFamilyRsvpsQuery(db, familyId).all());
 
       return rows;
     }).pipe(Effect.withSpan("cire.rsvp.list"));
+  },
+
+  /**
+   * {@link submitRsvps} and {@link getRsvpsForFamily} folded into one commit
+   * (P-W1): the read-back rides as the trailing statement in the same
+   * `db.batch()` array as the upserts instead of a second round-trip after
+   * it. Same ownership precondition as `submitRsvps` — the caller must have
+   * already validated every `guestId` belongs to `familyId` and every
+   * (guestId, eventId) is a real invitation. S1: the read-back is keyed only
+   * on the authenticated `familyId` passed in, never on anything in `inputs`.
+   *
+   * Same `now`/chunking/atomicity trade as `submitRsvps` — see its doc
+   * comment. An empty `inputs` list still runs the read-back and returns
+   * the family's current rows (an empty upsert set is a legal chunk).
+   */
+  submitRsvpsAndList(
+    inputs: readonly RsvpInput[],
+    familyId: string,
+  ): Effect.Effect<RsvpRecord[], never, DbService> {
+    return Effect.gen(function* () {
+      const db = yield* DbService;
+
+      const now = new Date();
+      const statements = buildRsvpUpsertStatements(db, inputs, now);
+      const tail = buildFamilyRsvpsQuery(db, familyId) as ReturningTail<RsvpRecord>;
+
+      const rows = yield* dbQuery(() =>
+        commitGroupedBatchesReturning<RsvpRecord>(
+          db,
+          statements.map((s) => [s]),
+          tail,
+        ),
+      );
+
+      for (const input of inputs) {
+        const writer = (input.consentSource ?? "guest") === "guest" ? "guest" : "organiser";
+        yield* Effect.sync(() => metricRsvpUpserted(input.status, writer, "ok"));
+      }
+
+      return rows;
+    }).pipe(Effect.withSpan("cire.rsvp.submitAndList"));
   },
 };


### PR DESCRIPTION
## Summary

After #716 the guest RSVP submit still made a separate D1 round-trip to read back the family's RSVPs it had just written. This folds that read into the same batch as the writes via a new `commitGroupedBatchesReturning` helper, taking the submit from four round-trips to three and closing the last bullet of the issue.

- `commitGroupedBatchesReturning(db, groups, tail)` in `cire/api/src/db/index.ts` — chunks exactly as `commitGroupedBatches` does, then appends one trailing SELECT and returns its rows.
- `RsvpService.submitRsvpsAndList(inputs, familyId)` replaces the submit-then-list pair, with helpers `buildRsvpUpsertStatements` / `buildFamilyRsvpsQuery`.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/cire-rsvp-readback.md` (`@cire/*` are version-less, so the changeset is named but carries no bump) |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#63 | P-W1 — RSVP submit round-trips; this closes the last bullet (#716 closed the first two) |

Closes xchromo/osn-tracker#63

**Opened**

None.

## Decisions

### The tail rides the final chunk, or ships alone — `P-W1`

- **Issue** — appending a SELECT to the write batch can push that batch over `MAX_STATEMENTS_PER_BATCH` (50).
- **Why** — an over-limit batch is rejected outright, which is the exact bug #713 fixed one PR down the stack. Re-introducing it here would be a poor way to save a round-trip.
- **Solution** — the tail joins the final chunk when `chunk.length + 1 <= MAX_STATEMENTS_PER_BATCH`, and otherwise ships as its own trailing batch.
- **Rationale** — either way the tail is the last statement of the last batch actually sent, so its rows are always `results.at(-1)`. Correctness never depends on the tail sharing a batch with the writes — every earlier batch is already committed by then. Only the saved round-trip does.

### Reading the tail's rows off `results.at(-1)` — `mechanics`

- **Issue** — D1's `batch()` returns one element per statement; the element for a SELECT has to be mapped to rows.
- **Why** — getting this wrong returns a `D1Result` where the caller expects records, and the type system would not catch it across the `unknown[]` boundary.
- **Solution** — rely on `drizzle-orm@0.45.2`'s `d1/session`, which maps a SELECT's element via `mapResult(result, true)` — so the element is already the row array. The version is named in the helper's docstring because this is a behaviour of that driver, not of D1.
- **Rationale** — the alternative is hand-mapping, which duplicates what the driver already does and drifts the moment it changes.

### The read-back is keyed on the authenticated `familyId` — `security`

- **Issue** — folding a read into a write batch is the sort of change that quietly widens what the read returns.
- **Why** — the RSVP list is family-scoped guest data; keying it on anything the request supplied would let one household read another's.
- **Solution** — `buildFamilyRsvpsQuery` takes the `familyId` from the authenticated guest session, the same value the writes are keyed on.
- **Rationale** — same key for the write and the read-back, taken from the session, so the two cannot disagree and neither is caller-controlled.

### bun:sqlite runs the tail in place — `test placement`

- **Issue** — the normal suite has no `.batch()`, so it exercises the fallback path, not the batching one.
- **Why** — as with #713, a test that only runs the fallback proves nothing about the chunking.
- **Solution** — the fallback awaits every statement in order and then awaits the tail, which is correct and covered by the normal suite; the batching path is covered by two new Miniflare tests under `bun run --cwd cire/api test:d1`.
- **Rationale** — both paths have to work, so both are tested, in the tier that can actually observe each.

**Out of scope** — the read gates and error precedence, unchanged from #716.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd cire/api test:d1` | pass — 9 pass (7 pre-existing + 2 new); re-run after the rebase onto #716 |
| `bun run --cwd cire/api test` | pass — 1693 pass |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Re-asserted after the rebase that the chunk-ceiling property from #713 still holds on this branch — the two D1 tests that cross the ceiling pass here as well as there.

Not verified: a latency measurement against deployed D1. The claim is four round-trips to three, counted in code.

Top of stack #717 — `fix/cire-rsvp-batch-ceiling` (#713) → `perf/cire-rsvp-roundtrips` (#716) → **`perf/cire-rsvp-readback`**. Merge last.
