### PR TITLE
Add @shared/sortable, with the keyboard path it owns

### DIFF
--- a/.changeset/shared-sortable-package.md
+++ b/.changeset/shared-sortable-package.md
@@ -1,0 +1,40 @@
+---
+"@shared/sortable": minor
+---
+
+Add `@shared/sortable` — internal drag-to-reorder for SolidJS, to replace
+`@thisbeyond/solid-dnd` (last released November 2023). No consumer uses it yet;
+the migration follows.
+
+The API mirrors what it replaces — `DragDropProvider`, `DragDropSensors`,
+`SortableProvider`, `createSortable`, `closestCenter`, `maybeTransformStyle`,
+`useDragDropContext` — so adopting it is an import swap. One difference:
+`transform`, `isActiveDraggable` and `active` are accessors rather than store
+properties, so call them.
+
+Two things the replaced library could not do:
+
+- **`createSortableList` owns the keyboard and screen-reader path.** solid-dnd
+  shipped a pointer sensor and nothing else, so every list that wanted dragging
+  had to hand-write ~120 lines of it — which is why three lists in the organiser
+  portal never adopted drag and said so in code. The package now carries all five
+  obligations, with tests: a real `<button>` grip owning the arrows with
+  `preventDefault` before the bounds check, `sr-only` move buttons for browse
+  mode, explicit focus restore after a keyboard move, a live region that clears
+  before it sets, and auto-repeat ignored. Hint ids are generated per list, so
+  several lists can share a page.
+- **Multi-container.** Items register with the `SortableProvider` they sit under,
+  and collision detection never crosses a group. Deliberately not
+  cross-container: moving an item between lists is a re-bucketing, not a
+  re-order.
+
+Geometry is measured **once, at drag start**. Layout cannot change during a drag
+except for the transforms this package writes, and those are exactly what must be
+excluded — a live read let the dragged row's own offset corrupt the stride, and
+let the detector see displaced rows in the slots they were moving *to*. It also
+keeps the cost flat: at 500 rows a per-event sweep is ~30–60k
+`getBoundingClientRect()` per second, each behind a forced style flush.
+
+The gesture owns its listeners: pointer capture so a release outside the window
+still ends the drag, a `pointerId` guard so a second touch cannot drive another
+finger's gesture, and an `onCleanup` so an unmount mid-drag tears them down.

--- a/bun.lock
+++ b/bun.lock
@@ -604,6 +604,23 @@
         "solid-js",
       ],
     },
+    "shared/sortable": {
+      "name": "@shared/sortable",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@shared/typescript-config": "workspace:*",
+        "@solidjs/testing-library": "^0.8.10",
+        "@testing-library/jest-dom": "^6.10.0",
+        "happy-dom": "^20.11.1",
+        "solid-js": "^1.9.14",
+        "vite": "^8.1.5",
+        "vite-plugin-solid": "^2.11.14",
+        "vitest": "^4.1.10",
+      },
+      "peerDependencies": {
+        "solid-js": ">=1.9",
+      },
+    },
     "shared/toast": {
       "name": "@shared/toast",
       "version": "0.0.0",
@@ -1435,6 +1452,8 @@
     "@shared/redis": ["@shared/redis@workspace:shared/redis"],
 
     "@shared/rp-auth": ["@shared/rp-auth@workspace:shared/rp-auth"],
+
+    "@shared/sortable": ["@shared/sortable@workspace:shared/sortable"],
 
     "@shared/toast": ["@shared/toast@workspace:shared/toast"],
 

--- a/shared/sortable/package.json
+++ b/shared/sortable/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@shared/sortable",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./list": "./src/list.tsx"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bunx --bun vitest",
+    "test:run": "bunx --bun vitest run"
+  },
+  "devDependencies": {
+    "@shared/typescript-config": "workspace:*",
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^6.10.0",
+    "happy-dom": "^20.11.1",
+    "solid-js": "^1.9.14",
+    "vite": "^8.1.5",
+    "vite-plugin-solid": "^2.11.14",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "solid-js": ">=1.9"
+  }
+}

--- a/shared/sortable/src/collision.ts
+++ b/shared/sortable/src/collision.ts
@@ -1,0 +1,40 @@
+import type { DragTarget, MeasuredTarget } from "./types";
+
+/**
+ * The droppable whose centre is nearest the pointer.
+ *
+ * The right detector for a single-column list: a row is "over" the neighbour it
+ * has travelled at least half-way into, which is what makes a drag feel like it
+ * displaces rows one at a time.
+ *
+ * Measures from the POINTER against geometry captured at drag start — not
+ * against live rects. A live read would see each row where its transform has
+ * currently put it, so a displaced row would be measured in the slot it is
+ * moving *to* rather than the one it belongs to, and the detector would chase
+ * its own output.
+ *
+ * Ties resolve to the FIRST candidate, which keeps the result stable when two
+ * rows have identical geometry — the usual case under a test DOM.
+ */
+export function closestCenter(
+  draggable: DragTarget,
+  droppables: MeasuredTarget[],
+  pointer: { x: number; y: number },
+): DragTarget | null {
+  let best: MeasuredTarget | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of droppables) {
+    if (candidate.id === draggable.id) continue;
+    const cx = candidate.rect.left + candidate.rect.width / 2;
+    const cy = candidate.rect.top + candidate.rect.height / 2;
+    const dx = cx - pointer.x;
+    const dy = cy - pointer.y;
+    const distance = dx * dx + dy * dy;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  return best ? { id: best.id, node: best.node } : null;
+}

