### PR TITLE
chore(ci): run every workflow on Node 24

### DIFF
--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -9,6 +9,9 @@ on:
   # whole stack collapsed onto main, which is the last moment a break is useful.
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # macOS runner minutes bill at a multiple of Linux, so the iOS build only
   # runs when a push/PR actually touches Swift/Xcode files. GitHub Actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/deploy-osn-pulse-landing.yml
+++ b/.github/workflows/deploy-osn-pulse-landing.yml
@@ -25,6 +25,9 @@ concurrency:
   group: deploy-osn-pulse-landing-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Build + deploy ${{ matrix.site.project }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,7 +152,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/set-osn-api-secret.yml
+++ b/.github/workflows/set-osn-api-secret.yml
@@ -75,6 +75,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set-secret:
     name: Set ${{ inputs.secret }} on ${{ inputs.tier }}


### PR DESCRIPTION
## What

One Node runtime across every workflow.

- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` added to the three workflows that lacked it — `ci-swift`, `deploy-osn-pulse-landing`, `set-osn-api-secret`. The other four (`ci`, `deploy`, `release`, `changeset-check`) already had it.
- `actions/setup-node` pins in `ci.yml` and `deploy.yml` bumped 22 → 24.

## Why

The flag makes GitHub run the JavaScript actions we call — `actions/checkout`, `actions/cache`, `oven-sh/setup-bun` — on Node 24 instead of the runner default. Three workflows were still on the old default, so the same actions ran on two different Node versions depending on which workflow fired.

The explicit `setup-node` pins only supply node for tooling; bun runs the code and no package pins a node engine, so nothing else needs to move with it.

## Checks

- All five edited files parse as YAML.
- `scripts/changeset-required.sh` returns `skip` for this diff — CI-only change, no versioned package touched, so no changeset.