### PR TITLE
perf(cire): self-host the invite typefaces, latin + latin-ext only

### DIFF
--- a/.changeset/cire-fonts-selfhost.md
+++ b/.changeset/cire-fonts-selfhost.md
@@ -1,0 +1,15 @@
+---
+"@cire/invites": patch
+---
+
+Self-host the invite typefaces instead of loading them from `fonts.googleapis.com`.
+
+Cormorant Garamond and Lato now ship via `@fontsource/cormorant-garamond` and
+`@fontsource/lato`, bundled and served from the app's own origin. This drops a
+third-party connection from the guest critical path and removes the preconnect
++ preload + `onload` swap dance from all four document shells. Metric-matched
+`@font-face` fallbacks (computed from `@capsizecss/metrics`) keep the layout
+stable while the real faces load, instead of reflowing the hero title on swap.
+The CSP `style-src`/`font-src` and the Google Fonts consent-vendor entry are
+gone with the origins they existed for; the woff2 files land under the
+content-hashed `/_astro/*` path and are cached immutably.

--- a/.changeset/cire-fonts-selfhost.md
+++ b/.changeset/cire-fonts-selfhost.md
@@ -13,3 +13,10 @@ stable while the real faces load, instead of reflowing the hero title on swap.
 The CSP `style-src`/`font-src` and the Google Fonts consent-vendor entry are
 gone with the origins they existed for; the woff2 files land under the
 content-hashed `/_astro/*` path and are cached immutably.
+
+Only the latin and latin-ext subsets are shipped, and each rule points at the
+`.woff2` alone. Pulling in fontsource's whole-family entrypoints instead would
+put 49 `@font-face` rules on the render-blocking critical path — every subset
+of both families, plus a legacy `.woff` per rule small enough that the bundler
+base64-inlined eight of them into the stylesheet. Names in Cyrillic or
+Vietnamese now paint in the metric-matched fallback by design.

--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,8 @@
         "@astrojs/solid-js": "^7.0.1",
         "@cire/invite-designs": "workspace:*",
         "@cire/theme": "workspace:*",
+        "@fontsource/cormorant-garamond": "^5.3.0",
+        "@fontsource/lato": "^5.3.0",
         "@shared/rp-auth": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
@@ -109,6 +111,7 @@
         "tailwindcss": "^4.3.3",
       },
       "devDependencies": {
+        "@capsizecss/metrics": "^4.2.0",
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
         "@testing-library/jest-dom": "^6.10.0",
@@ -177,7 +180,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.20.6",
+      "version": "3.20.9",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/openapi": "1.4.15",
@@ -266,7 +269,7 @@
     },
     "osn/social": {
       "name": "@osn/social",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -318,7 +321,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.5",
+      "version": "0.26.7",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -389,7 +392,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.8",
+      "version": "0.22.10",
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@pulse/api": "workspace:*",
@@ -419,7 +422,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.10.3",
+      "version": "0.10.5",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -450,7 +453,7 @@
     },
     "shared/email": {
       "name": "@shared/email",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@shared/observability": "workspace:*",
         "effect": "^3.22.0",
@@ -463,7 +466,7 @@
     },
     "shared/feature-flags": {
       "name": "@shared/feature-flags",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@growthbook/growthbook": "^1.6.5",
         "@shared/observability": "workspace:*",
@@ -475,7 +478,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "dependencies": {
         "@effect/opentelemetry": "^0.64.0",
         "@effect/platform": "^0.97.0",
@@ -508,7 +511,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.4.3",
+      "version": "0.4.5",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.4",
@@ -566,7 +569,7 @@
     },
     "shared/turnstile": {
       "name": "@shared/turnstile",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@shared/observability": "workspace:*",
       },
@@ -581,7 +584,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.8.17",
+      "version": "0.8.19",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -761,6 +764,8 @@
     "@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg=="],
 
     "@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g=="],
