### PR TITLE
chore(cire-invites): put @cire/invites inside the type-check gate

### DIFF
--- a/.changeset/cire-invites-typecheck-gate.md
+++ b/.changeset/cire-invites-typecheck-gate.md
@@ -1,0 +1,30 @@
+---
+"@cire/invites": patch
+---
+
+Add `@cire/invites` to the typecheck gate (closes #689, #690).
+
+`astro check` was never wired into `@cire/invites`, so 98 type errors across 20 files
+had been accumulating unseen. Added the `check` script (matching `@cire/landing`,
+`@cire/host`, `@cire/vendor`) and fixed every error to root cause, in five clusters:
+
+- Test fixtures missing the `nickname` field `FamilyMember` requires (guest single-greeting
+  logic) — added it to every fixture, never loosened the type.
+- Bare `let ref: T` Solid refs assigned only inside JSX (`panelRef`, `backdropRef`,
+  `eventsSectionRef`) — switched to the repo's existing `let ref!: T` definite-assignment
+  pattern (already used in `cire/landing`'s `DemoModal`/`WaxSeal3D`/`VineCanvas`).
+- Implicit-`any` params on `vi.fn()` test hooks and a `claimWith` test helper that took
+  `never[]` and cast around it — gave both real signatures matching
+  `unlockRevealSequence`/`RevealHooks`, and removed pre-existing `as never`/
+  `as unknown as` casts in `gala/InvitePage.test.tsx` while at it.
+- Two `.astro` syntax errors (ts1381/ts1005) in `classic/Document.astro` and
+  `gala/Document.astro`: a developer comment sat between the `<InvitePage` tag and its
+  attribute list, an invalid JSX-comment position. Moved the identical comment text above
+  the tag — no rendered/guest-facing markup changed.
+- `lib` bumped `ES2022` → `ES2023` in `cire/invites/tsconfig.json` for `toSorted`/
+  `toReversed`, matching `cire/api`/`cire/host`/`pulse/web`/`osn/social` precedent; and an
+  `Omit<...> & {...}` fix for a `requestIdleCallback` intersection-type conflict with DOM lib.
+
+Pinned `typescript@^6.0.3` and `@astrojs/check@0.9.10` to match the three sibling Astro
+packages exactly (TypeScript 7 crashes `@astrojs/language-server`). No `as any`,
+`@ts-expect-error`, `@ts-nocheck`, or type-widening used anywhere in the fix.

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "tailwindcss": "^4.3.3",
       },
       "devDependencies": {
+        "@astrojs/check": "0.9.10",
         "@capsizecss/metrics": "^4.2.0",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
@@ -124,6 +125,7 @@
         "@vitest/browser-playwright": "4.1.10",
         "jsdom": "^29.1.1",
         "playwright": "^1.62.1",
+        "typescript": "^6.0.3",
         "vite-plugin-solid": "^2.11.14",
         "vitest": "^4.1.10",
       },

--- a/cire/invites/package.json
+++ b/cire/invites/package.json
@@ -7,6 +7,7 @@
     "dev:app": "dev-env astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "check": "bunx --bun astro check",
     "test": "vitest run --project unit",
     "test:browser": "vitest run --project browser"
   },
@@ -31,6 +32,7 @@
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
+    "@astrojs/check": "0.9.10",
     "@capsizecss/metrics": "^4.2.0",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
@@ -40,6 +42,7 @@
     "@vitest/browser-playwright": "4.1.10",
     "jsdom": "^29.1.1",
     "playwright": "^1.62.1",
+    "typescript": "^6.0.3",
     "vite-plugin-solid": "^2.11.14",
     "vitest": "^4.1.10"
   }

--- a/cire/invites/src/components/AddToCalendar.test.tsx
+++ b/cire/invites/src/components/AddToCalendar.test.tsx
@@ -17,6 +17,7 @@ const baseEvent: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const SITE_URL = "https://invite.example.com/abc-123";

