### PR TITLE
perf(cire): serve the closing band a phone-sized crop at 1x

### DIFF
--- a/.changeset/cire-crop-imageset.md
+++ b/.changeset/cire-crop-imageset.md
@@ -1,0 +1,5 @@
+---
+"@cire/invites": patch
+---
+
+Stop the closing band fetching 1600w hero art on every phone (tracker #88). The crop layer now renders as two elements: narrow (`md:hidden`) uses `image-set(card 1x, hero 2x)` so a DPR-1 phone loads the 800w `card` variant instead of `hero`; wide (`hidden md:block`) keeps plain `hero`, unchanged, since the band renders near full viewport width there. `image-set()` only sees device-pixel-ratio, not viewport, so the viewport half of the split stays a breakpoint. A new `cropBackgroundImageSetDeclaration` in `image-crop.ts` returns a CSS declaration string (plain `url()` first, `image-set()` second, for the Safari < 17 fallback) rather than the style object `cropBackgroundStyle` returns — a style object can't repeat `background-image` — and is used only by `InviteClosing`; the three other crop-background call sites keep their unchanged object-returning helper.

--- a/cire/invites/src/components/InviteClosing.browser.test.tsx
+++ b/cire/invites/src/components/InviteClosing.browser.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { InviteClosing } from "./InviteClosing";
+
+import "../styles/global.css";
+
+/**
+ * The closing band's crop layer, MEASURED by a real CSS parser.
+ *
+ * The narrow layer carries `background-image` TWICE — a plain `url()` first for
+ * Safari < 17, then `image-set()` — because a style object cannot repeat a
+ * property and `image-set()` is how the 1x/2x pick is expressed. Whether that
+ * pair survives parsing is exactly the thing the jsdom tier cannot see: its CSS
+ * parser does not know `image-set()` and drops BOTH declarations, so
+ * `background-image` reads empty there no matter what the component set. A
+ * regression that broke the declaration string would look identical.
+ *
+ * Chromium parses it the way the specification says: the second declaration
+ * wins where it is understood, and the first survives where it is not. So this
+ * file asserts the guest-visible fact — at the default device-pixel-ratio of 1,
+ * the narrow layer resolves to the 800w `card` variant, not the 1600w `hero`.
+ */
+
+const API = "https://api.test";
+const IMG = "/api/invite/anita-ben/image/footer?v=7";
+const CROP = { x: 0.1, y: 0.1, w: 0.5, h: 0.5, natW: 1000, natH: 500 };
+
+describe("InviteClosing crop layers (real CSS engine)", () => {
+  it("keeps both background-image declarations, with image-set() naming card at 1x", () => {
+    const { container } = render(() => (
+      <InviteClosing apiUrl={API} imageUrl={IMG} imageCrop={CROP} />
+    ));
+    const narrow = container.querySelector("[aria-hidden='true'].md\\:hidden") as HTMLElement;
+    expect(narrow).toBeTruthy();
+
+    // Computed, not inline: this is what the engine kept after parsing both.
+    const bg = getComputedStyle(narrow).backgroundImage;
+    expect(bg).toContain(`${API}${IMG}&variant=card`);
+    expect(bg).toContain("image-set(");
+    // The 1600w hero is only ever the 2x candidate down here. A DPR-1 phone
+    // resolving it would be the whole regression this split exists to stop.
+    // Chromium serialises the `1x` resolution as `1dppx`; accept either.
+    expect(bg).toMatch(/variant=card[^)]*\)\s*(1x|1dppx)/);
+
+    // Crop framing is untouched by the split.
+    expect(getComputedStyle(narrow).backgroundSize).toBe("200%");
+  });
+
+  it("leaves the wide layer on a single plain hero url", () => {
+    const { container } = render(() => (
+      <InviteClosing apiUrl={API} imageUrl={IMG} imageCrop={CROP} />
+    ));
+    const wide = container.querySelector("[aria-hidden='true'].md\\:block") as HTMLElement;
+    const bg = getComputedStyle(wide).backgroundImage;
+    expect(bg).toContain(`${API}${IMG}&variant=hero`);
+    expect(bg).not.toContain("image-set(");
+  });
+});

