### PR TITLE
perf(pulse-api): bound the map queries with a bbox contract

### DIFF
--- a/.changeset/pulse-venues-bbox-contract.md
+++ b/.changeset/pulse-venues-bbox-contract.md
@@ -1,0 +1,11 @@
+---
+"@pulse/api": patch
+---
+
+Give the map surfaces a bounded, viewport-aware bbox contract.
+
+`listAllVenues` was `db.select().from(venues)` — an unbounded scan feeding `GET /venues`. Both `GET /venues` and `GET /events` now accept an optional `(minLat, maxLat, minLng, maxLng)` viewport plus `limit`, validated at the route (all four corners or none; inverted or out-of-range boxes reject 400). Venues gets a hard server ceiling (100) and a default (20) applied even with no bbox, so the scan is bounded whatever the client sends; `listEvents` keeps its existing ceiling unchanged.
+
+`GET /venues` now returns a new `VenuePin` model (`id, orgHandle, handle, name, kind, capacity, latitude, longitude`) instead of the full `Venue` shape, so the map list stays cheap. The existing `Venue` model and every other venue route are untouched.
+
+Antimeridian-crossing boxes (`minLng > maxLng`) are out of scope and rejected the same as any other inverted box. A bbox query drops NULL-lat/lng rows (`gte`/`lte` never match NULL); the no-bbox path still returns them for venues.

--- a/.changeset/pulse-venues-bbox-contract.md
+++ b/.changeset/pulse-venues-bbox-contract.md
@@ -4,7 +4,7 @@
 
 Give the map surfaces a bounded, viewport-aware bbox contract.
 
-`listAllVenues` was `db.select().from(venues)` — an unbounded scan feeding `GET /venues`. Both `GET /venues` and `GET /events` now accept an optional `(minLat, maxLat, minLng, maxLng)` viewport plus `limit`, validated at the route (all four corners or none; inverted or out-of-range boxes reject 400). Venues gets a hard server ceiling (100) and a default (20) applied even with no bbox, so the scan is bounded whatever the client sends; `listEvents` keeps its existing ceiling unchanged.
+`listAllVenues` was `db.select().from(venues)` — an unbounded scan feeding `GET /venues`. Both `GET /venues` and `GET /events` now accept an optional `(minLat, maxLat, minLng, maxLng)` viewport plus `limit`, validated at the route (all four corners or none; inverted or out-of-range boxes reject 400). Venues gets a hard server ceiling (100), applied as the default too so the no-bbox path is bounded without returning fewer pins than it did yesterday, and a deterministic `ORDER BY id` so the bounded page is the same one on every call, so the scan is bounded whatever the client sends; `listEvents` keeps its existing ceiling unchanged.
 
 `GET /venues` now returns a new `VenuePin` model (`id, orgHandle, handle, name, kind, capacity, latitude, longitude`) instead of the full `Venue` shape, so the map list stays cheap. The existing `Venue` model and every other venue route are untouched.
 

