### PR TITLE
docs(legal): give the identity app and Pulse the notices they promised

### DIFF
--- a/.changeset/legal-app-pages-cire.md
+++ b/.changeset/legal-app-pages-cire.md
@@ -1,0 +1,7 @@
+---
+"@cire/landing": patch
+---
+
+Name the vendor portal in the privacy notice's scope sentence. The notice already
+covered the marketing site, the invitation site and the organiser portal; the
+vendor portal is a fourth surface on the same service and was simply missed.

--- a/.changeset/legal-app-pages.md
+++ b/.changeset/legal-app-pages.md
@@ -1,0 +1,24 @@
+---
+"@osn/social": patch
+"@pulse/web": patch
+---
+
+Give the identity app and Pulse the privacy notices and terms they were already
+promising.
+
+`@osn/landing`'s notice says it "covers visitors to this site only" and that "the
+OSN identity service and each connected app publish their own, separate privacy
+notices". `@pulse/landing`'s says using the app "is governed by the OSN privacy
+notice shown when you sign in". None of those notices existed, and neither app
+carried a legal page or so much as a link to one — while holding accounts,
+passkeys, sessions, the social graph, OIDC grants, events, RSVPs and location.
+
+Both apps now serve `/privacy` and `/terms`, reachable without signing in, with
+every claim taken from `wiki/compliance/data-map.md` — the lawful basis per
+purpose, the real retention windows, and where the data is stored.
+
+Two things the notices say that were not said anywhere before: Pulse's share
+attribution records a platform name and nothing else, visible only to that event's
+organiser, and it rests on legitimate interest you can object to; and attending an
+event can reveal something protected about you even when the host published it
+freely, so that is treated as needing consent rather than as manifestly public.

--- a/bun.lock
+++ b/bun.lock
@@ -276,6 +276,7 @@
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
+        "@shared/legal": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",
         "@solidjs/router": "^0.16.2",
         "@tailwindcss/vite": "^4.3.3",
@@ -400,6 +401,7 @@
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@pulse/api": "workspace:*",
+        "@shared/legal": "workspace:*",
         "@shared/rp-auth": "workspace:*",
         "@solidjs/meta": "^0.29.4",
         "@solidjs/router": "^0.16.2",

--- a/cire/landing/src/pages/privacy.astro
+++ b/cire/landing/src/pages/privacy.astro
@@ -21,7 +21,7 @@ const ph = (value: string) => (isPlaceholder(value) ? 'placeholder' : undefined)
     This notice explains how <span class={ph(LEGAL_ENTITY.name)}>{LEGAL_ENTITY.name}</span>, trading as Cire
     (&ldquo;Cire&rdquo;, &ldquo;we&rdquo;), handles
     personal information across the Cire service — this marketing site, the invitation site your
-    guests use, and the organiser portal.
+    guests use, the organiser portal, and the vendor portal.
   </p>
 
   <h2>Two kinds of people use Cire</h2>

--- a/osn/social/package.json
+++ b/osn/social/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@osn/client": "workspace:*",
     "@osn/ui": "workspace:*",
+    "@shared/legal": "workspace:*",
     "@simplewebauthn/browser": "^13.3.0",
     "@solidjs/router": "^0.16.2",
     "@tailwindcss/vite": "^4.3.3",

--- a/osn/social/src/App.tsx
+++ b/osn/social/src/App.tsx
@@ -36,6 +36,10 @@ const SettingsPage = lazy(() =>
 const AuthorizePage = lazy(() =>
   import("./pages/AuthorizePage").then((m) => ({ default: m.AuthorizePage })),
 );
+const PrivacyPage = lazy(() =>
+  import("./pages/PrivacyPage").then((m) => ({ default: m.PrivacyPage })),
+);
+const TermsPage = lazy(() => import("./pages/TermsPage").then((m) => ({ default: m.TermsPage })));
 
 /**
  * The consent screen runs bare: no navigation out of the flow, nothing to
@@ -129,6 +133,10 @@ export default function App() {
       <Route path="/organisations/:id" component={OrgDetailPage} />
       <Route path="/settings" component={SettingsPage} />
       <Route path="/authorize" component={AuthorizePage} />
+      {/* Reachable signed-out on purpose: a notice you can only read once you have
+          already handed over your data is not a notice. */}
+      <Route path="/privacy" component={PrivacyPage} />
+      <Route path="/terms" component={TermsPage} />
     </Router>
   );
 }

