### PR TITLE
fix(cire/api): give the D1 integration tests the same cold-start budget as their hooks

### DIFF
--- a/.changeset/cire-d1-test-timeout.md
+++ b/.changeset/cire-d1-test-timeout.md
@@ -1,0 +1,7 @@
+---
+"@cire/api": patch
+---
+
+Give the D1 integration tests the same cold-start budget their hooks already had.
+
+The hooks in `cire/api/src/db/d1-integration.test.ts` carry a 30s timeout because booting workerd on a fresh CI runner takes seconds. The test bodies were left on bun's 5s default, and they are not cheap either — every statement is a real round-trip over workerd's loopback socket, so the test that seeds 51 events one at a time runs ~6-9s on CI against ~0.4s locally. It timed out, and the next test failed 16ms later on the now-disposed stub, taking `@cire/api#test` red on unrelated pull requests. One constant now covers hooks and tests alike.

--- a/cire/api/src/db/d1-integration.test.ts
+++ b/cire/api/src/db/d1-integration.test.ts
@@ -51,9 +51,17 @@ let db: Db;
 // workerd D1 call lands on a now-disposed ("poisoned") stub and surfaces as
 // "Unhandled error between tests", failing the whole `bun test` run. Locally the
 // runtime is warm so the hooks finish in ~400ms and never trip the limit; this
-// is the CI-only flake. Give every Miniflare-backed hook a generous budget so a
-// cold boot can never race the default timeout.
-const MF_HOOK_TIMEOUT_MS = 30_000;
+// is the CI-only flake.
+//
+// The same 5_000ms default applies per TEST, and the bodies here are not cheap:
+// every statement is a real round-trip over workerd's loopback socket, so a test
+// that seeds 51 events one at a time takes ~6-9s on a CI box against ~0.4s
+// locally. That is the same flake wearing a different hat, and it tears the
+// suite down the same way — the run that prompted this saw the 51-pair test time
+// out at 5_000ms and the next test fail 16ms later on the poisoned stub. So the
+// budget covers hooks and tests alike: nothing Miniflare-backed races the
+// default.
+const MF_TIMEOUT_MS = 30_000;
 
 const run = <A, E>(eff: Effect.Effect<A, E, DbService>): Promise<A> =>
   Effect.runPromise(eff.pipe(Effect.provideService(DbService, db)));
