### PR TITLE
perf(landing,pulse-web): self-host the last four Google Fonts surfaces

### DIFF
--- a/.changeset/selfhost-fonts-cire-landing.md
+++ b/.changeset/selfhost-fonts-cire-landing.md
@@ -1,0 +1,20 @@
+---
+"@cire/landing": patch
+---
+
+Self-host Cormorant Garamond and Lato instead of linking `fonts.googleapis.com`.
+
+Astro's font pipeline (`fontProviders.google()` in `astro.config.mjs`) downloads
+both faces at build time, serves them from our own origin, emits the preload
+links, and generates the metric-matched fallbacks — so the swap from fallback to
+real face no longer shifts the layout. Only the latin and latin-ext subsets ship.
+
+This removes the last render-blocking third-party request from the marketing
+site, and with it the transmission of every visitor's IP and user-agent to
+Google LLC (US) — which no consent gate covered, because the `<link>` sat in the
+server-rendered `<head>`. `public/_headers` drops both Google origins from
+`style-src` and `font-src`, and a new test asserts they stay gone.
+
+The two font tokens in `styles/global.css` are no longer byte-identical with
+`cire/invites` — both self-host the same two families at the same weights, by
+different routes. The comment there says so.

--- a/.changeset/selfhost-fonts-osn-pulse.md
+++ b/.changeset/selfhost-fonts-osn-pulse.md
@@ -1,0 +1,26 @@
+---
+"@osn/landing": patch
+"@pulse/landing": patch
+"@pulse/web": patch
+---
+
+Self-host the typefaces instead of linking `fonts.googleapis.com`.
+
+`@osn/landing` (Inter, Space Grotesk) and `@pulse/landing` (Geist, Geist Mono,
+Instrument Serif) use Astro's font pipeline: `fontProviders.google()` downloads
+each face at build time, serves it from our own origin, emits the preload links,
+and generates the metric-matched fallback so the swap does not shift layout.
+Both drop the Google origins from `style-src` and `font-src` in
+`public/_headers`, and both gain a test asserting they stay gone.
+
+`@pulse/web` is SolidStart, which has no equivalent pipeline, so its faces are
+written out in `src/app.css` over `@fontsource` — latin and latin-ext only, and
+`.woff2` only. Importing fontsource's whole-family entrypoints instead would
+have put every published subset on the critical path (Geist Mono ships six) and
+let Vite base64-inline the sub-4 KB legacy `.woff` files straight into the
+stylesheet.
+
+This removes the last render-blocking third-party request from all three, and
+with it the transmission of every visitor's IP and user-agent to Google LLC (US)
+— which no consent gate covered, because the `<link>` sat in the server-rendered
+`<head>`.

