### PR TITLE
test: cover the email-change UNIQUE conflict and expired-bearer 401s

### DIFF
--- a/.changeset/expired-token-and-unique-branch-tests.md
+++ b/.changeset/expired-token-and-unique-branch-tests.md
@@ -1,0 +1,9 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+"@zap/api": patch
+---
+
+Add missing test coverage: the UNIQUE-constraint conflict branch in
+`completeEmailChange`, and route-level 401 coverage for an expired bearer
+access token on a protected Pulse and Zap route.

--- a/osn/api/tests/services/email-change.test.ts
+++ b/osn/api/tests/services/email-change.test.ts
@@ -140,9 +140,52 @@ describe("beginEmailChange + completeEmailChange", () => {
 
       const result = yield* auth.beginEmailChange(profile.accountId, "ec-target@example.com");
       expect(result.sent).toBe(true);
-      // The complete step would still reject the collision via UNIQUE(email),
-      // so the protection is where it matters — on the write.
+      // The complete step still rejects the collision via UNIQUE(email) —
+      // see the next test, which drives a real write-time conflict through it.
       void stepUpToken;
+    }).pipe(Effect.provide(layer));
+  });
+
+  // O3/S-H2 write-time guard: the begin-time collision check only sees
+  // accounts as they stand *right then*. Account B can grab the target
+  // address (via its own, independent change) in the gap between account
+  // A's begin (collision check passes — nobody holds it yet) and A's
+  // complete. At that point the write hits UNIQUE(email) for real, and
+  // the catch in `completeEmailChange` must turn that into the same
+  // generic AuthError the OTP-mismatch path returns — never a raw
+  // DatabaseError, and never a hint that the address is taken.
+  it.effect("rejects at complete time when another account wins the email in the meantime", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const a = yield* setup("ec-race-a@example.com", "ecracea", captured);
+      const b = yield* setup("ec-race-b@example.com", "ecraceb", captured);
+
+      const target = "ec-race-target@example.com";
+
+      // A begins first — target is free, so the collision check passes
+      // and a pending change is stored.
+      yield* a.auth.beginEmailChange(a.profile.accountId, target);
+      const codeA = captured.latest()!;
+
+      // B independently begins AND completes a change to the same
+      // address before A completes — same target is still free from
+      // B's point of view too.
+      yield* b.auth.beginEmailChange(b.profile.accountId, target);
+      const codeB = captured.latest()!;
+      const bResult = yield* b.auth.completeEmailChange(
+        b.profile.accountId,
+        codeB,
+        b.stepUpToken,
+        null,
+      );
+      expect(bResult.email).toBe(target);
+
+      // A's write now collides for real: B already owns `target`.
+      const err = yield* Effect.flip(
+        a.auth.completeEmailChange(a.profile.accountId, codeA, a.stepUpToken, null),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/invalid or expired code/i);
     }).pipe(Effect.provide(layer));
   });
 

--- a/pulse/api/tests/routes/account.test.ts
+++ b/pulse/api/tests/routes/account.test.ts
@@ -50,6 +50,20 @@ describe("account routes — auth gates", () => {
     expect(res.status).toBe(401);
   });
 
