### PR TITLE
fix(osn-api): narrow the listMembers service projection

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,14 @@
+---
+"@osn/api": patch
+---
+
+Narrow the `listMembers` service projection to `{ id, handle, displayName }`.
+
+The service selected and returned `avatarUrl`, `createdAt` and `updatedAt` as
+well, and its only caller — the `GET /organisations/:id/members` route — never
+used them: the route already gates on membership and already projects the wire
+response down to `handle` and `displayName`. So nothing leaked; this is
+defence in depth. Handing back four unused fields meant a future route that
+spread the profile object instead of projecting it would widen the response
+without anyone noticing. `id` stays, because clients need it to call
+`removeMember` and `updateMemberRole`. The wire contract does not change.

--- a/osn/api/src/services/organisation.ts
+++ b/osn/api/src/services/organisation.ts
@@ -549,9 +549,6 @@ export function createOrganisationService() {
         id: string;
         handle: string;
         displayName: string | null;
-        avatarUrl: string | null;
-        createdAt: Date;
-        updatedAt: Date;
       };
       // The column's own enum, not a bare string: the roster is what a client
       // reads before PATCHing a role back, and both request bodies accept
@@ -590,9 +587,6 @@ export function createOrganisationService() {
               id: users.id,
               handle: users.handle,
               displayName: users.displayName,
-              avatarUrl: users.avatarUrl,
-              createdAt: users.createdAt,
-              updatedAt: users.updatedAt,
               role: organisationMembers.role,
               joinedAt: organisationMembers.createdAt,
             })
@@ -609,9 +603,6 @@ export function createOrganisationService() {
           id: r.id,
           handle: r.handle,
           displayName: r.displayName,
-          avatarUrl: r.avatarUrl,
-          createdAt: r.createdAt,
-          updatedAt: r.updatedAt,
         },
         role: r.role,
         joinedAt: r.joinedAt,

--- a/osn/api/tests/services/organisation.test.ts
+++ b/osn/api/tests/services/organisation.test.ts
@@ -494,6 +494,16 @@ describe("listMembers", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  it.effect("projects only id, handle and displayName on each profile", () =>
+    Effect.gen(function* () {
+      const { organisation } = yield* setupOrgWithOwner;
+
+      const members = yield* org.listMembers(organisation.id);
+      expect(members).toHaveLength(1);
+      expect(Object.keys(members[0].profile).toSorted()).toEqual(["displayName", "handle", "id"]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("fails when org not found", () =>
     Effect.gen(function* () {
       const error = yield* Effect.flip(org.listMembers("org_nonexistent"));


### PR DESCRIPTION
## Summary

`listMembers` in `osn/api/src/services/organisation.ts` selected whole profile rows and let the route pick fields off them. It now selects `{ id, handle, displayName }` — the three the response actually contains. The wire contract is byte-identical; this narrows what the service hands the route so a future field added to `profiles` cannot ride out through this path by accident.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@osn/api` | `.changeset/lucky-donkeys-shave.md` |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#212 | S-H1 — organisation member list selected whole profile rows |

Closes xchromo/osn-tracker#212

**Opened**

None.

## Decisions

### Narrow the select, do not filter at the route — `S-H1`

- **Issue** — the service returned full profile rows; the route projected them down to three fields.
- **Why** — the projection is one edit away from being wrong, and the wrong direction is a leak: add a column to `profiles` and it is in the service's return type immediately, waiting for any caller that spreads.
- **Solution** — `listMembers` selects `{ id, handle, displayName }` at the query.
- **Rationale** — the database returns less, so there is nothing to leak downstream regardless of what the route does with it.

### `id` stays in the projection — `correctness`

- **Issue** — `id` is not in the HTTP response, so it looks like a fourth field to drop.
- **Why** — dropping it breaks a caller: `osn/api/tests/services/profile.test.ts:216` uses the member `id`.
- **Solution** — kept.
- **Rationale** — the service is used by more than one route; the projection is "what callers need", not "what one route serialises".

### This is defence in depth, not a closed leak — `scope`

- **Issue** — the finding is filed as S-H1, which reads as an active exposure.
- **Why** — it is not one. The route was already projecting correctly, so no extra field ever reached a client.
- **Solution** — fixed anyway, and said so plainly here rather than overstating the impact.
- **Rationale** — an honest severity note is worth more than a dramatic one; the reason to fix it is the next column, not the current response.

**Out of scope** — other services returning whole rows. They were not surveyed here; if that is wanted it is its own sweep.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd osn/api test` | pass — 1077 pass across 66 files |
| `bun run --cwd osn/client test` | pass — 194 pass |
| `bun run check` | pass — 29/29 turbo tasks |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

Wire contract checked by hand against the route's response schema: the JSON a client receives is unchanged, which is the property that makes this safe to merge on its own.
