### PR TITLE
perf(pulse-web): fetch Explore venues by viewport, not all of them

### DIFF
--- a/.changeset/pulse-web-venue-bbox.md
+++ b/.changeset/pulse-web-venue-bbox.md
@@ -1,0 +1,19 @@
+---
+"@pulse/web": patch
+---
+
+The Explore map now asks the server for the venues in its box.
+
+`GET /venues` takes a viewport and returns a slim eight-field pin, so
+`fetchAllVenues` is replaced by `fetchVenuePins(bounds)`, which sends
+`minLat`/`maxLat`/`minLng`/`maxLng`. The client-side bbox filter in
+`ExploreMap` is gone with it — what stays is dropping a venue that already
+has an event pin at the same spot, which the server knows nothing about.
+
+Also ends a type lie: `fetchAllVenues` cast the response to `VenueSummary[]`,
+an 18-field row, while nine of those fields had stopped arriving. The new
+`VenuePin` interface matches what the endpoint actually returns. `VenueSummary`
+is untouched — the venue detail endpoint still returns the full row.
+
+`BBOX` moves to an export on `ExploreMap` so the map's projection and the
+venue query read one literal box.

--- a/pulse/web/src/explore/ExploreMap.tsx
+++ b/pulse/web/src/explore/ExploreMap.tsx
@@ -3,10 +3,15 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 
 import { Icon } from "../components/Icon";
 import type { EventItem } from "../lib/types";
-import type { VenueSummary } from "../lib/venues";
+import type { MapBounds, VenuePin } from "../lib/venues";
 
