### PR TITLE
fix(cire/db): seed the dev tier's budget, checklist and registry

### DIFF
--- a/.changeset/cire-dev-seed-planning-modules.md
+++ b/.changeset/cire-dev-seed-planning-modules.md
@@ -1,0 +1,28 @@
+---
+"@cire/db": patch
+---
+
+Seed the dev tier's planning modules, and let the dev seed hand the sample
+wedding to a real account.
+
+Budget, Checklist and Registry all shipped after the seed was written, so a dev
+tier rendered every one of them empty — no budget lines, no payment schedule, no
+checklist, no gift list and a guest registry that 404s because `published` was
+never set. Nothing could be tested there without hand-typing rows that the next
+`cire_api` deploy wiped.
+
+- `@cire/db`: three new seed-data modules — `budget.ts` (14 lines across the
+  service categories plus 10 payments, split between settled and outstanding;
+  estimates land just under the wedding's budget total), `tasks.ts` (18 checklist
+  tasks across all eight lead-time buckets, some already done) and `registry.ts`
+  (a published settings row, 10 items and 3 claims covering
+  purchased-and-thanked, purchased-not-thanked and still-reserved). Registry
+  images stay NULL — an R2 key with no bytes renders broken — and item links
+  point at `example.com` rather than live retailers.
+- `scripts/cire-db-seed.sh`: apply `CIRE_DEV_OWNER_PROFILE_ID` on the dev target
+  too, not just locally. The seed owns the wedding as `usr_dev_bootstrap_owner`,
+  an id no account holds, so the dev tier's sample wedding — guests, events and
+  the comped `registry`/`vendors` entitlements — was invisible to anyone signing
+  in to test it.
+- CI: the dev seed step passes `vars.CIRE_DEV_OWNER_PROFILE_ID` through. Set that
+  variable on the `dev` environment; unset, the seed says so and carries on.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,8 +242,19 @@ jobs:
       - name: Replay cire D1 migrations from zero (dev)
         run: bun run --cwd cire/db db:migrate:dev
 
+      # CIRE_DEV_OWNER_PROFILE_ID repoints the seeded wedding at a real dev
+      # account. The seed owns it as `usr_dev_bootstrap_owner`, an id no account
+      # holds, so without this the sample wedding — its guests, its events and
+      # its comped entitlements (registry, vendors, AI) — is invisible to
+      # everyone signing in to test, and this job resets the tier on every
+      # cire_api change, wiping any wedding a tester made by hand. It is a
+      # VARIABLE, not a secret: an OSN profile id is not a credential, and a
+      # masked value would only make the seed log unreadable. Unset, the seed
+      # says so and carries on.
       - name: Seed the dev D1
         run: bun run --cwd cire/db db:seed:dev
+        env:
+          CIRE_DEV_OWNER_PROFILE_ID: ${{ vars.CIRE_DEV_OWNER_PROFILE_ID }}
 
       - name: Deploy cire/api Worker (dev)
         run: bunx wrangler deploy --env dev

--- a/cire/db/seed/data/budget.ts
+++ b/cire/db/seed/data/budget.ts
@@ -1,0 +1,213 @@
+// Budget lines + payments on the sample wedding. Consumed only by
+// cire/db/seed/generate.ts.
+//
+// The Budget module shipped after this seed was first written, so a dev tier
+// carried the whole surface with nothing in it: no categories, no totals, no
+// payment schedule, and an Overview spend meter permanently at zero. Every read
+// path below the list (category grouping, the estimate/quote/actual columns, the
+// paid-vs-outstanding split, the over-budget tone on the meter) needs rows
+// before it shows anything at all.
+//
+// All amounts are MINOR units of the wedding's currency (AUD — see
+// wedding.ts). The estimates sum to A$99,450, just under the wedding's
+// A$100,000 `budget_total_minor`, so the meter renders its normal state; nudge
+// one line up if you want to exercise the `over` tone.
+//
+// `category` is a key from cire/api/src/lib/service-categories.ts — the closed
+// set the Budget HTTP schema validates against. A key that is not on that list
+// seeds fine and then fails every write the organiser attempts against the row.
+
+export type SeedPayment = {
+  readonly id: string;
+  readonly label: string;
+  readonly amountMinor: number;
+  /** ISO date (YYYY-MM-DD) the payment is due, or null for one already settled. */
+  readonly dueAt: string | null;
+  /** Days before seed time this was paid; null while outstanding. */
+  readonly paidDaysAgo: number | null;
+};
+
+export type SeedBudgetItem = {
+  readonly id: string;
+  readonly category: string;
+  readonly name: string;
+  readonly estimateMinor: number | null;
+  readonly quotedMinor: number | null;
+  readonly actualMinor: number | null;
+  readonly notes: string | null;
+  readonly payments: readonly SeedPayment[];
+};
+
+// Ids are fixed UUIDs in the shape the app writes, so dev links to a budget line
+// survive a reseed.
+const item = (n: number): string => `bud_e2a1c0d4-0000-4000-8000-${String(n).padStart(12, "0")}`;
+const pay = (n: number): string => `pay_e2a1c0d4-0000-4000-8000-${String(n).padStart(12, "0")}`;
+
+export const budgetItems = [
+  {
+    id: item(1),
+    category: "venue",
+    name: "Reception venue",
+    estimateMinor: 3_200_000,
+    quotedMinor: 3_450_000,
+    actualMinor: null,
+    notes: "Quote came in over the estimate — minimum spend on a Saturday.",
+    payments: [
+      { id: pay(1), label: "Deposit", amountMinor: 690_000, dueAt: null, paidDaysAgo: 120 },
+      {
+        id: pay(2),
+        label: "Balance",
+        amountMinor: 2_760_000,
+        dueAt: "2026-10-25",
+        paidDaysAgo: null,
+      },
+    ],
+  },
+  {
+    id: item(2),
+    category: "catering",
+    name: "Dinner and canapés",
+    estimateMinor: 2_800_000,
+    quotedMinor: 2_940_000,
+    actualMinor: null,
+    notes: "Per head, 560 guests. Final numbers due with the balance.",
+    payments: [
+      { id: pay(3), label: "Deposit", amountMinor: 588_000, dueAt: null, paidDaysAgo: 90 },
+      {
+        id: pay(4),
+        label: "Balance",
+        amountMinor: 2_352_000,
+        dueAt: "2026-11-10",
+        paidDaysAgo: null,
+      },
+    ],
+  },
+  {
+    id: item(3),
+    category: "photography",
+    name: "Photographer — full day",
+    estimateMinor: 650_000,
+    quotedMinor: 620_000,
+    actualMinor: 620_000,
+    notes: null,
+    payments: [
+      { id: pay(5), label: "Deposit", amountMinor: 200_000, dueAt: null, paidDaysAgo: 150 },
+      { id: pay(6), label: "Balance", amountMinor: 420_000, dueAt: null, paidDaysAgo: 10 },
+    ],
+  },
+  {
+    id: item(4),
+    category: "videography",
+    name: "Videographer — ceremony and speeches",
+    estimateMinor: 450_000,
+    quotedMinor: null,
+    actualMinor: null,
+    notes: "Two quotes outstanding.",
+    payments: [],
+  },
+  {
+    id: item(5),
+    category: "decor_styling",
+    name: "Styling and lighting",
+    estimateMinor: 420_000,
+    quotedMinor: 445_000,
+    actualMinor: null,
+    notes: null,
+    payments: [],
+  },
+  {
+    id: item(6),
+    category: "florals",
+    name: "Mandap and table florals",
+    estimateMinor: 380_000,
+    quotedMinor: 412_000,
+    actualMinor: null,
+    notes: null,
+    payments: [],
+  },
+  {
+    id: item(7),
+    category: "music_entertainment",
+    name: "DJ and dhol players",
+    estimateMinor: 300_000,
+    quotedMinor: 285_000,
+    actualMinor: 285_000,
+    notes: null,
+    payments: [
+      { id: pay(7), label: "Full fee", amountMinor: 285_000, dueAt: null, paidDaysAgo: 30 },
+    ],
+  },
+  {
+    id: item(8),
+    category: "celebrant",
+    name: "Celebrant",
+    estimateMinor: 90_000,
+    quotedMinor: 90_000,
+    actualMinor: null,
+    notes: null,
+    payments: [
+      { id: pay(8), label: "Booking fee", amountMinor: 30_000, dueAt: null, paidDaysAgo: 200 },
+      { id: pay(9), label: "Balance", amountMinor: 60_000, dueAt: "2026-11-20", paidDaysAgo: null },
+    ],
+  },
+  {
+    id: item(9),
+    category: "cake",
+    name: "Three-tier cake",
+    estimateMinor: 120_000,
+    quotedMinor: null,
+    actualMinor: null,
+    notes: null,
+    payments: [],
+  },
+  {
+    id: item(10),
+    category: "stationery",
+    name: "Invitations and signage",
+    estimateMinor: 95_000,
+    quotedMinor: 88_000,
+    actualMinor: 88_000,
+    notes: null,
+    payments: [],
+  },
+  {
+    id: item(11),
+    category: "hair_makeup",
+    name: "Hair and makeup, both sides",
+    estimateMinor: 260_000,
+    quotedMinor: 275_000,
+    actualMinor: null,
+    notes: null,
+    payments: [{ id: pay(10), label: "Trial", amountMinor: 45_000, dueAt: null, paidDaysAgo: 20 }],
+  },
+  {
+    id: item(12),
+    category: "transport",
+    name: "Guest coaches and the car",
+    estimateMinor: 180_000,
+    quotedMinor: null,
+    actualMinor: null,
+    notes: null,
+    payments: [],
+  },
+  {
+    id: item(13),
+    category: "attire",
+    name: "Outfits and jewellery",
+    estimateMinor: 700_000,
+    quotedMinor: null,
+    actualMinor: 760_000,
+    notes: "Came in over — the second outfit was not in the estimate.",
+    payments: [],
+  },
+  {
+    id: item(14),
+    category: "other",
+    name: "Contingency",
+    estimateMinor: 300_000,
+    quotedMinor: null,
+    actualMinor: null,
+    notes: null,
+    payments: [],
+  },
+] as const satisfies readonly SeedBudgetItem[];