--- a/shared/sortable/src/context.tsx
+++ b/shared/sortable/src/context.tsx
@@ -1,0 +1,282 @@
+import {
+  createContext,
+  createSignal,
+  onCleanup,
+  type Accessor,
+  type ParentProps,
+  useContext,
+} from "solid-js";
+
+import { closestCenter } from "./collision";
+import type { DragEvent, DragTarget, Id, MeasuredTarget, Transform } from "./types";
+
+/**
+ * How far the pointer must travel before a press becomes a drag.
+ *
+ * Not decoration: without it a plain click on the handle starts and ends a
+ * drag, and any list where the handle is also a button loses the button. The
+ * events list's tests press without moving and assert the order is untouched.
+ */
+export const ACTIVATION_DISTANCE = 4;
+
+type Detector = (
+  draggable: DragTarget,
+  droppables: MeasuredTarget[],
+  pointer: { x: number; y: number },
+) => DragTarget | null;
+
+export interface DragState {
+  active: Accessor<{ draggable: DragTarget | null; droppable: DragTarget | null }>;
+  /** The dragged row's offset from where it started. `null` when nothing is dragging. */
+  transform: Accessor<Transform | null>;
+  /** How far a NON-dragged row has been pushed to open the gap. 0 for most rows. */
+  displacement: (id: Id) => number;
+}
+
+export interface Registry {
+  register: (id: Id, node: HTMLElement, group: symbol) => void;
+  unregister: (id: Id) => void;
+  registerGroup: (group: symbol, ids: Accessor<Id[]>) => void;
+  unregisterGroup: (group: symbol) => void;
+  startDrag: (id: Id, event: PointerEvent) => void;
+}
+
+const DragDropContext = createContext<[DragState, Registry]>();
+
+export function useDragDropContext() {
+  return useContext(DragDropContext);
+}
+
+export interface DragDropProviderProps {
+  onDragStart?: (event: DragEvent) => void;
+  onDragOver?: (event: DragEvent) => void;
+  onDragEnd?: (event: DragEvent) => void;
+  collisionDetector?: Detector;
+}
+
+/**
+ * Owns one drag gesture and the set of items that can take part in it.
+ *
+ * ## Groups, and why multi-container is nearly free
+ *
+ * Every item registers with the `SortableProvider` it sits under, identified by
+ * a `symbol`. Collision detection only ever considers items sharing the
+ * dragged item's group, so N lists on one page are N independent sortables
+ * with no cross-talk — a task dragged inside "3 months out" cannot land in
+ * "1 month out", which is right, because moving between buckets is a
+ * re-bucketing (a semantic change), not a re-order.
+ *
+ * That also means one `DragDropProvider` can wrap several lists.
+ */
+export function DragDropProvider(props: ParentProps<DragDropProviderProps>) {
+  const items = new Map<Id, { node: HTMLElement; group: symbol }>();
+  /** A group's declared order, from its `SortableProvider`'s `ids`. */
+  const groups = new Map<symbol, Accessor<Id[]>>();
+
+  const [active, setActive] = createSignal<{
+    draggable: DragTarget | null;
+    droppable: DragTarget | null;
+  }>({ draggable: null, droppable: null });
+  const [transform, setTransform] = createSignal<Transform | null>(null);
+  const [displaced, setDisplaced] = createSignal<Map<Id, number>>(new Map());
+
+  const register = (id: Id, node: HTMLElement, group: symbol) => items.set(id, { node, group });
+  const unregister = (id: Id) => items.delete(id);
+  const registerGroup = (group: symbol, ids: Accessor<Id[]>) => groups.set(group, ids);
+  const unregisterGroup = (group: symbol) => groups.delete(group);
+
+  /**
+   * Measure a group ONCE, in the order its `SortableProvider` declares.
+   *
+   * Declared order rather than Map insertion order: items register as they
+   * mount, so after a re-order the Map no longer reflects the list, and both
+   * the stride and the displacement range depend on knowing which rows sit
+   * between two others.
+   */
+  function measure(group: symbol): MeasuredTarget[] {
+    const ids = groups.get(group)?.() ?? [];
+    const out: MeasuredTarget[] = [];
+    for (const id of ids) {
+      const entry = items.get(id);
+      if (entry) out.push({ id, node: entry.node, rect: entry.node.getBoundingClientRect() });
+    }
+    return out;
+  }
+
+  /**
+   * The distance one row occupies along the list, INCLUDING the gap to the next
+   * one — measured rather than assumed, because the gap lives in the consumer's
+   * CSS and a package that guessed it would open a hole of the wrong size.
+   *
+   * Taken from the first adjacent pair. For a uniform list (which is every list
+   * here) that is exact; for a ragged one it is an approximation, which is the
+   * same trade every sortable library makes.
+   */
+  function strideOf(measured: MeasuredTarget[]): number {
+    if (measured.length < 2) return measured[0]?.rect.height ?? 0;
+    return Math.abs(measured[1]!.rect.top - measured[0]!.rect.top);
+  }
+
+  /**
+   * Push the rows between the dragged one and its target out of the way, so the
+   * list previews the drop instead of only moving the row under the pointer.
+   *
+   * Dragging DOWN from `from` to `to` pulls every row in `(from, to]` up by one
+   * stride; dragging UP pushes every row in `[to, from)` down by one. The
+   * dragged row itself is excluded — it tracks the pointer.
+   */
+  function computeDisplacement(
+    measured: MeasuredTarget[],
+    stride: number,
+    fromId: Id,
+    toId: Id | null,
+  ): Map<Id, number> {
+    const out = new Map<Id, number>();
+    if (toId === null || stride === 0) return out;
+    const order = measured.map((m) => m.id);
+    const from = order.indexOf(fromId);
+    const to = order.indexOf(toId);
+    if (from === -1 || to === -1 || from === to) return out;
+
+    if (from < to) {
+      for (let i = from + 1; i <= to; i++) out.set(order[i]!, -stride);
+    } else {
+      for (let i = to; i < from; i++) out.set(order[i]!, stride);
+    }
+    return out;
+  }
+
+  const displacement = (id: Id) => displaced().get(id) ?? 0;
+
+  /** Tears down whatever gesture is live. Set by `startDrag`, cleared by it. */
+  let endGesture: (() => void) | null = null;
+
+  // A gesture that is still live when the provider unmounts would otherwise
+  // leave three document listeners behind, firing into a disposed scope — and
+  // the next `pointerup` anywhere would call the consumer's `onDragEnd` with
+  // stale indices, committing a reorder nobody made.
+  onCleanup(() => endGesture?.());
+
+  function startDrag(id: Id, event: PointerEvent) {
+    const entry = items.get(id);
+    if (!entry) return;
+
+    const draggable: DragTarget = { id, node: entry.node };
+    const detect = props.collisionDetector ?? closestCenter;
+    const origin = { x: event.clientX, y: event.clientY };
+    const pointerId = event.pointerId;
+    let activated = false;
+    let latest: DragEvent = { draggable, droppable: null };
+
+    // Capture the pointer, so `pointerup` is delivered even when the release
+    // happens outside the window. Without it a drag released off-screen never
+    // ends: the row stays stuck to a button-up pointer and the user's next
+    // click anywhere fires `onUp` with `activated` still true, committing a
+    // reorder they never made. Guarded because a test DOM may not implement it.
+    const captureTarget = event.currentTarget instanceof Element ? event.currentTarget : entry.node;
+    captureTarget.setPointerCapture?.(pointerId);
+
+    /** Ignore contacts other than the one that started this drag. Without this
+     *  a second finger drives — or ends — the first finger's gesture. */
+    const isOurs = (e: PointerEvent) => e.pointerId === pointerId;
+
+    /**
+     * The group's geometry, frozen at the moment the gesture began.
+     *
+     * Layout cannot change during a drag except for the transforms this package
+     * writes, and those are exactly what must be excluded. Measuring live got
+     * it wrong twice over: the stride was read from rects that already included
+     * the dragged row's offset — drag row 0 down by one row height in a single
+     * motion and the stride computed to ZERO, silently disabling shift-aside —
+     * and the detector saw displaced rows in the slots they were moving to
+     * rather than the ones they belonged to, so it chased its own output.
+     *
+     * It is also the difference between O(1) arithmetic and an
+     * n-rect forced-layout sweep on every pointer event.
+     */
+    const measured = measure(entry.group);
+    const stride = strideOf(measured);
+
+    const reset = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.removeEventListener("pointercancel", onCancel);
+      captureTarget.releasePointerCapture?.(pointerId);
+      endGesture = null;
+      setTransform(null);
+      setDisplaced(new Map());
+      setActive({ draggable: null, droppable: null });
+    };
+
+    const onMove = (moveEvent: PointerEvent) => {
+      if (!isOurs(moveEvent)) return;
+      const dx = moveEvent.clientX - origin.x;
+      const dy = moveEvent.clientY - origin.y;
+
+      if (!activated) {
+        if (Math.hypot(dx, dy) < ACTIVATION_DISTANCE) return;
+        activated = true;
+        setActive({ draggable, droppable: null });
+        props.onDragStart?.({ draggable, droppable: null });
+      }
+
+      setTransform({ x: dx, y: dy });
+      const droppable = detect(draggable, measured, {
+        x: moveEvent.clientX,
+        y: moveEvent.clientY,
+      });
+      // Only a CHANGE of slot is worth reporting: the pointer emits a stream of
+      // events inside one row, and a consumer ticking a haptic per event would
+      // buzz continuously instead of once per row crossed.
+      if (droppable?.id !== latest.droppable?.id) {
+        latest = { draggable, droppable };
+        setActive({ draggable, droppable });
+        setDisplaced(computeDisplacement(measured, stride, id, droppable?.id ?? null));
+        props.onDragOver?.(latest);
+      }
+    };
+
+    const onUp = (upEvent: PointerEvent) => {
+      if (!isOurs(upEvent)) return;
+      reset();
+      // A press that never crossed the threshold was a click, not a drag. Firing
+      // `onDragEnd` here would commit a no-op move on every handle click.
+      if (activated) props.onDragEnd?.(latest);
+    };
+
+    // Deliberately no `onDragEnd`: a cancelled gesture (the OS taking over, a
+    // context menu) is not a drop, and committing one would move a row the user
+    // never released.
+    const onCancel = (cancelEvent: PointerEvent) => {
+      if (!isOurs(cancelEvent)) return;
+      reset();
+    };
+
+    endGesture = reset;
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    document.addEventListener("pointercancel", onCancel);
+  }
+
+  return (
+    <DragDropContext.Provider
+      value={[
+        { active, transform, displacement },
+        { register, unregister, registerGroup, unregisterGroup, startDrag },
+      ]}
+    >
+      {props.children}
+    </DragDropContext.Provider>
+  );
+}
+
+/**
+ * Registers the pointer sensor.
+ *
+ * Kept as a component rather than folded into the provider so the call site
+ * reads the same as the library this replaced, and so a future keyboard or
+ * touch sensor can be opted into the same way. It renders nothing.
+ */
+export function DragDropSensors() {
+  return null;
+}

--- a/shared/sortable/src/index.ts
+++ b/shared/sortable/src/index.ts
@@ -1,0 +1,18 @@
+export { closestCenter } from "./collision";
+export {
+  ACTIVATION_DISTANCE,
+  DragDropProvider,
+  DragDropSensors,
+  useDragDropContext,
+  type DragDropProviderProps,
+} from "./context";
+export {
+  createSortableList,
+  type DragPhase,
+  type GripProps,
+  type MoveProps,
+  type SortableItem,
+  type SortableListOptions,
+} from "./list";
+export { createSortable, maybeTransformStyle, SortableProvider } from "./sortable";
+export type { DragActivators, DragEvent, DragTarget, Id, Sortable, Transform } from "./types";

