### PR TITLE
chore(deps): dependency review — drop dead deps, align peers, close install-gate hole

### DIFF
--- a/.changeset/dependency-review-2026-08-21.md
+++ b/.changeset/dependency-review-2026-08-21.md
@@ -9,8 +9,9 @@ Dependency review: drop unused `better-sqlite3`, align stale peer ranges, bump o
 
 - `@shared/db-utils` no longer declares `better-sqlite3` or `@types/better-sqlite3`.
   Neither was imported by `src/` or `tests/` — the package has no drizzle-kit and no
-  `db:*` scripts, so nothing there ever loaded the native module. The four `*/db`
-  workspaces keep theirs; drizzle-kit dynamically requires it for `db:studio`/`db:push`.
+  `db:*` scripts, so nothing there ever loaded the native module. The three `*/db`
+  workspaces that do run drizzle-kit against a local SQLite file — `osn/db`,
+  `pulse/db`, `zap/db` — keep theirs.
 - `@shared/osn-auth-client` peer `elysia` `^1.4.28` → `^1.4.29`, matching the range
   every other workspace declares.
 - `@shared/rp-auth` peer `solid-js` `^1.9.13` → `^1.9.14`, likewise. Both peers already
@@ -18,3 +19,7 @@ Dependency review: drop unused `better-sqlite3`, align stale peer ranges, bump o
 - Root `oxfmt` `^0.59.0` → `^0.62.0`. 0.62.0 changes how a type-annotated arrow return
   is wrapped, which reformats one file in `@pulse/api`
   (`src/services/events.ts`) — whitespace only, no behaviour change.
+- `fast-uri` dropped from `minimumReleaseAgeExcludes` in `bunfig.toml`. It was added
+  for the GHSA-v2hh-gcrm-f6hx fix in 3.1.4, which shipped inside the 3-day install
+  gate. The override now pins `^3.1.5` and 3.1.5 shipped 2026-07-31, so the entry
+  had stopped protecting anything and was exempting every future 3.x publish.

--- a/.changeset/dependency-review-2026-08-21.md
+++ b/.changeset/dependency-review-2026-08-21.md
@@ -1,0 +1,20 @@
+---
+"@shared/db-utils": patch
+"@shared/osn-auth-client": patch
+"@shared/rp-auth": patch
+"@pulse/api": patch
+---
+
+Dependency review: drop unused `better-sqlite3`, align stale peer ranges, bump oxfmt
+
+- `@shared/db-utils` no longer declares `better-sqlite3` or `@types/better-sqlite3`.
+  Neither was imported by `src/` or `tests/` — the package has no drizzle-kit and no
+  `db:*` scripts, so nothing there ever loaded the native module. The four `*/db`
+  workspaces keep theirs; drizzle-kit dynamically requires it for `db:studio`/`db:push`.
+- `@shared/osn-auth-client` peer `elysia` `^1.4.28` → `^1.4.29`, matching the range
+  every other workspace declares.
+- `@shared/rp-auth` peer `solid-js` `^1.9.13` → `^1.9.14`, likewise. Both peers already
+  resolved to the same version; this only stops the ranges drifting further apart.
+- Root `oxfmt` `^0.59.0` → `^0.62.0`. 0.62.0 changes how a type-annotated arrow return
+  is wrapped, which reformats one file in `@pulse/api`
+  (`src/services/events.ts`) — whitespace only, no behaviour change.

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@oxlint/plugins": "1.78.0",
         "bun-types": "^1.4.0",
         "lefthook": "^2.1.10",
-        "oxfmt": "^0.59.0",
+        "oxfmt": "^0.62.0",
         "oxlint": "1.78.0",
         "portless": "~0.15.5",
         "turbo": "^2.10.7",
@@ -188,7 +188,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.20.10",
+      "version": "3.20.11",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/openapi": "1.4.15",
@@ -334,7 +334,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.9",
+      "version": "0.26.10",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -408,7 +408,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.15",
+      "version": "0.22.16",
       "dependencies": {
         "@fontsource/geist-mono": "^5.3.0",
         "@fontsource/geist-sans": "^5.3.0",
@@ -443,7 +443,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -467,14 +467,12 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
         "@shared/typescript-config": "workspace:*",
-        "@types/better-sqlite3": "^7.6.13",
-        "better-sqlite3": "^12.11.1",
         "vitest": "^4.1.10",
       },
     },
     "shared/dev-urls": {
       "name": "@shared/dev-urls",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "dev-env": "./src/cli.ts",
       },
