### PR TITLE
refactor(osn-client): share one bearer-token fetch helper across the REST clients

### DIFF
--- a/.changeset/client-shared-auth-fetch.md
+++ b/.changeset/client-shared-auth-fetch.md
@@ -1,0 +1,5 @@
+---
+"@osn/client": patch
+---
+
+Factor the duplicated bearer-token fetch helpers out of `graph.ts`, `organisations.ts` and `recommendations.ts` into one shared `auth-fetch.ts` module. No behaviour change.

--- a/osn/client/src/auth-fetch.ts
+++ b/osn/client/src/auth-fetch.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared bearer-token fetch helpers for this package's REST clients
+ * (`graph.ts`, `organisations.ts`, `recommendations.ts`). Each of those
+ * modules calls the OSN core REST API with `Authorization: Bearer <token>`
+ * and throws its own error class on failure — `createAuthFetchers` takes
+ * that error class as a parameter so one implementation can serve all
+ * three.
+ *
+ * This is deliberately plain `fetch`, not `sessionFetch` from
+ * `./session-fetch.ts`. `sessionFetch` is the seam for requests that carry
+ * the HttpOnly session cookie — the seam iOS replaces with a Keychain-backed
+ * transport, because a native app has no cookie jar. These three modules
+ * send an access token in the `Authorization` header instead of relying on
+ * a cookie, so there is no cookie for a native transport to supply, and
+ * routing them through `sessionFetch` would be routing them through a seam
+ * that has nothing to do with. Keep using plain `fetch` here.
+ */
+
+export interface AuthFetchOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Parse response body as JSON, returning null if the body isn't JSON.
+ * Prevents SyntaxError from surfacing to UI toasts (S-L2).
+ */
+export async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
+  try {
+    return (await res.json()) as T & { error?: string };
+  } catch {
+    return null;
+  }
+}
+
+/** Cap server-supplied error strings before surfacing to the UI (S-L2). */
+export function safeErrorMessage(value: unknown, status: number): string {
+  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
+  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+}
+
+export interface AuthFetchers {
+  authGet<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T>;
+  authPost<T>(url: string, token: string, body?: unknown): Promise<T>;
+  authPatch<T>(url: string, token: string, body: unknown): Promise<T>;
+  /** For endpoints that return a JSON body on success (e.g. `{ ok: true }`). */
+  authDelete<T>(url: string, token: string): Promise<T>;
+  /** For endpoints that return no body on success (e.g. 204). Only parses JSON on the error path. */
+  authDeleteVoid(url: string, token: string): Promise<void>;
+}
+
+/** Build the four `auth*` helpers, parameterised on the error class each caller throws. */
+export function createAuthFetchers(ErrorCtor: new (message: string) => Error): AuthFetchers {
+  async function authGet<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T> {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: options?.signal,
+    });
+    const json = await safeJson<T>(res);
+    if (!res.ok) {
+      throw new ErrorCtor(safeErrorMessage(json?.error, res.status));
+    }
+    if (json === null) {
+      throw new ErrorCtor(`Invalid response: ${res.status}`);
+    }
+    return json;
+  }
+
+  async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const json = await safeJson<T>(res);
+    if (!res.ok) {
+      throw new ErrorCtor(safeErrorMessage(json?.error, res.status));
+    }
+    if (json === null) {
+      throw new ErrorCtor(`Invalid response: ${res.status}`);
+    }
+    return json;
+  }
+
+  async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const json = await safeJson<T>(res);
+    if (!res.ok) {
+      throw new ErrorCtor(safeErrorMessage(json?.error, res.status));
+    }
+    if (json === null) {
+      throw new ErrorCtor(`Invalid response: ${res.status}`);
+    }
+    return json;
+  }
+
+  async function authDelete<T>(url: string, token: string): Promise<T> {
+    const res = await fetch(url, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const json = await safeJson<T>(res);
+    if (!res.ok) {
+      throw new ErrorCtor(safeErrorMessage(json?.error, res.status));
+    }
+    if (json === null) {
+      throw new ErrorCtor(`Invalid response: ${res.status}`);
+    }
+    return json;
+  }
+
+  async function authDeleteVoid(url: string, token: string): Promise<void> {
+    const res = await fetch(url, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const json = await safeJson<{ error?: string }>(res);
+      throw new ErrorCtor(safeErrorMessage(json?.error, res.status));
+    }
+  }
+
+  return { authGet, authPost, authPatch, authDelete, authDeleteVoid };
+}

