### PR TITLE
perf(osn-api): read the session row once per token refresh

### DIFF
--- a/.changeset/refresh-single-session-read.md
+++ b/.changeset/refresh-single-session-read.md
@@ -1,0 +1,5 @@
+---
+"@osn/api": patch
+---
+
+Drop the duplicate session SELECT in the token-refresh path: `verifyRefreshToken` now returns the device metadata from the row it already loaded, and `refreshTokens` carries it onto the rotated-in row instead of re-reading the same session by primary key.

--- a/osn/api/src/services/auth/tokens.ts
+++ b/osn/api/src/services/auth/tokens.ts
@@ -190,14 +190,25 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
    *
    * Returns `accountId`, `familyId`, and `sessionId` (the hash). The
    * `familyId` is needed by `refreshTokens` for rotation; `sessionId` is
-   * needed by `invalidateOtherAccountSessions` (H1).
+   * needed by `invalidateOtherAccountSessions` (H1). The device metadata
+   * (`createdAt`, `uaLabel`, `ipHash`) rides along from the row loaded here so
+   * `refreshTokens` can carry it onto the rotated-in row without re-reading
+   * the same row by primary key (P-W1).
    *
    * Shared by `refreshTokens`, `switchProfile`, and `listAccountProfiles`.
    */
   const verifyRefreshToken = (
     token: string,
   ): Effect.Effect<
-    { accountId: string; familyId: string; sessionId: string; authenticatedAt: number },
+    {
+      accountId: string;
+      familyId: string;
+      sessionId: string;
+      authenticatedAt: number;
+      createdAt: number;
+      uaLabel: string | null;
+      ipHash: string | null;
+    },
     AuthError | DatabaseError,
     Db
   > =>
@@ -260,6 +271,9 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         familyId: session.familyId,
         sessionId,
         authenticatedAt: session.authenticatedAt ?? session.createdAt,
+        createdAt: session.createdAt,
+        uaLabel: session.uaLabel,
+        ipHash: session.ipHash,
       };
     });
 
@@ -457,6 +471,9 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         accountId,
         familyId,
         sessionId: oldSessionId,