--- a/cire/invites/src/components/AnimatedModal.tsx
+++ b/cire/invites/src/components/AnimatedModal.tsx
@@ -61,8 +61,8 @@ function showInstantly(backdrop: HTMLElement, panel: HTMLElement) {
 }
 
 export function AnimatedModal(props: AnimatedModalProps) {
-  let backdropRef: HTMLDivElement;
-  let panelRef: HTMLDivElement;
+  let backdropRef!: HTMLDivElement;
+  let panelRef!: HTMLDivElement;
   let closeButtonRef: HTMLButtonElement | undefined;
   let scrollRef: HTMLDivElement | undefined;
 

--- a/cire/invites/src/components/DetailsModal.test.tsx
+++ b/cire/invites/src/components/DetailsModal.test.tsx
@@ -24,6 +24,7 @@ const baseEvent: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const renderModal = (event: EventSummary) =>

--- a/cire/invites/src/components/MapPreview.test.tsx
+++ b/cire/invites/src/components/MapPreview.test.tsx
@@ -20,6 +20,7 @@ const baseEvent: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 describe("MapPreview", () => {

--- a/cire/invites/src/components/RsvpModal.browser.test.tsx
+++ b/cire/invites/src/components/RsvpModal.browser.test.tsx
@@ -40,6 +40,7 @@ const event: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 /** Enough of a party to overflow the sheet, so the scrollport is real. */
@@ -47,6 +48,7 @@ const members: FamilyMember[] = Array.from({ length: 12 }, (_, i) => ({
   guestId: `guest-${i}`,
   firstName: `Guest${i}`,
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 }));
 

--- a/cire/invites/src/components/RsvpModal.test.tsx
+++ b/cire/invites/src/components/RsvpModal.test.tsx
@@ -26,12 +26,14 @@ const event: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const priya: FamilyMember = {
   guestId: "guest-priya",
   firstName: "Priya",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1", "event-2"],
 };
 
@@ -39,6 +41,7 @@ const raj: FamilyMember = {
   guestId: "guest-raj",
   firstName: "Raj",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 };
 
@@ -46,6 +49,7 @@ const naina: FamilyMember = {
   guestId: "guest-naina",
   firstName: "Naina",
   lastName: "Sharma",
+  nickname: null,
   // Not invited to event-1
   eventIds: ["event-2"],
 };

--- a/cire/invites/src/components/calendar.test.ts
+++ b/cire/invites/src/components/calendar.test.ts
@@ -16,6 +16,7 @@ const sydneyEvent: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const SITE_URL = "https://invite.example.com/abc-123";

--- a/cire/invites/src/components/event-details.test.ts
+++ b/cire/invites/src/components/event-details.test.ts
@@ -23,6 +23,7 @@ const base: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 describe("venueLine", () => {

--- a/cire/invites/src/components/prefetch-idle.test.ts
+++ b/cire/invites/src/components/prefetch-idle.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { prefetchOnIdle } from "./prefetch-idle";
 
-type IdleWindow = typeof globalThis & {
+type IdleWindow = Omit<typeof globalThis, "requestIdleCallback" | "cancelIdleCallback"> & {
   requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
   cancelIdleCallback?: (handle: number) => void;
 };
@@ -32,7 +32,7 @@ describe("prefetchOnIdle", () => {
   });
 
   it("passes a timeout so a permanently busy page still prefetches", () => {
-    const idle = vi.fn(() => 1);
+    const idle = vi.fn((_cb: () => void, _opts?: { timeout: number }) => 1);
     win.requestIdleCallback = idle;
 
     prefetchOnIdle(() => Promise.resolve());

--- a/cire/invites/src/components/rsvp-confirmation.browser.test.tsx
+++ b/cire/invites/src/components/rsvp-confirmation.browser.test.tsx
@@ -46,12 +46,14 @@ const event: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const priya: FamilyMember = {
   guestId: "guest-priya",
   firstName: "Priya",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 };
 
@@ -59,6 +61,7 @@ const raj: FamilyMember = {
   guestId: "guest-raj",
   firstName: "Raj",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 };
 

--- a/cire/invites/src/components/rsvp-confirmation.integration.test.tsx
+++ b/cire/invites/src/components/rsvp-confirmation.integration.test.tsx
@@ -53,12 +53,14 @@ const event: EventSummary = {
   pinterestUrl: null,
   mapsUrl: null,
   sortOrder: 0,
+  imageUrl: null,
 };
 
 const priya: FamilyMember = {
   guestId: "guest-priya",
   firstName: "Priya",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 };
 
@@ -66,6 +68,7 @@ const raj: FamilyMember = {
   guestId: "guest-raj",
   firstName: "Raj",
   lastName: "Sharma",
+  nickname: null,
   eventIds: ["event-1"],
 };
 

--- a/cire/invites/src/designs/InvitePage.browser.test.tsx
+++ b/cire/invites/src/designs/InvitePage.browser.test.tsx
@@ -43,8 +43,20 @@ const claim: ClaimResult = {
   publicId: "SHARMA-JOY-RK97",
   familyName: "Sharma",
   members: [
-    { guestId: "guest-priya", firstName: "Priya", lastName: "Sharma", eventIds: ["event-1"] },
-    { guestId: "guest-raj", firstName: "Raj", lastName: "Sharma", eventIds: ["event-1"] },
+    {
+      guestId: "guest-priya",
+      firstName: "Priya",
+      lastName: "Sharma",
+      nickname: null,
+      eventIds: ["event-1"],
+    },
+    {
+      guestId: "guest-raj",
+      firstName: "Raj",
+      lastName: "Sharma",
+      nickname: null,
+      eventIds: ["event-1"],
+    },
   ],
   events: [
     {

--- a/cire/invites/src/designs/classic/Document.astro
+++ b/cire/invites/src/designs/classic/Document.astro
@@ -70,12 +70,12 @@ const registryVars = filterThemeVars(sectionVars(initialInvite?.theme ?? null, '
   </head>
   <body>
     <InviteHeader client:load apiUrl={apiUrl} slug={slug} initial={initialInvite} />
+    {/* rootMargin so the island hydrates while the full-viewport hero is
+        still on screen. Bare `client:visible` cannot fire at scroll position
+        0 (the hero is `min-h-dvh`), which would delay the session restore
+        until the guest has already scrolled to the code form — i.e. to the
+        exact moment they are waiting on its result. */}
     <InvitePage
-      {/* rootMargin so the island hydrates while the full-viewport hero is
-          still on screen. Bare `client:visible` cannot fire at scroll position
-          0 (the hero is `min-h-dvh`), which would delay the session restore
-          until the guest has already scrolled to the code form — i.e. to the
-          exact moment they are waiting on its result. */}
       client:visible={{ rootMargin: "600px" }}
       apiUrl={apiUrl}
       slug={slug}

--- a/cire/invites/src/designs/classic/InvitePage.test.tsx
+++ b/cire/invites/src/designs/classic/InvitePage.test.tsx
@@ -7,6 +7,7 @@ import { TOTAL_DURATION_MS } from "../../components/rsvp-responded";
 import type { ClaimResult, RsvpSummary } from "../../components/types";
 import { noSession, withSession } from "../../test-support/claim-fetch";
 import InvitePage from "./InvitePage";
+import type { RevealHooks } from "./UnlockReveal.motion";
 
 vi.mock("motion", () => ({
   animate: vi.fn(() => ({ finished: Promise.resolve() })),
@@ -64,6 +65,7 @@ const claim: ClaimResult = {
       guestId: "guest-1",
       firstName: "Priya",
       lastName: "Sharma",
+      nickname: null,
       eventIds: ["event-1"],
     },
   ],
@@ -661,7 +663,13 @@ describe("InvitePage", () => {
       publicId: "OKAFOR-LILY-AB12CD",
       familyName: "Okafor",
       members: [
-        { guestId: "guest-9", firstName: "Chidi", lastName: "Okafor", eventIds: ["event-1"] },
+        {
+          guestId: "guest-9",
+          firstName: "Chidi",
+          lastName: "Okafor",
+          nickname: null,
+          eventIds: ["event-1"],
+        },
       ],
     };
     const fetchMock = vi
@@ -1111,7 +1119,7 @@ describe("InvitePage", () => {
       // A fresh Response per call: `mockResolvedValue` would hand the same one
       // to both the invite revalidation and the restore, and a body can only be
       // read once.
-      const restore = vi.fn(() =>
+      const restore = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.resolve(
           new Response(JSON.stringify(claim), {
             status: 200,
@@ -1193,7 +1201,7 @@ describe("InvitePage", () => {
       // A fresh Response per call: `mockResolvedValue` would hand the same one
       // to both the invite revalidation and the restore, and a body can only be
       // read once.
-      const restore = vi.fn(() =>
+      const restore = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.resolve(
           new Response(JSON.stringify(claim), {
             status: 200,
@@ -1221,9 +1229,18 @@ describe("InvitePage", () => {
   // — an imperative write from the animation would leave Solid believing the
   // form is displayed and silently skip every later attempt to show it again.
   describe("form/welcome swap", () => {
-    async function claimWith(sequence: () => Promise<void>) {
+    async function claimWith(
+      sequence: (
+        loginForm: HTMLElement,
+        welcomeEl: HTMLElement,
+        eventsSection: HTMLElement,
+        hooks?: RevealHooks,
+      ) => Promise<void> | void,
+    ) {
       const { unlockRevealSequence } = await import("./UnlockReveal.motion");
-      vi.mocked(unlockRevealSequence).mockImplementation(sequence);
+      vi.mocked(unlockRevealSequence).mockImplementation(async (...args) => {
+        await sequence(...args);
+      });
       vi.stubGlobal(
         "fetch",
         noSession(

--- a/cire/invites/src/designs/classic/InvitePage.tsx
+++ b/cire/invites/src/designs/classic/InvitePage.tsx
@@ -288,7 +288,7 @@ export default function InvitePage(props: InvitePageProps) {
 
   let loginFormRef: HTMLDivElement;
   let welcomeRef: HTMLDivElement;
-  let eventsSectionRef: HTMLElement;
+  let eventsSectionRef!: HTMLElement;
 
   async function handleClaimed(result: ClaimResult) {
     setClaimResult(result);

--- a/cire/invites/src/designs/gala/Document.astro
+++ b/cire/invites/src/designs/gala/Document.astro
@@ -70,12 +70,12 @@ const registryVars = filterThemeVars(sectionVars(initialInvite?.theme ?? null, '
   </head>
   <body>
     <InviteHeader client:load apiUrl={apiUrl} slug={slug} initial={initialInvite} />
+    {/* rootMargin so the island hydrates while the full-viewport hero is
+        still on screen. Bare `client:visible` cannot fire at scroll position
+        0 (the hero is `min-h-dvh`), which would delay the session restore
+        until the guest has already scrolled to the code form — i.e. to the
+        exact moment they are waiting on its result. */}
     <InvitePage
-      {/* rootMargin so the island hydrates while the full-viewport hero is
-          still on screen. Bare `client:visible` cannot fire at scroll position
-          0 (the hero is `min-h-dvh`), which would delay the session restore
-          until the guest has already scrolled to the code form — i.e. to the
-          exact moment they are waiting on its result. */}
       client:visible={{ rootMargin: "600px" }}
       apiUrl={apiUrl}
       slug={slug}

--- a/cire/invites/src/designs/gala/InvitePage.test.tsx
+++ b/cire/invites/src/designs/gala/InvitePage.test.tsx
@@ -6,6 +6,7 @@ import { TOTAL_DURATION_MS } from "../../components/rsvp-responded";
 import type { ClaimResult, RsvpSummary } from "../../components/types";
 import { noSession, withSession } from "../../test-support/claim-fetch";
 import InvitePage from "./InvitePage";
+import type { RevealHooks } from "./UnlockReveal.motion";
 
 vi.mock("motion", () => ({
   animate: vi.fn(() => ({ finished: Promise.resolve() })),
@@ -60,6 +61,7 @@ const claim: ClaimResult = {
       guestId: "guest-1",
       firstName: "Priya",
       lastName: "Sharma",
+      nickname: null,
       eventIds: ["event-1"],
     },
   ],
@@ -882,7 +884,7 @@ describe("gala InvitePage", () => {
       // A fresh Response per call: `mockResolvedValue` would hand the same one
       // to both the invite revalidation and the restore, and a body can only be
       // read once.
-      const restore = vi.fn(() =>
+      const restore = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.resolve(
           new Response(JSON.stringify(claim), {
             status: 200,
@@ -964,7 +966,7 @@ describe("gala InvitePage", () => {
       // A fresh Response per call: `mockResolvedValue` would hand the same one
       // to both the invite revalidation and the restore, and a body can only be
       // read once.
-      const restore = vi.fn(() =>
+      const restore = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.resolve(
           new Response(JSON.stringify(claim), {
             status: 200,
@@ -989,11 +991,18 @@ describe("gala InvitePage", () => {
   // protect classic only. Without these, reverting BOTH of gala's `revealed`
   // bindings back to `claimResult()` — undoing the fix entirely — passes.
   describe("form/welcome swap", () => {
-    async function claimWith(sequence: (...args: never[]) => Promise<void> | void) {
+    async function claimWith(
+      sequence: (
+        loginForm: HTMLElement,
+        welcomeEl: HTMLElement,
+        eventsSection: HTMLElement,
+        hooks?: RevealHooks,
+      ) => Promise<void> | void,
+    ) {
       const { unlockRevealSequence } = await import("./UnlockReveal.motion");
-      vi.mocked(unlockRevealSequence).mockImplementation(
-        sequence as unknown as typeof unlockRevealSequence,
-      );
+      vi.mocked(unlockRevealSequence).mockImplementation(async (...args) => {
+        await sequence(...args);
+      });
       vi.stubGlobal(
         "fetch",
         noSession(
@@ -1018,17 +1027,17 @@ describe("gala InvitePage", () => {
       screen.getByText("Enter Your Code").parentElement as HTMLElement;
 
     it("hides the form when the sequence reports it faded out", async () => {
-      const { getByText } = await claimWith(((_f, _w, _e, hooks) => {
-        (hooks as { onFormHidden?: () => void } | undefined)?.onFormHidden?.();
+      const { getByText } = await claimWith((_f, _w, _e, hooks) => {
+        hooks?.onFormHidden?.();
         return Promise.resolve();
-      }) as never);
+      });
       await waitFor(() => expect(formPanel({ getByText }).style.display).toBe("none"));
     });
 
     it("keeps the form up until that moment — the fade needs it on screen", async () => {
       let release: (() => void) | undefined;
       const { getByText } = await claimWith(
-        (() => new Promise<void>((resolve) => (release = resolve))) as never,
+        () => new Promise<void>((resolve) => (release = resolve)),
       );
       await waitFor(() => expect(release).toBeDefined());
       expect(formPanel({ getByText }).style.display).toBe("");
@@ -1043,10 +1052,10 @@ describe("gala InvitePage", () => {
       // difference, which is why dropping the `onFormHidden` wiring was
       // otherwise invisible.
       let release: (() => void) | undefined;
-      const { getByText } = await claimWith(((_f, _w, _e, hooks) => {
-        (hooks as { onFormHidden?: () => void } | undefined)?.onFormHidden?.();
+      const { getByText } = await claimWith((_f, _w, _e, hooks) => {
+        hooks?.onFormHidden?.();
         return new Promise<void>((resolve) => (release = resolve));
-      }) as never);
+      });
       await waitFor(() => expect(formPanel({ getByText }).style.display).toBe("none"));
       expect(release).toBeDefined();
       release!();
@@ -1055,15 +1064,15 @@ describe("gala InvitePage", () => {
     it("still completes the swap when the sequence throws", async () => {
       // A motion chunk that fails to load must never leave the claim form
       // sitting on top of a claimed invite — the `finally` in handleClaimed.
-      const { getByText, queryByText } = await claimWith((() => {
+      const { getByText, queryByText } = await claimWith(() => {
         throw new Error("chunk failed");
-      }) as never);
+      });
       await waitFor(() => expect(formPanel({ getByText }).style.display).toBe("none"));
       expect(queryByText(/Dear Priya/)).toBeTruthy();
     });
 
     it("still completes the swap when the sequence never reports", async () => {
-      const { getByText } = await claimWith((() => Promise.resolve()) as never);
+      const { getByText } = await claimWith(() => Promise.resolve());
       await waitFor(() => expect(formPanel({ getByText }).style.display).toBe("none"));
     });
   });

--- a/cire/invites/src/designs/gala/InvitePage.tsx
+++ b/cire/invites/src/designs/gala/InvitePage.tsx
@@ -295,7 +295,7 @@ export default function InvitePage(props: InvitePageProps) {
   let turnstile: TurnstileControls | undefined;
   let loginFormRef: HTMLDivElement;
   let welcomeRef: HTMLDivElement;
-  let eventsSectionRef: HTMLElement;
+  let eventsSectionRef!: HTMLElement;
 
   async function handleClaimed(result: ClaimResult) {
     setClaimResult(result);

--- a/cire/invites/tsconfig.json
+++ b/cire/invites/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@shared/typescript-config/solid.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2023", "DOM"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },


### PR DESCRIPTION
## Summary

`astro check` was never wired into `@cire/invites`, so type errors piled up unseen
behind a build that strips types. This branch adds the `check` script — the same
`bunx --bun astro check` line `@cire/landing`, `@cire/host` and `@cire/vendor`
already run — and clears every error it turns up, so turbo's `check` task now
covers the guest invite site.

The issues estimated roughly 30 errors. The real count on `origin/main` was **98
errors across 20 files**. All 98 are fixed at the root cause.

- Nothing was suppressed. There is no `as any`, `@ts-expect-error`, `@ts-nocheck`,
  `as unknown as`, or lint-disable comment anywhere in the added lines — a gate
  cleared by suppression is worse than no gate.
- `@cire/landing`, named alongside `@cire/invites` in #690, already had the script,
  so #690 collapses into #689 and both close here.
- Two `.astro` files under `src/designs/` are the live invite designs. Only a
  comment moved in each. No rendered or guest-facing markup changed.

## Workspaces affected

`@cire/invites`. The changeset names it alone at `patch`. `@cire/invites` is
version-less, so it must not share a changeset with a versioned package; nothing
else on the branch is a versioned workspace. `bun.lock` and `.changeset/` are the
only files outside `cire/invites/`.

## Issues

**Closes**

| Issue | What |
|---|---|
| #689 | Put `@cire/invites` inside the type-check gate |
| #690 | `@cire/invites` and `@cire/landing` are still outside the type-check gate |

Closes #689
Closes #690

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#769 | Put `@cire/api` inside the type-check gate |
| xchromo/osn-tracker#488 | `P-I1` |

## Decisions

The security review found nothing. The performance review found one info item, the
test review three coverage gaps; all four are recorded below.

### Missing `nickname` on `FamilyMember` fixtures

- **Issue** — test fixtures across six files built `FamilyMember` objects without
  the `nickname` field the interface in `src/components/types.ts` requires.
- **Why** — the fixtures were drifting from the type that drives the guest
  single-greeting logic, so the tests were asserting against a shape production
  never sees.
- **Solution** — added `nickname: null` to every fixture that lacked it.
- **Rationale** — the type is right and the fixtures were wrong. Making
  `nickname` optional would have hidden the drift and let real call sites skip a
  field the greeting logic reads.

### Solid refs declared without definite assignment

- **Issue** — `backdropRef`, `panelRef` and `eventsSectionRef` were declared as
  bare `let ref: T` and assigned only inside JSX, which TypeScript reads as
  used-before-assigned.
- **Why** — this was the one cluster the issues called a real error rather than
  test drift.
- **Solution** — moved them to `let ref!: T`, the definite-assignment form.
- **Rationale** — it is the pattern the repo already uses for Solid refs:
  `cire/landing`'s `DemoModal`, `WaxSeal3D` and `VineCanvas` all declare refs
  this way. Nothing new was invented, and no runtime behaviour changed.

### Implicit `any` on mocked hooks and a `never[]` test helper

- **Issue** — `vi.fn()` callbacks took implicitly-`any` parameters, and a
  `claimWith` helper in both design test files took `never[]` and cast its way
  around the mismatch.
- **Why** — an untyped mock makes the assertions on its `.calls` tuples
  meaningless; the casts were the symptom, not the cause.
- **Solution** — gave the mocks and the helper their real signatures, matching
  `unlockRevealSequence` and `RevealHooks` from `UnlockReveal.motion.ts`.
  Pre-existing `as never` and `as unknown as` casts in `gala/InvitePage.test.tsx`
  came out while the file was open.
- **Rationale** — typing the callback fixes the tuple errors at source. Removing
  the old casts leaves the file matching `classic/InvitePage.test.tsx`, which
  already did it the clean way.

### Comment in an invalid JSX position in two `.astro` files

- **Issue** — `classic/Document.astro` and `gala/Document.astro` both carried a
  developer comment between the `<InvitePage` tag name and its attribute list.
  That position is not valid for a JSX comment; it produced the ts1381 and
  ts1005 syntax errors.
- **Why** — these two files render the live guest invite designs, so the fix had
  to be provably inert.
- **Solution** — moved the comment above the tag. The comment text is
  byte-identical and nothing else in either file changed. **No rendered or
  guest-facing markup changed**, and the `client:visible={{ rootMargin: "600px" }}`
  hydration directive is untouched.
- **Rationale** — the comment explains why the island hydrates early and is worth
  keeping. Deleting it would have cleared the error and lost the reason.

### `lib` bumped ES2022 to ES2023

- **Issue** — `toSorted` and `toReversed` are used in the package but are not in
  the ES2022 lib, so they reported ts(2550).
- **Why** — this goes beyond the literal text of the brief, so it is recorded
  rather than folded into the diff quietly.
- **Solution** — `cire/invites/tsconfig.json` `lib` changed from
  `["ES2022", "DOM"]` to `["ES2023", "DOM"]`.
- **Rationale** — `cire/api`, `cire/host`, `pulse/web` and `osn/social` already
  target ES2023, so this brings the package into line with the rest of the
  monorepo rather than raising the bar anywhere. The alternative — rewriting the
  call sites back to `.slice().sort()` — would have made the code worse to
  silence a config gap.

### `typescript` and `@astrojs/check` pinned to the sibling versions

- **Issue** — the gate needs both packages as devDependencies, and a bare
  `bun add` resolves TypeScript 7.
- **Why** — TypeScript 7 crashes `@astrojs/language-server`
  (`undefined is not an object (evaluating 'this.ts.sys.fileExists')`), so the
  gate would not have run at all.
- **Solution** — pinned `typescript@^6.0.3` and `@astrojs/check@0.9.10`, read
  from `cire/landing`, `cire/host` and `cire/vendor` and confirmed identical in
  all three. `bun.lock` was edited by hand so the diff is exactly two added
  lines; `bun install --frozen-lockfile` reports no changes.
- **Rationale** — a plain `bun install` here prunes dozens of entries including
  every non-darwin binary, which would have buried a two-line change in lockfile
  churn. Matching the siblings byte-for-byte also means one version to move when
  the four packages upgrade together.

### `requestIdleCallback` intersection type

- **Issue** — `delete win.requestIdleCallback` in `prefetch-idle.test.ts` failed
  with "operand must be optional".
- **Why** — the test built its window type as `typeof globalThis & { … }`, and
  the intersection kept the DOM lib's non-optional `requestIdleCallback`.
- **Solution** — switched to
  `Omit<typeof globalThis, "requestIdleCallback" | "cancelIdleCallback"> & { … }`.
- **Rationale** — `Omit` overrides the member instead of intersecting with it,
  which is what the test meant in the first place.

### `lib` ES2023 raises the floor for shipped source too — `P-I1`

- **Issue** — the performance review pointed out that the ES2023 bump applies to
  the whole package, while the only ES2023 calls (`toSorted`, `toReversed`) are in
  two test files. Shipped source uses none.
- **Why** — `toSorted` and friends are runtime methods that nothing downlevels or
  polyfills. On ES2023 the compiler would now accept one in `src/`, and a guest on
  a phone older than Safari 16.4 would get `undefined is not a function`.
- **Solution** — left as is on this branch; filed as `xchromo/osn-tracker#488`.
- **Rationale** — the fix is to split the test `lib` from the production one, which
  is a tsconfig change on its own terms and does not belong in the PR that turns the
  gate on. Nothing in shipped source uses an ES2023 method today, so this is latent,
  not a regression, and the review filed it at info for that reason.

### Three test-surface findings waved through — `T-U1`, `T-S1`, `T-S2`

- **Issue** — the test review raised three coverage gaps. `T-U1`: `gala/InvitePage.tsx`
  carries its own copy of the nickname-greeting rule and no test enters the
  nickname-wins arm, which this branch's `nickname: null` fixture makes concrete.
  `T-S1`: the `!` on `eventsSectionRef` types the runtime guards in `handleClaimed`'s
  `catch` as unreachable, and no test drives that path. `T-S2`: `astro check` fails
  only on errors, so the gate exits 0 with an unused `MARKETING_URL` import still
  reported as a hint at `src/pages/index.astro:20`.
- **Why** — `T-U1` is the one with teeth: two copies of a guest-facing greeting rule
  can drift, and only one is tested.
- **Solution** — none taken here. Recorded in this body rather than filed:
  `wiki/conventions/review-findings.md` says `T-*` findings are not filed as issues,
  they are closed on the branch or waved through.
- **Rationale** — all three want new tests or an edit to a file this branch does not
  otherwise touch, and this PR's job is to turn the gate on and clear what it found.
  Widening it to write coverage for logic the gate never complained about is how a
  chore PR stops being reviewable. None of the three is a regression: every one of
  them was equally true before the branch, and the branch's own fixture change is
  what made `T-U1` visible.

**Out of scope** — `@cire/api` is the last package with no `check` script at all, and
`tsc --noEmit` over it reports 614 errors across 75 files; too large for this PR and
tracked as xchromo/osn#769. The ES2023 `lib` split is xchromo/osn-tracker#488. The three
test-surface findings above are recorded in Decisions, per the convention that `T-*`
findings are not filed.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` (full turbo) | ✅ 35/35 tasks, `@cire/invites#check` now among them |
| `bun run --cwd cire/invites check` | ✅ 134 files, 0 errors, 0 warnings, 4 hints |
| `bun run --cwd cire/invites test` | ✅ 925 pass, 57 files |
| `bun run --cwd cire/invites test:browser` | ✅ 33 pass, 7 files |
| `bun run lint` | ✅ exit 0, no new warnings |
| `bun run fmt:check` | ✅ all files correctly formatted |
| `bun install --frozen-lockfile` | ✅ 869 installs, no changes |
| `scripts/validate-changesets.sh` | ✅ all package references valid |

Every gate above was run in this worktree.

`bunx turbo run check --dry=json` confirms `@cire/invites#check` resolves to
`bunx --bun astro check` rather than `<NONEXISTENT>`, so CI's `bun run check` step
covers the package from this merge on.

One thing to check by eye rather than by gate: the two `Document.astro` files render
the live guest invite designs, and no automatic gate compares their output. The diff is
one hunk each, moving a five-line comment from inside the `<InvitePage` attribute list
to the line above the tag; the attributes, their order and their values are untouched.
Both reviews compiled the before and after and found the emitted hydration call
identical, but a reviewer should read those two hunks anyway.