--- a/shared/sortable/src/list.tsx
+++ b/shared/sortable/src/list.tsx
@@ -1,0 +1,214 @@
+import { createSignal, createUniqueId, type Accessor, type JSX } from "solid-js";
+
+import type { Id } from "./types";
+
+export type DragPhase = "pickup" | "step" | "commit";
+
+/** What a grip button needs, beyond whatever the consumer adds. */
+export interface GripProps extends JSX.HTMLAttributes<HTMLButtonElement> {
+  type: "button";
+  "aria-label": string;
+  "aria-describedby": string;
+  ref: (el: HTMLButtonElement) => void;
+  onKeyDown: (event: KeyboardEvent) => void;
+}
+
+/** One row's slice of the list: the grip, and the two move controls. */
+export interface SortableItem {
+  gripProps: () => GripProps;
+  moveProps: (delta: -1 | 1) => MoveProps;
+  moveLabel: (delta: -1 | 1) => string;
+}
+
+/** What one screen-reader move control needs. */
+export interface MoveProps extends JSX.HTMLAttributes<HTMLButtonElement> {
+  type: "button";
+  disabled: boolean;
+  onClick: () => void;
+}
+
+export interface SortableListOptions {
+  /** The list's ids, in current order. */
+  ids: Accessor<Id[]>;
+  /** A human name for an item, used in labels and announcements. */
+  labelFor: (id: Id) => string;
+  /** What one item is called, for the instructions ("Drag to re-order this event"). */
+  noun: string;
+  /** Commit a move. Called for both pointer drops and keyboard moves. */
+  onMove: (from: number, to: number) => void;
+  /** Optional feedback hook — haptics, sound. Kept out of the package. */
+  onPhase?: (phase: DragPhase) => void;
+}
+
+/**
+ * The accessibility half of a sortable list, which is most of it.
+ *
+ * A drag affordance is invisible to a screen-reader user and unreachable from a
+ * keyboard unless every one of the following is supplied. None is optional, and
+ * each has a failure mode that is silent rather than obvious — which is exactly
+ * why they belong in a package rather than in each list that wants dragging:
+ *
+ * 1. **The grip is a real `<button>`** that owns Arrow Up/Down, with
+ *    `preventDefault()` BEFORE the bounds check so a focused grip owns the
+ *    arrows unconditionally rather than sometimes moving the row and sometimes
+ *    scrolling the page out from under it.
+ * 2. **`sr-only` move buttons as well as the arrows.** NVDA and JAWS run in
+ *    browse mode by default and consume unmodified arrow keys for their own
+ *    virtual cursor, forwarding them to a plain `<button>` only in focus mode,
+ *    which buttons do not trigger. Without an Enter/Space-activated control, a
+ *    screen-reader user reads the hint, presses the arrows, and gets nothing.
+ *    They are `focus:not-sr-only` so a sighted keyboard user never lands on an
+ *    invisible control (WCAG 2.4.7), and `disabled` at the ends so assistive
+ *    tech reports the boundary instead of the user pressing into nothing.
+ * 3. **Focus is restored explicitly** after a keyboard move. A keyed `<For>`
+ *    MOVES the row's node rather than re-creating it, but a DOM move is a
+ *    remove-then-insert and focus does not survive it — without this, one
+ *    keypress moves the row and focus lands on `<body>`, so the row cannot be
+ *    walked any further.
+ * 4. **Every move is announced** through a polite live region, and the
+ *    announcement **clears before it sets**: a live region only speaks when its
+ *    text changes, and walking one row down a list produces the identical
+ *    sentence every time, so setting it straight would make the second press
+ *    silent.
+ * 5. **Auto-repeat is ignored.** Repeat fires ~30x/s, and a consumer's `onMove`
+ *    is typically a draft checkpoint plus a revalidation — a held key would
+ *    both stall the list and burn through an undo stack in seconds.
+ *
+ * Ids are generated per instance rather than hardcoded, so several lists can
+ * coexist on one page without colliding `aria-describedby` targets.
+ */
+export function createSortableList(options: SortableListOptions) {
+  const hintId = createUniqueId();
+  const [announcement, setAnnouncement] = createSignal("");
+  /**
+   * The grip node per id, so focus can be put back after a keyboard move.
+   *
+   * Pruned of detached nodes on every move rather than by an `onCleanup` in
+   * `item()`. `item()` is called from a prop getter, so it re-runs on every
+   * access — an `onCleanup` registered there disposes with whatever scope
+   * happened to read the prop, and deleted the grip of a row that was still
+   * very much alive, which cost the focus restoration obligation 3 exists for.
+   *
+   * Pruning here keeps the map bounded (a deleted row's detached `<button>`
+   * survives only until the next move) without guessing at scope lifetimes.
+   */
+  const grips = new Map<Id, HTMLButtonElement>();
+  /** The slot the pointer was last over, so only a real change ticks. */
+  let lastOverId: Id | null = null;
+
+  function announce(id: Id, to: number) {
+    // Clear FIRST — see obligation 4 above. Solid applies each set
+    // synchronously, so this is two real DOM writes: empty, then the message.
+    setAnnouncement("");
+    setAnnouncement(
+      `${options.labelFor(id)} moved to position ${to + 1} of ${options.ids().length}.`,
+    );
+  }
+
+  /**
+   * Undo and discard rewind the order without going through `move`, so the
+   * region would otherwise keep asserting a move that has just been reversed.
+   * Cleared rather than re-announced: an undo may have reverted something other
+   * than a re-order, and guessing which would be worse than silence.
+   */
+  const clearAnnouncement = () => setAnnouncement("");
+
+  function move(index: number, delta: -1 | 1) {
+    for (const [gid, el] of grips) if (!el.isConnected) grips.delete(gid);
+    const ids = options.ids();
+    const target = index + delta;
+    if (target < 0 || target >= ids.length) return;
+    const id = ids[index]!;
+    options.onMove(index, target);
+    announce(id, target);
+    options.onPhase?.("commit");
+    // Restore focus AFTER the move — see obligation 3.
+    grips.get(id)?.focus();
+  }
+
+  /** Wire the provider's drag callbacks so phases and announcements are shared
+   *  with the pointer path rather than duplicated by the consumer. */
+  const dragHandlers = {
+    onDragStart: () => {
+      lastOverId = null;
+      options.onPhase?.("pickup");
+    },
+    onDragOver: ({ droppable }: { droppable: { id: Id } | null }) => {
+      const id = droppable?.id ?? null;
+      if (id === lastOverId) return;
+      lastOverId = id;
+      if (id !== null) options.onPhase?.("step");
+    },
+    onDragEnd: ({
+      draggable,
+      droppable,
+    }: {
+      draggable: { id: Id };
+      droppable: { id: Id } | null;
+    }) => {
+      lastOverId = null;
+      if (!droppable) return;
+      const ids = options.ids();
+      const from = ids.indexOf(draggable.id);
+      const to = ids.indexOf(droppable.id);
+      if (from === -1 || to === -1 || from === to) return;
+      const id = ids[from]!;
+      options.onMove(from, to);
+      announce(id, to);
+      // Only a drop that actually moved something is worth confirming — a row
+      // dropped back where it started has changed nothing.
+      options.onPhase?.("commit");
+    },
+  };
+
+  /** Props for the shared instructions every grip points at. */
+  const hintProps = () => ({ id: hintId, class: "sr-only" });
+
+  /** Props for the live region. `aria-live` as well as the role, because some
+   *  AT/browser pairs only honour one of them. */
+  const liveRegionProps = () => ({
+    class: "sr-only",
+    role: "status" as const,
+    "aria-live": "polite" as const,
+  });
+
+  function item(id: Id, index: Accessor<number>, count: Accessor<number>): SortableItem {
+    return {
+      /** Spread onto the grip button, BEFORE `dragActivators`' own handlers. */
+      gripProps: (): GripProps => ({
+        type: "button",
+        "aria-label": `Reorder ${options.labelFor(id)}, position ${index() + 1} of ${count()}`,
+        "aria-describedby": hintId,
+        ref: (el: HTMLButtonElement) => grips.set(id, el),
+        onKeyDown: (event: KeyboardEvent) => {
+          const delta = event.key === "ArrowUp" ? -1 : event.key === "ArrowDown" ? 1 : 0;
+          if (delta === 0) return;
+          // Before the bounds check — see obligation 1.
+          event.preventDefault();
+          // See obligation 5.
+          if (event.repeat) return;
+          move(index(), delta as -1 | 1);
+        },
+      }),
+      /** Props for one screen-reader move control. See obligation 2. */
+      moveProps: (delta: -1 | 1): MoveProps => ({
+        type: "button",
+        disabled: delta === -1 ? index() === 0 : index() === count() - 1,
+        onClick: () => move(index(), delta),
+      }),
+      moveLabel: (delta: -1 | 1) => `Move ${options.labelFor(id)} ${delta === -1 ? "up" : "down"}`,
+    };
+  }
+
+  return {
+    hintId,
+    hintProps,
+    hintText: `Drag to re-order, or press the up and down arrow keys to move this ${options.noun}. Move up and move down buttons follow this handle.`,
+    liveRegionProps,
+    announcement,
+    clearAnnouncement,
+    dragHandlers,
+    item,
+    move,
+  };
+}

--- a/shared/sortable/src/sortable.story.tsx
+++ b/shared/sortable/src/sortable.story.tsx
@@ -1,0 +1,199 @@
+import { createSignal, For, Show } from "solid-js";
+
+import { closestCenter } from "./collision";
+import { DragDropProvider, DragDropSensors, useDragDropContext } from "./context";
+import { createSortableList } from "./list";
+import { createSortable, maybeTransformStyle, SortableProvider } from "./sortable";
+
+/**
+ * Rendered by the component lab (`bun run dev:lab`) — a story living next to
+ * the package it exercises rather than in `tools/lab`. Nothing imports this
+ * file at build time; the lab finds it by glob.
+ *
+ * ## Why this bench exists
+ *
+ * Three things about a drag are invisible to every test tier we have, and all
+ * three are the difference between a list that feels right and one that does
+ * not:
+ *
+ * - **Drag feel** — does the row track the pointer without lag or easing?
+ * - **The shift/settle animation** — do the rows between the dragged one and
+ *   its target open a gap, and does the list settle rather than snap on drop?
+ * - **Grip hover / focus styling** — is the affordance findable with a mouse
+ *   and visible with a keyboard?
+ *
+ * happy-dom computes no layout, so the unit tests stub every rect and can only
+ * assert the numbers. This is where you look at it.
+ *
+ * The shift-aside in particular shipped broken once: `transform` returned
+ * `null` for every non-dragged row, so the "rows shifting aside" styling
+ * animated nothing while every drop-semantics test stayed green. A bench would
+ * have caught it in a second.
+ *
+ * See `wiki/architecture/drag-and-drop.md`.
+ */
+export const meta = { title: "shared/sortable", layout: "padded" as const };
+
+const EVENTS = ["Ceremony", "Cocktails", "Dinner", "Speeches", "Dancing", "Send-off"];
+
+function Row(props: {
+  id: string;
+  label: string;
+  index: () => number;
+  count: () => number;
+  item: ReturnType<ReturnType<typeof createSortableList>["item"]>;
+  active: () => boolean;
+}) {
+  const sortable = createSortable(props.id);
+  return (
+    <li
+      ref={sortable.ref}
+      style={maybeTransformStyle(sortable.transform())}
+      class="border-border bg-card flex items-center gap-3 rounded-lg border p-3"
+      classList={{
+        "shadow-lg ring-primary/40 z-10 ring-2": sortable.isActiveDraggable(),
+        // Animate the OTHER rows shifting aside, never the dragged one — that
+        // must track the pointer without easing. Only while a drag is live, so
+        // the post-drop settle isn't double-animated.
+        "transition-transform": props.active() && !sortable.isActiveDraggable(),
+      }}
+    >
+      <button
+        {...sortable.dragActivators}
+        {...props.item.gripProps()}
+        // `touch-none` is required — without it the browser scrolls instead of
+        // handing the gesture over. `py-2` brings the grip to the WCAG 2.5.8
+        // 24px minimum target.
+        class="text-muted-foreground hover:text-foreground focus-visible:text-foreground focus-visible:ring-ring cursor-grab touch-none rounded px-1 py-2 text-lg leading-none focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing"
+      >
+        ⠿
+      </button>
+      <span class="flex-1">{props.label}</span>
+      <span class="text-muted-foreground text-xs tabular-nums">
+        {props.index() + 1} / {props.count()}
+      </span>
+      <For each={[-1, 1] as const}>
+        {(delta) => (
+          <button
+            {...props.item.moveProps(delta)}
+            class="border-border text-muted-foreground hover:text-foreground sr-only rounded border px-2 py-1 text-xs focus:not-sr-only focus:relative"
+          >
+            {props.item.moveLabel(delta)}
+          </button>
+        )}
+      </For>
+    </li>
+  );
+}
+
+function List(props: { initial: string[]; label: string }) {
+  const [items, setItems] = createSignal(props.initial);
+  const [phase, setPhase] = createSignal<string>("—");
+
+  const reorder = createSortableList({
+    ids: items,
+    labelFor: (id) => String(id),
+    noun: "event",
+    onMove: (from, to) => {
+      const next = [...items()];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved!);
+      setItems(next);
+    },
+    // The package reports phases; a consumer decides what they mean. The host
+    // portal maps these to haptics — here they are just printed, which is the
+    // cheapest way to see that `step` fires once per row crossed rather than
+    // once per pointer event.
+    onPhase: setPhase,
+  });
+
+  return (
+    <DragDropProvider {...reorder.dragHandlers} collisionDetector={closestCenter}>
+      <DragDropSensors />
+      <DragInner label={props.label} items={items} reorder={reorder} phase={phase} />
+    </DragDropProvider>
+  );
+}
+
+/** Split out so it can read `useDragDropContext`, which only resolves under the provider. */
+function DragInner(props: {
+  label: string;
+  items: () => string[];
+  reorder: ReturnType<typeof createSortableList>;
+  phase: () => string;
+}) {
+  // Non-null: this only ever renders inside the provider above.
+  const [state] = useDragDropContext()!;
+  /** True while a drag is live — gates the shift transition on the other rows. */
+  const active = () => !!state.active().draggable;
+  return (
+    <section class="flex w-96 flex-col gap-3">
+      <header class="flex items-baseline justify-between">
+        <h3 class="text-sm font-medium">{props.label}</h3>
+        <span class="text-muted-foreground text-xs">
+          last phase: <code>{props.phase()}</code>
+        </span>
+      </header>
+      <ul class="flex flex-col gap-2">
+        <SortableProvider ids={props.items()}>
+          <For each={props.items()}>
+            {(id, index) => (
+              <Row
+                id={id}
+                label={id}
+                index={index}
+                count={() => props.items().length}
+                item={props.reorder.item(id, index, () => props.items().length)}
+                active={active}
+              />
+            )}
+          </For>
+        </SortableProvider>
+      </ul>
+      <p {...props.reorder.hintProps()}>{props.reorder.hintText}</p>
+      <p {...props.reorder.liveRegionProps()}>{props.reorder.announcement()}</p>
+      <Show when={props.reorder.announcement()}>
+        {(text) => (
+          <p class="text-muted-foreground text-xs">
+            announced: <em>{text()}</em>
+          </p>
+        )}
+      </Show>
+    </section>
+  );
+}
+
+/**
+ * The everyday case. Drag the grip; watch the rows between it and the drop
+ * target open a gap, and the list settle on release.
+ *
+ * Then put the mouse down and use the keyboard: Tab to a grip, Arrow Up/Down to
+ * move a row, and Tab once more to reveal the `sr-only` move buttons that exist
+ * for browse-mode screen readers. The announcement each move produces is
+ * printed under the list.
+ */
+export const Reorder = () => <List label="Schedule" initial={EVENTS} />;
+
+/**
+ * Two lists, one `DragDropProvider`. Collision detection is scoped to the
+ * `SortableProvider` a row sits under, so a row dragged from one list can never
+ * land in the other however far you drag it — try it.
+ *
+ * That is deliberate rather than a limitation: moving an item between lists is
+ * a re-bucketing (a semantic change), not a re-order.
+ */
+export const MultipleLists = () => (
+  <div class="flex flex-wrap gap-10">
+    <List label="Day one" initial={["Mehndi", "Sangeet", "Dinner"]} />
+    <List label="Day two" initial={["Ceremony", "Lunch", "Reception"]} />
+  </div>
+);
+
+/**
+ * A long list, for the two things a short one hides: whether the drag keeps up
+ * with a fast pointer over many rows, and whether `step` fires once per row
+ * crossed rather than once per pointer event (watch the phase readout).
+ */
+export const LongList = () => (
+  <List label="Twenty rows" initial={Array.from({ length: 20 }, (_, i) => `Item ${i + 1}`)} />
+);