+  it("GET /account/deletion-status returns 401 with an expired bearer token", async () => {
+    // Route-level coverage: an access token that verifies structurally but
+    // is past `exp` must be rejected at the route, not just at the
+    // `resolveCaller` lib layer (see caller.test.ts). Distinct from a
+    // stale *cookie session* — this is a bearer token, no cookie involved.
+    const expired = await signer.sign("usr_expired", { expiresIn: "-120s" });
+    const res = await makeApp().handle(
+      new Request("http://localhost/account/deletion-status", {
+        headers: { authorization: `Bearer ${expired}` },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it("DELETE /account returns 403 without a step-up token", async () => {
     const token = await makeToken("usr_gate");
     const res = await makeApp().handle(

--- a/zap/api/tests/routes/chats.test.ts
+++ b/zap/api/tests/routes/chats.test.ts
@@ -120,6 +120,17 @@ describe("chats routes", () => {
     expect(res.status).toBe(401);
   });
 
+  it("GET /chats returns 401 for an expired bearer token", async () => {
+    // Route-level coverage: a token that verifies (right key, right
+    // audience, right sub prefix) but is past `exp` must still be
+    // rejected — the neighbouring cases here cover a wrong key,
+    // wrong alg, and wrong/missing audience, but none of them exercise
+    // expiry specifically.
+    const expired = await signer.sign("usr_alice", { expiresIn: "-120s" });
+    const res = await req(app, "GET", "/chats", { token: expired });
+    expect(res.status).toBe(401);
+  });
+
   it("GET /chats returns 401 for a verified token whose sub is not a usr_ id (Z2)", async () => {
     const orgToken = await makeToken("org_evil");
     const res = await req(app, "GET", "/chats", { token: orgToken });


### PR DESCRIPTION
## Summary

Two branches that the suites asserted nothing about now have tests. `completeEmailChange`
guards the email swap with `UNIQUE(email)` on the write rather than with a transaction, but
no test ever drove that guard — the collision test stopped at `beginEmailChange` and left a
comment where the coverage should have been. And expired access tokens were only rejected
under test at the `resolveCaller` lib layer in Pulse, with nothing at all in Zap, so neither
route surface pinned expiry end to end.

- The osn test stages a real race: account A begins a change to a free address, account B
  begins and completes its own change to the same address, then A completes and its write
  loses to the constraint. The error it asserts is the generic one, which is the posture the
  begin path already keeps — no hint the address is taken.
- The Pulse and Zap cases each send a token that is correctly signed, correctly addressed and
  correctly subjected, differing from a working token only in `exp`.

## Workspaces affected

`@osn/api`, `@pulse/api`, `@zap/api`. `.changeset/expired-token-and-unique-branch-tests.md`
names all three at `patch`; every name matches the `name` field in that workspace's
`package.json`, and `scripts/validate-changesets.sh` passes. No version-less package is mixed
in. No wiki page needs an edit: `wiki/conventions/testing-patterns.md:139` already documents
`makeAccessTokenSigner`'s `expiresIn` claim for negative tests, and the branch introduces no
new pattern.

## Issues

**Closes**

| Issue | What |
|---|---|
| #645 | T-E1 — unit test for `completeEmailChange`'s UNIQUE-conflict catch branch |
| #646 | T-E2 — expired-token 401 coverage for the pulse and zap route suites |

Closes #645
Closes #646

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#507 | `S-M1` |
| xchromo/osn-tracker#508 | `S-L2` |
| xchromo/osn-tracker#509 | `S-L3` |
| xchromo/osn-tracker#511 | `S-L1` / `T-S1` / `T-S2` |
| xchromo/osn-tracker#512 | `T-E3` / `T-E4` |
| xchromo/osn-tracker#513 | `T-R2` |
| xchromo/osn-tracker#514 | `P-I4` / `P-I5` |
| xchromo/osn-tracker#515 | `P-I6` |

## Decisions

### Each new test was checked by breaking the thing it pins — `approach`

- **Issue** — a coverage PR fails quietly when a test passes for the wrong reason. An
  expired-token case that really rejects a malformed or wrong-audience token would look
  identical in CI, and a conflict case fed a hand-thrown error would too.
- **Why** — these three tests are the only evidence for two security properties, so a false
  green here is worse than the gap it replaced.
- **Solution** — mutation checks against the production line under each test. Raising
  `CLOCK_TOLERANCE_SECONDS` in `shared/osn-auth-client/src/verify.ts:62` from 30 to 86400
  makes both route cases fail and leaves every neighbouring 401 case passing, so expiry is
  the only variable. Changing the conflict classifier at
  `osn/api/src/services/auth/email-change.ts:266` to a pattern that never matches makes
  exactly one test fail — the new one — so a real `UNIQUE constraint failed` from bun:sqlite
  is reaching the catch. Both edits were reverted; the tree is at `bc082746` unchanged.
- **Rationale** — the constraint is the live one: `osn/db/src/schema/index.ts:10` declares
  `.unique()` and `applySchema` builds the in-memory DB from that same Drizzle schema, so
  nothing about the violation is staged.

### Findings left for follow-up rather than fixed here — `approach`

- **Issue** — the reviews turned up eight findings. All but one sit in production code or in
  test files this branch does not touch.
- **Why** — this branch is test-only and its changeset is three patches. Pulling a verifier
  change or a classifier change into it would widen the blast radius past what the gates here
  cover.
- **Solution** — filed every finding to the private tracker and changed nothing on the
  branch.
- **Rationale** — `S-M1` (#507) is the one worth reading first: it is adjacent to this
  branch's subject rather than part of it. The verifier enforces `exp` only when the claim is
  present, so these tests prove expiry is honoured without proving it is required.

**Out of scope** — `S-M1` no `requiredClaims: ["exp"]` on the access-token verifiers
(xchromo/osn-tracker#507). `S-L2` the conflict classifier also matches `NOT NULL` and
`FOREIGN KEY` failures (#508). `S-L3` cire's token helper drops its claims argument, so the
deployed API cannot get an expired-bearer case (#509). `S-L1`/`T-S1`/`T-S2` the new conflict
test asserts a string three branches share and checks no residue (#511). `T-E3`/`T-E4` the
ceremony's other rejection branches, including the per-account begin cap (#512). `T-R2` no
`/account` route test uses the cookie credential (#513). `P-I4`/`P-I5` a doomed pending
change survives the conflict, and preflight over-selects (#514). `P-I6` the pulse auth-gate
cases each build an in-memory DB they never read (#515).

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run test` | ✅ |
| `bun run --cwd osn/api test:run` | ✅ 1080 pass |
| `bun run --cwd pulse/api test:run` | ✅ 635 pass |
| `bun run --cwd zap/api test:run` | ✅ 131 pass |
| mutation: clock tolerance 30 → 86400 | ✅ both route cases fail, neighbours pass |
| mutation: UNIQUE classifier never matches | ✅ only the new osn case fails |

Nothing here needs manual exercise — the diff is three test files and a changeset, and it
adds no route, migration or config. Two honest negatives. The Pulse case uses sub
`usr_expired`, which has no same-sub positive control in the file; it is still attributable
to expiry, because `GET /account/deletion-status` answers 200 for any unseeded `usr_` sub
(the `usr_status` case at `pulse/api/tests/routes/account.test.ts:82`), and the mutation
check confirms it. And the conflict test's assertions alone cannot tell the write-time branch
from the two early returns that share its error string — the mutation check is what
establishes it today, which is why #511 asks for durable-state assertions to make that
structural.