--- a/cire/db/seed/data/index.ts
+++ b/cire/db/seed/data/index.ts
@@ -1,3 +1,5 @@
+export { budgetItems } from "./budget";
+export type { SeedBudgetItem, SeedPayment } from "./budget";
 export { customisation } from "./customisations";
 export type { SeedCustomisation } from "./customisations";
 export { entitlements } from "./entitlements";
@@ -9,6 +11,10 @@ export type { SeedFamily, SeedGuest } from "./guests";
 export { syntheticFamilies, syntheticRsvps } from "./households";
 export { hosts } from "./hosts";
 export type { SeedHost } from "./hosts";
+export { registryClaims, registryItems, registrySettings } from "./registry";
+export type { SeedRegistryClaim, SeedRegistryItem, SeedRegistrySettings } from "./registry";
 export { DIETARY_CONSENT_VERSION, rsvps } from "./rsvps";
 export type { SeedRsvp } from "./rsvps";
+export { tasks } from "./tasks";
+export type { SeedTask } from "./tasks";
 export { bootstrapWedding, DEV_OWNER_PROFILE_ID } from "./wedding";

--- a/cire/db/seed/data/registry.ts
+++ b/cire/db/seed/data/registry.ts
@@ -1,0 +1,218 @@
+// The gift registry on the sample wedding — settings, items, claims. Consumed
+// only by cire/db/seed/generate.ts.
+//
+// The registry is the one module gated by an entitlement no production wedding
+// holds (see entitlements.ts), so the dev tier is the ONLY place it can be
+// exercised end to end. It shipped with no seed data, which left the unlocked
+// module as empty as the locked one: no list, no gift log, no claimed/purchased
+// states, and a guest-side registry that 404s because `published` was never set.
+//
+// Prices are MINOR units of the wedding's currency (AUD — see wedding.ts).
+//
+// `image_key` is NULL on every item on purpose. It is an R2 object key, not a
+// URL, so a key with no bytes behind it renders a broken image on both the
+// organiser list and the guest site; the images that DO exist on a dev bucket
+// are the invite assets uploaded by `assets:seed:dev`, and none of them is a
+// gift. The link-preview path fills this column in normally when an organiser
+// pastes a URL.
+//
+// `external_url` points at example.com rather than a real retailer: the column
+// is rendered into an `<a href>` on the guest site, and seeding live third-party
+// links would put URLs in front of testers that rot, redirect, or track. The
+// hrefs are stored in the same normal form the write path produces (URL.href).
+
+export type SeedRegistrySettings = {
+  readonly published: boolean;
+  readonly headline: string;
+  readonly message: string;
+  readonly cashGiftsEnabled: boolean;
+  readonly shippingAddress: string;
+  /** ISO date (YYYY-MM-DD) before which the address stays hidden; null ⇒ visible. */
+  readonly shippingVisibleFrom: string | null;
+};
+
+export type SeedRegistryItem = {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly externalUrl: string | null;
+  readonly priceMinor: number | null;
+  readonly quantityWanted: number;
+  readonly category: string | null;
+  readonly sortOrder: number;
+};
+
+export type SeedRegistryClaim = {
+  readonly id: string;
+  readonly itemId: string;
+  /** A canonical seeded household — see guests.ts. */
+  readonly familyId: string;
+  readonly quantity: number;
+  readonly status: "reserved" | "purchased";
+  readonly note: string | null;
+  readonly displayName: string | null;
+  /** Days before seed time the couple sent thanks; null ⇒ not thanked yet. */
+  readonly thankedDaysAgo: number | null;
+  /** Days before seed time the claim was made. */
+  readonly daysAgo: number;
+};
+
+// `published` is on so the guest-side registry actually answers on dev. It is a
+// second, independent gate from the entitlement: both must hold, so leaving this
+// off would 404 the guest page on a wedding that holds the comp.
+export const registrySettings = {
+  published: true,
+  headline: "Our registry",
+  message:
+    "Your being there is the gift — but if you'd like to mark the day with something, here is our list.",
+  cashGiftsEnabled: false,
+  shippingAddress: "12 Wharf Road, Birchgrove NSW 2041",
+  shippingVisibleFrom: null,
+} as const satisfies SeedRegistrySettings;
+
+const item = (n: number): string => `reg_c4b8a2f1-0000-4000-8000-${String(n).padStart(12, "0")}`;
+
+export const registryItems = [
+  {
+    id: item(1),
+    title: "Cast-iron casserole, 26cm",
+    description: "Anything oven-to-table. Blue if there's a choice.",
+    externalUrl: "https://example.com/kitchen/cast-iron-casserole",
+    priceMinor: 45_000,
+    quantityWanted: 1,
+    category: "Kitchen",
+    sortOrder: 0,
+  },
+  {
+    id: item(2),
+    title: "Stand mixer",
+    description: null,
+    externalUrl: "https://example.com/kitchen/stand-mixer",
+    priceMinor: 79_900,
+    quantityWanted: 1,
+    category: "Kitchen",
+    sortOrder: 1,
+  },
+  {
+    id: item(3),
+    title: "Espresso machine",
+    description: "The one gift that gets used every single morning.",
+    externalUrl: "https://example.com/kitchen/espresso-machine",
+    priceMinor: 129_900,
+    quantityWanted: 1,
+    category: "Kitchen",
+    sortOrder: 2,
+  },
+  {
+    id: item(4),
+    title: "Wine glasses, set of six",
+    description: "Two sets would not go astray.",
+    externalUrl: "https://example.com/table/wine-glasses",
+    priceMinor: 12_000,
+    quantityWanted: 2,
+    category: "Table",
+    sortOrder: 3,
+  },
+  {
+    id: item(5),
+    title: "Cutlery set, 24 piece",
+    description: null,
+    externalUrl: "https://example.com/table/cutlery-set",
+    priceMinor: 34_900,
+    quantityWanted: 1,
+    category: "Table",
+    sortOrder: 4,
+  },
+  {
+    id: item(6),
+    title: "Hand-thrown serving platter",
+    description: "Made in Bowral, so no two are the same.",
+    externalUrl: "https://example.com/table/serving-platter",
+    priceMinor: 18_000,
+    quantityWanted: 1,
+    category: "Table",
+    sortOrder: 5,
+  },
+  {
+    id: item(7),
+    title: "Linen bedding set, queen",
+    description: null,
+    externalUrl: "https://example.com/home/linen-bedding",
+    priceMinor: 39_900,
+    quantityWanted: 1,
+    category: "Home",
+    sortOrder: 6,
+  },
+  {
+    id: item(8),
+    title: "Wool throw",
+    description: null,
+    externalUrl: "https://example.com/home/wool-throw",
+    priceMinor: 24_900,
+    quantityWanted: 2,
+    category: "Home",
+    sortOrder: 7,
+  },
+  {
+    id: item(9),
+    title: "Picnic hamper",
+    description: "For the drive up the coast afterwards.",
+    externalUrl: "https://example.com/outdoors/picnic-hamper",
+    priceMinor: 15_900,
+    quantityWanted: 1,
+    category: "Outdoors",
+    sortOrder: 8,
+  },
+  {
+    // Deliberately price-free: the column is nullable and the list, the guest
+    // page and the gift log all have to render a line with no number on it.
+    id: item(10),
+    title: "A recipe you actually cook",
+    description: "Written out, in your handwriting. That's the whole gift.",
+    externalUrl: null,
+    priceMinor: null,
+    quantityWanted: 1,
+    category: null,
+    sortOrder: 9,
+  },
+] as const satisfies readonly SeedRegistryItem[];
+
+// Three claims across the canonical households (guests.ts), covering every
+// state the gift log branches on: purchased-and-thanked, purchased-not-yet-
+// thanked, and a reservation that is still just a reservation. The two-wanted
+// items are claimed once, so the "1 of 2 left" arithmetic has something to show.
+export const registryClaims = [
+  {
+    id: "rgc_c4b8a2f1-0000-4000-8000-000000000001",
+    itemId: item(3),
+    familyId: "a0000000-0000-4000-8000-000000000001",
+    quantity: 1,
+    status: "purchased",
+    note: "Ordered — it should land the week before.",
+    displayName: "The Testfamilys",
+    thankedDaysAgo: 3,
+    daysAgo: 21,
+  },
+  {
+    id: "rgc_c4b8a2f1-0000-4000-8000-000000000002",
+    itemId: item(4),
+    familyId: "a0000000-0000-4000-8000-000000000002",
+    quantity: 1,
+    status: "purchased",
+    note: null,
+    displayName: null,
+    thankedDaysAgo: null,
+    daysAgo: 14,
+  },
+  {
+    id: "rgc_c4b8a2f1-0000-4000-8000-000000000003",
+    itemId: item(8),
+    familyId: "a0000000-0000-4000-8000-000000000003",
+    quantity: 1,
+    status: "reserved",
+    note: "Hope the colour's right.",
+    displayName: "Auntie Ros",
+    thankedDaysAgo: null,
+    daysAgo: 6,
+  },
+] as const satisfies readonly SeedRegistryClaim[];

