### PR TITLE
Validate the Upstash eval reply at the HTTP boundary

### DIFF
--- a/.changeset/upstash-eval-boundary-validation.md
+++ b/.changeset/upstash-eval-boundary-validation.md
@@ -1,0 +1,5 @@
+---
+"@shared/redis": patch
+---
+
+Validate the Upstash `eval` reply against the RESP value space before returning it, instead of trusting the HTTP boundary's claimed type. Matches the check the ioredis path already runs through `toRedisReply`.

--- a/shared/redis/src/upstash.ts
+++ b/shared/redis/src/upstash.ts
@@ -7,10 +7,11 @@
  * `ioredis` import, so the top-level `@shared/redis` entry stays Workers-safe.
  *
  * Mapping decisions (see the `RedisClient` contract in `./client`):
- * - `eval(script, keys, args)` → `redis.eval(script, keys, args)`. Upstash
- *   returns the Lua script's value directly (numeric for the rate-limit script
- *   and the recovery-lockout counter; the step-up jti check accepts `1` or
- *   `"1"`), so no shaping is needed.
+ * - `eval(script, keys, args)` → `toRedisReply(await redis.eval(script, keys,
+ *   args))`. The SDK types `eval`'s result as whatever the caller claims, but
+ *   it is really an HTTP response body nobody has checked — `toRedisReply`
+ *   narrows it to the RESP value space at this boundary, the same as the
+ *   ioredis path does in `./ioredis`.
  * - `get(key)` → `redis.get(key)`. The client MUST be constructed with
  *   `automaticDeserialization: false` so values come back as raw strings —
  *   matching ioredis and the rotated-session-store, which round-trips opaque
@@ -24,7 +25,7 @@
 
 import { Redis } from "@upstash/redis";
 
