### PR TITLE
Add @shared/toast and contrast-corrected cire toast tokens

### DIFF
--- a/.changeset/cire-toast-contrast-tokens.md
+++ b/.changeset/cire-toast-contrast-tokens.md
@@ -1,0 +1,21 @@
+---
+"@cire/theme": patch
+"@cire/invites": patch
+---
+
+Derive contrast-corrected toast tokens from an invite's palette.
+
+`--color-error` and `--color-success` are walked against `card`
+(`--color-surface`), but a toast paints on `--color-surface-raised`, which is
+derived as `card ± 0.05` lightness and sits outside that walk. Re-using the page
+tokens on a toast therefore had no contrast guarantee — and on the built-in
+**jewel** preset `--color-success` measures **4.29:1** against the raised surface,
+under the 4.5 WCAG text minimum. Every jewel invite that raised an RSVP
+confirmation was rendering a sub-threshold green.
+
+`derivePalette` now also emits `--toast-surface`, `--toast-ink`, `--toast-border`,
+`--toast-error` and `--toast-success`, identical in hue and chroma to the page's
+pair but walked against the surface the toast actually sits on. A scheme that
+already works gets its colours back untouched. The tokens ride the existing
+allow-list, so they reach the guest document through the same injection gate as
+every other palette variable.

--- a/.changeset/shared-toast-package.md
+++ b/.changeset/shared-toast-package.md
@@ -1,0 +1,28 @@
+---
+"@shared/toast": minor
+---
+
+Add `@shared/toast` — an internal SolidJS toast package, to replace `solid-toast`
+(unmaintained since 2023). No consumer changes yet; the migrations follow.
+
+The API is what the apps already call — `toast.success(message)` /
+`toast.error(message)` — plus the options object they had no way to reach:
+`duration`, `id`, `dismissible`, a per-toast `action`, `politeness`. With
+`toast.promise`, `loading`, `info`, `warning`, `dismiss` and `remove`.
+
+Three things the library it replaces could not do:
+
+- **The container sets no `z-index`.** `solid-toast` spread a hardcoded
+  `z-index: 9999` onto the container's inline style, which beat any class a caller
+  passed. The layer is the consumer's, via `class`.
+- **Theming without `!important`.** Colours come from `--toast-*` custom
+  properties an app maps onto its own tokens once, so overriding no longer means
+  out-shouting inline defaults.
+- **The container is portalled to `<body>`**, so an ancestor's `transform` cannot
+  make itself the containing block for the fixed container and trap the toast
+  below page-level overlays.
+
+Tone is carried by a differently-shaped glyph plus an `sr-only` word rather than
+by hue alone; errors announce `assertive`, everything else `polite`. The store
+owns the auto-dismiss clock and the queue is capped, so a toast that never renders
+still expires and a runaway raise cannot grow the queue without bound.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,8 +1,12 @@
 name: Changeset Check
 
 on:
+  # No `branches:` filter. This repo ships stacked PRs, so a PR's base is often
+  # the branch below it rather than `main` — and because this check is REQUIRED,
+  # filtering to `main` did not merely skip it, it left every stacked PR blocked
+  # on a status that could never report. Same reasoning, and the same fix, as
+  # `ci-swift.yml`.
   pull_request:
-    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -22,8 +26,14 @@ jobs:
         run: bash scripts/changeset-required.test.sh
 
       - name: Check for changeset
+        env:
+          # The PR's own base, not `main` — on a stacked PR those differ, and
+          # diffing against `main` would attribute every commit from the branches
+          # below to this PR. `fetch-depth: 0` above is what makes `origin/<base>`
+          # resolvable for a base that isn't the default branch.
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          diff=$(git diff --name-only origin/main...HEAD)
+          diff=$(git diff --name-only "origin/$BASE_REF...HEAD")
 
           # A PR touching nothing any versioned package ships — Swift/Xcode
           # scaffolding, CI, wiki — has no honest package to name in a

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.20.11",
+      "version": "3.20.12",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/openapi": "1.4.15",
@@ -237,7 +237,7 @@
     },
     "osn/db": {
       "name": "@osn/db",
-      "version": "0.20.6",
+      "version": "0.20.7",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -256,7 +256,7 @@
     },
     "osn/landing": {
       "name": "@osn/landing",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
         "@shared/legal": "workspace:*",
@@ -280,7 +280,7 @@
     },
     "osn/social": {
       "name": "@osn/social",
-      "version": "0.12.10",
+      "version": "0.12.11",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -334,7 +334,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.10",
+      "version": "0.26.11",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -365,7 +365,7 @@
     },
     "pulse/db": {
       "name": "@pulse/db",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -384,7 +384,7 @@
     },
     "pulse/landing": {
       "name": "@pulse/landing",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
         "@shared/legal": "workspace:*",
@@ -408,7 +408,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.16",
+      "version": "0.22.17",
       "dependencies": {
         "@fontsource/geist-mono": "^5.3.0",
         "@fontsource/geist-sans": "^5.3.0",
@@ -443,7 +443,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -459,7 +459,7 @@
     },
     "shared/db-utils": {
       "name": "@shared/db-utils",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "effect": "^3.22.0",
@@ -508,7 +508,7 @@
     },
     "shared/legal": {
       "name": "@shared/legal",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "vitest": "^4.1.10",
@@ -549,7 +549,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.4",
@@ -587,7 +587,7 @@
     },
     "shared/rp-auth": {
       "name": "@shared/rp-auth",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
@@ -604,6 +604,23 @@
       "optionalPeers": [
         "solid-js",
       ],
+    },
+    "shared/toast": {
+      "name": "@shared/toast",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@shared/typescript-config": "workspace:*",
+        "@solidjs/testing-library": "^0.8.10",
+        "@testing-library/jest-dom": "^6.10.0",
+        "happy-dom": "^20.11.1",
+        "solid-js": "^1.9.14",
+        "vite": "^8.1.5",
+        "vite-plugin-solid": "^2.11.14",
+        "vitest": "^4.1.10",
+      },
+      "peerDependencies": {
+        "solid-js": ">=1.9",
+      },
     },
     "shared/turnstile": {
       "name": "@shared/turnstile",
@@ -642,7 +659,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -669,7 +686,7 @@
     },
     "zap/db": {
       "name": "@zap/db",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -1419,6 +1436,8 @@
     "@shared/redis": ["@shared/redis@workspace:shared/redis"],
 
     "@shared/rp-auth": ["@shared/rp-auth@workspace:shared/rp-auth"],
+
+    "@shared/toast": ["@shared/toast@workspace:shared/toast"],
 
     "@shared/turnstile": ["@shared/turnstile@workspace:shared/turnstile"],
 

--- a/cire/invites/src/styles/global.css
+++ b/cire/invites/src/styles/global.css
@@ -371,6 +371,17 @@
   --color-bloom-dim: oklch(70.5% 0.1123 24.5 / 0.3);
   --color-error: oklch(72% 0.1401 21.48);
   --color-success: oklch(64% 0.1421 146.94);
+
+  /* Toast tokens. Same hue and chroma as the pair above, but walked against
+     `--color-surface-raised` — the surface a toast actually paints on — rather
+     than `--color-surface`. On evergreen the two pairs coincide; on `jewel`
+     they do not, which is why the toast has its own. Kept in lockstep with
+     `derivePalette` by `invite-theme.test.ts`. */
+  --toast-surface: oklch(27.7% 0.0275 152.78);
+  --toast-ink: oklch(94.62% 0.0111 89.72);
+  --toast-border: oklch(94.62% 0.0111 89.72 / 0.18);
+  --toast-error: oklch(72% 0.1401 21.48);
+  --toast-success: oklch(64% 0.1421 146.94);
   --font-display: "Cormorant Garamond", "Cormorant Garamond Fallback", Georgia, serif;
   --font-body: "Lato", "Lato Fallback", system-ui, sans-serif;
   --default-font-family: var(--font-body);

--- a/cire/theme/src/palette.test.ts
+++ b/cire/theme/src/palette.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  contrastOklch,
   contrastRatio,
   DERIVED_TOKENS,
   derivePalette,
@@ -16,6 +17,7 @@ import {
   paletteContrastWarnings,
   parseColor,
   resolveSeeds,
+  type DerivedToken,
   type PaletteSeeds,
   rgbToOklch,
   sectionToneVars,
@@ -673,5 +675,108 @@ describe("sectionToneVars", () => {
     expect(sectionToneVars("nonsense" as never)).toEqual({
       "--invite-section-bg": "var(--color-bg)",
     });
+  });
+});
+
+// ── Toast tokens ─────────────────────────────────────────────────────────────
+
+describe("toast tokens", () => {
+  test("emits a toast token for every name the allow-list expects", () => {
+    const tokens = derivePalette(PALETTE_PRESETS.evergreen);
+    for (const key of [
+      "--toast-surface",
+      "--toast-ink",
+      "--toast-border",
+      "--toast-error",
+      "--toast-success",
+    ]) {
+      expect(tokens[key as DerivedToken], key).toBeDefined();
+    }
+  });
+
+  test("paints the toast on the raised surface, matching where it actually sits", () => {
+    const tokens = derivePalette(PALETTE_PRESETS.evergreen);
+    expect(tokens["--toast-surface"]).toBe(tokens["--color-surface-raised"]);
+  });
+
+  /**
+   * The reason these tokens exist. `--color-error` / `--color-success` are
+   * walked against `card`; a toast paints on `raised`, which is derived as
+   * `card ± 0.05` lightness and is outside that walk. Every preset, both
+   * semantic tones, measured against the surface the toast is really on.
+   */
+  test("clears WCAG text contrast on every preset scheme", () => {
+    for (const key of PALETTE_PRESET_KEYS) {
+      const tokens = derivePalette(PALETTE_PRESETS[key]);
+      const surface = parseColor(tokens["--toast-surface"])!;
+      for (const token of ["--toast-ink", "--toast-error", "--toast-success"] as const) {
+        const fg = parseColor(tokens[token])!;
+        expect(contrastOklch(fg, surface), `${token} on ${key}`).toBeGreaterThanOrEqual(
+          WCAG_TEXT_MIN,
+        );
+      }
+    }
+  });
+
+  /**
+   * A straddling scheme — near-black page, near-white cards — is the case that
+   * defeats a single-surface walk, and the one where re-using `--color-error`
+   * on a toast is most likely to come out short.
+   */
+  test("clears contrast on a straddling scheme too", () => {
+    const tokens = derivePalette({
+      ground: "oklch(12% 0.02 260)",
+      card: "oklch(96% 0.01 90)",
+      ink: "oklch(20% 0.02 260)",
+      gilt: "oklch(70% 0.09 82)",
+      bloom: "oklch(65% 0.12 25)",
+    });
+    const surface = parseColor(tokens["--toast-surface"])!;
+    for (const token of ["--toast-ink", "--toast-error", "--toast-success"] as const) {
+      expect(contrastOklch(parseColor(tokens[token])!, surface), token).toBeGreaterThanOrEqual(
+        WCAG_TEXT_MIN,
+      );
+    }
+  });
+
+  /**
+   * The concrete failure that motivated these tokens, pinned so it cannot
+   * return. On the built-in JEWEL preset, `--color-success` measures 4.29:1
+   * against the raised surface a toast paints on — under the 4.5 text minimum —
+   * because it was walked against `card`. `--toast-success` clears it.
+   *
+   * A shipped preset, not a contrived one: every jewel invite that raised an
+   * RSVP confirmation was rendering a sub-threshold green.
+   */
+  test("fixes the jewel preset's sub-threshold success green", () => {
+    const tokens = derivePalette(PALETTE_PRESETS.jewel);
+    const raised = parseColor(tokens["--toast-surface"])!;
+    const page = contrastOklch(parseColor(tokens["--color-success"])!, raised);
+    const toast = contrastOklch(parseColor(tokens["--toast-success"])!, raised);
+    expect(page, "the page token really was short on raised").toBeLessThan(WCAG_TEXT_MIN);
+    expect(toast, "the toast token clears it").toBeGreaterThanOrEqual(WCAG_TEXT_MIN);
+  });
+
+  test("costs nothing on a scheme that already works", () => {
+    // Evergreen's semantics already clear on `raised`, so the extra walk must
+    // return them untouched rather than drifting the organiser's colour.
+    const tokens = derivePalette(PALETTE_PRESETS.evergreen);
+    expect(tokens["--toast-error"]).toBe(tokens["--color-error"]);
+    expect(tokens["--toast-success"]).toBe(tokens["--color-success"]);
+  });
+
+  test("keeps the organiser's hue — a corrected red is still their red", () => {
+    const tokens = derivePalette(PALETTE_PRESETS.jewel);
+    const page = parseColor(tokens["--color-error"])!;
+    const toast = parseColor(tokens["--toast-error"])!;
+    // Lightness may move to clear the surface; hue must not.
+    expect(Math.abs(toast.h - page.h)).toBeLessThan(1);
+  });
+
+  test("emits only safe CSS colours, like every other token", () => {
+    const tokens = derivePalette(PALETTE_PRESETS.chapel);
+    for (const token of ["--toast-surface", "--toast-ink", "--toast-error"] as const) {
+      expect(isSafeCssColor(tokens[token]), token).toBe(true);
+    }
   });
 });