--- a/cire/invites/src/components/InviteClosing.test.tsx
+++ b/cire/invites/src/components/InviteClosing.test.tsx
@@ -161,6 +161,38 @@ describe("InviteClosing", () => {
       expect(layer.style.getPropertyValue("max-height")).toBe("");
     });
 
+    it("splits the crop layer into a narrow and a wide element, one hidden at a time", () => {
+      const { container } = render(() => (
+        <InviteClosing
+          apiUrl={API}
+          imageUrl={IMG}
+          imageCrop={{ x: 0.1, y: 0.1, w: 0.5, h: 0.5, natW: 1000, natH: 500 }}
+        />
+      ));
+      const section = closing(container) as HTMLElement;
+
+      // Below `md:` a DPR-1 phone must resolve the 800w `card`; above it the
+      // band still needs the 1600w `hero`. A `display:none` layer never fetches
+      // its background, so exactly one of the two downloads.
+      const narrow = section.querySelector("[aria-hidden='true'].md\\:hidden") as HTMLElement;
+      expect(narrow).toBeTruthy();
+      // Same crop maths and box sizing as the wide layer — the split changes
+      // which file is fetched, never the framing.
+      expect(narrow.style.getPropertyValue("background-size")).toBe("200%");
+      expect(narrow.style.getPropertyValue("aspect-ratio")).toBe("2 / 1");
+
+      // The wide layer stays exactly today's single hero url.
+      const wide = wideCropLayer(section) as HTMLElement;
+      expect(wide.style.getPropertyValue("background-image")).toContain("variant=hero");
+      expect(wide.style.getPropertyValue("background-image")).not.toContain("image-set");
+
+      // The narrow layer's URLs are NOT asserted here on purpose: jsdom's CSS
+      // parser drops both `background-image` declarations rather than keeping
+      // the valid one, so the property reads empty no matter what was set. The
+      // string itself is pinned in `image-crop.test.ts`, and that a real engine
+      // parses the pair is pinned in `InviteClosing.browser.test.tsx`.
+    });
+
     it("asks for the hero width, the one a full-bleed band actually needs", () => {
       const { container } = render(() => (
         <InviteClosing

--- a/cire/invites/src/components/InviteClosing.test.tsx
+++ b/cire/invites/src/components/InviteClosing.test.tsx
@@ -16,6 +16,13 @@ const IMG = "/api/invite/anita-ben/image/footer?v=7";
 
 const closing = (el: HTMLElement) => el.querySelector("[data-invite-closing]");
 
+// BRIEF-88 split the crop layer into narrow (image-set) + wide (plain hero url)
+// divs. These pre-existing assertions pin "exactly today's behaviour" — the wide
+// layer — so they target it explicitly rather than the first `[aria-hidden]`
+// match, which is now the narrow layer.
+const wideCropLayer = (el: HTMLElement) =>
+  el.querySelector("[aria-hidden='true'].md\\:block") as HTMLElement | null;
+
 describe("InviteClosing", () => {
   afterEach(cleanup);
 
@@ -140,7 +147,7 @@ describe("InviteClosing", () => {
 
       // The crop path replaces the <img> entirely — one node, not both.
       expect(section.querySelector("img")).toBeNull();
-      const layer = section.querySelector("[aria-hidden='true']") as HTMLElement;
+      const layer = wideCropLayer(section) as HTMLElement;
       expect(layer).toBeTruthy();
       expect(layer.style.getPropertyValue("background-image")).toContain(`${API}${IMG}`);
       // The EXACT framed region, not a focal-point cover: single-value
@@ -162,9 +169,7 @@ describe("InviteClosing", () => {
           imageCrop={{ x: 0, y: 0, w: 0.9, h: 0.9, natW: 1000, natH: 1000 }}
         />
       ));
-      const layer = (closing(container) as HTMLElement).querySelector(
-        "[aria-hidden='true']",
-      ) as HTMLElement;
+      const layer = wideCropLayer(closing(container) as HTMLElement) as HTMLElement;
       // A background can't carry a srcset, so it names one bounded variant —
       // and at viewport width the 320w thumb the small box used is far too soft.
       expect(layer.style.getPropertyValue("background-image")).toContain("variant=hero");
@@ -179,9 +184,7 @@ describe("InviteClosing", () => {
           imageCrop={{ x: 0, y: 0, w: 0.4, h: 0.5, natW: 1000, natH: 1000 }}
         />
       ));
-      const layer = (closing(container) as HTMLElement).querySelector(
-        "[aria-hidden='true']",
-      ) as HTMLElement;
+      const layer = wideCropLayer(closing(container) as HTMLElement) as HTMLElement;
 
       // `width: 100%` + a max-width of cap × aspect IS `min(100%, cap × aspect)`
       // — full-bleed at any ordinary landscape shape, a centred column only when
@@ -223,9 +226,7 @@ describe("InviteClosing", () => {
       const { container } = render(() => (
         <InviteClosing apiUrl={API} imageUrl={IMG} imageCrop={{ x: 0, y: 0, w: 0.5, h: 0.5 }} />
       ));
-      const layer = (closing(container) as HTMLElement).querySelector(
-        "[aria-hidden='true']",
-      ) as HTMLElement;
+      const layer = wideCropLayer(closing(container) as HTMLElement) as HTMLElement;
       // True aspect needs the captured source dims; without them the box takes
       // the shape the closing slot's crop editor opens on (`CROP_ASPECT.footer`),
       // so the fallback matches what the organiser was shown.

--- a/cire/invites/src/components/InviteClosing.tsx
+++ b/cire/invites/src/components/InviteClosing.tsx
@@ -1,6 +1,11 @@
 import { Show } from "solid-js";
 
-import { cropAspectRatio, cropBackgroundStyle, type ImageCrop } from "./image-crop";
+import {
+  cropAspectRatio,
+  cropBackgroundImageSetDeclaration,
+  cropBackgroundStyle,
+  type ImageCrop,
+} from "./image-crop";
 import { isFooterEmpty } from "./invite-emptiness";
 import { buildSrcSet, variantSrc } from "./invite-images";
 
@@ -149,13 +154,34 @@ export function InviteClosing(props: InviteClosingProps) {
 
   // A saved crop paints a background layer instead of the `<img>`, rendering the
   // framed region EXACTLY: uniform scale, and the box below takes the crop's own
-  // aspect, so the region fills it with no distortion and no bars. Backgrounds
-  // can't carry a `srcset`, so we name one bounded variant: `hero` (1600w), the
-  // width a full-bleed band actually needs — the old tightness-based thumb/card
-  // pick was sized for a 200px box and would be visibly soft across a viewport.
-  const cropStyle = () => {
+  // aspect, so the region fills it with no distortion and no bars. A background
+  // layer can't carry a `srcset`, and `image-set()` only sees device-pixel-ratio
+  // — not viewport width — so the two axes split across two elements below
+  // `md:`. Above `md:` the band renders at 1200–1600px, where even DPR 1 needs
+  // the full `hero` (1600w): dropping to `card` there would be visibly soft
+  // across the viewport, so the wide layer keeps exactly today's behaviour.
+  // Below `md:` the band is ~400 CSS px wide, so `card` (800w) covers DPR 1 and
+  // `hero` only serves DPR 2 — `image-set()` picks between the two.
+  const wideCropStyle = () => {
     const url = imageSrc();
     return url ? cropBackgroundStyle(variantSrc(url, "hero"), props.imageCrop) : null;
+  };
+
+  // Folds the box's `aspect-ratio` / `max-width` into the same string as the
+  // background declarations — a style OBJECT can't carry `background-image`
+  // twice (the plain `url()` fallback + `image-set()`), so this layer's whole
+  // `style` is a CSS text string instead of the usual object.
+  const narrowCropStyle = () => {
+    const url = imageSrc();
+    if (!url) return null;
+    const bg = cropBackgroundImageSetDeclaration(
+      variantSrc(url, "card"),
+      variantSrc(url, "hero"),
+      props.imageCrop,
+    );
+    if (!bg) return null;
+    const aspect = bandAspect();
+    return `${bg}aspect-ratio:${aspect};max-width:${bandMaxWidth(aspect)};`;
   };
 
   // The band's height, expressed as the crop's true pixel aspect (from its
@@ -194,7 +220,7 @@ export function InviteClosing(props: InviteClosingProps) {
         <Show when={imageSrc()}>
           {(url) => (
             <Show
-              when={cropStyle()}
+              when={wideCropStyle()}
               fallback={
                 /* Two candidates so `sizes` has a real choice to make: `card`
                    (800w) covers the band on a phone, `hero` (1600w) from a
@@ -227,20 +253,30 @@ export function InviteClosing(props: InviteClosingProps) {
               }
             >
               {(style) => (
-                <div
-                  aria-hidden="true"
-                  // The cropped variant paints a background layer, so the box
-                  // owns its size (an empty div has no intrinsic dimensions):
-                  // the CROP's aspect, at the full width the screen-height bound
-                  // allows. Never a `max-height` clip — that would cut the
-                  // framing this whole path exists to honour.
-                  class="mx-auto block w-full"
-                  style={{
-                    ...style(),
-                    "aspect-ratio": String(bandAspect()),
-                    "max-width": bandMaxWidth(bandAspect()),
-                  }}
-                />
+                <>
+                  {/* Below md: — image-set() 1x=card/2x=hero, so a DPR-1 phone
+                      doesn't fetch the same 1600w desktop needs. */}
+                  <div
+                    aria-hidden="true"
+                    class="mx-auto block w-full md:hidden"
+                    style={narrowCropStyle() ?? undefined}
+                  />
+                  {/* md: and up — exactly today's behaviour: plain `hero` url,
+                      the box owns its size (an empty div has no intrinsic
+                      dimensions): the CROP's aspect, at the full width the
+                      screen-height bound allows. Never a `max-height` clip —
+                      that would cut the framing this whole path exists to
+                      honour. */}
+                  <div
+                    aria-hidden="true"
+                    class="mx-auto hidden w-full md:block"
+                    style={{
+                      ...style(),
+                      "aspect-ratio": String(bandAspect()),
+                      "max-width": bandMaxWidth(bandAspect()),
+                    }}
+                  />
+                </>
               )}
             </Show>
           )}

--- a/cire/invites/src/components/image-crop.test.ts
+++ b/cire/invites/src/components/image-crop.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 
 import {
   cropAspectRatio,
+  cropBackgroundImageSetDeclaration,
   cropBackgroundStyle,
   heroCropBackgroundStyle,
   heroCropLayers,
   heroImgRevealClass,
   isRenderableCrop,
 } from "./image-crop";
+import { VARIANT_WIDTHS } from "./invite-images";
 
 describe("isRenderableCrop", () => {
   it("treats null/undefined as not renderable (fall back to object-cover)", () => {
@@ -202,6 +204,54 @@ describe("heroCropLayers (per-breakpoint hero crops, migration 0046)", () => {
   it("an identity mobile crop is ignored (falls back to desktop)", () => {
     const layers = heroCropLayers("u", DESKTOP, { x: 0, y: 0, w: 1, h: 1 });
     expect(layers.narrow).toEqual(layers.wide);
+  });
+});
+
+describe("cropBackgroundImageSetDeclaration (viewport+DPR sibling of cropBackgroundStyle, BRIEF-88)", () => {
+  const CROP = { x: 0.25, y: 0.25, w: 0.5, h: 0.5 };
+
+  it("returns null when there's no renderable crop, same as the object helper", () => {
+    expect(cropBackgroundImageSetDeclaration("a", "b", null)).toBeNull();
+    expect(cropBackgroundImageSetDeclaration("a", "b", { x: 0, y: 0, w: 1, h: 1 })).toBeNull();
+  });
+
+  it("declares the plain url() fallback BEFORE image-set() (Safari < 17 has no unprefixed image-set)", () => {
+    const decl = cropBackgroundImageSetDeclaration(
+      "https://x/img.jpg?variant=card",
+      "https://x/img.jpg?variant=hero",
+      CROP,
+    )!;
+    const urlIndex = decl.indexOf('background-image:url("https://x/img.jpg?variant=card")');
+    const imageSetIndex = decl.indexOf("background-image:image-set(");
+    expect(urlIndex).toBeGreaterThanOrEqual(0);
+    expect(imageSetIndex).toBeGreaterThan(urlIndex);
+  });
+
+  it("names the image-set() candidates at 1x and 2x, matching the caller's card/hero URLs", () => {
+    const decl = cropBackgroundImageSetDeclaration(
+      "https://x/img.jpg?variant=card",
+      "https://x/img.jpg?variant=hero",
+      CROP,
+    )!;
+    expect(decl).toContain(
+      'image-set(url("https://x/img.jpg?variant=card") 1x, url("https://x/img.jpg?variant=hero") 2x)',
+    );
+  });
+
+  it("keeps both image-set() candidates inside the bounded VARIANT_WIDTHS allowlist", () => {
+    expect(Object.keys(VARIANT_WIDTHS)).toContain("card");
+    expect(Object.keys(VARIANT_WIDTHS)).toContain("hero");
+  });
+
+  it("computes byte-identical crop maths to the object helper for the same crop", () => {
+    const objectStyle = cropBackgroundStyle("https://x/img.jpg?variant=hero", CROP)!;
+    const decl = cropBackgroundImageSetDeclaration(
+      "https://x/img.jpg?variant=card",
+      "https://x/img.jpg?variant=hero",
+      CROP,
+    )!;
+    expect(decl).toContain(`background-size:${objectStyle["background-size"]};`);
+    expect(decl).toContain(`background-position:${objectStyle["background-position"]};`);
   });
 });
 

--- a/cire/invites/src/components/image-crop.ts
+++ b/cire/invites/src/components/image-crop.ts
@@ -180,6 +180,46 @@ function clamp01(n: number): number {
 }
 
 /**
+ * The `image-set()` sibling of {@link cropBackgroundStyle}, for a background
+ * layer that must vary by DEVICE-PIXEL-RATIO as well as crop. `image-set()`
+ * selects on DPR only — it cannot see viewport width — so a caller pairs this
+ * with a breakpoint (render it below the viewport cutoff, a plain
+ * {@link cropBackgroundStyle} hero-variant layer above it) to cover both axes.
+ *
+ * A style OBJECT cannot carry `background-image` twice, so this returns a CSS
+ * declaration STRING instead (Solid's `style` prop accepts a string, not just
+ * an object): the plain `url()` FIRST — Safari < 17 has no unprefixed
+ * `image-set`, and CSS drops a declaration it can't parse, so an unsupporting
+ * browser keeps this one — then `image-set()` SECOND, which a supporting
+ * browser parses and applies, overriding the first. `oneXUrl`/`twoXUrl` must
+ * already carry a bounded `?variant=` (`VARIANT_WIDTHS` in
+ * `invite-images.ts`) — this helper only renders the two URLs it's given, it
+ * does not choose or validate variant names. Every other declaration matches
+ * {@link cropBackgroundStyle}'s crop maths exactly, so the two stay
+ * byte-identical for the same crop.
+ */
+export function cropBackgroundImageSetDeclaration(
+  oneXUrl: string,
+  twoXUrl: string,
+  crop: ImageCrop | null | undefined,
+): string | null {
+  if (!isRenderableCrop(crop)) return null;
+  const { x, y, w, h } = crop;
+  const size = (100 / w).toFixed(4);
+  const posX = w >= 1 ? "0" : ((x / (1 - w)) * 100).toFixed(4);
+  const posY = h >= 1 ? "0" : ((y / (1 - h)) * 100).toFixed(4);
+  const oneX = cssUrlValue(oneXUrl);
+  const twoX = cssUrlValue(twoXUrl);
+  return (
+    `background-image:url("${oneX}");` +
+    `background-image:image-set(url("${oneX}") 1x, url("${twoX}") 2x);` +
+    `background-repeat:no-repeat;` +
+    `background-size:${size}%;` +
+    `background-position:${posX}% ${posY}%;`
+  );
+}
+
+/**
  * The hero's per-breakpoint crop layers (migration 0046). The hero is the one
  * full-bleed image rendered at both wide-desktop and tall-phone aspects, so the
  * organiser can save TWO focal rectangles: the desktop crop governs wide

--- a/cire/invites/src/components/image-crop.ts
+++ b/cire/invites/src/components/image-crop.ts
@@ -203,19 +203,20 @@ export function cropBackgroundImageSetDeclaration(
   twoXUrl: string,
   crop: ImageCrop | null | undefined,
 ): string | null {
-  if (!isRenderableCrop(crop)) return null;
-  const { x, y, w, h } = crop;
-  const size = (100 / w).toFixed(4);
-  const posX = w >= 1 ? "0" : ((x / (1 - w)) * 100).toFixed(4);
-  const posY = h >= 1 ? "0" : ((y / (1 - h)) * 100).toFixed(4);
+  // Crop maths is never re-derived here — it is read back off the object
+  // helper, so the two can't drift apart under a later edit to one of them.
+  const base = cropBackgroundStyle(oneXUrl, crop);
+  if (!base) return null;
   const oneX = cssUrlValue(oneXUrl);
   const twoX = cssUrlValue(twoXUrl);
+  const rest = Object.entries(base)
+    .filter(([property]) => property !== "background-image")
+    .map(([property, value]) => `${property}:${value};`)
+    .join("");
   return (
     `background-image:url("${oneX}");` +
     `background-image:image-set(url("${oneX}") 1x, url("${twoX}") 2x);` +
-    `background-repeat:no-repeat;` +
-    `background-size:${size}%;` +
-    `background-position:${posX}% ${posY}%;`
+    rest
   );
 }
 


### PR DESCRIPTION
## Summary

The closing band on the invite painted its art as a CSS background layer, and a
background layer carries no `srcset` — so every device fetched the 1600w `hero`
variant, including a DPR-1 phone rendering the band about 400 CSS px wide. The
crop layer now renders as two elements: the narrow one asks for the 800w `card`
variant at 1x and `hero` only at 2x; the wide one keeps `hero` unchanged.

- `image-set()` resolves on device-pixel-ratio alone — it cannot see viewport —
  so the viewport half of the fix stays a Tailwind breakpoint (`md:hidden` /
  `hidden md:block`) and the DPR half is `image-set()`. Two mechanisms, because
  one of them genuinely cannot do the other's job.
- A `display: none` element never fetches its background image, which is what
  makes the split save bytes rather than double them.

## Workspaces affected

`@cire/invites`. `.changeset/cire-crop-imageset.md` names it at `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#88 | `P-W1` |

**Opened**

| Issue | What |
|---|---|
| — | None |

Closes xchromo/osn-tracker#88

## Decisions

### The wide layer keeps `hero` — `approach`

- **Issue** — the obvious fix is to serve `card` everywhere and stop there.
- **Why** — it would trade a bandwidth win for a visible quality loss.
- **Solution** — only the narrow layer drops to `card`, and only at 1x.
- **Rationale** — above `md` the band renders near full viewport width, where
  the 800w `card` variant is a visible softness regression on the largest
  decorative image on the page. The saving is on phones, which is where it
  matters.

### A new declaration-string helper, rather than changing the existing one — `approach`

- **Issue** — the Safari-<17 fallback needs `background-image` declared twice
  (plain `url()` first, `image-set()` second), and a JS style object cannot hold
  a repeated key.
- **Why** — without the plain `url()` first, Safari < 17 gets no image at all.
- **Solution** — `cropBackgroundImageSetDeclaration` in `image-crop.ts` returns
  a CSS declaration string. `cropBackgroundStyle` keeps its signature and its
  three other call sites (gala/classic `InviteHeader`, `EventCard`) untouched.
- **Rationale** — the new helper reads its crop maths back off
  `cropBackgroundStyle` instead of re-deriving it, so the two cannot drift.
  Widening the object helper to serve both shapes would have changed three call
  sites that had no reason to move.

### The pair is asserted in a real engine, not jsdom — `approach`

- **Issue** — jsdom's CSS parser, given `background-image: url(...)` followed by
  `background-image: image-set(...)`, drops **both** rather than keeping the
  earlier valid one. The exact trick this change depends on is structurally
  invisible to the fast tier.
- **Why** — a green unit suite would have said nothing about whether the
  declaration pair parses at all.
- **Solution** — a browser-tier test (`InviteClosing.browser.test.tsx`) reads
  the computed value in Chromium: `card` at 1x, `hero` only at 2x, crop framing
  unchanged. The jsdom test keeps the structural half and says in a comment why
  it stops there.
- **Rationale** — the two tiers are complements. Note that Chromium serialises
  `image-set()` resolutions as `dppx`, so `1x` reads back as `1dppx`; the
  assertion accepts either.

**Out of scope** — none found and left.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run --cwd cire/invites test` | ✅ 891 pass / 55 files |
| `bun run --cwd cire/invites test:browser` | ✅ 31 pass / 7 files |

Not verified: Safari < 17 itself. The fallback ordering is the documented
workaround, and the browser tier runs Chromium only — no Safari engine is
exercised anywhere in CI.