+        authenticatedAt,
+        uaLabel,
+        ipHash,
       } = yield* verifyRefreshToken(sessionToken);
       const profile = yield* findDefaultProfile(accountId);
       if (!profile) {
@@ -481,13 +498,10 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
       const nowSec = Math.floor(Date.now() / 1000);
 
       const { db } = yield* Db;
-      // Read the old session's metadata up front (D1 has no interactive
-      // transaction) so the rotated-in row keeps the device's UA label + IP hash.
-      const existing = yield* Effect.tryPromise({
-        try: () => db.select().from(sessions).where(eq(sessions.id, oldSessionId)).limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-      const old = existing[0];
+      // The old session's metadata (UA label + IP hash + `authenticatedAt`)
+      // comes from the row `verifyRefreshToken` already loaded, so the
+      // rotated-in row keeps the device's identity without a second read of
+      // the same primary key (P-W1).
 
       // CAS gate (S-M refresh-rotation): the old-session DELETE is the atomic
       // compare-and-swap. Two concurrent refreshes of the same token both pass
@@ -545,10 +559,11 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
             // so a background silent refresh can't reset `auth_time` to "now"
             // and satisfy a relying party's `max_age` with zero user presence.
             // Fall back to the old row's `createdAt` for sessions minted before
-            // the column existed.
-            authenticatedAt: old?.authenticatedAt ?? old?.createdAt ?? nowSec,
-            uaLabel: old?.uaLabel ?? null,
-            ipHash: old?.ipHash ?? null,
+            // the column existed — `verifyRefreshToken` already applied that
+            // fallback, so this value is never null.
+            authenticatedAt,
+            uaLabel,
+            ipHash,
             lastUsedAt: nowSec,
           }),
         catch: (cause) => new DatabaseError({ cause }),

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -1325,6 +1325,61 @@ describe("refresh token rotation (C2)", () => {
       expect(result.sessionId).toBeTruthy();
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  // P-W1: the verifier carries the device metadata off the row it already
+  // loaded, so `refreshTokens` no longer re-reads the same session by primary
+  // key. If this stops being returned, the rotation path silently loses the
+  // device's identity.
+  it.effect("verifyRefreshToken returns the session's device metadata", () =>
+    Effect.gen(function* () {
+      // A pepper is required for `ipHash` to be stored at all (context.hashIp).
+      const svc = createAuthService({ ...config, sessionIpPepper: "x".repeat(32) });
+      const profile = yield* svc.registerProfile("verify-meta@example.com", "verifymeta");
+      const tokens = yield* svc.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+        undefined,
+        { uaLabel: "Firefox on macOS", ip: "203.0.113.7" },
+      );
+
+      const result = yield* svc.verifyRefreshToken(tokens.refreshToken);
+      expect(result.uaLabel).toBe("Firefox on macOS");
+      expect(result.ipHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.createdAt).toBeGreaterThan(0);
+      // Freshly issued: the ceremony time is the row's creation time.
+      expect(result.authenticatedAt).toBe(result.createdAt);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("rotation carries uaLabel, ipHash and authenticatedAt onto the new row", () =>
+    Effect.gen(function* () {
+      const svc = createAuthService({ ...config, sessionIpPepper: "x".repeat(32) });
+      const profile = yield* svc.registerProfile("rot-carry@example.com", "rotcarry");
+      const tokens = yield* svc.issueTokens(
+        profile.id,
+        profile.accountId,
+        profile.email,
+        profile.handle,
+        profile.displayName,
+        undefined,
+        { uaLabel: "Safari on iOS", ip: "203.0.113.9" },
+      );
+      const before = yield* svc.verifyRefreshToken(tokens.refreshToken);
+
+      const rotated = yield* svc.refreshTokens(tokens.refreshToken);
+      const after = yield* svc.verifyRefreshToken(rotated.refreshToken);
+
+      expect(after.sessionId).not.toBe(before.sessionId);
+      expect(after.familyId).toBe(before.familyId);
+      expect(after.uaLabel).toBe("Safari on iOS");
+      expect(after.ipHash).toBe(before.ipHash);
+      // `auth_time` survives the silent rotation (OIDC max_age honesty).
+      expect(after.authenticatedAt).toBe(before.authenticatedAt);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`refreshTokens` read the session row twice per refresh: `verifyRefreshToken` already had it, then the caller ran a second `SELECT … WHERE sessions.id = ?` for three fields. `verifyRefreshToken` now returns `uaLabel`, `ipHash` and `createdAt` alongside what it already returned, and the duplicate query is gone. One fewer round-trip on the hottest authenticated path in the product.

- `osn/api/src/services/auth/tokens.ts` — widened return, duplicate SELECT deleted.
- The rotation CAS gate is byte-identical; this touches what is read, not how rotation is decided.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@osn/api` | `.changeset/refresh-single-session-read.md` |

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#171 | P-W1 — refresh path read the session row twice |

Closes xchromo/osn-tracker#171

**Opened**

None.

## Decisions

### Widen the verifier's return rather than pass the row around — `P-W1`

- **Issue** — the second SELECT existed only because `verifyRefreshToken` did not return three fields it had already read.
- **Why** — every refresh is a round-trip, and `authFetch` silently refreshes on any 401, so this is the highest-frequency authenticated query we have.
- **Solution** — `verifyRefreshToken` returns `uaLabel`, `ipHash` and `createdAt` with the rest.
- **Rationale** — the verifier is the only place the row is fetched, so widening its return keeps one owner of the read. Threading the raw row through the caller would have exported the table shape into the calling code.

### The legacy `authenticatedAt ?? createdAt` coalesce stays — `correctness`

- **Issue** — with `createdAt` now returned, the coalesce looks like it could be simplified away.
- **Why** — sessions created before `authenticated_at` existed have it NULL, and that column is what OIDC's `auth_time` is derived from. Dropping the fallback would put a NULL into `auth_time` for old sessions.
- **Solution** — left exactly as it was.
- **Rationale** — the column is still backfill-less; until it is not, the coalesce is the correctness.

### Rotation CAS gate untouched — `security`

- **Issue** — this PR is in the middle of the token-rotation code, which is where session-family revocation is decided.
- **Why** — a change there is a security change, and this is meant to be a read-count change.
- **Solution** — the CAS gate and the reuse-detection path are byte-identical; only the read that feeds them moved.
- **Rationale** — stated explicitly so a reviewer can check one claim rather than re-reading the whole rotation path.

### New tests build the service with a session IP pepper — `mechanics`

- **Issue** — the new tests assert on `ipHash`, which came back `null` at first.
- **Why** — `hashIp` returns `null` when no pepper is configured, so the assertions were passing against a hash that was never computed.
- **Solution** — the tests construct the service with `sessionIpPepper: "x".repeat(32)`.
- **Rationale** — a test that asserts on a field the fixture cannot populate is a test that proves nothing; the pepper makes the assertion real.

**Out of scope** — the rest of the refresh path's queries. Only the duplicated session read is addressed here.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd osn/api test` | pass — 1078/1078 |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |
| CI — Lint & Format / Type Check / OpenAPI Freshness / Require changeset / Shell Scripts | pass |
| CI — Build & Test | pending at time of writing |
| CI — swift test + xcodebuild (Pulse) | skipping (no Swift files in the diff) |

The session-introspection tests (`GET /sessions`) cover `uaLabel` and `ipHash` end to end and pass unchanged — those are the two fields the deleted SELECT used to supply, so their passing is what says the widened return carries the same values.

Not verified: a latency measurement against production. The claim is one fewer query per refresh, counted in code.