@@ -551,7 +549,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.4",
@@ -562,7 +560,7 @@
         "vitest": "^4.1.10",
       },
       "peerDependencies": {
-        "elysia": "^1.4.28",
+        "elysia": "^1.4.29",
       },
     },
     "shared/rate-limit": {
@@ -601,7 +599,7 @@
         "vitest": "^4.1.10",
       },
       "peerDependencies": {
-        "solid-js": "^1.9.13",
+        "solid-js": "^1.9.14",
       },
       "optionalPeers": [
         "solid-js",
@@ -624,7 +622,7 @@
     },
     "tools/lab": {
       "name": "@tools/lab",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
@@ -644,7 +642,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.8.20",
+      "version": "0.8.21",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -1246,43 +1244,43 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
 
@@ -2180,7 +2178,7 @@
 
     "oxc-parser": ["oxc-parser@0.141.0", "", { "dependencies": { "@oxc-project/types": "^0.141.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.141.0", "@oxc-parser/binding-android-arm64": "0.141.0", "@oxc-parser/binding-darwin-arm64": "0.141.0", "@oxc-parser/binding-darwin-x64": "0.141.0", "@oxc-parser/binding-freebsd-x64": "0.141.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.141.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.141.0", "@oxc-parser/binding-linux-arm64-gnu": "0.141.0", "@oxc-parser/binding-linux-arm64-musl": "0.141.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.141.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.141.0", "@oxc-parser/binding-linux-riscv64-musl": "0.141.0", "@oxc-parser/binding-linux-s390x-gnu": "0.141.0", "@oxc-parser/binding-linux-x64-gnu": "0.141.0", "@oxc-parser/binding-linux-x64-musl": "0.141.0", "@oxc-parser/binding-openharmony-arm64": "0.141.0", "@oxc-parser/binding-wasm32-wasi": "0.141.0", "@oxc-parser/binding-win32-arm64-msvc": "0.141.0", "@oxc-parser/binding-win32-ia32-msvc": "0.141.0", "@oxc-parser/binding-win32-x64-msvc": "0.141.0" } }, "sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w=="],
 
-    "oxfmt": ["oxfmt@0.59.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.59.0", "@oxfmt/binding-android-arm64": "0.59.0", "@oxfmt/binding-darwin-arm64": "0.59.0", "@oxfmt/binding-darwin-x64": "0.59.0", "@oxfmt/binding-freebsd-x64": "0.59.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0", "@oxfmt/binding-linux-arm-musleabihf": "0.59.0", "@oxfmt/binding-linux-arm64-gnu": "0.59.0", "@oxfmt/binding-linux-arm64-musl": "0.59.0", "@oxfmt/binding-linux-ppc64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-musl": "0.59.0", "@oxfmt/binding-linux-s390x-gnu": "0.59.0", "@oxfmt/binding-linux-x64-gnu": "0.59.0", "@oxfmt/binding-linux-x64-musl": "0.59.0", "@oxfmt/binding-openharmony-arm64": "0.59.0", "@oxfmt/binding-win32-arm64-msvc": "0.59.0", "@oxfmt/binding-win32-ia32-msvc": "0.59.0", "@oxfmt/binding-win32-x64-msvc": "0.59.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w=="],
+    "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
     "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,16 +2,25 @@ telemetry = false
 
 [install]
 minimumReleaseAge = 259200
-# Escape hatch for advisory fixes younger than the gate: fast-uri 3.1.4 patches
-# GHSA-v2hh-gcrm-f6hx (high) and was published inside the 3-day window.
+# Every entry below is temporary and carries its own drop-trigger. An exclude
+# with no expiry stops being an exception and becomes a permanent hole: the
+# range keeps matching future releases, so the next publish under that name
+# installs with no soak at all.
 #
-# bun-types is here for a different reason, and it is temporary. `.bun-version`
-# pins the 1.4.0 runtime, so without the matching types the repo typechecks 1.4
-# APIs (Bun.TOML, Bun.Image, Bun.JSONC) against 1.3 definitions and every one of
-# them is an error. bun-types 1.4.0 was published 2026-08-20, inside the window.
+# bun-types: `.bun-version` pins the 1.4.0 runtime, so without the matching
+# types the repo typechecks 1.4 APIs (Bun.TOML, Bun.Image, Bun.JSONC) against
+# 1.3 definitions and every one of them is an error. bun-types 1.4.0 was
+# published 2026-08-20, inside the window.
 #
 # It is the mildest package to make an exception for: types only, no runtime
 # code, devDependency, never bundled into a Worker. It still gets no free pass —
 # DROP THIS ENTRY once 1.4.0 clears three days (after 2026-08-23). Leaving it
 # would silently exempt every future bun-types release from the gate.
-minimumReleaseAgeExcludes = ["fast-uri", "bun-types"]
+#
+# fast-uri was removed 2026-08-21. It was added for fast-uri 3.1.4, which
+# patched GHSA-v2hh-gcrm-f6hx (high) inside the window. That reason expired:
+# the `fast-uri` override in package.json pins ^3.1.5, and 3.1.5 shipped
+# 2026-07-31 — well past the gate on its own. The entry was buying nothing and
+# exempting every future 3.x publish of a package that parses URIs on the
+# request path via ajv.
+minimumReleaseAgeExcludes = ["bun-types"]

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@oxlint/plugins": "1.78.0",
     "bun-types": "^1.4.0",
     "lefthook": "^2.1.10",
-    "oxfmt": "^0.59.0",
+    "oxfmt": "^0.62.0",
     "oxlint": "1.78.0",
     "portless": "~0.15.5",
     "turbo": "^2.10.7",

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -551,13 +551,11 @@ export const listMyCalendarEvents = (
     // group (P-W5) — applyTransitions preserves row order, so the
     // parallel myStatus array zips back by index.
     const transitionedEvents = yield* applyTransitions(merged.map((m) => m.event));
-    const entries = transitionedEvents.map(
-      (e, i): CalendarEntry => ({
-        event: e,
-        myStatus: merged[i]!.myStatus,
-        isHost: e.createdByProfileId === viewerId,
-      }),
-    );
+    const entries = transitionedEvents.map((e, i): CalendarEntry => ({
+      event: e,
+      myStatus: merged[i]!.myStatus,
+      isHost: e.createdByProfileId === viewerId,
+    }));
 
     metricCalendarListed(entries.length);
     return entries;

--- a/shared/db-utils/package.json
+++ b/shared/db-utils/package.json
@@ -19,8 +19,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
     "@shared/typescript-config": "workspace:*",
-    "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "^12.11.1",
     "vitest": "^4.1.10"
   }
 }

