### PR TITLE
fix(osn-api): faster error-tag walk, no-store on security-events

### DIFF
--- a/.changeset/osn-api-error-walk-and-cache.md
+++ b/.changeset/osn-api-error-walk-and-cache.md
@@ -1,0 +1,5 @@
+---
+"@osn/api": patch
+---
+
+`publicError`'s tag walk reads each own key with a plain property access instead of allocating an `Object.getOwnPropertyDescriptor` per key, fixing an 8.7x slowdown on the common untagged-error path (tracker#446). `GET /account/security-events` now sets `Cache-Control: private, no-store`, since the list is per-user and names authentication events (tracker#346).

--- a/.changeset/osn-api-error-walk-and-cache.md
+++ b/.changeset/osn-api-error-walk-and-cache.md
@@ -2,4 +2,4 @@
 "@osn/api": patch
 ---
 
-`publicError`'s tag walk reads each own key with a plain property access instead of allocating an `Object.getOwnPropertyDescriptor` per key, fixing an 8.7x slowdown on the common untagged-error path (tracker#446). `GET /account/security-events` now sets `Cache-Control: private, no-store`, since the list is per-user and names authentication events (tracker#346).
+`publicError`'s tag walk reads each own key with a plain property access instead of allocating an `Object.getOwnPropertyDescriptor` per key, which is much faster on the common untagged-error path (tracker#446). `GET /account/security-events` now sets `Cache-Control: private, no-store` (tracker#346).

