### PR TITLE
fix(cire-api): type R2 put/delete after the real bucket, not bare void

### DIFF
--- a/.changeset/cire-r2-honest-promise-types.md
+++ b/.changeset/cire-r2-honest-promise-types.md
@@ -1,0 +1,7 @@
+---
+"@cire/api": patch
+---
+
+Type the R2 bucket `put`/`delete` interfaces after the real backend's return type (`R2Object` for a write, `void` for a delete, from the ambient Cloudflare `R2Bucket`) instead of bare `void`, so a dropped write can no longer typecheck as fine. The old `void` return let a real async delete or put be discarded silently — on the asset-erasure path, a dropped delete meant data that should be gone stayed. Callers that wrapped calls in `Promise.resolve(...)` only to satisfy the old lying type now just `await` them directly.
+
+This does not turn on floating-promise detection — nothing in the repo checks for that today, and lint is not type-aware. It makes the type honest, so a future type-aware lint rule could see the problem.

--- a/cire/api/src/services/asset-reconcile.ts
+++ b/cire/api/src/services/asset-reconcile.ts
@@ -208,13 +208,11 @@ export const assetReconcileService = {
           }
           const page = yield* Effect.tryPromise({
             try: () =>
-              Promise.resolve(
-                bucket.list({
-                  prefix: ASSETS_PREFIX,
-                  cursor: nextCursor,
-                  limit: LIST_PAGE_SIZE,
-                }),
-              ),
+              bucket.list({
+                prefix: ASSETS_PREFIX,
+                cursor: nextCursor,
+                limit: LIST_PAGE_SIZE,
+              }),
             catch: (cause) =>
               new AssetReconcileError({ op: "reconcile", reason: `list failed: ${String(cause)}` }),
           });

--- a/cire/api/src/services/invite-assets.ts
+++ b/cire/api/src/services/invite-assets.ts
@@ -35,20 +35,23 @@ export interface AssetObjectBody {
   readonly httpMetadata?: { contentType?: string };
 }
 
-// `put` / `delete` are declared `void` for the same reason as the CSV bucket's
-// (`r2-imports.ts`): the value a write resolves to is backend-specific (R2 hands
-// back the created `R2Object`, the stub hands back nothing) and no call site
-// reads it — awaiting is the whole contract. Declaring `void` states that and
-// keeps both R2 and the stub assignable; callers still `Promise.resolve(...)`
-// the call so an async backend is awaited at runtime.
+// `put` / `delete` are declared against the REAL backend's resolved type, for
+// the same reason as the CSV bucket's (`r2-imports.ts`): R2 hands a `put`
+// back the created `R2Object` and a `delete` back `void` (the ambient
+// `R2Bucket` from `@cloudflare/workers-types`); no call site here reads
+// either value — awaiting is the whole contract. A bare `void` would say that
+// too, but it would also make a real backend's promise legal to drop silently
+// — TypeScript's "return value is ignored" rule applies to a bare `void`
+// return, not to `void`/a concrete type inside a `Promise`. This union keeps
+// the promise visible to `await` while still accepting a synchronous stub.
 export interface AssetsBucket {
   put(
     key: string,
     value: ArrayBuffer | ArrayBufferView,
     options?: { httpMetadata?: { contentType?: string } },
-  ): void;
+  ): Promise<R2Object> | Promise<void> | void;
   get(key: string): Promise<AssetObjectBody | null> | AssetObjectBody | null;
-  delete(key: string): void;
+  delete(key: string): Promise<void> | void;
 }
 
 export class AssetsR2Service extends Context.Tag("AssetsR2Service")<