-// NYC bounding box for coordinate projection
-const BBOX = { minLng: -74.03, maxLng: -73.88, minLat: 40.63, maxLat: 40.76 };
+/**
+ * NYC bounding box. Two jobs: it projects a lat/lng onto the SVG, and it
+ * is the viewport the venue query is scoped to — the route passes it to
+ * `fetchVenuePins`, so this is the one literal box in the codebase. The
+ * map neither pans nor zooms, so it never changes at runtime.
+ */
+export const BBOX: MapBounds = { minLng: -74.03, maxLng: -73.88, minLat: 40.63, maxLat: 40.76 };
 
 function proj(lat: number, lng: number, w: number, h: number): [number, number] {
   const x = ((lng - BBOX.minLng) / (BBOX.maxLng - BBOX.minLng)) * w;
@@ -370,7 +375,7 @@ function Legend() {
 
 export function ExploreMap(props: {
   events: EventItem[];
-  venues?: VenueSummary[];
+  venues?: VenuePin[];
   hoveredId?: string | null;
   onHoverEvent?: (id: string | null) => void;
 }) {
@@ -420,7 +425,7 @@ export function ExploreMap(props: {
   // Map of venueId → venue summary so an event pin at a known venue can
   // upgrade itself into a clickable venue link.
   const venueById = createMemo(() => {
-    const m = new Map<string, VenueSummary>();
+    const m = new Map<string, VenuePin>();
     for (const v of props.venues ?? []) m.set(v.id, v);
     return m;
   });
@@ -434,24 +439,17 @@ export function ExploreMap(props: {
     return s;
   });
 
-  // Filter venues to the bbox client-side so off-screen venues don't paint
-  // outside the viewport. Drop venues that share a pin with an event.
-  // Will move server-side with the bbox query.
+  // The server already scoped the venues to BBOX, so all that's left here
+  // is dropping venues that share a pin with an event — something the
+  // server knows nothing about. The `!= null` guards narrow the type.
   const geoVenues = createMemo(() =>
     (props.venues ?? []).filter(
-      (v) =>
-        v.latitude != null &&
-        v.longitude != null &&
-        v.latitude >= BBOX.minLat &&
-        v.latitude <= BBOX.maxLat &&
-        v.longitude >= BBOX.minLng &&
-        v.longitude <= BBOX.maxLng &&
-        !venueIdsWithEvent().has(v.id),
+      (v) => v.latitude != null && v.longitude != null && !venueIdsWithEvent().has(v.id),
     ),
   );
 
   const [hoveredVenue, setHoveredVenue] = createSignal<{
-    venue: VenueSummary;
+    venue: VenuePin;
     x: number;
     y: number;
   } | null>(null);

--- a/pulse/web/src/lib/venues.ts
+++ b/pulse/web/src/lib/venues.ts
@@ -29,6 +29,31 @@ export interface VenueSummary {
   timezone: string;
 }
 
+/**
+ * Slim map projection returned by `GET /venues`. Eight fields, matching
+ * `VenuePin` in `pulse/api/src/services/venues.ts` — the heavy venue
+ * fields (`description`, `hours`, image/website URLs) are only on the
+ * detail endpoint, which still returns a `VenueSummary`.
+ */
+export interface VenuePin {
+  id: string;
+  orgHandle: string;
+  handle: string;
+  name: string;
+  kind: string;
+  capacity: number | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+/** Viewport the map paints, and the box the pin query is scoped to. */
+export interface MapBounds {
+  minLng: number;
+  maxLng: number;
+  minLat: number;
+  maxLat: number;
+}
+
 export interface VenueEvent {
   id: string;
   title: string;
@@ -71,16 +96,20 @@ export function parseVenueHours(raw: string | null): VenueHours | null {
 }
 
 /**
- * Pulls every venue. Feeds the Explore map's venue layer.
- *
- * TODO(venue-bbox-search): swap for a viewport-scoped fetch (pass
- * minLat/maxLat/minLng/maxLng) once the API supports it — tracked in
- * `P-W28` in `xchromo/osn-tracker`.
+ * Pulls the venue pins inside a viewport. Feeds the Explore map's venue
+ * layer — the box is applied by the server, so the caller paints what it
+ * gets back without a second filter.
  */
-export async function fetchAllVenues(): Promise<VenueSummary[]> {
-  const res = await fetch(`${BASE_URL}/venues`);
+export async function fetchVenuePins(bounds: MapBounds): Promise<VenuePin[]> {
+  const query = new URLSearchParams({
+    minLat: String(bounds.minLat),
+    maxLat: String(bounds.maxLat),
+    minLng: String(bounds.minLng),
+    maxLng: String(bounds.maxLng),
+  });
+  const res = await fetch(`${BASE_URL}/venues?${query.toString()}`);
   if (!res.ok) return [];
-  const body = (await res.json()) as { venues?: VenueSummary[] };
+  const body = (await res.json()) as { venues?: VenuePin[] };
   return body.venues ?? [];
 }
 

--- a/pulse/web/src/routes/index.tsx
+++ b/pulse/web/src/routes/index.tsx
@@ -10,13 +10,13 @@ import {
   type DiscoveryFilterValues,
 } from "../explore/DiscoveryFilters";
 import { ExploreCard } from "../explore/ExploreCard";
-import { ExploreMap } from "../explore/ExploreMap";
+import { BBOX, ExploreMap } from "../explore/ExploreMap";
 import { ExploreNav } from "../explore/ExploreNav";
 import { FilterRail } from "../explore/FilterRail";
 import { api } from "../lib/api";
 import { showCreateForm, setShowCreateForm } from "../lib/createEventSignal";
 import type { EventItem } from "../lib/types";
-import { fetchAllVenues } from "../lib/venues";
+import { fetchVenuePins } from "../lib/venues";
 
 import "../explore/explore.css";
 
@@ -142,8 +142,9 @@ export function ExplorePage() {
   const [discovery, { refetch }] = createResource(fetchSource, ({ q }) => fetchDiscovery(q));
 
   // Venues feed the Explore map's clickable venue layer. Public surface,
-  // no auth needed.
-  const [venues] = createResource(fetchAllVenues);
+  // no auth needed. The map neither pans nor zooms, so the viewport is a
+  // constant and the fetch runs once.
+  const [venues] = createResource(() => fetchVenuePins(BBOX));
 
   const [searchQuery, setSearchQuery] = createSignal("");
   const [hoveredId, setHoveredId] = createSignal<string | null>(null);

--- a/pulse/web/tests/explore/ExploreMap.test.tsx
+++ b/pulse/web/tests/explore/ExploreMap.test.tsx
@@ -4,28 +4,19 @@ import type { JSX } from "solid-js";
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { ExploreMap } from "../../src/explore/ExploreMap";
-import type { VenueSummary } from "../../src/lib/venues";
+import type { VenuePin } from "../../src/lib/venues";
 import { makeEvent } from "../helpers/events";
 import { wrapRouter } from "../helpers/router";
 
-const venueRow = (overrides: Partial<VenueSummary>): VenueSummary => ({
+const venueRow = (overrides: Partial<VenuePin>): VenuePin => ({
   id: "ven_x",
   orgHandle: "org",
   handle: "venue",
   name: "Some Venue",
   kind: "club",
-  description: null,
-  address: null,
-  city: null,
-  country: null,
+  capacity: null,
   latitude: null,
   longitude: null,
-  capacity: null,
-  hours: null,
-  heroImageUrl: null,
-  websiteUrl: null,
-  instagramHandle: null,
-  timezone: "UTC",
   ...overrides,
 });
 
@@ -157,7 +148,7 @@ describe("ExploreMap", () => {
   // Venue layer (T-R1)
   // -------------------------------------------------------------------------
 
-  it("renders a clickable venue pin for venues inside the bbox", () => {
+  it("renders a clickable venue pin for a venue the server returned", () => {
     const venues = [
       venueRow({
         id: "ven_1",
@@ -172,17 +163,11 @@ describe("ExploreMap", () => {
     expect(links.length).toBe(1);
   });
 
-  it("filters venues outside the NYC bbox", () => {
-    const venues = [
-      venueRow({
-        id: "ven_london",
-        orgHandle: "tpf",
-        handle: "london",
-        // London is well outside the NYC bbox.
-        latitude: 51.5326,
-        longitude: -0.0561,
-      }),
-    ];
+  // The bbox filter moved into the `/venues` query, so the map paints what
+  // it is given. What it must still drop is a venue with no coordinates —
+  // there is nowhere to put the pin.
+  it("drops a venue with no coordinates", () => {
+    const venues = [venueRow({ id: "ven_nowhere", orgHandle: "tpf", handle: "nowhere" })];
     const { container } = renderWithRouter(() => <ExploreMap events={[]} venues={venues} />);
     expect(container.querySelectorAll("a[href^='/venues/']").length).toBe(0);
   });

--- a/pulse/web/tests/lib/venues.test.ts
+++ b/pulse/web/tests/lib/venues.test.ts
@@ -3,13 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   computeOpenStatus,
-  fetchAllVenues,
   fetchEventLineup,
   fetchVenue,
   fetchVenueEvents,
+  fetchVenuePins,
   parseVenueHours,
   safeHttpUrl,
   venueMapsUrl,
+  type MapBounds,
+  type VenuePin,
   type VenueSummary,
 } from "../../src/lib/venues";
 
@@ -114,10 +116,25 @@ describe("computeOpenStatus", () => {
 });
 
 // ---------------------------------------------------------------------------
-// fetchAllVenues
+// fetchVenuePins
 // ---------------------------------------------------------------------------
 
-describe("fetchAllVenues", () => {
+const basePin: VenuePin = {
+  id: "v1",
+  orgHandle: "org",
+  handle: "venue",
+  name: "Venue",
+  kind: "club",
+  capacity: null,
+  latitude: null,
+  longitude: null,
+};
+
+// Four distinct values so a swapped pair (minLat sent as maxLat, say)
+// shows up as a mismatch rather than passing by symmetry.
+const bounds: MapBounds = { minLng: -74.03, maxLng: -73.88, minLat: 40.63, maxLat: 40.76 };
+
+describe("fetchVenuePins", () => {
   const realFetch = globalThis.fetch;
   beforeEach(() => {
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
@@ -126,31 +143,32 @@ describe("fetchAllVenues", () => {
     globalThis.fetch = realFetch;
   });
 
+  const mock = () => globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+
+  it("sends all four corners of the viewport as query parameters", async () => {
+    mock().mockResolvedValue({ ok: true, json: async () => ({ venues: [] }) });
+    await fetchVenuePins(bounds);
+    const url = new URL(mock().mock.calls[0][0] as string);
+    expect(url.pathname).toBe("/venues");
+    expect(url.searchParams.get("minLat")).toBe("40.63");
+    expect(url.searchParams.get("maxLat")).toBe("40.76");
+    expect(url.searchParams.get("minLng")).toBe("-74.03");
+    expect(url.searchParams.get("maxLng")).toBe("-73.88");
+  });
+
   it("returns the venues array on a 200 response", async () => {
-    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => ({ venues: [baseVenue] }),
-    });
-    const result = await fetchAllVenues();
-    expect(result).toEqual([baseVenue]);
+    mock().mockResolvedValue({ ok: true, json: async () => ({ venues: [basePin] }) });
+    expect(await fetchVenuePins(bounds)).toEqual([basePin]);
   });
 
   it("returns an empty array on a non-OK response (fail-soft)", async () => {
-    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      json: async () => ({}),
-    });
-    const result = await fetchAllVenues();
-    expect(result).toEqual([]);
+    mock().mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await fetchVenuePins(bounds)).toEqual([]);
   });
 
   it("returns an empty array when the body has no venues key", async () => {
-    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => ({}),
-    });
-    const result = await fetchAllVenues();
-    expect(result).toEqual([]);
+    mock().mockResolvedValue({ ok: true, json: async () => ({}) });
+    expect(await fetchVenuePins(bounds)).toEqual([]);
   });
 });
 

--- a/pulse/web/tests/routes/ExplorePage.test.tsx
+++ b/pulse/web/tests/routes/ExplorePage.test.tsx
@@ -3,6 +3,7 @@ import { render as _baseRender, cleanup, fireEvent } from "@solidjs/testing-libr
 import type { JSX } from "solid-js";
 import { vi, describe, it, expect, afterEach, beforeEach } from "vitest";
 
+import { BBOX } from "../../src/explore/ExploreMap";
 import { wrapRouter } from "../helpers/router";
 
 const mockGet = vi.fn();
@@ -31,14 +32,14 @@ vi.mock("solid-toast", async () => {
   return solidToastMock();
 });
 
-const mockFetchAllVenues = vi.fn().mockResolvedValue([]);
+const mockFetchVenuePins = vi.fn().mockResolvedValue([]);
 
 vi.mock("../../src/lib/venues", async () => {
   const actual =
     await vi.importActual<typeof import("../../src/lib/venues")>("../../src/lib/venues");
   return {
     ...actual,
-    fetchAllVenues: (...args: unknown[]) => mockFetchAllVenues(...args),
+    fetchVenuePins: (...args: unknown[]) => mockFetchVenuePins(...args),
   };
 });
 
@@ -304,30 +305,22 @@ describe("ExplorePage", () => {
       data: { events: [], nextCursor: null, series: {} },
       error: null,
     });
-    mockFetchAllVenues.mockResolvedValue([
+    mockFetchVenuePins.mockResolvedValue([
       {
         id: "ven_1",
         orgHandle: "tpf",
         handle: "factory",
         name: "The Factory",
         kind: "club",
-        description: null,
-        address: null,
-        city: null,
-        country: null,
+        capacity: null,
         latitude: 40.705,
         longitude: -73.93,
-        capacity: null,
-        hours: null,
-        heroImageUrl: null,
-        websiteUrl: null,
-        instagramHandle: null,
-        timezone: "UTC",
       },
     ]);
     const { container } = render(() => <ExplorePage />);
     await vi.waitFor(() => {
       expect(container.querySelector("a[href='/venues/tpf/factory']")).toBeTruthy();
     });
+    expect(mockFetchVenuePins).toHaveBeenCalledWith(BBOX);
   });
 });


### PR DESCRIPTION
## Summary

The client half of the venue bbox work. Stacked on #732, which gave
`GET /venues` a viewport and a slim eight-field pin model — this branch makes
the Explore map actually use both.

- `fetchAllVenues()` becomes `fetchVenuePins(bounds)`, sending all four corners.
- The client-side bbox filter in `ExploreMap` is deleted; the server applies the
  box now. What stays is dropping a venue that already has an event pin at the
  same coordinates, which the server knows nothing about.
- Ends a type lie: `fetchAllVenues` cast the response to `VenueSummary[]`, an
  18-field row, while nine of those fields had stopped arriving.

## Workspaces affected

`@pulse/web`. `.changeset/pulse-web-venue-bbox.md` names it at `patch`.
`@pulse/api` is deliberately absent — that changeset is on the branch below.

## Issues

**Closes**

| Issue | What |
|---|---|
| — | None. #732 carries `Closes xchromo/osn-tracker#308`; this branch completes it but the finding closes once. |

**Opened**

| Issue | What |
|---|---|
| — | None |

## Decisions

### There is no pan/zoom refetch, because there is no pan or zoom — `approach`

- **Issue** — the obvious shape for "consume a viewport contract" is a debounced
  refetch on map interaction. That would have been built on a false premise.
- **Why** — `BBOX` is a module constant, the `zoom` signal has no setter, and
  the zoom/layers buttons have never had a click handler. Comments in the file
  already said so. A debounce and an interaction handler would have been dead
  code that reads as a working feature.
- **Solution** — the route passes the one constant box to the fetch, and the
  resource runs once. `index.tsx` says why in a comment.
- **Rationale** — when the map becomes interactive, the fetch already takes
  bounds; the change is to pass a signal instead of a constant. Nothing here
  needs undoing first.

### `VenuePin` is a new type; `VenueSummary` is untouched — `approach`

- **Issue** — `GET /venues` and `GET /venues/:org/:handle` return different
  shapes now, and one type was standing in for both.
- **Why** — the detail page and `fetchVenue()` still need the full row.
- **Solution** — a `VenuePin` interface mirroring
  `pulse/api/src/services/venues.ts`, used by the list fetch and by `ExploreMap`.
  `VenueSummary` keeps every field and every other call site.
- **Rationale** — narrowing the shared type would have broken the detail
  surface to fix the map.

### `BBOX` is exported rather than duplicated — `approach`

- **Issue** — the box is now needed in two places: projecting lat/lng onto the
  SVG, and scoping the query.
- **Solution** — exported from `ExploreMap.tsx`, typed as `MapBounds`. One
  literal box in the codebase.
- **Rationale** — `proj()` reads it on every render and lives in that file;
  moving it out to be imported back would buy nothing.

### `limit` is not sent — `approach`

- **Issue** — the endpoint accepts one.
- **Solution** — omitted.
- **Rationale** — the server's default is its ceiling (100), so an explicit
  value would be a second number to keep in sync with the API for no behavioural
  difference.

**Out of scope** — none found and left.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run --cwd pulse/web test:run` | ✅ 463 pass / 40 files |
| `bun run --cwd pulse/api test:run` | ✅ 634 pass / 42 files (untouched, confirmed still green) |

Three existing test files changed because they encoded the old shape, and one
of those changes is a deletion worth flagging: `"filters venues outside the NYC
bbox"` asserted behaviour this branch removes. It is replaced by a test pinning
what the memo still drops — a venue with null coordinates. The bbox filtering
itself is asserted server-side in #732.

`tests/routes/ExplorePage.test.tsx` mocked the module by the old function name,
so it had silently stopped intercepting; it now mocks `fetchVenuePins` and
asserts the route passes `BBOX` to it.

Not verified by hand: nothing exercises this against a running API.