--- a/pulse/api/src/lib/bbox.ts
+++ b/pulse/api/src/lib/bbox.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared `(minLat, maxLat, minLng, maxLng)` viewport contract for the
+ * map surfaces (`GET /venues`, `GET /events`). Cross-field checks
+ * (all-four-or-none, ordering, antimeridian) can't be expressed as
+ * declarative route schema constraints, so both routes call this at
+ * the handler level and 400 on failure.
+ */
+export interface BboxCorners {
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
+}
+
+export interface Bbox {
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+}
+
+export type BboxValidation = { ok: true; bbox: Bbox | null } | { ok: false; error: string };
+
+export const validateBbox = (corners: BboxCorners): BboxValidation => {
+  const { minLat, maxLat, minLng, maxLng } = corners;
+  const provided = [minLat, maxLat, minLng, maxLng].filter((v) => v !== undefined);
+
+  if (provided.length === 0) return { ok: true, bbox: null };
+  if (provided.length !== 4) {
+    return {
+      ok: false,
+      error: "minLat, maxLat, minLng, and maxLng must all be provided together, or all omitted",
+    };
+  }
+
+  if (minLat! < -90 || minLat! > 90 || maxLat! < -90 || maxLat! > 90) {
+    return { ok: false, error: "minLat and maxLat must be between -90 and 90" };
+  }
+  if (minLng! < -180 || minLng! > 180 || maxLng! < -180 || maxLng! > 180) {
+    return { ok: false, error: "minLng and maxLng must be between -180 and 180" };
+  }
+  if (minLat! > maxLat!) {
+    return { ok: false, error: "minLat must not be greater than maxLat" };
+  }
+  // Antimeridian-crossing boxes (minLng > maxLng) are out of scope —
+  // rejected the same as any other inverted box.
+  if (minLng! > maxLng!) {
+    return {
+      ok: false,
+      error:
+        "minLng must not be greater than maxLng (antimeridian-crossing boxes are not supported)",
+    };
+  }
+
+  return { ok: true, bbox: { minLat: minLat!, maxLat: maxLat!, minLng: minLng!, maxLng: maxLng! } };
+};

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -10,6 +10,7 @@ import {
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { validateBbox } from "../lib/bbox";
 import { makeCallerResolver } from "../lib/caller";
 import { MAX_PRICE_MAJOR } from "../lib/currency";
 import { DEFAULT_JWKS_URL } from "../lib/jwks";
@@ -409,10 +410,15 @@ export const createEventsRoutes = (
       .model({ Event: eventResponseSchema, Rsvp: rsvpResponseSchema })
       .get(
         "/",
-        async ({ query, headers }) => {
+        async ({ query, headers, set }) => {
+          const validation = validateBbox(query);
+          if (!validation.ok) {
+            set.status = 400;
+            return { error: validation.error };
+          }
           const claims = await resolveCaller(headers);
           const result = await runtime.runPromise(
-            listEvents({ ...query, viewerId: claims?.profileId ?? null }),
+            listEvents({ ...query, ...validation.bbox, viewerId: claims?.profileId ?? null }),
           );
           return { events: result.map(serializeEvent) };
         },
@@ -421,8 +427,15 @@ export const createEventsRoutes = (
             status: statusEnum,
             category: t.Optional(t.String()),
             limit: t.Optional(t.String()),
+            minLat: t.Optional(t.Numeric()),
+            maxLat: t.Optional(t.Numeric()),
+            minLng: t.Optional(t.Numeric()),
+            maxLng: t.Optional(t.Numeric()),
           }),
-          response: { 200: t.Object({ events: t.Array(t.Ref("Event")) }) },
+          response: {
+            200: t.Object({ events: t.Array(t.Ref("Event")) }),
+            400: errorResponse,
+          },
           detail: { operationId: "listEvents" },
         },
       )

--- a/pulse/api/src/routes/venues.ts
+++ b/pulse/api/src/routes/venues.ts
@@ -4,6 +4,7 @@ import { createRateLimiter, getClientIp, type RateLimiterBackend } from "@shared
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
+import { validateBbox } from "../lib/bbox";
 import { metricEventAccessDenied } from "../metrics";
 import { loadVisibleEvent } from "../services/eventAccess";
 import { getVenue, listAllVenues, listEventLineup, listVenueEvents } from "../services/venues";
@@ -117,6 +118,31 @@ const lineupSlotSchema = t.Object({
   createdAt: t.String({ format: "date-time" }),
 });
 
+/**
+ * Thin pin projection for the map surface — deliberately excludes the
+ * heavy `Venue` fields (`description`, `hours`, image/website URLs) so
+ * the bbox-scoped list stays cheap. A named model distinct from `Venue`
+ * so the existing response shape (and generated Swift client) is untouched.
+ */
+const venuePinSchema = t.Object({
+  id: t.String(),
+  orgHandle: t.String(),
+  handle: t.String(),
+  name: t.String(),
+  kind: t.String(),
+  capacity: t.Nullable(t.Number()),
+  latitude: t.Nullable(t.Number()),
+  longitude: t.Nullable(t.Number()),
+});
+
+const bboxQuery = t.Object({
+  minLat: t.Optional(t.Numeric()),
+  maxLat: t.Optional(t.Numeric()),
+  minLng: t.Optional(t.Numeric()),
+  maxLng: t.Optional(t.Numeric()),
+  limit: t.Optional(t.Numeric({ minimum: 1, maximum: 100 })),
+});
+
 const errorResponse = t.Object({ error: t.String() });
 const messageResponse = t.Object({ message: t.String() });
 
@@ -151,7 +177,7 @@ export const createVenuesRoutes = (
     new Elysia({ prefix: "/venues" })
       // Named model, so the venue object lands once in `components/schemas` and
       // both routes `$ref` it — see the longer note in `routes/events.ts`.
-      .model({ Venue: venueSchema })
+      .model({ Venue: venueSchema, VenuePin: venuePinSchema })
       .onBeforeHandle(async ({ headers, set }) => {
         // S-L1: fail-closed per-IP limit, matching the discover route —
         // a broken limiter backend must not become a bypass.
@@ -169,15 +195,22 @@ export const createVenuesRoutes = (
       })
       .get(
         "/",
-        async () => {
-          // TODO(venue-bbox-search): swap for bbox-filtered query — see
-          // `P-W28` in `xchromo/osn-tracker` (explore).
-          const venues = await runtime.runPromise(listAllVenues());
-          return { venues: venues.map(serializeVenue) };
+        async ({ query, set }) => {
+          const validation = validateBbox(query);
+          if (!validation.ok) {
+            set.status = 400;
+            return { error: validation.error };
+          }
+          const rows = await runtime.runPromise(
+            listAllVenues({ ...validation.bbox, limit: query.limit }),
+          );
+          return { venues: rows };
         },
         {
+          query: bboxQuery,
           response: {
-            200: t.Object({ venues: t.Array(t.Ref("Venue")) }),
+            200: t.Object({ venues: t.Array(t.Ref("VenuePin")) }),
+            400: errorResponse,
             429: errorResponse,
           },
           detail: { operationId: "listVenues" },

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -172,6 +172,15 @@ interface ListEventsParams {
    * events are filtered out (discovery behaviour).
    */
   viewerId?: string | null;
+  /**
+   * Optional map viewport — all four present or none. When present, rows
+   * are filtered to the box; NULL-lat/lng events are dropped (`gte`/`lte`
+   * never match NULL), matching the venues bbox behaviour.
+   */
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
 }
 
 const deriveStatus = (event: Event, now: Date): Event["status"] => {
@@ -313,6 +322,18 @@ export const listEvents = (
 
     if (params.category) {
       filters.push(eq(events.category, params.category));
+    }
+
+    if (
+      params.minLat !== undefined &&
+      params.maxLat !== undefined &&
+      params.minLng !== undefined &&
+      params.maxLng !== undefined
+    ) {
+      filters.push(gte(events.latitude, params.minLat));
+      filters.push(lte(events.latitude, params.maxLat));
+      filters.push(gte(events.longitude, params.minLng));
+      filters.push(lte(events.longitude, params.maxLng));
     }
 
     // Discovery rule: private events are filtered at the SQL layer so

--- a/pulse/api/src/services/venues.ts
+++ b/pulse/api/src/services/venues.ts
@@ -32,8 +32,15 @@ export interface ListAllVenuesParams {
   limit?: number;
 }
 
-const VENUES_DEFAULT_LIMIT = 20;
 const VENUES_MAX_LIMIT = 100;
+/**
+ * No-bbox default. Deliberately the same as the ceiling: the point of this
+ * change is that the query is BOUNDED, not that it returns fewer pins than
+ * it did yesterday. A smaller default would silently drop venues off the
+ * Explore map in the window between this landing and the client sending a
+ * viewport.
+ */
+const VENUES_DEFAULT_LIMIT = VENUES_MAX_LIMIT;
 
 /**
  * List venues for the map. Public surface — feeds the Explore map.
@@ -62,9 +69,10 @@ export const listAllVenues = (
       filters.push(gte(venues.longitude, params.minLng));
       filters.push(lte(venues.longitude, params.maxLng));
     }
-    const limit = params.limit
-      ? Math.min(Math.max(1, params.limit), VENUES_MAX_LIMIT)
-      : VENUES_DEFAULT_LIMIT;
+    const limit =
+      params.limit === undefined
+        ? VENUES_DEFAULT_LIMIT
+        : Math.min(Math.max(1, params.limit), VENUES_MAX_LIMIT);
 
     const rows = yield* Effect.tryPromise({
       try: (): Promise<VenuePin[]> =>
@@ -81,6 +89,10 @@ export const listAllVenues = (
           })
           .from(venues)
           .where(filters.length > 0 ? and(...filters) : undefined)
+          // A LIMIT with no ORDER BY lets SQLite return any subset it likes,
+          // and a different one per call — the map would flicker between pin
+          // sets on refresh. `id` is the only column guaranteed unique.
+          .orderBy(asc(venues.id))
           .limit(limit) as Promise<VenuePin[]>,
       catch: (cause) => new DatabaseError({ cause }),
     }).pipe(Effect.tapError((e) => Effect.logError("venue.list_all failed", e)));

--- a/pulse/api/src/services/venues.ts
+++ b/pulse/api/src/services/venues.ts
@@ -1,7 +1,7 @@
 import { events, eventLineup, venues } from "@pulse/db/schema";
 import type { Event, EventLineupSlot, Venue } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
-import { and, asc, desc, eq, gte, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lt, lte, type SQL } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
 import { metricVenueDetail, metricVenueEventsListed, metricVenueLineupListed } from "../metrics";
@@ -12,21 +12,76 @@ export class VenueNotFound extends Data.TaggedError("VenueNotFound")<{
   readonly venueHandle: string;
 }> {}
 
+/** Thin pin projection for the map — no description/hours/image/website fields. */
+export interface VenuePin {
+  id: string;
+  orgHandle: string;
+  handle: string;
+  name: string;
+  kind: string;
+  capacity: number | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+export interface ListAllVenuesParams {
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
+  limit?: number;
+}
+
+const VENUES_DEFAULT_LIMIT = 20;
+const VENUES_MAX_LIMIT = 100;
+
 /**
- * List every venue. Public surface — feeds the Explore map.
+ * List venues for the map. Public surface — feeds the Explore map.
  *
- * TODO(P-perf, venue-bbox-search): Replace with a bbox/geohash-aware
- * query so the map only loads venues within the visible viewport. This
- * unbounded scan is fine while the catalogue is tiny but will break
- * once we ingest real venue data. Same applies to events — both
- * surfaces want the same `(minLat, maxLat, minLng, maxLng)` filter.
- * Open as `P-W28` in `xchromo/osn-tracker`.
+ * Bounded whatever the caller sends: a hard ceiling on `limit`
+ * (`VENUES_MAX_LIMIT`) plus a default (`VENUES_DEFAULT_LIMIT`) applied
+ * even with no bbox, so the scan can never be unbounded again. When all
+ * four corners are given, rows are filtered to the box; a bbox query
+ * drops NULL-lat/lng venues (`BETWEEN`/`gte`+`lte` never match NULL) —
+ * the no-bbox path still returns them.
  */
-export const listAllVenues = (): Effect.Effect<Venue[], DatabaseError, Db> =>
+export const listAllVenues = (
+  params: ListAllVenuesParams = {},
+): Effect.Effect<VenuePin[], DatabaseError, Db> =>
   Effect.gen(function* () {
     const { db } = yield* Db;
+    const filters: SQL[] = [];
+    if (
+      params.minLat !== undefined &&
+      params.maxLat !== undefined &&
+      params.minLng !== undefined &&
+      params.maxLng !== undefined
+    ) {
+      filters.push(gte(venues.latitude, params.minLat));
+      filters.push(lte(venues.latitude, params.maxLat));
+      filters.push(gte(venues.longitude, params.minLng));
+      filters.push(lte(venues.longitude, params.maxLng));
+    }
+    const limit = params.limit
+      ? Math.min(Math.max(1, params.limit), VENUES_MAX_LIMIT)
+      : VENUES_DEFAULT_LIMIT;
+
     const rows = yield* Effect.tryPromise({
-      try: (): Promise<Venue[]> => db.select().from(venues) as Promise<Venue[]>,
+      try: (): Promise<VenuePin[]> =>
+        db
+          .select({
+            id: venues.id,
+            orgHandle: venues.orgHandle,
+            handle: venues.handle,
+            name: venues.name,
+            kind: venues.kind,
+            capacity: venues.capacity,
+            latitude: venues.latitude,
+            longitude: venues.longitude,
+          })
+          .from(venues)
+          .where(filters.length > 0 ? and(...filters) : undefined)
+          .limit(limit) as Promise<VenuePin[]>,
       catch: (cause) => new DatabaseError({ cause }),
     }).pipe(Effect.tapError((e) => Effect.logError("venue.list_all failed", e)));
     return rows;

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -345,6 +345,36 @@ describe("events routes", () => {
     expect(body.events[0]!.title).toBe("Music Night");
   });
 
+  it("GET /events rejects a partial bbox with 400", async () => {
+    const res = await app.handle(new Request("http://localhost/events?minLat=51&maxLat=52"));
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /events rejects an inverted bbox with 400", async () => {
+    const res = await app.handle(
+      new Request("http://localhost/events?minLat=52&maxLat=51&minLng=-1&maxLng=1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /events?bbox filters to events inside the box", async () => {
+    await seedEvent({ title: "Inside", startTime: FUTURE, latitude: 51.5, longitude: -0.1 }).pipe(
+      Effect.provide(layer),
+      Effect.runPromise,
+    );
+    await seedEvent({ title: "Outside", startTime: FUTURE, latitude: 40.7, longitude: -74.0 }).pipe(
+      Effect.provide(layer),
+      Effect.runPromise,
+    );
+    const res = await app.handle(
+      new Request("http://localhost/events?minLat=51&maxLat=52&minLng=-0.5&maxLng=0.5"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: { title: string }[] };
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]!.title).toBe("Inside");
+  });
+
   it("PATCH /events/:id returns 422 for invalid startTime", async () => {
     const createRes = await post(
       app,

--- a/pulse/api/tests/routes/venues.test.ts
+++ b/pulse/api/tests/routes/venues.test.ts
@@ -79,6 +79,16 @@ describe("venue routes", () => {
     expect(body.venues).toEqual([]);
   });
 
+  it("GET /venues rejects a partial bbox with 400", async () => {
+    const res = await get(app, "/venues?minLat=51&maxLat=52");
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /venues rejects an inverted bbox with 400", async () => {
+    const res = await get(app, "/venues?minLat=52&maxLat=51&minLng=-1&maxLng=1");
+    expect(res.status).toBe(400);
+  });
+
   it("GET /venues/:org/:venue returns 404 for an unknown venue", async () => {
     const res = await get(app, "/venues/org-one/does-not-exist");
     expect(res.status).toBe(404);

--- a/pulse/api/tests/services/events.test.ts
+++ b/pulse/api/tests/services/events.test.ts
@@ -104,6 +104,49 @@ it.effect("listEvents filters by category", () =>
   ),
 );
 
+it.effect("listEvents bbox filters to rows inside the box and excludes rows outside it", () =>
+  provide(
+    Effect.gen(function* () {
+      yield* seedEvent({
+        title: "Inside London",
+        startTime: FUTURE,
+        latitude: 51.5,
+        longitude: -0.1,
+      });
+      yield* seedEvent({
+        title: "Outside NYC",
+        startTime: FUTURE,
+        latitude: 40.7,
+        longitude: -74.0,
+      });
+      const events = yield* listEvents({
+        minLat: 51.0,
+        maxLat: 52.0,
+        minLng: -0.5,
+        maxLng: 0.5,
+      });
+      expect(events.length).toBe(1);
+      expect(events[0]!.title).toBe("Inside London");
+    }),
+  ),
+);
+
+// NULL-lat/lng events are dropped by a bbox query (`gte`/`lte` never match
+// NULL) but still returned when no bbox is given — same asymmetry as
+// `listAllVenues`, pinned here so it stays a deliberate choice.
+it.effect("listEvents bbox query drops NULL-coordinate events; no-bbox path keeps them", () =>
+  provide(
+    Effect.gen(function* () {
+      yield* seedEvent({ title: "No Coords", startTime: FUTURE });
+      const boxed = yield* listEvents({ minLat: -90, maxLat: 90, minLng: -180, maxLng: 180 });
+      expect(boxed).toEqual([]);
+      const unboxed = yield* listEvents({});
+      expect(unboxed.length).toBe(1);
+      expect(unboxed[0]!.title).toBe("No Coords");
+    }),
+  ),
+);
+
 it.effect("listEvents boosts events organised by close friends to the top", () =>
   provide(
     Effect.gen(function* () {

--- a/pulse/api/tests/services/venues.test.ts
+++ b/pulse/api/tests/services/venues.test.ts
@@ -205,7 +205,7 @@ it.effect("listVenueEvents scope=all returns past + upcoming together", () =>
 // listAllVenues
 // ---------------------------------------------------------------------------
 
-it.effect("listAllVenues returns every venue row", () =>
+it.effect("listAllVenues returns every venue row within the default bound", () =>
   provide(
     Effect.gen(function* () {
       const { db } = yield* Db;
@@ -249,6 +249,138 @@ it.effect("listAllVenues returns an empty array when there are no venues", () =>
     Effect.gen(function* () {
       const rows = yield* listAllVenues();
       expect(rows).toEqual([]);
+    }),
+  ),
+);
+
+it.effect("listAllVenues no-bbox path is bounded by the default limit", () =>
+  provide(
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const now = new Date();
+      const rows = Array.from({ length: 25 }, (_, i) => ({
+        id: `v${i}`,
+        orgHandle: "org-a",
+        handle: `venue-${i}`,
+        name: `Venue ${i}`,
+        createdAt: now,
+        updatedAt: now,
+      }));
+      yield* Effect.promise(() => db.insert(venues).values(rows));
+      const result = yield* listAllVenues();
+      expect(result.length).toBe(20);
+    }),
+  ),
+);
+
+it.effect("listAllVenues clamps a caller-supplied limit to the server ceiling", () =>
+  provide(
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const now = new Date();
+      const rows = Array.from({ length: 120 }, (_, i) => ({
+        id: `v${i}`,
+        orgHandle: "org-a",
+        handle: `venue-${i}`,
+        name: `Venue ${i}`,
+        createdAt: now,
+        updatedAt: now,
+      }));
+      yield* Effect.promise(() => db.insert(venues).values(rows));
+      const result = yield* listAllVenues({ limit: 9999 });
+      expect(result.length).toBe(100);
+    }),
+  ),
+);
+
+it.effect("listAllVenues bbox filters to rows inside the box and excludes rows outside it", () =>
+  provide(
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const now = new Date();
+      yield* Effect.promise(() =>
+        db.insert(venues).values([
+          {
+            id: "inside",
+            orgHandle: "org-a",
+            handle: "inside",
+            name: "Inside",
+            latitude: 51.5,
+            longitude: -0.1,
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: "outside",
+            orgHandle: "org-a",
+            handle: "outside",
+            name: "Outside",
+            latitude: 40.7,
+            longitude: -74.0,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ]),
+      );
+      const rows = yield* listAllVenues({ minLat: 51, maxLat: 52, minLng: -1, maxLng: 0 });
+      expect(rows.map((r) => r.id)).toEqual(["inside"]);
+    }),
+  ),
+);
+
+it.effect("listAllVenues bbox query drops NULL-coordinate venues; no-bbox path keeps them", () =>
+  provide(
+    Effect.gen(function* () {
+      // seedVenue never sets latitude/longitude, so "the-club" is NULL/NULL.
+      // gte/lte never match NULL, so a bbox query silently loses it — that
+      // asymmetry is intentional (see BRIEF-308) and pinned here rather
+      // than papered over with an IS NULL branch.
+      yield* seedVenue;
+      const withBbox = yield* listAllVenues({ minLat: -90, maxLat: 90, minLng: -180, maxLng: 180 });
+      expect(withBbox.map((r) => r.id)).toEqual([]);
+
+      const withoutBbox = yield* listAllVenues();
+      expect(withoutBbox.map((r) => r.id)).toEqual(["the-club"]);
+    }),
+  ),
+);
+
+it.effect("listAllVenues projects only the thin pin fields", () =>
+  provide(
+    Effect.gen(function* () {
+      const { db } = yield* Db;
+      const now = new Date();
+      yield* Effect.promise(() =>
+        db.insert(venues).values({
+          id: "v1",
+          orgHandle: "org-a",
+          handle: "alpha",
+          name: "Alpha",
+          kind: "club",
+          capacity: 300,
+          latitude: 51.5,
+          longitude: -0.1,
+          description: "A description that must not leak into the pin projection",
+          hours: '{"1":{"open":"18:00","close":"02:00"}}',
+          heroImageUrl: "https://example.com/hero.jpg",
+          websiteUrl: "https://example.com",
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      const rows = yield* listAllVenues();
+      expect(rows).toEqual([
+        {
+          id: "v1",
+          orgHandle: "org-a",
+          handle: "alpha",
+          name: "Alpha",
+          kind: "club",
+          capacity: 300,
+          latitude: 51.5,
+          longitude: -0.1,
+        },
+      ]);
     }),
   ),
 );

--- a/pulse/api/tests/services/venues.test.ts
+++ b/pulse/api/tests/services/venues.test.ts
@@ -253,13 +253,15 @@ it.effect("listAllVenues returns an empty array when there are no venues", () =>
   ),
 );
 
-it.effect("listAllVenues no-bbox path is bounded by the default limit", () =>
+it.effect("listAllVenues no-bbox path is bounded even with no caller limit", () =>
   provide(
     Effect.gen(function* () {
       const { db } = yield* Db;
       const now = new Date();
-      const rows = Array.from({ length: 25 }, (_, i) => ({
-        id: `v${i}`,
+      // More rows than the ceiling, so the bound has to come from the service
+      // rather than from the size of the table.
+      const rows = Array.from({ length: 130 }, (_, i) => ({
+        id: `v${String(i).padStart(3, "0")}`,
         orgHandle: "org-a",
         handle: `venue-${i}`,
         name: `Venue ${i}`,
@@ -268,9 +270,37 @@ it.effect("listAllVenues no-bbox path is bounded by the default limit", () =>
       }));
       yield* Effect.promise(() => db.insert(venues).values(rows));
       const result = yield* listAllVenues();
-      expect(result.length).toBe(20);
+      expect(result.length).toBe(100);
     }),
   ),
+);
+
+it.effect(
+  "listAllVenues returns the SAME bounded page on every call (ordered, not arbitrary)",
+  () =>
+    provide(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        const now = new Date();
+        // A LIMIT with no ORDER BY is free to return a different subset each
+        // time — the map would show a different set of pins on every refresh.
+        const rows = Array.from({ length: 130 }, (_, i) => ({
+          id: `v${String(i).padStart(3, "0")}`,
+          orgHandle: "org-a",
+          handle: `venue-${i}`,
+          name: `Venue ${i}`,
+          createdAt: now,
+          updatedAt: now,
+        }));
+        yield* Effect.promise(() => db.insert(venues).values(rows));
+
+        const first = yield* listAllVenues();
+        const second = yield* listAllVenues();
+        expect(second.map((v) => v.id)).toEqual(first.map((v) => v.id));
+        // And it is the ordering the service declares, not whatever fell out.
+        expect(first.map((v) => v.id)).toEqual(first.map((v) => v.id).toSorted());
+      }),
+    ),
 );
 
 it.effect("listAllVenues clamps a caller-supplied limit to the server ceiling", () =>

--- a/shared/openapi/pulse.json
+++ b/shared/openapi/pulse.json
@@ -584,6 +584,54 @@
           "updatedAt"
         ],
         "type": "object"
+      },
+      "VenuePin": {
+        "properties": {
+          "capacity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "handle": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "orgHandle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "orgHandle",
+          "handle",
+          "name",
+          "kind",
+          "capacity",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -1541,6 +1589,74 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "minLat",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "maxLat",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "minLng",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "maxLng",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
           }
         ],
         "responses": {
@@ -1564,6 +1680,24 @@
               }
             },
             "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
           }
         }
       },
@@ -4937,6 +5071,97 @@
     "/venues/": {
       "get": {
         "operationId": "listVenues",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "minLat",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "maxLat",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "minLng",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "maxLng",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "default": 0,
+                  "format": "numeric",
+                  "type": "string"
+                },
+                {
+                  "maximum": 100,
+                  "minimum": 1,
+                  "type": "number"
+                }
+              ],
+              "maximum": 100,
+              "minimum": 1
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4945,7 +5170,7 @@
                   "properties": {
                     "venues": {
                       "items": {
-                        "$ref": "#/components/schemas/Venue"
+                        "$ref": "#/components/schemas/VenuePin"
                       },
                       "type": "array"
                     }
@@ -4958,6 +5183,24 @@
               }
             },
             "description": "Response for status 200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for status 400"
           },
           "429": {
             "content": {


### PR DESCRIPTION
## Summary

`listAllVenues` was `db.select().from(venues)` with no bound at all — a full
table scan on every load of the Explore map, growing linearly with the venue
table forever. `GET /venues` and `GET /events` now take an optional viewport
(`minLat`, `maxLat`, `minLng`, `maxLng`) plus a `limit`, and `GET /venues`
returns a slim pin model instead of the whole row.

- This is the **API half** of the change. The Explore client still sends no
  viewport, so the no-bbox path had to stay honest on its own — see the second
  decision. The client half is a follow-up branch stacked on this one.
- Validation lives at the route: all four corners or none; inverted or
  out-of-range boxes reject with 400.

## Workspaces affected

`@pulse/api`. `.changeset/pulse-venues-bbox-contract.md` names it at `patch`.
`shared/openapi/pulse.json` is regenerated from the routes, not hand-edited.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#308 | `P-W28` |

**Opened**

| Issue | What |
|---|---|
| — | None |

Closes xchromo/osn-tracker#308

## Decisions

### `GET /venues` returns a pin model, not a `Venue` — `P-W28`

- **Issue** — the map needed eight fields and was being sent the whole row.
- **Why** — every byte is paid on a surface that loads on first paint.
- **Solution** — a new `VenuePin` (`id, orgHandle, handle, name, kind, capacity,
  latitude, longitude`). The existing `Venue` model and every other venue route
  are untouched.
- **Rationale** — narrowing the one high-frequency read is cheaper and safer
  than reshaping a model four routes share.

### The no-bbox default is the ceiling, not a smaller number — `approach`

- **Issue** — the first pass defaulted the no-bbox path to 20 rows.
- **Why** — the Explore client does not send a viewport yet. Between this
  merging and the client branch landing, the map would have shown 20 venues
  where it previously showed all of them — a visible product regression
  introduced by a performance fix.
- **Solution** — `VENUES_DEFAULT_LIMIT = VENUES_MAX_LIMIT` (100). The path is
  bounded, but returns no fewer pins than it did yesterday.
- **Rationale** — a bound that is *smaller than current behaviour* is a feature
  change wearing a performance fix's clothes. Bounded-and-unchanged is the
  correct intermediate state for the bottom of a stack.

### The bounded page is ordered — `approach`

- **Issue** — a `LIMIT` with no `ORDER BY` lets SQLite return any subset it
  likes, and a different one per call.
- **Why** — the map would have shown a different arbitrary set of pins on each
  refresh, with nothing in the code saying why.
- **Solution** — `ORDER BY venues.id`, the only unique column.
- **Rationale** — `id` is stable and indexed; a geographic ordering would cost
  more and buy nothing while the page is a bound rather than a real pager.

**Out of scope**

- Antimeridian-crossing boxes (`minLng > maxLng`) are rejected the same as any
  other inverted box — no issue opened; the product has no venues either side of
  it, and supporting them means splitting into two ranges.
- A bbox query drops rows with NULL latitude/longitude, because `gte`/`lte`
  never match NULL. The no-bbox venues path still returns them. Pinned by tests
  on both the venues and the events side rather than left to be rediscovered.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run --cwd pulse/api test:run` | ✅ 634 pass / 42 files |

Tests seed past the ceiling and assert the bound comes from the service rather
than the caller, and assert two successive calls return the same ordered page.

Not verified: any real query plan. The bound and the ordering are asserted
behaviourally against in-memory SQLite; nothing here measures D1.
