### PR TITLE
fix(oidc): use Object.hasOwn for the three OIDC map guards

### DIFF
--- a/.changeset/oidc-hasown-guards.md
+++ b/.changeset/oidc-hasown-guards.md
@@ -1,0 +1,8 @@
+---
+"@osn/api": patch
+"@osn/social": patch
+---
+
+Fix the three OIDC map-membership guards to use `Object.hasOwn` instead of
+`in`, so an inherited `Object.prototype` key (`constructor`, `toString`,
+`__proto__`) can no longer pass as a real map entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,7 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 | Messaging | `@zap/api` shared backend — Pulse consumes for event chats; users don't need Zap install |
 | Privacy | E2E encryption everywhere; all personalisation data user-accessible + resettable |
 | Platform priority | iOS > Web > Android (Android deferred) |
+| Map-membership guards | A guard that narrows to `keyof typeof MAP` must test `Object.hasOwn(MAP, key)`, never `key in MAP`. `in` walks the prototype chain, so `constructor`, `toString` and `__proto__` pass and the predicate then asserts an inherited `Object.prototype` member is a real entry. No lint rule catches this — see `cire/theme/src/palette.ts` for the house form |
 | Pre-commit | lefthook runs oxlint + oxfmt (auto-fix + re-stage) on staged files |
 | Pre-push | lefthook runs type check |
 | oxlint | `oxlintrc.json` — plugins: typescript, unicorn, oxc, import, promise, vitest, node, jsx-a11y (React plugin disabled — SolidJS) |

--- a/osn/api/src/routes/auth/oidc.ts
+++ b/osn/api/src/routes/auth/oidc.ts
@@ -94,7 +94,7 @@ const AUTHORIZE_ERROR_COPY = {
 } satisfies Record<string, string>;
 
 const hasAuthorizeErrorCopy = (code: string): code is keyof typeof AUTHORIZE_ERROR_COPY =>
