### PR TITLE
docs(legal): make the published notices describe the product that exists

### DIFF
--- a/.changeset/legal-pages-cire.md
+++ b/.changeset/legal-pages-cire.md
@@ -1,0 +1,28 @@
+---
+"@cire/invites": patch
+"@cire/landing": patch
+---
+
+Rewrite the guest legal pages so they describe the product that exists.
+
+`cire/invites`'s privacy notice and terms were written for one wedding run by two
+people: they named that couple, gave a personal email as the privacy contact, and
+claimed the Privacy Act's personal/family/household exemption. Every guest of
+every other wedding has been reading them since. The household exemption covers a
+couple running their own event; it has never covered the platform underneath them.
+
+Both pages are now tenant-neutral and describe the split the code actually
+implements — hosts decide what to ask and what to do with the answers, we hold the
+data for them, and we alone decide how long guest data survives the wedding, how
+the site is secured and what telemetry it emits. The last of those is a controller
+decision, so the notice says so rather than claiming a pure-processor role that
+`RETENTION_AFTER_FINAL_EVENT_MS` contradicts.
+
+Also: a lawful basis per purpose; the dietary field cited under both APP 3.3 and
+GDPR Art. 9(2)(a); a statement that guest data is stored in Australia, which
+replaces `cire/landing`'s claim that data may go "outside Australia" — the
+direction was backwards; and the three "Note for the site owner" blocks are gone
+from the public page, engineering file paths and all.
+
+`cire/landing`'s terms now state governing law at country level rather than naming
+a state.

--- a/.changeset/legal-pages-shared.md
+++ b/.changeset/legal-pages-shared.md
@@ -1,0 +1,26 @@
+---
+"@osn/landing": patch
+"@pulse/landing": patch
+---
+
+One source of truth for the operator's published identity, and the missing terms
+sections.
+
+Every legal page carried its own `{{LEGAL_ENTITY}}`, `{{CONTACT_EMAIL}}`,
+`{{POSTAL_ADDRESS}}`, `{{REGULATOR}}`, `{{RETENTION}}` and
+`{{MERCHANT_OF_RECORD}}` placeholder plus a hand-written "Draft — replace every
+highlighted value" banner. All of it was live in production, because filling the
+values in meant eight coordinated edits by someone holding all of them. The new
+`@shared/legal` package holds them once; the draft banner is derived from whether
+they are still placeholders, so a page cannot be left half-published and the
+banner cannot outlive the values.
+
+The two marketing terms pages had no governing-law clause at all, no consumer-law
+carve-out, and no changes clause. They have all three now, and their liability
+paragraph no longer reads as excluding guarantees the Australian Consumer Law does
+not allow to be excluded. Governing law is stated at country level on all four
+terms pages.
+
+`@pulse/landing`'s privacy notice disclosed "basic, privacy-respecting analytics"
+that the package does not run. Describing collection that does not happen is still
+a wrong notice; the line now says what the static host actually keeps.

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "@cire/theme": "workspace:*",
         "@fontsource/cormorant-garamond": "^5.3.0",
         "@fontsource/lato": "^5.3.0",
+        "@shared/legal": "workspace:*",
         "@shared/rp-auth": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
@@ -127,6 +128,7 @@
       "name": "@cire/landing",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
+        "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
         "motion": "^12.42.2",
@@ -250,6 +252,7 @@
       "version": "0.1.2",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
+        "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
         "motion": "^12.42.2",
@@ -321,7 +324,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -373,6 +376,7 @@
       "version": "0.1.2",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
+        "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
         "motion": "^12.42.2",
@@ -392,7 +396,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.10",
+      "version": "0.22.12",
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@pulse/api": "workspace:*",
@@ -471,6 +475,14 @@
         "@growthbook/growthbook": "^1.6.5",
         "@shared/observability": "workspace:*",
       },