+
+    "@capsizecss/metrics": ["@capsizecss/metrics@4.2.0", "", {}, "sha512-BkLX2NonSAVuHrStmxlRG/PVUxq4uQWeQGPY/G/4pi7GRQt/4A+7RzMWR8m85+0Tv7BsuBpR7JoniMS9QwuVRw=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
@@ -973,6 +978,10 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource/cormorant-garamond": ["@fontsource/cormorant-garamond@5.3.0", "", {}, "sha512-weuGsCirGVWBWqpt6YUp0yLThTe4G8YO45noq8wxeJCRvEpq5lFrxNMFSTxcyOyV5k5otzJ8guDzYegdYlcLMQ=="],
+
+    "@fontsource/lato": ["@fontsource/lato@5.3.0", "", {}, "sha512-0WhF/4rhrw+ErIyneKvhHn2YAl+xf8GDtllgOgOzDmeaSlLQtjpChXaQOpWhG2BchQW0WJy2zLV12Hdg0ndOMw=="],
 
     "@growthbook/growthbook": ["@growthbook/growthbook@1.6.5", "", { "dependencies": { "dom-mutator": "^0.6.0" } }, "sha512-mUaMsgeUTpRIUOTn33EUXHRK6j7pxBjwqH4WpQyq+pukjd1AIzWlEa6w7i6bInJUcweGgP2beXZmaP6b6UPn7A=="],
 

--- a/cire/invites/package.json
+++ b/cire/invites/package.json
@@ -14,6 +14,8 @@
     "@astrojs/solid-js": "^7.0.1",
     "@cire/invite-designs": "workspace:*",
     "@cire/theme": "workspace:*",
+    "@fontsource/cormorant-garamond": "^5.3.0",
+    "@fontsource/lato": "^5.3.0",
     "@shared/rp-auth": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",
@@ -23,6 +25,7 @@
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
+    "@capsizecss/metrics": "^4.2.0",
     "@shared/typescript-config": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.10.0",

--- a/cire/invites/public/_headers
+++ b/cire/invites/public/_headers
@@ -21,4 +21,10 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Reporting-Endpoints: csp-endpoint="https://api.cireweddings.com/api/csp-report"
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://assets.pinterest.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://api.cireweddings.com http://localhost:8787 https://i.pinimg.com https://maps.gstatic.com https://maps.googleapis.com; connect-src 'self' https://api.cireweddings.com http://localhost:8787 https://widgets.pinterest.com; frame-src 'self' https://www.google.com https://assets.pinterest.com https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; report-uri https://api.cireweddings.com/api/csp-report; report-to csp-endpoint
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://assets.pinterest.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://api.cireweddings.com http://localhost:8787 https://i.pinimg.com https://maps.gstatic.com https://maps.googleapis.com; connect-src 'self' https://api.cireweddings.com http://localhost:8787 https://widgets.pinterest.com; frame-src 'self' https://www.google.com https://assets.pinterest.com https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; report-uri https://api.cireweddings.com/api/csp-report; report-to csp-endpoint
+
+# Fontsource woff2 (+ every other Vite-bundled asset) import through CSS and
+# land under the content-hashed /_astro/* path — a new font weight or a
+# rebuild changes the filename, so caching it forever is safe (tracker #98).
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/cire/invites/src/components/NotFoundDocument.astro
+++ b/cire/invites/src/components/NotFoundDocument.astro
@@ -22,17 +22,6 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{heading}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet" />
-    </noscript>
   </head>
   <body>
     <main class="flex min-h-dvh flex-col items-center justify-center gap-5 px-6 text-center">

--- a/cire/invites/src/components/consent/ConsentBanner.test.tsx
+++ b/cire/invites/src/components/consent/ConsentBanner.test.tsx
@@ -214,12 +214,14 @@ describe("ConsentPreferences dialog", () => {
   });
 
   it("names the vendors the switch does NOT govern, rather than hiding them", () => {
-    // Google Fonts loads from the document head before any choice can apply.
-    // Listing it under the toggle would overstate what the toggle does; omitting
-    // it would understate what the site loads.
+    // Turnstile loads before any choice can apply — the claim form can't
+    // function without it. Listing it under the toggle would overstate what
+    // the toggle does; omitting it would understate what the site loads.
+    // (Google Fonts used to be the other ungated vendor here; self-hosting
+    // removed it from the registry entirely — tracker #98.)
     const text = dialog()!.textContent ?? "";
     expect(text).toContain("Loads on every visit");
-    expect(text).toContain("Google Fonts");
+    expect(text).toContain("Cloudflare Turnstile");
   });
 
   it("offers accept-all and reject-all from inside the dialog too", () => {

--- a/cire/invites/src/components/consent/ConsentPreferences.tsx
+++ b/cire/invites/src/components/consent/ConsentPreferences.tsx
@@ -40,9 +40,10 @@ const FOCUSABLE_SELECTOR = [
  * confirmed. Nothing here persists without the explicit Save (or one of the two
  * one-click actions, which are unambiguous by construction).
  *
- * Vendors that the toggle does NOT govern (`enforcement: "always"` — today only
- * Google Fonts, loaded from the document head) are listed separately under an
- * explicit "loads on every visit" heading. Hiding them would leave the dialog
+ * Vendors that the toggle does NOT govern (`enforcement: "always"` — today
+ * Cloudflare Turnstile, which the claim form can't function without) are
+ * listed separately under an explicit "loads on every visit" heading. Hiding
+ * them would leave the dialog
  * quietly overstating what the switch controls; listing them under the switch
  * as though it applied would do the same thing more loudly.
  */

--- a/cire/invites/src/components/consent/ConsentPreferences.tsx
+++ b/cire/invites/src/components/consent/ConsentPreferences.tsx
@@ -43,9 +43,9 @@ const FOCUSABLE_SELECTOR = [
  * Vendors that the toggle does NOT govern (`enforcement: "always"` — today
  * Cloudflare Turnstile, which the claim form can't function without) are
  * listed separately under an explicit "loads on every visit" heading. Hiding
- * them would leave the dialog
- * quietly overstating what the switch controls; listing them under the switch
- * as though it applied would do the same thing more loudly.
+ * them would leave the dialog quietly overstating what the switch controls;
+ * listing them under the switch as though it applied would do the same thing
+ * more loudly.
  */
 export function ConsentPreferences() {
   const titleId = createUniqueId();

--- a/cire/invites/src/designs/classic/Document.astro
+++ b/cire/invites/src/designs/classic/Document.astro
@@ -66,17 +66,6 @@ const registryVars = filterThemeVars(sectionVars(initialInvite?.theme ?? null, '
         DNS+TCP+TLS handshake. */}
     {apiPreconnect && <link rel="preconnect" href={apiPreconnect} />}
     {apiPreconnect && <link rel="preconnect" href={apiPreconnect} crossorigin />}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet" />
-    </noscript>
     {preloadHeroHref && <link rel="preload" as="image" href={preloadHeroHref} />}
   </head>
   <body>

--- a/cire/invites/src/designs/gala/Document.astro
+++ b/cire/invites/src/designs/gala/Document.astro
@@ -66,17 +66,6 @@ const registryVars = filterThemeVars(sectionVars(initialInvite?.theme ?? null, '
         DNS+TCP+TLS handshake. */}
     {apiPreconnect && <link rel="preconnect" href={apiPreconnect} />}
     {apiPreconnect && <link rel="preconnect" href={apiPreconnect} crossorigin />}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet" />
-    </noscript>
     {preloadHeroHref && <link rel="preload" as="image" href={preloadHeroHref} />}
   </head>
   <body>

--- a/cire/invites/src/layouts/LegalLayout.astro
+++ b/cire/invites/src/layouts/LegalLayout.astro
@@ -17,17 +17,6 @@ const { title } = Astro.props
     {/* S-L1: keep the ?code= preview credential out of cross-origin Referer headers. */}
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{title}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet" />
-    </noscript>
   </head>
   <body>
     <main class="legal">

--- a/cire/invites/src/lib/api-origin.ts
+++ b/cire/invites/src/lib/api-origin.ts
@@ -21,8 +21,8 @@
  * pools for credentialed and anonymous connections, and every request the guest
  * site makes to the API is credentialed — `fetch(..., { credentials: "include" })`
  * for claim/restore/RSVP, and plain `<img>` loads for the hero and event images.
- * An anonymous preconnect (what the Google Fonts links need, because font
- * fetches are anonymous-CORS) would warm the wrong pool and buy nothing.
+ * An anonymous preconnect (the shape an anonymous-CORS asset fetch would need)
+ * would warm the wrong pool and buy nothing here.
  */
 export function apiPreconnectHref(apiUrl: string): string | null {
   try {

--- a/cire/invites/src/lib/consent/vendors.test.ts
+++ b/cire/invites/src/lib/consent/vendors.test.ts
@@ -130,13 +130,15 @@ describe("category partitioning", () => {
     expect(ids).toContain("google-maps");
   });
 
-  it("lists Google Fonts as loading regardless of the toggle", () => {
-    // Honesty check. Fonts load from the document <head>, before any consent can
-    // be applied, so the dialog must not imply the switch controls them. If this
-    // ever flips to `gated` (or the vendor is removed by self-hosting), this
-    // test is the prompt to update the privacy-page note that says so.
+  it("has no ungated embeds — Google Fonts was self-hosted out of the registry (tracker #98)", () => {
+    // Honesty check, inverted. Fonts used to load from the document <head>
+    // before any consent could apply, so `embeds` carried one "always" vendor.
+    // Self-hosting removed the vendor entirely rather than gating it, so
+    // `embeds` should now be gated-only. If this list is ever non-empty again,
+    // that is the prompt to update the privacy-page note that used to explain
+    // the exception.
     const ids = ungatedVendorsInCategory("embeds").map((vendor) => vendor.id);
-    expect(ids).toEqual(["google-fonts"]);
+    expect(ids).toEqual([]);
   });
 
   it("splits every category's vendors into exactly gated + ungated", () => {

--- a/cire/invites/src/lib/consent/vendors.ts
+++ b/cire/invites/src/lib/consent/vendors.ts
@@ -25,14 +25,15 @@ import type { ConsentCategory } from "./categories";
  *    grants its category. Pinterest and Google Maps are both gated: their
  *    components mount inside the click-opened details sheet, so nothing is in
  *    the server-rendered HTML and a client-side gate is genuinely sufficient.
- *  - `"always"` — loads on every visit regardless of the guest's choice. Only
- *    Google Fonts, and only because the font `<link>` lives in the `<head>` of
- *    the server-rendered document: gating it would either swap the typeface
- *    mid-visit (a jarring, consent-triggered redesign) or leave the prerendered
- *    legal pages inconsistent with the SSR'd invite. The right fix is to remove
- *    the vendor rather than gate it — self-host the two woff2 families and
- *    Google drops out of this table entirely. Tracked as an open issue in
- *    `xchromo/osn` (`label:product:cire`).
+ *  - `"always"` — loads on every visit regardless of the guest's choice. Used
+ *    for first-party necessities (the session cookie, the consent record
+ *    itself) and Turnstile, which the claim form cannot function without.
+ *    Google Fonts used to be the one third party in this bucket — its `<link>`
+ *    lived in the `<head>` of the server-rendered document, so gating it would
+ *    have either swapped the typeface mid-visit or left the prerendered legal
+ *    pages inconsistent with the SSR'd invite. Self-hosting the two woff2
+ *    families (tracker #98) removed the vendor from this table entirely rather
+ *    than gating it.
  *
  * The preferences dialog surfaces this distinction rather than hiding it: an
  * `"always"` vendor is listed with a plain "loads on every visit" note instead
@@ -97,18 +98,6 @@ export const CONSENT_VENDORS: readonly ConsentVendor[] = [
     transfer: "Cloudflare, Inc. (US)",
   },
   {
-    id: "google-fonts",
-    name: "Google Fonts",
-    category: "embeds",
-    purpose: "Serves the two typefaces the invite is set in.",
-    origins: ["https://fonts.googleapis.com", "https://fonts.gstatic.com"],
-    // See the module doc: `<head>`-level, so not gated. Being replaced by
-    // self-hosted font files rather than moved behind the toggle.
-    enforcement: "always",
-    privacyUrl: "https://policies.google.com/privacy",
-    transfer: "Google LLC (US)",
-  },
-  {
     id: "google-maps",
     name: "Google Maps",
     category: "embeds",
@@ -155,7 +144,7 @@ export function gatedVendorsInCategory(category: ConsentCategory): readonly Cons
 /**
  * Vendors in a category that load regardless of the toggle — listed separately
  * and labelled, so the dialog never implies a switch governs something it
- * doesn't. Today this is Google Fonts only.
+ * doesn't.
  */
 export function ungatedVendorsInCategory(category: ConsentCategory): readonly ConsentVendor[] {
   return vendorsInCategory(category).filter(

--- a/cire/invites/src/lib/security-headers.test.ts
+++ b/cire/invites/src/lib/security-headers.test.ts
@@ -38,9 +38,9 @@ describe("buildCsp", () => {
     expect(csp).toMatch(/img-src[^;]*https:\/\/maps\.googleapis\.com/);
   });
 
-  it("allowlists Google Fonts (stylesheet + font files)", () => {
-    expect(csp).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/);
-    expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
+  it("does NOT allowlist Google Fonts — the two families are self-hosted (tracker #98)", () => {
+    expect(csp).not.toMatch(/fonts\.googleapis\.com/);
+    expect(csp).not.toMatch(/fonts\.gstatic\.com/);
   });
 
   it("allowlists Cloudflare Turnstile (script + challenge frame)", () => {
@@ -75,8 +75,8 @@ describe("buildCsp", () => {
       const isHttpsHost = src.startsWith("https://");
       expect(isKeyword || isHttpsHost).toBe(true);
     }
-    // The documented, required relaxations for Astro island hydration + the
-    // font-link onload handler. Hosts beyond these are explicit allowlist only.
+    // The documented, required relaxation for Astro island hydration. Hosts
+    // beyond these are explicit allowlist only.
     expect(sources).toContain("'self'");
     expect(sources).toContain("'unsafe-inline'");
   });

--- a/cire/invites/src/lib/security-headers.ts
+++ b/cire/invites/src/lib/security-headers.ts
@@ -47,9 +47,6 @@ const ORIGINS = {
   googleMapsFrame: "https://www.google.com", // /maps/embed iframe host
   googleMapsImg: "https://maps.gstatic.com", // map tiles / static assets
   googleMapsImg2: "https://maps.googleapis.com", // map tile requests
-  // Google Fonts (Cormorant Garamond + Lato), loaded in the Astro head.
-  fontsStyle: "https://fonts.googleapis.com", // the @font-face stylesheet
-  fontsFile: "https://fonts.gstatic.com", // the woff2 font files
   // Cloudflare Turnstile (guest claim flow — LoginSection -> TurnstileWidget).
   turnstile: "https://challenges.cloudflare.com", // api.js + challenge iframe
 } as const;
@@ -81,16 +78,14 @@ export const REPORTING_ENDPOINT_NAME = "csp-endpoint" as const;
  *
  *  - `script-src` keeps `'unsafe-inline'`. Astro's SSR island hydration emits
  *    small inline `<script>` blocks (the `<astro-island>` custom-element
- *    definition + the per-directive `client:load` / `client:visible` bootstrap),
- *    and the font `<link rel="preload" ... onload="...">` in the document heads
- *    is an inline event-handler attribute. Neither can be covered by a hash or
- *    nonce from a single response header (event-handler attributes are never
- *    hash-eligible, and Astro's own CSP hashing only works via a `<meta>` tag
- *    that cannot express `frame-ancestors` and would conflict with this header).
- *    `'unsafe-inline'` is therefore required for hydration to work — but
- *    `script-src` stays host-restricted (no wildcard; only `'self'` + the two
- *    audited third-party script hosts), so injected *external* scripts are still
- *    blocked. This is the documented, provably-working relaxation.
+ *    definition + the per-directive `client:load` / `client:visible` bootstrap).
+ *    These cannot be covered by a hash or nonce from a single response header
+ *    (Astro's own CSP hashing only works via a `<meta>` tag that cannot express
+ *    `frame-ancestors` and would conflict with this header). `'unsafe-inline'`
+ *    is therefore required for hydration to work — but `script-src` stays
+ *    host-restricted (no wildcard; only `'self'` + the two audited third-party
+ *    script hosts), so injected *external* scripts are still blocked. This is
+ *    the documented, provably-working relaxation.
  *
  *  - `style-src` / `style-src-attr` keep `'unsafe-inline'`. The invite renders
  *    many element `style={{...}}` theme variables (governed by `style-src-attr`),
@@ -104,15 +99,16 @@ export const REPORTING_ENDPOINT_NAME = "csp-endpoint" as const;
  */
 export const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
-  // Astro island hydration inline scripts + the font-link onload handler need
-  // 'unsafe-inline'; hosts are still tightly allowlisted (no wildcard).
+  // Astro island hydration inline scripts need 'unsafe-inline'; hosts are
+  // still tightly allowlisted (no wildcard).
   "script-src": ["'self'", "'unsafe-inline'", ORIGINS.pinterestScript, ORIGINS.turnstile],
-  // Google Fonts stylesheet + Astro/Tailwind inline styles.
-  "style-src": ["'self'", "'unsafe-inline'", ORIGINS.fontsStyle],
+  // Astro/Tailwind inline styles. Fonts are self-hosted (tracker #98) — the
+  // @font-face rules load from 'self', no third-party stylesheet host needed.
+  "style-src": ["'self'", "'unsafe-inline'"],
   // Inline element style attributes (the invite theme vars). Low-risk.
   "style-src-attr": ["'unsafe-inline'"],
-  // Google Fonts woff2 files.
-  "font-src": ["'self'", ORIGINS.fontsFile],
+  // Self-hosted fontsource woff2 files (tracker #98) — served from 'self'.
+  "font-src": ["'self'"],
   // First-party invite/event image bytes (served from cire-api), Pinterest pin
   // thumbnails, Google Maps tiles, plus data:/blob: (inline SVG/blur placeholders).
   "img-src": [

--- a/cire/invites/src/pages/privacy.astro
+++ b/cire/invites/src/pages/privacy.astro
@@ -148,12 +148,12 @@ const vendors = thirdPartyVendors()
   </ul>
   <p class="owner-note">
     <strong>Note for the site owner:</strong> the entries marked “loads on every
-    visit” are not covered by the consent choice. Today that is Google Fonts,
-    which is requested from the page <code>&lt;head&gt;</code> before any choice
-    can be applied. The fix is to self-host the two font files so Google drops
-    out of this list entirely, rather than to put the site’s typography behind a
-    switch — tracked as an open issue. Until then this page says
-    so plainly instead of implying the toggle covers it.
+    visit” are not covered by the consent choice. Today that is Cloudflare
+    Turnstile, which the claim form can’t function without and which is
+    requested before any choice can be applied — so this page says so plainly
+    instead of implying the toggle covers it. (Google Fonts used to be listed
+    here too; self-hosting the two font files removed it from the vendor
+    registry entirely — tracker #98.)
   </p>
 
   <h3>Changing your mind</h3>

--- a/cire/invites/src/styles/global.css
+++ b/cire/invites/src/styles/global.css
@@ -1,5 +1,63 @@
 @import "tailwindcss";
 
+/* Self-hosted faces (tracker #98) — matches the weight set in
+   `src/designs/gala/Document.astro` (`ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700`
+   for Cormorant Garamond, `ital,wght@0,300;0,400;0,700;1,300;1,400;1,700` for Lato).
+   Cormorant 700 is load-bearing — organiser `headingWeight: "bold"` renders through it
+   (`components/invite-theme.ts`). */
+@import "@fontsource/cormorant-garamond/300.css";
+@import "@fontsource/cormorant-garamond/300-italic.css";
+@import "@fontsource/cormorant-garamond/400.css";
+@import "@fontsource/cormorant-garamond/400-italic.css";
+@import "@fontsource/cormorant-garamond/600.css";
+@import "@fontsource/cormorant-garamond/700.css";
+@import "@fontsource/cormorant-garamond/700-italic.css";
+@import "@fontsource/lato/300.css";
+@import "@fontsource/lato/300-italic.css";
+@import "@fontsource/lato/400.css";
+@import "@fontsource/lato/400-italic.css";
+@import "@fontsource/lato/700.css";
+@import "@fontsource/lato/700-italic.css";
+
+/*
+  Metric-matched fallback faces, so the fallback occupies the same box the
+  webfont will and the hero title doesn't reflow when the swap lands.
+
+  Formula (the one behind `@next/font`'s local-fallback generation and
+  Katie Hempenius's "Overriding font fallback metrics", web.dev 2021): match
+  average character width first, then re-derive the vertical metrics against
+  that adjusted scale.
+
+    sizeAdjust    = (webfont.xWidthAvg / webfont.unitsPerEm)
+                    / (fallback.xWidthAvg / fallback.unitsPerEm)
+    ascent-override    = (webfont.ascent  / webfont.unitsPerEm) / sizeAdjust
+    descent-override   = abs(webfont.descent / webfont.unitsPerEm) / sizeAdjust
+    line-gap-override  = (webfont.lineGap / webfont.unitsPerEm) / sizeAdjust
+
+  Source metrics, `@capsizecss/metrics` `entireMetricsCollection` (devDependency):
+    cormorantGaramond: ascent 924, descent -287, lineGap 0, unitsPerEm 1000, xWidthAvg 394
+    lato:              ascent 1974, descent -426, lineGap 0, unitsPerEm 2000, xWidthAvg 871
+    georgia:           unitsPerEm 2048, xWidthAvg 913
+    arial:             unitsPerEm 2048, xWidthAvg 913
+*/
+@font-face {
+  font-family: "Cormorant Garamond Fallback";
+  src: local("Georgia");
+  size-adjust: 88.38%;
+  ascent-override: 104.55%;
+  descent-override: 32.47%;
+  line-gap-override: 0%;
+}
+
+@font-face {
+  font-family: "Lato Fallback";
+  src: local("Arial");
+  size-adjust: 97.69%;
+  ascent-override: 101.03%;
+  descent-override: 21.8%;
+  line-gap-override: 0%;
+}
+
 /*
   The built-in scheme — the `evergreen` preset in `@cire/theme`, spelled out
   here as the Tailwind token defaults.
@@ -39,8 +97,8 @@
   --color-bloom-dim: oklch(70.5% 0.1123 24.5 / 0.3);
   --color-error: oklch(72% 0.1401 21.48);
   --color-success: oklch(64% 0.1421 146.94);
-  --font-display: "Cormorant Garamond", Georgia, serif;
-  --font-body: "Lato", system-ui, sans-serif;
+  --font-display: "Cormorant Garamond", "Cormorant Garamond Fallback", Georgia, serif;
+  --font-body: "Lato", "Lato Fallback", system-ui, sans-serif;
   --default-font-family: var(--font-body);
 
   /* The tick that confirms a recorded RSVP, drawing itself in behind the bloom

--- a/cire/invites/src/styles/global.css
+++ b/cire/invites/src/styles/global.css
@@ -1,23 +1,297 @@
 @import "tailwindcss";
 
-/* Self-hosted faces (tracker #98) — matches the weight set in
-   `src/designs/gala/Document.astro` (`ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700`
-   for Cormorant Garamond, `ital,wght@0,300;0,400;0,700;1,300;1,400;1,700` for Lato).
-   Cormorant 700 is load-bearing — organiser `headingWeight: "bold"` renders through it
-   (`components/invite-theme.ts`). */
-@import "@fontsource/cormorant-garamond/300.css";
-@import "@fontsource/cormorant-garamond/300-italic.css";
-@import "@fontsource/cormorant-garamond/400.css";
-@import "@fontsource/cormorant-garamond/400-italic.css";
-@import "@fontsource/cormorant-garamond/600.css";
-@import "@fontsource/cormorant-garamond/700.css";
-@import "@fontsource/cormorant-garamond/700-italic.css";
-@import "@fontsource/lato/300.css";
-@import "@fontsource/lato/300-italic.css";
-@import "@fontsource/lato/400.css";
-@import "@fontsource/lato/400-italic.css";
-@import "@fontsource/lato/700.css";
-@import "@fontsource/lato/700-italic.css";
+/* Self-hosted faces (tracker #98) — matches the weight set the guest site used
+   to pull from Google Fonts (`ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,700`
+   for Cormorant Garamond, `ital,wght@0,300;0,400;0,700;1,300;1,400;1,700` for
+   Lato). Cormorant 700 is load-bearing — organiser `headingWeight: "bold"`
+   renders through it (`components/invite-theme.ts`).
+
+   The rules below are WRITTEN OUT rather than pulled in with
+   `@import "@fontsource/lato/400.css"`, for two reasons that both cost real
+   bytes on the render-blocking critical path:
+
+     1. A whole-family entrypoint carries every subset fontsource publishes.
+        Cormorant ships five (cyrillic, cyrillic-ext, latin, latin-ext,
+        vietnamese), so thirteen weight imports produced 49 `@font-face` rules
+        and ~49 KB of stylesheet. The browser never DOWNLOADS an unused subset
+        — `unicode-range` gates the fetch — but the rules are parsed on every
+        page load regardless. Only latin and latin-ext are kept here.
+     2. Every fontsource rule carries a legacy `.woff` alongside the `.woff2`.
+        The latin-ext `.woff` files are under Vite's 4096-byte
+        `assetsInlineLimit`, so the bundler base64-INLINED eight of them
+        straight into the critical CSS — ~5 KB each. Every browser that can run
+        this site takes the woff2, so the fallback is dropped entirely.
+
+   The per-subset entrypoints (`@fontsource/lato/latin-400.css`) are NOT the fix
+   for (1): fontsource omits `unicode-range` from those files, so latin and
+   latin-ext become two indistinguishable faces for one family/weight/style and
+   the later declaration silently wins outright.
+
+   The trade-off, stated plainly: a name in Cyrillic or Vietnamese paints in the
+   metric-matched fallback below (Georgia / Arial) rather than in Cormorant or
+   Lato. To add a subset back, copy its rule out of
+   `node_modules/@fontsource/<family>/<weight>.css`, keep the `unicode-range`,
+   and point `src` at the `.woff2` alone. */
+
+/* cormorant-garamond-latin-ext-300-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-300-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-300-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-300-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-300-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-300-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-300-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-300-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-400-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-400-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-400-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-400-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-400-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-400-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-400-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-400-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-600-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-600-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-600-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-600-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-700-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-700-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-700-normal */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-700-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* cormorant-garamond-latin-ext-700-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-ext-700-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* cormorant-garamond-latin-700-italic */
+@font-face {
+  font-family: 'Cormorant Garamond';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/cormorant-garamond/files/cormorant-garamond-latin-700-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-300-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/lato/files/lato-latin-ext-300-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-300-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/lato/files/lato-latin-300-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-300-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/lato/files/lato-latin-ext-300-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-300-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 300;
+  src: url('@fontsource/lato/files/lato-latin-300-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-400-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/lato/files/lato-latin-ext-400-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-400-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/lato/files/lato-latin-400-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-400-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/lato/files/lato-latin-ext-400-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-400-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/lato/files/lato-latin-400-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-700-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/lato/files/lato-latin-ext-700-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-700-normal */
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/lato/files/lato-latin-700-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* lato-latin-ext-700-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/lato/files/lato-latin-ext-700-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* lato-latin-700-italic */
+@font-face {
+  font-family: 'Lato';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/lato/files/lato-latin-700-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
 
 /*
   Metric-matched fallback faces, so the fallback occupies the same box the


### PR DESCRIPTION
## Summary

The guest invite pulled Cormorant Garamond and Lato from `fonts.googleapis.com`
on every page load — a third-party origin on the render-blocking critical path,
a preconnect + preload + `onload`-swap dance repeated in four document shells,
and a consent vendor that the consent dialog could not actually gate because the
`<link>` sat in the server-rendered `<head>`. Both families now ship from the
site's own origin via `@fontsource`, with metric-matched fallback faces computed
from `@capsizecss/metrics` so the hero title keeps its box while the real face
loads.

- The Google origins are gone from the CSP (`style-src`, `font-src`) and from
  the consent vendor registry, rather than being gated. Two existing tests were
  **inverted** rather than deleted, so the absence is asserted.
- Only the latin and latin-ext subsets ship, and each rule points at the
  `.woff2` alone — see the first decision below, which is most of this PR.
- `/_astro/*` gains `Cache-Control: public, max-age=31536000, immutable`. Safe
  because Astro content-hashes everything under that path.

## Workspaces affected

`@cire/invites`. `.changeset/cire-fonts-selfhost.md` names it at `patch`; it is
a version-less package, so nothing else may be mixed into that changeset.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#98 | `P-W1` |

**Opened**

| Issue | What |
|---|---|
| — | None |

Closes xchromo/osn-tracker#98

## Decisions

### Font rules are written out by hand, not `@import`ed — `approach`

- **Issue** — the first pass imported fontsource's whole-family entrypoints
  (`@fontsource/lato/400.css`). That put **49** `@font-face` rules into the
  render-blocking stylesheet and took the guest bundle from 8584 to 33395
  gzipped bytes. Self-hosting had bought a slower first paint than the
  cross-origin request it replaced.
- **Why** — two separate costs, neither visible without building and measuring.
  A whole-family entrypoint carries every subset the family publishes; Cormorant
  ships five (cyrillic, cyrillic-ext, latin, latin-ext, vietnamese), so thirteen
  weight imports became 49 rules. `unicode-range` stops the browser *fetching* an
  unused subset, but every rule is still parsed on every page load. Separately,
  each fontsource rule lists a legacy `.woff` beside the `.woff2`, and the
  latin-ext `.woff` files fall under Vite's 4096-byte `assetsInlineLimit` — so
  the bundler base64-**inlined eight of them into the critical CSS**, ~5 KB each.
- **Solution** — the 26 rules live in `src/styles/global.css` with their real
  `unicode-range` values copied from fontsource and a woff2-only `src`, resolved
  through the package specifier so Vite still content-hashes and emits the files.
  Guest stylesheet: **90662 raw / 33395 gz → 50365 raw / 9485 gz**; 26 `.woff2`
  emitted, zero `.woff`, zero base64.
- **Rationale** — the obvious alternative, fontsource's per-subset entrypoints
  (`latin-400.css`), is wrong and quietly so: fontsource omits `unicode-range`
  from those files, which leaves latin and latin-ext as two indistinguishable
  faces for one family/weight/style, and the later declaration wins outright.
  Plain ASCII would have rendered from a file holding no ASCII glyphs. The
  written-out block is checked in with a comment saying where each rule came
  from and how to add a subset back.

### Cyrillic and Vietnamese fall back by design — `approach`

- **Issue** — dropping those subsets means a guest name in either script no
  longer paints in Cormorant or Lato.
- **Why** — it is a real, if narrow, product regression, and it should not be
  discovered from a diff.
- **Solution** — those names paint in the metric-matched Georgia / Arial
  fallback. The comment above the block states this and gives the recipe for
  restoring a subset.
- **Rationale** — the invite is a bespoke product with a known guest list; the
  three subsets cost every visitor bytes to serve scripts no current wedding
  uses. Restoring one is a three-line edit, not a redesign.

### The residual gap over the old bundle is the price of self-hosting — `approach`

- **Issue** — 9485 gz is still above the 8584 the stylesheet measured before
  this branch.
- **Why** — worth stating so nobody chases it as a regression.
- **Solution** — none. `main` carried **zero** `@font-face` rules; it had a
  cross-origin `<link>` instead. Self-hosting inherently adds the latin and
  latin-ext rules for both families.
- **Rationale** — ~900 gzipped bytes buys the removal of a third-party origin
  from the critical path, one fewer consent vendor, and no cross-origin
  render-blocking request.

**Out of scope** — none found and left.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run --cwd cire/invites test` | ✅ 884 pass / 55 files |
| `bun run --cwd cire/invites test:browser` | ✅ 29 pass / 6 files |
| `bun run --cwd cire/invites build` + bundle measure | ✅ 50365 raw / 9485 gz, 28 faces, 0 base64, 26 woff2 / 0 woff |

Verified by hand from the built bundle: every one of the 26 `url(/_astro/*.woff2)`
references resolves to a file that exists, no bare `@fontsource` specifier
survives the build, and each of the 13 family/style/weight combinations has
exactly two faces (latin + latin-ext), each carrying a `unicode-range`.

Not verified: how the metric-matched fallback actually looks mid-swap on a real
device. The overrides are derived from `@capsizecss/metrics` and checked
arithmetically, not visually.