--- a/cire/theme/src/palette.ts
+++ b/cire/theme/src/palette.ts
@@ -255,6 +255,13 @@ export const DERIVED_TOKENS = [
   "--color-bloom-dim",
   "--color-error",
   "--color-success",
+  // Toast tokens. Separate from the pair above because they are measured
+  // against a DIFFERENT surface — see the `--toast-*` block in the return.
+  "--toast-surface",
+  "--toast-ink",
+  "--toast-border",
+  "--toast-error",
+  "--toast-success",
   // Invite-specific compositions that used to be hardcoded literals.
   "--invite-hero-grad-1",
   "--invite-hero-grad-2",
@@ -461,6 +468,24 @@ export function derivePalette(
     "--color-bloom-dim": formatOklch(withAlpha(bloom, 0.3)),
     "--color-error": semantic(21.48, 0.1401, card),
     "--color-success": semantic(146.94, 0.1421, card, 0.64),
+
+    // ── Toast ────────────────────────────────────────────────────────────────
+    // A toast paints on `raised`, not on `card`. The two semantic tokens above
+    // are walked against `card`, and `raised` is derived as `card ± 0.05`
+    // lightness — outside that walk by construction (the same gap
+    // `RESIDUAL_PAIRS` documents for `ink` and `gilt`). Re-using
+    // `--color-error` on a toast therefore had NO contrast guarantee: on a
+    // scheme where the step goes the wrong way it can miss 4.5:1 outright.
+    //
+    // So the toast gets its own pair, identical in hue and chroma to the page's
+    // — an organiser's red is still their red — but walked against the surface
+    // the toast actually sits on. On a well-behaved scheme these come out equal
+    // to the `--color-*` pair and cost nothing.
+    "--toast-surface": formatOklch(raised),
+    "--toast-ink": formatOklch(ensureContrast(ink, raised, WCAG_TEXT_MIN)),
+    "--toast-border": formatOklch(withAlpha(ink, 0.18)),
+    "--toast-error": semantic(21.48, 0.1401, raised),
+    "--toast-success": semantic(146.94, 0.1421, raised, 0.64),
 
     // Hero base gradient — three stops walked across the palette's own
     // surfaces, replacing a hardcoded evergreen `linear-gradient` that ignored

--- a/shared/toast/package.json
+++ b/shared/toast/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@shared/toast",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./Toaster": "./src/Toaster.tsx",
+    "./toast.css": "./src/toast.css"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
+  },
+  "devDependencies": {
+    "@shared/typescript-config": "workspace:*",
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^6.10.0",
+    "happy-dom": "^20.11.1",
+    "solid-js": "^1.9.14",
+    "vite": "^8.1.5",
+    "vite-plugin-solid": "^2.11.14",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "solid-js": ">=1.9"
+  }
+}

--- a/shared/toast/src/Toast.tsx
+++ b/shared/toast/src/Toast.tsx
@@ -1,0 +1,100 @@
+import { Show } from "solid-js";
+
+import { DEFAULT_DURATION, dismiss, pause, scheduleDismiss } from "./store";
+import type { Toast as ToastModel } from "./types";
+
+interface Mark {
+  /** Seen, never read. */
+  glyph: string;
+  /** Read, never seen. */
+  word: string;
+}
+
+/**
+ * Tone marks, following `Notice.tsx` in the host portal: a differently-SHAPED
+ * glyph per tone rather than three colours of one shape. Tone carried by hue
+ * alone puts "saved" and "failed to save" in the same rectangle, and
+ * error/warning is exactly the pair red-green colour blindness collapses.
+ *
+ * The glyph is `aria-hidden` and a word is read in its place — "✕" is not a
+ * thing to hear.
+ */
+const MARK = {
+  success: { glyph: "✓", word: "Success" },
+  error: { glyph: "✕", word: "Error" },
+  warning: { glyph: "!", word: "Warning" },
+  info: { glyph: "i", word: "Note" },
+  loading: { glyph: "◠", word: "Working" },
+} satisfies Readonly<Record<ToastModel["tone"], Mark>>;
+
+export function ToastItem(props: { toast: ToastModel; class?: string }) {
+  /**
+   * Resume the dwell after a pause. NOT the clock's owner — `upsert` starts it,
+   * and this only ever restarts one it stopped.
+   *
+   * That split is deliberate. The first cut had the item own the clock via a
+   * `createEffect`, which looked like it restarted on a tone change but did
+   * not: `props.toast` is a plain object, so those reads track nothing. It
+   * worked only because an update replaces the toast object and `<For>`
+   * remounts the row — a mechanism nobody would know not to optimise away.
+   */
+  const resumeClock = () =>
+    scheduleDismiss(props.toast.id, props.toast.duration ?? DEFAULT_DURATION);
+
+  return (
+    <div
+      class={`osn-toast osn-toast--${props.toast.tone}${props.class ? ` ${props.class}` : ""}${
+        props.toast.class ? ` ${props.toast.class}` : ""
+      }${props.toast.dismissing ? " osn-toast--leaving" : ""}`}
+      // An error interrupts (`assertive`): the thing the user just did did not
+      // happen. Everything else waits its turn.
+      role={props.toast.tone === "error" ? "alert" : "status"}
+      aria-live={props.toast.politeness ?? (props.toast.tone === "error" ? "assertive" : "polite")}
+      data-tone={props.toast.tone}
+      // Pause while the pointer is on it or focus is inside — a toast that
+      // expires mid-sentence is a toast nobody finished reading.
+      onMouseEnter={() => pause(props.toast.id)}
+      onMouseLeave={resumeClock}
+      onFocusIn={() => pause(props.toast.id)}
+      onFocusOut={resumeClock}
+    >
+      <span aria-hidden="true" class="osn-toast__glyph">
+        {MARK[props.toast.tone].glyph}
+      </span>
+      <span class="osn-toast__sr">{MARK[props.toast.tone].word}: </span>
+      {/*
+        The message lives in its OWN element whose `textContent` is EXACTLY the
+        message, with the glyph and the screen-reader word as SIBLINGS outside
+        it. `cire/invites`'s browser test finds a toast with
+        `[...querySelectorAll("div")].find(d => d.textContent === message)` —
+        folding the tone word in here would break that lookup, and with it the
+        z-index regression guard that assertion protects.
+      */}
+      <div class="osn-toast__message">{props.toast.message}</div>
+      <Show when={props.toast.action}>
+        {(action) => (
+          <button
+            type="button"
+            class="osn-toast__action"
+            onClick={() => {
+              action().onClick();
+              dismiss(props.toast.id);
+            }}
+          >
+            {action().label}
+          </button>
+        )}
+      </Show>
+      <Show when={props.toast.dismissible}>
+        <button
+          type="button"
+          class="osn-toast__close"
+          aria-label="Dismiss notification"
+          onClick={() => dismiss(props.toast.id)}
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      </Show>
+    </div>
+  );
+}

