### PR TITLE
perf(ci): declare the frontend build's env inputs to turbo, and reuse its cache in the deploy jobs

### DIFF
--- a/.changeset/ci-turbo-cache-env-social.md
+++ b/.changeset/ci-turbo-cache-env-social.md
@@ -1,0 +1,9 @@
+---
+"@osn/social": patch
+---
+
+Declare the frontend build's environment inputs to turbo, and let the deploy jobs reuse the build cache.
+
+`turbo.json`'s `build` task listed no `env`, so `SITE` and every `PUBLIC_*`/`VITE_*` var not covered by turbo's framework inference were absent from the task hash — the dev and production builds of a package hashed identically. The Build & Test job builds with no environment set, so its artifacts are hashed against empty values and a deploy job restoring that cache could be handed them in place of a build carrying the tier's real values.
+
+`build` now declares `"env": ["PUBLIC_*", "VITE_*", "SITE"]`, and the deploy jobs restore the Build & Test cache and build through turbo (`bun run build --filter=@osn/social`) rather than around it.

--- a/.changeset/ci-turbo-cache-env.md
+++ b/.changeset/ci-turbo-cache-env.md
@@ -1,0 +1,13 @@
+---
+"@cire/landing": patch
+"@cire/invites": patch
+"@cire/host": patch
+---
+
+Declare the frontend build's environment inputs to turbo, and let the deploy jobs reuse the build cache.
+
+`turbo.json`'s `build` task listed no `env`, so a var that only reaches the build through the environment — `SITE`, and every `PUBLIC_*`/`VITE_*` var not covered by turbo's framework inference — was absent from the task hash. Two builds of the same commit that differ only in those vars hashed identically, so the dev build and the production build of a package were, to turbo, the same task.
+
+The Build & Test job runs a bare `bun run build` with no environment set at all. Its artifacts are therefore hashed against empty values, and once the deploy jobs restore that cache they can be handed those env-less artifacts instead of building with the tier's real values. `SITE` alone is enough to show it: it is not framework-inferred, and it is what Astro renders into `<link rel="canonical">` and `og:url`.
+
+`build` now declares `"env": ["PUBLIC_*", "VITE_*", "SITE"]`, which covers every var the ten frontend build steps set. Each deploy job restores the cache saved by Build & Test — keyed on the lockfile plus the commit SHA, falling back to the lockfile alone — and its build now runs as `bun run build --filter=<pkg>` so it goes through turbo at all; `bun run --cwd <pkg> build` bypassed the cache entirely.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,8 +170,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
       - name: Install dependencies
@@ -343,11 +344,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/invites (dev)
-        run: bun run --cwd cire/invites build
+        run: bun run build --filter=@cire/invites
         env:
           PUBLIC_API_URL: https://api.dev.cireweddings.com
           PUBLIC_SITE_URL: https://invite.dev.cireweddings.com
@@ -413,6 +423,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
@@ -423,7 +442,7 @@ jobs:
       #   widget, no gate — key-optional). The matching TURNSTILE_SECRET_KEY is a
       #   `wrangler secret` on the cire-api Worker (see production-deploy.md).
       - name: Build cire/invites
-        run: bun run --cwd cire/invites build
+        run: bun run build --filter=@cire/invites
         env:
           PUBLIC_API_URL: https://api.cireweddings.com
           # Domain reshuffle 2026-07-16: the guest site now lives on the `invite.`
@@ -500,11 +519,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/host (dev)
-        run: bun run --cwd cire/host build
+        run: bun run build --filter=@cire/host
         env:
           PUBLIC_CIRE_API_URL: https://api.dev.cireweddings.com
           # Dev account pages live on the dev identity app — a dev passkey is a
@@ -558,11 +586,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/host
-        run: bun run --cwd cire/host build
+        run: bun run build --filter=@cire/host
         env:
           PUBLIC_CIRE_API_URL: https://api.cireweddings.com
           # The account pages (passkeys, recovery codes) live on musubi's own
@@ -608,11 +645,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/vendor (dev)
-        run: bun run --cwd cire/vendor build
+        run: bun run build --filter=@cire/vendor
         env:
           PUBLIC_CIRE_API_URL: https://api.dev.cireweddings.com
           PUBLIC_OSN_ACCOUNT_URL: https://dev.musubi.social
@@ -656,11 +702,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/vendor
-        run: bun run --cwd cire/vendor build
+        run: bun run build --filter=@cire/vendor
         env:
           PUBLIC_CIRE_API_URL: https://api.cireweddings.com
           # Account management deep link (see the organiser build above).
@@ -703,11 +758,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
       - name: Build cire/landing (dev)
-        run: bun run --cwd cire/landing build
+        run: bun run build --filter=@cire/landing
         env:
           PUBLIC_ORGANISER_URL: https://host.dev.cireweddings.com
           SITE: https://dev.cireweddings.com
@@ -753,6 +817,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
@@ -762,7 +835,7 @@ jobs:
       #     (domain reshuffle 2026-07-16, moved off app.cireweddings.com).
       #   SITE — canonical origin for SEO meta; the apex cireweddings.com.
       - name: Build cire/landing
