### PR TITLE
perf(cire/host): lazy-load the spreadsheet import panel out of the first load

### DIFF
--- a/.changeset/cire-import-lazy.md
+++ b/.changeset/cire-import-lazy.md
@@ -1,0 +1,13 @@
+---
+"@cire/host": patch
+---
+
+Lazy-load the spreadsheet import panel out of the portal's first-load bundle.
+
+`ImportPanel` (~900 lines, pulling in `ChangeHistory`, `ChangePreview` and
+`import-templates`) now splits into its own chunk, loaded via
+`lazy(() => import("./ImportPanel"))` inside `EditWorkspace` and warmed on
+pointer/focus intent over the "Spreadsheet import" radio, matching the
+`warmPanel` pattern already used in `ModuleShell`. `PanelLoading` — the shared
+in-flight fallback — moved out of `ModuleShell.tsx` into its own
+`PanelLoading.tsx` so both consumers can import it without a cycle.

--- a/cire/host/src/components/EditWorkspace.test.tsx
+++ b/cire/host/src/components/EditWorkspace.test.tsx
@@ -57,10 +57,12 @@ describe("EditWorkspace", () => {
     expect(screen.queryByTestId("import")).toBeNull();
   });
 
-  it("swaps the editor for the import, and back", () => {
+  it("swaps the editor for the import, and back", async () => {
     mount();
     fireEvent.click(mode(/spreadsheet import/i));
-    expect(screen.getByTestId("import")).toBeTruthy();
+    // `lazy()` resolves the (mocked) module on a microtask, so the mount lands
+    // a tick after the click even though nothing is actually fetched.
+    expect(await screen.findByTestId("import")).toBeTruthy();
     expect(screen.queryByTestId("editor")).toBeNull();
 
     fireEvent.click(mode(/web editor/i));
@@ -68,13 +70,13 @@ describe("EditWorkspace", () => {
     expect(screen.queryByTestId("import")).toBeNull();
   });
 
-  it("gives the import the module's own sheet", () => {
+  it("gives the import the module's own sheet", async () => {
     mount("events");
     fireEvent.click(mode(/spreadsheet import/i));
-    expect(screen.getByTestId("import").getAttribute("data-kind")).toBe("events");
+    expect((await screen.findByTestId("import")).getAttribute("data-kind")).toBe("events");
   });
 
-  it("asks before dropping an unsaved editor draft", () => {
+  it("asks before dropping an unsaved editor draft", async () => {
     // The editor registers a dirty-check while mounted; switching mode unmounts
     // it, which would take the draft with it.
     const confirm = stubConfirm(false);
@@ -89,18 +91,18 @@ describe("EditWorkspace", () => {
 
     confirm.mockReturnValue(true);
     fireEvent.click(mode(/spreadsheet import/i));
-    expect(screen.getByTestId("import")).toBeTruthy();
+    expect(await screen.findByTestId("import")).toBeTruthy();
     unregister();
   });
 
-  it("switches silently when the draft is clean", () => {
+  it("switches silently when the draft is clean", async () => {
     const confirm = stubConfirm(true);
     const unregister = registerUnsavedGuard(() => false);
     mount();
 
     fireEvent.click(mode(/spreadsheet import/i));
     expect(confirm).not.toHaveBeenCalled();
-    expect(screen.getByTestId("import")).toBeTruthy();
+    expect(await screen.findByTestId("import")).toBeTruthy();
     unregister();
   });
 
@@ -149,5 +151,20 @@ describe("EditWorkspace", () => {
     expect(confirm).not.toHaveBeenCalled();
     expect(screen.getByTestId("editor")).toBeTruthy();
     unregister();
+  });
+
+  it("warms the import chunk on pointer or focus intent, without mounting or switching", () => {
+    mount();
+    const control = mode(/spreadsheet import/i);
+    // The warm is fire-and-forget (see `warmImportPanel`): hovering or
+    // keyboard-focusing the control must not throw, must not flip the mode, and
+    // must not mount the panel — only a click does that. If hover ever mounted
+    // it eagerly, the "never mounted until chosen" guarantee above would break.
+    expect(() => {
+      fireEvent.pointerEnter(control);
+      fireEvent.focus(control);
+    }).not.toThrow();
+    expect(control.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("import")).toBeNull();
   });
 });

--- a/cire/host/src/components/EditWorkspace.tsx
+++ b/cire/host/src/components/EditWorkspace.tsx
@@ -1,9 +1,22 @@
 import type { JSX } from "solid-js";
-import { createSignal, createUniqueId, For, Show } from "solid-js";
+import { createSignal, createUniqueId, For, lazy, Show, Suspense } from "solid-js";
 
 import { haptic } from "../lib/haptics";
 import { confirmNavigation } from "../lib/unsaved-guard";
-import ImportPanel, { type ImportKind } from "./ImportPanel";
+import type { ImportKind } from "./ImportPanel";
+import PanelLoading from "./PanelLoading";
+
+/** Split out of the eager portal bundle: ~900 lines dragging in `ChangeHistory`,
+ *  `ChangePreview` and `import-templates` for a surface two clicks deep that
+ *  most organisers never open. Warmed on intent — see the radio button below. */
+const loadImportPanel = () => import("./ImportPanel");
+const ImportPanel = lazy(loadImportPanel);
+
+function warmImportPanel(): void {
+  // Fire and forget, same as `warmPanel` in ModuleShell.tsx: a failed prefetch
+  // just means the real mount pays the cost it would have paid anyway.
+  void loadImportPanel().catch(() => {});
+}
 
 /** The two ways to change this module's data. */
 type EditMode = "editor" | "import";
@@ -89,6 +102,8 @@ export default function EditWorkspace(props: {
               role="radio"
               aria-checked={mode() === m.id}
               onClick={() => choose(m.id)}
+              onPointerEnter={m.id === "import" ? warmImportPanel : undefined}
+              onFocus={m.id === "import" ? warmImportPanel : undefined}
               class="font-body relative flex items-center gap-2 rounded-sm px-3.5 py-1.5 text-[0.74rem] tracking-[0.12em] whitespace-nowrap uppercase transition-colors duration-(--dur-fast) ease-(--ease-out)"
               classList={{
                 "bg-gold/12 text-gold": mode() === m.id,
@@ -120,7 +135,9 @@ export default function EditWorkspace(props: {
 
       <Show when={mode() === "editor"}>{props.editor()}</Show>
       <Show when={mode() === "import"}>
-        <ImportPanel weddingId={props.weddingId} kind={props.kind} />
+        <Suspense fallback={<PanelLoading />}>
+          <ImportPanel weddingId={props.weddingId} kind={props.kind} />
+        </Suspense>
       </Show>
     </div>
   );

--- a/cire/host/src/components/ModuleShell.test.tsx
+++ b/cire/host/src/components/ModuleShell.test.tsx
@@ -333,7 +333,9 @@ describe("ModuleShell", () => {
       renderShell({ module: "guests", sub: "edit" });
       await screen.findByTestId("guests-editor");
       fireEvent.click(importMode());
-      expect(screen.getByTestId("import").getAttribute("data-kind")).toBe("guests");
+      // `EditWorkspace` now `lazy()`-loads ImportPanel, so the mount lands a
+      // tick after the click even though nothing is actually fetched (mocked).
+      expect((await screen.findByTestId("import")).getAttribute("data-kind")).toBe("guests");
       expect(screen.queryByTestId("guests-editor")).toBeNull();
     });
 
@@ -341,7 +343,7 @@ describe("ModuleShell", () => {
       renderShell({ module: "events", sub: "edit" });
       await screen.findByTestId("events-editor");
       fireEvent.click(importMode());
-      expect(screen.getByTestId("import").getAttribute("data-kind")).toBe("events");
+      expect((await screen.findByTestId("import")).getAttribute("data-kind")).toBe("events");
       expect(screen.queryByTestId("events-editor")).toBeNull();
     });
 

--- a/cire/host/src/components/ModuleShell.tsx
+++ b/cire/host/src/components/ModuleShell.tsx
@@ -15,6 +15,7 @@ import GuestTable from "./GuestTable";
 import HostsPanel from "./HostsPanel";
 import ModuleSidebar from "./ModuleSidebar";
 import Overview from "./Overview";
+import PanelLoading from "./PanelLoading";
 import RemintPanel from "./RemintPanel";
 import RsvpView from "./RsvpView";
 import SettingsPanel from "./SettingsPanel";
@@ -112,28 +113,6 @@ function warmPanel(module: Module, sub: string): void {
   // Fire and forget: a failed prefetch is not an error, it just means the real
   // mount pays the cost it would have paid anyway.
   void PANEL_LOADERS[`${module}:${sub}`]?.().catch(() => {});
-}
-
-/** What a panel shows while its chunk is in flight. Deliberately a line of text
- *  rather than a skeleton: a skeleton that flashes reads as a fault, and with
- *  the prefetch above this is usually not painted at all.
- *
- *  The min-height is not decoration. This sits inside the auto-sized frame, so a
- *  fallback of its natural height (one line) would collapse the panel to ~40px,
- *  animate down, then snap back up when the chunk lands — two layout passes and
- *  two visible jumps where an eager panel had none. Holding roughly a panel's
- *  worth of height keeps the swap reading as one movement.
- *
- *  `aria-busy` is what tells a screen reader the panel is still coming. */
-function PanelLoading() {
-  return (
-    <p
-      class="font-body text-text-muted flex min-h-[20rem] items-start py-8 text-[0.85rem]"
-      aria-busy="true"
-    >
-      Loading…
-    </p>
-  );
 }
 
 interface ModuleShellProps {

--- a/cire/host/src/components/PanelLoading.tsx
+++ b/cire/host/src/components/PanelLoading.tsx
@@ -1,0 +1,26 @@
+/** What a panel shows while its chunk is in flight. Shared by every `lazy()`
+ *  panel in the portal — `ModuleShell`'s `warmPanel` map and `EditWorkspace`'s
+ *  import panel — which is why it lives here rather than in either of them:
+ *  `ModuleShell` imports `EditWorkspace`, so the other direction is a cycle.
+ *
+ *  Deliberately a line of text rather than a skeleton: a skeleton that flashes
+ *  reads as a fault, and both consumers warm their chunk on intent, so this is
+ *  usually not painted at all.
+ *
+ *  The min-height is not decoration. This sits inside the auto-sized frame, so a
+ *  fallback of its natural height (one line) would collapse the panel to ~40px,
+ *  animate down, then snap back up when the chunk lands — two layout passes and
+ *  two visible jumps where an eager panel had none. Holding roughly a panel's
+ *  worth of height keeps the swap reading as one movement.
+ *
+ *  `aria-busy` is what tells a screen reader the panel is still coming. */
+export default function PanelLoading() {
+  return (
+    <p
+      class="font-body text-text-muted flex min-h-[20rem] items-start py-8 text-[0.85rem]"
+      aria-busy="true"
+    >
+      Loading…
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary

The organiser portal's first-load bundle carried the spreadsheet import panel — a surface reached only after two deliberate clicks, and one most organisers never open at all. `EditWorkspace` imported it statically, so the panel and everything it drags in (`ChangeHistory`, `ChangePreview`, `import-templates`, `download`) landed in the eager entry chunk.

This splits it out with `lazy()` and warms it on intent, the same way `ModuleShell` already treats its own panels.

Measured on a real build of this branch against the same build of `main`:

| Chunk | main | this branch |
| --- | --- | --- |
| Entry (`OrganiserApp.*.js`) | 266,760 B | 234,375 B |
| `ImportPanel.*.js` | — (inlined) | 33,016 B, loaded on demand |

32 KB — about 12% — off what every organiser downloads before the portal paints.

## Workspaces affected

| Package | Changeset |
| --- | --- |
| `@cire/host` | `.changeset/cire-import-lazy.md` (patch) |

## Issues

**Closes**

| Issue | Finding |
| --- | --- |
| `xchromo/osn-tracker#66` | `P-W2` |

Closes xchromo/osn-tracker#66

**Opened**

None.

## Decisions

### Warm the chunk on intent, not on mount — `P-W2-a`

- **Issue** — A split that only loads on click trades bundle size for a visible wait at the moment the organiser acts.
- **Why** — The point of the split is that most sessions never pay for the panel. Loading it on mount would undo that; loading it on click would move the cost somewhere the user can feel it.
- **Solution** — `onPointerEnter` and `onFocus` on the "Spreadsheet import" radio call a fire-and-forget `warmImportPanel()`. Hover and keyboard focus both reach it; a click is still the only thing that mounts it.
- **Rationale** — Mirrors `warmPanel` in `ModuleShell.tsx`, including the swallowed rejection: a failed prefetch is not an error, it just means the real mount pays the cost it would have paid anyway. Pointer *and* focus because the control is a radio in a `radiogroup` — arrow-key navigation never fires a pointer event.

### Move `PanelLoading` into its own file — `P-W2-b`

- **Issue** — The `Suspense` fallback lived inside `ModuleShell.tsx`, and `EditWorkspace` now needs it.
- **Why** — `ModuleShell` imports `EditWorkspace`. Importing back the other way is a cycle.
- **Solution** — `cire/host/src/components/PanelLoading.tsx`, imported by both.
- **Rationale** — It was always shared behaviour rather than `ModuleShell` state; the file move is what the second consumer made obvious. Its doc comment now names both consumers and the cycle, so the next person does not put it back.

### `ImportKind` becomes a type-only import — `P-W2-c`

- **Issue** — `import ImportPanel, { type ImportKind } from "./ImportPanel"` still pulls the whole module eagerly.
- **Why** — A value import defeats the split entirely. The `lazy()` would be decorative and nothing would move out of the entry chunk.
- **Solution** — `import type { ImportKind } from "./ImportPanel"`, which erases at compile time.
- **Rationale** — Verified by the numbers above rather than by reading: the entry chunk carries zero occurrences of `ChangeHistory` or `import-templates` and references `ImportPanel.CpFCFQWV.js` by filename only.

### The async tests are a forced consequence, not a style change — `P-W2-d`

- **Issue** — `lazy()` makes the mount land a microtask after the click, so every synchronous `getByTestId("import")` straight after `fireEvent.click` now fails — even though the module is `vi.mock`ed and nothing is fetched.
- **Why** — Those assertions had to change or the suite could not pass.
- **Solution** — Four assertions in `EditWorkspace.test.tsx` and two in `ModuleShell.test.tsx` become `await screen.findByTestId(...)`. The negative assertions (`queryByTestId(...)` is null before the panel is chosen) stay synchronous and stay meaningful.
- **Rationale** — `ModuleShell.test.tsx` is outside the file the finding names, but it renders `EditWorkspace`, so the same change forces it. Splitting that into a second PR would leave this one red.

**Out of scope** — no drift guard pins the type-only import. `ImportKind` erases completely, so unlike `PANEL_LOADER_KEYS` there is no runtime artefact to assert against; the honest guard is the build-chunk measurement above, not a test that looks like one.

## Test plan

| Gate | Result |
| --- | --- |
| `verify-task.sh` (tree clean, 1 commit, no conflict markers, JSON/TOML parse) | pass |
| `bun run --cwd cire/host test` | pass — 1133 tests |
| `bun run --cwd cire/host build` | pass |
| `bun run check` | pass — 0 errors |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| Changeset Check | pass |

Every gate re-run from the worktree rather than taken on report. The chunk numbers in the summary come from two builds run back to back in the same worktree — this branch, then `origin/main`'s version of `cire/host/src/components/` — so they are comparable rather than remembered.

One new test covers the warm path: hovering or keyboard-focusing the import control must not throw, must not flip `aria-checked`, and must not mount the panel. That is the whole observable surface under happy-dom; it exists to catch a future change that makes hover eager, which would quietly undo the split.