--- a/shared/sortable/src/sortable.tsx
+++ b/shared/sortable/src/sortable.tsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  createMemo,
+  onCleanup,
+  type JSX,
+  type ParentProps,
+  useContext,
+} from "solid-js";
+
+import { useDragDropContext } from "./context";
+import type { Id, Sortable, Transform } from "./types";
+
+/**
+ * Identifies one sortable list. Collision detection never crosses a group, so
+ * several lists on a page stay independent without any extra wiring.
+ */
+const GroupContext = createContext<symbol>();
+
+/**
+ * One sortable list. `ids` is the list's order, and is load-bearing twice over:
+ * it scopes collision detection to this list, and it is what lets the provider
+ * work out which rows sit between the dragged one and its target, so they can
+ * shift aside to open the gap.
+ */
+export function SortableProvider(props: ParentProps<{ ids: Id[] }>) {
+  const ctx = useDragDropContext();
+  if (!ctx) throw new Error("<SortableProvider> must be used inside a <DragDropProvider>");
+  const [, registry] = ctx;
+
+  // One identity per provider instance, so two lists never share a group.
+  const group = Symbol("sortable-group");
+  registry.registerGroup(group, () => props.ids);
+  onCleanup(() => registry.unregisterGroup(group));
+
+  return <GroupContext.Provider value={group}>{props.children}</GroupContext.Provider>;
+}
+
+/**
+ * Wire one row into the drag.
+ *
+ * Put `ref` on the ROW and spread `dragActivators` onto the HANDLE. That split
+ * is the point: making the whole row the drag affordance swallows text
+ * selection and the row's own buttons.
+ *
+ * Because `ref` only registers the node, the row must paint its own offset —
+ * `style={maybeTransformStyle(sortable.transform())}`.
+ */
+export function createSortable(id: Id): Sortable {
+  const ctx = useDragDropContext();
+  if (!ctx) throw new Error("createSortable must be used inside a <DragDropProvider>");
+  const [state, registry] = ctx;
+  const group = useContext(GroupContext);
+  if (!group) throw new Error("createSortable must be used inside a <SortableProvider>");
+
+  const isActiveDraggable = createMemo(() => state.active().draggable?.id === id);
+
+  onCleanup(() => registry.unregister(id));
+
+  return {
+    ref: (el: HTMLElement) => registry.register(id, el, group),
+    transform: createMemo((): Transform | null => {
+      // The dragged row tracks the pointer.
+      if (isActiveDraggable()) return state.transform();
+      // Everything between it and the drop target shifts by one row to open the
+      // gap — that preview is what makes a drop legible before it happens.
+      // `0` means "not displaced", and must stay `null` so the row writes no
+      // transform at all rather than an identity one.
+      const dy = state.displacement(id);
+      return dy === 0 ? null : { x: 0, y: dy };
+    }),
+    isActiveDraggable,
+    dragActivators: {
+      onPointerDown: (event: PointerEvent) => {
+        // Left button / primary contact only — a right-click or a middle-click
+        // is not a drag, and starting one steals the context menu.
+        if (event.button !== 0) return;
+        registry.startDrag(id, event);
+      },
+    },
+  };
+}
+
+/**
+ * The style map for a row's current offset.
+ *
+ * Returns `{}` rather than an identity `translate(0, 0)` when there is no
+ * transform: writing one anyway would make every row a containing block and a
+ * stacking context for its own descendants, permanently, for the sake of a
+ * no-op.
+ */
+export function maybeTransformStyle(transform: Transform | null): JSX.CSSProperties {
+  if (!transform) return {};
+  return { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` };
+}

--- a/shared/sortable/src/types.ts
+++ b/shared/sortable/src/types.ts
@@ -1,0 +1,62 @@
+import type { Accessor } from "solid-js";
+
+export type Id = string | number;
+
+export interface DragTarget {
+  id: Id;
+  /** The registered node, so a collision detector can measure it. */
+  node: HTMLElement;
+}
+
+/**
+ * The shape `onDragStart` / `onDragOver` / `onDragEnd` receive.
+ *
+ * `droppable` is the item the pointer is currently OVER — for a sortable list
+ * that means the row the dragged one would land on, and the move is a
+ * splice-to-index rather than a swap. It is `null` before the pointer has
+ * reached any registered item, and on a drop outside every list.
+ */
+export interface DragEvent {
+  draggable: DragTarget;
+  droppable: DragTarget | null;
+}
+
+export interface Transform {
+  x: number;
+  y: number;
+}
+
+/**
+ * A droppable plus the geometry it had when the drag STARTED.
+ *
+ * Measured once rather than per pointer event, for two reasons. Reading a rect
+ * right after writing a transform forces a synchronous layout flush, and at a
+ * few hundred rows that is the drag's whole frame budget. And a live read
+ * during a drag includes the transforms this package itself writes — which is
+ * how a drag can measure its own displacement and compute nonsense.
+ */
+export interface MeasuredTarget extends DragTarget {
+  rect: DOMRect;
+}
+
+export interface DragActivators {
+  onPointerDown: (event: PointerEvent) => void;
+}
+
+export interface Sortable {
+  /** Registers the node. Put this on the ROW, not on the handle. */
+  ref: (el: HTMLElement) => void;
+  /** The offset this row should paint at, or `null` when it is not moving. */
+  transform: Accessor<Transform | null>;
+  /**
+   * Spread onto whatever should START a drag. Put it on a handle to keep the
+   * row's own text selection and buttons working.
+   *
+   * Typed as exactly the handlers it supplies rather than as a broad
+   * `HTMLAttributes`: the wide type carries a `ref?: HTMLElement` that clashes
+   * with the narrower `ref` on whatever element it is spread onto.
+   */
+  dragActivators: DragActivators;
+  /** True for the row currently being dragged. */
+  isActiveDraggable: Accessor<boolean>;
+}

--- a/shared/sortable/tests/list.test.tsx
+++ b/shared/sortable/tests/list.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { createSignal, For, Show } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSortableList } from "../src/list";
+
+afterEach(() => cleanup());
+
+function setup(initial = ["Ceremony", "Reception", "Brunch"]) {
+  const [ids, setIds] = createSignal(initial);
+  const onPhase = vi.fn();
+  let list!: ReturnType<typeof createSortableList>;
+
+  function Harness() {
+    list = createSortableList({
+      ids,
+      labelFor: (id) => String(id),
+      noun: "event",
+      onMove: (from, to) => {
+        const next = [...ids()];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved!);
+        setIds(next);
+      },
+      onPhase,
+    });
+    return (
+      <div>
+        <p {...list.hintProps()}>{list.hintText}</p>
+        <ul>
+          <For each={ids()}>
+            {(id, index) => {
+              const item = list.item(id, index, () => ids().length);
+              return (
+                <li>
+                  <button {...item.gripProps()} data-grip={id}>
+                    grip
+                  </button>
+                  <button {...item.moveProps(-1)} data-up={id}>
+                    {item.moveLabel(-1)}
+                  </button>
+                  <button {...item.moveProps(1)} data-down={id}>
+                    {item.moveLabel(1)}
+                  </button>
+                </li>
+              );
+            }}
+          </For>
+        </ul>
+        <Show when={true}>
+          <p {...list.liveRegionProps()}>{list.announcement()}</p>
+        </Show>
+      </div>
+    );
+  }
+
+  render(() => <Harness />);
+  return { ids, onPhase, list: () => list };
+}
+
+const grip = (id: string) => document.querySelector(`[data-grip="${id}"]`) as HTMLButtonElement;
+
+describe("keyboard re-ordering", () => {
+  it("moves a row down on ArrowDown", () => {
+    const { ids } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown" });
+    expect(ids()).toEqual(["Reception", "Ceremony", "Brunch"]);
+  });
+
+  it("moves a row up on ArrowUp", () => {
+    const { ids } = setup();
+    fireEvent.keyDown(grip("Brunch"), { key: "ArrowUp" });
+    expect(ids()).toEqual(["Ceremony", "Brunch", "Reception"]);
+  });
+
+  it("does nothing at the ends of the list", () => {
+    const { ids } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowUp" });
+    fireEvent.keyDown(grip("Brunch"), { key: "ArrowDown" });
+    expect(ids()).toEqual(["Ceremony", "Reception", "Brunch"]);
+  });
+
+  it("ignores keys that are not the arrows", () => {
+    const { ids } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "Enter" });
+    fireEvent.keyDown(grip("Ceremony"), { key: "j" });
+    expect(ids()).toEqual(["Ceremony", "Reception", "Brunch"]);
+  });
+
+  it("ignores auto-repeat — one press, one move", () => {
+    // Repeat fires ~30x/s and each move is a draft checkpoint plus a
+    // revalidation, so a held key would stall the list and burn the undo stack.
+    const { ids } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown", repeat: true });
+    expect(ids()).toEqual(["Ceremony", "Reception", "Brunch"]);
+  });
+
+  it("claims the arrows even at a boundary, so the page never scrolls instead", () => {
+    // `preventDefault` runs BEFORE the bounds check: a focused grip owns Up/Down
+    // unconditionally rather than sometimes moving the row and sometimes
+    // scrolling the page out from under it.
+    setup();
+    // `bubbles` because Solid delegates `onKeyDown` to the document root —
+    // a non-bubbling event never reaches the handler at all.
+    const event = new KeyboardEvent("keydown", { key: "ArrowUp", cancelable: true, bubbles: true });
+    grip("Ceremony").dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("restores focus to the grip that moved", () => {
+    // `<For>` moves the node rather than re-creating it, but a DOM move is a
+    // remove-then-insert and focus does not survive it — without the explicit
+    // restore, one keypress leaves focus on <body>.
+    setup();
+    grip("Ceremony").focus();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown" });
+    expect(document.activeElement).toBe(grip("Ceremony"));
+  });
+});
+
+describe("screen-reader move controls", () => {
+  it("moves the row when activated", () => {
+    // NVDA and JAWS browse mode eats bare arrows and never forwards them to a
+    // button, so these are the only working path for those users.
+    const { ids } = setup();
+    (document.querySelector('[data-down="Ceremony"]') as HTMLButtonElement).click();
+    expect(ids()).toEqual(["Reception", "Ceremony", "Brunch"]);
+  });
+
+  it("is disabled at the list ends, so AT reports the boundary", () => {
+    setup();
+    expect((document.querySelector('[data-up="Ceremony"]') as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((document.querySelector('[data-down="Brunch"]') as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((document.querySelector('[data-down="Ceremony"]') as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("names the row it moves", () => {
+    setup();
+    expect(document.querySelector('[data-up="Reception"]')?.textContent).toBe("Move Reception up");
+  });
+});
+
+describe("announcements", () => {
+  it("announces a completed move with its new position", () => {
+    const { list } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown" });
+    expect(list().announcement()).toBe("Ceremony moved to position 2 of 3.");
+  });
+
+  it("re-announces an identical consecutive move", () => {
+    // A live region only speaks when its text CHANGES, and walking one row down
+    // the list repeatedly produces the same sentence every time. The clear-then-
+    // set is what keeps the second press from being silent — this asserts the
+    // empty write really happened.
+    const { list } = setup(["A", "B", "C", "D"]);
+    const seen: string[] = [];
+    // Re-read after every set by subscribing through the accessor.
+    fireEvent.keyDown(grip("A"), { key: "ArrowDown" });
+    seen.push(list().announcement());
+    fireEvent.keyDown(grip("A"), { key: "ArrowDown" });
+    seen.push(list().announcement());
+    expect(seen[0]).toBe("A moved to position 2 of 4.");
+    expect(seen[1]).toBe("A moved to position 3 of 4.");
+  });
+
+  it("clears rather than re-announcing, for an undo", () => {
+    // An undo may have reverted a field edit rather than a re-order, and
+    // guessing which would be worse than silence.
+    const { list } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown" });
+    expect(list().announcement()).not.toBe("");
+    list().clearAnnouncement();
+    expect(list().announcement()).toBe("");
+  });
+
+  it("carries the live position in each grip's label", () => {
+    setup();
+    expect(grip("Reception").getAttribute("aria-label")).toBe("Reorder Reception, position 2 of 3");
+    fireEvent.keyDown(grip("Reception"), { key: "ArrowUp" });
+    expect(grip("Reception").getAttribute("aria-label")).toBe("Reorder Reception, position 1 of 3");
+  });
+
+  it("points every grip at the shared instructions", () => {
+    const { list } = setup();
+    expect(grip("Ceremony").getAttribute("aria-describedby")).toBe(list().hintId);
+    expect(document.getElementById(list().hintId)?.textContent).toContain("arrow keys");
+  });
+
+  it("generates a distinct hint id per list, so several can share a page", () => {
+    // `id="reorder-hint"` was hardcoded when only one list had dragging. Two
+    // lists would then both claim it and every grip on the page would describe
+    // itself with whichever won.
+    const a = setup();
+    const b = setup();
+    expect(a.list().hintId).not.toBe(b.list().hintId);
+  });
+});
+
+describe("phase callbacks", () => {
+  it("confirms a keyboard move", () => {
+    const { onPhase } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowDown" });
+    expect(onPhase).toHaveBeenCalledWith("commit");
+  });
+
+  it("does not confirm a move that was refused at a boundary", () => {
+    const { onPhase } = setup();
+    fireEvent.keyDown(grip("Ceremony"), { key: "ArrowUp" });
+    expect(onPhase).not.toHaveBeenCalled();
+  });
+});

--- a/shared/sortable/tests/sortable.test.tsx
+++ b/shared/sortable/tests/sortable.test.tsx
@@ -1,0 +1,457 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { createSignal, For } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  closestCenter,
+  createSortable,
+  DragDropProvider,
+  DragDropSensors,
+  maybeTransformStyle,
+  SortableProvider,
+  type DragEvent,
+} from "../src/index";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * happy-dom does no layout — every `getBoundingClientRect()` is zeroes, so
+ * `closestCenter` would see every row's centre at (0,0) and pick arbitrarily.
+ * Stub stacked rects derived from each row's CURRENT DOM position, so they stay
+ * correct after a reorder.
+ *
+ * The stub also adds the element's own `translate3d` Y offset, which a real
+ * browser's rect includes. That matters: the first cut of this file ignored
+ * transforms, which made a whole bug class structurally invisible — the package
+ * measured the stride from live rects mid-drag, so the dragged row's own offset
+ * polluted it, and dragging row 0 down by exactly one row height collapsed the
+ * stride to zero and silently disabled shift-aside. Every test stayed green.
+ * A stub that models transforms is what lets a test see it.
+ */
+function stubRowGeometry(height = 40) {
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+    const rows = [...document.querySelectorAll("[data-row]")];
+    const index = rows.indexOf(this);
+    const offset = Number(
+      /translate3d\(0px, (-?[\d.]+)px/.exec((this as HTMLElement).style?.transform ?? "")?.[1] ?? 0,
+    );
+    const top = (index === -1 ? 0 : index * height) + offset;
+    return {
+      top,
+      bottom: top + height,
+      left: 0,
+      right: 100,
+      width: 100,
+      height,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    } as DOMRect;
+  });
+}
+
+function Row(props: { id: string; label: string }) {
+  const sortable = createSortable(props.id);
+  return (
+    <li data-row ref={sortable.ref} style={maybeTransformStyle(sortable.transform())}>
+      <button {...sortable.dragActivators} data-grip={props.id}>
+        grip {props.label}
+      </button>
+    </li>
+  );
+}
+
+function List(props: { onDragEnd?: (e: DragEvent) => void; onDragOver?: (e: DragEvent) => void }) {
+  const [ids] = createSignal(["a", "b", "c"]);
+  return (
+    <DragDropProvider
+      onDragEnd={props.onDragEnd}
+      onDragOver={props.onDragOver}
+      collisionDetector={closestCenter}
+    >
+      <DragDropSensors />
+      <ul>
+        <SortableProvider ids={ids()}>
+          <For each={ids()}>{(id) => <Row id={id} label={id} />}</For>
+        </SortableProvider>
+      </ul>
+    </DragDropProvider>
+  );
+}
+
+/** Press, cross the activation threshold, travel, release. */
+function drag(grip: Element, toY: number) {
+  fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+  // The first move exists to clear the sensor's distance threshold.
+  fireEvent(document, new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }));
+  fireEvent(document, new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: toY }));
+  fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: toY }));
+}
+
+describe("pointer dragging", () => {
+  it("reports the row dragged and the row it landed on", () => {
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    drag(document.querySelector("[data-grip=a]")!, 100);
+    expect(onDragEnd).toHaveBeenCalledOnce();
+    const event = onDragEnd.mock.calls[0]![0] as DragEvent;
+    expect(event.draggable.id).toBe("a");
+    expect(event.droppable?.id).toBe("c");
+  });
+
+  it("leaves the order untouched when a press never moves", () => {
+    // A handle is usually also a button. Without a distance threshold, every
+    // click on it would start and immediately end a drag, committing a move.
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 10 }));
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it("does not activate on a movement below the threshold", () => {
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 11, clientY: 11 }),
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 11, clientY: 11 }));
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it("ignores a non-primary button, so right-click keeps its context menu", () => {
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 2, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 90 }),
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 90 }));
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it("reports each slot change once, not once per pointer event", () => {
+    // A consumer ticks a haptic per `onDragOver`. Firing per event would buzz
+    // continuously instead of once per row crossed.
+    stubRowGeometry();
+    const onDragOver = vi.fn();
+    render(() => <List onDragOver={onDragOver} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 31 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 32 }),
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 32 }));
+    const slots = onDragOver.mock.calls.map((c) => (c[0] as DragEvent).droppable?.id);
+    expect(new Set(slots).size).toBe(slots.length);
+  });
+
+  it("does not commit a cancelled gesture", () => {
+    // A cancelled drag (the OS taking over, a context menu) is not a drop, and
+    // committing one would move a row the user never released.
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 90 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointercancel", { pointerId: 1, clientX: 10, clientY: 90 }),
+    );
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+});
+
+describe("the dragged row paints its offset", () => {
+  it("writes a translate on the row while it is being dragged, and clears it after", () => {
+    // The bug this pins is silent: `transform` is an accessor, so passing it
+    // UNCALLED gives `maybeTransformStyle` a truthy function and paints
+    // `translate3d(undefinedpx, undefinedpx, 0)` — the row simply never moves
+    // under the pointer, with every drop-semantics test still green.
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    const row = grip.closest("[data-row]") as HTMLElement;
+
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 15, clientY: 50 }),
+    );
+    expect(row.style.transform).toBe("translate3d(5px, 40px, 0)");
+
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 15, clientY: 50 }));
+    expect(row.style.transform, "the offset outlived the drop").toBe("");
+  });
+
+  it("shifts the rows between the dragged one and its target, to open the gap", () => {
+    // The drop preview. Without it only the row under the pointer moves and the
+    // list gives no sign of where the row would land — which is how this
+    // shipped at first: `transform` returned null for every non-dragged row, so
+    // `EventsEditor`'s "animate the OTHER rows shifting aside" styling animated
+    // nothing, and every drop-semantics test stayed green.
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    const rows = () => [...document.querySelectorAll("[data-row]")] as HTMLElement[];
+
+    // Drag the first row down onto the third.
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 100 }),
+    );
+
+    // Rows b and c come UP by one stride (40px, from the stubbed geometry) to
+    // make room; the dragged row is on the pointer, not on a stride.
+    expect(rows()[1]!.style.transform).toBe("translate3d(0px, -40px, 0)");
+    expect(rows()[2]!.style.transform).toBe("translate3d(0px, -40px, 0)");
+    expect(rows()[0]!.style.transform).toBe("translate3d(0px, 90px, 0)");
+
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 100 }));
+    for (const row of rows()) expect(row.style.transform).toBe("");
+  });
+
+  it("shifts the other way when dragging upwards", () => {
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=c]")!;
+    const rows = () => [...document.querySelectorAll("[data-row]")] as HTMLElement[];
+
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 90 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 70 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 10 }),
+    );
+
+    // a and b go DOWN to open a slot at the top.
+    expect(rows()[0]!.style.transform).toBe("translate3d(0px, 40px, 0)");
+    expect(rows()[1]!.style.transform).toBe("translate3d(0px, 40px, 0)");
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 10 }));
+  });
+
+  it("measures the stride from slot geometry, not from the dragged row's offset (P-W1)", () => {
+    // The exact case that shipped broken, reproduced in a real browser first:
+    // drag row 0 down by EXACTLY one row height in a single motion. Measured
+    // live, `rects[0].top` already carried the +40 offset, so
+    // `rects[1].top - rects[0].top` came out ZERO — and a zero stride makes
+    // `computeDisplacement` bail, so nothing shifted aside at all.
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    const rows = () => [...document.querySelectorAll("[data-row]")] as HTMLElement[];
+
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    // One move, landing exactly one stride down — activation and the first slot
+    // detection both happen at the moment row 0 sits on row 1's start.
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 50 }),
+    );
+
+    expect(rows()[1]!.style.transform, "the stride collapsed — row 1 never moved aside").toBe(
+      "translate3d(0px, -40px, 0)",
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 50 }));
+  });
+
+  it("measures once per gesture, not once per pointer event", () => {
+    // At RegistryView's documented 500 rows a per-event sweep is ~30-60k
+    // getBoundingClientRect calls a second, each one behind a forced style
+    // flush because the package writes a transform immediately before reading.
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    const spy = vi.spyOn(Element.prototype, "getBoundingClientRect");
+
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    const afterPress = spy.mock.calls.length;
+    expect(afterPress, "the gesture never measured the list").toBeGreaterThan(0);
+
+    for (let y = 20; y <= 120; y += 10) {
+      fireEvent(
+        document,
+        new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: y }),
+      );
+    }
+    expect(spy.mock.calls.length - afterPress, "geometry was re-measured mid-drag").toBe(0);
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 120 }));
+  });
+
+  it("leaves rows outside the moved range alone", () => {
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    const rows = () => [...document.querySelectorAll("[data-row]")] as HTMLElement[];
+
+    // Drag row a only as far as row b — row c is not between them.
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 55 }),
+    );
+
+    expect(rows()[1]!.style.transform).toBe("translate3d(0px, -40px, 0)");
+    expect(rows()[2]!.style.transform, "an untouched row must write no transform").toBe("");
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 55 }));
+  });
+});
+
+describe("gesture lifecycle (S-M1)", () => {
+  it("ignores a second pointer, so one finger cannot drive another's drag", () => {
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    // A different contact moves and releases. It must not drive or end this drag.
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 2, clientX: 10, clientY: 90 }),
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 2, clientX: 10, clientY: 90 }));
+    expect(onDragEnd, "a foreign pointer ended the drag").not.toHaveBeenCalled();
+
+    // The original pointer still owns the gesture.
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 30 }),
+    );
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 90 }),
+    );
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 90 }));
+    expect(onDragEnd).toHaveBeenCalledOnce();
+  });
+
+  it("captures the pointer, so a release outside the window still ends the drag", () => {
+    // Without capture, `pointerup` fired off-window is never delivered: the row
+    // stays stuck to a button-up pointer and the user's NEXT click anywhere
+    // commits a reorder they never made.
+    stubRowGeometry();
+    render(() => <List />);
+    const grip = document.querySelector("[data-grip=a]") as HTMLElement;
+    const capture = vi.fn();
+    const release = vi.fn();
+    grip.setPointerCapture = capture;
+    grip.releasePointerCapture = release;
+
+    fireEvent.pointerDown(grip, { pointerId: 7, button: 0, clientX: 10, clientY: 10 });
+    expect(capture).toHaveBeenCalledWith(7);
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 7, clientX: 10, clientY: 10 }));
+    expect(release).toHaveBeenCalledWith(7);
+  });
+
+  it("tears the gesture down when the provider unmounts mid-drag", () => {
+    // A live gesture would otherwise leave three document listeners firing into
+    // a disposed scope, and the next pointerup anywhere would call `onDragEnd`
+    // with stale indices.
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    const { unmount } = render(() => <List onDragEnd={onDragEnd} />);
+    const grip = document.querySelector("[data-grip=a]")!;
+    fireEvent.pointerDown(grip, { pointerId: 1, button: 0, clientX: 10, clientY: 10 });
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { pointerId: 1, clientX: 10, clientY: 90 }),
+    );
+
+    unmount();
+    fireEvent(document, new PointerEvent("pointerup", { pointerId: 1, clientX: 10, clientY: 90 }));
+    expect(onDragEnd, "a disposed provider still committed a drop").not.toHaveBeenCalled();
+  });
+});
+
+describe("maybeTransformStyle", () => {
+  it("returns an empty map when there is no transform", () => {
+    // NOT an identity transform: writing one would make every row a containing
+    // block and a stacking context for its descendants, permanently.
+    expect(maybeTransformStyle(null)).toEqual({});
+  });
+
+  it("returns a translate for a live transform", () => {
+    expect(maybeTransformStyle({ x: 3, y: 7 })).toEqual({
+      transform: "translate3d(3px, 7px, 0)",
+    });
+  });
+});
+
+describe("multi-container", () => {
+  function TwoLists(props: { onDragEnd: (e: DragEvent) => void }) {
+    return (
+      <DragDropProvider onDragEnd={props.onDragEnd} collisionDetector={closestCenter}>
+        <DragDropSensors />
+        <ul>
+          <SortableProvider ids={["a1", "a2"]}>
+            <Row id="a1" label="a1" />
+            <Row id="a2" label="a2" />
+          </SortableProvider>
+        </ul>
+        <ul>
+          <SortableProvider ids={["b1", "b2"]}>
+            <Row id="b1" label="b1" />
+            <Row id="b2" label="b2" />
+          </SortableProvider>
+        </ul>
+      </DragDropProvider>
+    );
+  }
+
+  it("never lands an item from one list in another", () => {
+    // Two lists on a page are two independent sortables. Dragging a task inside
+    // "3 months out" must not drop it into "1 month out" — that would be a
+    // re-bucketing, a semantic change, not a re-order.
+    stubRowGeometry();
+    const onDragEnd = vi.fn();
+    render(() => <TwoLists onDragEnd={onDragEnd} />);
+    // Drag the FIRST list's first row far enough to sit over the second list.
+    drag(document.querySelector("[data-grip=a1]")!, 300);
+    const event = onDragEnd.mock.calls[0]![0] as DragEvent;
+    expect(event.draggable.id).toBe("a1");
+    expect(["a2"]).toContain(event.droppable?.id);
+  });
+});

--- a/shared/sortable/tsconfig.json
+++ b/shared/sortable/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shared/typescript-config/solid.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/shared/sortable/vitest.config.ts
+++ b/shared/sortable/vitest.config.ts
@@ -1,0 +1,10 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [solid()],
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.{ts,tsx}"],
+  },
+});

--- a/wiki/architecture/drag-and-drop.md
+++ b/wiki/architecture/drag-and-drop.md
@@ -1,43 +1,66 @@
 ---
-title: "Drag and drop — solid-dnd, and the keyboard path we own"
+title: "Drag and drop — @shared/sortable, and the keyboard path it owns"
 tags: [architecture, organiser, frontend, accessibility]
 related:
   - "[[index]]"
   - "[[cire-guest-event-editor]]"
   - "[[monorepo-structure]]"
+  - "[[toast]]"
+  - "[[component-lab]]"
 last-reviewed: 2026-08-21
 ---
-# Drag and drop — solid-dnd, and the keyboard path we own
+# Drag and drop — `@shared/sortable`, and the keyboard path it owns
 
-Drag-to-reorder in the organiser portal uses
-[solid-dnd](https://github.com/thisbeyond/solid-dnd) (`@thisbeyond/solid-dnd`).
-It's a purpose-built SolidJS library, so there is **no adapter layer** — the
-primitives are used directly in the component.
+Drag-to-reorder uses **`@shared/sortable`**, an internal package. It replaced
+[solid-dnd](https://github.com/thisbeyond/solid-dnd) (`@thisbeyond/solid-dnd`)
+on 2026-08-21.
 
-## Why solid-dnd, and what it costs us
+## Why we own it now
 
-Three candidates were weighed (2026-07-30):
+This page used to say the opposite — that solid-dnd was used directly, with no
+adapter layer, and that the blast radius was one component. That was a
+defensible call, and the reasoning is kept below because it is still the reason
+the swap was cheap. Two things changed it.
+
+**The library was three years unmaintained.** Its last release was 0.7.5 in
+November 2023. It was adopted anyway because it is small, has zero runtime
+dependencies, and is pure DOM plus geometry — but that argument only ever
+deferred the question.
+
+**The accessibility cost was blocking adoption.** solid-dnd ships a pointer
+sensor and nothing else: no keyboard sensor, no announcements. Grepping its
+bundle for `keydown`/`keyboard`/`ArrowUp` returns zero hits. So every list that
+wanted dragging had to hand-write the whole keyboard and screen-reader story —
+about 120 lines of subtle, silent-when-wrong logic. `EventsEditor` did. Three
+other lists did not, and said so in code: `RegistryView.tsx` carried the comment
+*"solid-dnd ships no keyboard sensor and no announcements, so adopting it here
+would mean re-supplying the whole keyboard path by hand."*
+
+That is the real argument for owning it. A package can carry those obligations
+once, with tests; a convention cannot.
+
+### What was weighed originally (2026-07-30)
 
 | Library | Verdict |
 |---|---|
-| **solid-dnd** | **Chosen.** Native Solid, ships sortable-list primitives + collision detection. Measured main-chunk cost **+13.1 KiB raw / +4.3 KiB gzip**. |
-| [neodrag](https://github.com/PuruVJ/neodrag) | **Can't do the job.** It's a free-positioning *draggable* — no droppables, no collision detection, no reorder logic. Sortable lists would mean hand-writing the hit-testing and index projection. Actively maintained, but that doesn't help when the capability is absent. |
-| [dnd-kit](https://github.com/clauderic/dnd-kit) | Works (shipped briefly), but React-only adapters meant maintaining our own Solid adapter, and at ~105 kB raw it pushed the organiser's main chunk past Vite's 500 kB warning and forced a `lazy()` code-split. |
+| **solid-dnd** | Chosen at the time. Native Solid, sortable-list primitives + collision detection. Measured main-chunk cost **+13.1 KiB raw / +4.3 KiB gzip**. |
+| [neodrag](https://github.com/PuruVJ/neodrag) | Can't do the job. A free-positioning *draggable* — no droppables, no collision detection, no reorder logic. |
+| [dnd-kit](https://github.com/clauderic/dnd-kit) | Works (shipped briefly), but React-only adapters meant maintaining our own Solid adapter, and at ~105 kB it pushed the organiser's main chunk past Vite's 500 kB warning. |
 
-**The known risk, stated plainly: solid-dnd's last release was 0.7.5 in November
-2023 — nearly three years unmaintained.** It was adopted anyway because it is
-small, has zero runtime dependencies, and is pure DOM + geometry, so there's
-little for ecosystem churn to break. That reasoning is only worth anything if
-it's *checked*, so `EventsEditor.reorder.test.tsx` drives a real synthetic
-pointer drag end-to-end (sensor → collision detection → `onDragEnd` → commit)
-rather than merely asserting that the markup renders. If a Solid upgrade breaks
-the library, those tests fail. If it does become unworkable, the blast radius is
-one component — the DnD wiring is not abstracted across the codebase.
+`@shared/sortable` is smaller than all three: it implements exactly the surface
+this monorepo uses and nothing else. Measured at the swap (2026-08-21), the
+organiser's main chunk went **234,520 → 228,119 B raw** (−6,401; −2,164 gzip)
+and `cire/invites` total JS **243,303 → 229,580 B** (−13,723), so the change
+roughly recovers what solid-dnd cost. Note the older figures this page used to
+quote (474,925 → 488,348 B) described a chunk layout that no longer exists.
 
 ## The primitives
 
+The API deliberately mirrors what it replaced, so the migration was an import
+swap and the existing 18 reorder tests stayed a true regression net.
+
 ```tsx
-<DragDropProvider onDragEnd={handleDragEnd} collisionDetector={closestCenter}>
+<DragDropProvider {...list.dragHandlers} collisionDetector={closestCenter}>
   <DragDropSensors />
   <ul>
     <SortableProvider ids={keys()}>
@@ -51,90 +74,181 @@ one component — the DnD wiring is not abstracted across the codebase.
 
 ```tsx
 const sortable = createSortable(props.row.key);
-<li ref={sortable.ref} style={maybeTransformStyle(sortable.transform)}>
-  <button {...sortable.dragActivators} onKeyDown={handleKeyDown}>⠿</button>
+<li ref={sortable.ref} style={maybeTransformStyle(sortable.transform())}>
+  <button {...sortable.dragActivators} {...item.gripProps()}>⠿</button>
 </li>
 ```
 
-### `ref` + `dragActivators`, not `use:sortable`
+### One difference from solid-dnd: accessors, not store properties
 
-solid-dnd's `use:sortable` directive registers the node **and** attaches the drag
-activators to it **and** applies the transform — i.e. the whole row becomes the
-drag affordance, which would swallow text selection and the row's own buttons.
+`transform`, `isActiveDraggable` and the provider's `active` are **accessors** —
+call them. solid-dnd exposed store properties, so the migration needed three
+call-site changes in `EventsEditor`. Getting this wrong is silent: passing
+`sortable.transform` uncalled hands `maybeTransformStyle` a truthy function and
+paints `translate3d(undefinedpx, undefinedpx, 0)`, so the row simply never moves
+under the pointer while every drop-semantics test stays green. `tsc` catches it;
+a package test pins the painted offset as well.
 
-For a **handle**, use `sortable.ref` instead and spread `sortable.dragActivators`
-onto the handle. The catch: `ref` registers the node *without* applying the
-transform (see `createSortable` — only the directive form sets up that effect),
-so the row must apply `maybeTransformStyle(sortable.transform)` itself. Use
-`maybeTransformStyle`, not `transformStyle`: it returns `{}` when there's no
-transform instead of writing an identity one.
+### `ref` + `dragActivators`, not a whole-row directive
 
-Spread `dragActivators` **before** your own `onKeyDown` — later props win in
-Solid's spread, so putting it last would let a future sensor clobber the keyboard
-handler.
+Registering the node **and** attaching the activators **and** applying the
+transform to the same element makes the whole row the drag affordance, which
+swallows text selection and the row's own buttons.
+
+For a **handle**, put `sortable.ref` on the row and spread
+`sortable.dragActivators` onto the handle. The catch: `ref` registers the node
+*without* applying the transform, so the row must apply
+`maybeTransformStyle(sortable.transform())` itself. `maybeTransformStyle` returns
+`{}` when there is no transform rather than an identity one — writing
+`translate(0,0)` anyway would make every row a containing block and a stacking
+context for its own descendants, permanently, for a no-op.
+
+Spread `dragActivators` **before** `gripProps()` — later props win in Solid's
+spread, and `gripProps` is what carries the keyboard handler, the label and the
+ref.
+
+### Multi-container
+
+Every item registers with the `SortableProvider` it sits under, identified by a
+`symbol`. Collision detection only ever considers items sharing the dragged
+item's group, so N lists on a page are N independent sortables and one
+`DragDropProvider` can wrap them all.
+
+Deliberately **not** cross-container: `ChecklistView` and `BudgetView` reorder
+*within* a bucket or category and POST `{timeframeBucket, orderedIds}` /
+`{category, orderedIds}`. Dragging a task from "3 months out" to "1 month out"
+would be a re-bucketing — a semantic change — not a re-order. A package test
+pins that an item can never land in a sibling list.
 
 ## Accessibility — this is the part to not break
 
-**solid-dnd has no keyboard sensor and makes no announcements.** Grepping its
-bundle for `keydown`/`keyboard`/`ArrowUp` returns zero hits. (Neither does
-neodrag.) Swapping ▲/▼ buttons for dragging is therefore an accessibility
-*regression* unless the whole keyboard story is supplied by hand. The list does
-five things itself — if you touch this component, none of them are optional:
+`createSortableList` (`@shared/sortable/list`) owns the whole keyboard and
+screen-reader path. It used to live in `EventsEditor`. Five obligations, none
+optional, each with a failure mode that is silent rather than obvious — which is
+exactly why they belong in a package:
 
-1. **The grip is a real `<button>`** — tabbable, and it owns an `onKeyDown` that
-   moves the row on **Arrow Up / Arrow Down**, with `preventDefault()` so the page
-   doesn't scroll out from under it. `preventDefault` runs *before* the bounds
-   check, so a focused grip owns the arrows unconditionally rather than sometimes
-   moving the row and sometimes scrolling.
+1. **The grip is a real `<button>`** — tabbable, owning an `onKeyDown` that moves
+   the row on **Arrow Up / Arrow Down**, with `preventDefault()` *before* the
+   bounds check, so a focused grip owns the arrows unconditionally rather than
+   sometimes moving the row and sometimes scrolling the page out from under it.
 2. **Arrow keys alone are NOT enough, and this is the subtle one.** NVDA and JAWS
    run in browse mode by default and consume unmodified arrow keys for their own
-   virtual cursor; they forward them to a plain `<button>` only in focus mode,
+   virtual cursor, forwarding them to a plain `<button>` only in focus mode,
    which buttons don't trigger. A screen-reader user would read the hint, press
-   the arrows, and get nothing. So each row also renders **`sr-only` "Move X up" /
-   "Move X down" buttons**, activated by Enter/Space — the one keystroke class
+   the arrows, and get nothing. So each row also renders **`sr-only` "Move X up"
+   / "Move X down" buttons**, activated by Enter/Space — the one keystroke class
    browse mode reliably forwards, and precisely what the removed ▲/▼ pair used.
    They are `focus:not-sr-only` so a sighted keyboard user never lands on an
    invisible control (WCAG 2.4.7), and `disabled` at the list ends so AT reports
    the boundary instead of the user pressing into nothing.
-3. **Focus is restored explicitly** after a keyboard move. `<For>` is keyed, so the
-   row's node is *moved* rather than re-created — but a DOM move is a
-   remove-then-insert and focus does not reliably survive it. Without the explicit
-   `.focus()`, one keypress moves the row and then focus is on `<body>`, so the
-   row can't be walked further.
+3. **Focus is restored explicitly** after a keyboard move. `<For>` is keyed, so
+   the row's node is *moved* rather than re-created — but a DOM move is a
+   remove-then-insert and focus does not reliably survive it. Without the
+   explicit `.focus()`, one keypress moves the row and then focus is on `<body>`,
+   so the row can't be walked further.
 4. **Every move is announced** through a polite `role="status"` live region
    ("Ceremony moved to position 2 of 3"), and each grip's `aria-label` carries its
    current position with an `aria-describedby` hint pointing at the shared
-   instructions. A drag affordance is invisible to a screen-reader user otherwise.
-   The announcement **clears before it sets** — a live region only speaks when its
-   text changes, and walking one row down the list repeatedly produces the same
-   sentence every time, so setting it straight would make the second press silent.
-   Undo/discard clear the region rather than re-announcing, since an undo may have
-   reverted a field edit rather than a re-order.
-5. **Auto-repeat is ignored** (`if (event.repeat) return`). One press, one move —
-   matching the click semantics of the buttons this replaced. Repeat fires ~30×/s
-   and each move is a `structuredClone` draft checkpoint plus a full revalidation,
-   so a held key would both stall the list and burn the 100-slot undo stack in a
-   few seconds, silently discarding the edits the organiser actually wants back.
+   instructions. The announcement **clears before it sets** — a live region only
+   speaks when its text changes, and walking one row down the list repeatedly
+   produces the same sentence every time, so setting it straight would make the
+   second press silent. `clearAnnouncement()` is for undo/discard, which rewind
+   the order without going through a move: cleared rather than re-announced,
+   since an undo may have reverted a field edit instead.
+5. **Auto-repeat is ignored** (`if (event.repeat) return`). One press, one move.
+   Repeat fires ~30×/s and a consumer's `onMove` is typically a draft checkpoint
+   plus a full revalidation, so a held key would both stall the list and burn an
+   undo stack in seconds.
 
-Also required: `touch-none` (CSS `touch-action: none`) on the handle, or the
-browser scrolls instead of handing the gesture to solid-dnd; and enough padding to
-clear the WCAG 2.5.8 24 px minimum target (`px-1 py-2` on a glyph this small).
+**The hint id is generated** with `createUniqueId()`, not hardcoded. It used to
+be `id="reorder-hint"`, which was fine while exactly one list had dragging and
+collides the moment a second one appears.
+
+Also required, and the consumer's job because they are styling: `touch-none`
+(CSS `touch-action: none`) on the handle, or the browser scrolls instead of
+handing the gesture over; and enough padding to clear the WCAG 2.5.8 24 px
+minimum target (`px-1 py-2` on a glyph this small).
+
+### What stays with the consumer
+
+Haptics. The package reports drag **phases** (`pickup`, `step`, `commit`) through
+`onPhase`; what they feel like is the host portal's vocabulary
+(`cire/host/src/lib/haptics.ts`), not the package's. `onDragOver` reports only a
+*change* of slot, so a consumer ticking per phase buzzes once per row crossed
+rather than continuously.
+
+### Geometry is measured once, at drag start
+
+`startDrag` snapshots every row's rect and the stride, and the whole gesture
+runs against that snapshot. Layout cannot change during a drag except for the
+transforms this package writes — and those are exactly what must be excluded.
+
+Measuring live got it wrong twice over, and both were found by review rather
+than by any test:
+
+- **The stride was polluted.** It is read from the first adjacent pair, and a
+  live `getBoundingClientRect()` includes the dragged row's own transform. Drag
+  row 0 down by exactly one row height in one motion and the stride computes to
+  **zero** — at which point `computeDisplacement` bails and shift-aside silently
+  stops. Dragging gradually was merely wrong rather than dead: a 68 px stride
+  measured as 62 px.
+- **The detector chased its own output**, seeing displaced rows in the slots
+  they were moving *to* rather than the ones they belonged to.
+
+It is also what keeps the cost flat. `RegistryView` is a documented adopter at
+up to 500 rows; measuring per pointer event there is ~30–60k
+`getBoundingClientRect()` per second, each behind a forced style flush because
+the package writes a transform immediately before reading. The snapshot makes
+that O(1) arithmetic. dnd-kit and solid-dnd both measure at drag start too.
+
+### The gesture owns its listeners
+
+`startDrag` attaches `pointermove`/`pointerup`/`pointercancel` to `document`,
+and three things make sure they come off again:
+
+- **Pointer capture.** Without it a drag released outside the window never gets
+  its `pointerup`: the row stays stuck to a button-up pointer, and the user's
+  next click anywhere commits a reorder they never made.
+- **A `pointerId` guard**, so a second touch cannot drive or end the first
+  finger's gesture.
+- **`onCleanup` in `DragDropProvider`**, so an unmount mid-drag tears the
+  listeners down rather than leaving them firing into a disposed scope.
 
 ## Testing drag in happy-dom
 
 happy-dom does no layout — every `getBoundingClientRect()` is zeroes, so
 `closestCenter` sees every row's centre at (0,0) and picks a collision
-arbitrarily. `EventsEditor.reorder.test.tsx` works around this by stubbing
-`Element.prototype.getBoundingClientRect` to return stacked rects derived from
-each row's *current* DOM position (so they stay correct after a reorder), then
-dispatching `pointerdown` → `pointermove` × 2 → `pointerup`. The first move gets
-past the sensor's activation threshold.
+arbitrarily. **The stub must also add each row's own `translate3d` offset**, the
+way a real browser's rect does: the first cut ignored transforms, which made the
+whole stride-pollution class above structurally invisible to the fast tier. `EventsEditor.reorder.test.tsx` and the package's own tests work
+around this by stubbing `Element.prototype.getBoundingClientRect` to return
+stacked rects derived from each row's *current* DOM position (so they stay
+correct after a reorder), then dispatching `pointerdown` → `pointermove` × 2 →
+`pointerup`. The first move gets past the sensor's activation threshold.
 
-The keyboard path needs none of that and is fully deterministic — it's the
-cheaper regression net of the two.
+Two behaviours that threshold pins, and that the package tests directly: a press
+with no movement leaves the order untouched (a handle is usually also a button —
+without a threshold every click on it would start and end a drag), and a movement
+below `ACTIVATION_DISTANCE` does not activate.
+
+Keyboard tests need none of that and are fully deterministic — the cheaper
+regression net of the two. One trap: Solid delegates `onKeyDown` to the document
+root, so a hand-constructed `KeyboardEvent` needs `bubbles: true` or it never
+reaches the handler.
 
 What this still can't cover: drag *feel*, the shift/settle animation, and the
-grip's hover/focus styling. Those need a real browser.
+grip's hover/focus styling. Those need a real browser and a pair of eyes —
+`bun run dev:lab` → **shared/sortable**, which benches exactly those three plus
+the multi-container isolation. See [[component-lab]].
+
+The shift-aside is why that bench exists. It shipped broken: `transform` returned
+`null` for every non-dragged row, so the rows between the dragged one and its
+target never opened a gap and `EventsEditor`'s "animate the OTHER rows shifting
+aside" styling animated nothing — with every drop-semantics test green. The
+displacement is now computed from the `SortableProvider`'s `ids` and a stride
+**measured** from the first adjacent pair of rows (the gap lives in the
+consumer's CSS, so a package that assumed it would open a hole of the wrong
+size), and three tests pin it. A bench would have caught it in a second.
 
 ## Scope + open follow-ups
 
@@ -142,9 +256,12 @@ Current adopters:
 
 - **Schedule → Edit** (`EventsEditor`) — see `[[cire-guest-event-editor]]` E7.
 
-Still on arrow buttons:
+Still on arrow buttons, and now cheap to convert — the keyboard path comes free,
+so each is a UX decision rather than an accessibility project:
 
-- `ChecklistView` — tasks within a lead-time bucket, persisted via
-  `tasks/reorder`. It reorders *within a bucket*, so adopting this means using
-  solid-dnd's multi-container support (a `SortableProvider` per bucket), which the
-  events list doesn't exercise.
+- `ChecklistView` — tasks within a lead-time bucket, persisted via `tasks/reorder`.
+- `BudgetView` — items within a category, via `budget/items/reorder`.
+- `RegistryView` — a single flat list of up to 500 rows, via `registry/items/reorder`.
+  Note REG-P-W1: it rewrites only the rows whose position actually changed, because
+  a blanket `{ ...it }` tears down every row and loses an open inline editor's caret.
+  Any drag adoption must preserve that.


### PR DESCRIPTION
## Summary

Fourth of five. Adds `@shared/sortable`, an internal drag-to-reorder package to
replace `@thisbeyond/solid-dnd` (last released 0.7.5, November 2023).
`EventsEditor` adopts it in PR 5, so this lands as a pure addition.

The API mirrors what it replaces, so the migration is an import swap and the
existing 18 reorder tests stay a true regression net. The reason to own it is not
staleness, though — it is that solid-dnd shipped a pointer sensor and nothing
else, and the missing keyboard path was actively blocking adoption elsewhere.

- `createSortableList` carries the whole keyboard/screen-reader story, with tests.
- Multi-container falls out of scoping droppables to their `SortableProvider`.
- Geometry is measured once, at drag start — which is both a correctness fix and
  the difference between O(1) arithmetic and an n-rect layout sweep per event.

## Workspaces affected

`@shared/sortable` (new). One changeset, minor.

## Issues

**Closes**

| Issue | What |
|---|---|
| — | None — see xchromo/osn-tracker#429 under Out of scope |

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#457 | `P-I1` |

## Decisions

### The package owns the accessibility layer — `approach`

- **Issue** — solid-dnd has no keyboard sensor and makes no announcements; grepping its bundle for `keydown`/`ArrowUp` returns zero hits.
- **Why** — Every list wanting drag had to hand-write ~120 lines of subtle, silent-when-wrong logic. `EventsEditor` did. Three others did not and said so in code — `RegistryView.tsx` carried *"solid-dnd ships no keyboard sensor and no announcements, so adopting it here would mean re-supplying the whole keyboard path by hand."*
- **Solution** — `createSortableList` supplies all five obligations: a real `<button>` grip owning the arrows with `preventDefault()` **before** the bounds check, `sr-only` move buttons (NVDA/JAWS browse mode never forwards bare arrows to a button), explicit focus restore after a keyboard move, a live region that clears before it sets, and auto-repeat ignored.
- **Rationale** — A package can carry obligations once, with tests; a convention cannot. Hint ids are generated with `createUniqueId()` rather than the hardcoded `"reorder-hint"`, which collides the moment a second list appears on a page.

### Geometry is snapshotted at drag start — `P-W1`

- **Issue** — The first cut measured live rects on every `pointermove`, and re-measured the stride on every slot change.
- **Why** — Two real bugs, both confirmed in Chromium before being believed. `getBoundingClientRect()` includes transforms, so the stride was read from rects that already carried the dragged row's own offset: **dragging row 0 down by exactly one row height in a single motion computed a stride of zero**, and shift-aside stopped entirely; dragging gradually merely measured a 68 px stride as 62 px. The detector also saw displaced rows in the slots they were moving *to*, chasing its own output. Separately, at `RegistryView`'s documented 500 rows a per-event sweep is ~30–60k `getBoundingClientRect()` per second, each behind a forced style flush because the package writes a transform immediately before reading.
- **Solution** — `startDrag` measures the group once; collision detection and displacement run against that snapshot for the whole gesture.
- **Rationale** — Layout cannot change during a drag except for the transforms this package writes, and those are exactly what must be excluded — so the snapshot is not a cache to be invalidated, it is the correct input. dnd-kit and solid-dnd both measure at drag start.

### The gesture owns its listeners — `S-M1`

- **Issue** — `startDrag` attached three `document` listeners with no pointer capture, no `pointerId` guard, and no unmount cleanup.
- **Why** — A drag released outside the window never received `pointerup`: the row stayed stuck to a button-up pointer and the user's **next click anywhere** ended the drag and committed the move. A second touch could drive or end the first finger's gesture. An unmount mid-drag left the listeners firing into a disposed scope.
- **Solution** — `setPointerCapture`, an `isOurs(event)` guard on all three handlers, and `onCleanup` in `DragDropProvider`. Three regression tests.
- **Rationale** — Pointer capture is the platform mechanism designed for exactly this, and tying listener lifetime to component lifetime via `onCleanup` makes the invariant structural rather than approximate.

**Out of scope**

- `xchromo/osn-tracker#429` (*reorder loses focus and announces nothing*, repo-wide) asks for exactly the shared mechanism this PR builds, and says the fix "belongs in one shared place". It stays open: `ChecklistView`, `BudgetView` and `RegistryView` have not adopted it yet, and each is a UX decision of its own.
- `xchromo/osn-tracker#457` — `P-I1`, O(n) reactive fan-out per slot change. Measured as sub-millisecond at 500 rows and dwarfed by the sweep this PR removes; filed rather than fixed.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 34/34 |
| `bun run test` | ✅ 37/37 tasks |
| `bun run fmt:check` | ✅ |
| `bun run --cwd shared/sortable test:run` | ✅ 36 pass |
| `scripts/validate-changesets.sh` | ✅ |

The stride-collapse bug was reproduced and the fix confirmed **in Chromium**, not
just in the unit tier — dragging row 0 down one row height now shifts the
neighbour a full 68 px stride where it previously shifted nothing.

That matters because the fast tier could not see it: `stubRowGeometry` derived
rects from DOM index and ignored transforms entirely. The stub now adds each row's
`translate3d` offset the way a real browser's rect does, and two tests pin the
behaviour — one on the exact collapse case, one asserting geometry is read once per
gesture rather than once per event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PR77MaQFVcSwQmnimeN2t9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR77MaQFVcSwQmnimeN2t9)_