--- a/osn/social/src/components/LegalDocument.tsx
+++ b/osn/social/src/components/LegalDocument.tsx
@@ -19,9 +19,8 @@ export function LegalDocument(props: {
     <article class="prose-legal mx-auto w-full max-w-2xl px-6 py-12">
       {LEGAL_DETAILS_PENDING && (
         <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
-          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
-          away by itself.
+          <strong>Draft</strong> — this notice is not final. Some details of the operator are still
+          to be confirmed, and this banner disappears once they are.
         </p>
       )}
       <h1 class="mb-1 text-2xl font-semibold">{props.title}</h1>

--- a/osn/social/src/components/LegalDocument.tsx
+++ b/osn/social/src/components/LegalDocument.tsx
@@ -1,0 +1,32 @@
+import { LEGAL_DETAILS_PENDING } from "@shared/legal";
+import type { JSX } from "solid-js";
+
+/**
+ * Shell for the two legal routes. They are the only pages in this app that are
+ * long-form prose rather than UI, so they own their own measure and rhythm
+ * instead of inheriting the app shell's density.
+ *
+ * These routes are deliberately reachable without signing in: a privacy notice
+ * a person can only read once they have already handed over their data is not
+ * a notice. The router serves them to anyone with the URL.
+ */
+export function LegalDocument(props: {
+  title: string;
+  updated: string;
+  children?: JSX.Element;
+}): JSX.Element {
+  return (
+    <article class="prose-legal mx-auto w-full max-w-2xl px-6 py-12">
+      {LEGAL_DETAILS_PENDING && (
+        <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
+          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
+          away by itself.
+        </p>
+      )}
+      <h1 class="mb-1 text-2xl font-semibold">{props.title}</h1>
+      <p class="text-muted-foreground mb-8 text-sm">Last updated: {props.updated}</p>
+      {props.children}
+    </article>
+  );
+}

--- a/osn/social/src/pages/PrivacyPage.tsx
+++ b/osn/social/src/pages/PrivacyPage.tsx
@@ -76,9 +76,11 @@ export function PrivacyPage(): JSX.Element {
       <p>
         When you use your OSN account to sign in to another app, we record that you granted it —
         which app, which profile, what it may see, and when. That record <em>is</em> your consent,
-        and withdrawing it in Settings under Connected apps deletes the grant and kills any
-        authorisation still in flight. The identifier each app receives for you is derived per-app,
-        so two apps that compare notes cannot tell they are looking at the same person.
+        and withdrawing it in Settings under Connected apps stops the app receiving anything more
+        and kills any authorisation still in flight. The row itself stays, marked withdrawn, as the
+        record that you withdrew — and goes when your account does. The identifier each app receives
+        for you is derived per-app, so two apps that compare notes cannot tell they are looking at
+        the same person.
       </p>
 
       <h2>The legal bases</h2>

--- a/osn/social/src/pages/PrivacyPage.tsx
+++ b/osn/social/src/pages/PrivacyPage.tsx
@@ -1,0 +1,145 @@
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from "@shared/legal";
+import type { JSX } from "solid-js";
+
+import { LegalDocument } from "../components/LegalDocument";
+
+/**
+ * The identity service's own privacy notice, at `/privacy`.
+ *
+ * It exists because `@osn/landing`'s notice says in as many words that it
+ * "covers visitors to this site only" and that "the OSN identity service and
+ * each connected app publish their own, separate privacy notices" — and then
+ * no such notice existed. The account, the passkeys, the social graph and the
+ * OIDC connections all live here, and this is where they are described.
+ *
+ * Every claim below is taken from `wiki/compliance/data-map.md`, which lists
+ * the lawful basis and retention per field. If a field changes there and not
+ * here, the two have drifted and this page is the one that is wrong.
+ */
+export function PrivacyPage(): JSX.Element {
+  const entity = () => (
+    <span class={LEGAL_DETAILS_PENDING ? "underline decoration-dotted" : undefined}>
+      {LEGAL_ENTITY.name}
+    </span>
+  );
+  const email = () => (
+    <a class="underline" href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+      {LEGAL_ENTITY.contactEmail}
+    </a>
+  );
+
+  return (
+    <LegalDocument title="Privacy Notice" updated="2026-08-20">
+      <p>
+        This notice covers your OSN account — the identity you sign in with, the profiles you create
+        under it, your connections, and the apps you have allowed to recognise you. It is published
+        by {entity()}, who operates the service.
+      </p>
+
+      <h2>What we hold, and why</h2>
+      <h3>Your account</h3>
+      <p>
+        An email address, which is how you sign in and where security notices and one-time codes go.
+        One or more passkeys — we store the public key and a label you chose ("iPhone 15 Pro"),
+        never a password and never anything that could be used to sign in as you elsewhere. We keep
+        this because we cannot provide you an account without it.
+      </p>
+      <h3>Your profiles</h3>
+      <p>
+        A handle, a display name and an avatar, per profile. These are public by design — they are
+        how other people find and recognise you. An account can hold more than one profile, and the
+        identifier a passkey is bound to is deliberately opaque so two of your profiles cannot be
+        linked back to one account by anyone but us.
+      </p>
+      <h3>Your sessions</h3>
+      <p>
+        For each signed-in device: a coarse label ("Firefox on macOS"), when it was last used, and a{" "}
+        <em>hash</em> of the IP address — keyed with a secret, so it can be compared against itself
+        for anomaly detection but not turned back into an address. Sessions expire 30 days after
+        last use. You can see and revoke every one of them in Settings.
+      </p>
+      <h3>Your social graph</h3>
+      <p>
+        Connections between profiles, and blocks. Connections are shared with other OSN apps when
+        they need them — Pulse to show which of your connections are attending an event, Zap to
+        honour a block, Cire to offer co-host suggestions from your own accepted connections. Blocks
+        are enforced everywhere.
+      </p>
+      <h3>Security records</h3>
+      <p>
+        An audit trail of security-relevant actions on your account — a passkey added or removed,
+        recovery codes generated, an email change — kept 12 months, and visible to you. Recovery
+        codes are stored only as hashes; the codes themselves are shown once, to you, and never
+        again. Email-change attempts are logged for 90 days to enforce the two-changes-per-week cap.
+      </p>
+      <h3>Apps you have connected</h3>
+      <p>
+        When you use your OSN account to sign in to another app, we record that you granted it —
+        which app, which profile, what it may see, and when. That record <em>is</em> your consent,
+        and withdrawing it in Settings under Connected apps deletes the grant and kills any
+        authorisation still in flight. The identifier each app receives for you is derived per-app,
+        so two apps that compare notes cannot tell they are looking at the same person.
+      </p>
+
+      <h2>The legal bases</h2>
+      <p>
+        Most of the above is processed because we cannot give you the account you asked for without
+        it — contract, in GDPR terms (Art. 6(1)(b)). The IP hash, the passkey metadata and the
+        session timestamps rest on our legitimate interest in detecting abuse and showing you a
+        useful device list (Art. 6(1)(f)). The security audit trail is partly a legal obligation
+        (Art. 6(1)(c), read with Art. 32). Connecting another app to your account is consent (Art.
+        6(1)(a)), and consent you can withdraw.
+      </p>
+
+      <h2>What we do not do</h2>
+      <p>
+        We do not sell your information, run advertising, or profile you for it. There is no
+        third-party analytics on this app. We do not store your passwords, because there are none.
+      </p>
+
+      <h2>Who else sees it</h2>
+      <p>
+        Other people see what you make public: your handle, display name and avatar, and whatever a
+        given app shows about you within it. Behind the service, a small number of providers process
+        data on our instructions — Cloudflare for hosting and databases, Resend for outbound email,
+        Upstash for rate-limit and session state (all of it hashed or pseudonymised), and Grafana
+        Cloud for technical telemetry. Beyond that, only where the law requires it.
+      </p>
+
+      <h2>Where it is stored</h2>
+      <p>
+        In <strong>Australia</strong>. The databases and the supporting infrastructure are hosted in
+        Sydney and the service is operated from there; some technical records are processed by
+        providers elsewhere. If you are in the EEA or the UK, this means your information is
+        transferred outside that area. Ask us and we will tell you what protections apply.
+      </p>
+
+      <h2>How long we keep it</h2>
+      <p>
+        Account and profile data while the account is live. Deleting an account leaves a tombstone
+        for 30 days, which stops your handle being taken by someone else in the meantime, and is
+        then purged. Sessions: 30 days from last use. Security events: 12 months. Email-change
+        records: 90 days.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>
+        You can ask for a copy of everything we hold about you, correct it, delete it, object to the
+        processing that rests on legitimate interests, or withdraw a consent you gave. Much of it
+        you can do yourself in Settings — revoke a session, disconnect an app, change your email,
+        delete your account. For anything else, email {email()}. We answer within a month.
+      </p>
+      <p>
+        If you are unhappy with how we have handled it, you can complain to the{" "}
+        {LEGAL_ENTITY.regulator}, or — in the EEA or the UK — to your local data protection
+        authority.
+      </p>
+
+      <h2>Changes</h2>
+      <p>
+        If this changes, the date at the top changes with it, and anything material is flagged in
+        the app before it takes effect.
+      </p>
+    </LegalDocument>
+  );
+}

--- a/osn/social/src/pages/TermsPage.tsx
+++ b/osn/social/src/pages/TermsPage.tsx
@@ -1,0 +1,111 @@
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from "@shared/legal";
+import type { JSX } from "solid-js";
+
+import { LegalDocument } from "../components/LegalDocument";
+
+/**
+ * Terms for the identity service itself, at `/terms`.
+ *
+ * `@osn/landing`'s site terms say that "creating an OSN identity and using the
+ * connected apps is governed by separate terms entered into when you sign up",
+ * and that those site terms grant no right to the service. This is the separate
+ * agreement that sentence points at.
+ */
+export function TermsPage(): JSX.Element {
+  const entity = () => (
+    <span class={LEGAL_DETAILS_PENDING ? "underline decoration-dotted" : undefined}>
+      {LEGAL_ENTITY.name}
+    </span>
+  );
+
+  return (
+    <LegalDocument title="Terms of Service" updated="2026-08-20">
+      <p>
+        These terms govern your OSN account and the identity service run by {entity()} ("we", "us").
+        Each app you use your account with may add its own terms; those cover that app, and these
+        cover the account underneath it.
+      </p>
+
+      <h2>Your account</h2>
+      <p>
+        You sign in with a passkey. Keep the device and the passkey secure — anyone holding them can
+        act as you, and we cannot tell the difference. Recovery codes exist for when you lose the
+        device; store them somewhere other than the device. You are responsible for what happens
+        under your account.
+      </p>
+      <p>
+        You may hold more than one profile under one account. Impersonating someone else, or
+        creating profiles to evade a block or a suspension, is not allowed.
+      </p>
+
+      <h2>Acceptable use</h2>
+      <ul>
+        <li>Nothing unlawful, and nothing that harasses, abuses or endangers another person.</li>
+        <li>
+          No attempt to disrupt the service, probe it, or reach it other than through the interfaces
+          we provide.
+        </li>
+        <li>No scraping profiles or the social graph, whether by hand or by machine.</li>
+        <li>No use of the service to send unsolicited bulk messages.</li>
+      </ul>
+
+      <h2>Connecting other apps</h2>
+      <p>
+        You can let another app recognise you through your OSN account. What it receives is shown to
+        you before you agree, and you can withdraw it at any time in Settings under Connected apps.
+        Once an app holds information about you, its own privacy notice governs what it does with it
+        — we can stop it receiving more, not make it forget.
+      </p>
+
+      <h2>Your content</h2>
+      <p>
+        Your handle, display name, avatar and anything else you publish stays yours. You grant us
+        only the licence needed to host and show it as part of running the service.
+      </p>
+
+      <h2>Ending it</h2>
+      <p>
+        You can delete your account at any time from Settings. We may suspend or close an account
+        that seriously or repeatedly breaks these terms, and we will tell you why unless the law
+        stops us. If we discontinue the service we will give reasonable notice and a way to take
+        your data with you.
+      </p>
+
+      <h2>Your rights as a consumer</h2>
+      <p>
+        Our services come with guarantees that cannot be excluded under the Australian Consumer Law.
+        Nothing here excludes, restricts or modifies any consumer guarantee, right or remedy you
+        have under that law or any other law that cannot lawfully be excluded. If you are reading
+        this elsewhere in the world, you keep the consumer protections of the place you live.
+      </p>
+
+      <h2>Liability</h2>
+      <p>
+        Subject to those guarantees and to the extent permitted by law, our liability in connection
+        with the service is limited to re-supplying it, and we are not liable for indirect or
+        consequential loss. We provide the service with due care and skill, but we do not promise it
+        will be uninterrupted or error-free.
+      </p>
+
+      <h2>Changes to these terms</h2>
+      <p>
+        We may update these terms. The date at the top changes when we do, anything material is
+        flagged in the app before it takes effect, and changes are not retroactive.
+      </p>
+
+      <h2>Governing law</h2>
+      <p>
+        These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>. This
+        does not take away the protections you have under the consumer laws of the place where you
+        live.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        <a class="underline" href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+          {LEGAL_ENTITY.contactEmail}
+        </a>
+      </p>
+    </LegalDocument>
+  );
+}

--- a/osn/social/tests/legal-pages.test.ts
+++ b/osn/social/tests/legal-pages.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The same hole that opened on the cire guest pages, closed where it is most
+ * likely to reopen. A legal page that hardcodes a contact address drifts
+ * silently, and the only symptom is a reader emailing an address nobody reads.
+ */
+const pages = ["PrivacyPage.tsx", "TermsPage.tsx"] as const;
+const dir = join(import.meta.dirname, "..", "src", "pages");
+
+/** Any literal address in the body. The real one arrives via LEGAL_ENTITY. */
+const LITERAL_EMAIL = /[\w.+-]+@[\w-]+\.[\w.]+/;
+
+describe.each(pages)("%s", (page) => {
+  const source = readFileSync(join(dir, page), "utf8");
+
+  it("takes the operator's identity from the shared legal module", () => {
+    expect(source).toContain("@shared/legal");
+    expect(source).toContain("LEGAL_ENTITY.contactEmail");
+  });
+
+  it("hardcodes no email address", () => {
+    expect(source.replaceAll("${LEGAL_ENTITY.contactEmail}", "")).not.toMatch(LITERAL_EMAIL);
+  });
+
+  it("publishes no repo path to the reader", () => {
+    expect(source).not.toContain("shared/legal/src/index.ts");
+  });
+});
+
+describe("PrivacyPage.tsx", () => {
+  const source = readFileSync(join(dir, "PrivacyPage.tsx"), "utf8");
+
+  /**
+   * `oauth_consents` rows are kept, marked withdrawn, until the account is
+   * deleted — the row IS the withdrawal record. The page said "deletes the
+   * grant", which is the friendlier claim and the wrong one.
+   */
+  it("does not claim a withdrawn OIDC grant is deleted", () => {
+    expect(source).not.toMatch(/deletes the grant/i);
+  });
+});

--- a/pulse/web/package.json
+++ b/pulse/web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@osn/ui": "workspace:*",
     "@pulse/api": "workspace:*",
+    "@shared/legal": "workspace:*",
     "@shared/rp-auth": "workspace:*",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.16.2",

--- a/pulse/web/src/routes/privacy.tsx
+++ b/pulse/web/src/routes/privacy.tsx
@@ -1,0 +1,120 @@
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from "@shared/legal";
+import type { JSX } from "solid-js";
+
+/**
+ * Pulse's own privacy notice, at `/privacy`.
+ *
+ * `@pulse/landing`'s notice says using the app "is governed by the OSN privacy
+ * notice shown when you sign in" — true of your account, and not true of the
+ * things Pulse holds that OSN never sees: which events you RSVP'd to, where
+ * they were, and which platform you found them through. Those are described
+ * here, and the account underneath is described in the OSN notice this page
+ * links to.
+ *
+ * Claims below come from `wiki/compliance/data-map.md` § Pulse, which lists the
+ * lawful basis and retention per field.
+ */
+export default function PrivacyRoute(): JSX.Element {
+  return (
+    <article class="mx-auto w-full max-w-2xl px-6 py-12 leading-relaxed">
+      {LEGAL_DETAILS_PENDING && (
+        <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
+          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
+          away by itself.
+        </p>
+      )}
+      <h1 class="mb-1 text-2xl font-semibold">Privacy Notice</h1>
+      <p class="text-muted-foreground mb-8 text-sm">Last updated: 2026-08-20</p>
+
+      <p>
+        This notice covers Pulse — events, RSVPs and venues. The account you sign in with belongs to
+        OSN, and{" "}
+        <a class="underline" href="https://musubi.social/privacy">
+          its own notice
+        </a>{" "}
+        covers your email, passkeys, profiles and connections. Both are published by{" "}
+        <span class={LEGAL_DETAILS_PENDING ? "underline decoration-dotted" : undefined}>
+          {LEGAL_ENTITY.name}
+        </span>
+        .
+      </p>
+
+      <h2>What Pulse holds</h2>
+      <h3>Events you create</h3>
+      <p>
+        Title, description, times, and a location — free text plus coordinates. Your profile is
+        recorded as the host. You choose who can see the event and whether attendance is visible;
+        that choice is yours to change.
+      </p>
+      <h3>Events you respond to</h3>
+      <p>
+        Whether you are going, interested, or not going. Who can see that depends on the host's
+        visibility setting, not ours.
+      </p>
+      <h3>How you found an event</h3>
+      <p>
+        When you arrive at an event through a shared link, we record the <em>platform name</em> the
+        link came from — Instagram, WhatsApp, a copied link, and so on — first time and most recent.
+        It is a platform name and nothing else: no third-party identifier, no cookie, no cross-site
+        token, and it is shown only to the organiser of that one event. You are not followed
+        anywhere off Pulse. This rests on our legitimate interest in telling organisers where their
+        audience came from; you can object, and we will remove it.
+      </p>
+      <h3>Venues and line-ups</h3>
+      <p>
+        Public venue listings — address, coordinates, website, social handle — and the billed names
+        of performers. For a sole trader, a venue listing can identify a person; it is published
+        because the business is publicly listed, and it is removed on request.
+      </p>
+      <h3>Close friends</h3>
+      <p>
+        A Pulse-only list, separate from your OSN connections, used to scope who sees what. Only
+        Pulse sees it.
+      </p>
+
+      <h2>A note on what an RSVP can reveal</h2>
+      <p>
+        Some events say something about the people at them — a health event, a religious one, a
+        political one, a Pride event. A host publishing such an event has chosen to; someone
+        RSVP'ing to it has not made anything public about themselves. We treat attendance at events
+        of that kind as protected information, ask before recording it, and honour the event's
+        visibility setting strictly. If you would rather not be listed, mark yourself interested
+        rather than going, or ask us to remove the record.
+      </p>
+
+      <h2>The legal bases</h2>
+      <p>
+        Creating and attending events is contract — you asked for the service (GDPR Art. 6(1)(b)).
+        Share attribution and public venue listings rest on legitimate interest (Art. 6(1)(f)), and
+        you can object to either. Attendance visibility and anything in the paragraph above rest on
+        your explicit consent (Art. 6(1)(a) and, where it applies, Art. 9(2)(a)).
+      </p>
+
+      <h2>What we do not do</h2>
+      <p>
+        No advertising, no third-party trackers, no selling your information, and no following you
+        around other sites. Pulse loads a map, and that is the only third-party content on it.
+      </p>
+
+      <h2>Where it is stored, and for how long</h2>
+      <p>
+        In <strong>Australia</strong>. Events and their RSVPs are kept while the event is live and
+        for 90 days after it ends, then removed; hosts can delete sooner. Host-to-attendee messages
+        are logged for 90 days. If you are in the EEA or the UK, your information is transferred
+        outside that area to Australia — ask us and we will tell you what protections apply.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>
+        Access, correction, deletion, portability, objection to the two legitimate-interest uses
+        above, and withdrawal of any consent you gave. Much of it is in the app; for the rest, email{" "}
+        <a class="underline" href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+          {LEGAL_ENTITY.contactEmail}
+        </a>
+        . We answer within a month. Complaints go to the {LEGAL_ENTITY.regulator}, or to your local
+        data protection authority if you are in the EEA or the UK.
+      </p>
+    </article>
+  );
+}

--- a/pulse/web/src/routes/privacy.tsx
+++ b/pulse/web/src/routes/privacy.tsx
@@ -19,9 +19,8 @@ export default function PrivacyRoute(): JSX.Element {
     <article class="mx-auto w-full max-w-2xl px-6 py-12 leading-relaxed">
       {LEGAL_DETAILS_PENDING && (
         <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
-          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
-          away by itself.
+          <strong>Draft</strong> — this notice is not final. Some details of the operator are still
+          to be confirmed, and this banner disappears once they are.
         </p>
       )}
       <h1 class="mb-1 text-2xl font-semibold">Privacy Notice</h1>
@@ -77,10 +76,14 @@ export default function PrivacyRoute(): JSX.Element {
       <p>
         Some events say something about the people at them — a health event, a religious one, a
         political one, a Pride event. A host publishing such an event has chosen to; someone
-        RSVP'ing to it has not made anything public about themselves. We treat attendance at events
-        of that kind as protected information, ask before recording it, and honour the event's
-        visibility setting strictly. If you would rather not be listed, mark yourself interested
-        rather than going, or ask us to remove the record.
+        RSVP'ing to it has not made anything public about themselves.
+      </p>
+      <p>
+        Today the control is the host's visibility setting, which we honour strictly, and your own
+        choice of whether to respond at all. We do not yet ask you separately before recording an
+        RSVP to an event of that kind, and we should — it is on our list. Until it exists: if you
+        would rather not be listed, mark yourself interested rather than going, or ask us to remove
+        the record and we will.
       </p>
 
       <h2>The legal bases</h2>
@@ -88,13 +91,37 @@ export default function PrivacyRoute(): JSX.Element {
         Creating and attending events is contract — you asked for the service (GDPR Art. 6(1)(b)).
         Share attribution and public venue listings rest on legitimate interest (Art. 6(1)(f)), and
         you can object to either. Attendance visibility and anything in the paragraph above rest on
-        your explicit consent (Art. 6(1)(a) and, where it applies, Art. 9(2)(a)).
+        your explicit consent (Art. 6(1)(a)). Where an RSVP would reveal something protected about
+        you, Art. 9(2)(a) is the basis we are building towards — see the note above for what stands
+        in its place today.
       </p>
+
+      <h2>Who else sees it</h2>
+      <p>
+        Behind the service, a small number of providers process data on our instructions: Cloudflare
+        for hosting and databases, Upstash for rate-limit state (hashed), and Grafana Cloud for
+        technical telemetry, which carries pseudonymised identifiers and no event content.
+      </p>
+      <p>Two third parties your browser contacts directly:</p>
+      <ul class="my-4 list-disc space-y-2 pl-6">
+        <li>
+          <strong>OpenStreetMap</strong> — map tiles. Opening a page with a map sends your IP
+          address to the OpenStreetMap Foundation's tile servers, because that is what fetching a
+          tile is.
+        </li>
+        <li>
+          <strong>Komoot (Photon)</strong> — address autocomplete. While you type an address into an
+          event, what you have typed so far goes to Komoot's geocoder in Germany, with your IP. It
+          fires as you type rather than when you submit, and it is not currently behind a consent
+          gate. We are moving it behind our own server and a gate; until then it is stated here
+          rather than left for you to find in a network log.
+        </li>
+      </ul>
 
       <h2>What we do not do</h2>
       <p>
         No advertising, no third-party trackers, no selling your information, and no following you
-        around other sites. Pulse loads a map, and that is the only third-party content on it.
+        around other sites.
       </p>
 
       <h2>Where it is stored, and for how long</h2>

--- a/pulse/web/src/routes/terms.tsx
+++ b/pulse/web/src/routes/terms.tsx
@@ -11,9 +11,8 @@ export default function TermsRoute(): JSX.Element {
     <article class="mx-auto w-full max-w-2xl px-6 py-12 leading-relaxed">
       {LEGAL_DETAILS_PENDING && (
         <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
-          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
-          away by itself.
+          <strong>Draft</strong> — this notice is not final. Some details of the operator are still
+          to be confirmed, and this banner disappears once they are.
         </p>
       )}
       <h1 class="mb-1 text-2xl font-semibold">Terms of Service</h1>

--- a/pulse/web/src/routes/terms.tsx
+++ b/pulse/web/src/routes/terms.tsx
@@ -1,0 +1,113 @@
+import { LEGAL_ENTITY, LEGAL_DETAILS_PENDING } from "@shared/legal";
+import type { JSX } from "solid-js";
+
+/**
+ * Pulse's own terms, at `/terms`. The account underneath is governed by the OSN
+ * terms; these cover what you do with it here — hosting events, RSVP'ing, and
+ * what you may put in an event listing.
+ */
+export default function TermsRoute(): JSX.Element {
+  return (
+    <article class="mx-auto w-full max-w-2xl px-6 py-12 leading-relaxed">
+      {LEGAL_DETAILS_PENDING && (
+        <p class="mb-8 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <strong>Draft</strong> — the operator's own details are not filled in yet, so this page is
+          not final. Fill them in at <code>shared/legal/src/index.ts</code> and this banner goes
+          away by itself.
+        </p>
+      )}
+      <h1 class="mb-1 text-2xl font-semibold">Terms of Service</h1>
+      <p class="text-muted-foreground mb-8 text-sm">Last updated: 2026-08-20</p>
+
+      <p>
+        These terms cover Pulse, operated by{" "}
+        <span class={LEGAL_DETAILS_PENDING ? "underline decoration-dotted" : undefined}>
+          {LEGAL_ENTITY.name}
+        </span>
+        . Your account itself is governed by the{" "}
+        <a class="underline" href="https://musubi.social/terms">
+          OSN terms
+        </a>
+        , which you accepted when you created it.
+      </p>
+
+      <h2>Hosting an event</h2>
+      <p>
+        You are responsible for what you publish — the description, the imagery, the venue, the
+        line-up, and for having the right to use all of it. Don't list an event you have no part in
+        organising, and don't name a venue or a performer who has not agreed to appear.
+      </p>
+      <p>
+        You are also responsible for the event itself. Pulse lists events; it does not run them, vet
+        them, or stand behind them.
+      </p>
+
+      <h2>Attending an event</h2>
+      <p>
+        An RSVP is a signal to the host, not a ticket or a contract with us. What the host can see
+        about your response depends on the visibility they set, which is shown to you before you
+        respond.
+      </p>
+
+      <h2>Acceptable use</h2>
+      <ul>
+        <li>
+          Nothing unlawful, and nothing that harasses, endangers or discriminates against anyone.
+        </li>
+        <li>No events that exist to mislead — fake listings, fake venues, fake line-ups.</li>
+        <li>No scraping events, attendees or venues, by hand or by machine.</li>
+        <li>
+          No attempt to disrupt the service or reach it other than through the interfaces we
+          provide.
+        </li>
+      </ul>
+
+      <h2>Your content</h2>
+      <p>
+        Event listings stay yours. You grant us the licence needed to host and display them —
+        including in discovery, in search, and on a public event page if you made the event public.
+      </p>
+
+      <h2>Moderation</h2>
+      <p>
+        We may remove an event or suspend an account that breaks these terms, and we will say why
+        unless the law stops us. If you think we got it wrong, reply and tell us.
+      </p>
+
+      <h2>Your rights as a consumer</h2>
+      <p>
+        Our services come with guarantees that cannot be excluded under the Australian Consumer Law.
+        Nothing here excludes, restricts or modifies any consumer guarantee, right or remedy you
+        have under that law or any other law that cannot lawfully be excluded. If you are reading
+        this elsewhere in the world, you keep the consumer protections of the place you live.
+      </p>
+
+      <h2>Liability</h2>
+      <p>
+        Subject to those guarantees and to the extent permitted by law, our liability is limited to
+        re-supplying the service, and we are not liable for indirect or consequential loss —
+        including anything that happens at an event you found here.
+      </p>
+
+      <h2>Changes</h2>
+      <p>
+        We may update these terms. The date at the top changes when we do, and changes are not
+        retroactive.
+      </p>
+
+      <h2>Governing law</h2>
+      <p>
+        These terms are governed by the laws of <strong>{LEGAL_ENTITY.governingLaw}</strong>. This
+        does not take away the protections you have under the consumer laws of the place where you
+        live.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        <a class="underline" href={`mailto:${LEGAL_ENTITY.contactEmail}`}>
+          {LEGAL_ENTITY.contactEmail}
+        </a>
+      </p>
+    </article>
+  );
+}

--- a/pulse/web/tests/routes/legal-pages.test.ts
+++ b/pulse/web/tests/routes/legal-pages.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The same hole that opened on the cire guest pages, closed where it is most
+ * likely to reopen: a legal page that hardcodes a contact address instead of
+ * taking it from the shared module drifts silently, and the only symptom is a
+ * reader emailing an address nobody reads.
+ */
+const routes = ["privacy.tsx", "terms.tsx"] as const;
+const dir = join(import.meta.dirname, "..", "..", "src", "routes");
+
+/** Any literal address in the body. The real one arrives via LEGAL_ENTITY. */
+const LITERAL_EMAIL = /[\w.+-]+@[\w-]+\.[\w.]+/;
+
+describe.each(routes)("%s", (route) => {
+  const source = readFileSync(join(dir, route), "utf8");
+
+  it("takes the operator's identity from the shared legal module", () => {
+    expect(source).toContain("@shared/legal");
+    expect(source).toContain("LEGAL_ENTITY.contactEmail");
+  });
+
+  it("hardcodes no email address", () => {
+    // Strip the mailto template that renders LEGAL_ENTITY.contactEmail itself.
+    expect(source.replaceAll("${LEGAL_ENTITY.contactEmail}", "")).not.toMatch(LITERAL_EMAIL);
+  });
+
+  it("publishes no repo path to the reader", () => {
+    expect(source).not.toContain("shared/legal/src/index.ts");
+  });
+});
+
+describe("privacy.tsx", () => {
+  const source = readFileSync(join(dir, "privacy.tsx"), "utf8");
+
+  /**
+   * Both fire from the browser, so both are disclosures the reader is owed.
+   * The notice claimed the map was the only third-party content; Photon had
+   * been sending keystrokes to Komoot the whole time.
+   */
+  it("names the third parties the browser contacts directly", () => {
+    expect(source).toContain("OpenStreetMap");
+    expect(source).toContain("Komoot");
+  });
+
+  /**
+   * `wiki/compliance/data-map.md` asks for an explicit consent banner on RSVPs
+   * to sensitive-category events. It does not exist yet, and the notice must not
+   * claim it does. Delete this test when the ask ships — and change the copy.
+   */
+  it("does not claim a consent ask that pulse has not built", () => {
+    expect(source).not.toMatch(/ask before recording it/i);
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #737. Three published notices point at legal pages that do not exist:

- `@osn/landing` — *"covers visitors to this site only"*, and *"the OSN identity
  service and each connected app publish their own, separate privacy notices"*.
- `@pulse/landing` — using the app *"is governed by the OSN privacy notice shown
  when you sign in"*.

None of those notices existed. Neither app carried a legal page, or a link to
one, while holding email addresses, passkeys, sessions, the social graph, OIDC
grants, events, RSVPs and location. Both now serve `/privacy` and `/terms`.

## Workspaces affected

`@osn/social`, `@pulse/web`, `@cire/landing`. Two changesets — `@cire/landing` is
version-less and cannot share a file with the versioned two.

## Issues

**Closes**

| Issue | What |
|---|---|
| — | None — found by the audit in #737. |

**Opened**

| Issue | What |
|---|---|
| — | None yet; the link-placement gap under Out of scope needs your call first. |

## Decisions

### The notices are derived from the data map, not drafted fresh — `approach`

- **Issue** — a privacy notice written from scratch agrees with the code on the
  day it ships and drifts from then on.
- **Solution** — every claim comes from `wiki/compliance/data-map.md`, which
  already carried the lawful basis and retention per field. Where it says
  `Art. 6(1)(f)`, the page says legitimate interest and offers the objection;
  where it says 30-day sliding, the page says 30 days from last use.
- **Rationale** — the data map is maintained as part of shipping features, so it
  is the thing least likely to be wrong. A file header on each page says this, so
  the next person updates the map and these together.

### Two balancing tests are now readable by the people they are about — `approach`

- **Issue** — both lived only in the data map's balancing notes.
- **Solution** —
  - Pulse's **share attribution** stores a *platform name* and nothing else: no
    third-party identifier, no cookie, no cross-site token, visible only to that
    one event's organiser, on a legitimate-interest basis the attendee can object
    to.
  - **Attending an event can reveal something protected about you** even when the
    host published it freely. `Art. 9(2)(e)` — manifestly made public — covers the
    *host*, who chose to publish. It does not cover the *attendee*, who did not.
    The notice says attendance at events of that kind is treated as needing
    consent.
- **Rationale** — a balancing test the data subject cannot read is not much of a
  balancing test.

### Both routes render signed-out — `approach`

- **Solution** — `/privacy` and `/terms` are outside any auth gate in both apps.
- **Rationale** — a notice you can only read once you have already handed over
  your data is not a notice.

### `cire/landing`'s scope sentence now names the vendor portal — `approach`

- **Issue** — it listed the marketing site, the invitation site and the organiser
  portal. The vendor portal is a fourth surface on the same service.
- **Rationale** — `cire/host` and `cire/vendor` genuinely are covered by that
  notice; they were missing from the sentence, not from the coverage.

**Out of scope**

- **Neither app has a footer**, so there is nowhere established to link these
  from. Both pages are reachable by URL and cross-link each other. Where a
  persistent link belongs is a UI decision, not a legal one, and inventing chrome
  inside a legal PR is how a legal PR stops being reviewable. Worth filing once
  you've decided — my suggestion would be the existing Settings page in each app
  plus the OIDC consent screen, which is exactly where someone is being asked to
  agree to something.
- `cire/host` and `cire/vendor` still carry no link to the cire notices that
  cover them, for the same reason.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1357 files |
| `bun run test` | ✅ 33/33 packages |
| `bun run --cwd osn/social build` | ✅ |
| `bun run --cwd pulse/web build` | ✅ |

Not verified: nobody has loaded either route in a browser. They are new routes in
two SPAs and both builds pass, but the rendered look is unchecked — worth a glance
on the previews.

Not verified, and more important: **no lawyer has read any of this.** It is an
engineering pass that makes the published claims match what the code does. That is
a necessary condition for these being correct, not a sufficient one.
