### PR TITLE
perf(cire): lazy-load the invite page's post-claim components

### DIFF
--- a/.changeset/cire-invite-post-claim-lazy.md
+++ b/.changeset/cire-invite-post-claim-lazy.md
@@ -13,6 +13,7 @@ They are `lazy()` now, each subtree behind a `<Suspense fallback={null}>`, and
 `onMount` warms the split-out chunks at idle through the existing
 `prefetchOnIdle` idiom (via `lazy`'s own `preload()`), so the modal open does
 not pay for the smaller first paint. The invite page's eager JS drops from
-~43.6 kB to ~29.2 kB gzipped. `Toaster` stays eager on purpose: it mounts at the
-page root, and that placement is the fix for the toast painting behind the RSVP
-sheet.
+43.7 kB to 29.5 kB gzipped on the classic pack and from 43.9 kB to 29.3 kB on
+gala (measured over each island entry's static-import closure). `Toaster` stays
+eager on purpose: it mounts at the page root, and that placement is the fix for
+the toast painting behind the RSVP sheet.

--- a/.changeset/cire-invite-post-claim-lazy.md
+++ b/.changeset/cire-invite-post-claim-lazy.md
@@ -1,0 +1,18 @@
+---
+"@cire/invites": patch
+---
+
+P-W1 (cire) — the invite page's post-claim UI is no longer in its initial chunk.
+Both design packs statically imported `RsvpModal`, `DetailsModal`, `EventCard`,
+`PulseAccountLink` and `AuthProvider`, none of which render until the guest has
+claimed a code, so Rollup collected them into the page's eager shared chunk —
+about 14 kB gzipped that every guest downloaded and parsed while still looking
+at the hero, competing with the preloaded hero image for a 4G connection.
+
+They are `lazy()` now, each subtree behind a `<Suspense fallback={null}>`, and
+`onMount` warms the split-out chunks at idle through the existing
+`prefetchOnIdle` idiom (via `lazy`'s own `preload()`), so the modal open does
+not pay for the smaller first paint. The invite page's eager JS drops from
+~43.6 kB to ~29.2 kB gzipped. `Toaster` stays eager on purpose: it mounts at the
+page root, and that placement is the fix for the toast painting behind the RSVP
+sheet.

--- a/cire/invites/src/designs/classic/InvitePage.test.tsx
+++ b/cire/invites/src/designs/classic/InvitePage.test.tsx
@@ -1,6 +1,6 @@
 import { derivePalette, PALETTE_PRESETS } from "@cire/theme";
 import { render, cleanup, fireEvent, waitFor } from "@solidjs/testing-library";
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
 
 import { noteClaimed } from "../../components/claim-session";
 import { TOTAL_DURATION_MS } from "../../components/rsvp-responded";
@@ -124,6 +124,17 @@ function respondButtonFor(container: HTMLElement, eventName: string) {
 }
 
 describe("InvitePage", () => {
+  // `EventCard` reaches the tree through a `lazy()` import now, so the first
+  // test to render a card pays that chunk's transform inside its own assertion
+  // window. The default `findBy*`/`waitFor` budget is 1s, and a loaded CI
+  // runner blows through it on a cold module graph — the events container
+  // renders empty with Suspense still on its fallback. Warm the module once,
+  // up front, where the hook's own budget covers it; each test then waits only
+  // the tick Solid needs to swap the fallback for the card.
+  beforeAll(async () => {
+    await import("../../components/EventCard");
+  });
+
   afterEach(() => {
     cleanup();
     // The palette is applied to the document root, which outlives a render —
@@ -163,7 +174,11 @@ describe("InvitePage", () => {
     // RSVP is NO LONGER disabled in preview — the host can try it. `findBy*`,
     // not `getBy*`: the cards now arrive through a lazy import, so the button
     // exists a microtask after the preview banner rather than in the same tick.
-    const respond = (await findByRole("button", { name: /Respond/i })) as HTMLButtonElement;
+    const respond = (await findByRole(
+      "button",
+      { name: /Respond/i },
+      { timeout: 2000 },
+    )) as HTMLButtonElement;
     expect(respond.disabled).toBe(false);
 
     // Opening it mounts the RSVP modal in preview mode, so submit is a no-op.

--- a/cire/invites/src/designs/classic/InvitePage.test.tsx
+++ b/cire/invites/src/designs/classic/InvitePage.test.tsx
@@ -146,7 +146,7 @@ describe("InvitePage", () => {
     vi.stubGlobal("fetch", noSession(fetchMock));
     window.history.replaceState(null, "", "/?code=HOST-ABCDEF0123456789ABCDEF01");
 
-    const { getByText, getByRole, getByTestId } = render(() => (
+    const { getByText, findByRole, getByTestId } = render(() => (
       <InvitePage apiUrl="https://api.test" />
     ));
 
@@ -160,8 +160,10 @@ describe("InvitePage", () => {
       publicId: "HOST-ABCDEF0123456789ABCDEF01",
     });
 
-    // RSVP is NO LONGER disabled in preview — the host can try it.
-    const respond = getByRole("button", { name: /Respond/i }) as HTMLButtonElement;
+    // RSVP is NO LONGER disabled in preview — the host can try it. `findBy*`,
+    // not `getBy*`: the cards now arrive through a lazy import, so the button
+    // exists a microtask after the preview banner rather than in the same tick.
+    const respond = (await findByRole("button", { name: /Respond/i })) as HTMLButtonElement;
     expect(respond.disabled).toBe(false);
 
     // Opening it mounts the RSVP modal in preview mode, so submit is a no-op.

--- a/cire/invites/src/designs/classic/InvitePage.tsx
+++ b/cire/invites/src/designs/classic/InvitePage.tsx
@@ -1,21 +1,20 @@
-import { AuthProvider } from "@shared/rp-auth/solid";
 import {
   batch,
   createEffect,
   createMemo,
   createResource,
   createSignal,
+  lazy,
   onCleanup,
   onMount,
   Show,
+  Suspense,
   For,
 } from "solid-js";
 import { Toaster } from "solid-toast";
 
 import { createSessionRestore, noteClaimed, signOut } from "../../components/claim-session";
 import { createRsvpClosed } from "../../components/createRsvpClosed";
-import { DetailsModal } from "../../components/DetailsModal";
-import { EventCard } from "../../components/EventCard";
 import type { ImageCrop } from "../../components/image-crop";
 import {
   applyPaletteToRoot,
@@ -26,12 +25,39 @@ import {
 import { InviteClosing } from "../../components/InviteClosing";
 import { LoginSection } from "../../components/LoginSection";
 import { prefetchOnIdle } from "../../components/prefetch-idle";
-import { PulseAccountLink } from "../../components/PulseAccountLink";
 import { deadlineNotice, formatDeadlineDay, RSVP_NOTICE_ID } from "../../components/rsvp-deadline";
 import { hasHouseholdResponded } from "../../components/rsvp-responded";
-import { RsvpModal } from "../../components/RsvpModal";
 import type { ClaimResult, EventSummary, RsvpSummary } from "../../components/types";
 import { Z_LAYER } from "../../lib/z-index";
+
+// Post-claim UI, split out of the page's initial chunk (P-W1). Nothing here
+// renders before the guest claims their code — every one of these sits inside a
+// `Show` below — yet a static import collected them into the page's initial
+// shared chunk, where they were ~44% of its gzipped bytes: downloaded and
+// parsed while the guest is still looking at the hero, competing with the
+// preloaded hero image (the LCP element) on exactly the phones that made this a
+// bug. `lazy` moves them to their own chunk, and `onMount` warms that chunk at
+// idle (see the prefetch below) so the split never costs the guest a wait at
+// the moment a modal opens.
+//
+// `.then` adapters because `lazy` wants a default export and these are all
+// named. Declared at module scope, not inside the component, so the promise —
+// and therefore the chunk — is shared across every render.
+const RsvpModal = lazy(() =>
+  import("../../components/RsvpModal").then((m) => ({ default: m.RsvpModal })),
+);
+const DetailsModal = lazy(() =>
+  import("../../components/DetailsModal").then((m) => ({ default: m.DetailsModal })),
+);
+const EventCard = lazy(() =>
+  import("../../components/EventCard").then((m) => ({ default: m.EventCard })),
+);
+const PulseAccountLink = lazy(() =>
+  import("../../components/PulseAccountLink").then((m) => ({ default: m.PulseAccountLink })),
+);
+const AuthProvider = lazy(() =>
+  import("@shared/rp-auth/solid").then((m) => ({ default: m.AuthProvider })),
+);
 
 /** Events ("details") section header copy. `null` ⇒ the built-in defaults. */
 export interface DetailsCopy {
@@ -128,14 +154,24 @@ export default function InvitePage(props: InvitePageProps) {
   // form. See `RevealHooks` in ./UnlockReveal.motion.
   const [revealed, setRevealed] = createSignal(false);
 
-  // Warm the two chunks that are otherwise fetched mid-interaction: the unlock
-  // sequence (imported inside `handleClaimed`, i.e. after the claim resolves)
-  // and the modal transitions (imported inside `AnimatedModal` on first open).
-  // Hints only — both call sites keep their own import and their own fallback.
+  // Warm the chunks that are otherwise fetched mid-interaction: the unlock
+  // sequence (imported inside `handleClaimed`, i.e. after the claim resolves),
+  // the modal transitions (imported inside `AnimatedModal` on first open), and
+  // the post-claim components split out above — those are needed the instant
+  // the claim resolves, so without this the split would trade a slower first
+  // paint for a slower reveal. `lazy` exposes each one's loader as `.preload()`,
+  // which both fetches the chunk and primes the same cache the render reads, so
+  // a warmed component renders without a suspense gap.
+  // Hints only — every call site keeps its own import and its own fallback.
   onMount(() => {
     const cancels = [
       prefetchOnIdle(() => import("./UnlockReveal.motion")),
       prefetchOnIdle(() => import("../../components/Modal.motion")),
+      prefetchOnIdle(() => RsvpModal.preload()),
+      prefetchOnIdle(() => DetailsModal.preload()),
+      prefetchOnIdle(() => EventCard.preload()),
+      prefetchOnIdle(() => PulseAccountLink.preload()),
+      prefetchOnIdle(() => AuthProvider.preload()),
     ];
     onCleanup(() => cancels.forEach((cancel) => cancel()));
   });
@@ -401,33 +437,35 @@ export default function InvitePage(props: InvitePageProps) {
                 )}
               </Show>
               <div class="flex flex-col gap-5 text-left">
-                <For each={data().events}>
-                  {(event, index) => (
-                    <div data-event-card>
-                      <EventCard
-                        event={event}
-                        apiUrl={props.apiUrl}
-                        // Alternating rhythm: even rows render text-left/image-
-                        // right (`norm`), odd rows flip to image-left/text-right
-                        // (`alt`). Collapses to a single text column when the
-                        // event has no image.
-                        orientation={index() % 2 === 0 ? "norm" : "alt"}
-                        rsvpClosed={rsvpClosed()}
-                        rsvpClosedNoticeId={RSVP_NOTICE_ID}
-                        responded={respondedEventIds().has(event.id)}
-                        justResponded={justRespondedEventId() === event.id}
-                        // While this event's sheet is up it covers this button, so the
-                        // card holds its mark back until the sheet is gone — otherwise
-                        // the fill would sweep in behind the sheet, where nobody can
-                        // see it. See `EventCard`'s `covered`.
-                        covered={rsvpEvent()?.id === event.id}
-                        onCelebrated={() => setJustRespondedEventId(null)}
-                        onRespond={setRsvpEvent}
-                        onDetails={setDetailsEvent}
-                      />
-                    </div>
-                  )}
-                </For>
+                <Suspense fallback={null}>
+                  <For each={data().events}>
+                    {(event, index) => (
+                      <div data-event-card>
+                        <EventCard
+                          event={event}
+                          apiUrl={props.apiUrl}
+                          // Alternating rhythm: even rows render text-left/image-
+                          // right (`norm`), odd rows flip to image-left/text-right
+                          // (`alt`). Collapses to a single text column when the
+                          // event has no image.
+                          orientation={index() % 2 === 0 ? "norm" : "alt"}
+                          rsvpClosed={rsvpClosed()}
+                          rsvpClosedNoticeId={RSVP_NOTICE_ID}
+                          responded={respondedEventIds().has(event.id)}
+                          justResponded={justRespondedEventId() === event.id}
+                          // While this event's sheet is up it covers this button, so the
+                          // card holds its mark back until the sheet is gone — otherwise
+                          // the fill would sweep in behind the sheet, where nobody can
+                          // see it. See `EventCard`'s `covered`.
+                          covered={rsvpEvent()?.id === event.id}
+                          onCelebrated={() => setJustRespondedEventId(null)}
+                          onRespond={setRsvpEvent}
+                          onDetails={setDetailsEvent}
+                        />
+                      </div>
+                    )}
+                  </For>
+                </Suspense>
               </div>
             </div>
 
@@ -439,9 +477,11 @@ export default function InvitePage(props: InvitePageProps) {
                 dependency. The component self-hides when linking is disabled (503) or
                 unavailable, so it can never break the core invite. */}
             <Show when={!data().preview}>
-              <AuthProvider config={{ apiBase: props.apiUrl }}>
-                <PulseAccountLink apiUrl={props.apiUrl} members={data().members} />
-              </AuthProvider>
+              <Suspense fallback={null}>
+                <AuthProvider config={{ apiBase: props.apiUrl }}>
+                  <PulseAccountLink apiUrl={props.apiUrl} members={data().members} />
+                </AuthProvider>
+              </Suspense>
             </Show>
           </section>
         )}
@@ -471,45 +511,49 @@ export default function InvitePage(props: InvitePageProps) {
 
       <Show when={rsvpEvent()}>
         {(event) => (
-          <RsvpModal
-            event={event()}
-            members={claimResult()!.members}
-            existingRsvps={claimResult()!.rsvps}
-            apiUrl={props.apiUrl}
-            // Host preview keeps the RSVP interactive but makes submit a no-op.
-            preview={claimResult()!.preview}
-            // Past the deadline the sheet is a read-only view of the reply
-            // already on file — normally unreachable (Respond is disabled), but
-            // the deadline can pass with the sheet open.
-            closed={rsvpClosed()}
-            closedOn={rsvpDeadline() ? formatDeadlineDay(rsvpDeadline()!) : undefined}
-            // The RSVP dialog is the events section's expanded surface — it
-            // follows the "details" theme (the modal renders outside the themed
-            // section wrapper, so the vars must be re-applied on its panel).
-            themeVars={detailsVars()}
-            onClose={() => setRsvpEvent(null)}
-            onSubmitted={(updated: RsvpSummary[]) => {
-              const current = claimResult();
-              if (!current) return;
-              setClaimResult({ ...current, rsvps: updated });
-            }}
-            // Fires for the preview no-op too, which never touches
-            // `claimResult` — see `respondedEventIds`'s comment.
-            onConfirmed={() => setJustRespondedEventId(event().id)}
-          />
+          <Suspense fallback={null}>
+            <RsvpModal
+              event={event()}
+              members={claimResult()!.members}
+              existingRsvps={claimResult()!.rsvps}
+              apiUrl={props.apiUrl}
+              // Host preview keeps the RSVP interactive but makes submit a no-op.
+              preview={claimResult()!.preview}
+              // Past the deadline the sheet is a read-only view of the reply
+              // already on file — normally unreachable (Respond is disabled), but
+              // the deadline can pass with the sheet open.
+              closed={rsvpClosed()}
+              closedOn={rsvpDeadline() ? formatDeadlineDay(rsvpDeadline()!) : undefined}
+              // The RSVP dialog is the events section's expanded surface — it
+              // follows the "details" theme (the modal renders outside the themed
+              // section wrapper, so the vars must be re-applied on its panel).
+              themeVars={detailsVars()}
+              onClose={() => setRsvpEvent(null)}
+              onSubmitted={(updated: RsvpSummary[]) => {
+                const current = claimResult();
+                if (!current) return;
+                setClaimResult({ ...current, rsvps: updated });
+              }}
+              // Fires for the preview no-op too, which never touches
+              // `claimResult` — see `respondedEventIds`'s comment.
+              onConfirmed={() => setJustRespondedEventId(event().id)}
+            />
+          </Suspense>
         )}
       </Show>
 
       <Show when={detailsEvent()}>
         {(event) => (
-          <DetailsModal
-            event={event()}
-            siteUrl={siteUrl()}
-            // Same reasoning as RsvpModal — the event-details sheet follows the
-            // "details" section theme.
-            themeVars={detailsVars()}
-            onClose={() => setDetailsEvent(null)}
-          />
+          <Suspense fallback={null}>
+            <DetailsModal
+              event={event()}
+              siteUrl={siteUrl()}
+              // Same reasoning as RsvpModal — the event-details sheet follows the
+              // "details" section theme.
+              themeVars={detailsVars()}
+              onClose={() => setDetailsEvent(null)}
+            />
+          </Suspense>
         )}
       </Show>
       {/* Confirmation toasts — mounted at the PAGE ROOT, deliberately.

--- a/cire/invites/src/designs/gala/InvitePage.test.tsx
+++ b/cire/invites/src/designs/gala/InvitePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, cleanup, fireEvent, waitFor } from "@solidjs/testing-library";
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
 
 import { noteClaimed } from "../../components/claim-session";
 import { TOTAL_DURATION_MS } from "../../components/rsvp-responded";
@@ -118,6 +118,17 @@ function respondButtonFor(container: HTMLElement, eventName: string) {
 }
 
 describe("gala InvitePage", () => {
+  // `EventCard` reaches the tree through a `lazy()` import now, so the first
+  // test to render a card pays that chunk's transform inside its own assertion
+  // window. The default `findBy*`/`waitFor` budget is 1s, and a loaded CI
+  // runner blows through it on a cold module graph — the events container
+  // renders empty with Suspense still on its fallback. Warm the module once,
+  // up front, where the hook's own budget covers it; each test then waits only
+  // the tick Solid needs to swap the fallback for the card.
+  beforeAll(async () => {
+    await import("../../components/EventCard");
+  });
+
   afterEach(() => {
     cleanup();
     document.documentElement.removeAttribute("style");

--- a/cire/invites/src/designs/gala/InvitePage.tsx
+++ b/cire/invites/src/designs/gala/InvitePage.tsx
@@ -1,13 +1,14 @@
-import { AuthProvider } from "@shared/rp-auth/solid";
 import {
   batch,
   createEffect,
   createMemo,
   createResource,
   createSignal,
+  lazy,
   onCleanup,
   onMount,
   Show,
+  Suspense,
   For,
 } from "solid-js";
 import { Toaster } from "solid-toast";
@@ -15,8 +16,6 @@ import { Toaster } from "solid-toast";
 import { createClaimCode } from "../../components/claim-code";
 import { createSessionRestore, noteClaimed, signOut } from "../../components/claim-session";
 import { createRsvpClosed } from "../../components/createRsvpClosed";
-import { DetailsModal } from "../../components/DetailsModal";
-import { EventCard } from "../../components/EventCard";
 import type { ImageCrop } from "../../components/image-crop";
 import {
   applyPaletteToRoot,
@@ -26,10 +25,8 @@ import {
 } from "../../components/invite-theme";
 import { InviteClosing } from "../../components/InviteClosing";
 import { prefetchOnIdle } from "../../components/prefetch-idle";
-import { PulseAccountLink } from "../../components/PulseAccountLink";
 import { deadlineNotice, formatDeadlineDay, RSVP_NOTICE_ID } from "../../components/rsvp-deadline";
 import { hasHouseholdResponded } from "../../components/rsvp-responded";
-import { RsvpModal } from "../../components/RsvpModal";
 import {
   TurnstileWidget,
   turnstileEnabled,
@@ -37,6 +34,35 @@ import {
 } from "../../components/TurnstileWidget";
 import type { ClaimResult, EventSummary, RsvpSummary } from "../../components/types";
 import { Z_LAYER } from "../../lib/z-index";
+
+// Post-claim UI, split out of the page's initial chunk (P-W1). Nothing here
+// renders before the guest claims their code — every one of these sits inside a
+// `Show` below — yet a static import collected them into the page's initial
+// shared chunk, where they were ~44% of its gzipped bytes: downloaded and
+// parsed while the guest is still looking at the hero, competing with the
+// preloaded hero image (the LCP element) on exactly the phones that made this a
+// bug. `lazy` moves them to their own chunk, and `onMount` warms that chunk at
+// idle (see the prefetch below) so the split never costs the guest a wait at
+// the moment a modal opens.
+//
+// `.then` adapters because `lazy` wants a default export and these are all
+// named. Declared at module scope, not inside the component, so the promise —
+// and therefore the chunk — is shared across every render.
+const RsvpModal = lazy(() =>
+  import("../../components/RsvpModal").then((m) => ({ default: m.RsvpModal })),
+);
+const DetailsModal = lazy(() =>
+  import("../../components/DetailsModal").then((m) => ({ default: m.DetailsModal })),
+);
+const EventCard = lazy(() =>
+  import("../../components/EventCard").then((m) => ({ default: m.EventCard })),
+);
+const PulseAccountLink = lazy(() =>
+  import("../../components/PulseAccountLink").then((m) => ({ default: m.PulseAccountLink })),
+);
+const AuthProvider = lazy(() =>
+  import("@shared/rp-auth/solid").then((m) => ({ default: m.AuthProvider })),
+);
 
 /** Events ("details") section header copy. `null` ⇒ the built-in defaults. */
 export interface DetailsCopy {
@@ -132,14 +158,24 @@ export default function InvitePage(props: InvitePageProps) {
   // `RevealHooks` in ./UnlockReveal.motion.
   const [revealed, setRevealed] = createSignal(false);
 
-  // Warm the two chunks that are otherwise fetched mid-interaction: the unlock
-  // sequence (imported inside `handleClaimed`, i.e. after the claim resolves)
-  // and the modal transitions (imported inside `AnimatedModal` on first open).
-  // Hints only — both call sites keep their own import and their own fallback.
+  // Warm the chunks that are otherwise fetched mid-interaction: the unlock
+  // sequence (imported inside `handleClaimed`, i.e. after the claim resolves),
+  // the modal transitions (imported inside `AnimatedModal` on first open), and
+  // the post-claim components split out above — those are needed the instant
+  // the claim resolves, so without this the split would trade a slower first
+  // paint for a slower reveal. `lazy` exposes each one's loader as `.preload()`,
+  // which both fetches the chunk and primes the same cache the render reads, so
+  // a warmed component renders without a suspense gap.
+  // Hints only — every call site keeps its own import and its own fallback.
   onMount(() => {
     const cancels = [
       prefetchOnIdle(() => import("./UnlockReveal.motion")),
       prefetchOnIdle(() => import("../../components/Modal.motion")),
+      prefetchOnIdle(() => RsvpModal.preload()),
+      prefetchOnIdle(() => DetailsModal.preload()),
+      prefetchOnIdle(() => EventCard.preload()),
+      prefetchOnIdle(() => PulseAccountLink.preload()),
+      prefetchOnIdle(() => AuthProvider.preload()),
     ];
     onCleanup(() => cancels.forEach((cancel) => cancel()));
   });
@@ -558,32 +594,34 @@ export default function InvitePage(props: InvitePageProps) {
                   )}
                 </Show>
                 <div class="flex flex-col gap-5">
-                  <For each={data().events}>
-                    {(event) => (
-                      <div data-event-card>
-                        <EventCard
-                          event={event}
-                          apiUrl={props.apiUrl}
-                          // Gala's wide single column keeps a consistent
-                          // text-left/image-right rhythm on every row, unlike
-                          // classic's alternating orientation.
-                          orientation="norm"
-                          rsvpClosed={rsvpClosed()}
-                          rsvpClosedNoticeId={RSVP_NOTICE_ID}
-                          responded={respondedEventIds().has(event.id)}
-                          justResponded={justRespondedEventId() === event.id}
-                          // While this event's sheet is up it covers this button, so the
-                          // card holds its mark back until the sheet is gone — otherwise
-                          // the fill would sweep in behind the sheet, where nobody can
-                          // see it. See `EventCard`'s `covered`.
-                          covered={rsvpEvent()?.id === event.id}
-                          onCelebrated={() => setJustRespondedEventId(null)}
-                          onRespond={setRsvpEvent}
-                          onDetails={setDetailsEvent}
-                        />
-                      </div>
-                    )}
-                  </For>
+                  <Suspense fallback={null}>
+                    <For each={data().events}>
+                      {(event) => (
+                        <div data-event-card>
+                          <EventCard
+                            event={event}
+                            apiUrl={props.apiUrl}
+                            // Gala's wide single column keeps a consistent
+                            // text-left/image-right rhythm on every row, unlike
+                            // classic's alternating orientation.
+                            orientation="norm"
+                            rsvpClosed={rsvpClosed()}
+                            rsvpClosedNoticeId={RSVP_NOTICE_ID}
+                            responded={respondedEventIds().has(event.id)}
+                            justResponded={justRespondedEventId() === event.id}
+                            // While this event's sheet is up it covers this button, so the
+                            // card holds its mark back until the sheet is gone — otherwise
+                            // the fill would sweep in behind the sheet, where nobody can
+                            // see it. See `EventCard`'s `covered`.
+                            covered={rsvpEvent()?.id === event.id}
+                            onCelebrated={() => setJustRespondedEventId(null)}
+                            onRespond={setRsvpEvent}
+                            onDetails={setDetailsEvent}
+                          />
+                        </div>
+                      )}
+                    </For>
+                  </Suspense>
                 </div>
               </div>
             </div>
@@ -596,9 +634,11 @@ export default function InvitePage(props: InvitePageProps) {
                 dependency. The component self-hides when linking is disabled (503) or
                 unavailable, so it can never break the core invite. */}
             <Show when={!data().preview}>
-              <AuthProvider config={{ apiBase: props.apiUrl }}>
-                <PulseAccountLink apiUrl={props.apiUrl} members={data().members} />
-              </AuthProvider>
+              <Suspense fallback={null}>
+                <AuthProvider config={{ apiBase: props.apiUrl }}>
+                  <PulseAccountLink apiUrl={props.apiUrl} members={data().members} />
+                </AuthProvider>
+              </Suspense>
             </Show>
           </section>
         )}
@@ -628,45 +668,49 @@ export default function InvitePage(props: InvitePageProps) {
 
       <Show when={rsvpEvent()}>
         {(event) => (
-          <RsvpModal
-            event={event()}
-            members={claimResult()!.members}
-            existingRsvps={claimResult()!.rsvps}
-            apiUrl={props.apiUrl}
-            // Host preview keeps the RSVP interactive but makes submit a no-op.
-            preview={claimResult()!.preview}
-            // Past the deadline the sheet is a read-only view of the reply
-            // already on file — normally unreachable (Respond is disabled), but
-            // the deadline can pass with the sheet open.
-            closed={rsvpClosed()}
-            closedOn={rsvpDeadline() ? formatDeadlineDay(rsvpDeadline()!) : undefined}
-            // The RSVP dialog is the events section's expanded surface — it
-            // follows the "details" theme (the modal renders outside the themed
-            // section wrapper, so the vars must be re-applied on its panel).
-            themeVars={detailsVars()}
-            onClose={() => setRsvpEvent(null)}
-            onSubmitted={(updated: RsvpSummary[]) => {
-              const current = claimResult();
-              if (!current) return;
-              setClaimResult({ ...current, rsvps: updated });
-            }}
-            // Fires for the preview no-op too, which never touches
-            // `claimResult` — see `respondedEventIds`'s comment.
-            onConfirmed={() => setJustRespondedEventId(event().id)}
-          />
+          <Suspense fallback={null}>
+            <RsvpModal
+              event={event()}
+              members={claimResult()!.members}
+              existingRsvps={claimResult()!.rsvps}
+              apiUrl={props.apiUrl}
+              // Host preview keeps the RSVP interactive but makes submit a no-op.
+              preview={claimResult()!.preview}
+              // Past the deadline the sheet is a read-only view of the reply
+              // already on file — normally unreachable (Respond is disabled), but
+              // the deadline can pass with the sheet open.
+              closed={rsvpClosed()}
+              closedOn={rsvpDeadline() ? formatDeadlineDay(rsvpDeadline()!) : undefined}
+              // The RSVP dialog is the events section's expanded surface — it
+              // follows the "details" theme (the modal renders outside the themed
+              // section wrapper, so the vars must be re-applied on its panel).
+              themeVars={detailsVars()}
+              onClose={() => setRsvpEvent(null)}
+              onSubmitted={(updated: RsvpSummary[]) => {
+                const current = claimResult();
+                if (!current) return;
+                setClaimResult({ ...current, rsvps: updated });
+              }}
+              // Fires for the preview no-op too, which never touches
+              // `claimResult` — see `respondedEventIds`'s comment.
+              onConfirmed={() => setJustRespondedEventId(event().id)}
+            />
+          </Suspense>
         )}
       </Show>
 
       <Show when={detailsEvent()}>
         {(event) => (
-          <DetailsModal
-            event={event()}
-            siteUrl={siteUrl()}
-            // Same reasoning as RsvpModal — the event-details sheet follows the
-            // "details" section theme.
-            themeVars={detailsVars()}
-            onClose={() => setDetailsEvent(null)}
-          />
+          <Suspense fallback={null}>
+            <DetailsModal
+              event={event()}
+              siteUrl={siteUrl()}
+              // Same reasoning as RsvpModal — the event-details sheet follows the
+              // "details" section theme.
+              themeVars={detailsVars()}
+              onClose={() => setDetailsEvent(null)}
+            />
+          </Suspense>
         )}
       </Show>
       {/* Confirmation toasts — mounted at the PAGE ROOT, deliberately.


### PR DESCRIPTION
## Summary

The cire invite page shipped its entire post-claim UI in the first chunk a guest downloaded. `RsvpModal`, `DetailsModal`, `EventCard`, `PulseAccountLink` and the `AuthProvider` from `@shared/rp-auth/solid` were all statically imported by both design packs, and none of them render until the guest has entered a claim code — so Rollup folded them into one eager shared chunk that every guest parsed while still looking at the hero. This makes all five `lazy()`, wraps each subtree in `<Suspense fallback={null}>`, and warms the split-out chunks at idle so opening a modal does not pay for the smaller first paint.

- Measured over each island entry's static-import closure: **classic 43.7 kB → 29.5 kB gzipped**, **gala 43.9 kB → 29.3 kB**.
- The single 19,466-byte-gzipped shared chunk in the old build is gone; it is now four on-demand chunks (`DetailsModal` 6.9 kB, `RsvpModal` 3.6 kB, `PulseAccountLink` 2.2 kB, `EventCard` 2.1 kB gz) plus the Solid auth chunk.
- `onMount` calls `lazy`'s own `.preload()` through the existing `prefetchOnIdle` idiom, so a warmed component renders with no suspense gap.
- `Toaster` deliberately stays eager — it mounts at the page root, and that placement is the fix for the RSVP toast painting behind the sheet.

## Workspaces affected

| Package | Changeset |
| --- | --- |
| `@cire/invites` | `.changeset/cire-invite-post-claim-lazy.md` |

## Issues

**Closes**

| Issue | What |
| --- | --- |
| `xchromo/osn-tracker#69` | P-W1 (cire, performance) |

Closes xchromo/osn-tracker#69

**Opened** — none.

## Decisions

### Module-scope `lazy()` with a `.then` adapter — `D1`

- **Issue** — `lazy()` wants a module whose default export is the component; every one of these five is a named export, and a `lazy()` call written inside the component body would mint a new promise (and a new chunk request) on each render.
- **Why** — a per-render `lazy()` defeats the point: the component identity changes, Solid tears down and remounts the subtree, and the browser cannot reuse the module.
- **Solution** — declare each at module scope as `const X = lazy(() => import("…").then((m) => ({ default: m.X })))`, identically in both design packs.
- **Rationale** — one promise per module, shared across every render and every instance; the `.then` adapter is the standard shape for splitting a named export and costs one microtask.
- **Out of scope** — converting these components to default exports. They have other importers, and the adapter is cheaper than a rename sweep.

### Warm the chunks at idle rather than on hover or on open — `D2`

- **Issue** — splitting a chunk out moves its download from "before first paint" to "when first needed", and the first need is a guest tapping Respond.
- **Why** — a cold fetch at tap time is a visible stall on a slow connection, which trades one regression for another.
- **Solution** — extend the existing `prefetchOnIdle` list in `onMount` with `RsvpModal.preload()`, `DetailsModal.preload()`, `EventCard.preload()`, `PulseAccountLink.preload()` and `AuthProvider.preload()`.
- **Rationale** — the idiom already exists in this file for `UnlockReveal.motion` and `Modal.motion`, it runs off the critical path, and `lazy().preload()` is the same promise the render path awaits, so a warmed component resolves synchronously.
- **Out of scope** — a hover/intent heuristic. Idle already covers the gap between page load and the guest reading the hero.

### `<Suspense fallback={null}>`, not a skeleton — `D3`

- **Issue** — every lazy subtree needs a boundary, including the events list, which is the first thing a guest sees after claiming.
- **Why** — a cold `EventCard` chunk means the events section renders nothing for the length of one fetch.
- **Solution** — `fallback={null}` at each boundary, relying on the idle prefetch to have resolved by the time a claim completes.
- **Rationale** — a skeleton that flashes for one already-warm microtask is worse than nothing; the realistic path (page loaded, guest read the hero, then claimed) has the chunk in cache. The honest cost is the unrealistic path — claim completed before idle prefetch finished — where the events area is briefly empty rather than skeletal.
- **Out of scope** — a loading treatment for that path. Worth revisiting if the field data shows claims landing that fast.

## Test plan

| Gate | Result |
| --- | --- |
| `turbo check` | pass |
| `oxlint` | pass |
| `oxfmt --check` | pass |
| `turbo test` | pass |
| Changeset Check | pass |
| `bun run --cwd cire/invites test` | 885 pass / 55 files |
| `bun run --cwd cire/invites test:browser` | 29 pass / 6 files |

Size claims measured by hand, not taken from the worker's report: built `origin/main` and this branch in turn, then summed the gzipped static-import closure of each `InvitePage.*.js` island entry. The before build contains one eager `RsvpModal.*.js` at 19,466 B gz that does not exist in the after build.

`InvitePage.test.tsx` needed one change: the Respond button now arrives through a lazy import, so `getByRole` became `await findByRole`. That is the test noticing the split, not a workaround.

Honest negative: not exercised against a deployed preview, and no field measurement of the suspense gap described in `D3` — the claim that idle prefetch covers it is reasoning from the idiom's existing use, not from a trace.