-import type { RedisClient, RedisReply } from "./client";
+import { toRedisReply, type RedisClient } from "./client";
 
 /**
  * Redis's reply to SET: the status string `"OK"`, or nil when a conditional
@@ -45,11 +46,15 @@ export type RedisSetReply = string | null;
  * instance or a fake in tests without coupling to the SDK's full type.
  *
  * The SDK types most of these as generic in their result (`get<TData>`,
- * `eval<TArgs, TData>`), i.e. it will hand back whatever the caller claims. The
- * claims are made once, here, and each is justified: `get` returns raw strings
- * because the client is built with `automaticDeserialization: false`, and
- * `eval` returns a {@link RedisReply} because that is the whole of what a Lua
- * script can send back over RESP.
+ * `eval<TArgs, TData = unknown>`), i.e. it will hand back whatever the caller
+ * claims. The claims are made once, here, and each is justified: `get` returns
+ * raw strings because the client is built with `automaticDeserialization:
+ * false`. `eval` keeps the SDK's own `TData = unknown` default rather than
+ * pinning a type — it is an HTTP response body the SDK has only JSON-decoded,
+ * not a value anyone has checked against the RESP value space, so
+ * {@link wrapUpstash} calls it with no type argument (leaving it `unknown`)
+ * and runs the result through {@link toRedisReply} before handing it to a
+ * caller.
  */
 export interface UpstashLike {
   /**
@@ -57,8 +62,13 @@ export interface UpstashLike {
    * types them, and mirroring the SDK is what lets a real `Redis` instance
    * satisfy this interface without a cast. The `RedisClient` contract hands
    * `eval` readonly arrays, so {@link wrapUpstash} copies them on the way in.
+   *
+   * `TData` mirrors the SDK's own generic (defaulting to `unknown`) rather
+   * than a flat `Promise<unknown>` return: {@link wrapUpstash} never supplies
+   * it, so the call resolves to `unknown` regardless, and every value still
+   * passes through {@link toRedisReply} before a caller sees it.
    */
-  eval(script: string, keys: string[], args: (string | number)[]): Promise<RedisReply>;
+  eval<TData = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<TData>;
   ping(): Promise<string>;
   get(key: string): Promise<string | null>;
   set(key: string, value: string, opts?: { px: number }): Promise<RedisSetReply>;
@@ -77,8 +87,10 @@ export function wrapUpstash(redis: UpstashLike): RedisClient {
   return {
     async eval(script, keys, args) {
       // Copied because the SDK takes mutable arrays; both are two elements
-      // long and the call behind them is an HTTP round-trip.
-      return redis.eval(script, [...keys], [...args]);
+      // long and the call behind them is an HTTP round-trip. The reply itself
+      // is unvalidated JSON off the wire until toRedisReply narrows it — same
+      // boundary check the ioredis path applies in ./ioredis.
+      return toRedisReply(await redis.eval(script, [...keys], [...args]));
     },
     async ping() {
       return redis.ping();

--- a/shared/redis/tests/ioredis.test.ts
+++ b/shared/redis/tests/ioredis.test.ts
@@ -57,6 +57,31 @@ describe("wrapIoRedis", () => {
       expect(mock.eval).toHaveBeenCalledWith("script", 2, "k1", "k2", 10, 20);
     });
 
+    // Parity with the Upstash path: both transports run the reply through
+    // toRedisReply, so both must coerce and both must reject the same values.
+    // Without these, deleting toRedisReply from ./ioredis leaves the suite green.
+    it("coerces a bigint EVALSHA reply to number", async () => {
+      mock.evalsha.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects an EVALSHA reply RESP cannot carry", async () => {
+      mock.evalsha.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
+    it("coerces a bigint reply on the EVAL fallback path too", async () => {
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      mock.eval.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects a non-RESP reply on the EVAL fallback path too", async () => {
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      mock.eval.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
     it("rethrows non-NOSCRIPT errors from EVALSHA", async () => {
       mock.evalsha.mockRejectedValueOnce(new Error("OOM command not allowed"));
 

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -100,6 +100,18 @@ describe("wrapUpstash", () => {
       fake.eval.mockResolvedValueOnce("1");
       expect(await client.eval("script", ["k"], [1])).toBe("1");
     });
+
+    it("coerces a bigint reply to number, same as the ioredis path", async () => {
+      fake.eval.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects a reply RESP cannot carry (toRedisReply's contract)", async () => {
+      fake.eval.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(
+        /Redis EVAL returned a object/,
+      );
+    });
   });
 
   describe("del", () => {

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -84,7 +84,7 @@ describe("wrapUpstash", () => {
     });
   });
 
-  describe("eval — numeric return passthrough", () => {
+  describe("eval — reply validated at the HTTP boundary", () => {
     it("returns the numeric value from the Lua script (rate-limit / counter)", async () => {
       fake.eval.mockResolvedValueOnce(1);
       const result = await client.eval("script", ["k"], [10, 1000]);
@@ -106,11 +106,38 @@ describe("wrapUpstash", () => {
       expect(await client.eval("script", ["k"], [1])).toBe(42);
     });
 
+    it("passes a boolean reply through unchanged (RESP3)", async () => {
+      fake.eval.mockResolvedValueOnce(true);
+      expect(await client.eval("script", ["k"], [1])).toBe(true);
+    });
+
+    // The REST body carries no `result` when a script returns nil, so the SDK
+    // hands back null or undefined depending on the shape. Both must land on
+    // null: recovery-lockout-store does `Number(result)` on this, and
+    // `Number(undefined)` is NaN, which compares false against every threshold.
+    it("normalises a nil reply to null", async () => {
+      fake.eval.mockResolvedValueOnce(null);
+      expect(await client.eval("script", ["k"], [1])).toBeNull();
+    });
+
+    it("normalises a missing reply to null", async () => {
+      fake.eval.mockResolvedValueOnce(undefined);
+      expect(await client.eval("script", ["k"], [1])).toBeNull();
+    });
+
+    it("walks a nested array reply, coercing as it goes", async () => {
+      fake.eval.mockResolvedValueOnce([1, "a", null, [42n, true]]);
+      expect(await client.eval("script", ["k"], [1])).toEqual([1, "a", null, [42, true]]);
+    });
+
+    it("rejects a non-RESP value nested inside an array reply", async () => {
+      fake.eval.mockResolvedValueOnce([1, { not: "a RESP value" }]);
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
     it("rejects a reply RESP cannot carry (toRedisReply's contract)", async () => {
       fake.eval.mockResolvedValueOnce({ not: "a RESP value" });
-      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(
-        /Redis EVAL returned a object/,
-      );
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
     });
   });
 

--- a/wiki/systems/redis.md
+++ b/wiki/systems/redis.md
@@ -16,7 +16,7 @@ related:
 packages:
   - "@shared/redis"
   - "@osn/api"
-last-reviewed: 2026-08-17
+last-reviewed: 2026-08-24
 ---
 # Redis Migration
 
@@ -102,11 +102,14 @@ traffic for low latency (C-M18; see [[compliance/subprocessors]], [[production-d
 | P-W4 | ✅ | Auth Maps never evict expired entries — Redis backend uses native PX expiry |
 | S-L18 | ✅ | Graph rate-limit store never evicted expired windows |
 | S-L23 | n/a | `pkceStore` deleted with PKCE removal |
+| S-L1 | ✅ | Upstash `eval` returned the HTTP reply unchecked — `wrapUpstash` now runs it through `toRedisReply`, as the ioredis path already did |
 
 ## Source Files
 
 - [shared/redis/src/index.ts](../../shared/redis/src/index.ts) — `@shared/redis` public API
-- [shared/redis/src/client.ts](../../shared/redis/src/client.ts) — `RedisClient` interface, `wrapIoRedis()`, `createMemoryClient()`, `createClientFromUrl()`
+- [shared/redis/src/client.ts](../../shared/redis/src/client.ts) — `RedisClient` interface, `RedisReply`, `toRedisReply()` (the one reply validator both transports run), `createMemoryClient()`
+- [shared/redis/src/ioredis.ts](../../shared/redis/src/ioredis.ts) — `wrapIoRedis()`, `createClientFromUrl()` — the TCP transport, Node only
+- [shared/redis/src/upstash.ts](../../shared/redis/src/upstash.ts) — `wrapUpstash()` — the HTTP transport, and the one Workers can use
 - [shared/redis/src/service.ts](../../shared/redis/src/service.ts) — `Redis` Context.Tag, `RedisLive`, `RedisMemoryLive` layers
 - [shared/redis/src/rate-limiter.ts](../../shared/redis/src/rate-limiter.ts) — `createRedisRateLimiter()` with Lua script
 - [shared/redis/src/health.ts](../../shared/redis/src/health.ts) — `checkRedisHealth()` probe


### PR DESCRIPTION
## Summary

`@shared/redis` has two backends. The ioredis one runs every EVAL reply through
`toRedisReply` before handing it back; the Upstash one declared
`eval(): Promise<RedisReply>` and returned the SDK's value untouched — a value off
an HTTP wire, typed as though something had checked it. `wrapUpstash` now returns
`toRedisReply(await redis.eval(...))`, so both transports narrow a Lua script's
reply to the RESP value space at the same place.

Upstash is the production backend on Workers, and it serves the rate limiters, the
step-up jti replay guard and the recovery-code lockout counter. Nothing was
exploitable — every caller narrows defensively — but the counter path did
`Number(result)` on an unchecked value, and `Number` of an off-shape reply is
`NaN`, which compares false against every threshold.

- A malformed reply now throws instead of passing through. All three `eval` call
  sites already catch: the rate limiter and the jti guard deny, the lockout
  counter records nothing and logs. No path flips from deny to allow.
- The test review found the branch set the fix leans on was only half asserted, so
  a second commit covers the rest — nil, missing, boolean and array replies, and
  the ioredis side, which never asserted `toRedisReply` at all.

## Workspaces affected

`shared/redis`. One changeset, `.changeset/upstash-eval-boundary-validation.md`,
naming `@shared/redis` at `patch` — the only versioned package touched. The wiki
edit needs no entry of its own.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#439 | `S-L1` |

Closes xchromo/osn-tracker#439

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#472 | `S-L25` |
| xchromo/osn#764 | T-U1 — `toRedisReply` has no test of its own |
| xchromo/osn#765 | T-S2 — no test shows a malformed reply ending as a rate-limit denial |

## Decisions

### Mirror the SDK's generic instead of a flat `Promise<unknown>` — `S-L1`

- **Issue** — the fix as specified in xchromo/osn-tracker#439 asked for
  `UpstashLike.eval(): Promise<unknown>`. That trips `anti-slop/no-unknown-returns`,
  which is `"error"` for source at `oxlintrc.json:110` and turned off only for test
  files at `:176`. There is no override for this path.
- **Why** — the two ways out are both bad: disable a lint rule the repo turned on
  deliberately, or keep asserting a type nobody checks, which is the finding.
- **Solution** — declare `eval<TData = unknown>(script, keys, args): Promise<TData>`,
  the same shape `@upstash/redis` declares. `wrapUpstash` never supplies the type
  argument, so the call still resolves to `unknown`, and the result still goes
  through `toRedisReply` before any caller sees it.
- **Rationale** — same guarantee as the flat return, no rule disabled, and a real
  `Redis` instance still satisfies the interface without a cast, which `tsc`
  confirms at the one construction site. The residual — an outside caller picking
  their own `TData` — is inherited from the SDK and nothing in this repo does it.
  A previous run of this PR stalled on the same tension; it is settled in the
  committed code, not open.

### Fold in the coverage the test review would have blocked on — `T-U2`, `T-S1`

- **Issue** — the review found five gaps. Two mattered: nil and missing replies had
  no test at the Upstash boundary, and the ioredis side never asserted
  `toRedisReply` at all, so the parity this PR claims could be deleted with all 55
  tests still green.
- **Why** — nil is the case the counter path reads with `Number()`, so it is the one
  whose behaviour actually changed. And a symmetry only one side tests is an
  assumption.
- **Solution** — a second commit, tests only, no source change: nil, missing,
  boolean and nested-array replies on the Upstash path; bigint coercion and
  non-RESP rejection on both the `EVALSHA` and `EVAL` fallback paths in
  `ioredis.test.ts`. Also matched the throw assertion on `/not a RESP value/`
  rather than on the full sentence, which contained a grammatical slip anyone
  might fix. 55 tests to 64.
- **Rationale** — cheap, in the files this branch already touches, and it turns the
  PR's central claim into an assertion. The two gaps that needed their own files or
  crossed modules were filed instead (#764, #765) rather than grown into this diff.

### Keep the bigint case on the Upstash test too — `approach`

- **Issue** — the performance review noted that the Upstash transport is JSON over
  HTTP and so can never produce a bigint; the test asserting bigint coercion there
  documents a branch this backend cannot reach.
- **Why** — a test for an unreachable case is noise if it is read as a claim about
  the transport.
- **Solution** — kept, and the parity commit puts the same assertion on the ioredis
  path, where the case is real.
- **Rationale** — the assertion is about `wrapUpstash` delegating to `toRedisReply`,
  not about what Upstash can send. Read that way it earns its line, and having it
  on both sides is what makes the pair a parity test.

**Out of scope**

- `wrapUpstash` still claims types for `get`, `ping` and `del` at the same
  unchecked boundary — the same argument, three more methods. Tracked as
  xchromo/osn-tracker#472. Left out because this PR closes one finding and the fix
  there is a wider change to the adapter.
- `toRedisReply` has no test of its own even though both transports now depend on
  it — xchromo/osn#764.
- Nothing joins `wrapUpstash` and the rate limiter to show a malformed body ending
  as a denial — xchromo/osn#765.
- The Upstash path re-sends the full Lua body on every call where ioredis caches
  script SHAs. Pre-existing, and right for this transport: Workers isolates are
  short-lived, so a per-isolate SHA cache would miss often and each miss costs a
  second HTTP round-trip. No issue filed.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd shared/redis check` (`tsc --noEmit`) | ✅ |
| `bun run --cwd shared/redis test:run` | ✅ 64 pass, 7 files |
| `bunx oxlint -c oxlintrc.json shared/redis` | ✅ 0 |
| `bunx --bun oxfmt shared/redis --check` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |
| `bash scripts/changeset-required.sh` | ✅ |

Ran in this worktree, after the test commit. The security review separately ran
`tsc --noEmit` in `osn/api`, the only consumer of the package, clean.

Nothing here needs exercising by hand. What stays unverified: no test hits a live
Upstash instance, so "a real REST body decodes to something `toRedisReply` accepts"
rests on reading the SDK, not on an observation. The behaviour change is only
visible when a reply is malformed, which no production script can currently
produce — so a green deploy proves nothing either way, and the value of the change
is that the next script cannot introduce the hole quietly.