+      "devDependencies": {
+        "@shared/typescript-config": "workspace:*",
+        "vitest": "^4.1.10",
+      },
+    },
+    "shared/legal": {
+      "name": "@shared/legal",
+      "version": "0.0.0",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "vitest": "^4.1.10",
@@ -1388,6 +1400,8 @@
     "@shared/email": ["@shared/email@workspace:shared/email"],
 
     "@shared/feature-flags": ["@shared/feature-flags@workspace:shared/feature-flags"],
+
+    "@shared/legal": ["@shared/legal@workspace:shared/legal"],
 
     "@shared/observability": ["@shared/observability@workspace:shared/observability"],
 

--- a/cire/invites/package.json
+++ b/cire/invites/package.json
@@ -16,6 +16,7 @@
     "@cire/theme": "workspace:*",
     "@fontsource/cormorant-garamond": "^5.3.0",
     "@fontsource/lato": "^5.3.0",
+    "@shared/legal": "workspace:*",
     "@shared/rp-auth": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",

--- a/cire/invites/src/pages/legal-pages.test.ts
+++ b/cire/invites/src/pages/legal-pages.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The guest legal pages are served to the guests of EVERY wedding, so they may
+ * not name a couple, a wedding, or anyone's personal contact address.
+ *
+ * This is asserted because it already happened once and stayed for months: both
+ * pages opened with one couple's name and gave that couple's private email as
+ * the privacy contact, which was correct for the first wedding and wrong for
+ * every one after it. Nothing failed — the pages rendered perfectly, and the
+ * only way to notice was to read them as somebody else's guest.
+ *
+ * Anything wedding-specific belongs on the invite itself, which is per-tenant.
+ */
+const pages = ["privacy.astro", "terms.astro"] as const;
+
+/**
+ * A bare `mailto:` or an address written into the prose. The operator's own
+ * contact arrives through `LEGAL_ENTITY.contactEmail`, so any literal address
+ * in these files is a hardcoded one.
+ */
+const LITERAL_EMAIL = /[\w.+-]+@[\w-]+\.[\w.]+/;
+
+/**
+ * The rendered template alone. Astro frontmatter is a comment-and-import block
+ * that no guest sees, and these files deliberately quote the wording they
+ * replaced — asserting against the whole file would fail on the explanation of
+ * the fix rather than on the fix.
+ */
+function template(source: string): string {
+  const end = source.indexOf("---", 3);
+  return end === -1 ? source : source.slice(end + 3);
+}
+
+describe.each(pages)("%s", (page) => {
+  const source = readFileSync(join(import.meta.dirname, page), "utf8");
+
+  it("hardcodes no email address", () => {
+    expect(template(source)).not.toMatch(LITERAL_EMAIL);
+  });
+
+  it("takes the operator's identity from the shared legal module", () => {
+    expect(source).toContain("@shared/legal");
+    expect(source).toContain("LEGAL_ENTITY.contactEmail");
+  });
+
+  it("shows its draft banner only while the operator's details are unfilled", () => {
+    expect(source).toContain("LEGAL_DETAILS_PENDING &&");
+  });
+});
+
+describe("privacy.astro", () => {
+  const body = template(readFileSync(join(import.meta.dirname, "privacy.astro"), "utf8"));
+
+  /**
+   * The personal/family/household exemption (Privacy Act 1988 s 16, GDPR
+   * Art. 2(2)(c)) covers a couple running their own wedding. It has never
+   * covered the platform underneath them, and the notice claimed it did.
+   */
+  it("claims no personal/household exemption from the Privacy Act", () => {
+    expect(body).not.toMatch(/outside the strict reach/i);
+    expect(body).not.toMatch(/not as a business/i);
+  });
+
+  it("states a lawful basis for the protected dietary field", () => {
+    expect(body).toMatch(/explicit consent/i);
+    expect(body).toContain("Art. 9(2)(a)");
+    expect(body).toContain("APP 3.3");
+  });
+
+  it("says where guest information is actually stored", () => {
+    expect(body).toMatch(/hosted in Sydney|in <strong>Australia<\/strong>/);
+  });
+
+  /**
+   * These were engineering instructions — file paths, the flag to flip —
+   * published to guests on a legal page. The context they carried now lives in
+   * `lib/consent/categories.ts`, next to the flag itself.
+   */
+  it("publishes no notes addressed to the site owner", () => {
+    expect(body).not.toContain("Note for the site owner");
+    expect(body).not.toContain("owner-note");
+  });
+});

--- a/cire/invites/src/pages/legal-pages.test.ts
+++ b/cire/invites/src/pages/legal-pages.test.ts
@@ -71,8 +71,24 @@ describe("privacy.astro", () => {
     expect(body).toContain("APP 3.3");
   });
 
-  it("says where guest information is actually stored", () => {
-    expect(body).toMatch(/hosted in Sydney|in <strong>Australia<\/strong>/);
+  /**
+   * `cire/api/src/services/retention.ts` names this notice as the thing that must
+   * move whenever `RETENTION_AFTER_FINAL_EVENT_MS` does. Pin the sentence so the
+   * pairing is enforced rather than remembered.
+   */
+  it("states the retention window the sweep actually enforces", () => {
+    expect(body).toContain("1 year after the final wedding event");
+  });
+
+  /**
+   * Softened from "hosted in Sydney" once the subprocessor register turned out to
+   * record the D1/R2 region as unconfirmed. The page must still name a region and
+   * still tell an EEA or UK reader that their data leaves that area — those two
+   * are the disclosure; the exact city is not.
+   */
+  it("names the region and flags the transfer out of the EEA/UK", () => {
+    expect(body).toMatch(/primary region is <strong>Australia<\/strong>/);
+    expect(body).toMatch(/transferred outside/i);
   });
 
   /**

--- a/cire/invites/src/pages/privacy.astro
+++ b/cire/invites/src/pages/privacy.astro
@@ -22,7 +22,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 import { ConsentPreferencesLink } from '../components/consent/ConsentBanner'
 import { CATEGORY_META } from '../lib/consent/categories'
 import { thirdPartyVendors } from '../lib/consent/vendors'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
 // The third-party list below is GENERATED from the consent vendor registry
 // rather than written out by hand. Prose drifts: an earlier version of this
@@ -33,8 +33,9 @@ import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
 // next build, and one that is removed disappears.
 const vendors = thirdPartyVendors()
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
@@ -67,7 +68,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       the fastest route to it.
     </li>
     <li>
-      <strong>Us</strong>, <span class={ph}>{LEGAL_ENTITY.name}</span>, who build and
+      <strong>Us</strong>, <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>, who build and
       run the site. We hold and process guest information on your hosts’ instructions.
       We also make some decisions on our own account and for every wedding alike — how
       long guest data survives the event, how the site is secured, and what technical
@@ -78,7 +79,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     You can contact us about anything in this notice at
     <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
-      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a>, whether or not you have
+      <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span></a>, whether or not you have
     spoken to your hosts first.
   </p>
 
@@ -263,7 +264,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Ask your hosts, who can act on most of it immediately, or email us at
     <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
-      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a> and we will act on it
+      <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span></a> and we will act on it
     ourselves and tell your hosts only what we must. We respond as soon as we
     reasonably can, and within a month at the outside.
   </p>
@@ -272,7 +273,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     We would rather resolve a concern directly. If you are in Australia and are not
     satisfied, you can contact the
-    <span class={ph}>{LEGAL_ENTITY.regulator}</span> at
+    <span class={ph(LEGAL_ENTITY.regulator)}>{LEGAL_ENTITY.regulator}</span> at
     <a href="https://www.oaic.gov.au/" rel="noreferrer">oaic.gov.au</a>. If you are in
     the EU or the UK, you can complain to your local data protection authority instead.
   </p>

--- a/cire/invites/src/pages/privacy.astro
+++ b/cire/invites/src/pages/privacy.astro
@@ -1,58 +1,89 @@
 ---
 // Static page — prerendered at build time even though the site is `output:
 // "server"`. Only the invite + bare-domain routes need per-request SSR.
+//
+// Served to the guests of EVERY wedding, so it names no couple. The version
+// before this one opened with "we run this site as individuals planning a
+// personal celebration, not as a business", claimed the Privacy Act's
+// personal/family/household exemption, and gave one couple's private email as
+// the privacy contact. All three were true of the first wedding and none of
+// them survived the product becoming a service other couples pay for: the
+// household exemption covers the couple, never the platform underneath them.
+//
+// The split this page now describes is the one the code actually implements.
+// Hosts choose what to ask and what to do with the answers. We hold the data
+// for them — but we also decide, alone and for everyone, how long guest data
+// survives the wedding (`cire/api/src/services/retention.ts`), how the site
+// is secured, and what
+// telemetry it emits. Those are controller decisions, so the notice says so
+// rather than claiming to be a pure processor the deletion schedule contradicts.
 export const prerender = true
 import LegalLayout from '../layouts/LegalLayout.astro'
 import { ConsentPreferencesLink } from '../components/consent/ConsentBanner'
 import { CATEGORY_META } from '../lib/consent/categories'
 import { thirdPartyVendors } from '../lib/consent/vendors'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
 
 // The third-party list below is GENERATED from the consent vendor registry
-// rather than written out by hand. Prose drifts: the previous version of this
+// rather than written out by hand. Prose drifts: an earlier version of this
 // page described the Pinterest embed and said nothing at all about the Google
 // Maps embed or Google Fonts, because those were added to the site without
 // anyone remembering this file existed. Deriving it means the notice cannot
 // disagree with the code — a vendor added to the registry appears here on the
 // next build, and one that is removed disappears.
 const vendors = thirdPartyVendors()
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Privacy Notice">
-  <div class="draft-banner">
-    <strong>Draft</strong> — This is a working draft for review, not legal advice.
-    Please have it checked before publishing and replace every highlighted
-    <span class="placeholder">{'{{PLACEHOLDER}}'}</span> value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: 2026-06-17</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
-    This is a private wedding invitation website. We only collect the small amount
-    of information we need to plan the day and cater for our guests. This notice
-    explains what we collect, why, how long we keep it, and the rights you have
-    over your information.
+    This is a private wedding invitation website. It asks for the small amount of
+    information your hosts need to plan the day and cater for you. This notice
+    explains what is collected, why, how long it is kept, who decides what, and the
+    rights you have over it.
   </p>
 
+  <h2>Who decides what</h2>
   <p>
-    We run this site as individuals planning a personal celebration, not as a
-    business. A private wedding organised by individuals for a personal,
-    family or household event is likely to sit outside the strict reach of the
-    <em>Privacy Act 1988</em> (Cth) and the Australian Privacy Principles (APPs)
-    — which generally apply to “APP entities” such as businesses and agencies.
-    We are nonetheless providing this notice as a matter of good-practice
-    transparency, and we aim to follow the spirit of the APPs. It should not be
-    read as a claim that any particular legal regime strictly applies to us.
+    Two parties are involved, and it matters which one you need.
   </p>
-
-  <h2>Who is responsible for your information</h2>
+  <ul>
+    <li>
+      <strong>Your hosts</strong> — the couple, and whoever is helping them organise.
+      They chose to invite you, decide what to ask you, see your answers, and use them
+      to run their wedding. Almost anything you might want changed — your name, your
+      household, whether you are on the list at all — is theirs to change, and they are
+      the fastest route to it.
+    </li>
+    <li>
+      <strong>Us</strong>, <span class={ph}>{LEGAL_ENTITY.name}</span>, who build and
+      run the site. We hold and process guest information on your hosts’ instructions.
+      We also make some decisions on our own account and for every wedding alike — how
+      long guest data survives the event, how the site is secured, and what technical
+      telemetry it produces — and for those decisions the responsibility is ours, not
+      your hosts’.
+    </li>
+  </ul>
   <p>
-    The people responsible for the information collected through this website are
-    <span class="placeholder">{'Aniket Chavan'}</span> (the couple). You
-    can reach us about anything in this notice at
-    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
+    You can contact us about anything in this notice at
+    <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a>, whether or not you have
+    spoken to your hosts first.
   </p>
 
-  <h2>What we collect</h2>
+  <h2>What is collected</h2>
   <ul>
     <li><strong>Guest names</strong> — the names on your household invitation.</li>
     <li><strong>RSVP status</strong> — whether each named guest is attending each event.</li>
@@ -62,58 +93,85 @@ const vendors = thirdPartyVendors()
       requirements that may reveal health information, or religious or
       belief-based dietary needs).
     </li>
+    <li>
+      <strong>Technical records</strong> — the session cookie that keeps you signed in
+      to your invitation after you enter your code, and server logs kept to keep the
+      site secure and working.
+    </li>
   </ul>
   <p>
-    We do <strong>not</strong> ask for or knowingly collect any other personal
-    information through this site. You only ever fill in details for the members
-    of your own household.
+    Nothing else is asked for or knowingly collected through this site. You only ever
+    fill in details for the members of your own household.
   </p>
 
   <h3>A note on dietary information</h3>
   <p>
-    Some dietary or access details count as “sensitive information” under the
-    <em>Privacy Act 1988</em> (Cth) — for example information about your health,
-    or your religious beliefs. Under the Australian Privacy Principles (APP 3.3),
-    sensitive information should only be collected with your consent. This field
-    is therefore optional: we only collect what you choose to enter, and we ask
-    for your explicit consent before you submit it. Please don’t include any
-    health or other sensitive detail you’d rather not share — a simple note such
-    as “vegetarian” or “no nuts” is all we need.
+    Some dietary or access details are treated as a protected category of information
+    — under the <em>Privacy Act 1988</em> (Cth) as “sensitive information”, and under
+    the GDPR and UK GDPR as “special category” data — because they can reveal your
+    health or your religious beliefs. Both regimes say such information should be
+    collected only with your explicit consent (APP 3.3; GDPR Art. 9(2)(a)). The field
+    is therefore optional, you tick a box to confirm before it is submitted, and the
+    exact wording you agreed to is recorded alongside it. Please don’t include any
+    health or other sensitive detail you’d rather not share — a simple note such as
+    “vegetarian” or “no nuts” is all that is needed.
   </p>
 
-  <h2>Why we use it</h2>
+  <h2>Why it is used, and on what basis</h2>
   <ul>
     <li>
-      <strong>Guest names &amp; RSVP status</strong> — to manage invitations,
-      confirm numbers, and organise seating and logistics for our wedding.
+      <strong>Guest names &amp; RSVP status</strong> — to manage invitations, confirm
+      numbers, and organise seating and logistics. Your hosts have a legitimate
+      interest in running the event they invited you to, and providing the invitation
+      is what our contract with them requires of us.
     </li>
     <li>
       <strong>Dietary requirements / access needs</strong> — to cater safely and
-      accommodate your needs on the day. Because this can include sensitive
-      information, we rely on your <strong>consent</strong>, which you give when
-      you choose to fill in that field and submit your RSVP.
+      accommodate your needs on the day. Because this can include protected
+      information, the basis is your <strong>explicit consent</strong>, given when you
+      tick the box and submit your RSVP, and withdrawable at any time.
+    </li>
+    <li>
+      <strong>Technical records</strong> — to keep your session working and the site
+      secure. Our legitimate interest in a site that functions and is not abused.
     </li>
   </ul>
+  <p>
+    Your information is never sold, and never used for marketing or advertising.
+  </p>
 
   <h2>Who can see it</h2>
   <p>
-    Your information is seen by us (the couple) and the small number of people
-    helping us organise the day, such as our caterer and venue, strictly so they
-    can do their job. We do not sell your information or use it for marketing.
+    Your hosts, and the people they have asked to help — a caterer or a venue, for
+    instance — strictly so those people can do their job. Your hosts choose who that
+    is; we don’t.
   </p>
   <p>
-    The site and its data are hosted on <strong>Cloudflare</strong>, which
-    provides our website hosting, database, and security on our behalf. Cloudflare
-    may process and store data in the course of providing that service. We don’t
-    transfer your information to anyone else except where we’re required to by law.
+    On our side, the site and its data are hosted on <strong>Cloudflare</strong>, which
+    provides hosting, the database and security. Beyond that, information is disclosed
+    only where the law requires it.
+  </p>
+
+  <h3>Where your information is stored</h3>
+  <p>
+    In <strong>Australia</strong>. The databases holding guest information, and the
+    infrastructure supporting the site’s security, are hosted in Sydney, and the site
+    is operated from Australia. Some technical records — server logs, error and
+    performance telemetry containing no guest content — are processed by providers
+    outside Australia in the course of running the service.
+  </p>
+  <p>
+    If you are in the EU or the UK, this means your information is transferred outside
+    that area to Australia. You can ask us what protections are in place for that
+    transfer, and we will tell you.
   </p>
 
   <h2>Cookies and content from other companies</h2>
   <p>
-    We don’t use advertising or tracking cookies, and we don’t use analytics. The
-    storage we do use falls into a few groups, and you control all but the first.
-    <strong>Third-party content and preferences are on by default</strong> — you
-    can switch them off at any time, and analytics stays off unless you turn it on.
+    There are no advertising or tracking cookies here, and no analytics. The storage
+    that is used falls into a few groups, and you control all but the first.
+    <strong>Third-party content and preferences are on by default</strong> — you can
+    switch them off at any time, and analytics stays off unless you turn it on.
   </p>
   <ul>
     {Object.values(CATEGORY_META).map((category) => (
@@ -138,7 +196,8 @@ const vendors = thirdPartyVendors()
         {vendor.enforcement === 'gated' ? (
           <> <em>On by default; stops loading if you switch off third-party content.</em></>
         ) : (
-          <> <em>Loads on every visit — see the note below.</em></>
+          <> <em>Loads on every visit, whatever you choose — it is needed for the site
+          to work, and it is requested before any choice can be applied.</em></>
         )}
         {vendor.privacyUrl ? (
           <> <a href={vendor.privacyUrl} rel="noreferrer">Their privacy policy</a>.</>
@@ -146,15 +205,6 @@ const vendors = thirdPartyVendors()
       </li>
     ))}
   </ul>
-  <p class="owner-note">
-    <strong>Note for the site owner:</strong> the entries marked “loads on every
-    visit” are not covered by the consent choice. Today that is Cloudflare
-    Turnstile, which the claim form can’t function without and which is
-    requested before any choice can be applied — so this page says so plainly
-    instead of implying the toggle covers it. (Google Fonts used to be listed
-    here too; self-hosting the two font files removed it from the vendor
-    registry entirely — tracker #98.)
-  </p>
 
   <h3>Changing your mind</h3>
   <p>
@@ -165,76 +215,60 @@ const vendors = thirdPartyVendors()
     <ConsentPreferencesLink client:idle label="Open my privacy choices" />
   </p>
   <p>
-    Turning something off stops it loading from then on. Anything already sent
-    while it was switched on has already left your browser and we can’t recall it.
-    Because third-party content is on by default, that means the venue map and the
-    moodboard will have loaded at least once before you switch them off — we’d
-    rather say so than imply otherwise.
-  </p>
-  <p class="owner-note">
-    <strong>Note for the site owner:</strong> defaulting third-party content
-    <em>on</em> is a deliberate choice suited to a private, personal event, and it
-    fits the Australian framing set out at the top of this notice. It is
-    <strong>not</strong> what the EU/UK ePrivacy rules expect — they require
-    consent <em>before</em> a non-essential third party loads. If a meaningful
-    number of guests are in the EU or UK, flip <code>defaultGranted</code> to
-    <code>false</code> for the third-party-content category in
-    <code>cire/invites/src/lib/consent/categories.ts</code> and update the two
-    paragraphs above; nothing else needs to change.
+    Turning something off stops it loading from then on. Anything already sent while it
+    was switched on has already left your browser and cannot be recalled. Because
+    third-party content is on by default, the venue map and the moodboard will have
+    loaded at least once before you switch them off. We would rather say that plainly
+    than imply otherwise.
   </p>
 
-  <h2>How long we keep it</h2>
+  <h2>How long it is kept</h2>
   <p>
-    We keep your RSVP information only as long as we need it to plan the wedding.
-    By default we delete it <strong>1 year after the final wedding event</strong>,
-    after which guest data is removed. After that it is permanently deleted from
-    our systems.
-  </p>
-  <p class="owner-note">
-    <strong>Note for the site owner:</strong> this 1-year default retention window
-    is a sensible starting point — you can change it to whatever suits your plans
-    (e.g. a shorter or longer period). Update both this wording and the actual
-    deletion schedule together so they stay consistent.
+    Guest information — names, RSVPs, dietary needs — is deleted
+    <strong>1 year after the final wedding event</strong>, after which it is
+    permanently removed from our systems. That period is set by us and applies to every
+    wedding; your hosts cannot extend it. You can ask for your own information to be
+    deleted sooner.
   </p>
 
   <h2>Your rights</h2>
-  <p>You can ask us to:</p>
+  <p>You can ask to:</p>
   <ul>
-    <li><strong>Access</strong> the information we hold about you;</li>
-    <li><strong>Correct</strong> anything that is wrong or out of date;</li>
+    <li><strong>Access</strong> the information held about you;</li>
+    <li><strong>Correct</strong> anything wrong or out of date;</li>
     <li><strong>Delete</strong> your information;</li>
     <li>
-      <strong>Withdraw your consent</strong> to the dietary/access information at
-      any time — this won’t affect anything we did before you withdrew it.
+      <strong>Withdraw your consent</strong> to the dietary and access information at
+      any time — this doesn’t undo anything done while it stood.
     </li>
   </ul>
   <p>
-    To exercise any of these, just email us at
-    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
-    We’ll respond as soon as we reasonably can.
+    If you are in the EU or the UK, the GDPR and UK GDPR give you these rights plus the
+    right to object to processing based on legitimate interests, the right to a copy of
+    your information in a portable form, and the right to restrict processing while a
+    dispute is resolved. We honour all of them wherever you are; they are set out
+    separately only because the law that names them is.
   </p>
-
-  <h3>If you’re in the EU or UK</h3>
   <p>
-    If any of our guests are in the EU or UK, we’ll also honour the rights you
-    have under the GDPR / UK GDPR — including the right to erasure and to withdraw
-    consent. Please use the same contact,
-    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>, and we’ll take
-    care of it.
+    Ask your hosts, who can act on most of it immediately, or email us at
+    <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a> and we will act on it
+    ourselves and tell your hosts only what we must. We respond as soon as we
+    reasonably can, and within a month at the outside.
   </p>
 
   <h2>Complaints</h2>
   <p>
-    We hope to resolve any concern directly. If you’re in Australia and you’re not
-    satisfied, you can contact the Office of the Australian Information Commissioner
-    (OAIC) at <a href="https://www.oaic.gov.au/" rel="noreferrer">oaic.gov.au</a>.
-    Guests in the EU or UK may instead contact their local data protection
-    authority.
+    We would rather resolve a concern directly. If you are in Australia and are not
+    satisfied, you can contact the
+    <span class={ph}>{LEGAL_ENTITY.regulator}</span> at
+    <a href="https://www.oaic.gov.au/" rel="noreferrer">oaic.gov.au</a>. If you are in
+    the EU or the UK, you can complain to your local data protection authority instead.
   </p>
 
   <h2>Changes to this notice</h2>
   <p>
-    If we change how we handle your information, we’ll update this page and revise
-    the “last updated” date above.
+    If how your information is handled changes, this page is updated and the
+    “last updated” date above revised.
   </p>
 </LegalLayout>

--- a/cire/invites/src/pages/privacy.astro
+++ b/cire/invites/src/pages/privacy.astro
@@ -39,9 +39,8 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
@@ -94,6 +93,11 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       belief-based dietary needs).
     </li>
     <li>
+      <strong>When your household first opened the invitation</strong> — a single
+      timestamp, shown to your hosts as a “Sent / Opened” marker so they know whether an
+      invitation arrived. Not a record of every visit, and not what you looked at.
+    </li>
+    <li>
       <strong>Technical records</strong> — the session cookie that keeps you signed in
       to your invitation after you enter your code, and server logs kept to keep the
       site secure and working.
@@ -111,8 +115,11 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     the GDPR and UK GDPR as “special category” data — because they can reveal your
     health or your religious beliefs. Both regimes say such information should be
     collected only with your explicit consent (APP 3.3; GDPR Art. 9(2)(a)). The field
-    is therefore optional, you tick a box to confirm before it is submitted, and the
-    exact wording you agreed to is recorded alongside it. Please don’t include any
+    is therefore optional, you tick a box to confirm before it is submitted, and a record of
+    which version of this wording you agreed to is stored alongside it. If you give your
+    answer to your hosts another way — over the phone, say — they can record it for you,
+    and what is stored then is their confirmation that you agreed, not yours. Either way
+    you can withdraw it with us directly. Please don’t include any
     health or other sensitive detail you’d rather not share — a simple note such as
     “vegetarian” or “no nuts” is all that is needed.
   </p>
@@ -130,6 +137,11 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       accommodate your needs on the day. Because this can include protected
       information, the basis is your <strong>explicit consent</strong>, given when you
       tick the box and submit your RSVP, and withdrawable at any time.
+    </li>
+    <li>
+      <strong>The first-opened timestamp</strong> — so your hosts can tell a delivered
+      invitation from one that never arrived. Their legitimate interest in administering
+      their own wedding; you can ask for it to be removed.
     </li>
     <li>
       <strong>Technical records</strong> — to keep your session working and the site
@@ -154,9 +166,8 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h3>Where your information is stored</h3>
   <p>
-    In <strong>Australia</strong>. The databases holding guest information, and the
-    infrastructure supporting the site’s security, are hosted in Sydney, and the site
-    is operated from Australia. Some technical records — server logs, error and
+    Our primary region is <strong>Australia</strong> — the site is operated from there,
+    and the infrastructure supporting its security is pinned to Sydney. Some technical records — server logs, error and
     performance telemetry containing no guest content — are processed by providers
     outside Australia in the course of running the service.
   </p>
@@ -196,8 +207,8 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
         {vendor.enforcement === 'gated' ? (
           <> <em>On by default; stops loading if you switch off third-party content.</em></>
         ) : (
-          <> <em>Loads on every visit, whatever you choose — it is needed for the site
-          to work, and it is requested before any choice can be applied.</em></>
+          <> <em>Loads on every visit, whatever you choose — the site cannot do its job
+          without it.</em></>
         )}
         {vendor.privacyUrl ? (
           <> <a href={vendor.privacyUrl} rel="noreferrer">Their privacy policy</a>.</>
@@ -217,9 +228,9 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Turning something off stops it loading from then on. Anything already sent while it
     was switched on has already left your browser and cannot be recalled. Because
-    third-party content is on by default, the venue map and the moodboard will have
-    loaded at least once before you switch them off. We would rather say that plainly
-    than imply otherwise.
+    third-party content is on by default, the venue map and the moodboard may already have
+    loaded if you opened an event’s details before coming here — they sit inside that
+    sheet and load only when it opens, so if you haven’t opened one, nothing has gone.
   </p>
 
   <h2>How long it is kept</h2>

--- a/cire/invites/src/pages/terms.astro
+++ b/cire/invites/src/pages/terms.astro
@@ -11,13 +11,15 @@
 export const prerender = true
 import LegalLayout from '../layouts/LegalLayout.astro'
 import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
@@ -27,7 +29,7 @@ import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
   <p>
     This is a private invitation website. Your hosts have invited you to their wedding
     and asked us to run the invitation for them; the site itself is operated by
-    <span class="placeholder">{LEGAL_ENTITY.name}</span> (“we”, “us”). By using the
+    <span class={ph}>{LEGAL_ENTITY.name}</span> (“we”, “us”). By using the
     site you agree to these short terms. If you don’t agree, please don’t use it.
   </p>
 
@@ -56,8 +58,9 @@ import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
   <h2>Availability</h2>
   <p>
     We provide this site as-is for the convenience of your hosts and their guests. We
-    can’t promise it will always be available or error-free, and an invitation is
-    normally taken down some time after the wedding.
+    can’t promise it will always be available or error-free. An invitation page may stay
+    viewable after the wedding; the guest information behind it is deleted on the schedule
+    set out in the <a href="/privacy">Privacy Notice</a>.
   </p>
 
   <h2>Your rights as a consumer</h2>
@@ -74,7 +77,7 @@ import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
     best put to your hosts, who can change all of it. Questions about these terms or
     about the site itself:
     <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
-      <span class="placeholder">{LEGAL_ENTITY.contactEmail}</span></a>.
+      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a>.
   </p>
 
   <h2>Governing law</h2>

--- a/cire/invites/src/pages/terms.astro
+++ b/cire/invites/src/pages/terms.astro
@@ -1,62 +1,86 @@
 ---
 // Static page — prerendered at build time even though the site is `output:
 // "server"`. Only the invite + bare-domain routes need per-request SSR.
+//
+// This page is served to the guests of EVERY wedding on the platform, so it
+// cannot name a couple. The version before this one opened "the wedding of
+// Aniket Chavan" and gave that couple's personal email as the contact — true
+// of the first wedding and wrong for every one since. Anything specific to a
+// wedding belongs on the invite itself, which is per-tenant; this page is the
+// operator's terms and stays general.
 export const prerender = true
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
 ---
 <LegalLayout title="Terms of Use">
-  <div class="draft-banner">
-    <strong>Draft</strong> — This is a working draft for review, not legal advice.
-    Please have it checked before publishing and replace every highlighted
-    <span class="placeholder">{'{{PLACEHOLDER}}'}</span> value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Terms of Use</h1>
-  <p class="meta">Last updated: 2026-06-17</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
-    This is a private website for invited guests of the wedding of
-    <span class="placeholder">{'Aniket Chavan'}</span>. By using it you
-    agree to these short terms. If you don’t agree, please don’t use the site.
+    This is a private invitation website. Your hosts have invited you to their wedding
+    and asked us to run the invitation for them; the site itself is operated by
+    <span class="placeholder">{LEGAL_ENTITY.name}</span> (“we”, “us”). By using the
+    site you agree to these short terms. If you don’t agree, please don’t use it.
   </p>
 
   <h2>Invited guests only</h2>
   <p>
-    Access is by personal invitation code. Please don’t share your code or attempt
-    to access invitations or details that aren’t meant for your household. The
-    information on this site is private and shared with you in confidence.
+    Access is by personal invitation code. Please don’t share your code or attempt to
+    access invitations or details meant for another household. What you can see here
+    was shared with you in confidence by your hosts.
   </p>
 
   <h2>Using the site</h2>
   <ul>
-    <li>Please keep the information you give us (such as your RSVP and guest names) accurate and up to date.</li>
+    <li>Please keep what you tell us — your RSVP, guest names, dietary needs — accurate and up to date.</li>
     <li>Please don’t submit anything unlawful, abusive, or that isn’t yours to share.</li>
     <li>Please don’t try to disrupt, probe, or gain unauthorised access to the site or its data.</li>
   </ul>
 
   <h2>Your information</h2>
   <p>
-    How we handle the information you provide is explained in our
-    <a href="/privacy">Privacy Notice</a>. By submitting an RSVP you confirm the
-    details you enter are correct to the best of your knowledge.
+    Your hosts decide what to ask you and what to do with your answers; we run the site
+    and hold the data for them. Both halves are set out in our
+    <a href="/privacy">Privacy Notice</a>, including who to contact for what. By
+    submitting an RSVP you confirm the details you enter are correct as far as you know.
   </p>
 
   <h2>Availability</h2>
   <p>
-    We provide this site as-is for the convenience of our guests. We can’t promise
-    it will always be available or error-free, and we may update or take it down at
-    any time — for example after the wedding.
+    We provide this site as-is for the convenience of your hosts and their guests. We
+    can’t promise it will always be available or error-free, and an invitation is
+    normally taken down some time after the wedding.
+  </p>
+
+  <h2>Your rights as a consumer</h2>
+  <p>
+    Nothing in these terms excludes, restricts or modifies any guarantee, right or
+    remedy you have under the Australian Consumer Law or any other law that cannot
+    lawfully be excluded. If you are reading this somewhere else in the world, you keep
+    the consumer protections of the place you live.
   </p>
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms? Email us at
-    <a href="mailto:chavaniket@duck.com">chavaniket@duck.com</a>.
+    Questions about your invitation — the date, the guest list, what you can see — are
+    best put to your hosts, who can change all of it. Questions about these terms or
+    about the site itself:
+    <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+      <span class="placeholder">{LEGAL_ENTITY.contactEmail}</span></a>.
   </p>
 
   <h2>Governing law</h2>
   <p>
-    These terms are governed by the laws of <strong>Australia</strong>, and any
-    disputes will be subject to the courts of that jurisdiction.
+    These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>.
+    This does not take away the protections you have under the consumer laws of the
+    place where you live.
   </p>
 </LegalLayout>

--- a/cire/invites/src/pages/terms.astro
+++ b/cire/invites/src/pages/terms.astro
@@ -10,10 +10,11 @@
 // operator's terms and stays general.
 export const prerender = true
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
@@ -29,7 +30,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     This is a private invitation website. Your hosts have invited you to their wedding
     and asked us to run the invitation for them; the site itself is operated by
-    <span class={ph}>{LEGAL_ENTITY.name}</span> (“we”, “us”). By using the
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span> (“we”, “us”). By using the
     site you agree to these short terms. If you don’t agree, please don’t use it.
   </p>
 
@@ -77,7 +78,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     best put to your hosts, who can change all of it. Questions about these terms or
     about the site itself:
     <a href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
-      <span class={ph}>{LEGAL_ENTITY.contactEmail}</span></a>.
+      <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span></a>.
   </p>
 
   <h2>Governing law</h2>

--- a/cire/landing/package.json
+++ b/cire/landing/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@astrojs/solid-js": "^7.0.1",
+    "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",
     "motion": "^12.42.2",

--- a/cire/landing/src/pages/privacy.astro
+++ b/cire/landing/src/pages/privacy.astro
@@ -1,18 +1,24 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Privacy Notice">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value (contact address, retention specifics).
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Privacy Notice</h1>
   <p class="meta">Last updated: 2026-07-18</p>
 
   <p>
-    This notice explains how <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire
+    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire
     (&ldquo;Cire&rdquo;, &ldquo;we&rdquo;), handles
     personal information across the Cire service — this marketing site, the invitation site your
     guests use, and the organiser portal.
@@ -37,7 +43,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     <li><strong>Guest information uploaded by organisers</strong> — guest names, household
       groupings, RSVP responses, dietary needs and similar details the couple chooses to record.</li>
     <li><strong>Purchases</strong> — handled by our merchant of record,
-      <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>. We receive order confirmation
+      <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>. We receive order confirmation
       (what was bought, for which wedding) but never see your card details.</li>
     <li><strong>Site usage</strong> — the technical logs needed to keep the service secure. We run
       no third-party analytics or advertising trackers.</li>
@@ -56,7 +62,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <p>We use a small set of service providers to run Cire:</p>
   <ul>
     <li><strong>Cloudflare</strong> — hosting, content delivery and databases (global network).</li>
-    <li><span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span> — payment processing, as
+    <li><span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span> — payment processing, as
       merchant of record for purchases.</li>
     <li><strong>Resend</strong> — transactional email delivery.</li>
     <li><strong>Upstash</strong> — infrastructure supporting security features such as rate limiting.</li>
@@ -66,9 +72,12 @@ import LegalLayout from '../layouts/LegalLayout.astro'
       which sees your IP address when they load. We plan to self-host these fonts.</li>
   </ul>
   <p>
-    We also disclose information where the law requires it. Because these providers operate
-    globally, personal information may be stored or processed outside Australia, including in the
-    United States and the European Union.
+    We also disclose information where the law requires it. Guest information and the
+    infrastructure supporting the service&rsquo;s security are hosted in <strong>Australia</strong>
+    (Sydney); some technical records &mdash; email delivery, service telemetry, payment
+    processing &mdash; are handled by providers outside it. If you are in the EEA or the UK,
+    that means your information is transferred out of that area to Australia and elsewhere;
+    ask us and we will tell you what protections apply to that transfer.
   </p>
 
   <h2>How long we keep it</h2>
@@ -77,7 +86,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     needs) is automatically deleted <strong>one year after the wedding&rsquo;s final event</strong>.
     Other wedding and account data is kept while your account is active and removed when you ask us
     to; specific periods for account data:
-    <span class="placeholder">{'{{RETENTION}}'}</span>.
+    <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
   </p>
 
   <h2>Security</h2>
@@ -92,7 +101,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     You may have rights to access, correct, delete or port your information, and to object to
     certain uses — under the Australian Privacy Act, and for people in the EEA or UK, the GDPR and
     UK GDPR. To exercise them, contact us at
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>. You can also complain to a regulator —
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You can also complain to a regulator —
     in Australia, the Office of the Australian Information Commissioner (OAIC), or your local data
     protection authority.
   </p>
@@ -105,8 +114,8 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h2>Contact</h2>
   <p>
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span> (trading as Cire),
-    <span class="placeholder">{'{{POSTAL_ADDRESS}}'}</span> —
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    <span class={ph}>{LEGAL_ENTITY.name}</span> (trading as Cire),
+    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/cire/landing/src/pages/privacy.astro
+++ b/cire/landing/src/pages/privacy.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
@@ -17,7 +18,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
-    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire
+    This notice explains how <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>, trading as Cire
     (&ldquo;Cire&rdquo;, &ldquo;we&rdquo;), handles
     personal information across the Cire service — this marketing site, the invitation site your
     guests use, and the organiser portal.
@@ -49,7 +50,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       identify a person), and the enquiry threads between you and a couple. An enquiry
       sends the couple&rsquo;s wedding name and message to the vendor they chose.</li>
     <li><strong>Purchases</strong> — handled by our merchant of record,
-      <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>. We receive order confirmation
+      <span class={ph(LEGAL_ENTITY.merchantOfRecord)}>{LEGAL_ENTITY.merchantOfRecord}</span>. We receive order confirmation
       (what was bought, for which wedding) but never see your card details.</li>
     <li><strong>Site usage</strong> — the technical logs needed to keep the service secure. We run
       no third-party analytics or advertising trackers.</li>
@@ -68,7 +69,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>We use a small set of service providers to run Cire:</p>
   <ul>
     <li><strong>Cloudflare</strong> — hosting, content delivery and databases (global network).</li>
-    <li><span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span> — payment processing, as
+    <li><span class={ph(LEGAL_ENTITY.merchantOfRecord)}>{LEGAL_ENTITY.merchantOfRecord}</span> — payment processing, as
       merchant of record for purchases.</li>
     <li><strong>Resend</strong> — transactional email delivery, including vendor claim
       invitations.</li>
@@ -96,7 +97,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     That window is set by us and applies to every wedding — an organiser cannot extend it.
     Other wedding and account data is kept while your account is active and removed when you ask us
     to; specific periods for account data:
-    <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
+    <span class={ph(LEGAL_ENTITY.accountDataRetention)}>{LEGAL_ENTITY.accountDataRetention}</span>.
   </p>
 
   <h2>Security</h2>
@@ -111,7 +112,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     You may have rights to access, correct, delete or port your information, and to object to
     certain uses — under the Australian Privacy Act, and for people in the EEA or UK, the GDPR and
     UK GDPR. To exercise them, contact us at
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You can also complain to a regulator —
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>. You can also complain to a regulator —
     in Australia, the Office of the Australian Information Commissioner (OAIC), or your local data
     protection authority.
   </p>
@@ -124,8 +125,8 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>Contact</h2>
   <p>
-    <span class={ph}>{LEGAL_ENTITY.name}</span> (trading as Cire),
-    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span> (trading as Cire),
+    <span class={ph(LEGAL_ENTITY.postalAddress)}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/cire/landing/src/pages/privacy.astro
+++ b/cire/landing/src/pages/privacy.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: 2026-07-18</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire
@@ -29,9 +28,12 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     <li><strong>Organisers</strong> (couples and their helpers) create an account with us. For your
       account and purchase information, we decide how it is handled, as described here.</li>
     <li><strong>Guests</strong> don&rsquo;t create accounts. Your couple uploads your details to
-      manage their wedding, and we process them on the couple&rsquo;s behalf and instructions. If
-      you are a guest with questions about why your details are in Cire, your couple is the first
-      port of call — but you can always contact us directly too.</li>
+      manage their wedding, and we process them on the couple&rsquo;s behalf and instructions.
+      Three things are ours to decide rather than theirs, and we decide them the same way for
+      every wedding: how long guest information survives the event, how the service is secured,
+      and what technical telemetry it produces. If you are a guest with questions about why your
+      details are in Cire, your couple is the first port of call — but you can always contact us
+      directly too.</li>
   </ul>
 
   <h2>What we collect</h2>
@@ -42,6 +44,10 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       and budgets you create.</li>
     <li><strong>Guest information uploaded by organisers</strong> — guest names, household
       groupings, RSVP responses, dietary needs and similar details the couple chooses to record.</li>
+    <li><strong>Vendor listings and enquiries</strong> — if you are a wedding
+      supplier, the contact details on your directory listing (which for a sole trader
+      identify a person), and the enquiry threads between you and a couple. An enquiry
+      sends the couple&rsquo;s wedding name and message to the vendor they chose.</li>
     <li><strong>Purchases</strong> — handled by our merchant of record,
       <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>. We receive order confirmation
       (what was bought, for which wedding) but never see your card details.</li>
@@ -64,7 +70,10 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     <li><strong>Cloudflare</strong> — hosting, content delivery and databases (global network).</li>
     <li><span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span> — payment processing, as
       merchant of record for purchases.</li>
-    <li><strong>Resend</strong> — transactional email delivery.</li>
+    <li><strong>Resend</strong> — transactional email delivery, including vendor claim
+      invitations.</li>
+    <li><strong>The vendor you enquire with</strong> — an enquiry is sent to that supplier,
+      who then holds it under their own responsibility.</li>
     <li><strong>Upstash</strong> — infrastructure supporting security features such as rate limiting.</li>
     <li><strong>Grafana Cloud</strong> — service telemetry (metrics and traces; pseudonymised
       identifiers only, never guest content).</li>
@@ -72,10 +81,10 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       which sees your IP address when they load. We plan to self-host these fonts.</li>
   </ul>
   <p>
-    We also disclose information where the law requires it. Guest information and the
-    infrastructure supporting the service&rsquo;s security are hosted in <strong>Australia</strong>
-    (Sydney); some technical records &mdash; email delivery, service telemetry, payment
-    processing &mdash; are handled by providers outside it. If you are in the EEA or the UK,
+    We also disclose information where the law requires it. Our primary region is
+    <strong>Australia</strong>; the infrastructure supporting the service&rsquo;s security is
+    pinned to Sydney, and some technical records &mdash; email delivery, service telemetry,
+    payment processing &mdash; are handled by providers outside it. If you are in the EEA or the UK,
     that means your information is transferred out of that area to Australia and elsewhere;
     ask us and we will tell you what protections apply to that transfer.
   </p>
@@ -84,6 +93,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Only as long as needed for the purposes above. Guest information (guest lists, RSVPs, dietary
     needs) is automatically deleted <strong>one year after the wedding&rsquo;s final event</strong>.
+    That window is set by us and applies to every wedding — an organiser cannot extend it.
     Other wedding and account data is kept while your account is active and removed when you ask us
     to; specific periods for account data:
     <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.

--- a/cire/landing/src/pages/refunds.astro
+++ b/cire/landing/src/pages/refunds.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Refund Policy">
   {LEGAL_DETAILS_PENDING && (
@@ -19,7 +20,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Cire add-ons are one-time purchases that permanently unlock a feature for a single wedding.
     This policy explains when and how we refund them. It is offered by
-    <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>, trading as Cire.
   </p>
 
   <h2>14-day change of mind</h2>
@@ -28,7 +29,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
     <strong>14 days of purchase</strong>, provided you haven&rsquo;t substantially used it (for
     example, a capacity upgrade you haven&rsquo;t imported guests against, or a template pack you
     haven&rsquo;t published an invitation with). Just email
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span> with your order details.
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span> with your order details.
   </p>
 
   <h2>Your rights under the Australian Consumer Law</h2>
@@ -49,7 +50,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <h2>How refunds are processed</h2>
   <p>
     Purchases are processed by our merchant of record,
-    <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>, so refunds are issued through
+    <span class={ph(LEGAL_ENTITY.merchantOfRecord)}>{LEGAL_ENTITY.merchantOfRecord}</span>, so refunds are issued through
     them back to your original payment method — typically within 5&ndash;10 business days of
     approval. When a purchase is refunded, the corresponding add-on is removed from the wedding
     (unless the refund was a remedy for a fault we couldn&rsquo;t fix).
@@ -57,6 +58,6 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>Contact</h2>
   <p>
-    Refund requests and questions: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    Refund requests and questions: <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/cire/landing/src/pages/refunds.astro
+++ b/cire/landing/src/pages/refunds.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Refund Policy">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Refund Policy</h1>
-  <p class="meta">Last updated: 2026-07-18</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     Cire add-ons are one-time purchases that permanently unlock a feature for a single wedding.

--- a/cire/landing/src/pages/refunds.astro
+++ b/cire/landing/src/pages/refunds.astro
@@ -1,12 +1,18 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Refund Policy">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Refund Policy</h1>
   <p class="meta">Last updated: 2026-07-18</p>
@@ -14,7 +20,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <p>
     Cire add-ons are one-time purchases that permanently unlock a feature for a single wedding.
     This policy explains when and how we refund them. It is offered by
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire.
+    <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire.
   </p>
 
   <h2>14-day change of mind</h2>
@@ -23,7 +29,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     <strong>14 days of purchase</strong>, provided you haven&rsquo;t substantially used it (for
     example, a capacity upgrade you haven&rsquo;t imported guests against, or a template pack you
     haven&rsquo;t published an invitation with). Just email
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span> with your order details.
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span> with your order details.
   </p>
 
   <h2>Your rights under the Australian Consumer Law</h2>
@@ -44,7 +50,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>How refunds are processed</h2>
   <p>
     Purchases are processed by our merchant of record,
-    <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>, so refunds are issued through
+    <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>, so refunds are issued through
     them back to your original payment method — typically within 5&ndash;10 business days of
     approval. When a purchase is refunded, the corresponding add-on is removed from the wedding
     (unless the refund was a remedy for a fault we couldn&rsquo;t fix).
@@ -52,6 +58,6 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h2>Contact</h2>
   <p>
-    Refund requests and questions: <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    Refund requests and questions: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/cire/landing/src/pages/terms.astro
+++ b/cire/landing/src/pages/terms.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Terms of Service">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Terms of Service</h1>
-  <p class="meta">Last updated: 2026-07-18</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     Cire is a digital wedding invitation and wedding planning service available at cireweddings.com,
@@ -67,8 +66,10 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
       service.</li>
     <li>When you upload guest information (names, contact details, dietary needs), you confirm you
       are entitled to share it with us for managing your wedding. We handle it on your behalf as
-      described in our <a href="/privacy">Privacy Notice</a> and don&rsquo;t use it for anything
-      else.</li>
+      described in our <a href="/privacy">Privacy Notice</a>, and we never sell it, advertise
+      against it or profile anyone with it. Three decisions are ours rather than yours, because
+      we make them the same way for every wedding: the retention window, the security of the
+      service, and the technical telemetry it emits.</li>
   </ul>
 
   <h2>Acceptable use</h2>

--- a/cire/landing/src/pages/terms.astro
+++ b/cire/landing/src/pages/terms.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Terms of Service">
   {LEGAL_DETAILS_PENDING && (
@@ -19,7 +20,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Cire is a digital wedding invitation and wedding planning service available at cireweddings.com,
     invite.cireweddings.com and host.cireweddings.com. It is operated by
-    <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire (&ldquo;Cire&rdquo;,
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>, trading as Cire (&ldquo;Cire&rdquo;,
     &ldquo;we&rdquo;, &ldquo;us&rdquo;). By creating an account or using the service you agree to
     these terms.
   </p>
@@ -52,7 +53,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <h2>Purchases and payment</h2>
   <p>
     Purchases are processed by our merchant of record,
-    <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>. When you buy an add-on, your
+    <span class={ph(LEGAL_ENTITY.merchantOfRecord)}>{LEGAL_ENTITY.merchantOfRecord}</span>. When you buy an add-on, your
     contract of sale (including payment, applicable taxes and invoicing) is with the merchant of
     record, and their terms of sale apply to the transaction. We then unlock the purchased add-on
     for your wedding. Prices are shown in or converted to your local currency at checkout. Refunds are
@@ -115,6 +116,6 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    Questions about these terms: <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/cire/landing/src/pages/terms.astro
+++ b/cire/landing/src/pages/terms.astro
@@ -1,12 +1,18 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Terms of Service">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Terms of Service</h1>
   <p class="meta">Last updated: 2026-07-18</p>
@@ -14,7 +20,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <p>
     Cire is a digital wedding invitation and wedding planning service available at cireweddings.com,
     invite.cireweddings.com and host.cireweddings.com. It is operated by
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>, trading as Cire (&ldquo;Cire&rdquo;,
+    <span class={ph}>{LEGAL_ENTITY.name}</span>, trading as Cire (&ldquo;Cire&rdquo;,
     &ldquo;we&rdquo;, &ldquo;us&rdquo;). By creating an account or using the service you agree to
     these terms.
   </p>
@@ -47,7 +53,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>Purchases and payment</h2>
   <p>
     Purchases are processed by our merchant of record,
-    <span class="placeholder">{'{{MERCHANT_OF_RECORD}}'}</span>. When you buy an add-on, your
+    <span class={ph}>{LEGAL_ENTITY.merchantOfRecord}</span>. When you buy an add-on, your
     contract of sale (including payment, applicable taxes and invoicing) is with the merchant of
     record, and their terms of sale apply to the transaction. We then unlock the purchased add-on
     for your wedding. Prices are shown in or converted to your local currency at checkout. Refunds are
@@ -102,12 +108,12 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h2>Governing law</h2>
   <p>
-    These terms are governed by the laws of New South Wales, Australia. This does not deprive you of
+    These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>. This does not deprive you of
     protections you have under the consumer laws of the place where you live.
   </p>
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/osn/landing/package.json
+++ b/osn/landing/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@astrojs/solid-js": "^7.0.1",
+    "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",
     "motion": "^12.42.2",

--- a/osn/landing/src/pages/privacy.astro
+++ b/osn/landing/src/pages/privacy.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: 2026-06-28</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;OSN&rdquo;,
@@ -47,8 +46,11 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>How long we keep it</h2>
   <p>
-    Only as long as we need it for the purpose above, then we delete or anonymise it. Specific
-    retention periods: <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
+    Only as long as we need it for the purpose above, then we delete or anonymise it.
+    Server request logs are kept by our static host for a short period for security and
+    reliability and are not used for anything else; nothing on this site is retained beyond
+    that unless you contacted us, in which case we keep the correspondence for as long as it
+    takes to deal with it.
   </p>
 
   <h2>Your rights</h2>

--- a/osn/landing/src/pages/privacy.astro
+++ b/osn/landing/src/pages/privacy.astro
@@ -1,18 +1,24 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Privacy Notice">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value (legal entity, contact address, regulator details).
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Privacy Notice</h1>
   <p class="meta">Last updated: 2026-06-28</p>
 
   <p>
-    This notice explains how <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span> (&ldquo;OSN&rdquo;,
+    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;OSN&rdquo;,
     &ldquo;we&rdquo;) handles personal information collected through this marketing site. It covers
     visitors to this site only. The OSN identity service and each connected app publish their own,
     separate privacy notices governing the data they process.
@@ -42,21 +48,21 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>How long we keep it</h2>
   <p>
     Only as long as we need it for the purpose above, then we delete or anonymise it. Specific
-    retention periods: <span class="placeholder">{'{{RETENTION}}'}</span>.
+    retention periods: <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
   </p>
 
   <h2>Your rights</h2>
   <p>
     Depending on where you live, you may have rights to access, correct, delete or port your
     information, and to object to certain uses. To exercise them, contact us at
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>. You may also complain to your local data
-    protection regulator (<span class="placeholder">{'{{REGULATOR}}'}</span>).
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
+    protection regulator (<span class={ph}>{LEGAL_ENTITY.regulator}</span>).
   </p>
 
   <h2>Contact</h2>
   <p>
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>,
-    <span class="placeholder">{'{{POSTAL_ADDRESS}}'}</span> —
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    <span class={ph}>{LEGAL_ENTITY.name}</span>,
+    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/osn/landing/src/pages/privacy.astro
+++ b/osn/landing/src/pages/privacy.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
@@ -17,7 +18,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
-    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;OSN&rdquo;,
+    This notice explains how <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span> (&ldquo;OSN&rdquo;,
     &ldquo;we&rdquo;) handles personal information collected through this marketing site. It covers
     visitors to this site only. The OSN identity service and each connected app publish their own,
     separate privacy notices governing the data they process.
@@ -57,14 +58,14 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Depending on where you live, you may have rights to access, correct, delete or port your
     information, and to object to certain uses. To exercise them, contact us at
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
-    protection regulator (<span class={ph}>{LEGAL_ENTITY.regulator}</span>).
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
+    protection regulator (<span class={ph(LEGAL_ENTITY.regulator)}>{LEGAL_ENTITY.regulator}</span>).
   </p>
 
   <h2>Contact</h2>
   <p>
-    <span class={ph}>{LEGAL_ENTITY.name}</span>,
-    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>,
+    <span class={ph(LEGAL_ENTITY.postalAddress)}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/osn/landing/src/pages/terms.astro
+++ b/osn/landing/src/pages/terms.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Terms of Use</h1>
-  <p class="meta">Last updated: 2026-06-28</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     These terms govern your use of the OSN marketing site, operated by

--- a/osn/landing/src/pages/terms.astro
+++ b/osn/landing/src/pages/terms.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
@@ -18,7 +19,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <p>
     These terms govern your use of the OSN marketing site, operated by
-    <span class={ph}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
   </p>
 
   <h2>Using the site</h2>
@@ -70,6 +71,6 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    Questions about these terms: <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/osn/landing/src/pages/terms.astro
+++ b/osn/landing/src/pages/terms.astro
@@ -1,19 +1,25 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Terms of Use">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Terms of Use</h1>
   <p class="meta">Last updated: 2026-06-28</p>
 
   <p>
     These terms govern your use of the OSN marketing site, operated by
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>. By using the site you agree to them.
+    <span class={ph}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
   </p>
 
   <h2>Using the site</h2>
@@ -37,13 +43,34 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h2>No warranty &amp; liability</h2>
   <p>
-    This site is provided &ldquo;as is&rdquo;. To the extent permitted by law we exclude implied
-    warranties and limit our liability for your use of it. Nothing here limits liability that cannot
-    be limited by law.
+    This site is provided &ldquo;as is&rdquo;. Subject to the consumer guarantees below, and to the
+    extent permitted by law, we exclude implied warranties and limit our liability for your use of
+    it. Nothing here limits liability that cannot lawfully be limited.
+  </p>
+
+  <h2>Your rights as a consumer</h2>
+  <p>
+    Our services come with guarantees that cannot be excluded under the Australian Consumer
+    Law. Nothing in these terms excludes, restricts or modifies any consumer guarantee, right
+    or remedy you have under that law or any other law that cannot lawfully be excluded. If you
+    are reading this elsewhere in the world, you keep the consumer protections of the place you
+    live.
+  </p>
+
+  <h2>Changes to these terms</h2>
+  <p>
+    We may update these terms from time to time. The &ldquo;last updated&rdquo; date above changes
+    when we do, and changes are not retroactive.
+  </p>
+
+  <h2>Governing law</h2>
+  <p>
+    These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>. This does
+    not take away the protections you have under the consumer laws of the place where you live.
   </p>
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/pulse/landing/package.json
+++ b/pulse/landing/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@astrojs/solid-js": "^7.0.1",
+    "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",
     "motion": "^12.42.2",

--- a/pulse/landing/src/pages/privacy.astro
+++ b/pulse/landing/src/pages/privacy.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
@@ -17,7 +18,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
-    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;Pulse&rdquo;,
+    This notice explains how <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span> (&ldquo;Pulse&rdquo;,
     &ldquo;we&rdquo;) handles personal information collected through this marketing site. It covers
     visitors to this site only. Using the Pulse app itself is governed by the OSN privacy notice
     shown when you sign in.
@@ -53,14 +54,14 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
   <p>
     Depending on where you live, you may have rights to access, correct, delete or port your
     information, and to object to certain uses. To exercise them, contact us at
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
-    protection regulator (<span class={ph}>{LEGAL_ENTITY.regulator}</span>).
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
+    protection regulator (<span class={ph(LEGAL_ENTITY.regulator)}>{LEGAL_ENTITY.regulator}</span>).
   </p>
 
   <h2>Contact</h2>
   <p>
-    <span class={ph}>{LEGAL_ENTITY.name}</span>,
-    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
-    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>,
+    <span class={ph(LEGAL_ENTITY.postalAddress)}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/pulse/landing/src/pages/privacy.astro
+++ b/pulse/landing/src/pages/privacy.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Privacy Notice">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Privacy Notice</h1>
-  <p class="meta">Last updated: 2026-06-28</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;Pulse&rdquo;,
@@ -26,7 +25,10 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>What we collect here</h2>
   <ul>
-    <li>This is a static marketing site — it has no sign-in, no forms and no first-party API calls, so it does not collect personal information directly.</li>
+    <li>This is a static marketing site — no sign-in, no forms, no accounts.</li>
+    <li>A coarse, city-level location derived from your IP address by our own
+      <code>/api/geo</code> endpoint, used once on page load to tailor the headline. It is
+      not stored, not logged against you, and not shared.</li>
     <li>Standard server request logs kept by our static host for security and reliability.</li>
     <li>Anything you choose to send us if you contact us through a channel linked here — for example your name and email.</li>
   </ul>
@@ -40,8 +42,11 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>How long we keep it</h2>
   <p>
-    Only as long as we need it for the purpose above, then we delete or anonymise it. Specific
-    retention periods: <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
+    Only as long as we need it for the purpose above, then we delete or anonymise it.
+    Server request logs are kept by our static host for a short period for security and
+    reliability and are not used for anything else; nothing on this site is retained beyond
+    that unless you contacted us, in which case we keep the correspondence for as long as it
+    takes to deal with it.
   </p>
 
   <h2>Your rights</h2>

--- a/pulse/landing/src/pages/privacy.astro
+++ b/pulse/landing/src/pages/privacy.astro
@@ -1,18 +1,24 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Privacy Notice">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value (legal entity, contact address, regulator details).
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Privacy Notice</h1>
   <p class="meta">Last updated: 2026-06-28</p>
 
   <p>
-    This notice explains how <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span> (&ldquo;Pulse&rdquo;,
+    This notice explains how <span class={ph}>{LEGAL_ENTITY.name}</span> (&ldquo;Pulse&rdquo;,
     &ldquo;we&rdquo;) handles personal information collected through this marketing site. It covers
     visitors to this site only. Using the Pulse app itself is governed by the OSN privacy notice
     shown when you sign in.
@@ -21,7 +27,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>What we collect here</h2>
   <ul>
     <li>This is a static marketing site — it has no sign-in, no forms and no first-party API calls, so it does not collect personal information directly.</li>
-    <li>Basic, privacy-respecting analytics about how this site is used, so we can improve it.</li>
+    <li>Standard server request logs kept by our static host for security and reliability.</li>
     <li>Anything you choose to send us if you contact us through a channel linked here — for example your name and email.</li>
   </ul>
 
@@ -35,21 +41,21 @@ import LegalLayout from '../layouts/LegalLayout.astro'
   <h2>How long we keep it</h2>
   <p>
     Only as long as we need it for the purpose above, then we delete or anonymise it. Specific
-    retention periods: <span class="placeholder">{'{{RETENTION}}'}</span>.
+    retention periods: <span class={ph}>{LEGAL_ENTITY.accountDataRetention}</span>.
   </p>
 
   <h2>Your rights</h2>
   <p>
     Depending on where you live, you may have rights to access, correct, delete or port your
     information, and to object to certain uses. To exercise them, contact us at
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>. You may also complain to your local data
-    protection regulator (<span class="placeholder">{'{{REGULATOR}}'}</span>).
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>. You may also complain to your local data
+    protection regulator (<span class={ph}>{LEGAL_ENTITY.regulator}</span>).
   </p>
 
   <h2>Contact</h2>
   <p>
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>,
-    <span class="placeholder">{'{{POSTAL_ADDRESS}}'}</span> —
-    <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    <span class={ph}>{LEGAL_ENTITY.name}</span>,
+    <span class={ph}>{LEGAL_ENTITY.postalAddress}</span> —
+    <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/pulse/landing/src/pages/terms.astro
+++ b/pulse/landing/src/pages/terms.astro
@@ -1,19 +1,25 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+
+// Only highlight the operator's details while they are still placeholders.
+const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 ---
 <LegalLayout title="Terms of Use">
-  <div class="draft-banner">
-    <strong>Draft</strong> — A working draft for review, not legal advice. Have it checked before
-    publishing and replace every highlighted <span class="placeholder">{'{{PLACEHOLDER}}'}</span>
-    value.
-  </div>
+  {LEGAL_DETAILS_PENDING && (
+    <div class="draft-banner">
+      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
+      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
+      banner goes away by itself.
+    </div>
+  )}
 
   <h1>Terms of Use</h1>
   <p class="meta">Last updated: 2026-06-28</p>
 
   <p>
     These terms govern your use of the Pulse marketing site, operated by
-    <span class="placeholder">{'{{LEGAL_ENTITY}}'}</span>. By using the site you agree to them.
+    <span class={ph}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
   </p>
 
   <h2>Using the site</h2>
@@ -36,13 +42,34 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 
   <h2>No warranty &amp; liability</h2>
   <p>
-    This site is provided &ldquo;as is&rdquo;. To the extent permitted by law we exclude implied
-    warranties and limit our liability for your use of it. Nothing here limits liability that cannot
-    be limited by law.
+    This site is provided &ldquo;as is&rdquo;. Subject to the consumer guarantees below, and to the
+    extent permitted by law, we exclude implied warranties and limit our liability for your use of
+    it. Nothing here limits liability that cannot lawfully be limited.
+  </p>
+
+  <h2>Your rights as a consumer</h2>
+  <p>
+    Our services come with guarantees that cannot be excluded under the Australian Consumer
+    Law. Nothing in these terms excludes, restricts or modifies any consumer guarantee, right
+    or remedy you have under that law or any other law that cannot lawfully be excluded. If you
+    are reading this elsewhere in the world, you keep the consumer protections of the place you
+    live.
+  </p>
+
+  <h2>Changes to these terms</h2>
+  <p>
+    We may update these terms from time to time. The &ldquo;last updated&rdquo; date above changes
+    when we do, and changes are not retroactive.
+  </p>
+
+  <h2>Governing law</h2>
+  <p>
+    These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>. This does
+    not take away the protections you have under the consumer laws of the place where you live.
   </p>
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class="placeholder">{'{{CONTACT_EMAIL}}'}</span>.
+    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/pulse/landing/src/pages/terms.astro
+++ b/pulse/landing/src/pages/terms.astro
@@ -8,14 +8,13 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
     <div class="draft-banner">
-      <strong>Draft</strong> — the operator's own details are not filled in yet, so this
-      page is not final. Fill them in at <code>shared/legal/src/index.ts</code> and this
-      banner goes away by itself.
+      <strong>Draft</strong> — this notice is not final. Some details of the operator are
+      still to be confirmed, and this banner disappears once they are.
     </div>
   )}
 
   <h1>Terms of Use</h1>
-  <p class="meta">Last updated: 2026-06-28</p>
+  <p class="meta">Last updated: 2026-08-20</p>
 
   <p>
     These terms govern your use of the Pulse marketing site, operated by

--- a/pulse/landing/src/pages/terms.astro
+++ b/pulse/landing/src/pages/terms.astro
@@ -1,9 +1,10 @@
 ---
 import LegalLayout from '../layouts/LegalLayout.astro'
-import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from '@shared/legal'
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING, isPlaceholder } from '@shared/legal'
 
-// Only highlight the operator's details while they are still placeholders.
-const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
+// Highlight a detail only while THAT detail is still a placeholder. A page-wide
+// flag would mark a filled field as pending the moment any other one wasn't.
+const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
 ---
 <LegalLayout title="Terms of Use">
   {LEGAL_DETAILS_PENDING && (
@@ -18,7 +19,7 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <p>
     These terms govern your use of the Pulse marketing site, operated by
-    <span class={ph}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
+    <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>. By using the site you agree to them.
   </p>
 
   <h2>Using the site</h2>
@@ -69,6 +70,6 @@ const ph = LEGAL_DETAILS_PENDING ? 'placeholder' : undefined
 
   <h2>Contact</h2>
   <p>
-    Questions about these terms: <span class={ph}>{LEGAL_ENTITY.contactEmail}</span>.
+    Questions about these terms: <span class={ph(LEGAL_ENTITY.contactEmail)}>{LEGAL_ENTITY.contactEmail}</span>.
   </p>
 </LegalLayout>

--- a/shared/legal/package.json
+++ b/shared/legal/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@shared/legal",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
+  },
+  "devDependencies": {
+    "@shared/typescript-config": "workspace:*",
+    "vitest": "^4.1.10"
+  }
+}

--- a/shared/legal/src/index.ts
+++ b/shared/legal/src/index.ts
@@ -1,0 +1,97 @@
+/**
+ * The identity of the operator, as every published legal page must state it.
+ *
+ * ## Why this is a package and not eight copies
+ *
+ * Each privacy notice and terms page used to carry its own `{{LEGAL_ENTITY}}`,
+ * `{{CONTACT_EMAIL}}`, `{{POSTAL_ADDRESS}}` and `{{REGULATOR}}` placeholder,
+ * plus a hand-written "Draft — replace every highlighted value" banner. Eight
+ * pages, all of them served in production with the placeholders and the banner
+ * still in them, because filling them in meant eight coordinated edits and
+ * nobody had the values to hand.
+ *
+ * Now there is one file. Fill in the four fields below and every page resolves
+ * at once — and the draft banner disappears on its own, because
+ * `LEGAL_DETAILS_PENDING` is derived from the values rather than hand-maintained.
+ * A page cannot be left half-published.
+ *
+ * ## What may live here
+ *
+ * Only what a published legal page must already say out loud: the operating
+ * entity's name, its service address, its privacy contact and its regulator.
+ * Naming the controller is a GDPR Art. 13(1)(a) / APP 1.4 requirement, so none
+ * of it is confidential once a notice is live.
+ *
+ * Nothing else. Company numbers, tax registrations, banking details and
+ * commercial terms are not required on a notice and do not belong in the repo.
+ */
+export interface LegalEntity {
+  /** Registered name, plus any trading name, exactly as it should be published. */
+  readonly name: string;
+  /** Service address for legal notices — a postal address, not a PO box alone. */
+  readonly postalAddress: string;
+  /** Where a person exercises their rights. Must be monitored by a human. */
+  readonly contactEmail: string;
+  /**
+   * The supervisory authority a complaint goes to, named so a reader does not
+   * have to find it. Australia's is the Office of the Australian Information
+   * Commissioner; readers elsewhere are pointed at their own in the page copy.
+   */
+  readonly regulator: string;
+  /**
+   * Governing law, at country level. Deliberately not a state or territory:
+   * the law that actually decides a dispute with a guest or an organiser here
+   * is federal — the Australian Consumer Law and the Privacy Act 1988 (Cth) —
+   * and a consumer keeps the protections of where they live regardless of what
+   * a clause says.
+   */
+  readonly governingLaw: string;
+  /**
+   * The merchant of record for paid add-ons — the party a buyer's contract of
+   * sale is actually with, which the terms and the refund policy must name.
+   * Unset while nothing is for sale. Only the published name belongs here; the
+   * commercial arrangement behind it does not go in the repo.
+   */
+  readonly merchantOfRecord: string;
+  /**
+   * How long account data is kept, in one publishable sentence. Guest data is
+   * NOT this: that window is 365 days after the final event, enforced in code
+   * by `RETENTION_AFTER_FINAL_EVENT_MS` in
+   * `cire/api/src/services/retention.ts`, and stated as a fact on the notices
+   * rather than as a field here — a retention promise that can drift from the
+   * scheduler enforcing it is worse than no promise.
+   */
+  readonly accountDataRetention: string;
+}
+
+/**
+ * PLACEHOLDER VALUES. Replace all four before the pages are treated as
+ * published — see `LEGAL_DETAILS_PENDING`, which every page reads to decide
+ * whether to show its draft banner.
+ */
+export const LEGAL_ENTITY: LegalEntity = {
+  name: "{{LEGAL_ENTITY}}",
+  postalAddress: "{{POSTAL_ADDRESS}}",
+  contactEmail: "{{CONTACT_EMAIL}}",
+  regulator: "Office of the Australian Information Commissioner (OAIC)",
+  governingLaw: "Australia",
+  merchantOfRecord: "{{MERCHANT_OF_RECORD}}",
+  accountDataRetention: "{{RETENTION}}",
+};
+
+/** A field still holding its `{{PLACEHOLDER}}` token. */
+export function isPlaceholder(value: string): boolean {
+  return value.startsWith("{{") && value.endsWith("}}");
+}
+
+/**
+ * True while any identity field is unfilled. Drives the draft banner on every
+ * legal page, so the banner cannot outlive the placeholders or vice versa.
+ */
+export const LEGAL_DETAILS_PENDING: boolean = [
+  LEGAL_ENTITY.name,
+  LEGAL_ENTITY.postalAddress,
+  LEGAL_ENTITY.contactEmail,
+  LEGAL_ENTITY.merchantOfRecord,
+  LEGAL_ENTITY.accountDataRetention,
+].some(isPlaceholder);

--- a/shared/legal/src/index.ts
+++ b/shared/legal/src/index.ts
@@ -54,12 +54,15 @@ export interface LegalEntity {
    */
   readonly merchantOfRecord: string;
   /**
-   * How long account data is kept, in one publishable sentence. Guest data is
-   * NOT this: that window is 365 days after the final event, enforced in code
-   * by `RETENTION_AFTER_FINAL_EVENT_MS` in
-   * `cire/api/src/services/retention.ts`, and stated as a fact on the notices
-   * rather than as a field here — a retention promise that can drift from the
-   * scheduler enforcing it is worse than no promise.
+   * How long account data is kept, in one publishable sentence.
+   *
+   * Two things this is NOT. It is not guest data: that window is 365 days after
+   * the final event, enforced by `RETENTION_AFTER_FINAL_EVENT_MS` in
+   * `cire/api/src/services/retention.ts` and stated as a fact on the notices —
+   * a retention promise that can drift from the scheduler enforcing it is worse
+   * than no promise. And it is not a marketing site's server logs, which have
+   * their own answer; those notices say what their host keeps rather than
+   * borrowing this.
    */
   readonly accountDataRetention: string;
 }
@@ -85,13 +88,32 @@ export function isPlaceholder(value: string): boolean {
 }
 
 /**
- * True while any identity field is unfilled. Drives the draft banner on every
- * legal page, so the banner cannot outlive the placeholders or vice versa.
+ * The fields every legal page renders, whatever else it says. The draft banner
+ * derives from these alone.
+ *
+ * Deliberately NOT `merchantOfRecord`: it is unset while nothing is for sale,
+ * which is the expected steady state, and only three of eleven pages mention a
+ * purchase at all. Deriving the banner from it would leave the identity app's
+ * privacy notice flagged draft over a field it never renders.
  */
-export const LEGAL_DETAILS_PENDING: boolean = [
+const IDENTITY_FIELDS = [
   LEGAL_ENTITY.name,
   LEGAL_ENTITY.postalAddress,
   LEGAL_ENTITY.contactEmail,
-  LEGAL_ENTITY.merchantOfRecord,
-  LEGAL_ENTITY.accountDataRetention,
-].some(isPlaceholder);
+] as const;
+
+/**
+ * True while any field every page renders is unfilled. Drives the draft banner,
+ * so the banner cannot outlive the placeholders or vice versa.
+ */
+export const LEGAL_DETAILS_PENDING: boolean = IDENTITY_FIELDS.some(isPlaceholder);
+
+/**
+ * Per-field pendingness, for a page that renders something outside the identity
+ * set — a purchase page naming the merchant of record, say. `LEGAL_DETAILS_PENDING`
+ * will not cover it, and a page that renders `{{MERCHANT_OF_RECORD}}` without
+ * flagging itself is exactly what this module exists to prevent.
+ */
+export function pendingAny(...values: readonly string[]): boolean {
+  return values.some(isPlaceholder);
+}

--- a/shared/legal/src/index.ts
+++ b/shared/legal/src/index.ts
@@ -68,14 +68,15 @@ export interface LegalEntity {
 }
 
 /**
- * PLACEHOLDER VALUES. Replace all four before the pages are treated as
+ * Fill the remaining `{{PLACEHOLDER}}` values before the pages are treated as
  * published — see `LEGAL_DETAILS_PENDING`, which every page reads to decide
- * whether to show its draft banner.
+ * whether to show its draft banner, and which resolves on its own once the
+ * identity fields are real.
  */
 export const LEGAL_ENTITY: LegalEntity = {
   name: "{{LEGAL_ENTITY}}",
   postalAddress: "{{POSTAL_ADDRESS}}",
-  contactEmail: "{{CONTACT_EMAIL}}",
+  contactEmail: "aniket@englishstventures.com",
   regulator: "Office of the Australian Information Commissioner (OAIC)",
   governingLaw: "Australia",
   merchantOfRecord: "{{MERCHANT_OF_RECORD}}",

--- a/shared/legal/tests/entity.test.ts
+++ b/shared/legal/tests/entity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlaceholder, LEGAL_DETAILS_PENDING, LEGAL_ENTITY } from "../src/index";
+
+describe("isPlaceholder", () => {
+  it("recognises an unfilled token", () => {
+    expect(isPlaceholder("{{LEGAL_ENTITY}}")).toBe(true);
+  });
+
+  it("does not fire on ordinary copy that merely contains braces", () => {
+    expect(isPlaceholder("Example Pty Ltd {trading as Example}")).toBe(false);
+    expect(isPlaceholder("Example Pty Ltd")).toBe(false);
+  });
+});
+
+describe("LEGAL_DETAILS_PENDING", () => {
+  it("agrees with the fields it is derived from", () => {
+    const anyUnfilled = [
+      LEGAL_ENTITY.name,
+      LEGAL_ENTITY.postalAddress,
+      LEGAL_ENTITY.contactEmail,
+    ].some(isPlaceholder);
+    expect(LEGAL_DETAILS_PENDING).toBe(anyUnfilled);
+  });
+});
+
+describe("LEGAL_ENTITY", () => {
+  /**
+   * The regulator and the governing law are answers, not placeholders — both
+   * were decided rather than deferred, so a page may state them even while the
+   * entity's own details are pending.
+   */
+  it("names a regulator and a governing law", () => {
+    expect(isPlaceholder(LEGAL_ENTITY.regulator)).toBe(false);
+    expect(isPlaceholder(LEGAL_ENTITY.governingLaw)).toBe(false);
+  });
+
+  it("states governing law at country level, not state level", () => {
+    expect(LEGAL_ENTITY.governingLaw).toBe("Australia");
+  });
+});

--- a/shared/legal/tests/entity.test.ts
+++ b/shared/legal/tests/entity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isPlaceholder, LEGAL_DETAILS_PENDING, LEGAL_ENTITY } from "../src/index";
+import { isPlaceholder, LEGAL_DETAILS_PENDING, LEGAL_ENTITY, pendingAny } from "../src/index";
 
 describe("isPlaceholder", () => {
   it("recognises an unfilled token", () => {
@@ -14,13 +14,34 @@ describe("isPlaceholder", () => {
 });
 
 describe("LEGAL_DETAILS_PENDING", () => {
-  it("agrees with the fields it is derived from", () => {
+  it("agrees with the identity fields it is derived from", () => {
     const anyUnfilled = [
       LEGAL_ENTITY.name,
       LEGAL_ENTITY.postalAddress,
       LEGAL_ENTITY.contactEmail,
     ].some(isPlaceholder);
     expect(LEGAL_DETAILS_PENDING).toBe(anyUnfilled);
+  });
+
+  /**
+   * The state this has to survive: identity filled in, nothing for sale yet.
+   * An earlier derivation included `merchantOfRecord`, which would have left
+   * every page — including the ones that never mention a purchase — flagged
+   * draft forever.
+   */
+  it("ignores the merchant of record, which is unset until something is sold", () => {
+    expect(isPlaceholder(LEGAL_ENTITY.merchantOfRecord)).toBe(true);
+    const identityFilled = !["Example Pty Ltd", "1 Example St", "privacy@example.com"].some(
+      isPlaceholder,
+    );
+    expect(identityFilled).toBe(true);
+  });
+});
+
+describe("pendingAny", () => {
+  it("lets a page flag a field outside the identity set", () => {
+    expect(pendingAny(LEGAL_ENTITY.merchantOfRecord)).toBe(true);
+    expect(pendingAny(LEGAL_ENTITY.governingLaw)).toBe(false);
   });
 });
 

--- a/shared/legal/tsconfig.json
+++ b/shared/legal/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/node.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/wiki/compliance/data-map.md
+++ b/wiki/compliance/data-map.md
@@ -9,7 +9,7 @@ related:
   - "[[cire]]"
   - "[[cire-auth]]"
   - "[[dpia/cire-guest-data]]"
-last-reviewed: 2026-08-17
+last-reviewed: 2026-08-20
 ---
 
 # Data Map
@@ -105,7 +105,9 @@ Cire is a wedding-invite app merged into the monorepo as the `cire/*`
 workspace. It runs its **own** Cloudflare D1 and R2, separate from `osn/db`
 (see [[cire]], [[cire-auth]]). The **controller** for guest data is the
 wedding organiser (the couple) who uploads the guest list; OSN/cire is the
-**platform / processor** and provides the technical means. The wedding owner
+**platform / processor** and provides the technical means — **except** for the
+three decisions cire makes unilaterally and identically for every wedding, where
+cire is the controller (see the Controller / processor note below). The wedding owner
 is identified by `weddings.owner_osn_profile_id` — an opaque OSN profile id
 (`usr_*` string, cross-DB reference, **no FK**). Lawful basis is
 organiser-initiated wedding administration.
@@ -175,7 +177,23 @@ Vendor personal data arises when the vendor is a **sole trader**, so their conta
 
 **Controller / processor note.** For guest data the organiser is the
 controller (they decide to upload the list, set the field contents); cire
-is the processor. The organiser is themselves an OSN data subject (their
+is the processor **for that content**.
+
+Cire is the **controller** for three decisions it takes on its own account,
+applies to every wedding alike, and no organiser can override:
+
+| Decision | Where it is made | Why it is controllership |
+|---|---|---|
+| Retention of guest data | `RETENTION_AFTER_FINAL_EVENT_MS` (365 d) in `cire/api/src/services/retention.ts` | Choosing how long personal data is kept is a purposes-and-means decision. An organiser cannot extend or shorten it. |
+| Security posture of the service | CSP, session hashing, Turnstile, rate limits | Ordinarily an Art. 28(3)(c) processor obligation — recorded here because the published notices describe it in the same breath. **Do not rest the controllership argument on this leg alone.** |
+| Technical telemetry | `@shared/observability` → Grafana Cloud, per §Observability | Collected for cire's own purposes (running and improving the platform), not on the organiser's instruction. |
+
+This is what `cire/invites/src/pages/privacy.astro` and
+`cire/landing/src/pages/privacy.astro` publish. If this table changes, those two
+pages change with it — a notice that disagrees with the Art. 30 record is the
+defect this row exists to prevent.
+
+The organiser is themselves an OSN data subject (their
 `owner_osn_profile_id` ties the wedding to an OSN account — see
 [[identity-model]]). DSAR reachability + the cross-DB deletion orphan are
 covered in [[dsar]] (C-M1).


### PR DESCRIPTION
## Summary

An audit of all eight published legal pages against Australian, EU/UK and US
requirements, and the fixes for what it found. Not a redraft — every change below
is a defect.

The headline: **`cire/invites`'s privacy notice and terms were written for one
wedding run by two individuals.** They named that couple, published a personal
email as the privacy contact, and claimed the Privacy Act's personal, family or
household exemption — *"we run this site as individuals planning a personal
celebration, not as a business"*. That was true of the first wedding, and has
been wrong for every guest of every wedding since. The household exemption
(Privacy Act s 16, GDPR Art. 2(2)(c)) covers a couple running their own event; it
has never covered the platform underneath them.

## Workspaces affected

`@cire/invites`, `@cire/landing`, `@osn/landing`, `@pulse/landing`, and a new
`@shared/legal`. **Two** changesets — `@cire/*` are version-less, and
`scripts/validate-changesets.sh` rejects a file mixing them with versioned
packages.

## Issues

**Closes**

| Issue | What |
|---|---|
| — | None — these were found by this audit, not previously filed. |

**Opened**

| Issue | What |
|---|---|
| — | None yet. Three items below need a decision, not a patch, and are listed under Out of scope for filing once you've read them. |

## Decisions

### The notice now describes the split the code implements — `approach`

- **Issue** — `cire/landing` said Cire processes guest data *on the couple's
  behalf* (a pure processor). `cire/invites` said the couple was responsible
  **and** outside the Privacy Act. Between them, guest data had no one owing
  duties over it.
- **Why** — the two notices contradicted each other, and the product contradicts
  the tidier of the two: `RETENTION_AFTER_FINAL_EVENT_MS` in
  `cire/api/src/services/retention.ts` deletes guest data one year after the
  final event, for every wedding, and no organiser can change it.
- **Solution** — hosts decide what to ask and what to do with the answers; we
  hold the data for them; **and** we alone decide retention, security posture and
  telemetry. The notice says the third part out loud.
- **Rationale** — choosing a retention period is a controller decision. Claiming
  processor-only status while unilaterally setting one is the kind of claim that
  falls apart precisely when it matters.

### Placeholders resolve from one file, and the draft banner is derived — `approach`

- **Issue** — every page carried its own `{{LEGAL_ENTITY}}`, `{{CONTACT_EMAIL}}`,
  `{{POSTAL_ADDRESS}}`, `{{REGULATOR}}`, `{{RETENTION}}` and
  `{{MERCHANT_OF_RECORD}}`, plus a hand-written "Draft — not legal advice"
  banner. All of it live in production.
- **Why** — filling them in meant eight coordinated edits by someone holding
  every value, so nobody did.
- **Solution** — `@shared/legal` holds them once. `LEGAL_DETAILS_PENDING` is
  *derived* from whether they are still placeholders, and every banner reads it.
- **Rationale** — a page can no longer be left half-published, and the banner
  cannot outlive the values or vice versa. **Filling in `shared/legal/src/index.ts`
  is now the whole job** — four fields, and all eight pages go live at once.

### Governing law at country level — `approach`

- **Issue** — `cire/invites` said "Australia", `cire/landing` said "New South
  Wales, Australia", and `osn/landing` and `pulse/landing` said nothing at all.
- **Solution** — all four now state the laws of Australia, from one constant.
- **Rationale** — your call, and defensible: the law that actually decides a
  dispute here is federal (Australian Consumer Law, Privacy Act 1988 (Cth)), and
  a consumer keeps the protections of where they live regardless. Naming a state
  is the more conventional drafting because contract law is state-based; noted
  and not taken.

### US state-privacy furniture deliberately absent — `approach`

- **Issue** — the reference templates carry notice-at-collection tables, "Do Not
  Sell/Share", sensitive-PI sections and GPC language.
- **Solution** — none of it added.
- **Rationale** — CCPA/CPRA and the VA/CO/CT/UT laws apply above revenue and
  volume thresholds this product is nowhere near, and each clause would be a
  claim about a process that does not exist. Global Privacy Control recognition
  is worth having regardless and is already tracked as `C-L7`.

**Out of scope** — three things this PR deliberately does not fix, because each
needs a decision rather than wording:

- **The EEA→Australia transfer has no Art. 46 mechanism named anywhere.** The
  databases are in Sydney; Australia has no EU adequacy decision. The pages now
  state the fact and offer to explain the protections on request — which is
  honest, and currently the honest answer is thin. This is the sharpest legal gap
  found and needs SCCs or a documented position.
- **No EU/UK Art. 27 representative decision is recorded.** The exemption is
  arguable — special-category data, but small scale. It needs a decision, not
  silence.
- **Four surfaces still have no legal pages at all**: `osn/social`, `pulse/web`,
  `cire/host`, `cire/vendor` — and none of the four so much as links to one. The
  marketing notices each say the real apps *"publish their own, separate privacy
  notices"*, which do not exist. Follow-up branch, stacked on this one.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1351 files |
| `bun run test` | ✅ 33/33 packages |
| `bun run --cwd cire/invites test` | ✅ 900 pass |
| Build all four sites + inspect rendered HTML | ✅ |

Verified from the built HTML, not the source: zero occurrences of the couple's
name or the personal email anywhere in `cire/invites/dist`; the household-exemption
paragraph and all three owner-notes gone; the generated vendor list (Turnstile,
Google Maps, Pinterest) still rendering; governing law reading "Australia" on all
four terms pages.

`cire/invites/src/pages/legal-pages.test.ts` pins what would regress quietly — no
hardcoded email, no exemption claim, no owner-notes, and the APP 3.3 / Art. 9(2)(a)
citations present. It asserts against the rendered template, not the whole file,
since the frontmatter deliberately quotes the wording it replaced.

Not verified: no lawyer has read any of this. It is a considered engineering pass
over what the pages claim versus what the code does, and the two now agree — that
is a different thing from legal sign-off, and the remaining `{{PLACEHOLDER}}`
values mean the pages are still flagged draft in production until you fill them in.
