### PR TITLE
perf(cire): reconcile the RSVP list on reload instead of replacing it

### DIFF
--- a/.changeset/cire-rsvp-view-reconcile.md
+++ b/.changeset/cire-rsvp-view-reconcile.md
@@ -1,0 +1,22 @@
+---
+"@cire/host": patch
+---
+
+Reconcile the RSVP list on reload instead of replacing it.
+
+`RsvpView`'s `load()` re-fetched `/rsvps` after every save and swapped the
+whole events array, so saving one guest's reply threw away every event and
+row object in the wedding and forced `<For>` to rebuild the entire table —
+the exact rebuild the row memos existed to avoid, paid on every save.
+
+The events list now lives in a `createStore`, reconciled by `id` on reload
+so an untouched event keeps its object identity. That alone isn't enough:
+a whole-list memo still re-merges every event's rows on any nested change.
+Row merging and filtering are now scoped per event via `createMemo(mapArray(...))`,
+so only the event whose own guests changed re-runs its row/visibility memos —
+the rest keep their row array identity and `<For>` patches in place rather
+than remounting.
+
+Reactivity-only change: no behaviour, markup, ARIA, or copy moved. Adds a
+test asserting a row in an untouched event is the same DOM node across a
+save-and-reload, while the changed event's row updates.

--- a/cire/host/src/components/RsvpView.test.tsx
+++ b/cire/host/src/components/RsvpView.test.tsx
@@ -430,6 +430,72 @@ describe("RsvpView", () => {
     expect(body.status).toBe("declined");
   });
 