@@ -142,7 +150,7 @@ beforeAll(async () => {
     await d1.prepare(stmt).run();
   }
   db = createD1Db(d1);
-}, MF_HOOK_TIMEOUT_MS);
+}, MF_TIMEOUT_MS);
 
 afterAll(async () => {
   // `dispose()` poisons every D1 stub this instance handed out — only call it
@@ -150,7 +158,7 @@ afterAll(async () => {
   // dead stub. (All hooks/tests above `await` their D1 ops, so nothing is
   // pending here; this stays defensive in case that ever changes.)
   await mf?.dispose();
-}, MF_HOOK_TIMEOUT_MS);
+}, MF_TIMEOUT_MS);
 
 beforeEach(async () => {
   // FK-safe truncate, then reseed — keeps each test isolated on the shared D1.
@@ -158,193 +166,221 @@ beforeEach(async () => {
     await db.delete(table);
   }
   await seed();
-}, MF_HOOK_TIMEOUT_MS);
+}, MF_TIMEOUT_MS);
 
 describe("cire/api over real D1 (Miniflare)", () => {
-  it("claim.lookup resolves a seeded family across async D1 reads", async () => {
-    const res = await run(claimService.lookup(PUBLIC_ID));
-    expect(res.familyId).toBe(FAMILY_ID);
-    expect(res.publicId).toBe(PUBLIC_ID);
-    expect(res.members).toHaveLength(2);
-    expect(res.events.map((e) => e.name).toSorted()).toEqual(["Ceremony", "Reception"]);
-  });
+  it(
+    "claim.lookup resolves a seeded family across async D1 reads",
+    async () => {
+      const res = await run(claimService.lookup(PUBLIC_ID));
+      expect(res.familyId).toBe(FAMILY_ID);
+      expect(res.publicId).toBe(PUBLIC_ID);
+      expect(res.members).toHaveLength(2);
+      expect(res.events.map((e) => e.name).toSorted()).toEqual(["Ceremony", "Reception"]);
+    },
+    MF_TIMEOUT_MS,
+  );
 
-  it("claim.lookup fails for an unknown code", async () => {
-    await expect(run(claimService.lookup("NOPE-0000"))).rejects.toThrow();
-  });
+  it(
+    "claim.lookup fails for an unknown code",
+    async () => {
+      await expect(run(claimService.lookup("NOPE-0000"))).rejects.toThrow();
+    },
+    MF_TIMEOUT_MS,
+  );
 
-  it("submitRsvp upserts over async D1 (insert then in-place update)", async () => {
-    await run(
-      rsvpService.submitRsvp({
-        guestId: GUEST_1,
-        eventId: EVENT_A,
-        status: "attending",
-        dietary: "none",
-      }),
-    );
-    let rows = await run(rsvpService.getRsvpsForFamily(FAMILY_ID));
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ guestId: GUEST_1, eventId: EVENT_A, status: "attending" });
-
-    // Same (guest, event) conflict target → updates the row in place, no dup.
-    await run(
-      rsvpService.submitRsvp({
-        guestId: GUEST_1,
-        eventId: EVENT_A,
-        status: "declined",
-        dietary: "veg",
-      }),
-    );
-    rows = await run(rsvpService.getRsvpsForFamily(FAMILY_ID));
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ status: "declined", dietary: "veg" });
-  });
-
-  it("applyImport commits a write set via the D1 batch path", async () => {
-    const newEventId = "evt_new";
-    const newFamilyId = "fam_new";
-    const newGuestId = "g_new";
-    const plan: ImportPlan = {
-      eventCreates: [
-        {
-          id: newEventId,
-          event: {
-            name: "Mehndi",
-            startAt: "2026-11-22T10:00",
-            endAt: "2026-11-22T14:00",
-            timezone: "Australia/Sydney",
-            location: "Hall",
-            address: null,
-            dressCodeDescription: null,
-            dressCodePalette: [],
-            pinterestUrl: null,
-            mapsUrl: null,
-            sortOrder: 2,
-          },
-        },
-      ],
-      eventUpdates: [],
-      eventRemoves: [],
-      familyCreates: [{ id: newFamilyId, publicId: "NEWFAM-BB02", familyName: "New" }],
-      familyUpdates: [],
-      familyRemoves: [],
-      guestCreates: [
-        {
-          id: newGuestId,
-          familyId: newFamilyId,
-          firstName: "Carol",
-          lastName: "New",
-          sortOrder: 0,
-        },
-      ],
-      guestUpdates: [],
-      guestRemoves: [],
-      eventLinkCreates: [{ guestId: newGuestId, eventId: newEventId }],
-      eventLinkRemoves: [],
-      warnings: [],
-    };
-
-    const summary = await run(applyImport("imp_test", plan, BOOTSTRAP_WEDDING_ID));
-    expect(summary).toMatchObject({ eventsCreated: 1, familiesCreated: 1, guestsCreated: 1 });
-
-    expect(await db.select().from(events).where(eq(events.id, newEventId))).toHaveLength(1);
-    expect(await db.select().from(families).where(eq(families.id, newFamilyId))).toHaveLength(1);
-    expect(
-      await db.select().from(guestEvents).where(eq(guestEvents.guestId, newGuestId)),
-    ).toHaveLength(1);
-  });
-
-  it("applyImport batch is atomic — a mid-batch constraint violation persists nothing", async () => {
-    // Two family creates share a publicId; the second trips the UNIQUE index.
-    // On D1 the whole batch is one transaction, so NEITHER row may survive.
-    const plan: ImportPlan = {
-      eventCreates: [],
-      eventUpdates: [],
-      eventRemoves: [],
-      familyCreates: [
-        { id: "fam_x", publicId: "DUP-CODE", familyName: "X" },
-        { id: "fam_y", publicId: "DUP-CODE", familyName: "Y" },
-      ],
-      familyUpdates: [],
-      familyRemoves: [],
-      guestCreates: [],
-      guestUpdates: [],
-      guestRemoves: [],
-      eventLinkCreates: [],
-      eventLinkRemoves: [],
-      warnings: [],
-    };
-
-    await expect(run(applyImport("imp_dup", plan, BOOTSTRAP_WEDDING_ID))).rejects.toThrow();
-    expect(await db.select().from(families).where(eq(families.id, "fam_x"))).toHaveLength(0);
-    expect(await db.select().from(families).where(eq(families.id, "fam_y"))).toHaveLength(0);
-  });
-
-  it("submitRsvps commits a 51-pair batch over D1's per-batch ceiling (P-W2)", async () => {
-    // MAX_STATEMENTS_PER_BATCH is 50; a 51-statement submit must be chunked by
-    // commitGroupedBatches rather than sent as one over-ceiling db.batch() call
-    // (which D1 rejects outright). bun:sqlite cannot exercise this: commitBatch
-    // feature-detects `.batch()` and falls back to a sequential loop there, so
-    // only the real (Miniflare-backed) D1 driver proves the fix.
-    const eventIds = Array.from({ length: 51 }, (_, i) => `evt_bulk_${i}`);
-    // One insert per event, not a single 51-row bulk insert — the bulk form
-    // trips D1's own bound-parameter ceiling on a single statement, a
-    // different limit than the per-batch statement ceiling this test targets.
-    for (const [i, id] of eventIds.entries()) {
-      await db.insert(events).values({
-        id,
-        weddingId: BOOTSTRAP_WEDDING_ID,
-        slug: `bulk-${i}`,
-        name: `Bulk ${i}`,
-        description: "",
-        startAt: "",
-        endAt: "",
-        timezone: "",
-        sortOrder: 10 + i,
-      });
-    }
-
-    const inputs = eventIds.map((eventId) => ({
-      guestId: GUEST_1,
-      eventId,
-      status: "attending" as const,
-      dietary: "",
-      dietaryConsent: false,
-    }));
-
-    await run(rsvpService.submitRsvps(inputs));
-
-    const rows = await db.select().from(rsvps).where(eq(rsvps.guestId, GUEST_1));
-    expect(rows).toHaveLength(51);
-  });
-
-  it("tasks.reorder commits its per-row updates over the D1 batch path", async () => {
-    // Regression guard: reorder used to run through db.transaction(), which the
-    // D1 driver implements as literal BEGIN/COMMIT (rejected by D1) with
-    // fire-and-forget .run() calls that the async driver never awaited. It now
-    // goes through commitBatch — this is the only D1 coverage of a reorder.
-    const created: string[] = [];
-    for (const title of ["first", "second", "third"]) {
-      const dto = await run(
-        tasksService.create({
-          weddingId: BOOTSTRAP_WEDDING_ID,
-          title,
-          timeframeBucket: "12m",
-          notes: null,
-          dueAt: null,
+  it(
+    "submitRsvp upserts over async D1 (insert then in-place update)",
+    async () => {
+      await run(
+        rsvpService.submitRsvp({
+          guestId: GUEST_1,
+          eventId: EVENT_A,
+          status: "attending",
+          dietary: "none",
         }),
       );
-      created.push(dto.id);
-    }
+      let rows = await run(rsvpService.getRsvpsForFamily(FAMILY_ID));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ guestId: GUEST_1, eventId: EVENT_A, status: "attending" });
 
-    const reversed = created.toReversed();
-    await run(tasksService.reorder(BOOTSTRAP_WEDDING_ID, "12m", reversed));
+      // Same (guest, event) conflict target → updates the row in place, no dup.
+      await run(
+        rsvpService.submitRsvp({
+          guestId: GUEST_1,
+          eventId: EVENT_A,
+          status: "declined",
+          dietary: "veg",
+        }),
+      );
+      rows = await run(rsvpService.getRsvpsForFamily(FAMILY_ID));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ status: "declined", dietary: "veg" });
+    },
+    MF_TIMEOUT_MS,
+  );
 
-    const rows = await db
-      .select({ id: tasks.id })
-      .from(tasks)
-      .where(eq(tasks.weddingId, BOOTSTRAP_WEDDING_ID))
-      .orderBy(asc(tasks.sortOrder));
-    expect(rows.map((r) => r.id)).toEqual(reversed);
-  });
+  it(
+    "applyImport commits a write set via the D1 batch path",
+    async () => {
+      const newEventId = "evt_new";
+      const newFamilyId = "fam_new";
+      const newGuestId = "g_new";
+      const plan: ImportPlan = {
+        eventCreates: [
+          {
+            id: newEventId,
+            event: {
+              name: "Mehndi",
+              startAt: "2026-11-22T10:00",
+              endAt: "2026-11-22T14:00",
+              timezone: "Australia/Sydney",
+              location: "Hall",
+              address: null,
+              dressCodeDescription: null,
+              dressCodePalette: [],
+              pinterestUrl: null,
+              mapsUrl: null,
+              sortOrder: 2,
+            },
+          },
+        ],
+        eventUpdates: [],
+        eventRemoves: [],
+        familyCreates: [{ id: newFamilyId, publicId: "NEWFAM-BB02", familyName: "New" }],
+        familyUpdates: [],
+        familyRemoves: [],
+        guestCreates: [
+          {
+            id: newGuestId,
+            familyId: newFamilyId,
+            firstName: "Carol",
+            lastName: "New",
+            sortOrder: 0,
+          },
+        ],
+        guestUpdates: [],
+        guestRemoves: [],
+        eventLinkCreates: [{ guestId: newGuestId, eventId: newEventId }],
+        eventLinkRemoves: [],
+        warnings: [],
+      };
+
+      const summary = await run(applyImport("imp_test", plan, BOOTSTRAP_WEDDING_ID));
+      expect(summary).toMatchObject({ eventsCreated: 1, familiesCreated: 1, guestsCreated: 1 });
+
+      expect(await db.select().from(events).where(eq(events.id, newEventId))).toHaveLength(1);
+      expect(await db.select().from(families).where(eq(families.id, newFamilyId))).toHaveLength(1);
+      expect(
+        await db.select().from(guestEvents).where(eq(guestEvents.guestId, newGuestId)),
+      ).toHaveLength(1);
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "applyImport batch is atomic — a mid-batch constraint violation persists nothing",
+    async () => {
+      // Two family creates share a publicId; the second trips the UNIQUE index.
+      // On D1 the whole batch is one transaction, so NEITHER row may survive.
+      const plan: ImportPlan = {
+        eventCreates: [],
+        eventUpdates: [],
+        eventRemoves: [],
+        familyCreates: [
+          { id: "fam_x", publicId: "DUP-CODE", familyName: "X" },
+          { id: "fam_y", publicId: "DUP-CODE", familyName: "Y" },
+        ],
+        familyUpdates: [],
+        familyRemoves: [],
+        guestCreates: [],
+        guestUpdates: [],
+        guestRemoves: [],
+        eventLinkCreates: [],
+        eventLinkRemoves: [],
+        warnings: [],
+      };
+
+      await expect(run(applyImport("imp_dup", plan, BOOTSTRAP_WEDDING_ID))).rejects.toThrow();
+      expect(await db.select().from(families).where(eq(families.id, "fam_x"))).toHaveLength(0);
+      expect(await db.select().from(families).where(eq(families.id, "fam_y"))).toHaveLength(0);
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "submitRsvps commits a 51-pair batch over D1's per-batch ceiling (P-W2)",
+    async () => {
+      // MAX_STATEMENTS_PER_BATCH is 50; a 51-statement submit must be chunked by
+      // commitGroupedBatches rather than sent as one over-ceiling db.batch() call
+      // (which D1 rejects outright). bun:sqlite cannot exercise this: commitBatch
+      // feature-detects `.batch()` and falls back to a sequential loop there, so
+      // only the real (Miniflare-backed) D1 driver proves the fix.
+      const eventIds = Array.from({ length: 51 }, (_, i) => `evt_bulk_${i}`);
+      // One insert per event, not a single 51-row bulk insert — the bulk form
+      // trips D1's own bound-parameter ceiling on a single statement, a
+      // different limit than the per-batch statement ceiling this test targets.
+      for (const [i, id] of eventIds.entries()) {
+        await db.insert(events).values({
+          id,
+          weddingId: BOOTSTRAP_WEDDING_ID,
+          slug: `bulk-${i}`,
+          name: `Bulk ${i}`,
+          description: "",
+          startAt: "",
+          endAt: "",
+          timezone: "",
+          sortOrder: 10 + i,
+        });
+      }
+
+      const inputs = eventIds.map((eventId) => ({
+        guestId: GUEST_1,
+        eventId,
+        status: "attending" as const,
+        dietary: "",
+        dietaryConsent: false,
+      }));
+
+      await run(rsvpService.submitRsvps(inputs));
+
+      const rows = await db.select().from(rsvps).where(eq(rsvps.guestId, GUEST_1));
+      expect(rows).toHaveLength(51);
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "tasks.reorder commits its per-row updates over the D1 batch path",
+    async () => {
+      // Regression guard: reorder used to run through db.transaction(), which the
+      // D1 driver implements as literal BEGIN/COMMIT (rejected by D1) with
+      // fire-and-forget .run() calls that the async driver never awaited. It now
+      // goes through commitBatch — this is the only D1 coverage of a reorder.
+      const created: string[] = [];
+      for (const title of ["first", "second", "third"]) {
+        const dto = await run(
+          tasksService.create({
+            weddingId: BOOTSTRAP_WEDDING_ID,
+            title,
+            timeframeBucket: "12m",
+            notes: null,
+            dueAt: null,
+          }),
+        );
+        created.push(dto.id);
+      }
+
+      const reversed = created.toReversed();
+      await run(tasksService.reorder(BOOTSTRAP_WEDDING_ID, "12m", reversed));
+
+      const rows = await db
+        .select({ id: tasks.id })
+        .from(tasks)
+        .where(eq(tasks.weddingId, BOOTSTRAP_WEDDING_ID))
+        .orderBy(asc(tasks.sortOrder));
+      expect(rows.map((r) => r.id)).toEqual(reversed);
+    },
+    MF_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

`@cire/api#test` has been failing on pull requests that touch no API code — #724 and #725 both went red on the same two tests. The cause is a timeout, not a regression: the Miniflare-backed D1 integration tests carry a 30s budget on their hooks but left the test bodies on bun's 5s default, and those bodies are just as expensive as the hooks. This gives both the same budget.

- One constant, `MF_TIMEOUT_MS`, replaces `MF_HOOK_TIMEOUT_MS` and now applies to all seven tests as well as the three hooks.
- The comment explaining the cold-start flake is extended to cover the per-test half.
- No production code changes.

## Workspaces affected

| Package | Changeset |
|---|---|
| `@cire/api` | `.changeset/cire-d1-test-timeout.md` |

## Issues

**Closes** — none. Found while checking CI on an unrelated PR.

**Opened** — none.

## Decisions

### One budget for hooks and tests, not a per-test number — `MF_TIMEOUT_MS`

- **Issue** — the 51-pair batch test ran 6.3s in one CI run and 8.7s in another, against ~0.4s locally. The next test then failed 16ms later on a stub bun had already disposed, so a single slow test takes two tests and the whole `bun test` run with it.
- **Why** — the reason is the same one already written down for the hooks: every statement in this file is a real round-trip over workerd's loopback socket, and a cold, network-constrained GitHub runner is several times slower at it than a warm laptop. Nothing about that is specific to which test is running.
- **Solution** — rename the constant to `MF_TIMEOUT_MS` and pass it to every `it` in the file as well as every hook.
- **Rationale** — a per-test number tuned to the observed 8.7s would be a new tripwire the next time a runner is slow, and the file would then carry two different timeouts for one cause. 30s is far above anything these tests should ever take, so a test that hits it is genuinely stuck and should fail.
- **Out of scope** — making the tests faster. Seeding 51 events one at a time is deliberate (a bulk insert trips D1's bound-parameter ceiling, a different limit than the one under test), and the round-trip cost is the thing being exercised.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run --cwd cire/api test` | pass — 1693 tests, 0 fail |
| `bun run changeset:validate` | pass |

Local runs cannot reproduce the failure: workerd is warm here and the tests finish in ~0.4s, well inside the old 5s default. CI is the only place the fix is provable, so the real check is whether `Build & Test` goes green on this PR and on the two it unblocks.