@@ -110,7 +113,7 @@ export function storeAsset(
     const key = assetKey(weddingId, slot);
     yield* Effect.tryPromise({
       try: async () => {
-        await Promise.resolve(bucket.put(key, bytes, { httpMetadata: { contentType } }));
+        await bucket.put(key, bytes, { httpMetadata: { contentType } });
       },
       catch: (cause) => new AssetR2Error({ reason: "store failed", key, cause }),
     });
@@ -193,7 +196,7 @@ export function deleteAsset(key: string): Effect.Effect<void, AssetR2Error, Asse
     const bucket = yield* AssetsR2Service;
     yield* Effect.tryPromise({
       try: async () => {
-        await Promise.resolve(bucket.delete(key));
+        await bucket.delete(key);
       },
       catch: (cause) => new AssetR2Error({ reason: "delete failed", key, cause }),
     });

--- a/cire/api/src/services/r2-cleanup.ts
+++ b/cire/api/src/services/r2-cleanup.ts
@@ -38,13 +38,17 @@ export type R2BucketLabel = "sheets" | "assets";
  * delete; the in-memory test stubs implement only the single-key form. We
  * feature-detect the array form at call time so both work.
  *
- * The result is `void`: a delete either happened or threw, and nothing here
- * reads what R2 (or a stub) resolves with. Declaring `void` says so, and keeps
- * every backend assignable — the caller `Promise.resolve(...)`s the call, so an
- * async binding is still awaited at runtime.
+ * The result is `Promise<void> | void`, matching the real backend: R2's
+ * `delete` resolves `Promise<void>` (the ambient `R2Bucket` from
+ * `@cloudflare/workers-types`), and nothing here reads a resolved value — a
+ * delete either happened or threw. A bare `void` would say that too, but it
+ * would also make a real backend's promise legal to drop silently —
+ * TypeScript's "return value is ignored" rule applies to a bare `void`
+ * return, not to `void` inside a `Promise`, so only this union keeps the
+ * promise visible to `await` while still accepting a synchronous stub.
  */
 export interface DeletableBucket {
-  delete(keys: string | string[]): void;
+  delete(keys: string | string[]): Promise<void> | void;
 }
 
 /** Max keys per R2 multi-delete request — R2's documented cap is 1000. */
@@ -96,14 +100,14 @@ export function reapR2Objects(
           // the in-memory test stub / any single-key binding may not. Attempt the
           // array form first, fall back to per-key deletes if it throws.
           try {
-            await Promise.resolve(bucket.delete(batch));
+            await bucket.delete(batch);
             return;
           } catch {
             // Binding rejected the array form — fall through to per-key deletes.
           }
           for (const key of batch) {
             // eslint-disable-next-line no-await-in-loop
-            await Promise.resolve(bucket.delete(key));
+            await bucket.delete(key);
           }
         },
         catch: (cause) => cause,

--- a/cire/api/src/services/r2-imports.ts
+++ b/cire/api/src/services/r2-imports.ts
@@ -4,21 +4,29 @@ import { Context, Data, Effect } from "effect";
 // `R2Bucket` type satisfies this structurally; the in-memory stub used in
 // tests implements just these three methods.
 //
-// `put` and `delete` are declared `void`: what the write CALL resolves to
-// differs per backend (R2 hands back the created `R2Object`, the in-memory stub
-// hands back nothing) and no call site here reads it — the guarantee callers
-// need is that the write happened, which they get by awaiting. A `void` return
-// says exactly that, and TypeScript's "return value is ignored" rule keeps both
-// backends assignable. Callers still wrap the result in `Promise.resolve(...)`
-// before awaiting, so an async backend is awaited properly at runtime.
+// `put` and `delete` are declared against the REAL backend's resolved type
+// (`R2Object` for a write, `void` for a delete — see the ambient `R2Bucket`
+// from `@cloudflare/workers-types`, listed in `tsconfig.json`'s `types` and
+// used unqualified elsewhere, e.g. `index.ts`), unioned with a bare `void` so
+// a synchronous test stub stays assignable. A bare `void` alone would also
+// say "the caller doesn't need this value", but it would additionally make a
+// real backend's returned promise legal to drop silently (TypeScript's
+// "return value is ignored" rule applies to a bare `void` return, not to
+// `void`/a concrete type inside a `Promise`) — exactly the bug this type
+// exists to catch. Naming `R2Object` instead of `unknown` keeps the promise
+// visible to `await` while still naming what a real write actually resolves
+// to, rather than erasing it.
 export interface R2Bucket {
-  put(key: string, value: string | ArrayBuffer | ArrayBufferView): void;
+  put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<R2Object> | Promise<void> | void;
   get(
     key: string,
   ): Promise<{ text(): Promise<string> } | null> | { text(): Promise<string> } | null;
   // Cloudflare R2 accepts a single key or an array (multi-key delete); the
   // shared reaper (`r2-cleanup.ts`) prefers the array form and falls back.
-  delete(keys: string | string[]): void;
+  delete(keys: string | string[]): Promise<void> | void;
 }
 
 export class R2Service extends Context.Tag("R2Service")<R2Service, R2Bucket>() {}
@@ -68,8 +76,8 @@ export function storeBeforeImage(
 
     yield* Effect.tryPromise({
       try: async () => {
-        await Promise.resolve(r2.put(ek, eventsCsv));
-        await Promise.resolve(r2.put(gk, guestsCsv));
+        await r2.put(ek, eventsCsv);
+        await r2.put(gk, guestsCsv);
       },
       catch: (cause) => new R2Error({ reason: "before-image store failed", cause }),
     });
@@ -90,8 +98,8 @@ export function storeUpload(
 
     yield* Effect.tryPromise({
       try: async () => {
-        await Promise.resolve(r2.put(ek, eventsCsv));
-        await Promise.resolve(r2.put(gk, guestsCsv));
+        await r2.put(ek, eventsCsv);
+        await r2.put(gk, guestsCsv);
       },
       catch: (cause) => new R2Error({ reason: "store failed", cause }),
     });


### PR DESCRIPTION
## Summary

`cire/api` declares its own narrow bucket interfaces over R2, and they said `put`
and `delete` return bare `void`. The real calls are async, so callers wrote
`await Promise.resolve(...)` around them to work past a type that lied. On the
asset-erasure path that matters: a delete that is dropped leaves guest data in R2
after the row pointing at it is gone.

The interfaces now name what the real backend resolves to — `Promise<R2Object>`
for a write, `Promise<void>` for a delete, taken from the ambient `R2Bucket` in
`@cloudflare/workers-types` — each unioned with a bare `void` so the in-memory
test stubs stay assignable. The `Promise.resolve(...)` wrappers are gone and
callers `await` the call directly.

- Runtime behaviour is unchanged. `await Promise.resolve(p)` and `await p` differ
  by one promise allocation and one microtask hop, and `Effect.tryPromise` still
  catches a synchronous throw from its thunk either way — so `r2-cleanup`'s
  array-form feature detection still falls back on the same conditions.
- **This does not add floating-promise detection.** The repo has no
  `no-floating-promises` rule and lint is not type-aware — `oxlintrc.json` turns
  on exactly one promise rule, `promise/no-return-wrap`. A caller who drops the
  `await` still compiles. What the change buys is a type shaped so a future
  type-aware gate could see the problem; under bare `void` no such rule could
  ever fire.

## Workspaces affected

`cire/api` (`@cire/api`). One changeset,
`.changeset/cire-r2-honest-promise-types.md`, naming `@cire/api` at `patch` and
nothing else. `@cire/api` is version-less, so the changeset names no versioned
package. `scripts/validate-changesets.sh` passes.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#440 | `S-L2` |

Closes xchromo/osn-tracker#440

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#475 | `P-I1` |
| xchromo/osn-tracker#476 | `P-I2` |
| xchromo/osn-tracker#477 | `S-I1` |
| xchromo/osn-tracker#478 | `T-S1`, `T-S2`, `T-E1`, `T-E2`, `T-M1` (series) |

## Decisions

### Name `R2Object` rather than `void` or `unknown` — `approach`

- **Issue** — the return type had to cover three backends at once: the real R2
  binding, which resolves a created `R2Object` on a write and `void` on a delete,
  and two shapes of in-memory test stub, one returning an already-resolved
  promise and one returning nothing at all.
- **Why** — the type is the only thing that says this I/O is asynchronous. Get it
  wrong and either the real binding stops typechecking, or the lie stays.
- **Solution** — `put(...): Promise<R2Object> | Promise<void> | void` and
  `delete(...): Promise<void> | void`, with `R2Object` resolved from the ambient
  `@cloudflare/workers-types` already listed in `cire/api/tsconfig.json`.
- **Rationale** — two other candidates were tried in this worktree and rejected
  on measured results, not on taste. `Promise<void> | void`, which
  xchromo/osn-tracker#440 proposed, does not hold: `Promise<R2Object>` is not
  assignable to it, and swapping it in takes `cire/api` from 614 typecheck errors
  to 615, the new one being `TS2322` at `cire/api/src/index.ts:400` where
  `env.SHEETS` is handed to `AppOptions`. `Promise<unknown> | void` typechecks
  but trips `anti-slop/no-unknown-returns` — confirmed by running oxlint over the
  edited file, one error at `r2-imports.ts:23`. That rule is ratcheted to zero
  hits in `src`, and the answer to a lint rule is not to silence it. Naming
  `R2Object` satisfies both, and says what a write actually resolves to instead
  of erasing it.

### Keep the bare `void` arm in the union — `S-I1`

- **Issue** — leaving `void` in the union means `bucket.delete(key)` without an
  `await` still typechecks, so the branch does not by itself stop a dropped
  delete.
- **Why** — the finding this branch closes is about guest personal data
  surviving its retention window. An honest type that nothing enforces is half a
  fix.
- **Solution** — keep the arm. One stub returns a genuine `void`
  (`cire/api/src/routes/maintenance-sweeps.test.ts:88`), so dropping it would
  break the suite, and the security review traced every R2 `put`/`delete` call
  site in `cire/api` and found all of them awaited — including the one
  deliberately deferred delete at `cire/api/src/routes/registry.ts:114-117`,
  which `waitUntil` holds open.
- **Rationale** — enforcement needs a type-aware linter, which oxlint is not.
  Adopting a second linter is the repo owner's call, so it is filed as
  xchromo/osn-tracker#477 rather than decided here. The union is exactly what
  such a rule would need to fire on.

### File the review findings on the tracker, not the public repo — `approach`

- **Issue** — the coverage gaps and the two performance findings are `T-*` and
  `P-I*`, and `prep-pr`'s routing table names only `S-*`, `P-*` and `C-*` as
  tracker-bound.
- **Why** — `xchromo/osn` is public. Every one of these findings names a file and
  line on the guest-data erasure path.
- **Solution** — all four went to the private `xchromo/osn-tracker`. The five
  coverage gaps went in as one series issue rather than five, following
  xchromo/osn-tracker#264, because the fix for the first two is a single shared
  change to the stubs.
- **Rationale** — filing privately costs nothing; publishing a described gap in
  an erasure guarantee does.

### Leave the test gaps and both performance findings to follow-ups — `approach`

- **Issue** — the test review found the suite cannot catch the bug this type
  describes, and the performance review found two pre-existing inefficiencies on
  lines this diff rewrites.
- **Why** — all four are real, and all four are wider than a type change.
- **Solution** — none of them were fixed here. They are xchromo/osn-tracker#475,
  #476 and #478, each with the concrete fix written out.
- **Rationale** — this branch is a type correction whose runtime behaviour is
  provably unchanged, which makes it cheap to review. Folding in new stubs, new
  tests and a rewritten delete-fallback would lose that.

**Out of scope** — type-aware linting to enforce the awaits
(xchromo/osn-tracker#477); the two serial R2 puts in `storeBeforeImage` /
`storeUpload` (xchromo/osn-tracker#475); the per-chunk multi-delete probe that
fans an async failure out to 1000 single-key deletes
(xchromo/osn-tracker#476); the five test-coverage gaps on the R2 write and
delete paths (xchromo/osn-tracker#478).

## Test plan

| Gate | Result |
|---|---|
| `bun test` (`cire/api`) | ✅ 1696 pass, 0 fail |
| `bun run build` (`cire/api`, `wrangler deploy --dry-run`) | ✅ |
| `bunx oxlint -c oxlintrc.json .` | ✅ exit 0 |
| `bunx oxlint` over the four changed files | ✅ exit 0 |
| `oxfmt --check` | ✅ 1414 files |
| `scripts/validate-changesets.sh` | ✅ |
| `bunx tsc --noEmit` (`cire/api`) | 614 errors — see below |

`@cire/api` has no `check` script, so `turbo check` skips it and the typecheck was
run by hand. It reports **614 errors, which is the pre-existing baseline, not a
number this branch introduces**. Verified rather than assumed: reverting the four
changed files to their `main` versions and re-running gives the same 614. None of
the errors sit in the changed files; they are Drizzle `Result<"sync" | "async",
…>` noise in unrelated test files, plus `shared/crypto/src/jwk.ts:36`.

Two things stayed unverified, both stated plainly rather than implied. Nothing
was deployed — the build is a dry run. And the suite cannot catch the failure
this branch is about: every in-memory bucket stub mutates its map synchronously
before returning an already-resolved promise, so removing an `await` from
`r2-cleanup.ts:103` or `invite-assets.ts:199` leaves all 1696 tests green. Green
tests here confirm the change is a runtime no-op, which is what it claims to be —
they do not confirm the erasure guarantee. That is what
xchromo/osn-tracker#478 is for.