--- a/bun.lock
+++ b/bun.lock
@@ -321,7 +321,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -392,8 +392,11 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.10",
+      "version": "0.22.12",
       "dependencies": {
+        "@fontsource/geist-mono": "^5.3.0",
+        "@fontsource/geist-sans": "^5.3.0",
+        "@fontsource/instrument-serif": "^5.3.0",
         "@osn/ui": "workspace:*",
         "@pulse/api": "workspace:*",
         "@shared/rp-auth": "workspace:*",
@@ -980,6 +983,12 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@fontsource/cormorant-garamond": ["@fontsource/cormorant-garamond@5.3.0", "", {}, "sha512-weuGsCirGVWBWqpt6YUp0yLThTe4G8YO45noq8wxeJCRvEpq5lFrxNMFSTxcyOyV5k5otzJ8guDzYegdYlcLMQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.3.0", "", {}, "sha512-UtJ1BBBCVpMYdIcW7nEB45UAoAw5M53ZXs2t0ciPW+IokuAAIc56M8+kW5tXbRJCTpDw4XTtU7proT6NdQAHTg=="],
+
+    "@fontsource/geist-sans": ["@fontsource/geist-sans@5.3.0", "", {}, "sha512-AmG7cE1AvE4NHROPaOl1sN+a02cB5xy6pA/ZV76HXqWTCsJTV2SCBc9DTFHfJqnVOODm7HhXIYtUIb75NP5QXQ=="],
+
+    "@fontsource/instrument-serif": ["@fontsource/instrument-serif@5.3.0", "", {}, "sha512-mDiaIg0u67sYV59fie92Wz4sM8UiVlbL7fLxnFPCKkX15DMASEnQTREbaP5S5/3DCcsoAOcQ0sV9E4AeY4QqYQ=="],
 
     "@fontsource/lato": ["@fontsource/lato@5.3.0", "", {}, "sha512-0WhF/4rhrw+ErIyneKvhHn2YAl+xf8GDtllgOgOzDmeaSlLQtjpChXaQOpWhG2BchQW0WJy2zLV12Hdg0ndOMw=="],
 

--- a/cire/landing/astro.config.mjs
+++ b/cire/landing/astro.config.mjs
@@ -1,6 +1,6 @@
 import solidJs from "@astrojs/solid-js";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 
 // Pure static marketing site — serves the apex `cireweddings.com` (domain
 // reshuffle 2026-07-16; guest invites moved to `invite.`, organiser to `host.` —
@@ -19,6 +19,46 @@ export default defineConfig({
   // own URL and the apex deploy advertises cireweddings.com.
   site: process.env.SITE ?? "https://cireweddings.com",
   integrations: [solidJs()],
+
+  // Every face is downloaded at build time and served from our own origin. The
+  // three page shells used to <link> fonts.googleapis.com, which cost a DNS
+  // lookup, a TLS handshake and a render-blocking round trip to a third party
+  // before a single word could paint — and told Google LLC (US) the IP and
+  // user-agent of every visitor, with no consent gate in front of it
+  // (`xchromo/osn-tracker#388`). Astro's pipeline also emits the preload links
+  // and the fallback metrics (`optimizedFallbacks`), so the swap from fallback
+  // face to real face doesn't shift the layout.
+  //
+  // Self-hosting is also what lets `public/_headers` drop both Google origins
+  // from `style-src` and `font-src`.
+  fonts: [
+    {
+      // The stationery serif. Same family, same weights as the guest site
+      // (`cire/invites`) — the apex and the invite are one brand, and the
+      // token comment in `styles/global.css` already says so.
+      name: "Cormorant Garamond",
+      cssVariable: "--font-cormorant",
+      provider: fontProviders.google(),
+      weights: [300, 400, 600],
+      styles: ["normal", "italic"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["Georgia", "serif"],
+      optimizedFallbacks: true,
+    },
+    {
+      // Body copy. 700 is the only weight the legal pages don't use, and it
+      // ships anyway because the marketing page sets it.
+      name: "Lato",
+      cssVariable: "--font-lato",
+      provider: fontProviders.google(),
+      weights: [300, 400, 700],
+      styles: ["normal"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["system-ui", "sans-serif"],
+      optimizedFallbacks: true,
+    },
+  ],
+
   vite: {
     plugins: [tailwindcss()],
   },

--- a/cire/landing/public/_headers
+++ b/cire/landing/public/_headers
@@ -3,7 +3,10 @@
 # first-party API, so unlike the organiser portal it CAN carry a tight CSP:
 #   - script-src: own bundles ('self') + the small inline reveal/hydration
 #     scripts ('unsafe-inline' — Astro's island bootstrap + our is:inline IO).
-#   - style/font-src: Google Fonts (matches the <link> in BaseLayout).
+#   - style-src 'unsafe-inline': Astro inlines small critical CSS.
+#   - font-src 'self': the faces are SELF-HOSTED — `astro.config.mjs`
+#     downloads them at build time via `fontProviders.google()`, so no
+#     fonts.googleapis.com / fonts.gstatic.com (tracker #388).
 #   - img-src: self + data: + Unsplash's CDN (the hotlinked imagery).
 # Keep in sync with the imagery host in src/lib/site.ts if it ever changes.
 /*
@@ -11,7 +14,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://images.unsplash.com; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://images.unsplash.com; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 # Long-cache the immutable hashed bundles.
 /_astro/*

--- a/cire/landing/src/layouts/BaseLayout.astro
+++ b/cire/landing/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import { VineCanvas } from '../components/VineCanvas'
 import SiteNav from '../components/SiteNav.astro'
 import SiteFooter from '../components/SiteFooter.astro'
 import { SITE_DESCRIPTION, SITE_NAME, SITE_TAGLINE } from '../lib/site'
+import { Font } from 'astro:assets'
 
 interface Props {
   /** Document <title>. Defaults to the brand + tagline. */
@@ -45,22 +46,15 @@ const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : As
     <meta name="twitter:description" content={description} />
     <meta name="theme-color" content="#0d1f17" />
 
-    {/* Same font strategy as cire/invites so the marketing site and the invites it
-        advertises render in the exact same type. */}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400;700&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
     <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400;700&display=swap" rel="stylesheet" />
       {/* No JS ⇒ the scroll-reveal observer never runs, so reveal everything up
           front rather than leaving it hidden (SEO + accessibility). */}
       <style is:inline>[data-reveal]{opacity:1 !important;transform:none !important}</style>
     </noscript>
+    <!-- Both faces are above the fold — the wordmark is Cormorant, the copy beside
+         it is Lato — so both preload. -->
+    <Font cssVariable="--font-cormorant" preload />
+    <Font cssVariable="--font-lato" preload />
   </head>
   <body>
     <div class="page-root">

--- a/cire/landing/src/layouts/LegalLayout.astro
+++ b/cire/landing/src/layouts/LegalLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import SiteFooter from '../components/SiteFooter.astro'
+import { Font } from 'astro:assets'
 
 interface Props {
   title: string
@@ -15,17 +16,10 @@ const { title } = Astro.props
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{title} — Cire</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet" />
-    </noscript>
+    <!-- Both faces are above the fold — the wordmark is Cormorant, the copy beside
+         it is Lato — so both preload. -->
+    <Font cssVariable="--font-cormorant" preload />
+    <Font cssVariable="--font-lato" preload />
   </head>
   <body>
     <main class="legal">

--- a/cire/landing/src/self-hosted-fonts.test.ts
+++ b/cire/landing/src/self-hosted-fonts.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The faces are self-hosted by Astro's font pipeline (`astro.config.mjs`,
+ * `fontProviders.google()`), so nothing on this site may reach
+ * fonts.googleapis.com or fonts.gstatic.com — not the document head, and not
+ * the CSP that would have to allow it.
+ *
+ * This is asserted rather than assumed because the failure is silent: a
+ * re-added `<link>` still renders correctly in dev, and the only visible
+ * symptom is a third-party request that transmits every visitor's IP and
+ * user-agent to Google LLC (US) with no consent gate in front of it
+ * (tracker #388).
+ */
+const pkgRoot = join(import.meta.dirname, "..");
+const layoutDir = join(pkgRoot, "src", "layouts");
+
+describe("self-hosted fonts", () => {
+  const csp = readFileSync(join(pkgRoot, "public", "_headers"), "utf8")
+    .split("\n")
+    .find((line) => line.trim().startsWith("Content-Security-Policy:"));
+
+  it("has a Content-Security-Policy to check", () => {
+    expect(csp).toBeDefined();
+  });
+
+  it("allows fonts from our own origin only", () => {
+    expect(csp).toContain("font-src 'self'");
+    expect(csp).not.toContain("fonts.gstatic.com");
+    expect(csp).not.toContain("fonts.googleapis.com");
+  });
+
+  it.each(readdirSync(layoutDir).filter((f) => f.endsWith(".astro")))(
+    "%s links no Google Fonts stylesheet",
+    (file) => {
+      const source = readFileSync(join(layoutDir, file), "utf8");
+      expect(source).not.toContain("fonts.googleapis.com");
+      expect(source).not.toContain("fonts.gstatic.com");
+    },
+  );
+});

--- a/cire/landing/src/styles/global.css
+++ b/cire/landing/src/styles/global.css
@@ -3,7 +3,15 @@
 /* Brand tokens — kept byte-identical to cire/invites's theme block so the marketing
    site, the invites it advertises, and the organiser portal all read as one
    brand. If you change a token here, change it in cire/invites/src/styles/global.css
-   too (and vice versa). See [[wiki/apps/cire-landing]] → "Brand parity". */
+   too (and vice versa). See [[wiki/apps/cire-landing]] → "Brand parity".
+
+   The COLOUR tokens are byte-identical. The two font tokens are not, and cannot
+   be: both sites now self-host Cormorant Garamond and Lato, but by different
+   routes — this one through Astro's font pipeline (`astro.config.mjs`), the
+   guest site through hand-written `@font-face` rules over `@fontsource`, because
+   its build is an SSR Worker that predates this config. What matters for brand
+   parity is that they resolve to the same two families at the same weights, and
+   both carry a metric-matched fallback. */
 @theme {
   --color-bg: oklch(19.96% 0.0331 147.34);
   --color-surface: oklch(22.7% 0.0275 152.78);
@@ -15,8 +23,11 @@
   --color-gold-dim: oklch(74.99% 0.0854 82.08 / 0.35);
   --color-error: oklch(67.56% 0.1401 21.48);
   --color-success: oklch(75.96% 0.1421 146.94);
-  --font-display: "Cormorant Garamond", Georgia, serif;
-  --font-body: "Lato", system-ui, sans-serif;
+  /* Both faces are self-hosted by Astro's font pipeline, which defines
+     `--font-cormorant` / `--font-lato` on :root with their metric-matched
+     fallbacks already in the chain (see astro.config.mjs). */
+  --font-display: var(--font-cormorant);
+  --font-body: var(--font-lato);
   --default-font-family: var(--font-body);
 
   /* Landing-only additions (not part of the shared cire/invites brand block above —

--- a/osn/landing/astro.config.mjs
+++ b/osn/landing/astro.config.mjs
@@ -1,6 +1,6 @@
 import solidJs from "@astrojs/solid-js";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 
 // Pure static marketing site for OSN. The landing page is the same for every
 // visitor (unlike the identity app `@osn/social`, which is per-user), so it
@@ -17,6 +17,43 @@ export default defineConfig({
   // advertises the real apex.
   site: process.env.SITE ?? "https://osn.social",
   integrations: [solidJs()],
+
+  // Every face is downloaded at build time and served from our own origin. The
+  // three page shells used to <link> fonts.googleapis.com, which cost a DNS
+  // lookup, a TLS handshake and a render-blocking round trip to a third party
+  // before a single word could paint — and told Google LLC (US) the IP and
+  // user-agent of every visitor, with no consent gate in front of it
+  // (`xchromo/osn-tracker#388`). Astro's pipeline also emits the preload links
+  // and the fallback metrics (`optimizedFallbacks`), so the swap from fallback
+  // face to real face doesn't shift the layout.
+  //
+  // Self-hosting is also what lets `public/_headers` drop both Google origins
+  // from `style-src` and `font-src`.
+  fonts: [
+    {
+      // Headings and the wordmark.
+      name: "Space Grotesk",
+      cssVariable: "--font-space-grotesk",
+      provider: fontProviders.google(),
+      weights: [400, 500, 600, 700],
+      styles: ["normal"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["system-ui", "sans-serif"],
+      optimizedFallbacks: true,
+    },
+    {
+      // Body copy.
+      name: "Inter",
+      cssVariable: "--font-inter",
+      provider: fontProviders.google(),
+      weights: [400, 500, 600],
+      styles: ["normal"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["system-ui", "sans-serif"],
+      optimizedFallbacks: true,
+    },
+  ],
+
   vite: {
     plugins: [tailwindcss()],
   },

--- a/osn/landing/public/_headers
+++ b/osn/landing/public/_headers
@@ -4,14 +4,17 @@
 # a tight CSP:
 #   - script-src: own bundles ('self') + the small inline reveal/hydration
 #     scripts ('unsafe-inline' — Astro's island bootstrap + our is:inline IO).
-#   - style/font-src: Google Fonts (matches the <link> in BaseLayout).
+#   - style-src 'unsafe-inline': Astro inlines small critical CSS.
+#   - font-src 'self': the faces are SELF-HOSTED — `astro.config.mjs`
+#     downloads them at build time via `fontProviders.google()`, so no
+#     fonts.googleapis.com / fonts.gstatic.com (tracker #388).
 #   - img-src: self + data: only (no external image host — visuals are SVG/CSS).
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 # Long-cache the immutable hashed bundles.
 /_astro/*

--- a/osn/landing/src/layouts/BaseLayout.astro
+++ b/osn/landing/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css'
 import { ConstellationCanvas } from '../components/ConstellationCanvas'
 import SiteFooter from '../components/SiteFooter.astro'
 import { SITE_DESCRIPTION, SITE_NAME, SITE_TAGLINE } from '../lib/site'
+import { Font } from 'astro:assets'
 
 interface Props {
   /** Document <title>. Defaults to the brand + tagline. */
@@ -46,20 +47,15 @@ const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : As
 
     {/* Space Grotesk (display) + Inter (body), loaded with the preload+noscript
         strategy so they never block first paint. */}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
     <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
       {/* No JS ⇒ the scroll-reveal observer never runs, so reveal everything up
           front rather than leaving it hidden (SEO + accessibility). */}
       <style is:inline>[data-reveal]{opacity:1 !important;transform:none !important}</style>
     </noscript>
+    <!-- Both faces are above the fold — the wordmark and the hero heading are Space
+         Grotesk, the copy under them is Inter — so both preload. -->
+    <Font cssVariable="--font-space-grotesk" preload />
+    <Font cssVariable="--font-inter" preload />
   </head>
   <body>
     <div class="page-root">

--- a/osn/landing/src/layouts/LegalLayout.astro
+++ b/osn/landing/src/layouts/LegalLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import SiteFooter from '../components/SiteFooter.astro'
+import { Font } from 'astro:assets'
 
 interface Props {
   title: string
@@ -16,17 +17,10 @@ const { title } = Astro.props
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{title} — OSN</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    </noscript>
+    <!-- Both faces are above the fold — the wordmark and the hero heading are Space
+         Grotesk, the copy under them is Inter — so both preload. -->
+    <Font cssVariable="--font-space-grotesk" preload />
+    <Font cssVariable="--font-inter" preload />
   </head>
   <body>
     <main class="legal">

--- a/osn/landing/src/self-hosted-fonts.test.ts
+++ b/osn/landing/src/self-hosted-fonts.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The faces are self-hosted by Astro's font pipeline (`astro.config.mjs`,
+ * `fontProviders.google()`), so nothing on this site may reach
+ * fonts.googleapis.com or fonts.gstatic.com — not the document head, and not
+ * the CSP that would have to allow it.
+ *
+ * This is asserted rather than assumed because the failure is silent: a
+ * re-added `<link>` still renders correctly in dev, and the only visible
+ * symptom is a third-party request that transmits every visitor's IP and
+ * user-agent to Google LLC (US) with no consent gate in front of it
+ * (tracker #388).
+ */
+const pkgRoot = join(import.meta.dirname, "..");
+const layoutDir = join(pkgRoot, "src", "layouts");
+
+describe("self-hosted fonts", () => {
+  const csp = readFileSync(join(pkgRoot, "public", "_headers"), "utf8")
+    .split("\n")
+    .find((line) => line.trim().startsWith("Content-Security-Policy:"));
+
+  it("has a Content-Security-Policy to check", () => {
+    expect(csp).toBeDefined();
+  });
+
+  it("allows fonts from our own origin only", () => {
+    expect(csp).toContain("font-src 'self'");
+    expect(csp).not.toContain("fonts.gstatic.com");
+    expect(csp).not.toContain("fonts.googleapis.com");
+  });
+
+  it.each(readdirSync(layoutDir).filter((f) => f.endsWith(".astro")))(
+    "%s links no Google Fonts stylesheet",
+    (file) => {
+      const source = readFileSync(join(layoutDir, file), "utf8");
+      expect(source).not.toContain("fonts.googleapis.com");
+      expect(source).not.toContain("fonts.gstatic.com");
+    },
+  );
+});

--- a/osn/landing/src/styles/global.css
+++ b/osn/landing/src/styles/global.css
@@ -15,8 +15,11 @@
   --color-accent-2: oklch(0.78 0.12 205);
   --color-error: oklch(67.56% 0.1401 21.48);
   --color-success: oklch(75.96% 0.1421 146.94);
-  --font-display: "Space Grotesk", system-ui, sans-serif;
-  --font-body: "Inter", system-ui, sans-serif;
+  /* Both faces are self-hosted by Astro's font pipeline, which defines
+     `--font-space-grotesk` / `--font-inter` on :root with their
+     metric-matched fallbacks already in the chain (see astro.config.mjs). */
+  --font-display: var(--font-space-grotesk);
+  --font-body: var(--font-inter);
   --default-font-family: var(--font-body);
 }
 

--- a/pulse/landing/astro.config.mjs
+++ b/pulse/landing/astro.config.mjs
@@ -1,6 +1,6 @@
 import solidJs from "@astrojs/solid-js";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 
 // Pure static marketing site for Pulse. Like cire/landing it prerenders to plain
 // HTML (the page is the same for everyone) and deploys to Cloudflare Pages —
@@ -17,6 +17,54 @@ export default defineConfig({
   // advertises the real apex.
   site: process.env.SITE ?? "https://pulse.events",
   integrations: [solidJs()],
+
+  // Every face is downloaded at build time and served from our own origin. The
+  // three page shells used to <link> fonts.googleapis.com, which cost a DNS
+  // lookup, a TLS handshake and a render-blocking round trip to a third party
+  // before a single word could paint — and told Google LLC (US) the IP and
+  // user-agent of every visitor, with no consent gate in front of it
+  // (`xchromo/osn-tracker#388`). Astro's pipeline also emits the preload links
+  // and the fallback metrics (`optimizedFallbacks`), so the swap from fallback
+  // face to real face doesn't shift the layout.
+  //
+  // Self-hosting is also what lets `public/_headers` drop both Google origins
+  // from `style-src` and `font-src`.
+  fonts: [
+    {
+      // Display face. Instrument Serif ships one weight; the italic is a
+      // separate file, and the marketing page sets both.
+      name: "Instrument Serif",
+      cssVariable: "--font-instrument-serif",
+      provider: fontProviders.google(),
+      weights: [400],
+      styles: ["normal", "italic"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["Georgia", "serif"],
+      optimizedFallbacks: true,
+    },
+    {
+      name: "Geist",
+      cssVariable: "--font-geist",
+      provider: fontProviders.google(),
+      weights: [400, 500, 600, 700],
+      styles: ["normal"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["system-ui", "sans-serif"],
+      optimizedFallbacks: true,
+    },
+    {
+      // Real tabular numerals for the ticker and the category chips.
+      name: "Geist Mono",
+      cssVariable: "--font-geist-mono",
+      provider: fontProviders.google(),
+      weights: [400, 500],
+      styles: ["normal"],
+      subsets: ["latin", "latin-ext"],
+      fallbacks: ["ui-monospace", "SF Mono", "Menlo", "monospace"],
+      optimizedFallbacks: true,
+    },
+  ],
+
   vite: {
     plugins: [tailwindcss()],
   },

--- a/pulse/landing/public/_headers
+++ b/pulse/landing/public/_headers
@@ -3,7 +3,10 @@
 # first-party API, so it carries a tight CSP:
 #   - script-src: own bundles ('self') + the small inline reveal/hydration
 #     scripts ('unsafe-inline' — Astro's island bootstrap + our is:inline IO).
-#   - style/font-src: Google Fonts (matches the <link> in BaseLayout).
+#   - style-src 'unsafe-inline': Astro inlines small critical CSS.
+#   - font-src 'self': the faces are SELF-HOSTED — `astro.config.mjs`
+#     downloads them at build time via `fontProviders.google()`, so no
+#     fonts.googleapis.com / fonts.gstatic.com (tracker #388).
 #   - img-src: self + data: only — the site uses NO external images (pure
 #     CSS/SVG visuals), so no third-party image host is allowed.
 /*
@@ -11,7 +14,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 # Long-cache the immutable hashed bundles.
 /_astro/*

--- a/pulse/landing/src/layouts/BaseLayout.astro
+++ b/pulse/landing/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css'
 import { PulseField } from '../components/PulseField'
 import SiteFooter from '../components/SiteFooter.astro'
 import { SITE_DESCRIPTION, SITE_NAME, SITE_TAGLINE } from '../lib/site'
+import { Font } from 'astro:assets'
 
 interface Props {
   /** Document <title>. Defaults to the brand + tagline. */
@@ -48,20 +49,16 @@ const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : As
     {/* The three Pulse families (DESIGN.md): Instrument Serif (display), Geist
         (body), Geist Mono (eyebrow/meta). Same preload + noscript reveal-all
         strategy as cire so type lands fast and degrades gracefully. */}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
     <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
       {/* No JS ⇒ the scroll-reveal observer never runs, so reveal everything up
           front rather than leaving it hidden (SEO + accessibility). */}
       <style is:inline>[data-reveal]{opacity:1 !important;transform:none !important}</style>
     </noscript>
+    <!-- Instrument Serif and Geist are above the fold and preload; Geist Mono is
+         the ticker and the category chips, further down, so it does not. -->
+    <Font cssVariable="--font-instrument-serif" preload />
+    <Font cssVariable="--font-geist" preload />
+    <Font cssVariable="--font-geist-mono" />
   </head>
   <body>
     <div class="page-root">

--- a/pulse/landing/src/layouts/LegalLayout.astro
+++ b/pulse/landing/src/layouts/LegalLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import SiteFooter from '../components/SiteFooter.astro'
+import { Font } from 'astro:assets'
 
 interface Props {
   title: string
@@ -16,17 +17,11 @@ const { title } = Astro.props
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{title} — Pulse</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
-    </noscript>
+    <!-- Instrument Serif and Geist are above the fold and preload; Geist Mono is
+         used further down, so it does not. -->
+    <Font cssVariable="--font-instrument-serif" preload />
+    <Font cssVariable="--font-geist" preload />
+    <Font cssVariable="--font-geist-mono" />
   </head>
   <body>
     <main class="legal">

--- a/pulse/landing/src/self-hosted-fonts.test.ts
+++ b/pulse/landing/src/self-hosted-fonts.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The faces are self-hosted by Astro's font pipeline (`astro.config.mjs`,
+ * `fontProviders.google()`), so nothing on this site may reach
+ * fonts.googleapis.com or fonts.gstatic.com — not the document head, and not
+ * the CSP that would have to allow it.
+ *
+ * This is asserted rather than assumed because the failure is silent: a
+ * re-added `<link>` still renders correctly in dev, and the only visible
+ * symptom is a third-party request that transmits every visitor's IP and
+ * user-agent to Google LLC (US) with no consent gate in front of it
+ * (tracker #388).
+ */
+const pkgRoot = join(import.meta.dirname, "..");
+const layoutDir = join(pkgRoot, "src", "layouts");
+
+describe("self-hosted fonts", () => {
+  const csp = readFileSync(join(pkgRoot, "public", "_headers"), "utf8")
+    .split("\n")
+    .find((line) => line.trim().startsWith("Content-Security-Policy:"));
+
+  it("has a Content-Security-Policy to check", () => {
+    expect(csp).toBeDefined();
+  });
+
+  it("allows fonts from our own origin only", () => {
+    expect(csp).toContain("font-src 'self'");
+    expect(csp).not.toContain("fonts.gstatic.com");
+    expect(csp).not.toContain("fonts.googleapis.com");
+  });
+
+  it.each(readdirSync(layoutDir).filter((f) => f.endsWith(".astro")))(
+    "%s links no Google Fonts stylesheet",
+    (file) => {
+      const source = readFileSync(join(layoutDir, file), "utf8");
+      expect(source).not.toContain("fonts.googleapis.com");
+      expect(source).not.toContain("fonts.gstatic.com");
+    },
+  );
+});

--- a/pulse/landing/src/styles/global.css
+++ b/pulse/landing/src/styles/global.css
@@ -42,9 +42,13 @@
   --color-cat-5: var(--cat-5);
   --color-cat-6: var(--cat-6);
 
-  --font-display: "Instrument Serif", Georgia, serif;
-  --font-body: "Geist", system-ui, sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* All three faces are self-hosted by Astro's font pipeline, which defines
+     `--font-instrument-serif` / `--font-geist` / `--font-geist-mono` on :root
+     with their metric-matched fallbacks already in the chain (see
+     astro.config.mjs). */
+  --font-display: var(--font-instrument-serif);
+  --font-body: var(--font-geist);
+  --font-mono: var(--font-geist-mono);
   --default-font-family: var(--font-body);
 }
 

--- a/pulse/web/package.json
+++ b/pulse/web/package.json
@@ -14,6 +14,9 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
+    "@fontsource/geist-mono": "^5.3.0",
+    "@fontsource/geist-sans": "^5.3.0",
+    "@fontsource/instrument-serif": "^5.3.0",
     "@osn/ui": "workspace:*",
     "@pulse/api": "workspace:*",
     "@shared/rp-auth": "workspace:*",

--- a/pulse/web/src/app.css
+++ b/pulse/web/src/app.css
@@ -1,6 +1,156 @@
-/* Pulse editorial fonts loaded via <link> in index.html (non-blocking) */
-
 @import "tailwindcss";
+
+/* Self-hosted faces (tracker #388). The app shell used to <link>
+   fonts.googleapis.com from `entry-server.tsx`, which cost a DNS lookup, a TLS
+   handshake and a render-blocking round trip to a third party before a word
+   painted — and told Google LLC (US) the IP and user-agent of every visitor.
+
+   The three landing sites solved this with Astro's font pipeline
+   (`fontProviders.google()` in their `astro.config.mjs`). @solidjs/start has no
+   equivalent, so the rules are WRITTEN OUT here over `@fontsource`, for two
+   reasons that both cost real bytes on the render-blocking critical path:
+
+     1. A whole-family entrypoint (`@fontsource/geist-mono/400.css`) carries
+        every subset the family publishes — Geist Mono ships six, including
+        cyrillic and vietnamese. `unicode-range` stops the browser FETCHING an
+        unused subset, but every rule is parsed on every page load. Only latin
+        and latin-ext are kept. (Geist Sans ships one unsubsetted file per
+        weight, so there is nothing to trim there.)
+     2. Every fontsource rule carries a legacy `.woff` beside the `.woff2`, and
+        the small subset `.woff` files fall under Vite's 4096-byte
+        `assetsInlineLimit` — so the bundler base64-INLINES them straight into
+        the critical CSS. Every browser that can run this app takes the woff2.
+
+   The per-subset entrypoints (`@fontsource/geist-mono/latin-400.css`) are NOT
+   the fix for (1): fontsource omits `unicode-range` from those files, so latin
+   and latin-ext become two indistinguishable faces for one
+   family/weight/style and the later declaration wins outright.
+
+   `@fontsource/geist-sans` names the family `Geist Sans`; the rules below say
+   `Geist`, which is what Google Fonts called it and what `--font-sans` has
+   always spelled. Renaming here rather than at the token keeps every component
+   untouched.
+
+   Names in Cyrillic or Vietnamese paint in the fallback chain on the tokens
+   below. To add a subset back, copy its rule out of
+   `node_modules/@fontsource/<family>/<weight>.css`, keep the `unicode-range`,
+   and point `src` at the `.woff2` alone. */
+
+/* geist-sans-latin-400-normal */
+@font-face {
+  font-family: 'Geist';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/geist-sans/files/geist-sans-latin-400-normal.woff2') format('woff2');
+}
+
+/* geist-sans-latin-500-normal */
+@font-face {
+  font-family: 'Geist';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/geist-sans/files/geist-sans-latin-500-normal.woff2') format('woff2');
+}
+
+/* geist-sans-latin-600-normal */
+@font-face {
+  font-family: 'Geist';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/geist-sans/files/geist-sans-latin-600-normal.woff2') format('woff2');
+}
+
+/* geist-sans-latin-700-normal */
+@font-face {
+  font-family: 'Geist';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/geist-sans/files/geist-sans-latin-700-normal.woff2') format('woff2');
+}
+
+/* geist-mono-latin-ext-400-normal */
+@font-face {
+  font-family: 'Geist Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/geist-mono/files/geist-mono-latin-ext-400-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* geist-mono-latin-400-normal */
+@font-face {
+  font-family: 'Geist Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/geist-mono/files/geist-mono-latin-400-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* geist-mono-latin-ext-500-normal */
+@font-face {
+  font-family: 'Geist Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/geist-mono/files/geist-mono-latin-ext-500-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* geist-mono-latin-500-normal */
+@font-face {
+  font-family: 'Geist Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/geist-mono/files/geist-mono-latin-500-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* instrument-serif-latin-ext-400-normal */
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/instrument-serif/files/instrument-serif-latin-ext-400-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* instrument-serif-latin-400-normal */
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/instrument-serif/files/instrument-serif-latin-400-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* instrument-serif-latin-ext-400-italic */
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/instrument-serif/files/instrument-serif-latin-ext-400-italic.woff2') format('woff2');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* instrument-serif-latin-400-italic */
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/instrument-serif/files/instrument-serif-latin-400-italic.woff2') format('woff2');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
 @source "../../../osn/ui/src";
 
 @custom-variant base (:where(&));

--- a/pulse/web/src/entry-server.tsx
+++ b/pulse/web/src/entry-server.tsx
@@ -9,12 +9,6 @@ const handler: StartHandler = createHandler(() => (
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <title>Pulse</title>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Instrument+Serif:ital@0;1&display=swap"
-          />
           {assets}
         </head>
         <body>


### PR DESCRIPTION
## Summary

Four surfaces still linked `fonts.googleapis.com` from the document head — the
three marketing sites and the Pulse app shell. That is a DNS lookup, a TLS
handshake and a render-blocking round trip to a third party before a word
paints, and it transmits every visitor's IP and user-agent to Google LLC (US)
with no consent gate in front of it, because the `<link>` sits in the
server-rendered `<head>`.

- The three Astro sites use the pipeline `cire/host` and `cire/vendor` already
  run on. `pulse/web` is SolidStart and needed a different mechanism.
- Each `public/_headers` drops both Google origins, and each site gains a test
  asserting they stay gone.
- Closes the finding for good: the guest site was fixed in #730, these are the
  four that remained.

## Workspaces affected

`@cire/landing`, `@osn/landing`, `@pulse/landing`, `@pulse/web`. **Two**
changesets, not one: `@cire/landing` has no `version` field, so changesets
treats it as ignored and `scripts/validate-changesets.sh` rejects a file that
mixes it with the three versioned packages.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#388 | `C-L33` |

**Opened**

| Issue | What |
|---|---|
| — | None |

Closes xchromo/osn-tracker#388

## Decisions

### Astro's font pipeline for the three Astro sites — `approach`

- **Issue** — the same self-hosting job, four times, in two frameworks.
- **Why** — `cire/host` and `cire/vendor` already solved it; a second in-repo
  pattern for the same problem is a maintenance tax.
- **Solution** — `fontProviders.google()` in each `astro.config.mjs`, with
  `subsets: ["latin", "latin-ext"]` and `optimizedFallbacks: true`, and
  `<Font cssVariable=… preload />` in both layouts. Astro downloads each face at
  build time, serves it from our origin, emits the preload links, and generates
  the metric-matched fallback so the swap does not shift layout.
- **Rationale** — it is the established pattern here, and it is strictly better
  than what #730 did by hand on the guest site. See Out of scope.

### `pulse/web` writes its faces out by hand — `approach`

- **Issue** — `@solidjs/start` has no font pipeline.
- **Solution** — twelve `@font-face` rules in `src/app.css` over `@fontsource`,
  latin and latin-ext only, `.woff2` only, `url()` pointed at the package so
  Vite still content-hashes and emits.
- **Rationale** — the three obvious shortcuts are all wrong, and each is wrong
  quietly:
  - **Whole-family entrypoints** (`@fontsource/geist-mono/400.css`) carry every
    subset the family publishes — Geist Mono ships six, including cyrillic and
    vietnamese. `unicode-range` stops the browser *fetching* an unused subset,
    but every rule is parsed on every page load.
  - **The legacy `.woff`** each fontsource rule lists beside the `.woff2` falls
    under Vite's 4096-byte `assetsInlineLimit`, so the bundler base64-inlines it
    into the critical CSS.
  - **Per-subset entrypoints** (`latin-400.css`) look like the fix and are not:
    fontsource omits `unicode-range` from those files, so latin and latin-ext
    become two indistinguishable faces for one family/weight/style and the later
    declaration wins outright — plain ASCII would render from a file holding no
    ASCII glyphs.

### `Geist Sans` is declared as `Geist` — `approach`

- **Issue** — `@fontsource/geist-sans` names the family `Geist Sans`;
  `--font-sans` has always spelled `Geist`, which is what Google Fonts called it.
- **Solution** — the hand-written rules say `Geist`.
- **Rationale** — renaming at the `@font-face` leaves every component untouched;
  renaming the token would have touched all of them.

### A test per site, not a comment — `approach`

- **Issue** — a re-added `<link>` renders perfectly in dev. The only symptom is
  a third-party request nobody is looking at.
- **Solution** — `src/self-hosted-fonts.test.ts` in each landing package reads
  `public/_headers` and every layout, and asserts no Google origin appears in
  either.
- **Rationale** — same shape as `cire/host/src/lib/headers.test.ts:45-49`, which
  exists for the same reason.

**Out of scope**

- `cire/invites` (merged as #730) self-hosts by hand-written `@font-face` rules
  because it predates this config — but it is Astro too, and Astro's pipeline
  would do the same job in about fifteen lines. Worth migrating; no issue opened
  yet, and I would rather raise it after this merges than stack a third font PR.
- `pulse/web` gains no metric-matched fallback. Deriving the overrides honestly
  needs `@capsizecss/metrics` data per family, and inventing the percentages
  would be worse than the existing `system-ui` / `Georgia` / `ui-monospace`
  chains. Left alone deliberately.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ (also clears the `ts(6133)` `'rel'/'onload' is declared but never read` warnings the preload hack produced) |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1352 files |
| `bun run test` | ✅ 32/32 packages |
| Build + inspect, all four | ✅ see below |

Every build was inspected rather than assumed. Across all four: **zero**
base64-inlined fonts, **zero** `.woff` emitted, and no Google origin in any
build output. Gzipped cost of dropping the third-party origin:

| Package | before | after | delta |
|---|---|---|---|
| `cire/landing` | 96757 | 97681 | +924 |
| `osn/landing` | 7963 | 8685 | +722 |
| `pulse/landing` | 17186 | 18094 | +908 |
| `pulse/web` | 11163 | 11695 | +532 |

The landing numbers are `dist/index.html` (Astro inlines the face rules); the
`pulse/web` number is its `entry-client` CSS bundle. Font files themselves are
separate hashed assets and are not in those totals.

Not verified: nothing renders these in a real browser here. The families,
weights and styles were taken from the Google Fonts URL each file was already
requesting, so the set is unchanged — but a visual check of the three marketing
sites on the deploy previews is worth doing before merge.