--- a/cire/db/seed/data/tasks.ts
+++ b/cire/db/seed/data/tasks.ts
@@ -1,0 +1,218 @@
+// Checklist tasks on the sample wedding. Consumed only by
+// cire/db/seed/generate.ts.
+//
+// Same gap as budget.ts and registry.ts: the Checklist module shipped after this
+// seed was written, so a dev tier rendered eight empty lead-time buckets. The
+// list is bucket-ordered and drag-reorderable within a bucket, and neither of
+// those has anything to exercise it at zero rows.
+//
+// `timeframeBucket` is a key from cire/api/src/lib/checklist-buckets.ts — the
+// closed set the tasks HTTP schema validates against. Buckets run furthest-out
+// first (12m → day_of); `sortOrder` orders WITHIN a bucket and starts at 0 for
+// each one, which is what the reorder endpoint rewrites.
+
+export type SeedTask = {
+  readonly id: string;
+  readonly title: string;
+  readonly notes: string | null;
+  readonly timeframeBucket: "12m" | "9m" | "6m" | "3m" | "1m" | "2w" | "week_of" | "day_of";
+  /** Optional ISO date (YYYY-MM-DD), independent of the bucket. */
+  readonly dueAt: string | null;
+  readonly status: "open" | "done";
+  readonly sortOrder: number;
+  /** Days before seed time it was ticked off; null while open. */
+  readonly completedDaysAgo: number | null;
+};
+
+const task = (n: number): string => `tsk_f7d3b1e0-0000-4000-8000-${String(n).padStart(12, "0")}`;
+
+export const tasks = [
+  // 12+ months out — the early, mostly-done end of the list.
+  {
+    id: task(1),
+    title: "Set the date and the guest-count ceiling",
+    notes: null,
+    timeframeBucket: "12m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 0,
+    completedDaysAgo: 240,
+  },
+  {
+    id: task(2),
+    title: "Book the reception venue",
+    notes: "Deposit paid — see the Venue line in Budget.",
+    timeframeBucket: "12m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 1,
+    completedDaysAgo: 210,
+  },
+  {
+    id: task(3),
+    title: "Book the celebrant",
+    notes: null,
+    timeframeBucket: "12m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 2,
+    completedDaysAgo: 200,
+  },
+  // 9 months out
+  {
+    id: task(4),
+    title: "Book the photographer",
+    notes: null,
+    timeframeBucket: "9m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 0,
+    completedDaysAgo: 150,
+  },
+  {
+    id: task(5),
+    title: "Choose a videographer",
+    notes: "Two quotes still outstanding.",
+    timeframeBucket: "9m",
+    dueAt: null,
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+  // 6 months out
+  {
+    id: task(6),
+    title: "Send the invitations",
+    notes: null,
+    timeframeBucket: "6m",
+    dueAt: "2026-08-30",
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(7),
+    title: "Book hair and makeup trials",
+    notes: null,
+    timeframeBucket: "6m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 1,
+    completedDaysAgo: 20,
+  },
+  {
+    id: task(8),
+    title: "Open the gift registry",
+    notes: null,
+    timeframeBucket: "6m",
+    dueAt: null,
+    status: "done",
+    sortOrder: 2,
+    completedDaysAgo: 28,
+  },
+  // 3 months out
+  {
+    id: task(9),
+    title: "Confirm the catering menu",
+    notes: "Final head count goes with the balance payment.",
+    timeframeBucket: "3m",
+    dueAt: "2026-09-15",
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(10),
+    title: "Order the cake",
+    notes: null,
+    timeframeBucket: "3m",
+    dueAt: null,
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+  // 1 month out
+  {
+    id: task(11),
+    title: "Chase the households who haven't replied",
+    notes: null,
+    timeframeBucket: "1m",
+    dueAt: "2026-10-25",
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(12),
+    title: "Book the guest coaches",
+    notes: null,
+    timeframeBucket: "1m",
+    dueAt: null,
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+  // 2 weeks out
+  {
+    id: task(13),
+    title: "Send the run sheet to every supplier",
+    notes: null,
+    timeframeBucket: "2w",
+    dueAt: "2026-11-11",
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(14),
+    title: "Pay the outstanding balances",
+    notes: "Venue, catering and the celebrant — all in Budget.",
+    timeframeBucket: "2w",
+    dueAt: "2026-11-10",
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+  // Week of
+  {
+    id: task(15),
+    title: "Final head count to the caterer",
+    notes: null,
+    timeframeBucket: "week_of",
+    dueAt: "2026-11-20",
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(16),
+    title: "Print the seating chart and the signage",
+    notes: null,
+    timeframeBucket: "week_of",
+    dueAt: null,
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+  // Day of
+  {
+    id: task(17),
+    title: "Hand the rings to the best man",
+    notes: null,
+    timeframeBucket: "day_of",
+    dueAt: null,
+    status: "open",
+    sortOrder: 0,
+    completedDaysAgo: null,
+  },
+  {
+    id: task(18),
+    title: "Pack the emergency kit",
+    notes: "Safety pins, plasters, a phone charger, painkillers.",
+    timeframeBucket: "day_of",
+    dueAt: null,
+    status: "open",
+    sortOrder: 1,
+    completedDaysAgo: null,
+  },
+] as const satisfies readonly SeedTask[];

--- a/cire/db/seed/dev-seed.sql
+++ b/cire/db/seed/dev-seed.sql
@@ -198,6 +198,320 @@ INSERT OR IGNORE INTO wedding_entitlements (wedding_id, entitlement, source, gra
   ('wed_bootstrap', 'vendors', 'comp', unixepoch(), 'dev-seed', NULL);
 
 -- ────────────────────────────────────────────────────────────────────────────
+-- Budget lines (14) — estimates, quotes, actuals
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- `category` is a key from cire/api/src/lib/service-categories.ts; the Budget
+-- HTTP schema validates writes against that same list, so a category invented
+-- here would seed a row the organiser can read but never save.
+INSERT OR IGNORE INTO budget_items (
+  id, wedding_id, category, name,
+  estimate_minor, quoted_minor, actual_minor,
+  notes, sort_order, created_at, updated_at
+) VALUES
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000001', 'wed_bootstrap', 'venue', 'Reception venue',
+    3200000, 3450000, NULL,
+    'Quote came in over the estimate — minimum spend on a Saturday.', 0, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000002', 'wed_bootstrap', 'catering', 'Dinner and canapés',
+    2800000, 2940000, NULL,
+    'Per head, 560 guests. Final numbers due with the balance.', 1, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000003', 'wed_bootstrap', 'photography', 'Photographer — full day',
+    650000, 620000, 620000,
+    NULL, 2, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000004', 'wed_bootstrap', 'videography', 'Videographer — ceremony and speeches',
+    450000, NULL, NULL,
+    'Two quotes outstanding.', 3, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000005', 'wed_bootstrap', 'decor_styling', 'Styling and lighting',
+    420000, 445000, NULL,
+    NULL, 4, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000006', 'wed_bootstrap', 'florals', 'Mandap and table florals',
+    380000, 412000, NULL,
+    NULL, 5, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000007', 'wed_bootstrap', 'music_entertainment', 'DJ and dhol players',
+    300000, 285000, 285000,
+    NULL, 6, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000008', 'wed_bootstrap', 'celebrant', 'Celebrant',
+    90000, 90000, NULL,
+    NULL, 7, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000009', 'wed_bootstrap', 'cake', 'Three-tier cake',
+    120000, NULL, NULL,
+    NULL, 8, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000010', 'wed_bootstrap', 'stationery', 'Invitations and signage',
+    95000, 88000, 88000,
+    NULL, 9, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000011', 'wed_bootstrap', 'hair_makeup', 'Hair and makeup, both sides',
+    260000, 275000, NULL,
+    NULL, 10, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000012', 'wed_bootstrap', 'transport', 'Guest coaches and the car',
+    180000, NULL, NULL,
+    NULL, 11, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000013', 'wed_bootstrap', 'attire', 'Outfits and jewellery',
+    700000, NULL, 760000,
+    'Came in over — the second outfit was not in the estimate.', 12, unixepoch(), unixepoch()
+  ),
+  (
+    'bud_e2a1c0d4-0000-4000-8000-000000000014', 'wed_bootstrap', 'other', 'Contingency',
+    300000, NULL, NULL,
+    NULL, 13, unixepoch(), unixepoch()
+  );
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Payments (10) — deposits paid, balances outstanding
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- FK'd to the budget lines above, so this block must follow them. Both states
+-- are seeded: `paid_at` set (settled) and NULL with a `due_at` (outstanding),
+-- which is the split every payment summary in the module reads.
+INSERT OR IGNORE INTO payments (
+  id, budget_item_id, label, amount_minor, due_at, paid_at, created_at
+) VALUES
+  ('pay_e2a1c0d4-0000-4000-8000-000000000001', 'bud_e2a1c0d4-0000-4000-8000-000000000001', 'Deposit', 690000, NULL, unixepoch() - 10368000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000002', 'bud_e2a1c0d4-0000-4000-8000-000000000001', 'Balance', 2760000, '2026-10-25', NULL, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000003', 'bud_e2a1c0d4-0000-4000-8000-000000000002', 'Deposit', 588000, NULL, unixepoch() - 7776000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000004', 'bud_e2a1c0d4-0000-4000-8000-000000000002', 'Balance', 2352000, '2026-11-10', NULL, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000005', 'bud_e2a1c0d4-0000-4000-8000-000000000003', 'Deposit', 200000, NULL, unixepoch() - 12960000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000006', 'bud_e2a1c0d4-0000-4000-8000-000000000003', 'Balance', 420000, NULL, unixepoch() - 864000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000007', 'bud_e2a1c0d4-0000-4000-8000-000000000007', 'Full fee', 285000, NULL, unixepoch() - 2592000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000008', 'bud_e2a1c0d4-0000-4000-8000-000000000008', 'Booking fee', 30000, NULL, unixepoch() - 17280000, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000009', 'bud_e2a1c0d4-0000-4000-8000-000000000008', 'Balance', 60000, '2026-11-20', NULL, unixepoch()),
+  ('pay_e2a1c0d4-0000-4000-8000-000000000010', 'bud_e2a1c0d4-0000-4000-8000-000000000011', 'Trial', 45000, NULL, unixepoch() - 1728000, unixepoch());
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Checklist tasks (18) — across every lead-time bucket
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- `timeframe_bucket` is a key from cire/api/src/lib/checklist-buckets.ts.
+-- `sort_order` restarts at 0 in each bucket — it orders within a bucket, and
+-- the reorder endpoint rewrites exactly that run.
+INSERT OR IGNORE INTO tasks (
+  id, wedding_id, title, notes,
+  timeframe_bucket, due_at, status, sort_order,
+  created_at, completed_at
+) VALUES
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000001', 'wed_bootstrap', 'Set the date and the guest-count ceiling', NULL,
+    '12m', NULL, 'done', 0,
+    unixepoch(), unixepoch() - 20736000
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000002', 'wed_bootstrap', 'Book the reception venue', 'Deposit paid — see the Venue line in Budget.',
+    '12m', NULL, 'done', 1,
+    unixepoch(), unixepoch() - 18144000
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000003', 'wed_bootstrap', 'Book the celebrant', NULL,
+    '12m', NULL, 'done', 2,
+    unixepoch(), unixepoch() - 17280000
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000004', 'wed_bootstrap', 'Book the photographer', NULL,
+    '9m', NULL, 'done', 0,
+    unixepoch(), unixepoch() - 12960000
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000005', 'wed_bootstrap', 'Choose a videographer', 'Two quotes still outstanding.',
+    '9m', NULL, 'open', 1,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000006', 'wed_bootstrap', 'Send the invitations', NULL,
+    '6m', '2026-08-30', 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000007', 'wed_bootstrap', 'Book hair and makeup trials', NULL,
+    '6m', NULL, 'done', 1,
+    unixepoch(), unixepoch() - 1728000
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000008', 'wed_bootstrap', 'Open the gift registry', NULL,
+    '6m', NULL, 'done', 2,
+    unixepoch(), unixepoch() - 2419200
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000009', 'wed_bootstrap', 'Confirm the catering menu', 'Final head count goes with the balance payment.',
+    '3m', '2026-09-15', 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000010', 'wed_bootstrap', 'Order the cake', NULL,
+    '3m', NULL, 'open', 1,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000011', 'wed_bootstrap', 'Chase the households who haven''t replied', NULL,
+    '1m', '2026-10-25', 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000012', 'wed_bootstrap', 'Book the guest coaches', NULL,
+    '1m', NULL, 'open', 1,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000013', 'wed_bootstrap', 'Send the run sheet to every supplier', NULL,
+    '2w', '2026-11-11', 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000014', 'wed_bootstrap', 'Pay the outstanding balances', 'Venue, catering and the celebrant — all in Budget.',
+    '2w', '2026-11-10', 'open', 1,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000015', 'wed_bootstrap', 'Final head count to the caterer', NULL,
+    'week_of', '2026-11-20', 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000016', 'wed_bootstrap', 'Print the seating chart and the signage', NULL,
+    'week_of', NULL, 'open', 1,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000017', 'wed_bootstrap', 'Hand the rings to the best man', NULL,
+    'day_of', NULL, 'open', 0,
+    unixepoch(), NULL
+  ),
+  (
+    'tsk_f7d3b1e0-0000-4000-8000-000000000018', 'wed_bootstrap', 'Pack the emergency kit', 'Safety pins, plasters, a phone charger, painkillers.',
+    'day_of', NULL, 'open', 1,
+    unixepoch(), NULL
+  );
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Registry settings — one row, and the guest-side publish gate
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- `published` is the SECOND gate on the guest registry: the guest read needs
+-- both this flag AND the wedding's `registry` entitlement (comped above), so a
+-- dev tier with the entitlement and no row still 404s the guest page.
+--
+-- Cash gifts stay off. They need a Stripe Connect account per wedding, and a
+-- registry is fully usable as an honour-system list without one.
+INSERT OR IGNORE INTO registry_settings (
+  wedding_id, published, headline, message,
+  cash_gifts_enabled, shipping_address, shipping_visible_from,
+  created_at, updated_at
+) VALUES (
+  'wed_bootstrap', 1, 'Our registry',
+  'Your being there is the gift — but if you''d like to mark the day with something, here is our list.',
+  0, '12 Wharf Road, Birchgrove NSW 2041', NULL,
+  unixepoch(), unixepoch()
+);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Registry items (10)
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- `image_key` is left NULL on every row: it is an R2 object key, and a key
+-- with no bytes behind it renders a broken image on both the organiser list and
+-- the guest site. The link-preview path fills it in normally.
+--
+-- `kind` is 'product' throughout — 'cash_fund' is a declared seam with no UI in
+-- v1, so seeding one would put a row on screen that nothing can edit.
+INSERT OR IGNORE INTO registry_items (
+  id, wedding_id, kind, title, description,
+  external_url, price_minor, quantity_wanted, category, sort_order,
+  created_at, updated_at
+) VALUES
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000001', 'wed_bootstrap', 'product', 'Cast-iron casserole, 26cm',
+    'Anything oven-to-table. Blue if there''s a choice.',
+    'https://example.com/kitchen/cast-iron-casserole',
+    45000, 1, 'Kitchen', 0,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000002', 'wed_bootstrap', 'product', 'Stand mixer',
+    NULL,
+    'https://example.com/kitchen/stand-mixer',
+    79900, 1, 'Kitchen', 1,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000003', 'wed_bootstrap', 'product', 'Espresso machine',
+    'The one gift that gets used every single morning.',
+    'https://example.com/kitchen/espresso-machine',
+    129900, 1, 'Kitchen', 2,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000004', 'wed_bootstrap', 'product', 'Wine glasses, set of six',
+    'Two sets would not go astray.',
+    'https://example.com/table/wine-glasses',
+    12000, 2, 'Table', 3,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000005', 'wed_bootstrap', 'product', 'Cutlery set, 24 piece',
+    NULL,
+    'https://example.com/table/cutlery-set',
+    34900, 1, 'Table', 4,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000006', 'wed_bootstrap', 'product', 'Hand-thrown serving platter',
+    'Made in Bowral, so no two are the same.',
+    'https://example.com/table/serving-platter',
+    18000, 1, 'Table', 5,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000007', 'wed_bootstrap', 'product', 'Linen bedding set, queen',
+    NULL,
+    'https://example.com/home/linen-bedding',
+    39900, 1, 'Home', 6,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000008', 'wed_bootstrap', 'product', 'Wool throw',
+    NULL,
+    'https://example.com/home/wool-throw',
+    24900, 2, 'Home', 7,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000009', 'wed_bootstrap', 'product', 'Picnic hamper',
+    'For the drive up the coast afterwards.',
+    'https://example.com/outdoors/picnic-hamper',
+    15900, 1, 'Outdoors', 8,
+    unixepoch(), unixepoch()
+  ),
+  (
+    'reg_c4b8a2f1-0000-4000-8000-000000000010', 'wed_bootstrap', 'product', 'A recipe you actually cook',
+    'Written out, in your handwriting. That''s the whole gift.',
+    NULL,
+    NULL, 1, NULL, 9,
+    unixepoch(), unixepoch()
+  );
+
+-- ────────────────────────────────────────────────────────────────────────────
 -- Families (4) — stable UUIDs so dev links don't drift between seeds
 -- ────────────────────────────────────────────────────────────────────────────
 
@@ -269,6 +583,42 @@ INSERT OR IGNORE INTO rsvps (id, guest_id, event_id, status, dietary, dietary_co
   ('c0000000-0000-4000-8000-000000000008', 'b0000000-0000-4000-8000-000000000004', '9f7a2c14-1b3d-4e5f-8a01-000000000003', 'maybe', '', NULL, NULL, 'guest', unixepoch() - 259200),
   ('c0000000-0000-4000-8000-000000000009', 'b0000000-0000-4000-8000-000000000005', '9f7a2c14-1b3d-4e5f-8a01-000000000001', 'attending', 'Severe nut allergy — please keep preparation separate.', unixepoch() - 518400, '2026-06-17', 'guest', unixepoch() - 518400),
   ('c0000000-0000-4000-8000-000000000010', 'b0000000-0000-4000-8000-000000000005', '9f7a2c14-1b3d-4e5f-8a01-000000000003', 'attending', '', NULL, NULL, 'guest', unixepoch() - 518400);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Registry claims (3) — the gift log
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- FK'd to the canonical households, so this block must follow the families
+-- above. Gifts come from a HOUSEHOLD, not a guest — that is the unit the couple
+-- thanks, and `display_name` overrides the household name when the giver is
+-- someone the list does not name ("Auntie Ros").
+INSERT OR IGNORE INTO registry_claims (
+  id, wedding_id, item_id, family_id,
+  quantity, status, note, display_name,
+  thanked_at, thanked_by,
+  created_at, updated_at
+) VALUES
+  (
+    'rgc_c4b8a2f1-0000-4000-8000-000000000001', 'wed_bootstrap', 'reg_c4b8a2f1-0000-4000-8000-000000000003', 'a0000000-0000-4000-8000-000000000001',
+    1, 'purchased', 'Ordered — it should land the week before.', 'The Testfamilys',
+    unixepoch() - 259200,
+    'usr_dev_bootstrap_owner',
+    unixepoch() - 1814400, unixepoch() - 1814400
+  ),
+  (
+    'rgc_c4b8a2f1-0000-4000-8000-000000000002', 'wed_bootstrap', 'reg_c4b8a2f1-0000-4000-8000-000000000004', 'a0000000-0000-4000-8000-000000000002',
+    1, 'purchased', NULL, NULL,
+    NULL,
+    NULL,
+    unixepoch() - 1209600, unixepoch() - 1209600
+  ),
+  (
+    'rgc_c4b8a2f1-0000-4000-8000-000000000003', 'wed_bootstrap', 'reg_c4b8a2f1-0000-4000-8000-000000000008', 'a0000000-0000-4000-8000-000000000003',
+    1, 'reserved', 'Hope the colour''s right.', 'Auntie Ros',
+    NULL,
+    NULL,
+    unixepoch() - 518400, unixepoch() - 518400
+  );
 
 -- ────────────────────────────────────────────────────────────────────────────
 -- Synthetic households (195) — brings the list to production scale

--- a/cire/db/seed/generate.ts
+++ b/cire/db/seed/generate.ts
@@ -15,6 +15,7 @@ import { getTableConfig, SQLiteTable } from "drizzle-orm/sqlite-core";
 import * as schema from "../src/schema";
 import {
   bootstrapWedding,
+  budgetItems,
   customisation,
   DEV_OWNER_PROFILE_ID,
   DIETARY_CONSENT_VERSION,
@@ -22,15 +23,26 @@ import {
   events,
   guests,
   hosts,
+  registryClaims,
+  registryItems,
+  registrySettings,
   rsvps,
   syntheticFamilies,
   syntheticRsvps,
+  tasks,
   type SeedFamily,
   type SeedRsvp,
 } from "./data";
 
 // SQL single-quote escaping: double any embedded apostrophe.
 const sql = (value: string): string => `'${value.replaceAll("'", "''")}'`;
+
+// The two null-aware emitters. Every optional column below is nullable in the
+// schema and meaningfully so — an unquoted estimate, a task with no due date, a
+// gift with no price — so a seed that coerced null to 0 or "" would be seeding a
+// state the app cannot produce.
+const sqlOrNull = (value: string | null): string => (value === null ? "NULL" : sql(value));
+const numOrNull = (value: number | null): string => (value === null ? "NULL" : String(value));
 
 // A reply's `created_at` (and its consent stamp) as an offset from seed time, so
 // seeded replies always read as recent however long ago the seed was written.
@@ -379,6 +391,152 @@ function describeEvents(ids: readonly string[]): string {
   return ids.map((id) => SLUG_BY_ID.get(id) ?? id).join(" + ");
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Planning modules — budget, checklist, registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+function budgetBlock(): string {
+  const rows = budgetItems.map(
+    (b, index) => `  (
+    ${sql(b.id)}, ${sql(bootstrapWedding.id)}, ${sql(b.category)}, ${sql(b.name)},
+    ${numOrNull(b.estimateMinor)}, ${numOrNull(b.quotedMinor)}, ${numOrNull(b.actualMinor)},
+    ${sqlOrNull(b.notes)}, ${index}, unixepoch(), unixepoch()
+  )`,
+  );
+  return section(
+    `Budget lines (${rows.length}) — estimates, quotes, actuals`,
+    `-- \`category\` is a key from cire/api/src/lib/service-categories.ts; the Budget
+-- HTTP schema validates writes against that same list, so a category invented
+-- here would seed a row the organiser can read but never save.
+INSERT OR IGNORE INTO budget_items (
+  id, wedding_id, category, name,
+  estimate_minor, quoted_minor, actual_minor,
+  notes, sort_order, created_at, updated_at
+) VALUES
+${rows.join(",\n")};`,
+  );
+}
+
+function paymentsBlock(): string {
+  const rows: string[] = [];
+  for (const b of budgetItems) {
+    for (const p of b.payments) {
+      const paidAt = p.paidDaysAgo === null ? "NULL" : daysAgo(p.paidDaysAgo);
+      rows.push(
+        `  (${sql(p.id)}, ${sql(b.id)}, ${sql(p.label)}, ${p.amountMinor}, ${sqlOrNull(p.dueAt)}, ${paidAt}, unixepoch())`,
+      );
+    }
+  }
+  return section(
+    `Payments (${rows.length}) — deposits paid, balances outstanding`,
+    `-- FK'd to the budget lines above, so this block must follow them. Both states
+-- are seeded: \`paid_at\` set (settled) and NULL with a \`due_at\` (outstanding),
+-- which is the split every payment summary in the module reads.
+INSERT OR IGNORE INTO payments (
+  id, budget_item_id, label, amount_minor, due_at, paid_at, created_at
+) VALUES
+${rows.join(",\n")};`,
+  );
+}
+
+function tasksBlock(): string {
+  const rows = tasks.map(
+    (t) => `  (
+    ${sql(t.id)}, ${sql(bootstrapWedding.id)}, ${sql(t.title)}, ${sqlOrNull(t.notes)},
+    ${sql(t.timeframeBucket)}, ${sqlOrNull(t.dueAt)}, ${sql(t.status)}, ${t.sortOrder},
+    unixepoch(), ${t.completedDaysAgo === null ? "NULL" : daysAgo(t.completedDaysAgo)}
+  )`,
+  );
+  return section(
+    `Checklist tasks (${rows.length}) — across every lead-time bucket`,
+    `-- \`timeframe_bucket\` is a key from cire/api/src/lib/checklist-buckets.ts.
+-- \`sort_order\` restarts at 0 in each bucket — it orders within a bucket, and
+-- the reorder endpoint rewrites exactly that run.
+INSERT OR IGNORE INTO tasks (
+  id, wedding_id, title, notes,
+  timeframe_bucket, due_at, status, sort_order,
+  created_at, completed_at
+) VALUES
+${rows.join(",\n")};`,
+  );
+}
+
+function registrySettingsBlock(): string {
+  const r = registrySettings;
+  return section(
+    "Registry settings — one row, and the guest-side publish gate",
+    `-- \`published\` is the SECOND gate on the guest registry: the guest read needs
+-- both this flag AND the wedding's \`registry\` entitlement (comped above), so a
+-- dev tier with the entitlement and no row still 404s the guest page.
+--
+-- Cash gifts stay off. They need a Stripe Connect account per wedding, and a
+-- registry is fully usable as an honour-system list without one.
+INSERT OR IGNORE INTO registry_settings (
+  wedding_id, published, headline, message,
+  cash_gifts_enabled, shipping_address, shipping_visible_from,
+  created_at, updated_at
+) VALUES (
+  ${sql(bootstrapWedding.id)}, ${r.published ? 1 : 0}, ${sql(r.headline)},
+  ${sql(r.message)},
+  ${r.cashGiftsEnabled ? 1 : 0}, ${sql(r.shippingAddress)}, ${sqlOrNull(r.shippingVisibleFrom)},
+  unixepoch(), unixepoch()
+);`,
+  );
+}
+
+function registryItemsBlock(): string {
+  const rows = registryItems.map(
+    (i) => `  (
+    ${sql(i.id)}, ${sql(bootstrapWedding.id)}, 'product', ${sql(i.title)},
+    ${sqlOrNull(i.description)},
+    ${sqlOrNull(i.externalUrl)},
+    ${numOrNull(i.priceMinor)}, ${i.quantityWanted}, ${sqlOrNull(i.category)}, ${i.sortOrder},
+    unixepoch(), unixepoch()
+  )`,
+  );
+  return section(
+    `Registry items (${rows.length})`,
+    `-- \`image_key\` is left NULL on every row: it is an R2 object key, and a key
+-- with no bytes behind it renders a broken image on both the organiser list and
+-- the guest site. The link-preview path fills it in normally.
+--
+-- \`kind\` is 'product' throughout — 'cash_fund' is a declared seam with no UI in
+-- v1, so seeding one would put a row on screen that nothing can edit.
+INSERT OR IGNORE INTO registry_items (
+  id, wedding_id, kind, title, description,
+  external_url, price_minor, quantity_wanted, category, sort_order,
+  created_at, updated_at
+) VALUES
+${rows.join(",\n")};`,
+  );
+}
+
+function registryClaimsBlock(): string {
+  const rows = registryClaims.map(
+    (c) => `  (
+    ${sql(c.id)}, ${sql(bootstrapWedding.id)}, ${sql(c.itemId)}, ${sql(c.familyId)},
+    ${c.quantity}, ${sql(c.status)}, ${sqlOrNull(c.note)}, ${sqlOrNull(c.displayName)},
+    ${c.thankedDaysAgo === null ? "NULL" : daysAgo(c.thankedDaysAgo)},
+    ${c.thankedDaysAgo === null ? "NULL" : sql(DEV_OWNER_PROFILE_ID)},
+    ${daysAgo(c.daysAgo)}, ${daysAgo(c.daysAgo)}
+  )`,
+  );
+  return section(
+    `Registry claims (${rows.length}) — the gift log`,
+    `-- FK'd to the canonical households, so this block must follow the families
+-- above. Gifts come from a HOUSEHOLD, not a guest — that is the unit the couple
+-- thanks, and \`display_name\` overrides the household name when the giver is
+-- someone the list does not name ("Auntie Ros").
+INSERT OR IGNORE INTO registry_claims (
+  id, wedding_id, item_id, family_id,
+  quantity, status, note, display_name,
+  thanked_at, thanked_by,
+  created_at, updated_at
+) VALUES
+${rows.join(",\n")};`,
+  );
+}
+
 export function generateSeedSql(): string {
   return `${[
     HEADER,
@@ -393,6 +551,16 @@ export function generateSeedSql(): string {
     "",
     entitlementsBlock(),
     "",
+    budgetBlock(),
+    "",
+    paymentsBlock(),
+    "",
+    tasksBlock(),
+    "",
+    registrySettingsBlock(),
+    "",
+    registryItemsBlock(),
+    "",
     familiesBlock(),
     "",
     guestsBlock(),
@@ -400,6 +568,9 @@ export function generateSeedSql(): string {
     guestEventsBlock(),
     "",
     rsvpsBlock(),
+    "",
+    // After the families above: a claim is FK'd to the household that made it.
+    registryClaimsBlock(),
     "",
     syntheticFamiliesBlock(),
     "",

--- a/scripts/cire-db-seed.sh
+++ b/scripts/cire-db-seed.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Seed a cire D1 with the sample wedding from seed/dev-seed.sql, then (local
-# convenience) re-point that wedding's owner at your OSN profile so your
-# signed-in account owns it. The seed creates the wedding owned by the fixed dev
-# id usr_dev_bootstrap_owner; set CIRE_DEV_OWNER_PROFILE_ID (in cire/db/.env or
-# the environment) to override it after every seed/reset.
+# Seed a cire D1 with the sample wedding from seed/dev-seed.sql, then re-point
+# that wedding's owner at a real OSN profile so a signed-in account owns it. The
+# seed creates the wedding owned by the fixed dev id usr_dev_bootstrap_owner; set
+# CIRE_DEV_OWNER_PROFILE_ID (in cire/db/.env, or as a GitHub environment variable
+# for the dev tier) to override it after every seed/reset.
 #
 #   bun run --cwd cire/db db:seed          # local miniflare D1
 #   bun run --cwd cire/db db:seed:dev      # remote cire-db-dev (this script --dev)
@@ -52,17 +52,22 @@ fi
 
 "${WRANGLER[@]}" --file=./seed/dev-seed.sql
 
-# The owner override is a LOCAL convenience only. On dev the wedding stays owned
-# by usr_dev_bootstrap_owner; sign in on host-dev and create your own wedding, or
-# add yourself as a host — a CI-set owner would just be whoever ran the deploy.
-if [ "$TARGET" != "local" ]; then
-  echo "db:seed: seeded $CIRE_DEV_DB_NAME (owner stays usr_dev_bootstrap_owner)"
-elif [ -n "${CIRE_DEV_OWNER_PROFILE_ID:-}" ]; then
+# Repoint the sample wedding at a real account. This runs on BOTH targets:
+# locally the id comes from cire/db/.env, on dev from the CIRE_DEV_OWNER_PROFILE_ID
+# variable the deploy workflow passes in (a GitHub environment variable, so no
+# profile id is committed here).
+#
+# It is not a nicety on dev. The seed owns the wedding as usr_dev_bootstrap_owner,
+# an id no account holds, and every cire_api deploy resets and reseeds the tier —
+# so without the override the seeded wedding, its 494 guests and its comped
+# entitlements (registry, vendors, AI) are invisible to whoever signs in to test
+# them, and any wedding a tester makes by hand is wiped on the next deploy.
+if [ -n "${CIRE_DEV_OWNER_PROFILE_ID:-}" ]; then
   # The value is interpolated into a SQL string literal below. It comes from
-  # cire/db/.env or the ambient environment — trusted-ish, but a stray apostrophe
-  # closes the literal and the rest of the value runs as SQL against the whole
-  # local database. Profile ids are `usr_` + url-safe base64, so an exact match
-  # on that shape costs nothing and removes the question.
+  # cire/db/.env, the workflow, or the ambient environment — trusted-ish, but a
+  # stray apostrophe closes the literal and the rest of the value runs as SQL
+  # against the whole database. Profile ids are `usr_` + url-safe base64, so an
+  # exact match on that shape costs nothing and removes the question.
   if ! printf '%s' "$CIRE_DEV_OWNER_PROFILE_ID" | grep -qE '^usr_[A-Za-z0-9_-]+$'; then
     echo "db:seed: CIRE_DEV_OWNER_PROFILE_ID='${CIRE_DEV_OWNER_PROFILE_ID}' is not a profile id (expected usr_ followed by letters, digits, - or _). Refusing." >&2
     exit 1
@@ -70,6 +75,8 @@ elif [ -n "${CIRE_DEV_OWNER_PROFILE_ID:-}" ]; then
   "${WRANGLER[@]}" --command \
     "UPDATE weddings SET owner_osn_profile_id='${CIRE_DEV_OWNER_PROFILE_ID}' WHERE id='wed_bootstrap';"
   echo "db:seed: wedding owner set to ${CIRE_DEV_OWNER_PROFILE_ID}"
+elif [ "$TARGET" = "dev" ]; then
+  echo "db:seed: CIRE_DEV_OWNER_PROFILE_ID unset - the seeded wedding stays owned by usr_dev_bootstrap_owner and NO real account can open it. Set it as a variable on the dev environment in GitHub."
 else
   echo "db:seed: CIRE_DEV_OWNER_PROFILE_ID unset - sample wedding owner stays the dev default usr_dev_bootstrap_owner (set it in cire/db/.env to own it from your account)"
 fi


### PR DESCRIPTION
## Why

Budget and Registry could not be tested on dev. Two independent causes, both confirmed against the live tier:

1. **No seed data.** `cire-db-dev` held `guests=494`, `events=5` — and `budget_items=0`, `registry_items=0`, `tasks=0`. Budget, Checklist and Registry all shipped after the seed was written and no seed data was ever added, so the modules render but have nothing in them. The guest registry additionally 404s because `registry_settings.published` was never set.
2. **The sample wedding is unreachable.** The seed owns `wed_bootstrap` as `usr_dev_bootstrap_owner` and its three co-hosts are `usr_dev_cohost_*` — ids no account holds. `scripts/cire-db-seed.sh` applied `CIRE_DEV_OWNER_PROFILE_ID` only when the target was `local`, so on dev nobody can open the wedding, its 494 guests, or its comped `registry` / `vendors` entitlements. A wedding a tester creates by hand instead has no entitlements at all (Registry and Vendors render `UpsellPanel`; the API answers `402 payment_required`), and `deploy-cire-api-dev` runs `db:reset:dev` on every `cire_api` change, wiping it.

Budget itself is not entitlement-gated anywhere — its dev emptiness was purely cause 1.

## What

- **`cire/db/seed/data/budget.ts`** — 14 lines across the service categories, with estimates, quotes and actuals variously present and null, plus 10 payments split between settled (`paid_at`) and outstanding (`due_at`). Estimates total A$99,450 against the wedding's A$100,000, so the spend meter shows its normal state.
- **`cire/db/seed/data/tasks.ts`** — 18 checklist tasks across all eight lead-time buckets, some done, `sort_order` restarting per bucket.
- **`cire/db/seed/data/registry.ts`** — a published settings row (the second, independent gate on the guest page), 10 items, and 3 claims covering purchased-and-thanked, purchased-not-thanked and still-reserved. Item images stay NULL (an R2 key with no bytes renders broken) and links point at `example.com` rather than live retailers.
- **`scripts/cire-db-seed.sh`** — apply `CIRE_DEV_OWNER_PROFILE_ID` on the dev target as well as locally, keeping the existing `usr_` shape guard on the value.
- **`.github/workflows/deploy.yml`** — the dev seed step passes `vars.CIRE_DEV_OWNER_PROFILE_ID` through.

Checklist is in scope alongside the two named modules: same root cause, same file set, same fix.

## Deploy gate

Set **`CIRE_DEV_OWNER_PROFILE_ID`** as a variable on the `dev` environment (a profile id is not a credential — a secret would only mask the seed log). Unset, the seed logs that the wedding stays on the dead id and carries on.

## Verification

- `bun run --cwd cire/db test` — 5 pass (dev-seed.sql / dev-reset.sql drift guards).
- `bun run --cwd cire/api test` — 1696 pass, 0 fail.
- `bun run --cwd cire/db check` — clean.
- Applied for real against local D1 (`db:reset`, FKs enforced): `budget_items=14`, `payments=10`, `tasks=18`, `registry_items=10`, `registry_claims=3`, `registry_settings=1`, `guests=494`.
- Owner override exercised both ways: unset → stays `usr_dev_bootstrap_owner`; set → the wedding row moves to the given id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)