--- a/shared/osn-auth-client/package.json
+++ b/shared/osn-auth-client/package.json
@@ -23,7 +23,7 @@
     "jose": "^6.2.4"
   },
   "peerDependencies": {
-    "elysia": "^1.4.28"
+    "elysia": "^1.4.29"
   },
   "devDependencies": {
     "@shared/typescript-config": "workspace:*",

--- a/shared/rp-auth/package.json
+++ b/shared/rp-auth/package.json
@@ -13,7 +13,7 @@
     "test:run": "bunx --bun vitest run"
   },
   "peerDependencies": {
-    "solid-js": "^1.9.13"
+    "solid-js": "^1.9.14"
   },
   "peerDependenciesMeta": {
     "solid-js": {


### PR DESCRIPTION
## Summary

A full audit of the monorepo's dependencies — 300 declared entries, 81 unique packages, 36 `package.json` files, every one checked against the npm registry for drift, available upgrades and upstream staleness. Most of the tree turned out to be current; this branch lands the small set of changes that were both correct and eligible, and records why each of the remaining upgrades is being held rather than leaving the next person to re-derive it.

The one finding worth a reviewer's attention is not an upgrade. The `fast-uri` entry in `minimumReleaseAgeExcludes` had outlived the advisory it was added for and was silently exempting a request-path dependency from the repo's 3-day supply-chain gate.

- Dropping `better-sqlite3` from `@shared/db-utils` removes a native-module build from a workspace that never imported it.
- The `@pulse/api` change is not a backend edit — it is one whitespace hunk produced by the oxfmt bump, and it is the bump's complete blast radius across all 1395 formatted files.

## Workspaces affected

`@pulse/api`, `@shared/db-utils`, `@shared/osn-auth-client`, `@shared/rp-auth`, plus root infra (`package.json`, `bunfig.toml`, `bun.lock`, `.changeset/`).

One changeset, `dependency-review-2026-08-21.md`, naming all four packages at `patch`. All four are versioned workspaces, no ignored/versioned mixing, and `changeset-required.sh` fed the real file list returns `required` — correctly, since workspace source changed.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#455 | `S-L1` |

Closes xchromo/osn-tracker#455

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#749 | TypeScript 7 upgrade is blocked on `@astrojs/check` |
| xchromo/osn#750 | `cire/db` relies on a phantom `better-sqlite3`; breaks under the isolated linker |
| xchromo/osn-tracker#456 | `S-I1` |

## Decisions

### Drop the stale `fast-uri` install-gate exemption — `S-L1`

- **Issue** — `bunfig.toml` listed `fast-uri` in `minimumReleaseAgeExcludes`, exempting it from the repo's 3-day `minimumReleaseAge` gate. It was added because fast-uri 3.1.4 patched a high-severity advisory published inside that window.
- **Why** — The reason had expired: the root `overrides` block pins `^3.1.5` and 3.1.5 shipped 2026-07-31, 21 days ago, clearing the gate on its own. Because `^3.1.5` matches every future 3.x publish, the entry granted a permanent zero-soak exemption to a package that parses URIs on the request path via `ajv`. Second entry on that list to outlive its stated reason.
- **Solution** — Removed the entry, leaving only `bun-types`. Rewrote the comment block so the surviving entry leads with its drop-trigger and the general rule is stated: an exclude with no expiry is a hole, not an exception.
- **Rationale** — A no-op for today's tree (`bun install --frozen-lockfile` reports no changes, `bun.lock` byte-identical) and real protection for the next publish. Rejected leaving it with a `DROP AFTER` comment — the reason had already expired, so there was nothing left to wait for.

### Move the vitest family in one commit, or not at all — `approach`

- **Issue** — `@vitest/browser` and `@vitest/browser-playwright` are pinned to an exact `4.1.10` while `vitest` and `@vitest/coverage-istanbul` use `^4.1.10`. 4.1.11 exists.
- **Why** — The exact pins are correct: `@vitest/browser@4.1.11` declares `peerDependencies: { vitest: "4.1.11" }` — exact, not a range. But they silently hold the caret ranges back, and the lockfile currently sits at 4.1.10 across all four. Any lock refresh that moves `vitest` alone produces a peer mismatch.
- **Solution** — Not bumped here. I attempted all four together and the repo's own `minimumReleaseAge` gate rejected it: 4.1.11 was published 2026-08-18T14:22Z and clears the 3-day gate at 2026-08-21T14:22Z, roughly 13 hours after this branch was cut.
- **Rationale** — Reverted rather than add a `minimumReleaseAgeExcludes` entry. The file reserves those for confirmed-exploitable advisories with an inline drop-trigger, and adding one to save half a day — in the same PR that removes a stale entry for exactly that reason — would be self-defeating. 4.1.11 carries a security fix (redirect mocks restricted to the filesystem allowlist), so it is worth doing promptly, as its own one-line change.

### Hold `better-sqlite3` 13 until its types clear the gate — `approach`

- **Issue** — `better-sqlite3` 12.11.1 → 13.0.1 has soaked (published 2026-07-21, 31 days). `@types/better-sqlite3` 7.6.13 → 9.6.0 has not (published 2026-08-01, 20 days).
- **Why** — The types release is DefinitelyTyped catching up to v13. Bumping the runtime alone leaves the two a major version apart in three workspaces.
- **Solution** — Neither bumped. Eligible together from 2026-08-31, by which point 13.0.3 will also have soaked.
- **Rationale** — Waiting ten days turns three separate bumps into one. There is no pressure the other way: nothing in the repo imports better-sqlite3 at runtime, it is a drizzle-kit tooling dependency only.

### Take oxfmt 0.62.0 rather than latest — `approach`

- **Issue** — oxfmt `^0.59.0` was four minors behind. 0.64.0 is latest.
- **Why** — 0.62.0 (published 2026-08-03, 18 days) is the newest version past the review waiting period; 0.63.0 and 0.64.0 are 11 and 3 days old.
- **Solution** — Bumped to `^0.62.0`. One file reformats — `pulse/api/src/services/events.ts`, under 0.62.0's changed wrapping of a type-annotated arrow return.
- **Rationale** — Verified that hunk is the bump's *complete* effect, not a sample: `fmt:check` under 0.62.0 passes across all 1395 files, so no later branch inherits formatting churn. 0.62.0's other change routes YAML through a new formatter, which is inert here because the root `fmt` glob excludes `yml`/`yaml`. `oxlint` and `@oxlint/plugins` were left at 1.78.0 — 1.79.0 is 3 days old, and they version independently of oxfmt.

### Remove `better-sqlite3` from `@shared/db-utils` — `approach`

- **Issue** — The workspace declared `better-sqlite3` and `@types/better-sqlite3`. Nothing in `src/` or `tests/` imports either; the only textual hits are a doc comment and a test *name*.
- **Why** — It is the one dependency in this diff with real install cost — a `prebuild-install` native binary download. The package has no drizzle-kit and no `db:*` scripts, so nothing there could ever have loaded it.
- **Solution** — Both removed. `tests/rowsChanged.test.ts` exercises driver result shapes with plain object literals and never loads a driver; 45 tests and `tsc --noEmit` pass without them.
- **Rationale** — Declared dependencies should be the ones a package actually uses, so that dropping one elsewhere is a decision rather than an accident. Note this does not reduce install time — three workspaces still declare the package and the native build is keyed on version in the shared store, not on reference count.

**Out of scope**

- TypeScript 6.0.3 → 7.0.2, blocked upstream by `@astrojs/check@0.9.10`'s `typescript: "^5.0.0 || ^6.0.0"` peer range across five `astro check` workspaces — xchromo/osn#749.
- `cire/db` resolving `better-sqlite3` it never declared, which the isolated-linker trial would break — xchromo/osn#750. Pre-existing; this branch does not touch it.
- No enforcement of the drop-triggers on `minimumReleaseAgeExcludes`, including `bun-types` coming off after 2026-08-23 — xchromo/osn-tracker#456.
- `@cloudflare/workers-types` v5, held so it moves together with wrangler and miniflare. Note `miniflare`'s `latest` dist-tag currently points at a `-alpha` prerelease; 4.20260730.0 is the newest stable and the repo is on it.
- `@solidjs/router` 1.0.0, `jsdom` 30, `ioredis` 6, `motion` 13, `@testing-library/jest-dom` 7, `@changesets/cli` 3 — all inside their waiting periods, eligible between 2026-08-27 and 2026-09-19.
- `solid-toast` (last release 2023-03, used in 6 workspaces) and `@thisbeyond/solid-dnd` (2023-11) are effectively unmaintained. Not actionable now; noted so it is not rediscovered from scratch.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` (full monorepo) | ✅ 32/32 tasks, 0 errors |
| `turbo check --force` (4 affected workspaces) | ✅ 4/4, 0 cached |
| `bun run --cwd pulse/api test:run` | ✅ 634 pass / 42 files |
| `bun run --cwd shared/osn-auth-client test:run` | ✅ 89 pass / 5 files |
| `bun run --cwd shared/rp-auth test:run` | ✅ 43 pass / 2 files |
| `bun run --cwd shared/db-utils test:run` | ✅ 45 pass / 4 files |
| `@pulse/api` build (`wrangler deploy --dry-run`) | ✅ 3305.66 KiB / 598.17 KiB gzip |
| `bun run lint` | ✅ exit 0 (warnings only, all in untouched files) |
| `bun run fmt:check` | ✅ all 1395 files correct under oxfmt 0.62.0 |
| `bun install --frozen-lockfile` | ✅ 875 installs / 1026 packages, no changes |
| `scripts/validate-changesets.sh` | ✅ all package references valid |
| `scripts/changeset-required.sh` | ✅ `required`, and one is present |

811 tests across 53 files, 0 failures.

Supply-chain checks run specifically because this is a dependency PR:

- **Lockfile diff audited entry by entry.** `origin/main` and `HEAD` both resolve exactly 1086 entries. The only differences are `oxfmt` 0.59.0 → 0.62.0 and its 19 `@oxfmt/binding-*` platform packages moving in lockstep. No new or removed transitive packages. `tinypool`, oxfmt's sole runtime dependency, stays pinned at 2.1.0 on both sides. The workspace `version` field churn in the lock diff is `main`'s lockfile catching up to versions already committed in each `package.json`; this branch changes no package's version.
- **Advisories:** none across the full resolved tree, checked via npm's bulk advisory endpoint (the data `npm audit` consumes). GitHub's advisory API and osv.dev are both blocked by the session proxy, so that endpoint was the available source.

Nothing here needs manual exercise — no route, schema, UI or runtime behaviour changed. Two honest negatives: the `@pulse/api` reformat is not covered by a test asserting formatting (nothing is, and `fmt:check` is the gate that matters), and the claim that `bun.lock` is unchanged by the `bunfig.toml` edit was verified by `git status` on the file rather than by a clean-cache reinstall.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHxZ617oaxEfkG2vbnDvGd)_