### PR TITLE
fix(crypto,osn-api): derive token exp from the same clock read as iat

### DIFF
--- a/.changeset/arc-token-single-clock-read.md
+++ b/.changeset/arc-token-single-clock-read.md
@@ -1,0 +1,12 @@
+---
+"@shared/crypto": patch
+"@osn/api": patch
+---
+
+Derive a signed token's `exp` from the same clock read as its `iat`.
+
+Both ARC tokens (`signArcToken`) and OSN access/step-up tokens (`signToken`)
+called `setIssuedAt()` — which takes its own `Date.now()` — and then computed
+the expiry from a second, later read. A token minted across a second boundary
+therefore carried `exp - iat = ttl + 1`, a lifetime nobody configured, and made
+`@shared/crypto`'s TTL assertion fail intermittently in CI.

--- a/osn/api/src/services/auth/helpers.ts
+++ b/osn/api/src/services/auth/helpers.ts
@@ -149,11 +149,15 @@ export async function signJwt(
    */
   typ?: string,
 ): Promise<string> {
+  // One clock read for both claims — `setIssuedAt()` takes its own Date.now(),
+  // so a token minted across a second boundary lived ttl + 1 seconds.
+  const issuedAt = Math.floor(Date.now() / 1000);
+
   return new SignJWT(payload)
     .setProtectedHeader(typ ? { alg: "ES256", kid, typ } : { alg: "ES256", kid })
-    .setIssuedAt()
+    .setIssuedAt(issuedAt)
     .setIssuer(issuer)
-    .setExpirationTime(Math.floor(Date.now() / 1000) + ttl)
+    .setExpirationTime(issuedAt + ttl)
     .sign(privateKey);
 }
 

--- a/shared/crypto/src/jwk.ts
+++ b/shared/crypto/src/jwk.ts
@@ -201,11 +201,17 @@ export async function signArcToken(
   const scopes = normaliseScopes(claims.scope);
   validateScopeFormat(scopes);
 
+  // One clock read for both claims. `setIssuedAt()` and a relative
+  // `setExpirationTime("300s")` each call Date.now() separately, so a token
+  // minted across a second boundary carries exp - iat = ttl + 1 — a lifetime
+  // the caller never asked for, and a flaky assertion for anyone checking it.
+  const issuedAt = Math.floor(Date.now() / 1000);
+
   return new SignJWT({ scope: scopes.join(",") })
     .setProtectedHeader({ alg: ARC_ALG, kid: claims.kid })
     .setIssuer(claims.iss)
     .setAudience(claims.aud)
-    .setIssuedAt()
-    .setExpirationTime(`${ttl}s`)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(issuedAt + ttl)
     .sign(privateKey);
 }


### PR DESCRIPTION
## Summary

Both token signers read the clock twice: `setIssuedAt()` takes its own `Date.now()`, then the expiry was computed from a second, later read. A token minted across a second boundary carried `exp - iat = ttl + 1`.

Two consequences. Every signed token had a lifetime that could be one second longer than configured. And `@shared/crypto`'s round-trip test asserts `payload.exp - payload.iat === 300`, so it failed intermittently in CI — `expected 301 to be 300` — reddening PRs that touch nothing near it.

Both signers now read the clock once and derive `iat` and `exp` from that value.

## Workspaces affected

- `@shared/crypto` — `signArcToken` (`shared/crypto/src/jwk.ts`), the Worker-safe ARC signer
- `@osn/api` — `signToken` (`osn/api/src/services/auth/helpers.ts`), which mints access, step-up and OIDC tokens

## Decisions

- **Fixed the signers, not the assertion.** Widening the test to `toBeGreaterThanOrEqual(300)` would have hidden a real off-by-one in issued token lifetimes.
- **Left the test helpers alone.** `shared/crypto/src/testing.ts` and `shared/osn-auth-client/src/testing/oidc-issuer.ts` have the same split read, but nothing asserts their exact TTL and they mint nothing that leaves a test process.

## Test plan

- `bun run --cwd shared/crypto test` — 5 files / 81 tests pass
- `bun run --cwd osn/api test:run` — 66 files / 1076 tests pass
- `bun run --cwd shared/osn-auth-client test` — 89 tests pass
- `bun run --cwd cire/api test` — 1693 tests pass (consumes `signArcToken` for S2S calls)