### PR TITLE
fix(ci): bound the Chromium install so one stalled step can't wedge every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
   build-test:
     name: Build & Test
     runs-on: ubuntu-latest
+    # The backstop under the per-step timeouts below. Without it the job's
+    # ceiling is GitHub's six hours, which is long enough for one stuck runner
+    # to hold up a day of review.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -124,12 +128,39 @@ jobs:
       # step above: it needs a dependency the default path doesn't, and keeping
       # it separate leaves the fast tier fast.
       #
-      # `--with-deps` installs Chromium's shared libraries as well as the
-      # browser; on ubuntu-latest the browser alone is not enough. Only chromium
-      # is installed — the tier pins a single instance, so pulling Firefox and
-      # WebKit too would be ~3x the download for nothing.
+      # `--with-deps` used to do both halves of the install in one line: an apt
+      # install of Chromium's shared libraries, and a ~150MB download of the
+      # browser itself. On ubuntu-latest the browser alone is not enough, so
+      # both have to happen — but neither half had a timeout, and a step with no
+      # timeout inherits the job's, which is six hours. On 2026-08-19 one of them
+      # stalled and every open PR's Build & Test sat in `pending` behind it for
+      # most of a day, with no log to read because a job's logs only appear once
+      # it ends. Three changes, all aimed at that:
+      #
+      #   * the halves are separate steps, so a stall names which half stalled;
+      #   * each is bounded, so a stall is a red X in ten minutes instead of a
+      #     wedged runner;
+      #   * the download half is cached on the lockfile, so the usual run never
+      #     makes it. The system libraries are not cacheable (apt writes into the
+      #     image, not the workspace) and are reinstalled each run.
+      #
+      # Only chromium is installed — the tier pins a single instance, so pulling
+      # Firefox and WebKit too would be ~3x the download for nothing.
+      - name: Cache Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Chromium's system libraries
+        timeout-minutes: 10
+        run: bunx playwright install-deps chromium
+
       - name: Install Chromium for browser tests
-        run: bunx playwright install --with-deps chromium
+        timeout-minutes: 10
+        run: bunx playwright install chromium
 
       - name: Browser tests
         run: bun run test:browser


### PR DESCRIPTION
## Summary

On 2026-08-19 every open PR's `Build & Test` sat in `pending` for most of a day. The cause was not any diff: the `Install Chromium for browser tests` step — `bunx playwright install --with-deps chromium` — stalled, and because neither the step nor the job carried a `timeout-minutes`, it inherited GitHub's six-hour job ceiling and held its runner there. A job publishes no logs until it ends, so there was nothing to read while it hung.

This bounds it. The apt half and the download half become separate steps with 10 minutes each, the download is cached on the lockfile, and the job gets a 30-minute backstop.

## Workspaces affected

| Package | Changeset |
| --- | --- |
| None — `.github/` only | Not required (`scripts/changeset-required.sh` allowlist) |

## Issues

**Closes**

| Issue | Title |
| --- | --- |
| None | — |

**Opened**

None.

## Decisions

### Split the two halves of the install into their own steps — `CI-1`

- **Issue** — `playwright install --with-deps chromium` does two unrelated jobs in one line: an apt install of Chromium's shared libraries, and a ~150MB download of the browser. When the line stalled, the log said only "installing", so which half had stalled was unknowable.
- **Why** — A stall you cannot localise is a stall you cannot fix. The two halves have different failure modes (apt mirror vs. CDN) and different fixes.
- **Solution** — `bunx playwright install-deps chromium` and `bunx playwright install chromium` as separate steps.
- **Rationale** — On `ubuntu-latest` the browser binary alone is not enough, so both halves genuinely have to run; separating them costs nothing and names the failure.

### Bound each install step at 10 minutes and the job at 30 — `CI-2`

- **Issue** — A step with no `timeout-minutes` inherits the job's, and a job with none inherits six hours. One stuck runner therefore blocks a day of review.
- **Why** — The failure mode that matters is not "the install broke" — it is "the install never returns". Only a timeout turns the second into the first.
- **Solution** — `timeout-minutes: 10` on both install steps, `timeout-minutes: 30` on the `build-test` job as the backstop under them.
- **Rationale** — Both installs finish in about a minute on a warm runner and two on a cold one, so 10 is generous without being useless. The job-level 30 catches anything else in the job that acquires the same shape later.

### Cache the browser download on the lockfile — `CI-3`

- **Issue** — Every run re-downloaded ~150MB.
- **Why** — The usual run should not touch the network for this at all.
- **Solution** — `actions/cache@v4` on `~/.cache/ms-playwright`, keyed on `bun.lock` with an OS-prefix restore key.
- **Rationale** — The Playwright version is pinned in the lockfile, so the lockfile hash is exactly the right key. The system-library half is deliberately **not** cached: apt writes into the runner image, not the workspace, so there is nothing for `actions/cache` to save.

**Out of scope** — the wedged runs from 2026-08-19 are still burning toward their six-hour ceiling; cancelling them is a separate manual step.

## Test plan

| Gate | Result |
| --- | --- |
| `verify-task.sh` (tree clean, 1 commit, no conflict markers, JSON/TOML parse, changesets) | pass |
| YAML parse + step-order check (`js-yaml`) | pass — job `timeout-minutes: 30`, both install steps `10`, step order otherwise unchanged |

The real gate is this PR's own CI run: if `Build & Test` reports at all — green or red — rather than hanging in `pending`, the change did its job.