--- a/osn/api/src/lib/public-error.ts
+++ b/osn/api/src/lib/public-error.ts
@@ -41,15 +41,16 @@ export function publicError(
       // `Object.values` never reaches — so the real `_tag` would otherwise be
       // invisible and every Effect failure would fall through to the default.
       for (const key of Reflect.ownKeys(node)) {
-        // Read through the descriptor rather than the property: a data
-        // property hands back its `value` without running anything, and an
-        // accessor is invoked explicitly (bound to `node`, as a plain read
-        // would) inside the try.
+        // Plain property read via computed destructuring: one [[Get]], no
+        // descriptor allocation. An accessor still runs bound to `node`
+        // (exactly as the old `descriptor.get?.call(node)` did), and the try
+        // still guards against a throwing getter. `node`'s own key set is
+        // genuinely unknowable ahead of time (arbitrary thrown values), so
+        // `as never` — not `as any` — lets the computed key through without
+        // asserting a shape we don't have.
         let v: unknown;
         try {
-          const descriptor = Object.getOwnPropertyDescriptor(node, key);
-          if (!descriptor) continue;
-          v = "value" in descriptor ? descriptor.value : descriptor.get?.call(node);
+          ({ [key]: v } = node as never);
         } catch {
           continue; // a throwing getter is not a tag carrier
         }

--- a/osn/api/src/routes/auth/security-events.ts
+++ b/osn/api/src/routes/auth/security-events.ts
@@ -20,6 +20,10 @@ export function createSecurityEventRoutes(ctx: AuthRouteContext) {
       .get(
         "/account/security-events",
         async ({ headers, set, server, request }) => {
+          // Per-user and sensitive (lists auth events) — never cached or
+          // stored by a shared cache or the browser (tracker#346).
+          set.headers["cache-control"] = "private, no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),

--- a/osn/api/tests/lib/public-error.test.ts
+++ b/osn/api/tests/lib/public-error.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { publicError } from "../../src/lib/public-error";
+
+/**
+ * The tag walk (P-I1 / tracker#446) reads each own key through a plain
+ * property access now, not `Object.getOwnPropertyDescriptor`. These tests
+ * pin the behaviour that read has to preserve: a tagged error still maps to
+ * its status, an untagged error still falls through to the default, a
+ * throwing getter is skipped rather than propagating, and a null-prototype
+ * object (no `Object.prototype`, so no inherited helpers) is still walkable.
+ */
+describe("publicError", () => {
+  it("maps a tagged error to its dedicated status", () => {
+    const err = { _tag: "ValidationError" };
+    expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
+  });
+
+  it("falls through to the generic default for an untagged error", () => {
+    const err = new Error("boom");
+    expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
+  });
+
+  it("skips a throwing getter instead of propagating the throw", () => {
+    const err = {
+      get poison(): never {
+        throw new Error("do not read me");
+      },
+      _tag: "DatabaseError",
+    };
+    expect(() => publicError(err)).not.toThrow();
+    expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
+  it("walks a null-prototype object without throwing", () => {
+    const err = Object.assign(Object.create(null), { _tag: "AuthError" }) as {
+      _tag: string;
+    };
+    expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
+  });
+});

--- a/osn/api/tests/lib/public-error.test.ts
+++ b/osn/api/tests/lib/public-error.test.ts
@@ -3,19 +3,26 @@ import { describe, it, expect } from "vitest";
 import { publicError } from "../../src/lib/public-error";
 
 /**
- * The tag walk (P-I1 / tracker#446) reads each own key through a plain
- * property access now, not `Object.getOwnPropertyDescriptor`. These tests
- * pin the behaviour that read has to preserve: a tagged error still maps to
- * its status, an untagged error still falls through to the default, a
- * throwing getter is skipped rather than propagating, and a null-prototype
- * object (no `Object.prototype`, so no inherited helpers) is still walkable.
+ * The tag walk (P-I2 / tracker#446) reads each own key through a plain
+ * property access now, not `Object.getOwnPropertyDescriptor`. These tests pin
+ * the behaviour that read has to preserve.
+ *
+ * Three tags collapse to the same 400 (`ValidationError`, `AuthError`, and the
+ * `default`), so a test asserting 400 cannot tell a found tag from a missed
+ * one. Every case that means to prove the walk found something therefore uses
+ * a discriminating tag: `DatabaseError` (500) or `AgeRestrictionError` (422).
  */
 describe("publicError", () => {
   it("maps a tagged error to its dedicated status", () => {
-    const err = { _tag: "ValidationError" };
-    expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
+    const err = { _tag: "AgeRestrictionError" };
+    expect(publicError(err)).toEqual({
+      status: 422,
+      body: { error: "age_restricted", message: "OSN is for users 13 and older" },
+    });
   });
 
+  // 400 is also what a found `ValidationError` returns, so this one pins the
+  // fall-through and nothing more. The cases below carry the walk.
   it("falls through to the generic default for an untagged error", () => {
     const err = new Error("boom");
     expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
@@ -32,10 +39,51 @@ describe("publicError", () => {
     expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
   });
 
+  it("invokes an own accessor with `this` bound to the node it sits on", () => {
+    // `_inner` lives on the prototype, so `Reflect.ownKeys` never yields it.
+    // The only route to the tag is `cause`, invoked with `this` === err — a
+    // read that skipped accessors, or bound them wrongly, would find nothing.
+    const proto = { _inner: { _tag: "DatabaseError" } };
+    const err = Object.create(proto) as object;
+    Object.defineProperty(err, "cause", {
+      enumerable: true,
+      get(this: { _inner: unknown }) {
+        return this._inner;
+      },
+    });
+    expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
+  it("finds a tag stored under a symbol key", () => {
+    // The reason the walk uses `Reflect.ownKeys` at all: `Effect.runPromise`
+    // rejects with a `FiberFailure` holding its `Cause` under a symbol.
+    const err = { [Symbol("Cause")]: { _tag: "DatabaseError" } };
+    expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
+  it("steps over an Effect Cause tag and keeps descending", () => {
+    const err = { [Symbol("Cause")]: { _tag: "Fail", error: { _tag: "DatabaseError" } } };
+    expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
   it("walks a null-prototype object without throwing", () => {
-    const err = Object.assign(Object.create(null), { _tag: "AuthError" }) as {
+    const err = Object.assign(Object.create(null), { _tag: "DatabaseError" }) as {
       _tag: string;
     };
+    expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
+  it("returns rather than looping on a self-referencing error", () => {
+    const err: Record<string, unknown> = { note: "no tag here" };
+    err.self = err;
     expect(publicError(err)).toEqual({ status: 400, body: { error: "invalid_request" } });
+  });
+
+  it("truncates past the 512-node budget instead of walking a large graph", () => {
+    // Deliberate: a real tag sits within a few hops, so a tag this deep is a
+    // graph the walk is meant to give up on, not a lookup it should complete.
+    let node: Record<string, unknown> = { _tag: "DatabaseError" };
+    for (let i = 0; i < 600; i++) node = { next: node };
+    expect(publicError(node)).toEqual({ status: 400, body: { error: "invalid_request" } });
   });
 });

--- a/osn/api/tests/lib/public-error.test.ts
+++ b/osn/api/tests/lib/public-error.test.ts
@@ -29,11 +29,15 @@ describe("publicError", () => {
   });
 
   it("skips a throwing getter instead of propagating the throw", () => {
+    // The root's own `_tag` has to be a Cause tag. A domain tag on the root
+    // returns before the key loop ever runs, so the getter would never be
+    // read and this test would pass without touching the changed code.
     const err = {
+      _tag: "Fail",
       get poison(): never {
         throw new Error("do not read me");
       },
-      _tag: "DatabaseError",
+      error: { _tag: "DatabaseError" },
     };
     expect(() => publicError(err)).not.toThrow();
     expect(publicError(err)).toEqual({ status: 500, body: { error: "internal_error" } });

--- a/osn/api/tests/routes/auth.test.ts
+++ b/osn/api/tests/routes/auth.test.ts
@@ -2421,6 +2421,18 @@ describe("auth routes", () => {
       expect(typeof json.events[0]!.createdAt).toBe("number");
     });
 
+    // tracker#346: the list is per-user and names auth events — nothing may
+    // cache or store it.
+    it("GET /account/security-events sets cache-control: private, no-store", async () => {
+      const { app: freshApp, accessToken } = await setupWithRecovery();
+      const res = await freshApp.handle(
+        new Request("http://localhost/account/security-events", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }),
+      );
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
+    });
+
     // S-M1: an access-token-only ack would let an XSS silently dismiss the
     // very banner that warns about its own compromise.
     it("POST /account/security-events/:id/ack without a step-up token returns 403", async () => {

--- a/osn/api/tests/routes/auth.test.ts
+++ b/osn/api/tests/routes/auth.test.ts
@@ -2385,6 +2385,9 @@ describe("auth routes", () => {
     it("GET /account/security-events requires Bearer auth", async () => {
       const res = await app.handle(new Request("http://localhost/account/security-events"));
       expect(res.status).toBe(401);
+      // tracker#346: the header is set above the guards, so it lands on the
+      // rejections too — not only on the 200.
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
     });
 
     it("GET /account/security-events surfaces the recovery_code_generate event end-to-end", async () => {
@@ -2589,6 +2592,7 @@ describe("auth routes", () => {
         }),
       );
       expect(res.status).toBe(429);
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
     });
   });
 });


### PR DESCRIPTION
## Summary

Two unrelated one-file fixes in `@osn/api`, both from the performance backlog.
`publicError` walks a thrown value looking for a `_tag`, and it read every own
key through `Object.getOwnPropertyDescriptor` — one descriptor object allocated
and discarded per key, per node. The walk only runs its full budget on
**untagged** throws, which is the common case, so the cost landed on the hot
error path inside a Worker with a 10 ms CPU budget. It now reads the key
directly. Separately, `GET /account/security-events` sent no `Cache-Control`;
it now sends `private, no-store`.

- The header is set as the handler's first statement, so it lands on the 401 and
  429 rejections as well as the 200. Tests pin all three.
- It is set imperatively rather than in the route schema. `shared/openapi/` is
  generated from the static schemas and CI has a freshness job, so declaring the
  header there would fail that gate. Regenerating produced no drift.
- The reviews in this run turned up four things worth fixing in the branch's own
  tests, and nine pre-existing problems elsewhere in `osn/api`. Both are below.

## Workspaces affected

`@osn/api`. One changeset, `@osn/api` at `patch` — two bug fixes, no API change.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#446 | `P-I2` |
| xchromo/osn-tracker#346 | `P-I4` — the `Cache-Control` half only; see Out of scope |

Closes xchromo/osn-tracker#446
Closes xchromo/osn-tracker#346

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#466 | `S-M1` |
| xchromo/osn-tracker#467 | `S-M2` |
| xchromo/osn-tracker#468 | `S-L3` (carries the security review's `S-L3` and the performance review's `P-W1`, which agreed) |
| xchromo/osn-tracker#469 | `S-L4` |
| xchromo/osn-tracker#470 | `C-L1` |
| xchromo/osn-tracker#471 | `P-I5` |
| xchromo/osn-tracker#473 | `P-I6` |
| xchromo/osn-tracker#474 | `P-I7` |

None of these are regressions from this branch. All are on `main` today.

## Decisions

### How the tag walk reads a key — `tracker#446`

- **Issue** — the walk needed the value behind each own key. The descriptor
  lookup allocated an object per key to get it.
- **Why** — 8.7x slower on the untagged path, which is the path most throws take,
  on every route error. The comment above the code already recorded an earlier
  finding on the same lines, so this was the second regression there.
- **Solution** — computed-key destructuring: `({ [key]: v } = node as never)`.
- **Rationale** — the brief asked for a plain property read, and neither obvious
  spelling of one survives this repo's lint rules. A literal `node[key]` needs a
  cast that trips `anti-slop/no-unsafe-dictionary-type`, and `Reflect.get` trips
  `anti-slop/no-reflect-get`; both are `error`. I checked by linting both forms
  in a scratch file: `(node as Record<PropertyKey, unknown>)[key]` errors,
  the destructuring form passes. Semantics match the old walk on every path — a
  data property yields its value, an accessor runs bound to `node`, a
  setter-only property yields `undefined`, and an own key still shadows the
  prototype. The `try` still guards a throwing getter, and a test pins that.
  `as never` rather than `as any` is what lets an arbitrary computed key through
  without asserting a shape we do not have.

### Where the cache header goes — `tracker#346`

- **Issue** — the response lists the caller's authentication events and carried
  no cache directive.
- **Why** — a per-user list of auth events should not sit in a disk cache on a
  shared machine.
- **Solution** — `set.headers["cache-control"] = "private, no-store"` as the
  first statement of the handler.
- **Rationale** — imperative, matching `oidc-clients.ts:47`, because the OpenAPI
  document is generated from the static route schemas and a schema change would
  fail the freshness job. First statement, so the rejections carry it too. The
  value is `private, no-store` where the rest of `osn/api` says bare `no-store`;
  `private` is redundant next to `no-store`, and settling on one string across
  the whole surface belongs with #468, not here.

### The first pass of tests did not test the change

- **Issue** — the test-surface review found four gaps, all in the tests this
  branch adds. Three of the four `publicError` cases asserted `400`, which is
  what `ValidationError`, `AuthError` and the `default` all return, so gutting
  the walk to `return null` left them green. No case proved an accessor gets
  invoked, none used a symbol key — the whole reason the walk uses
  `Reflect.ownKeys` — and the header was asserted only on the 200. The
  performance review then found that the throwing-getter case never reached the
  getter: the root carried a domain `_tag`, so the walk returned before the key
  loop ran.
- **Why** — a test that passes when the feature is removed is worse than no test,
  because it reads as cover.
- **Solution** — two commits. Retarget the assertions on `DatabaseError` (500)
  and `AgeRestrictionError` (422), add the accessor-`this`-binding, symbol-key,
  Cause-skip, cycle and budget cases, assert the header on 401 and 429, and give
  the poison getter a Cause tag on the root so the loop actually runs.
- **Rationale** — these are this branch's own tests for this branch's own change,
  so they belong here rather than in a follow-up. I confirmed the getter fix
  rather than assuming it: instrumented, it is invoked exactly once and the
  throw is swallowed. Nine tests, five gates green.

### Proxy behaviour, left alone — `S-L1`, dismissed

- **Issue** — against a `Proxy` whose `ownKeys` trap reports a key its
  `getOwnPropertyDescriptor` trap denies, the old code skipped the key and the
  new read invokes the `get` trap and takes the result.
- **Why** — in principle a hostile object could steer the walk one hop and supply
  a `_tag` of its choosing.
- **Solution** — none.
- **Rationale** — nothing in `@osn/api` throws a `Proxy`; thrown values are
  Effect `FiberFailure` / `Cause` nodes and `Error` instances. The reachable
  effect is a choice among four fixed public responses and the `tag` string on a
  server log line — no attacker data reaches a response body. The 512-node
  budget and the `seen` set already bound the work an adversarial graph can
  force. Both reviews reached this independently and both said leave it.

### The changeset said too much

- **Issue** — it repeated tracker#346's reasoning, naming the route and why the
  response is sensitive. Changesets become a public changelog.
- **Why** — `wiki/conventions/review-findings.md` says public work references a
  tracker issue by number and finding ID, never its body.
- **Solution** — trimmed to what changed, with the issue numbers.
- **Rationale** — the route ships patched in the same release, so nothing was
  exposed, but the convention is worded without exceptions and the shorter entry
  reads better anyway.

**Out of scope**

- The ETag half of tracker#346 — its trigger has not happened. The Settings
  banner still fetches once per mount, so a conditional request would save
  nothing. Now tracked as xchromo/osn-tracker#471.
- Sibling authenticated routes that still send no cache directive, and the
  wiki page that would stop the next one being added without it —
  xchromo/osn-tracker#466, #467, #468, #469, #470.
- Two more problems in the same walk, both pre-existing: the queue holds
  primitives that burn the node budget (and can make it miss a real tag), and
  `shift()` is O(n) once the queue grows — xchromo/osn-tracker#473, #474. They
  are one commit together, and deliberately not folded into a branch that was
  already reviewed and green.
- Nothing was promoted in the OSN Platform project. That is the repo owner's
  call, not this run's.

## Test plan

| Gate | Result |
|---|---|
| `bun run check --filter=@osn/api --force` (`tsc --noEmit`) | ✅ |
| `bun run --cwd osn/api test:run` | ✅ 1089 pass, 67 files |
| `bun run build --filter=@osn/api` (wrangler dry-run) | ✅ |
| `bunx oxlint -c oxlintrc.json osn/api` | ✅ 0 errors |
| `bun run fmt:check` | ✅ 1415 files |
| `bun run --cwd osn/api openapi:generate` then `git diff --exit-code shared/openapi/` | ✅ no drift |
| `bash scripts/validate-changesets.sh` | ✅ |

All run in this worktree. 1084 tests before the branch, 1089 after — five new,
four on `publicError` and one on the header.

Nothing here needs exercising by hand: both changes are covered by unit and
route tests, and the OpenAPI document is unchanged by construction. Two honest
negatives. The 8.7x figure comes from tracker#446's own measurement; the
performance review re-measured on a different error shape and got 3.2x, which is
the same direction and the same cause — the win scales with how many keys each
node has. And the header is asserted through Elysia's `app.handle`, not against a
deployed Worker, so what is pinned is that the handler sets it, not that
Cloudflare passes it through untouched.