--- a/shared/toast/src/Toaster.tsx
+++ b/shared/toast/src/Toaster.tsx
@@ -1,0 +1,60 @@
+import { createMemo, For } from "solid-js";
+import { Portal } from "solid-js/web";
+
+import { toasts } from "./store";
+import { ToastItem } from "./Toast";
+import type { ToasterProps } from "./types";
+
+const DEFAULT_LIMIT = 4;
+
+/**
+ * The toast container. Mount ONE per page, as a sibling of your modals at the
+ * page root.
+ *
+ * ## Why the root, and not wherever the toast is raised
+ *
+ * The container is `position: fixed`, and a `transform`, `filter`, `contain` or
+ * `will-change` on ANY ancestor makes that ancestor the containing block for a
+ * fixed descendant — and a stacking context with it. Mounted inside an animated
+ * section, a toast is positioned against that section and stacked inside it,
+ * below every page-level overlay, whatever `z-index` it carries. That is the
+ * bug that put the cire RSVP toast behind the sheet it fires under.
+ *
+ * `<Portal>` moves the container to `document.body`, which makes this robust by
+ * construction rather than by convention.
+ *
+ * ## No `z-index` here
+ *
+ * Deliberately. The layer belongs to the consumer's stacking order, so pass it
+ * with `class` (e.g. `Z_CLASS.TOAST`). The library this replaced hardcoded
+ * `z-index: 9999` into the container's inline style, which silently beat every
+ * class a caller passed and parked toasts above the consent banner — the one
+ * layer they must never cover.
+ */
+export function Toaster(props: ToasterProps) {
+  const position = () => props.position ?? "bottom-right";
+  const limit = () => props.limit ?? DEFAULT_LIMIT;
+
+  /**
+   * Newest last, and only the last `limit` of them.
+   *
+   * No sort: the queue is already in raise order by construction — a new toast
+   * is appended, and an in-place update rewrites an entry where it sits rather
+   * than moving it. `seq` exists to make that order assertable in tests.
+   */
+  const visible = createMemo(() => {
+    const all = toasts();
+    return all.slice(Math.max(0, all.length - limit()));
+  });
+
+  return (
+    <Portal>
+      <div
+        class={`osn-toaster osn-toaster--${position()}${props.class ? ` ${props.class}` : ""}`}
+        style={props.style}
+      >
+        <For each={visible()}>{(t) => <ToastItem toast={t} class={props.toastClass} />}</For>
+      </div>
+    </Portal>
+  );
+}

--- a/shared/toast/src/index.ts
+++ b/shared/toast/src/index.ts
@@ -1,0 +1,80 @@
+import type { JSX } from "solid-js";
+
+import { dismiss, remove, upsert } from "./store";
+import type { ToastOptions, ToastTone } from "./types";
+
+export { EXIT_MS, resetToasts, toasts } from "./store";
+export { Toaster } from "./Toaster";
+export type { Toast, ToastOptions, ToastPosition, ToastTone, ToasterProps } from "./types";
+
+type Message = JSX.Element;
+
+function raise(tone: ToastTone, message: Message, options?: ToastOptions): string {
+  return upsert({ ...options, tone, message });
+}
+
+interface PromiseMessages<T> {
+  loading: Message;
+  success: Message | ((value: T) => Message);
+  error: Message | ((error: unknown) => Message);
+}
+
+function resolveMessage<A>(message: Message | ((arg: A) => Message), arg: A): Message {
+  return typeof message === "function" ? (message as (a: A) => Message)(arg) : message;
+}
+
+/**
+ * Raise a toast.
+ *
+ * `toast(message)` is the neutral tone; the tone helpers are what the apps
+ * actually call. Every form takes the same optional `ToastOptions`, so a call
+ * site that starts as `toast.success("Saved")` can grow a duration or an
+ * action without changing shape.
+ */
+function toast(message: Message, options?: ToastOptions): string {
+  return raise("info", message, options);
+}
+
+toast.success = (message: Message, options?: ToastOptions) => raise("success", message, options);
+toast.error = (message: Message, options?: ToastOptions) => raise("error", message, options);
+toast.info = (message: Message, options?: ToastOptions) => raise("info", message, options);
+toast.warning = (message: Message, options?: ToastOptions) => raise("warning", message, options);
+
+/**
+ * A toast that stays until something dismisses it. `Infinity` rather than a
+ * long duration: a spinner that times out on its own leaves the user believing
+ * the work finished.
+ */
+toast.loading = (message: Message, options?: ToastOptions) =>
+  raise("loading", message, { duration: Number.POSITIVE_INFINITY, ...options });
+
+toast.dismiss = (id?: string) => dismiss(id);
+/** Drop a toast with no exit animation. Rarely what you want — prefer `dismiss`. */
+toast.remove = (id: string) => remove(id);
+
+/**
+ * Bind a toast to a promise: one toast that starts as a spinner and becomes
+ * the outcome in place, because `id` stays the same across all three states.
+ *
+ * Re-throws on rejection. The toast is a report on the promise, not a handler
+ * for it — swallowing here would silently turn a failed save into a caller
+ * that thinks it succeeded.
+ */
+toast.promise = async <T>(
+  promise: Promise<T>,
+  messages: PromiseMessages<T>,
+  options?: ToastOptions,
+): Promise<T> => {
+  const id = toast.loading(messages.loading, options);
+  try {
+    const value = await promise;
+    raise("success", resolveMessage(messages.success, value), { ...options, id });
+    return value;
+  } catch (error) {
+    raise("error", resolveMessage(messages.error, error), { ...options, id });
+    throw error;
+  }
+};
+
+export { toast };
+export default toast;

--- a/shared/toast/src/store.ts
+++ b/shared/toast/src/store.ts
@@ -1,0 +1,167 @@
+import { createSignal } from "solid-js";
+
+import type { Toast, ToastOptions, ToastTone } from "./types";
+
+/**
+ * The toast queue.
+ *
+ * A module-level signal rather than a context, deliberately: `toast.success(…)`
+ * is called from event handlers, `catch` blocks and non-component modules all
+ * over the apps, none of which sit inside a provider's reactive scope. A
+ * context would force every one of those call sites to become a hook.
+ *
+ * The trade is that there is ONE queue per page. That is what we want — the
+ * `<Toaster>` is mounted once at a page root, and a second one rendering the
+ * same toasts twice would be a bug, not a feature.
+ */
+const [toasts, setToasts] = createSignal<Toast[]>([]);
+
+export { toasts };
+
+/** Timers keyed by toast id, so an update can restart a toast's clock. */
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * How long a dismissing toast stays mounted so its exit animation can run.
+ * Must stay >= the `--toast-exit-duration` the stylesheet uses; under
+ * `prefers-reduced-motion` the animation collapses to ~0 and this just becomes
+ * a short delay nobody sees.
+ */
+export const EXIT_MS = 200;
+
+let seq = 0;
+let autoId = 0;
+
+/**
+ * Hard cap on the QUEUE, as opposed to `Toaster`'s `limit`, which caps what
+ * renders. The two are different: a toast that never mounts never starts its
+ * own clock, so without a cap here a burst raised inside one Solid batch (every
+ * event handler is batched) leaves the toasts beyond `limit` in the array for
+ * the life of the page. Comfortably above any sane `limit`, so it only ever
+ * catches runaway raises — a degraded backend pumping error toasts at a
+ * long-lived tab.
+ */
+const MAX_QUEUED = 24;
+
+function clearTimer(id: string) {
+  const t = timers.get(id);
+  if (t !== undefined) {
+    clearTimeout(t);
+    timers.delete(id);
+  }
+}
+
+/** Remove immediately, no exit animation. Used once the animation has run. */
+export function remove(id: string) {
+  clearTimer(id);
+  setToasts((list) => list.filter((t) => t.id !== id));
+}
+
+/**
+ * Start a toast leaving: mark it `dismissing` so the exit animation plays,
+ * then drop it. Idempotent — dismissing an already-dismissing toast is a no-op
+ * rather than a second timer racing the first.
+ */
+export function dismiss(id?: string) {
+  if (id === undefined) {
+    for (const t of toasts()) dismiss(t.id);
+    return;
+  }
+  const current = toasts().find((t) => t.id === id);
+  if (!current || current.dismissing) return;
+  clearTimer(id);
+  setToasts((list) => list.map((t) => (t.id === id ? { ...t, dismissing: true } : t)));
+  timers.set(
+    id,
+    setTimeout(() => remove(id), EXIT_MS),
+  );
+}
+
+/** (Re)start the auto-dismiss clock for a toast. `Infinity` pins it. */
+export function scheduleDismiss(id: string, duration: number) {
+  clearTimer(id);
+  if (!Number.isFinite(duration)) return;
+  timers.set(
+    id,
+    setTimeout(() => dismiss(id), duration),
+  );
+}
+
+/** Stop a toast's clock — hover/focus pauses it, so a toast can be read. */
+export function pause(id: string) {
+  clearTimer(id);
+}
+
+/**
+ * The dwell a toast gets when it does not ask for one. Long enough to read a
+ * sentence, short enough not to nag.
+ *
+ * It lives here because the STORE owns the clock — see `upsert`. There is
+ * deliberately no per-`Toaster` default: two owners of one timer is what made
+ * the first cut of this fragile, and the only mount that ever passed one passed
+ * exactly this value.
+ */
+export const DEFAULT_DURATION = 4000;
+
+export interface UpsertInput extends ToastOptions {
+  tone: ToastTone;
+  message: Toast["message"];
+}
+
+/**
+ * Raise a toast, or update the one already carrying this id.
+ *
+ * The update path is what makes `toast.promise` work: the same id goes from
+ * `loading` to `success` in place, so the user sees one toast change rather
+ * than a spinner vanishing and a tick appearing somewhere else in the stack.
+ * An update also clears `dismissing`, so re-raising an id mid-exit revives it
+ * rather than leaving a zombie that is about to disappear.
+ */
+export function upsert(input: UpsertInput): string {
+  const id = input.id ?? `t${++autoId}`;
+  const existing = toasts().find((t) => t.id === id);
+
+  if (existing) {
+    // Reviving a toast that was on its way out: kill the pending removal, or
+    // the stale timer fires a moment later and takes the revived toast with it.
+    // The item's effect restarts the dwell when `dismissing` flips back.
+    if (existing.dismissing) clearTimer(id);
+    // REPLACE the options rather than merging over them. An upsert declares the
+    // toast's whole new state, and a merge would let the previous state's
+    // fields leak into it — `toast.promise` turning a `loading` (pinned at
+    // `Infinity`) into a `success` would carry that duration across and pin the
+    // result on screen for ever. Only `seq` survives, so raise order holds.
+    setToasts((list) =>
+      list.map((t) => (t.id === id ? { ...input, id, seq: t.seq, dismissing: false } : t)),
+    );
+  } else {
+    setToasts((list) => {
+      const next = [...list, { ...input, id, seq: ++seq }];
+      if (next.length <= MAX_QUEUED) return next;
+      // Evict the oldest entries that are not already leaving — a dismissing
+      // toast is mid-animation and owns its own removal.
+      const overflow = next.length - MAX_QUEUED;
+      const doomed = next.filter((t) => !t.dismissing).slice(0, overflow);
+      for (const t of doomed) clearTimer(t.id);
+      const drop = new Set(doomed.map((t) => t.id));
+      return next.filter((t) => !drop.has(t.id));
+    });
+  }
+
+  // The STORE starts the clock, not the rendered item — one owner. A toast
+  // beyond the Toaster's `limit` never mounts, and a paused toast pushed out of
+  // the visible window unmounts without `onMouseLeave` ever firing; with an
+  // item-owned clock neither ever starts, and the entry sits in the queue for
+  // the life of the page.
+  scheduleDismiss(id, input.duration ?? DEFAULT_DURATION);
+  return id;
+}
+
+/** Test seam — drop everything and cancel every timer. */
+export function resetToasts() {
+  for (const t of timers.values()) clearTimeout(t);
+  timers.clear();
+  setToasts([]);
+  seq = 0;
+  autoId = 0;
+}