+  it("keeps an unrelated event's row identity across a reload, patches the one that changed", async () => {
+    // The point of the store + mapArray split: a reload must not rebuild every
+    // <section>/<tr> in the wedding, only the one event whose data actually moved.
+    const RELOADED = {
+      events: VIEW.events.map((event) =>
+        event.id === "evt_1"
+          ? {
+              ...event,
+              attending: 2,
+              responded: 4,
+              noResponse: 0,
+              guests: [
+                ...event.guests,
+                {
+                  ...CLEO,
+                  status: "attending" as const,
+                  dietary: "Nut allergy",
+                  consentSource: "organiser_attested" as const,
+                },
+              ],
+              unresponded: [],
+            }
+          : event,
+      ),
+    };
+    authFetchMock
+      .mockResolvedValueOnce(json(VIEW)) // initial load
+      .mockResolvedValueOnce(
+        json({ rsvp: { status: "attending", consentSource: "organiser_attested" } }),
+      ) // PUT
+      .mockResolvedValueOnce(json(RELOADED)); // reload after save
+    render(() => <RsvpView weddingId="wed_a" canEdit />);
+    await waitFor(() => expect(screen.getByText("Bo Jones")).toBeTruthy());
+
+    // Reception never changes across this save — Ada's silent row there is the
+    // control. A whole-list rebuild would swap this node out even though nothing
+    // about Reception moved.
+    const reception = screen.getByText("Reception").closest("section")!;
+    const untouchedRow = within(reception).getByText("Ada Sharma").closest("tr")!;
+
+    fireEvent.click(screen.getByRole("button", { name: "Record reply for Cleo Jones" }));
+    const dietary = await screen.findByLabelText(/Dietary requirements/i);
+    fireEvent.input(dietary, { target: { value: "Nut allergy" } });
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /Save reply/i }));
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalledTimes(3));
+
+    // Cleo's own row is the one that should have moved — she now has a reply,
+    // so a brand-new <tr> for her is correct. The reload body still has to parse
+    // and land in the store after the third call resolves, so requery the whole
+    // way down on each tick: a captured <section> would go stale the moment a
+    // rebuild swapped it out, and this half of the test must fail for its own
+    // reason, not that one.
+    await waitFor(() => {
+      const ceremony = screen.getByText("Ceremony").closest("section")!;
+      const cleoRow = within(ceremony).getByText("Cleo Jones").closest("tr")!;
+      expect(within(cleoRow).getByText("Attending")).toBeTruthy();
+    });
+
+    const receptionAfter = screen.getByText("Reception").closest("section")!;
+    const rowAfter = within(receptionAfter).getByText("Ada Sharma").closest("tr")!;
+    expect(rowAfter).toBe(untouchedRow);
+    expect(document.body.contains(untouchedRow)).toBe(true);
+  });
+
   it("closes the open editor when a filter hides the row it belongs to", async () => {
     authFetchMock.mockResolvedValueOnce(json(VIEW));
     render(() => <RsvpView weddingId="wed_a" canEdit />);

--- a/cire/host/src/components/RsvpView.tsx
+++ b/cire/host/src/components/RsvpView.tsx
@@ -1,5 +1,15 @@
 import { useAuth } from "@shared/rp-auth/solid";
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  mapArray,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { createStore, reconcile } from "solid-js/store";
 
 import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { haptic } from "../lib/haptics";
@@ -76,7 +86,7 @@ interface EditTarget {
  */
 export default function RsvpView(props: RsvpViewProps) {
   const { authFetch } = useAuth();
-  const [events, setEvents] = createSignal<RsvpViewEvent[]>([]);
+  const [state, setState] = createStore<{ events: RsvpViewEvent[] }>({ events: [] });
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
 
@@ -98,7 +108,7 @@ export default function RsvpView(props: RsvpViewProps) {
       if (res.status === 401) return redirectToLogin();
       if (!res.ok) throw new Error(`Failed to load (${res.status})`);
       const body = (await res.json()) as { events: RsvpViewEvent[] };
-      setEvents(body.events);
+      setState("events", reconcile(body.events, { key: "id" }));
     } catch (err) {
       if (isAuthExpired(err)) return redirectToLogin();
       setError("Could not load RSVPs. Is the API running?");
@@ -109,27 +119,30 @@ export default function RsvpView(props: RsvpViewProps) {
 
   onMount(load);
 
-  const hasEvents = () => events().length > 0;
+  const hasEvents = () => state.events.length > 0;
 
-  // Two memos, both keyed by event id. Without them the merge and the filter
-  // ran once per read — and the markup reads them four times per event, on
-  // every keystroke. The rows also keep their identity between reads, which is
-  // what lets <For> patch the table instead of rebuilding it.
-  /** Every guest invited to each event, replied or not, before filtering. */
-  const merged = createMemo(
-    () => new Map(events().map((event) => [event.id, mergeRows(event)] as const)),
+  // A store, not a signal: reload writes patch each event's own fields in
+  // place, so an event nothing touched keeps its object identity and <For>
+  // leaves its <section> alone. That alone is not enough, though — a plain
+  // memo over the whole event list reads every event's guests, so it
+  // subscribes to all of them and re-merges every row when any one changes.
+  // `mapArray` is the fix: its callback runs once per event,
+  // cached by identity, so the per-event row memos below only re-run for the
+  // event whose own guests actually changed. Everything reads `sections()`.
+  const sections = createMemo(
+    mapArray(
+      () => state.events,
+      (event) => {
+        const rows = createMemo(() => mergeRows(event));
+        const visible = createMemo(() => filterRows(rows(), query(), filter()));
+        return { event, rows, visible };
+      },
+    ),
   );
-  const shown = createMemo(() => {
-    const q = query();
-    const f = filter();
-    return new Map([...merged()].map(([id, rows]) => [id, filterRows(rows, q, f)] as const));
-  });
-  const rowsFor = (event: RsvpViewEvent) => merged().get(event.id) ?? [];
-  const shownFor = (event: RsvpViewEvent) => shown().get(event.id) ?? [];
 
-  const counts = createMemo(() => statusCounts(merged().values()));
+  const counts = createMemo(() => statusCounts(sections().map((section) => section.rows())));
   const shownCount = createMemo(() =>
-    [...shown().values()].reduce((total, rows) => total + rows.length, 0),
+    sections().reduce((total, section) => total + section.visible().length, 0),
   );
   const filtering = () => query().trim().length > 0 || filter() !== "all";
 
@@ -180,7 +193,9 @@ export default function RsvpView(props: RsvpViewProps) {
   createEffect(() => {
     const target = edit();
     if (!target) return;
-    const rows = shown().get(target.eventId);
+    const rows = sections()
+      .find((section) => section.event.id === target.eventId)
+      ?.visible();
     if (!rows?.some((row) => row.guestId === target.guestId)) closeEditor();
   });
 
@@ -234,8 +249,9 @@ export default function RsvpView(props: RsvpViewProps) {
         setSaving(false);
         return;
       }
-      // Recorded. The reload that follows redraws the whole list, so the buzz
-      // is the only thing that marks *this* row as the one that changed.
+      // Recorded. The reload that follows patches only the row that changed,
+      // but that patch still takes a moment to land — the buzz is what tells
+      // the host the save landed, not the redraw.
       haptic("commit");
       closeEditor();
       await load();
@@ -324,39 +340,39 @@ export default function RsvpView(props: RsvpViewProps) {
         </div>
 
         <div class="flex flex-col gap-10">
-          <For each={events()}>
-            {(event) => (
+          <For each={sections()}>
+            {(section) => (
               <section class="border-border bg-surface/30 flex flex-col gap-4 rounded-sm border p-5">
                 <header class="flex flex-wrap items-end justify-between gap-3">
                   <h3 class="font-display text-text text-[1.3rem] leading-none font-light">
-                    {event.name}
+                    {section.event.name}
                   </h3>
                   <dl class="font-body text-text-muted flex flex-wrap gap-x-4 gap-y-1 text-[0.78rem]">
                     <div class="flex items-center gap-1.5">
                       <dt class="text-gold tracking-[0.08em] uppercase">Attending</dt>
-                      <dd class="text-text font-mono">{event.attending}</dd>
+                      <dd class="text-text font-mono">{section.event.attending}</dd>
                     </div>
                     <div class="flex items-center gap-1.5">
                       <dt class="tracking-[0.08em] uppercase">Declined</dt>
-                      <dd class="text-text font-mono">{event.declined}</dd>
+                      <dd class="text-text font-mono">{section.event.declined}</dd>
                     </div>
                     <div class="flex items-center gap-1.5">
                       <dt class="tracking-[0.08em] uppercase">Maybe</dt>
-                      <dd class="text-text font-mono">{event.maybe}</dd>
+                      <dd class="text-text font-mono">{section.event.maybe}</dd>
                     </div>
                     <div class="flex items-center gap-1.5">
                       <dt class="tracking-[0.08em] uppercase">No reply</dt>
-                      <dd class="text-text font-mono">{event.noResponse}</dd>
+                      <dd class="text-text font-mono">{section.event.noResponse}</dd>
                     </div>
                     <div class="flex items-center gap-1.5">
                       <dt class="tracking-[0.08em] uppercase">Invited</dt>
-                      <dd class="text-text font-mono">{event.invited}</dd>
+                      <dd class="text-text font-mono">{section.event.invited}</dd>
                     </div>
                   </dl>
                 </header>
 
                 <Show
-                  when={rowsFor(event).length > 0}
+                  when={section.rows().length > 0}
                   fallback={
                     <p class="font-body text-text-muted text-[0.82rem] italic">
                       No guests to show for this event.
@@ -364,15 +380,15 @@ export default function RsvpView(props: RsvpViewProps) {
                   }
                 >
                   <Show
-                    when={shownFor(event).length > 0}
+                    when={section.visible().length > 0}
                     fallback={
                       <p class="font-body text-text-muted text-[0.82rem] italic">
                         No guests match this filter.
                       </p>
                     }
                   >
-                    <Table label={`Replies for ${event.name}`} class="font-body">
-                      <caption class="sr-only">RSVPs for {event.name}</caption>
+                    <Table label={`Replies for ${section.event.name}`} class="font-body">
+                      <caption class="sr-only">RSVPs for {section.event.name}</caption>
                       <thead>
                         <tr>
                           <Th>Guest</Th>
@@ -387,7 +403,7 @@ export default function RsvpView(props: RsvpViewProps) {
                         </tr>
                       </thead>
                       <tbody>
-                        <For each={shownFor(event)}>
+                        <For each={section.visible()}>
                           {(row) => (
                             <>
                               <tr class="hover:[&>td]:bg-surface">
@@ -425,14 +441,16 @@ export default function RsvpView(props: RsvpViewProps) {
                                       type="button"
                                       class="border-border text-text-muted hover:text-text hover:border-gold/40 rounded-sm border px-2.5 py-1 text-[0.7rem] tracking-[0.08em] uppercase"
                                       aria-label={`${row.responded ? "Edit" : "Record"} reply for ${row.firstName} ${row.lastName}`}
-                                      onClick={() => openRow(event.id, row)}
+                                      onClick={() => openRow(section.event.id, row)}
                                     >
                                       {row.responded ? "Edit" : "Record"}
                                     </button>
                                   </Td>
                                 </Show>
                               </tr>
-                              <Show when={props.canEdit && isEditing(event.id, row.guestId)}>
+                              <Show
+                                when={props.canEdit && isEditing(section.event.id, row.guestId)}
+                              >
                                 {renderEditorRow()}
                               </Show>
                             </>


### PR DESCRIPTION
## Summary

Saving one RSVP reloaded the wedding's whole payload and replaced every object in it, so `<For>` rebuilt every section and every table row in the wedding — the rebuild the row memos exist to avoid, paid on every save. The list now lives in a `createStore` reconciled by event id, and the per-event merge/filter is scoped with `createMemo(mapArray(...))`.

- `load()` applies the reload with `reconcile(body.events, { key: "id" })` instead of swapping the array, so an untouched event keeps its object identity.
- Row merging and filtering moved from two whole-list memos into one memo per event, cached by event identity, so only the event whose guests actually changed re-runs.
- Reading `section.event.attending` straight from the store makes an event's tally header a fine-grained update rather than a rebuild.
- Reactivity only — no behaviour, markup, ARIA name or copy changed.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/host` | `.changeset/cire-rsvp-view-reconcile.md` |

## Issues

**Closes**

| Issue | What |
|---|---|
| `xchromo/osn-tracker#421` | `P-W3` |

Closes xchromo/osn-tracker#421

**Opened**

None.

## Decisions

### `createStore` + `reconcile` is not sufficient on its own — `P-W3`

- **Issue** — the obvious fix here is a `createStore` plus `reconcile(body.events, { key: "id" })`, and stopping there.
- **Why** — that keeps the identity of the unchanged event objects, so the outer `<For>` leaves the `<section>`s alone. But the row objects came from a whole-list memo that mapped every event through `mergeRows`. Any nested change re-ran it, re-merged every event, and emitted brand-new row objects for all of them, so the inner row `<For>`s rebuilt regardless. That change alone would have read as "done" while the expensive half of the rebuild survived.
- **Solution** — the store and the reconcile as written, plus `createMemo(mapArray(() => state.events, ...))` holding a `rows` memo and a `visible` memo per event. `mapArray`'s callback runs once per item and is cached by item identity, so a nested guest-field change re-runs only the inner memo belonging to that one event.
- **Rationale** — `mapArray` is the primitive `<For>` itself is built on, so the caching rule is the one already governing the list. Everything downstream (`counts`, `shownCount`, the editor-closing effect, the JSX) now reads one `sections()` accessor instead of two id-keyed `Map`s, which is less machinery than it replaced.

**Out of scope** — the API still returns the full wedding payload on every save; narrowing that to the changed event is a server-side change, not this one.

### The nested guest arrays are reconciled positionally, on purpose — `P-W3`

- **Issue** — `reconcile`'s array branch only replaces an array wholesale when `key && target[key] !== previous[key]`. The nested `guests` and `unresponded` items carry `guestId`, not `id`, so both sides read `undefined` and the guard never fires.
- **Why** — that could look like a bug worth "fixing" with a second key option, and a future reader will hit it.
- **Solution** — leave it. Those arrays deep-diff field by field instead, which is exactly what is wanted, and no second key was added.
- **Rationale** — the API returns guests in a stable order, so positional diffing lands the changed fields on the right rows and does less work than re-keying would. `key: "id"` is Solid's default but is written out at the call site because it is load-bearing for the event array.

**Out of scope** — nothing here depends on guest ordering beyond what the API already guarantees.

### The regression test asserts DOM node identity, not a render count — `P-W3`

- **Issue** — "the table is not rebuilt" has no direct assertion in a happy-dom test.
- **Why** — counting renders means instrumenting the component, which the test would then be measuring instead of the behaviour.
- **Solution** — capture a `<tr>` from an event the save does not touch, run the record flow, and assert after the reload that the same node object is still there — while a second assertion checks the changed event's row did update.
- **Rationale** — node identity is the property, not a proxy for it: a rebuild produces a different node by definition. Checked against `main`'s component, where it fails on the `Object.is` assertion and nothing else.

**Out of scope** — no browser-tier test was added; nothing here is a CSS, layout or paint question.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd cire/host test` | pass — 1133 tests, 83 files |
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `scripts/validate-changesets.sh` | pass |

The new test was run against `main`'s `RsvpView.tsx` with the rest of the branch in place, and fails there on the row-identity assertion (`Object.is`) — so it fails for the reason it claims and not an incidental one. All 19 pre-existing `RsvpView` tests pass unchanged; none was edited.

Not run: the real-Chromium tier (`test:browser`). This change moves no styles and no layout, so that tier has nothing to say about it. Nothing here was exercised against the deployed dev tier either — the behaviour is identical by construction and the property under test is a client-side render one.