--- a/osn/client/src/auth-fetch.ts
+++ b/osn/client/src/auth-fetch.ts
@@ -44,7 +44,8 @@ export interface AuthFetchers {
   authPatch<T>(url: string, token: string, body: unknown): Promise<T>;
   /** For endpoints that return a JSON body on success (e.g. `{ ok: true }`). */
   authDelete<T>(url: string, token: string): Promise<T>;
-  /** For endpoints that return no body on success (e.g. 204). Only parses JSON on the error path. */
+  /** For callers that want no body back. Parses JSON only on the error path, so a
+   * success response that is empty or unparseable still resolves. */
   authDeleteVoid(url: string, token: string): Promise<void>;
 }
 

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -4,6 +4,8 @@
  * Bearer token auth.
  */
 
+import { createAuthFetchers } from "./auth-fetch";
+
 export interface GraphClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
   issuerUrl: string;
@@ -51,90 +53,7 @@ export class GraphClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Parse response body as JSON, returning null if the body isn't JSON.
- * Prevents SyntaxError from surfacing to UI toasts (S-L2).
- */
-async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
-  try {
-    return (await res.json()) as T & { error?: string };
-  } catch {
-    return null;
-  }
-}
-
-/** Cap server-supplied error strings before surfacing to the UI (S-L2). */
-function safeErrorMessage(value: unknown, status: number): string {
-  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
-  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
-}
-
-async function authGet<T>(url: string, token: string): Promise<T> {
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new GraphClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new GraphClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
-  const res = await fetch(url, {
-    method: "PATCH",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new GraphClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authDelete<T>(url: string, token: string): Promise<T> {
-  const res = await fetch(url, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new GraphClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new GraphClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
+const { authGet, authPost, authPatch, authDelete } = createAuthFetchers(GraphClientError);
 
 // ---------------------------------------------------------------------------
 // Query string helper

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -53,7 +53,8 @@ export class GraphClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
-const { authGet, authPost, authPatch, authDelete } = createAuthFetchers(GraphClientError);
+const { authGet, authPost, authPatch, authDelete } =
+  /* @__PURE__ */ createAuthFetchers(GraphClientError);
 
 // ---------------------------------------------------------------------------
 // Query string helper

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -50,13 +50,6 @@ export class GraphClientError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Internal fetch helpers
-// ---------------------------------------------------------------------------
-
-const { authGet, authPost, authPatch, authDelete } =
-  /* @__PURE__ */ createAuthFetchers(GraphClientError);
-
-// ---------------------------------------------------------------------------
 // Query string helper
 // ---------------------------------------------------------------------------
 
@@ -101,6 +94,15 @@ export interface GraphClient {
 
 export function createGraphClient(config: GraphClientConfig): GraphClient {
   const base = `${config.issuerUrl.replace(/\/$/, "")}/graph`;
+  // Built here rather than at module scope on purpose. A top-level
+  // `createAuthFetchers(...)` is a call a bundler will not drop — a
+  // `/* @__PURE__ */` comment does not help, because neither esbuild nor
+  // rolldown removes a declarator whose binding is a destructuring pattern.
+  // That pinned this module into the entry chunk of every app that imports
+  // the barrel. Inside the factory there is no top-level statement left to
+  // keep. These deletes return a JSON body; `organisations.ts` uses the
+  // void-returning variant instead.
+  const { authGet, authPost, authPatch, authDelete } = createAuthFetchers(GraphClientError);
 
   return {
     listConnections: (token, options) =>

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -4,6 +4,8 @@
  * Bearer token auth.
  */
 
+import { createAuthFetchers } from "./auth-fetch";
+
 export interface OrgClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
   issuerUrl: string;
@@ -42,91 +44,12 @@ export class OrgClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
-/**
- * A failed response body. The API sends `{ error }` on every failure path and
- * this client reads nothing else off it.
- */
-interface ErrorResponseBody {
-  error?: string;
-}
+const { authGet, authPost, authPatch, authDeleteVoid } = createAuthFetchers(OrgClientError);
 
-/** Parse response body as JSON, returning null if the body isn't JSON (S-L2). */
-async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
-  try {
-    return (await res.json()) as T & { error?: string };
-  } catch {
-    return null;
-  }
-}
-
-/** Cap server-supplied error strings before surfacing to the UI (S-L2). */
-function safeErrorMessage(value: unknown, status: number): string {
-  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
-  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
-}
-
-async function authGet<T>(url: string, token: string): Promise<T> {
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new OrgClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new OrgClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
-  const res = await fetch(url, {
-    method: "PATCH",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-  const json = await safeJson<T>(res);
-  if (!res.ok) {
-    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
-  }
-  if (json === null) {
-    throw new OrgClientError(`Invalid response: ${res.status}`);
-  }
-  return json;
-}
-
-async function authDelete(url: string, token: string): Promise<void> {
-  const res = await fetch(url, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) {
-    const json = await safeJson<ErrorResponseBody>(res);
-    throw new OrgClientError(safeErrorMessage(json?.error, res.status));
-  }
-}
+// `deleteOrg`/`removeMember`'s endpoints return no body on success, so this
+// module uses the void-returning delete, unlike graph.ts's `{ ok: true }`
+// endpoints.
+const authDelete = authDeleteVoid;
 
 // ---------------------------------------------------------------------------
 // Query string helper

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -41,18 +41,6 @@ export class OrgClientError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Internal fetch helpers
-// ---------------------------------------------------------------------------
-
-const { authGet, authPost, authPatch, authDeleteVoid } =
-  /* @__PURE__ */ createAuthFetchers(OrgClientError);
-
-// `deleteOrg`/`removeMember`'s endpoints return no body on success, so this
-// module uses the void-returning delete, unlike graph.ts's `{ ok: true }`
-// endpoints.
-const authDelete = authDeleteVoid;
-
-// ---------------------------------------------------------------------------
 // Query string helper
 // ---------------------------------------------------------------------------
 
@@ -107,6 +95,17 @@ export interface OrgClient {
 
 export function createOrgClient(config: OrgClientConfig): OrgClient {
   const base = `${config.issuerUrl.replace(/\/$/, "")}/organisations`;
+  // Built here, not at module scope: a top-level `createAuthFetchers(...)` is
+  // a call no bundler will drop, which pinned this module into the entry
+  // chunk of every app importing the barrel. `/* @__PURE__ */` does not fix
+  // that on a destructuring declarator.
+  const { authGet, authPost, authPatch, authDeleteVoid } = createAuthFetchers(OrgClientError);
+  // `deleteOrg` and `removeMember` are declared `Promise<void>` on `OrgClient`
+  // and their callers use no body, so this module discards it. The routes do
+  // return `{ ok: true }` (see `osn/api/src/routes/organisation.ts`) — the
+  // void variant simply never reads it, which also means a success response
+  // that does not parse cannot throw.
+  const authDelete = authDeleteVoid;
 
   return {
     listMyOrgs: (token, options) =>

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -44,7 +44,8 @@ export class OrgClientError extends Error {
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
 
-const { authGet, authPost, authPatch, authDeleteVoid } = createAuthFetchers(OrgClientError);
+const { authGet, authPost, authPatch, authDeleteVoid } =
+  /* @__PURE__ */ createAuthFetchers(OrgClientError);
 
 // `deleteOrg`/`removeMember`'s endpoints return no body on success, so this
 // module uses the void-returning delete, unlike graph.ts's `{ ok: true }`

--- a/osn/client/src/recommendations.ts
+++ b/osn/client/src/recommendations.ts
@@ -54,7 +54,7 @@ export class RecommendationClientError extends Error {
   }
 }
 
-const { authGet } = createAuthFetchers(RecommendationClientError);
+const { authGet } = /* @__PURE__ */ createAuthFetchers(RecommendationClientError);
 
 export interface RecommendationClient {
   suggestConnections(
@@ -87,13 +87,13 @@ export function createRecommendationClient(
   const base = `${config.issuerUrl.replace(/\/$/, "")}/recommendations`;
 
   return {
-    suggestConnections: (token, options) => {
+    suggestConnections: async (token, options) => {
       const limit = options?.limit;
       const qs = limit !== undefined ? `?limit=${encodeURIComponent(String(limit))}` : "";
       return authGet<{ suggestions: Suggestion[] }>(`${base}/connections${qs}`, token);
     },
 
-    search: (token, query, options) => {
+    search: async (token, query, options) => {
       const params = new URLSearchParams({ q: query });
       if (options?.limit !== undefined) params.set("limit", String(options.limit));
       if (options?.orgLimit !== undefined) params.set("orgLimit", String(options.orgLimit));

--- a/osn/client/src/recommendations.ts
+++ b/osn/client/src/recommendations.ts
@@ -3,6 +3,8 @@
  * `./graph.ts` and `./organisations.ts`.
  */
 
+import { createAuthFetchers } from "./auth-fetch";
+
 export interface RecommendationClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
   issuerUrl: string;
@@ -52,18 +54,7 @@ export class RecommendationClientError extends Error {
   }
 }
 
-async function safeJson<T>(res: Response): Promise<(T & { error?: string }) | null> {
-  try {
-    return (await res.json()) as T & { error?: string };
-  } catch {
-    return null;
-  }
-}
-
-function safeErrorMessage(value: unknown, status: number): string {
-  if (typeof value !== "string" || value.length === 0) return `Request failed: ${status}`;
-  return value.length > 200 ? `${value.slice(0, 200)}…` : value;
-}
+const { authGet } = createAuthFetchers(RecommendationClientError);
 
 export interface RecommendationClient {
   suggestConnections(
@@ -96,38 +87,19 @@ export function createRecommendationClient(
   const base = `${config.issuerUrl.replace(/\/$/, "")}/recommendations`;
 
   return {
-    suggestConnections: async (token, options) => {
+    suggestConnections: (token, options) => {
       const limit = options?.limit;
       const qs = limit !== undefined ? `?limit=${encodeURIComponent(String(limit))}` : "";
-      const res = await fetch(`${base}/connections${qs}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const json = await safeJson<{ suggestions: Suggestion[] }>(res);
-      if (!res.ok) {
-        throw new RecommendationClientError(safeErrorMessage(json?.error, res.status));
-      }
-      if (json === null) {
-        throw new RecommendationClientError(`Invalid response: ${res.status}`);
-      }
-      return json;
+      return authGet<{ suggestions: Suggestion[] }>(`${base}/connections${qs}`, token);
     },
 
-    search: async (token, query, options) => {
+    search: (token, query, options) => {
       const params = new URLSearchParams({ q: query });
       if (options?.limit !== undefined) params.set("limit", String(options.limit));
       if (options?.orgLimit !== undefined) params.set("orgLimit", String(options.orgLimit));
-      const res = await fetch(`${base}/search?${params.toString()}`, {
-        headers: { Authorization: `Bearer ${token}` },
+      return authGet<SearchResults>(`${base}/search?${params.toString()}`, token, {
         signal: options?.signal,
       });
-      const json = await safeJson<SearchResults>(res);
-      if (!res.ok) {
-        throw new RecommendationClientError(safeErrorMessage(json?.error, res.status));
-      }
-      if (json === null) {
-        throw new RecommendationClientError(`Invalid response: ${res.status}`);
-      }
-      return json;
     },
   };
 }

--- a/osn/client/src/recommendations.ts
+++ b/osn/client/src/recommendations.ts
@@ -54,8 +54,6 @@ export class RecommendationClientError extends Error {
   }
 }
 
-const { authGet } = /* @__PURE__ */ createAuthFetchers(RecommendationClientError);
-
 export interface RecommendationClient {
   suggestConnections(
     token: string,
@@ -85,6 +83,11 @@ export function createRecommendationClient(
   config: RecommendationClientConfig,
 ): RecommendationClient {
   const base = `${config.issuerUrl.replace(/\/$/, "")}/recommendations`;
+  // Built here, not at module scope: a top-level `createAuthFetchers(...)` is
+  // a call no bundler will drop, which pinned this module into the entry
+  // chunk of every app importing the barrel. `/* @__PURE__ */` does not fix
+  // that on a destructuring declarator.
+  const { authGet } = createAuthFetchers(RecommendationClientError);
 
   return {
     suggestConnections: async (token, options) => {

--- a/osn/client/tests/graph.test.ts
+++ b/osn/client/tests/graph.test.ts
@@ -110,10 +110,12 @@ describe("createGraphClient — connection mutations", () => {
     });
   });
 
-  it("removeConnection DELETEs /graph/connections/:handle", async () => {
+  it("removeConnection DELETEs /graph/connections/:handle and returns the body", async () => {
     mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
-    await client.removeConnection(TOKEN, "alice");
+    const result = await client.removeConnection(TOKEN, "alice");
     expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+    // graph's deletes return a JSON body, unlike organisations' 204 deletes.
+    expect(result).toEqual({ ok: true });
   });
 
   it("URL-encodes handles with special chars", async () => {
@@ -130,10 +132,11 @@ describe("createGraphClient — blocks", () => {
     expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/blocks/alice`);
   });
 
-  it("unblockProfile DELETEs /graph/blocks/:handle", async () => {
+  it("unblockProfile DELETEs /graph/blocks/:handle and returns the body", async () => {
     mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
-    await client.unblockProfile(TOKEN, "alice");
+    const result = await client.unblockProfile(TOKEN, "alice");
     expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+    expect(result).toEqual({ ok: true });
   });
 });
 
@@ -186,6 +189,15 @@ describe("createGraphClient — error surface", () => {
     const long = "x".repeat(500);
     mockFetch({ ok: false, json: () => Promise.resolve({ error: long }) });
     await expect(client.sendConnectionRequest(TOKEN, "alice")).rejects.toThrow(/^x{200}…$/);
+  });
+
+  it("throws GraphClientError on non-2xx PATCH and DELETE", async () => {
+    // Each verb closes over the caller's own error class, so assert the class
+    // per verb rather than trusting the message alone.
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
+    await expect(client.acceptConnection(TOKEN, "alice")).rejects.toBeInstanceOf(GraphClientError);
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
+    await expect(client.removeConnection(TOKEN, "alice")).rejects.toBeInstanceOf(GraphClientError);
   });
 });
 

--- a/osn/client/tests/organisations.test.ts
+++ b/osn/client/tests/organisations.test.ts
@@ -71,6 +71,13 @@ describe("createOrgClient — mutations", () => {
     expect(result).toBeUndefined();
     expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
   });
+
+  it("deleteOrg never reads the body of a real 204", async () => {
+    // The endpoint returns 204 with no body, so res.json() rejects. The void
+    // delete must not touch it on the success path.
+    mockFetch({ ok: true, status: 204, json: () => Promise.reject(new SyntaxError("no body")) });
+    await expect(client.deleteOrg(TOKEN, "org_1")).resolves.toBeUndefined();
+  });
 });
 
 describe("createOrgClient — member mutations", () => {
@@ -95,6 +102,11 @@ describe("createOrgClient — member mutations", () => {
     expect((call[1] as RequestInit).method).toBe("DELETE");
   });
 
+  it("removeMember never reads the body of a real 204", async () => {
+    mockFetch({ ok: true, status: 204, json: () => Promise.reject(new SyntaxError("no body")) });
+    await expect(client.removeMember(TOKEN, "org_1", "usr_1")).resolves.toBeUndefined();
+  });
+
   it("updateMemberRole PATCHes with {role} and resolves to undefined", async () => {
     mockFetch({ ok: true, json: () => Promise.resolve({}) });
     const result = await client.updateMemberRole(TOKEN, "org_1", "usr_1", "member");
@@ -114,7 +126,18 @@ describe("createOrgClient — error surface", () => {
 
   it("throws OrgClientError on non-2xx DELETE (reads error body)", async () => {
     mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
+    await expect(client.deleteOrg(TOKEN, "org_1")).rejects.toBeInstanceOf(OrgClientError);
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
     await expect(client.deleteOrg(TOKEN, "org_1")).rejects.toThrow("Forbidden");
+  });
+
+  it("throws OrgClientError on non-2xx PATCH", async () => {
+    // Each verb closes over the caller's own error class, so assert the class
+    // per verb rather than trusting the message alone.
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "Forbidden" }) });
+    await expect(client.updateOrg(TOKEN, "org_1", { name: "X" })).rejects.toBeInstanceOf(
+      OrgClientError,
+    );
   });
 
   it("falls back to a generic message when the server omits one", async () => {

--- a/osn/client/tests/organisations.test.ts
+++ b/osn/client/tests/organisations.test.ts
@@ -72,9 +72,10 @@ describe("createOrgClient — mutations", () => {
     expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
   });
 
-  it("deleteOrg never reads the body of a real 204", async () => {
-    // The endpoint returns 204 with no body, so res.json() rejects. The void
-    // delete must not touch it on the success path.
+  it("deleteOrg resolves even when the success body does not parse", async () => {
+    // The void delete must not read the body on the success path, so an
+    // unparseable one cannot make a successful delete throw. Driven with a
+    // rejecting json() to prove the success path never calls it.
     mockFetch({ ok: true, status: 204, json: () => Promise.reject(new SyntaxError("no body")) });
     await expect(client.deleteOrg(TOKEN, "org_1")).resolves.toBeUndefined();
   });
@@ -102,7 +103,7 @@ describe("createOrgClient — member mutations", () => {
     expect((call[1] as RequestInit).method).toBe("DELETE");
   });
 
-  it("removeMember never reads the body of a real 204", async () => {
+  it("removeMember resolves even when the success body does not parse", async () => {
     mockFetch({ ok: true, status: 204, json: () => Promise.reject(new SyntaxError("no body")) });
     await expect(client.removeMember(TOKEN, "org_1", "usr_1")).resolves.toBeUndefined();
   });

--- a/wiki/apps/social.md
+++ b/wiki/apps/social.md
@@ -16,7 +16,7 @@ related:
   - "[[identity-model]]"
   - "[[passkey-primary]]"
   - "[[rate-limiting]]"
-last-reviewed: 2026-08-06
+last-reviewed: 2026-08-24
 ---
 
 # Social
@@ -73,7 +73,7 @@ Pages talk to `@osn/api` via three plain-fetch clients factored out of `@osn/cli
 - `createOrgClient` — org CRUD and membership (`osn/client/src/organisations.ts`)
 - `createRecommendationClient` — contact suggestions + search (`osn/client/src/recommendations.ts`). `search` returns people and organisations together and takes an `AbortSignal` because it backs typeahead: the caller aborts the in-flight request when the query changes, so a slow early keystroke can't land after a fast later one.
 
-All three share the same hardening: `authGet/authPost/authPatch/authDelete` with `safeJson` wrapping (no `SyntaxError` leakage), capped error strings, and per-module typed error classes. These helpers are duplicated per module; factoring them out is tracked as P-I1.
+All three share the same hardening: `authGet/authPost/authPatch/authDelete` with `safeJson` wrapping (no `SyntaxError` leakage), capped error strings, and per-module typed error classes. The helpers now live once in `osn/client/src/auth-fetch.ts`; each module calls `createAuthFetchers(ErrorCtor)` and gets back the set bound to its own error class. The module is internal — `index.ts` does not export it, so the package's public surface is unchanged. It uses plain `fetch`, not `sessionFetch`: these clients send a bearer token in the `Authorization` header, so there is no session cookie for the native transport seam to supply.
 
 ## Dev
 

--- a/wiki/apps/social.md
+++ b/wiki/apps/social.md
@@ -75,6 +75,10 @@ Pages talk to `@osn/api` via three plain-fetch clients factored out of `@osn/cli
 
 All three share the same hardening: `authGet/authPost/authPatch/authDelete` with `safeJson` wrapping (no `SyntaxError` leakage), capped error strings, and per-module typed error classes. The helpers now live once in `osn/client/src/auth-fetch.ts`; each module calls `createAuthFetchers(ErrorCtor)` and gets back the set bound to its own error class. The module is internal — `index.ts` does not export it, so the package's public surface is unchanged. It uses plain `fetch`, not `sessionFetch`: these clients send a bearer token in the `Authorization` header, so there is no session cookie for the native transport seam to supply.
 
+Each client calls `createAuthFetchers` **inside** its `create*Client` factory, not at module scope. This is load-bearing for bundle size, not style. A top-level call is a statement a bundler cannot drop, so it pinned all three modules into the entry chunk of every app importing the barrel — `osn/social` paid about 0.9 KB gzipped on first paint. A `/* @__PURE__ */` annotation does **not** rescue it: neither esbuild nor rolldown will remove a declarator whose binding is a destructuring pattern. Keep the call inside the factory.
+
+The two delete shapes are deliberately different and must not be merged. `graph.ts` uses `authDelete`, which parses and returns the JSON body; `organisations.ts` uses `authDeleteVoid`, which reads the body only on the error path. Both sets of routes answer `200` with `{ ok: true }` — the difference is that `OrgClient` declares `deleteOrg` and `removeMember` as `Promise<void>`, so that client discards the body rather than there being no body to read.
+
 ## Dev
 
 ```bash


### PR DESCRIPTION
## Summary

`graph.ts`, `organisations.ts` and `recommendations.ts` in `@osn/client` each
carried their own copy of the same four bearer-token fetch helpers, plus the
`safeJson` and `safeErrorMessage` hardening from S-L2. This branch moves that
one implementation into `osn/client/src/auth-fetch.ts` and hands each client
its own error class through `createAuthFetchers(ErrorCtor)`. No call site
changes and no behaviour changes.

- The module is package-private. `osn/client/src/index.ts` does not export it,
  so the package's public surface is the same as before.
- It uses plain `fetch`, not `sessionFetch`. These three clients send an access
  token in the `Authorization` header and carry no session cookie, so there is
  nothing for the native transport seam to supply. The header docblock says so,
  to stop a later reader "fixing" it.
- Two delete shapes survive the merge and must not be collapsed into one:
  `graph.ts` uses `authDelete`, which parses and returns the JSON body;
  `organisations.ts` uses `authDeleteVoid`, which reads the body only on the
  error path.
- One regression the branch introduced along the way is fixed here rather than
  shipped — see Decisions.

## Workspaces affected

`@osn/client`. `.changeset/client-shared-auth-fetch.md` names `"@osn/client"` at
`patch`, which matches the workspace `name` field exactly and is the only
versioned package this branch touches. The wiki edit needs no changeset of its
own.

`@osn/social` is the only consumer and needs no source change:
`osn/social/src/lib/api.ts` calls the three factories, whose signatures are
unchanged.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#348 | `P-I1` |

Closes xchromo/osn-tracker#348

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#505 | `T-M1` / `T-U1` / `T-U2` / `T-U3` / `T-S1` / `T-S2` / `T-S3` |
| xchromo/osn-tracker#506 | `P-I2` |
| xchromo/osn-tracker#525 | `P-I` |
| xchromo/osn-tracker#526 | `P-I` |

## Decisions

### Build the fetchers inside each client factory, not at module scope — `P-W1`

- **Issue** — the second commit on this branch (`a10dd412`) moved
  `createAuthFetchers(...)` to module scope behind a `/* @__PURE__ */`
  annotation and stated in its message that the bundle came out byte for byte
  the same. It did not. Measured on a consumer that imports the barrel and uses
  none of the three clients (esbuild, minified, dependencies external):
  `origin/main` 1610 B, that commit 3363 B.
- **Why** — neither esbuild nor rolldown will drop a declarator whose binding is
  a destructuring pattern, annotation or not. So `const { authGet, ... } =
  createAuthFetchers(X)` at module scope is a statement the bundler must keep,
  and keeping it pins all three REST clients into the entry chunk of every app
  that imports the barrel. `@osn/social` paid about 0.9 KB gzipped on first
  paint for code most of its pages never call.
- **Solution** — the call now sits inside each `create*Client` factory, one line
  after `const base = ...`, with a comment in each of the three files saying why
  it must stay there. Same measurement after the fix: 1610 B, identical to
  `origin/main`, with the client route strings gone from the output.
- **Rationale** — it costs nothing, because every use of the helpers was already
  inside those factories; no call site moved. Two alternatives were tested and
  rejected. Holding the returned object and reaching through it by property
  (`fetchers.authGet(...)`) also tree-shakes, but touches every call site for no
  further gain. Leaving it at module scope and adding a bundler config exception
  puts the fix in the consumer rather than the package, so the next consumer
  inherits the problem. A class declaration is not hoisted-initialised, so the
  call also has to follow the error class it is given — inside the factory it
  does, unconditionally.

### The organisations delete endpoints are not 204 — `approach`

- **Issue** — the branch's comment in `organisations.ts` said those endpoints
  "return no body on success … unlike graph.ts's `{ ok: true }` endpoints", and
  two tests repeated it in their titles, describing "a real 204".
- **Why** — it is false. `osn/api/src/routes/organisation.ts` returns
  `{ ok: true }` at line 332 (`deleteOrg`) and line 423 (`removeMember`), both
  declared `200: okResponse` at lines 341 and 432. The graph deletes do exactly
  the same. A false comment about API behaviour is worse than none: the next
  person changing those routes reads it as a contract.
- **Solution** — reworded the comment, the `authDeleteVoid` doc comment, the two
  test titles and the wiki paragraph to say what is actually true. The real
  reason `organisations.ts` uses the void variant is that `OrgClient` declares
  `deleteOrg` (line 75) and `removeMember` (line 87) as `Promise<void>`, so the
  caller has no typed body to read whatever the server sends.
- **Rationale** — labels only. The assertions were correct and are unchanged, and
  neither the client's behaviour nor the API routes were touched. The tests do
  still drive a rejecting `json()` on the success path, which is the right thing
  to assert — it proves the void variant never reads the body — so only the name
  needed to stop claiming a 204 arrives.

### Correct the blast radius in the record, not in history — `approach`

- **Issue** — `a10dd412`'s message names `pulse/web` and `tools/lab` as affected
  packages. Neither reaches `@osn/client`; both import `@osn/ui/ui/*` and
  `@osn/ui/lib/utils` only. The real consumer is `osn/social`.
- **Why** — a reviewer trusting that message would look for a Pulse regression
  that cannot exist, and would miss the one place the bundle actually grew.
- **Solution** — the correction is stated in the new commit's message and here,
  and the wiki now names `osn/social`.
- **Rationale** — rewriting a pushed commit to fix prose costs every reviewer
  their place in the diff for no gain. The record is corrected where people read
  it.

### Flat `src/`, not `src/lib/` — `approach`

- **Issue** — tracker#348 suggested `src/lib/auth-fetch.ts`.
- **Why** — `osn/client/src/` is flat and has no `lib/` directory.
- **Solution** — the module is at `osn/client/src/auth-fetch.ts`.
- **Rationale** — matching the layout that exists beats matching a path written
  before anyone looked.

**Out of scope** — `@osn/client` declares no `"sideEffects"` field, so a bundler
must assume every module in it may have one; tracked as xchromo/osn-tracker#506
(`P-I2`), left out because it changes how every consumer bundles the package and
wants its own before/after measurement. The new module has no test file of its
own and the bearer header is asserted on GETs only; tracked as
xchromo/osn-tracker#505 (`T-M1` and the `T-U`/`T-S` series), left out because
this branch is a refactor with no behaviour change, and adding the missing
coverage is a change of its own worth reviewing separately. The `qs()` pagination helper is
still duplicated byte for byte in `graph.ts` and `organisations.ts`; tracked as
xchromo/osn-tracker#525, left out because tracker#348 named the fetch helpers
only and the second move wants its own diff. The four write verbs take no
`AbortSignal`, though the GET does; tracked as xchromo/osn-tracker#526, left
out because widening them is a behaviour change and this branch claims none.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 34/34 tasks |
| `bun run test` | ✅ 37/37 tasks |
| `bun run --cwd osn/client test:run` | ✅ 20 files, 198 tests |
| `scripts/validate-changesets.sh` | ✅ |
| lefthook pre-commit (oxlint + oxfmt) | ✅ |
| Wikilink resolution in `wiki/apps/social.md` | ✅ all resolve |

The test count is unchanged from `origin/main` — 198 before, 198 after — which
is the point: this is a refactor, and the two renamed tests kept their
assertions.

Checked by hand, because no gate covers it:

- **Behaviour preservation, call site by call site.** Every one of the three
  clients' call sites is byte-identical to `origin/main`; the diff touches only
  the helper block and one import per file. Argument order is `(url, token,
  body?)` everywhere, unchanged. Each client still throws its own error class.
  The `safeJson` and `safeErrorMessage` capping is intact on every path,
  including the error path of the void DELETE.
- **`credentials: "include"`.** No regression. None of these three modules ever
  set it, on either side of the diff, and none should: they authenticate with a
  bearer token and carry no session cookie, so the cross-origin `Set-Cookie`
  trap does not apply to them. The modules that do depend on it — `service.ts`
  and `session-fetch.ts` — are not touched by this branch.
- **The 401 silent-refresh path.** Not in these modules before or after. It
  lives in `OsnAuthService.authFetch`, which this branch does not touch.
- **Bundle size.** Measured with esbuild on a synthetic barrel importer, as set
  out under `P-W1` above. Not covered by any CI gate.

Not verified: nothing here was exercised against a running API. The change is
a code move within one package, and the three clients' request shapes are
unchanged, so the existing route tests in `@osn/api` still describe the same
contract.