--- a/shared/toast/src/toast.css
+++ b/shared/toast/src/toast.css
@@ -1,0 +1,250 @@
+/*
+ * @shared/toast — the whole visual surface, in plain CSS.
+ *
+ * Deliberately NOT Tailwind. Consumers span two token vocabularies (shadcn
+ * names in `@osn/social`/`@pulse/web`, cire's own in `@cire/*`) and only two of
+ * the five apps declare the `base:` variant or `@source` a workspace package,
+ * so utilities here would mean threading Tailwind config changes through every
+ * consumer. A stylesheet keyed off custom properties needs none of that, and
+ * makes theming a pure variable exercise.
+ *
+ * ## Theming
+ *
+ * Every colour is a `var(--toast-*)` with a neutral fallback, so the package
+ * renders sanely with nothing set and takes an app's identity the moment it
+ * maps its own tokens onto these names — once, anywhere in the cascade above
+ * the container:
+ *
+ *   :root {
+ *     --toast-surface: var(--color-surface-raised);
+ *     --toast-ink: var(--color-text);
+ *     --toast-accent-error: var(--toast-error);
+ *   }
+ *
+ * The container is portalled to <body>, so anything set on :root or <html>
+ * reaches it. cire's palette lands on <html>, so its invites theme their
+ * toasts with no extra wiring at all.
+ */
+
+.osn-toaster {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  /*
+   * No z-index. The layer is the consumer's to set via `class` — see the
+   * docblock on `Toaster`.
+   *
+   * `pointer-events: none` so the container never eats clicks meant for the
+   * page under it; each toast re-enables them for itself. Note for tests:
+   * this makes `document.elementFromPoint` see straight through the container,
+   * so assert on computed style and DOM position instead.
+   */
+  pointer-events: none;
+  max-width: min(100vw, 26rem);
+}
+
+.osn-toaster--top-left {
+  top: 0;
+  left: 0;
+  align-items: flex-start;
+}
+.osn-toaster--top-center {
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+.osn-toaster--top-right {
+  top: 0;
+  right: 0;
+  align-items: flex-end;
+}
+.osn-toaster--bottom-left {
+  bottom: 0;
+  left: 0;
+  align-items: flex-start;
+}
+.osn-toaster--bottom-center {
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+.osn-toaster--bottom-right {
+  bottom: 0;
+  right: 0;
+  align-items: flex-end;
+}
+
+/* Newest nearest the edge the stack grows from. */
+.osn-toaster--bottom-left,
+.osn-toaster--bottom-center,
+.osn-toaster--bottom-right {
+  flex-direction: column-reverse;
+}
+
+.osn-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  box-sizing: border-box;
+  max-width: 100%;
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--toast-border, rgb(0 0 0 / 0.12));
+  border-radius: var(--toast-radius, 0.375rem);
+  background: var(--toast-surface, #ffffff);
+  color: var(--toast-ink, #1c1c1c);
+  box-shadow: var(--toast-shadow, 0 6px 20px rgb(0 0 0 / 0.18));
+  font-family: var(--toast-font, inherit);
+  font-size: var(--toast-font-size, 0.85rem);
+  line-height: 1.45;
+  animation: osn-toast-in var(--toast-enter-duration, 160ms) ease-out both;
+}
+
+.osn-toast--leaving {
+  animation: osn-toast-out var(--toast-exit-duration, 160ms) ease-in both;
+}
+
+/*
+ * The glyph is the tone's SHAPE, and the accent is its colour. Both carry the
+ * tone, so neither alone has to.
+ */
+.osn-toast__glyph {
+  flex: none;
+  width: 0.9rem;
+  text-align: center;
+  font-weight: 700;
+  color: var(--toast-accent, currentColor);
+  user-select: none;
+}
+
+.osn-toast--success {
+  --toast-accent: var(--toast-accent-success, #1a7f4b);
+}
+.osn-toast--error {
+  --toast-accent: var(--toast-accent-error, #b3261e);
+}
+.osn-toast--warning {
+  --toast-accent: var(--toast-accent-warn, #8a5a00);
+}
+.osn-toast--info {
+  --toast-accent: var(--toast-accent-info, currentColor);
+}
+.osn-toast--loading {
+  --toast-accent: var(--toast-accent-info, currentColor);
+}
+
+.osn-toast--loading .osn-toast__glyph {
+  animation: osn-toast-spin 900ms linear infinite;
+}
+
+.osn-toast__message {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.osn-toast__action,
+.osn-toast__close {
+  flex: none;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+}
+
+.osn-toast__action {
+  align-self: center;
+  margin-left: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--toast-border, rgb(0 0 0 / 0.12));
+  border-radius: calc(var(--toast-radius, 0.375rem) - 0.125rem);
+  color: var(--toast-accent, inherit);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/*
+ * `padding` here is not decoration: it brings the close button to the WCAG
+ * 2.5.8 24px minimum target on a glyph this small.
+ */
+.osn-toast__close {
+  align-self: flex-start;
+  margin: -0.25rem -0.25rem -0.25rem 0.25rem;
+  padding: 0.375rem;
+  line-height: 1;
+  opacity: 0.65;
+}
+
+.osn-toast__close:hover,
+.osn-toast__close:focus-visible {
+  opacity: 1;
+}
+
+.osn-toast__action:focus-visible,
+.osn-toast__close:focus-visible {
+  outline: 2px solid var(--toast-focus, var(--toast-accent, currentColor));
+  outline-offset: 2px;
+}
+
+/* Read, never seen. Matches the repo's `sr-only`. */
+.osn-toast__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes osn-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes osn-toast-out {
+  from {
+    opacity: 1;
+    transform: none;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(0.25rem) scale(0.97);
+  }
+}
+
+@keyframes osn-toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/*
+ * Motion is opt-out at the source as well as globally. `cire/invites` already
+ * clamps every animation under this query, but the other four consumers do not
+ * all have such a clamp, and a package that only behaves inside one app's
+ * global CSS is not portable.
+ *
+ * Near-zero rather than `none` so `animationend` listeners still fire.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .osn-toast,
+  .osn-toast--leaving,
+  .osn-toast--loading .osn-toast__glyph {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
+}

--- a/shared/toast/src/toast.story.tsx
+++ b/shared/toast/src/toast.story.tsx
@@ -1,0 +1,282 @@
+import { For, onMount } from "solid-js";
+
+import { resetToasts, toast } from "./index";
+import { Toaster } from "./Toaster";
+import type { ToastPosition, ToastTone } from "./types";
+
+/**
+ * Rendered by the component lab (`bun run dev:lab`) — a story living next to
+ * the package it exercises rather than in `tools/lab`. Nothing imports this
+ * file at build time; the lab finds it by glob.
+ *
+ * ## Why this bench exists
+ *
+ * A toast is almost entirely the things a unit test cannot see: how it enters
+ * and leaves, whether it reads at a glance, whether the tone is legible on the
+ * surface it lands on, and whether the stack behaves when four of them arrive
+ * at once. `shared/toast/tests` asserts the queue and the DOM contract; this is
+ * where you look at the result.
+ *
+ * The lab borrows `@osn/social`'s stylesheet, which maps the shadcn ramp onto
+ * the `--toast-*` contract — so the lab's **light · dark** toggle re-themes
+ * these toasts exactly as it re-themes the app. Use it: the accent colours are
+ * per-ramp, and dark is where a too-dark accent hides.
+ *
+ * See `wiki/systems/toast.md`.
+ */
+export const meta = { title: "shared/toast", layout: "padded" as const };
+
+const TONES: ToastTone[] = ["success", "error", "warning", "info", "loading"];
+
+/** Realistic copy — a bench that says "this is a error toast" tests nothing about
+ *  how a real message wraps, and reads as a placeholder rather than a sample. */
+const MESSAGE = {
+  success: "Schedule saved",
+  error: "Could not save the schedule",
+  warning: "Two events share a name",
+  info: "Guests are matched to events by name",
+  loading: "Saving the schedule…",
+} satisfies Record<ToastTone, string>;
+const POSITIONS: ToastPosition[] = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+];
+
+/**
+ * Empty the queue when a bench opens.
+ *
+ * The store is a module singleton — deliberately, so `toast.success(…)` works
+ * from a `catch` block with no provider in scope — which means toasts raised in
+ * one story are still queued when you navigate to the next one. Fine in an app,
+ * where there is one page; confusing in a bench, where "four toasts" when you
+ * raised one is the first thing you'd chase.
+ */
+function useCleanQueue() {
+  onMount(resetToasts);
+}
+
+function Button(props: { onClick: () => void; children: string }) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      class="border-border bg-card hover:bg-muted focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {props.children}
+    </button>
+  );
+}
+
+function Section(props: {
+  title: string;
+  hint?: string;
+  children: import("solid-js").JSX.Element;
+}) {
+  return (
+    <section class="flex flex-col gap-2">
+      <h3 class="text-sm font-medium">{props.title}</h3>
+      {props.hint ? <p class="text-muted-foreground max-w-prose text-xs">{props.hint}</p> : null}
+      <div class="flex flex-wrap gap-2">{props.children}</div>
+    </section>
+  );
+}
+
+/**
+ * Every tone, raised on demand.
+ *
+ * The thing to check is that tone is never carried by hue alone: each one leads
+ * with a differently-*shaped* glyph, because `error` and `warning` are exactly
+ * the pair red-green colour blindness collapses. Squint, or switch the lab to
+ * dark, and they should still be tellable apart.
+ */
+export const Tones = () => {
+  useCleanQueue();
+  return (
+    <div class="flex flex-col gap-6">
+      <Section
+        title="Tones"
+        hint="Errors announce assertively (role=alert); everything else waits its turn (role=status)."
+      >
+        <For each={TONES}>
+          {(tone) => <Button onClick={() => toast[tone](MESSAGE[tone])}>{tone}</Button>}
+        </For>
+      </Section>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+};
+
+/**
+ * All six positions. Worth walking through on a phone viewport as well as a
+ * laptop one — the container is capped at `min(100vw, 26rem)`, and the
+ * top/bottom-centre variants are the ones that can collide with app chrome.
+ */
+export const Positions = () => {
+  useCleanQueue();
+  let current: ToastPosition = "bottom-right";
+  return (
+    <div class="flex flex-col gap-6">
+      <Section title="Positions" hint="Raises a toast in the chosen corner.">
+        <For each={POSITIONS}>
+          {(position) => (
+            <Button
+              onClick={() => {
+                current = position;
+                toast.info(position, { id: "position" });
+              }}
+            >
+              {position}
+            </Button>
+          )}
+        </For>
+      </Section>
+      {/* One Toaster per position so the story can show all six without
+          remounting — each only ever holds the toast raised into it. */}
+      <For each={POSITIONS}>{(position) => <Toaster position={position} limit={1} />}</For>
+      <p class="text-muted-foreground text-xs">
+        Six Toasters are mounted here, one per corner — a real app mounts exactly one. Current:{" "}
+        <code>{current}</code>
+      </p>
+    </div>
+  );
+};
+
+/**
+ * The stack. `limit` caps what is on screen and drops the oldest, so a burst
+ * cannot bury the page.
+ *
+ * Raise "five at once" and watch them enter staggered by their own animation
+ * rather than all at once; then hover the stack — the dwell pauses while the
+ * pointer is on it, so a toast can't expire mid-sentence.
+ */
+export const Stacking = () => {
+  useCleanQueue();
+  return (
+    <div class="flex flex-col gap-6">
+      <Section
+        title="Stacking"
+        hint="Hover the stack to pause every dwell. Limit is 3 here, so the fourth pushes the first out."
+      >
+        <Button
+          onClick={() => {
+            for (const [i, tone] of (
+              ["success", "error", "info", "warning", "success"] as const
+            ).entries()) {
+              toast[tone](`Message ${i + 1}`);
+            }
+          }}
+        >
+          five at once
+        </Button>
+        <Button onClick={() => toast.success("One more")}>one more</Button>
+        <Button onClick={() => toast.dismiss()}>dismiss all</Button>
+      </Section>
+      <Toaster position="bottom-right" limit={3} />
+    </div>
+  );
+};
+
+/**
+ * The richer surface: a pinned toast with an action, a dismissible one, and
+ * `toast.promise` turning one spinner into one result **in place** — the id
+ * stays the same, so you should see the toast change rather than one vanish and
+ * another appear somewhere else in the stack.
+ */
+export const Interactive = () => {
+  useCleanQueue();
+  return (
+    <div class="flex flex-col gap-6">
+      <Section title="Actions and promises">
+        <Button
+          onClick={() =>
+            toast.error("Could not save the schedule", {
+              duration: Number.POSITIVE_INFINITY,
+              action: { label: "Retry", onClick: () => toast.success("Saved") },
+            })
+          }
+        >
+          with an action
+        </Button>
+        <Button
+          onClick={() =>
+            toast.info("A standing note", { duration: Number.POSITIVE_INFINITY, dismissible: true })
+          }
+        >
+          dismissible
+        </Button>
+        <Button
+          onClick={() => {
+            void toast.promise(new Promise((r) => setTimeout(r, 1800)), {
+              loading: "Saving the schedule…",
+              success: "Schedule saved",
+              error: "Could not save",
+            });
+          }}
+        >
+          promise — resolves
+        </Button>
+        <Button
+          onClick={() => {
+            void toast
+              .promise(
+                new Promise((_, reject) => setTimeout(() => reject(new Error("503")), 1800)),
+                {
+                  loading: "Saving the schedule…",
+                  success: "Schedule saved",
+                  error: (e) => `Could not save: ${(e as Error).message}`,
+                },
+              )
+              // `toast.promise` re-throws — the toast reports on the promise, it
+              // does not handle it. Swallow it here so the lab console stays clean.
+              .catch(() => {});
+          }}
+        >
+          promise — rejects
+        </Button>
+      </Section>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+};
+
+/**
+ * A long message and a short one, side by side.
+ *
+ * The message wraps inside a capped container and the glyph stays pinned to the
+ * first line — `align-items: flex-start`, not `center`, which is the difference
+ * between a tidy three-line toast and one with a glyph floating in the middle
+ * of it.
+ */
+export const Overflow = () => {
+  useCleanQueue();
+  return (
+    <div class="flex flex-col gap-6">
+      <Section title="Long content">
+        <Button onClick={() => toast.success("Saved")}>short</Button>
+        <Button
+          onClick={() =>
+            toast.error(
+              "We couldn't save the schedule because two events now claim the same name, and the invite resolves events by name when it matches guests to them.",
+            )
+          }
+        >
+          long
+        </Button>
+        <Button
+          onClick={() =>
+            toast.info(
+              "supercalifragilisticexpialidocious-and-then-some-unbroken-token-that-cannot-wrap",
+            )
+          }
+        >
+          unbreakable token
+        </Button>
+      </Section>
+      <Toaster position="bottom-right" />
+    </div>
+  );
+};

--- a/shared/toast/src/types.ts
+++ b/shared/toast/src/types.ts
@@ -1,0 +1,71 @@
+import type { JSX } from "solid-js";
+
+/**
+ * The four tones a toast can carry.
+ *
+ * `success` and `error` are the only two the apps use today; `info` and
+ * `warning` exist because a tone set that can't say "heads up" pushes callers
+ * back onto `error`, and an error that isn't one trains people to ignore the
+ * real ones.
+ *
+ * Tone is never carried by hue alone — see `MARK` in `Toast.tsx`. `error` and
+ * `warning` are exactly the pair red-green colour blindness collapses, so each
+ * tone leads with a differently-SHAPED glyph and an `sr-only` word.
+ */
+export type ToastTone = "success" | "error" | "info" | "warning" | "loading";
+
+export type ToastPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
+export interface ToastOptions {
+  /**
+   * Milliseconds on screen. `Infinity` pins the toast until it is dismissed —
+   * which is what `loading` uses, and the only sane default for one.
+   */
+  duration?: number;
+  /**
+   * Stable identity. Raising a toast with an id that is already on screen
+   * UPDATES it rather than stacking a second copy, which is what makes
+   * `toast.promise` able to turn one spinner into one result.
+   */
+  id?: string;
+  /** Show a close button. Off by default — a toast that auto-dismisses doesn't need one. */
+  dismissible?: boolean;
+  /** One optional action. `onClick` runs, then the toast dismisses itself. */
+  action?: { label: string; onClick: () => void };
+  /** Extra classes on the toast element. Appended, so they win on ties. */
+  class?: string;
+  /**
+   * Override the live-region politeness. Defaults to `assertive` for `error`
+   * and `polite` for everything else: an error interrupts because the thing
+   * the user just did did not happen, a confirmation does not.
+   */
+  politeness?: "polite" | "assertive";
+}
+
+export interface Toast extends ToastOptions {
+  id: string;
+  tone: ToastTone;
+  message: JSX.Element;
+  /** Monotonic, so the render order is raise order regardless of Map iteration. */
+  seq: number;
+  /** Set when the toast is leaving, so the exit animation can run before removal. */
+  dismissing?: boolean;
+}
+
+export interface ToasterProps {
+  position?: ToastPosition;
+  /** Classes on the fixed container — this is where a consumer's z-index layer goes. */
+  class?: string;
+  /** Inline styles on the fixed container, for offsets a class can't express. */
+  style?: JSX.CSSProperties;
+  /** Classes applied to every toast this Toaster renders. */
+  toastClass?: string;
+  /** Max toasts on screen at once. Older ones are dropped from the far end. */
+  limit?: number;
+}

--- a/shared/toast/tests/Toaster.test.tsx
+++ b/shared/toast/tests/Toaster.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { toast } from "../src/index";
+import { resetToasts, toasts } from "../src/store";
+import { Toaster } from "../src/Toaster";
+
+afterEach(() => {
+  cleanup();
+  resetToasts();
+  vi.useRealTimers();
+});
+
+describe("Toaster", () => {
+  it("renders a raised toast", async () => {
+    render(() => <Toaster />);
+    toast.success("Saved");
+    expect(await screen.findByText("Saved")).toBeTruthy();
+  });
+
+  it("portals the container to <body>, so an animated ancestor can't trap it", () => {
+    // A `transform` on an ancestor makes it the containing block AND a stacking
+    // context for a `position: fixed` descendant — the exact mechanism that put
+    // the cire RSVP toast behind the sheet it fires under. The portal is what
+    // makes that impossible rather than merely discouraged.
+    const { container } = render(() => (
+      <div style={{ transform: "translateY(0)" }}>
+        <Toaster />
+      </div>
+    ));
+    expect(container.querySelector(".osn-toaster")).toBeNull();
+    expect(document.body.querySelector(".osn-toaster")).toBeTruthy();
+  });
+
+  it("sets NO z-index of its own, and takes the layer from `class`", () => {
+    // The library this replaced hardcoded `z-index: 9999` into the container's
+    // inline style, which silently beat every class a caller passed and parked
+    // toasts above the consent banner. An inline z-index here would be that bug.
+    render(() => <Toaster class="z-150" />);
+    const el = document.body.querySelector(".osn-toaster") as HTMLElement;
+    expect(el.style.zIndex).toBe("");
+    expect(el.className).toContain("z-150");
+  });
+
+  it("puts the message in an element whose textContent is EXACTLY the message", () => {
+    // `cire/invites`'s browser test finds a toast with
+    // `[...querySelectorAll("div")].find(d => d.textContent === message)`.
+    // Folding the tone word into this element would break that lookup, and with
+    // it the two-sided z-index regression guard it protects.
+    render(() => <Toaster />);
+    toast.error("Could not save");
+    const match = [...document.querySelectorAll("div")].find(
+      (d) => d.textContent === "Could not save",
+    );
+    expect(match, "no element whose textContent is exactly the message").toBeTruthy();
+  });
+
+  it("names the tone for assistive tech without showing the word", () => {
+    render(() => <Toaster />);
+    toast.error("Could not save");
+    const sr = document.querySelector(".osn-toast__sr");
+    expect(sr?.textContent).toBe("Error: ");
+    expect(document.querySelector(".osn-toast__glyph")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("interrupts for an error and waits its turn for a confirmation", () => {
+    render(() => <Toaster />);
+    toast.error("Could not save");
+    toast.success("Saved");
+    const error = document.querySelector(".osn-toast--error")!;
+    const success = document.querySelector(".osn-toast--success")!;
+    expect(error.getAttribute("role")).toBe("alert");
+    expect(error.getAttribute("aria-live")).toBe("assertive");
+    expect(success.getAttribute("role")).toBe("status");
+    expect(success.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("caps the stack at `limit`, dropping the oldest", () => {
+    render(() => <Toaster limit={2} />);
+    toast.info("One");
+    toast.info("Two");
+    toast.info("Three");
+    expect(document.querySelectorAll(".osn-toast")).toHaveLength(2);
+    expect(screen.queryByText("One")).toBeNull();
+    expect(screen.getByText("Three")).toBeTruthy();
+  });
+
+  it("dismisses on its own once the dwell elapses", async () => {
+    render(() => <Toaster />);
+    toast.success("Saved", { duration: 50 });
+    expect(screen.getByText("Saved")).toBeTruthy();
+    await waitFor(() => expect(toasts()).toHaveLength(0), { timeout: 2000 });
+  });
+
+  it("pauses the dwell while the pointer is over it, so a toast can be read", async () => {
+    render(() => <Toaster />);
+    toast.success("Saved", { duration: 60 });
+    const el = document.querySelector(".osn-toast") as HTMLElement;
+    el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    await new Promise((r) => setTimeout(r, 150));
+    expect(toasts(), "the toast expired while being read").toHaveLength(1);
+  });
+
+  it("runs an action and then dismisses", async () => {
+    const onClick = vi.fn();
+    render(() => <Toaster />);
+    toast.error("Could not save", { action: { label: "Retry", onClick }, duration: 10_000 });
+    (screen.getByText("Retry") as HTMLButtonElement).click();
+    expect(onClick).toHaveBeenCalledOnce();
+    await waitFor(() => expect(toasts()).toHaveLength(0));
+  });
+
+  it("offers a dismiss button only when asked", async () => {
+    render(() => <Toaster />);
+    toast.info("Standing note", { dismissible: true, duration: 10_000 });
+    const close = screen.getByLabelText("Dismiss notification");
+    close.click();
+    await waitFor(() => expect(toasts()).toHaveLength(0));
+  });
+});
+
+describe("toast.promise", () => {
+  it("turns one spinner into one result, in place", async () => {
+    render(() => <Toaster />);
+    let settle: (v: string) => void;
+    const p = new Promise<string>((r) => {
+      settle = r;
+    });
+    const done = toast.promise(p, {
+      loading: "Saving…",
+      success: (v) => `Saved ${v}`,
+      error: "Failed",
+    });
+    expect(screen.getByText("Saving…")).toBeTruthy();
+    expect(document.querySelectorAll(".osn-toast")).toHaveLength(1);
+
+    settle!("draft");
+    await done;
+    // Same single toast, now the outcome — not a spinner vanishing and a tick
+    // appearing elsewhere in the stack.
+    expect(document.querySelectorAll(".osn-toast")).toHaveLength(1);
+    expect(screen.getByText("Saved draft")).toBeTruthy();
+  });
+
+  it("re-throws, so a failed save can't look like a successful one to the caller", async () => {
+    render(() => <Toaster />);
+    const boom = new Error("nope");
+    await expect(
+      toast.promise(Promise.reject(boom), {
+        loading: "Saving…",
+        success: "Saved",
+        error: (e) => `Failed: ${(e as Error).message}`,
+      }),
+    ).rejects.toThrow("nope");
+    expect(screen.getByText("Failed: nope")).toBeTruthy();
+  });
+
+  it("gives the outcome its own dwell instead of inheriting the spinner's Infinity", async () => {
+    render(() => <Toaster />);
+    await toast.promise(
+      Promise.resolve(1),
+      { loading: "Saving…", success: "Saved", error: "No" },
+      {
+        duration: 60,
+      },
+    );
+    expect(screen.getByText("Saved")).toBeTruthy();
+    // Would hang for ever if the success inherited `loading`'s pinned duration.
+    await waitFor(() => expect(toasts()).toHaveLength(0), { timeout: 2000 });
+  });
+});

--- a/shared/toast/tests/store.test.ts
+++ b/shared/toast/tests/store.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { dismiss, EXIT_MS, resetToasts, scheduleDismiss, toasts, upsert } from "../src/store";
+
+afterEach(() => {
+  resetToasts();
+  vi.useRealTimers();
+});
+
+describe("the toast queue", () => {
+  it("raises a toast and hands back its id", () => {
+    const id = upsert({ tone: "success", message: "Saved" });
+    expect(toasts()).toHaveLength(1);
+    expect(toasts()[0]).toMatchObject({ id, tone: "success", message: "Saved" });
+  });
+
+  it("gives each toast a distinct auto id, so two raises stack", () => {
+    upsert({ tone: "success", message: "One" });
+    upsert({ tone: "success", message: "Two" });
+    expect(toasts()).toHaveLength(2);
+    expect(toasts()[0]!.id).not.toBe(toasts()[1]!.id);
+  });
+
+  it("UPDATES in place when the id is already on screen rather than stacking a copy", () => {
+    upsert({ tone: "loading", message: "Saving…", id: "save" });
+    upsert({ tone: "success", message: "Saved", id: "save" });
+    expect(toasts()).toHaveLength(1);
+    expect(toasts()[0]).toMatchObject({ id: "save", tone: "success", message: "Saved" });
+  });
+
+  it("keeps raise order through an in-place update", () => {
+    upsert({ tone: "info", message: "First", id: "a" });
+    upsert({ tone: "info", message: "Second", id: "b" });
+    upsert({ tone: "success", message: "First done", id: "a" });
+    // `seq` is assigned once at raise, so an update must not jump the queue.
+    expect(toasts().map((t) => t.seq)).toEqual([1, 2]);
+  });
+
+  it("revives a dismissing toast when its id is re-raised, rather than leaving a zombie", () => {
+    vi.useFakeTimers();
+    upsert({ tone: "loading", message: "Saving…", id: "save" });
+    dismiss("save");
+    expect(toasts()[0]!.dismissing).toBe(true);
+    upsert({ tone: "success", message: "Saved", id: "save" });
+    expect(toasts()[0]!.dismissing).toBe(false);
+    // The pending removal must not fire now that the toast is live again.
+    vi.advanceTimersByTime(EXIT_MS + 10);
+    expect(toasts()).toHaveLength(1);
+  });
+});
+
+describe("dismissal", () => {
+  it("marks the toast leaving first, then removes it once the exit has run", () => {
+    vi.useFakeTimers();
+    const id = upsert({ tone: "success", message: "Saved" });
+    dismiss(id);
+    // Still mounted — otherwise the exit animation has nothing to animate.
+    expect(toasts()).toHaveLength(1);
+    expect(toasts()[0]!.dismissing).toBe(true);
+    vi.advanceTimersByTime(EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it("is idempotent — a second dismiss does not race the first", () => {
+    vi.useFakeTimers();
+    const id = upsert({ tone: "success", message: "Saved" });
+    dismiss(id);
+    dismiss(id);
+    vi.advanceTimersByTime(EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it("dismisses everything when called with no id", () => {
+    vi.useFakeTimers();
+    upsert({ tone: "info", message: "One" });
+    upsert({ tone: "info", message: "Two" });
+    dismiss();
+    vi.advanceTimersByTime(EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+});
+
+describe("the auto-dismiss clock", () => {
+  it("dismisses after the duration elapses", () => {
+    vi.useFakeTimers();
+    const id = upsert({ tone: "success", message: "Saved" });
+    scheduleDismiss(id, 1000);
+    vi.advanceTimersByTime(1000 + EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it("pins the toast when the duration is Infinity — a spinner must not time out", () => {
+    vi.useFakeTimers();
+    const id = upsert({ tone: "loading", message: "Saving…" });
+    scheduleDismiss(id, Number.POSITIVE_INFINITY);
+    vi.advanceTimersByTime(600_000);
+    expect(toasts()).toHaveLength(1);
+  });
+
+  it("restarts the clock rather than stacking two timers", () => {
+    vi.useFakeTimers();
+    const id = upsert({ tone: "success", message: "Saved" });
+    scheduleDismiss(id, 1000);
+    vi.advanceTimersByTime(900);
+    scheduleDismiss(id, 1000);
+    vi.advanceTimersByTime(500);
+    expect(toasts(), "the first timer should have been cancelled").toHaveLength(1);
+    vi.advanceTimersByTime(500 + EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+});
+
+describe("the queue is bounded (S-L1)", () => {
+  it("expires a toast that never renders", () => {
+    // The zombie path. A `Toaster` caps what it RENDERS, and an item-owned
+    // clock only starts on mount — so a burst raised inside one Solid batch
+    // leaves everything past the limit un-mounted, un-clocked, and in the queue
+    // for the life of the page. The store starting the clock is what closes it.
+    vi.useFakeTimers();
+    for (let i = 0; i < 10; i++) upsert({ tone: "info", message: `m${i}` });
+    expect(toasts()).toHaveLength(10);
+    vi.advanceTimersByTime(4000 + EXIT_MS);
+    expect(toasts(), "un-rendered toasts never expired").toHaveLength(0);
+  });
+
+  it("caps the queue, so a runaway raise cannot grow it without bound", () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < 200; i++) upsert({ tone: "error", message: `m${i}` });
+    expect(toasts().length).toBeLessThanOrEqual(24);
+    // The survivors are the newest — the oldest are what get evicted.
+    expect(toasts().at(-1)?.message).toBe("m199");
+  });
+
+  it("honours a per-toast duration over the default", () => {
+    vi.useFakeTimers();
+    upsert({ tone: "success", message: "quick", duration: 100 });
+    vi.advanceTimersByTime(100 + EXIT_MS);
+    expect(toasts()).toHaveLength(0);
+  });
+});

--- a/shared/toast/tsconfig.json
+++ b/shared/toast/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/solid.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/shared/toast/vitest.config.ts
+++ b/shared/toast/vitest.config.ts
@@ -1,0 +1,10 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [solid()],
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.{ts,tsx}"],
+  },
+});

--- a/wiki/conventions/stacked-prs.md
+++ b/wiki/conventions/stacked-prs.md
@@ -6,7 +6,7 @@ related:
   - "[[contributing]]"
   - "[[review-findings]]"
   - "[[commands]]"
-last-reviewed: 2026-08-20
+last-reviewed: 2026-08-21
 ---
 
 # Stacked PRs
@@ -138,7 +138,9 @@ git rebase --onto <bottom> <old-base> <middle> && git push --force-with-lease or
 
 Path-filtered jobs must diff against the PR's own base, not `main`, or a stacked PR sees its parent's files as changed. `.github/workflows/ci-swift.yml` does this: on `pull_request` it diffs `origin/$BASE_REF`. Copy that shape for any new filter.
 
-Changeset checks behave the same way — a stacked PR whose parent already carries the changeset does not need a second one.
+Changeset checks behave the same way, and `.github/workflows/changeset-check.yml` was fixed to match on 2026-08-21. It had `on: pull_request: branches: [main]`, which matches the PR's *base* — so a stacked PR never triggered it at all. Because the check is **required**, that did not skip the gate, it left every stacked PR blocked on a status that could never report. It now has no `branches:` filter and diffs `origin/$BASE_REF...HEAD`.
+
+The consequence for authors: **each stacked PR needs a changeset in its own diff**, not just somewhere in the stack. The check sees only what that PR adds on top of its parent, which is the point — it is gating this PR, not the whole chain.
 
 ## When to stack, and when not to
 

--- a/wiki/systems/toast.md
+++ b/wiki/systems/toast.md
@@ -1,0 +1,231 @@
+---
+title: "Toasts — @shared/toast and the --toast-* contract"
+tags: [systems, frontend, accessibility, design-system]
+related:
+  - "[[index]]"
+  - "[[drag-and-drop]]"
+  - "[[component-library]]"
+  - "[[cire-invite-builder]]"
+  - "[[browser-tests]]"
+  - "[[component-lab]]"
+last-reviewed: 2026-08-21
+---
+# Toasts — `@shared/toast` and the `--toast-*` contract
+
+Transient confirmations and errors across every frontend. An internal package
+since 2026-08-21, replacing [solid-toast](https://github.com/ardeora/solid-toast)
+(unmaintained since 2023).
+
+## Why we own it
+
+Three concrete costs, all visible in the code it replaced:
+
+- **A hardcoded `z-index: 9999`.** solid-toast spread its own
+  `defaultContainerStyle` onto the container's inline `style`, and inline style
+  beats a Tailwind utility — so `containerClassName={Z_CLASS.TOAST}` was
+  *silently inert* and cire's toasts sat above the consent banner, the one layer
+  they must never cover. The only override that won was `containerStyle`.
+- **`!important` as the only way to theme.** The cire invite carried
+  `!bg-surface-raised !text-text !border-border !font-body`, which existed purely
+  to out-shout the library's inline defaults.
+- **No contrast story.** Four of the six mounts passed no styling at all and
+  rendered a white pill in dark apps.
+
+## The API
+
+```ts
+import { toast, Toaster } from "@shared/toast";
+
+toast.success("Saved");
+toast.error("Could not save");
+toast.info(msg); toast.warning(msg); toast.loading(msg);
+
+toast.success("Saved", {
+  duration: 6000,          // ms; `Infinity` pins it
+  id: "save",              // stable identity — re-raising UPDATES in place
+  dismissible: true,       // adds a close button
+  action: { label: "Undo", onClick: undo },
+  politeness: "polite",    // overrides the per-tone default
+});
+
+toast.dismiss(id?);        // animate out; no id dismisses everything
+await toast.promise(save(), {
+  loading: "Saving…", success: (v) => `Saved ${v}`, error: (e) => `Failed: ${e}`,
+});
+```
+
+`toast.promise` re-throws on rejection — the toast reports on the promise, it
+does not handle it. Swallowing would turn a failed save into a caller that
+believes it succeeded.
+
+Three behaviours worth knowing, all of them bugs first:
+
+- An upsert **replaces** the toast's options rather than merging over them. A
+  merge lets the previous state leak: `toast.promise` turning a `loading` (pinned
+  at `Infinity`) into a `success` would carry that duration across and pin the
+  result on screen for ever.
+- Re-raising an id mid-exit **cancels the pending removal**. Without that, the
+  revived toast dies a moment later when the stale timer fires.
+- **The store owns the auto-dismiss clock**, and there is no per-`Toaster`
+  default duration. `upsert` schedules; a mounted item only pauses on
+  hover/focus and resumes what it stopped.
+
+  That last one is a correction. The clock used to live in the item, behind a
+  `createEffect` that appeared to restart on a tone change but tracked nothing —
+  `props.toast` is a plain object. It worked only because an update replaces the
+  toast object and `<For>` remounts the row, a mechanism nobody would know not to
+  "optimise" away. Worse, an item-owned clock never starts at all for a toast
+  that never mounts: a burst raised inside one Solid batch leaves everything past
+  the `Toaster`'s `limit` un-rendered, un-clocked and in the queue for the life of
+  the page, and a paused toast pushed out of the visible window unmounts without
+  `onMouseLeave` ever firing. The queue is also capped (`MAX_QUEUED`), so a
+  degraded backend pumping error toasts at a long-lived tab cannot grow it
+  without bound.
+
+## The `--toast-*` contract
+
+The package serves two token vocabularies — shadcn names in `@osn/social` and
+`@pulse/web`, cire's own in `@cire/*` — so it hardcodes neither. It styles itself
+from its own custom properties, each with a neutral fallback, and every app maps
+its vocabulary onto them once:
+
+| Variable | What it is |
+|---|---|
+| `--toast-surface` | The toast's background |
+| `--toast-ink` | Message colour |
+| `--toast-border` | Border |
+| `--toast-radius`, `--toast-shadow`, `--toast-font`, `--toast-font-size` | Shape and type |
+| `--toast-focus` | Focus ring on the action/close buttons |
+| `--toast-accent-success` / `-error` / `-warn` / `-info` | The tone glyph's colour |
+
+```css
+/* osn/social, pulse/web — the shadcn ramp */
+--toast-surface: var(--popover);
+--toast-ink: var(--popover-foreground);
+--toast-accent-error: var(--destructive);
+
+/* cire — the derived invite palette */
+--toast-surface: var(--color-surface-raised);
+--toast-accent-error: var(--toast-error);      /* note the alias; see below */
+```
+
+**Styled in plain CSS, not Tailwind.** Only `pulse/web` and `osn/social` declare
+`@custom-variant base (:where(&))`, and none of the three cire apps declares
+`@source` for a workspace package. Utilities in the package would mean threading
+Tailwind config into five apps across two vocabularies; a stylesheet keyed off
+custom properties needs none of it. Each app adds one line —
+`@import "@shared/toast/toast.css";` — to its global CSS.
+
+## Contrast, and the gap this closed
+
+`derivePalette` in `@cire/theme` enforces WCAG contrast on what it emits, but
+`--color-error` and `--color-success` are walked against `card`
+(`--color-surface`). **A toast paints on `--color-surface-raised`**, which is
+derived as `card ± 0.05` lightness and sits outside that walk — the same gap
+`RESIDUAL_PAIRS` documents for `ink` and `gilt`.
+
+That was not theoretical. On the built-in **jewel** preset, `--color-success`
+measures **4.29:1** against the raised surface — under the 4.5 text minimum.
+Every jewel invite that raised an RSVP confirmation rendered a sub-threshold
+green.
+
+So `derivePalette` also emits `--toast-surface`, `--toast-ink`, `--toast-border`,
+`--toast-error` and `--toast-success`: identical in hue and chroma to the page's
+pair, so an organiser's red is still their red, but walked against the surface
+the toast actually sits on. A scheme that already works gets its colours back
+untouched (`evergreen`'s two pairs are byte-identical). Because the names are in
+`DERIVED_TOKENS`, they ride the existing `ALLOWED_THEME_VAR_KEYS` allow-list, the
+`styleAttr` injection gate and `applyPaletteToRoot`'s stale-key tracking — no new
+CSS sink.
+
+> [!warning]
+> `derivePalette` emits `--toast-error` / `--toast-success`; the package reads
+> `--toast-accent-error` / `--toast-accent-success`. `cire/invites`'s
+> `global.css` aliases between them, and that alias is load-bearing: without it
+> the package falls back to its built-in green, which measures **2.9:1** on
+> evergreen's raised surface. The browser test below catches exactly this — it
+> did, on its first run.
+
+## Accessibility
+
+- **Tone is never hue alone.** Each tone leads with a differently-*shaped* glyph
+  (`✓ ✕ ! i`), `aria-hidden`, with an `sr-only` word read in its place —
+  following `cire/host`'s `Notice.tsx`. `error` and `warning` are exactly the
+  pair red-green colour blindness collapses.
+- **Errors interrupt, confirmations wait.** `role="alert"` +
+  `aria-live="assertive"` for `error`; `role="status"` + `polite` otherwise. The
+  thing the user just did did not happen — that is worth interrupting for; a
+  confirmation is not. Override per call with `politeness`.
+- **The dwell pauses** on hover and on focus-within, so a toast can't expire
+  mid-sentence.
+- **Motion is opt-out at the source**, not only via an app's global clamp:
+  animations collapse to ~0.01ms under `prefers-reduced-motion: reduce` (near-zero
+  rather than `none`, so `animationend` listeners still fire).
+
+## Mounting
+
+One `<Toaster>` per page, as a sibling of your modals at the page root.
+
+The container is `position: fixed` and **portalled to `<body>`**. That matters: a
+`transform`, `filter`, `contain` or `will-change` on any ancestor makes that
+ancestor the containing block for a fixed descendant — and a stacking context
+with it — so a toast mounted inside an animated section is positioned against
+that section and stacked inside it, below every page-level overlay, whatever
+`z-index` it carries. That is exactly what put cire's RSVP toast behind the sheet
+it fires under (Motion One leaves an inline `transform` on the events section).
+The portal makes it robust by construction.
+
+The package sets **no `z-index`**. Pass the layer as a class —
+`class={Z_CLASS.TOAST}` — so it participates in the consumer's own stacking
+order. For cire that order is `MODAL (100) < TOAST (150) < CONSENT (200)`; see
+`cire/invites/src/lib/z-index.ts`.
+
+Current mounts:
+
+| App | Position | Notes |
+|---|---|---|
+| `@cire/invites` | `top-center` | Per design pack; `Z_CLASS.TOAST`, 4s dwell. The RSVP sheet's sticky bar owns the bottom edge |
+| `@cire/host`, `@cire/vendor` | `bottom-right` | — |
+| `@osn/social` | responsive | `top-center` on mobile with a `top` offset clearing the 3rem bar + `env(safe-area-inset-top)` |
+| `@pulse/web` | `bottom-right` | — |
+
+## Testing
+
+Unit: mock `@shared/toast`. Two shared factories exist —
+`cire/host/src/test-support/mocks.ts` (`toastMock()`) and
+`pulse/web/tests/helpers/toast.ts` — see `[[testing-patterns]]`.
+
+**The DOM contract, which is easy to break.**
+`cire/invites/src/designs/InvitePage.browser.test.tsx` finds a toast with
+`[...document.querySelectorAll("div")].find(d => d.textContent === message)` and
+then walks parents until `position: fixed`. So the message must live in an
+element whose `textContent` is **exactly** the message — the tone glyph and its
+`sr-only` word are siblings *outside* it, deliberately. Fold them in and the
+lookup breaks, taking the z-index regression guard with it.
+
+`document.elementFromPoint` is useless against the container: it is
+`pointer-events: none` and hit-testing sees straight through it. Assert computed
+style, DOM position and containing-block ancestry instead.
+
+**Contrast needs the browser tier.** jsdom parses no stylesheet, so every
+`getComputedStyle` returns the empty string and a contrast assertion is
+meaningless there. `InvitePage.browser.test.tsx` composites the painted toast on
+a 1×1 canvas (`paintedBackdrop` / `paintedInk`) and asserts both the message and
+the tone glyph clear 4.5:1 against the surface they land on. Compositing rather
+than reading one node's colour is the point — `--toast-border` is an alpha
+colour and Tailwind's `/12`-style modifiers compute to `color-mix` results Chrome
+serialises as `oklab(… / .12)`. The canvas parses whatever `getComputedStyle`
+returns, so no colour parser here has to keep up with CSS Color 4.
+
+```bash
+bun run --cwd shared/toast test:run
+bun run --cwd cire/invites test:browser     # the contrast + stacking assertions
+```
+
+**By hand.** `bun run dev:lab` → **shared/toast** benches the half no assertion
+reaches: how a toast enters and leaves, whether the tone glyphs are tellable
+apart at a glance, how the stack behaves when five arrive at once, and what a
+three-line message does to the layout. The lab borrows `@osn/social`'s
+stylesheet — the one that maps the shadcn ramp onto `--toast-*` — so its
+**light · dark** toggle re-themes toasts exactly as the app does, which is where
+a too-dark accent shows up. See [[component-lab]].


### PR DESCRIPTION
## Summary

Adds `@shared/toast`, an internal SolidJS toast package to replace `solid-toast`
(unmaintained since 2023), and the contrast-corrected palette tokens it reads. No
consumer uses either yet, so this lands as a pure addition — the migrations are
PRs 2 and 3 of this stack.

The toast half is motivated by three things the old library could not do. The
palette half is motivated by a contrast bug that is already shipping.

- Call sites keep the API they already use (`toast.success(message)`), and gain
  the options object they had no way to reach: `duration`, `id`, `dismissible`, a
  per-toast `action`, `politeness`, plus `toast.promise`/`loading`/`dismiss`.
- Styled in plain CSS, not Tailwind: consumers span two token vocabularies and
  only two of the five declare the `base:` variant or `@source` a workspace
  package, so utilities here would mean threading config through every app.

> [!NOTE]
> **Why a CI change rides along in a toast PR.** This branch also carries
> `ci: run the changeset check on stacked PRs`. `changeset-check.yml` was gated
> `on: pull_request: branches: [main]`, which matches the PR's *base* — so the
> four stacked PRs above this one never triggered it, and because the check is
> **required** they sat blocked on a status that could never report.
> GitHub resolves workflow files from each PR's merge commit, so the fix has to be
> reachable from every stacked base, and this is the only branch all four others
> descend from. It cannot land separately on `main` and reach them. See the
> commit message and `wiki/conventions/stacked-prs.md` for the full reasoning.

## Workspaces affected

`@shared/toast` (new), `@cire/theme`, `@cire/invites`. Two changesets, split
because `scripts/validate-changesets.sh` rejects one that mixes ignored
(version-less `@cire/*`) and versioned packages: `@shared/toast` minor;
`@cire/theme` + `@cire/invites` patch. The CI/wiki commit needs none — the
allowlist in `scripts/changeset-required.sh` reports it as `skip`.

## Issues

**Closes**

| Issue | What |
|---|---|
| — | None |

**Opened**

| Issue | What |
|---|---|
| — | None (this stack's findings are filed from PRs 4–5) |

## Decisions

### The toast container sets no `z-index` — `approach`

- **Issue** — `solid-toast` spread its own `defaultContainerStyle`, carrying a hardcoded `z-index: 9999`, onto the container's inline `style`.
- **Why** — Inline style beats a Tailwind utility, so `containerClassName={Z_CLASS.TOAST}` was *silently inert* and cire's toasts sat above the consent banner — the one layer a guest must always be able to reach.
- **Solution** — The package declares no `z-index` anywhere. The layer is the consumer's, passed as `class`.
- **Rationale** — A library that owns the layer can only ever be fought, not configured. Leaving it unset makes the consumer's stacking order authoritative by construction; PR 2 restores `class={Z_CLASS.TOAST}` and a browser test asserts the measured value against both bounds.

### Contrast is enforced against the surface a toast actually paints on — `approach`

- **Issue** — `derivePalette` walks `--color-error` and `--color-success` against `card` (`--color-surface`), but a toast paints on `--color-surface-raised`, derived as `card ± 0.05` lightness and outside that walk.
- **Why** — Not theoretical: on the built-in **jewel** preset `--color-success` measures **4.29:1** on the raised surface, under the 4.5 WCAG text minimum. Every jewel invite that raised an RSVP confirmation was rendering a sub-threshold green.
- **Solution** — `derivePalette` also emits `--toast-surface`, `--toast-ink`, `--toast-border`, `--toast-error` and `--toast-success` — same hue and chroma as the page's pair, walked against the raised surface.
- **Rationale** — Keeping hue and chroma means an organiser's red is still their red; a scheme that already works gets its colours back byte-identical (evergreen does). Emitting from `derivePalette` puts the tokens in `DERIVED_TOKENS`, so they ride the existing `ALLOWED_THEME_VAR_KEYS` allow-list and `styleAttr` injection gate — no new CSS sink on the organiser-controlled path.

### The store owns the auto-dismiss clock — `S-L1`

- **Issue** — The clock first lived in the rendered item, behind a `createEffect`.
- **Why** — Two failures. The effect's dependency reads were inert (`props.toast` is a plain object), so it only restarted because an update replaces the toast and `<For>` remounts the row — a mechanism nobody would know not to "optimise" away. And an item-owned clock never starts for a toast that never mounts, so a burst past the `Toaster`'s `limit` sat in the queue for the life of the page.
- **Solution** — `upsert` schedules; the item only pauses on hover/focus and resumes what it stopped. The queue is capped (`MAX_QUEUED`). The `<Toaster duration>` prop is gone.
- **Rationale** — One owner. The prop was dropped rather than plumbed because the only mount that ever passed one passed `4000`, already the default — it bought nothing and cost the ownership split. Per-toast `duration` is unchanged.

### The changeset check now runs on stacked PRs — `approach`

- **Issue** — `changeset-check.yml` was gated `on: pull_request: branches: [main]`, and diffed a hardcoded `origin/main...HEAD`.
- **Why** — The filter matches the PR's base, so stacked PRs never triggered it; being a *required* check, that blocked them on a status that could never report rather than merely skipping the gate. The hardcoded diff is a second bug: it attributes every commit from the branches below to this PR.
- **Solution** — Drop the `branches:` filter and diff `origin/$BASE_REF...HEAD`, copying `ci-swift.yml`, which already carries this fix and a comment explaining it.
- **Rationale** — `ci-swift.yml` is the proof the shape works here: it ran green on all four stacked PRs while this check ran on none. The consequence for authors — each stacked PR needs a changeset in its *own* diff — is the honest behaviour, and `wiki/conventions/stacked-prs.md` is corrected to say so.

**Out of scope** — Nothing found and left in this PR.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 34/34 |
| `bun run test` | ✅ 37/37 tasks |
| `bun run fmt:check` | ✅ |
| `bun run --cwd shared/toast test:run` | ✅ 28 pass |
| `bun run --cwd cire/theme test:run` | ✅ 109 pass |
| `bun run --cwd cire/invites test` | ✅ 925 pass |
| `scripts/changeset-required.test.sh` | ✅ 19 pass |
| `scripts/validate-changesets.test.sh` | ✅ 8 pass |
| `scripts/validate-changesets.sh` | ✅ |

The fixed changeset check was simulated against all five branches in the stack
before pushing — each returns `required` and each carries at least one changeset
in its own diff, so all five pass.

The toast bench (`bun run dev:lab` → **shared/toast**) renders on this branch but
is **unthemed** — the per-app `--toast-*` mappings arrive in PRs 2 and 3, so it
falls back to the package's neutral defaults here. That is expected, not a defect.

Not exercised on this branch: nothing renders a `<Toaster>` yet, so the visual and
stacking behaviour is covered by the browser tests in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PR77MaQFVcSwQmnimeN2t9