### PR TITLE
fix(auth): require an exp claim when verifying access and step-up tokens

### DIFF
--- a/.changeset/require-exp-claim.md
+++ b/.changeset/require-exp-claim.md
@@ -1,0 +1,10 @@
+---
+"@shared/osn-auth-client": patch
+"@osn/api": patch
+---
+
+Require an `exp` claim when verifying an access or step-up token. `jose`
+validates expiry only when the claim is present, so a token minted without one
+verified for as long as the signing key lived — no expiry, and neither verifier
+looks at token age by any other route. The issuer always sets `exp` (5 minutes
+for access tokens), so requiring it rejects nothing that was ever meant to work.

--- a/osn/api/src/services/auth/helpers.ts
+++ b/osn/api/src/services/auth/helpers.ts
@@ -182,6 +182,12 @@ export async function verifyJwt(
     algorithms: ["ES256"],
     issuer,
     clockTolerance: 30,
+    // jose only checks `exp` when the claim is present, so a token minted
+    // without one never expires. Every token this verifier is meant to accept
+    // carries an `exp` — the 5-minute access token and the step-up token both
+    // set it — so requiring it costs nothing and closes the case where a
+    // signing key is used to mint one that does not.
+    requiredClaims: ["exp"],
   });
   return payload;
 }

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -824,6 +824,26 @@ describe("verifyAccessToken", () => {
       expect(error.message).toContain("Invalid token claims");
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  // jose checks `exp` only when the claim is present, so a token minted
+  // without one would authenticate for as long as the signing key lives —
+  // no expiry, and nothing else in the verifier looks at token age.
+  // `requiredClaims: ["exp"]` is what makes this a rejection.
+  it.effect("rejects a token with no exp claim", () =>
+    Effect.gen(function* () {
+      const { SignJWT } = yield* Effect.tryPromise(() => import("jose"));
+      const everlasting = yield* Effect.tryPromise(() =>
+        new SignJWT({ sub: "usr_forged00000", email: "x@x.com", handle: "x", aud: "osn-access" })
+          .setProtectedHeader({ alg: "ES256", kid: config.jwtKid })
+          .setIssuedAt()
+          .setIssuer(config.issuerUrl)
+          .sign(config.jwtPrivateKey),
+      );
+      const error = yield* Effect.flip(auth.verifyAccessToken(everlasting));
+      expect(error._tag).toBe("AuthError");
+      expect(error.message).toContain("Invalid or expired access token");
+    }).pipe(Effect.provide(createTestLayer())),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/shared/osn-auth-client/src/verify.ts
+++ b/shared/osn-auth-client/src/verify.ts
@@ -87,6 +87,12 @@ async function verifyTokenWithKey(
       algorithms: ["ES256"],
       audience,
       clockTolerance: CLOCK_TOLERANCE_SECONDS,
+      // jose enforces `exp` only when the claim is there, so an access token
+      // minted without one would verify for as long as the signing key lives.
+      // The issuer always sets it (5-minute TTL), which makes requiring it
+      // free here and turns a missing `exp` into a terminal failure rather
+      // than a token that never ages out.
+      requiredClaims: ["exp"],
     };
     // Unset issuer ⇒ omit the option ⇒ jose does not enforce `iss` (X2).
     if (issuer) verifyOptions.issuer = issuer;

--- a/shared/osn-auth-client/tests/verify.test.ts
+++ b/shared/osn-auth-client/tests/verify.test.ts
@@ -93,6 +93,22 @@ describe("extractClaims", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null for a token with no exp claim", async () => {
+    // jose validates `exp` only when it is present, so without
+    // `requiredClaims` this token would verify forever. The issuer never mints
+    // one — which is exactly why nothing else would catch it.
+    const token = await new SignJWT({ email: "alice@example.com", handle: "alice" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setSubject("usr_alice")
+      .setIssuedAt()
+      .sign(signKey);
+
+    const result = await extractClaims(`Bearer ${token}`, "http://test/.well-known/jwks.json", {
+      testKey: verifyKey,
+    });
+    expect(result).toBeNull();
+  });
+
   it("does not export DEFAULT_JWKS_URL (env reads stay app-side)", () => {
     expect("DEFAULT_JWKS_URL" in verifyModule).toBe(false);
   });


### PR DESCRIPTION
Fixes a finding in the private tracker (S-M1): the access-token verifier accepts a token with no `exp` claim.

## The problem

`jose` validates expiry **only when `exp` is present**. Neither of the repo's two verifiers asked for it:

- `shared/osn-auth-client/src/verify.ts:86` built its `JWTVerifyOptions` from `algorithms`, `audience` and `clockTolerance`.
- `osn/api/src/services/auth/helpers.ts:181` (`verifyJwt`, used by both `verifyAccessToken` and the step-up gate) passed `algorithms`, `issuer` and `clockTolerance`.

Neither looks at token age by any other route — `verifyAccessToken` checks `aud`, `sub`, `email` and `handle` and then trusts the library. So a token signed with the issuer's key but minted without an `exp` authenticated for as long as that key lived. `shared/crypto/src/arc.ts:122` already gets this right, passing `requiredClaims: ["exp", "iat", "iss", "aud"]`.

## The fix

`requiredClaims: ["exp"]` at both sites. The issuer always sets `exp` — five minutes for access tokens, and the step-up token likewise — so nothing that was ever meant to verify stops verifying.

Scoped to `exp` alone rather than copying ARC's fuller list: `iss` is already pinned by option at both sites, and `aud` is checked explicitly by each caller (`tokens.ts:604`, `step-up.ts:133`), so adding them to `requiredClaims` would change error text without changing what is accepted.

## Tests

Two, one per verifier, each minting a token that is correct in every other respect and simply has no `exp`:

- `shared/osn-auth-client/tests/verify.test.ts` — "returns null for a token with no exp claim"
- `osn/api/tests/services/auth.test.ts` — "rejects a token with no exp claim"

Both were proved to fail without the fix. With `requiredClaims` stripped from both source files:

```
FAIL  tests/verify.test.ts > extractClaims > returns null for a token with no exp claim
      Tests  1 failed | 89 passed (90)

FAIL  tests/services/auth.test.ts > verifyAccessToken > rejects a token with no exp claim
      Tests  1 failed | 1091 passed (1092)
```

Restored, both pass.

## Verification

- `bun run --cwd osn/api test:run` → 68 files, 1092 tests, all passing
- `bun run --cwd shared/osn-auth-client test:run` → 5 files, 90 tests, all passing
- `bun run check`, `bun run lint`, `bun run fmt:check`, `bun run test` — green
- Changeset present (`@osn/api` + `@shared/osn-auth-client`, both patch); `validate-changesets.sh` passes
- `bun.lock` untouched