-  code in AUTHORIZE_ERROR_COPY;
+  Object.hasOwn(AUTHORIZE_ERROR_COPY, code);
 
 const renderAuthorizeErrorPage = (code: string): string => {
   const message = hasAuthorizeErrorCopy(code)

--- a/osn/api/src/services/auth/oidc.ts
+++ b/osn/api/src/services/auth/oidc.ts
@@ -401,7 +401,8 @@ const CONFUSABLE_FOLD = {
 } satisfies Record<string, string>;
 
 /** Is this character one the fold table knows how to rewrite? */
-const isConfusable = (ch: string): ch is keyof typeof CONFUSABLE_FOLD => ch in CONFUSABLE_FOLD;
+const isConfusable = (ch: string): ch is keyof typeof CONFUSABLE_FOLD =>
+  Object.hasOwn(CONFUSABLE_FOLD, ch);
 
 /**
  * Folds a name to a confusable skeleton for impersonation checks: NFKC,

--- a/osn/api/tests/services/auth/oidc.test.ts
+++ b/osn/api/tests/services/auth/oidc.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { clientNameSkeleton } from "../../../src/services/auth/oidc";
 
 /**
- * S-L1-style guard test. `clientNameSkeleton` folds each character through
+ * S-L3 (`xchromo/osn-tracker#441`). `clientNameSkeleton` folds each character through
  * `CONFUSABLE_FOLD` via `Object.hasOwn`, not the `in` operator — `in` walks
  * the prototype chain, so a name containing a character that only exists as
  * an *inherited* `Object.prototype` property would have folded through that
@@ -19,7 +19,14 @@ describe("clientNameSkeleton", () => {
     const proto = Object.prototype as Record<string, string>;
     // "δ" (Greek delta) is not a key CONFUSABLE_FOLD owns.
     expect(Object.hasOwn(proto, "δ")).toBe(false);
-    proto.δ = "z";
+    // Non-enumerable, so no `for...in` anywhere in the realm can see it while
+    // the test holds it. Removed again in the `finally`.
+    Object.defineProperty(proto, "δ", {
+      value: "z",
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
     try {
       // With `in`, "δ" would resolve through the prototype chain and fold to
       // "z". With `Object.hasOwn`, it stays unrecognised and is dropped by

--- a/osn/api/tests/services/auth/oidc.test.ts
+++ b/osn/api/tests/services/auth/oidc.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { clientNameSkeleton } from "../../../src/services/auth/oidc";
+
+/**
+ * S-L1-style guard test. `clientNameSkeleton` folds each character through
+ * `CONFUSABLE_FOLD` via `Object.hasOwn`, not the `in` operator — `in` walks
+ * the prototype chain, so a name containing a character that only exists as
+ * an *inherited* `Object.prototype` property would have folded through that
+ * inherited value instead of being left alone and dropped.
+ *
+ * There is no such collision under normal `Object.prototype` (its own member
+ * names are multi-character, and this fold runs one code point at a time), so
+ * the test pollutes the prototype itself with a single-character property to
+ * prove the guard checks OWN membership rather than trusting on that absence.
+ */
+describe("clientNameSkeleton", () => {
+  it("does not fold a character that is only an inherited property", () => {
+    const proto = Object.prototype as Record<string, string>;
+    // "δ" (Greek delta) is not a key CONFUSABLE_FOLD owns.
+    expect(Object.hasOwn(proto, "δ")).toBe(false);
+    proto.δ = "z";
+    try {
+      // With `in`, "δ" would resolve through the prototype chain and fold to
+      // "z". With `Object.hasOwn`, it stays unrecognised and is dropped by
+      // the trailing `[^a-z]` strip.
+      expect(clientNameSkeleton("aδb")).toBe("ab");
+    } finally {
+      delete proto.δ;
+    }
+  });
+});

--- a/osn/social/src/pages/AuthorizePage.tsx
+++ b/osn/social/src/pages/AuthorizePage.tsx
@@ -63,7 +63,8 @@ const SCOPE_COPY = {
 } satisfies Record<string, ScopeCopy>;
 
 /** A scope the map has copy for — anything else is shown as its raw name. */
-const isKnownScope = (scope: string): scope is keyof typeof SCOPE_COPY => scope in SCOPE_COPY;
+const isKnownScope = (scope: string): scope is keyof typeof SCOPE_COPY =>
+  Object.hasOwn(SCOPE_COPY, scope);
 
 const scopeCopy = (scope: string): ScopeCopy | undefined =>
   isKnownScope(scope) ? SCOPE_COPY[scope] : undefined;

--- a/osn/social/tests/components/AuthorizePage.test.tsx
+++ b/osn/social/tests/components/AuthorizePage.test.tsx
@@ -169,6 +169,19 @@ describe("<AuthorizePage />", () => {
     expect(mocks.getContext).toHaveBeenCalledWith(REQUEST_ID, withAbortSignal);
   });
 
+  it("does not resolve a scope named after an inherited Object property", async () => {
+    // "constructor" is not an own SCOPE_COPY entry — it is inherited from
+    // Object.prototype. `isKnownScope` checks membership with
+    // `Object.hasOwn`, not `in`, so this must fall back to the raw scope name
+    // rather than resolving to `Object.prototype.constructor`.
+    mocks.getContext.mockResolvedValue(context({ scopes: ["openid", "constructor"] }));
+
+    renderPage();
+
+    expect(await screen.findByText("Confirm who you are")).toBeDefined();
+    expect(screen.getByText("constructor")).toBeDefined();
+  });
+
   it("posts an approval with the selected profile and assigns the redirect verbatim", async () => {
     const redirectTo = "https://app.example.com/cb?code=abc&state=xyz";
     mocks.getContext.mockResolvedValue(context());

--- a/osn/social/tests/components/AuthorizePage.test.tsx
+++ b/osn/social/tests/components/AuthorizePage.test.tsx
@@ -128,6 +128,10 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  // S-L2. The inherited-scope test below restores this in its own `finally`,
+  // which does not run if the test body is abandoned on a vitest timeout. This
+  // runs on every exit path, so one hang cannot pollute the rest of the file.
+  delete (Object.prototype as Record<string, unknown>).inheritedScope;
 });
 
 describe("<AuthorizePage />", () => {
@@ -170,7 +174,8 @@ describe("<AuthorizePage />", () => {
   });
 
   it("does not resolve a scope that is only an inherited Object property", async () => {
-    // S-L1. `isKnownScope` must test OWN membership: `in` walks the prototype
+    // S-L3 (`xchromo/osn-tracker#441`). `isKnownScope` must test OWN
+    // membership: `in` walks the prototype
     // chain, so an inherited entry would be read as real consent copy.
     //
     // A scope named after a stock Object.prototype key ("constructor") does not

--- a/osn/social/tests/components/AuthorizePage.test.tsx
+++ b/osn/social/tests/components/AuthorizePage.test.tsx
@@ -169,17 +169,39 @@ describe("<AuthorizePage />", () => {
     expect(mocks.getContext).toHaveBeenCalledWith(REQUEST_ID, withAbortSignal);
   });
 
-  it("does not resolve a scope named after an inherited Object property", async () => {
-    // "constructor" is not an own SCOPE_COPY entry — it is inherited from
-    // Object.prototype. `isKnownScope` checks membership with
-    // `Object.hasOwn`, not `in`, so this must fall back to the raw scope name
-    // rather than resolving to `Object.prototype.constructor`.
-    mocks.getContext.mockResolvedValue(context({ scopes: ["openid", "constructor"] }));
+  it("does not resolve a scope that is only an inherited Object property", async () => {
+    // S-L1. `isKnownScope` must test OWN membership: `in` walks the prototype
+    // chain, so an inherited entry would be read as real consent copy.
+    //
+    // A scope named after a stock Object.prototype key ("constructor") does not
+    // prove that — `scopeLabel` is `scopeCopy(scope)?.label ?? scope`, and no
+    // Object.prototype member carries a `label`, so both guards fall through to
+    // the raw name and the test passes either way. The difference only shows
+    // when the inherited value is shaped like a ScopeCopy, so put one there.
+    // Non-enumerable, so no `for...in` in the renderer can see it, and removed
+    // again in `finally`.
+    const proto = Object.prototype as Record<string, unknown>;
+    expect(Object.hasOwn(proto, "inheritedScope")).toBe(false);
+    Object.defineProperty(proto, "inheritedScope", {
+      value: { label: "Leaked copy", detail: "Leaked detail" },
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    try {
+      mocks.getContext.mockResolvedValue(context({ scopes: ["openid", "inheritedScope"] }));
 
-    renderPage();
+      renderPage();
 
-    expect(await screen.findByText("Confirm who you are")).toBeDefined();
-    expect(screen.getByText("constructor")).toBeDefined();
+      expect(await screen.findByText("Confirm who you are")).toBeDefined();
+      // With `in`, the page would render the inherited copy. With
+      // `Object.hasOwn`, an unknown scope shows as its raw name.
+      expect(screen.getByText("inheritedScope")).toBeDefined();
+      expect(screen.queryByText("Leaked copy")).toBeNull();
+      expect(screen.queryByText("Leaked detail")).toBeNull();
+    } finally {
+      delete proto.inheritedScope;
+    }
   });
 
   it("posts an approval with the selected profile and assigns the redirect verbatim", async () => {


### PR DESCRIPTION
## Summary

Three type guards in the OIDC provider narrowed a string to `keyof typeof MAP`
by testing `key in MAP`. `in` walks the prototype chain, so `constructor`,
`toString` and `__proto__` pass it, and the predicate then tells TypeScript
that an inherited `Object.prototype` member is a real map entry. All three now
test `Object.hasOwn(MAP, key)`.

- The three sites are the `/authorize` error-copy lookup
  (`osn/api/src/routes/auth/oidc.ts:96`), the confusable-fold table used to
  build a client-name skeleton (`osn/api/src/services/auth/oidc.ts:403`), and
  the consent-screen scope copy (`osn/social/src/pages/AuthorizePage.tsx:65`).
- Two tests come with it, one per package. Both plant a non-enumerable property
  on `Object.prototype` and assert the guard ignores it; both were run against
  the old `in` guards and fail there.
- `CLAUDE.md` gains one Conventions row stating the rule, because no lint rule
  catches this and the three sites drifted the same way independently.

## Workspaces affected

`@osn/api`, `@osn/social`. `.changeset/oidc-hasown-guards.md` names both at
`patch`; both are versioned workspaces and the changeset covers every workspace
this branch touches. `CLAUDE.md` is repo-root documentation and needs no bump.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#441 | `S-L3` |

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#491 | `S-I1` |
| xchromo/osn-tracker#492 | `T-U1` |
| xchromo/osn-tracker#493 | `T-S1`, `T-S2`, `T-S3` |

Closes xchromo/osn-tracker#441

## Decisions

### All three sites are hardening, not a reachable bug — `S-L3`

- **Issue** — the original commit message on `a8c52eed` says "Only
  AuthorizePage.tsx had real exposure (scope names come straight from the OAuth
  request)". That is wrong, and the security and performance reviews on this
  branch both say so.
- **Why** — a reviewer who believes it will read the scope-copy site as a live
  hole and the other two as filler, and will weigh the risk of merging by the
  wrong site. The truth is the reverse: no site is reachable today, and the
  sharpest of the three is the one the message calls incidental.
- **Solution** — leave the commit alone and correct it here. Site by site:
  `routes/auth/oidc.ts:96` takes `code` from a closed 12-member internal union
  (`services/auth/errors.ts:33`) or the literal `"rate_limited"`, never from
  the relying party. `services/auth/oidc.ts:403` is handed exactly one code
  point, and every own key on `Object.prototype` is seven characters or more,
  so no collision exists to hit. `AuthorizePage.tsx:65` reads scopes that
  `narrowScope` has already intersected against `client.allowedScopes`, and
  both read sites end in `?? fallback`, so a hit changes nothing a user sees.
- **Rationale** — the error-copy site is still the one worth fixing first,
  because it is the only one with no fallback and its `message` is
  interpolated into the page unescaped (only `code` is scrubbed). Today the
  guard is fed a closed union, so that is a property of the call sites, not of
  the function. The other two are defence in depth. The guards are one-line
  changes either way, so all three go together rather than waiting for one to
  become reachable.

### The rule goes in `CLAUDE.md`, not a new wiki page — `approach`

- **Issue** — the mistake has to be written down somewhere, or the next
  `keyof typeof` guard repeats it.
- **Why** — three sites drifted to `in` inside one pull request precisely
  because the rule was unwritten. oxlint has no rule for it.
- **Solution** — one row in the `CLAUDE.md` Conventions table, pointing at
  `cire/theme/src/palette.ts` as the house form.
- **Rationale** — no existing wiki page owns type-guard style, and this branch
  changes no wiki file. A new page for two sentences costs more to find than
  it saves. If a scan ever enforces the rule (tracker#493), the page can follow
  the scan.

### Nothing on this branch gets a file-then-close issue — `approach`

- **Issue** — the reviews raised four findings against work this branch itself
  introduced, all fixed in `7ba36eda` before the PR opened.
- **Why** — prep-pr routes findings to issues, and applied literally that
  would file four tracker issues and close them in the same breath.
- **Solution** — fix them in the branch, record them nowhere but here.
- **Rationale** — an issue tracks a defect that exists outside the branch it
  was found on. These never did.

**Out of scope**

- `osn/social/src/components/MobileNav.tsx:18` has the same `in` shape and is
  deliberately left as is — its key is `NAV_ITEMS.length`, a number, so no
  prototype key can reach it. Tracked by xchromo/osn-tracker#491.
- The `/authorize` error page has no test asserting the copy a stranded user
  reads. Tracked by xchromo/osn-tracker#492.
- Three polish items on the two new tests, none of them defects. Tracked by
  xchromo/osn-tracker#493.

## Test plan

| Gate | Result |
|---|---|
| `bun run check --filter @osn/api --filter @osn/social` | ✅ 2 successful |
| `bun run --cwd osn/api test:run` | ✅ 67 files, 1080 pass |
| `bun run --cwd osn/social test:run` | ✅ 18 files, 139 pass |
| `bun run fmt:check` | ✅ 1415 files |
| `bunx --bun oxlint` on the changed directories | ✅ |
| `scripts/validate-changesets.sh` | ✅ |

oxlint reports one warning in `osn/social/src/pages/SearchPage.tsx:25`. It is
pre-existing and unrelated to this branch.

Nothing here needs manual exercise: no behaviour changes for any input the
provider can currently receive, which is the whole claim of the first decision
above. Both new tests were checked against the pre-fix guards and fail there,
so they are real regression tests rather than assertions that pass either way.
