### PR TITLE
feat(cire-host): stack Overview top-down — agenda band, then module cards

### DIFF
--- a/.changeset/cire-overview-briefing-stack.md
+++ b/.changeset/cire-overview-briefing-stack.md
@@ -1,0 +1,26 @@
+---
+"@cire/host": patch
+---
+
+Overview: stack the home top-down — the agenda band first, the module cards
+beneath it.
+
+The home was split down the middle at wide panel widths: "What's next" held a
+fixed 20–26rem left column and the six module snapshots filled the rest. It
+read lopsided — one list down one side, a block of cards down the other — and
+the two halves ran to different depths, so the page ended in a ragged step.
+
+The agenda now runs full width as a band across the top and the cards sit under
+it in the same intrinsic `auto-grid` they already used. That gives the home one
+reading order — what needs attention, then how each module is tracking — and
+leaves a slot at the top of the band for the written summary that will lead it.
+
+Full width was the reason the agenda was put in a column in the first place: six
+dated rows across 1300px is a date on the left, a figure on the right, and a
+hole in the middle. So the rows themselves now wrap into columns — two at a
+panel width of 48rem, three at 72rem — which fills the band and halves its
+depth. Order stays chronological, read left-to-right along each row.
+
+The rules between rows moved from `divide-y` on the list to `border-t` on each
+row. `divide-y` follows DOM order, which in a wrapped grid draws its lines down
+the middle of the layout rather than between the rows you can see.

--- a/cire/host/src/components/Overview.tsx
+++ b/cire/host/src/components/Overview.tsx
@@ -352,10 +352,15 @@ export default function Overview(props: {
           </p>
         }
       >
-        <ul class="divide-border/40 flex flex-col divide-y">
+        {/* The band runs the full width, so the rows run in columns rather than
+            one 1300px-wide line of six dated entries with a hole in the middle.
+            Order stays chronological, read left-to-right along each row. A rule
+            per row rather than `divide-y`, which follows DOM order and so draws
+            its lines in the wrong places once the list wraps into columns. */}
+        <ul class="grid gap-x-8 @3xl/panel:grid-cols-2 @6xl/panel:grid-cols-3">
           <For each={agenda()}>
             {(item) => (
-              <li>
+              <li class="border-border/40 border-t">
                 <button
                   type="button"
                   onClick={() =>
@@ -433,13 +438,15 @@ export default function Overview(props: {
         </Show>
 
         <Show when={!isFresh()}>
-          {/* Narrow: agenda above the stat cards, one column each. Wide: the
-              agenda becomes a fixed-measure left column and the stat cards fill
-              the rest — a full-width list of six dated rows across 1300px is
-              mostly empty space, and the cards are what benefit from the room.
-              A container query (not `auto-grid`) because this changes the
-              layout's *shape*, not just its column count. */}
-          <div class="flex flex-col gap-4 @4xl/panel:grid @4xl/panel:grid-cols-[minmax(20rem,26rem)_minmax(0,1fr)] @4xl/panel:items-start">
+          {/* The home reads top-down as a briefing: the agenda band first —
+              what needs attention, dated — then the module snapshots beneath
+              it. (The agenda used to be a fixed-measure left column beside the
+              cards, which left the page lopsided: one list down one side, six
+              cards down the other.) The written summary the band will lead
+              with slots in at the top of this stack, above `<WhatsNext />`.
+              The band earns the full width by laying its rows out in columns —
+              see the list inside `WhatsNext`. */}
+          <div class="flex flex-col gap-4">
             <WhatsNext />
             {/* The cards themselves need no breakpoints: as many ≥15rem columns
                 as fit, so the widescreen fills rows instead of leaving three


### PR DESCRIPTION
The Overview home was split down the middle at wide panel widths: **What's next** held a fixed 20–26rem left column and the six module snapshots filled the rest. It read lopsided — one list down one side, a block of cards down the other — and the halves ran to different depths, so the page ended in a ragged step.

## What changed

**The agenda is now a full-width band across the top**, with the module cards beneath it in the same intrinsic `auto-grid` they already used. The home reads in one order: what needs attention, then how each module is tracking. The written summary that will lead the band slots in at the top of that stack, above `<WhatsNext />` — the layout is ready for it, and nothing stands in for it in the meantime.

**The agenda rows wrap into columns** — two at a 48rem panel, three at 72rem. Full width was the reason the agenda was put in a column in the first place: six dated rows across 1300px is a date on the left, a figure on the right, and a hole in the middle. Columns fill the band and halve its depth. Order stays chronological, read left-to-right along each row.

**Row rules move from `divide-y` to `border-t` per row.** `divide-y` follows DOM order, which in a wrapped grid draws lines down the middle of the layout instead of between the rows you can see.

## Checks

- `bun run test:run` in `cire/host` — 1134 passed (83 files)
- `bun run check` (astro check) — 0 errors, 2 pre-existing deprecation hints
- `bun run build` — clean; confirmed `@container panel (width>=48rem)` and `(width>=72rem)` land in the built CSS

Not visually verified in a browser — the host dashboard sits behind organiser auth and has no deployed preview. Worth an eyeball on a real wedding before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)