-        run: bun run --cwd cire/landing build
+        run: bun run build --filter=@cire/landing
         env:
           PUBLIC_ORGANISER_URL: https://host.cireweddings.com
           SITE: https://cireweddings.com
@@ -977,6 +1050,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
@@ -985,7 +1067,7 @@ jobs:
       # per-tier choice (key-optional, fail-closed only when the secret is set).
       # The prod job's gate is what protects the pairing that actually matters.
       - name: Build osn/social (dev)
-        run: bun run --cwd osn/social build
+        run: bun run build --filter=@osn/social
         env:
           VITE_OSN_ISSUER_URL: https://id.dev.musubi.social
           VITE_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
@@ -1029,6 +1111,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-build-
+
       - name: Install dependencies
         run: bun install
 
@@ -1065,7 +1156,7 @@ jobs:
           VITE_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Build osn/social
-        run: bun run --cwd osn/social build
+        run: bun run build --filter=@osn/social
         env:
           VITE_OSN_ISSUER_URL: https://id.musubi.social
           VITE_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,8 @@
         "dist/**",
         ".output/**",
         "build/**"
-      ]
+      ],
+      "env": ["PUBLIC_*", "VITE_*", "SITE"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

`turbo.json`'s `build` task declared no `env` inputs, so a dev build and a production build of the same commit hashed **identically** — and the second one to run got the first one's artifacts out of the cache. `PUBLIC_*` is framework-inferred for Astro, but `SITE` is not, and `SITE` is what writes the canonical URL into every page.

- `"env": ["PUBLIC_*", "VITE_*", "SITE"]` on the `build` task.
- The deploy workflow's ten build steps move from `bun run --cwd <dir> build` to `--filter`, so they go through turbo and get the hash.
- Cache key gains the commit SHA, with lockfile and bare prefixes as fallbacks.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@osn/social` | `.changeset/ci-turbo-cache-env-social.md` |
| root `turbo.json` + `.github/workflows/deploy.yml` | `.changeset/ci-turbo-cache-env.md` — root `turbo.json` is **not** on the allowlist, so it needs one |

Two changeset files because the two touched packages fall on opposite sides of the ignored/versioned split, and `scripts/validate-changesets.sh` forbids mixing those in one file.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#280 | Turbo build task declared no environment inputs — cross-tier cache poisoning |

Closes xchromo/osn-tracker#280

**Opened**

None.

## Decisions

### `SITE` has to be declared; `PUBLIC_*` would have been enough for Astro alone — `correctness`

- **Issue** — Astro's framework inference covers `PUBLIC_*`, so the obvious reading is that turbo already knew about the env that matters.
- **Why** — `SITE` is not `PUBLIC_`-prefixed and is not inferred. It sets Astro's `site` config, which is what renders `<link rel="canonical">` and `<meta property="og:url">` — so a cache hit across tiers ships production pages pointing at dev URLs, or the reverse.
- **Solution** — `"env": ["PUBLIC_*", "VITE_*", "SITE"]` on the `build` task, covering the inferred prefixes explicitly plus the one that was missing.
- **Rationale** — declaring the prefixes alongside `SITE` costs nothing and makes the list readable as "everything that can change output", rather than "the one thing inference missed".

### The deploy workflow's build steps go through turbo — `necessary`

- **Issue** — ten steps ran `bun run --cwd <dir> build`, which bypasses turbo entirely.
- **Why** — a hash fix in `turbo.json` does nothing for a build that never asks turbo for a hash. Without this the `env` declaration would be correct and inert.
- **Solution** — each of the ten becomes a `--filter` invocation.
- **Rationale** — the two halves only work together, which is why they are one PR rather than two.

### Cache key carries the commit SHA — `approach`

- **Issue** — the previous key could serve a stale local cache into a build for a different commit.
- **Why** — belt and braces on top of the hash fix: even with correct hashes, a coarse key means restoring more than the run should see.
- **Solution** — `${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-${{ github.sha }}`, with the lockfile-prefix key and then the bare prefix as `restore-keys` fallbacks.
- **Rationale** — exact-match on SHA when it exists, warm partial restore when it does not; the fallbacks keep the cache useful rather than making every run cold.

**Out of scope** — other turbo tasks (`check`, `test`, `dev`) keep their current inputs; only `build` writes deployable artifacts.

## Test plan

| Gate | Result |
|---|---|
| negative control — build once with `SITE=a`, once with `SITE=b` | **pre-fix**: identical hash, false cache hit. **post-fix**: `1faddcfd93b9f4f4` vs `2cb731a8d482a49e` |
| artifact diff between the two builds | differs in `<link rel="canonical">` and `<meta property="og:url">`, as predicted |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass (two files, split correctly) |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

The negative control is the real evidence: the two differing hashes above are what the bug was, reproduced before the fix and gone after it.

Honest negative: an end-to-end deploy has not been run. The workflow change is verified by reading the ten steps and by the local `--filter` builds succeeding, not by watching dev and production deploy from one commit and land different artifacts. That check belongs to the first merge after this one.
