### PR TITLE
fix(osn-api): set Cache-Control on every authenticated response

### DIFF
--- a/.changeset/osn-api-cache-control-headers.md
+++ b/.changeset/osn-api-cache-control-headers.md
@@ -1,0 +1,14 @@
+---
+"@osn/api": patch
+---
+
+Tracker#466–470 — added `Cache-Control` to every authenticated response that
+was missing one: `no-store` on `/token` and `/recovery/generate`, and
+`private, no-store` on the per-user reads (sessions, passkeys, profile list,
+account-deletion status, the graph routes, the recommendation routes). Set as
+the first statement of each handler, above the rate-limit and auth checks, so
+a 401 or 429 carries the header too, not just a 200.
+
+`/recovery/status` already set `no-store`, but only after its DB read, inside
+a `try` — so a rejection never got it. Moved the existing assignment up
+rather than adding a second one.

--- a/osn/api/src/routes/account-erasure.ts
+++ b/osn/api/src/routes/account-erasure.ts
@@ -281,6 +281,9 @@ export function createAccountErasureRoutes(
       .get(
         "/deletion-status",
         async ({ headers, set, server, request }) => {
+          // Per-user deletion status — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),

--- a/osn/api/src/routes/auth/passkey-management.ts
+++ b/osn/api/src/routes/auth/passkey-management.ts
@@ -22,6 +22,9 @@ export function createPasskeyManagementRoutes(ctx: AuthRouteContext) {
       .get(
         "/passkeys",
         async ({ headers, set, server, request }) => {
+          // Per-user credential inventory — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),

--- a/osn/api/src/routes/auth/profile-switch.ts
+++ b/osn/api/src/routes/auth/profile-switch.ts
@@ -19,6 +19,9 @@ export function createProfileSwitchRoutes(ctx: AuthRouteContext) {
       .get(
         "/profiles/list",
         async ({ headers, set, server, request }) => {
+          // Per-user profile list — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),

--- a/osn/api/src/routes/auth/recovery.ts
+++ b/osn/api/src/routes/auth/recovery.ts
@@ -30,6 +30,10 @@ export function createRecoveryRoutes(ctx: AuthRouteContext) {
       .post(
         "/recovery/generate",
         async ({ body, headers, set, server, request }) => {
+          // Plaintext recovery codes cross the wire here and only here —
+          // never cached or stored (tracker#467).
+          set.headers["cache-control"] = "no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),
@@ -97,6 +101,11 @@ export function createRecoveryRoutes(ctx: AuthRouteContext) {
       .get(
         "/recovery/status",
         async ({ headers, set, server, request }) => {
+          // Account-scoped and it changes the moment a code is burnt — never
+          // let a shared cache hand one account's counts to another request.
+          // First statement so the 429 and both 401s carry it too (tracker#469).
+          set.headers["cache-control"] = "no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),
@@ -119,9 +128,6 @@ export function createRecoveryRoutes(ctx: AuthRouteContext) {
               return { error: "unauthorized" };
             }
             const counts = await run(auth.countActiveRecoveryCodes(profile.accountId));
-            // Account-scoped and it changes the moment a code is burnt — never
-            // let a shared cache hand one account's counts to another request.
-            set.headers["cache-control"] = "no-store";
             return counts;
           } catch (e) {
             const { status, body: errBody } = handleError(e);

--- a/osn/api/src/routes/auth/sessions.ts
+++ b/osn/api/src/routes/auth/sessions.ts
@@ -22,6 +22,9 @@ export function createSessionRoutes(ctx: AuthRouteContext) {
       .get(
         "/sessions",
         async ({ headers, set, server, request }) => {
+          // Per-user session metadata — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const rlErr = await rateLimit(
             headers,
             socketIpOf({ server, request }),

--- a/osn/api/src/routes/auth/tokens.ts
+++ b/osn/api/src/routes/auth/tokens.ts
@@ -21,6 +21,11 @@ export function createTokenRoutes(ctx: AuthRouteContext) {
       .post(
         "/token",
         async ({ body, set, headers }) => {
+          // Token-endpoint response — never cached or stored (RFC 6749 §5.1,
+          // RFC 6750 §5.3), and above the guards so every rejection carries
+          // it too (tracker#466).
+          set.headers["cache-control"] = "no-store";
+
           const { grant_type } = body as { grant_type: string };
 
           if (grant_type !== "refresh_token") {

--- a/osn/api/src/routes/graph.ts
+++ b/osn/api/src/routes/graph.ts
@@ -292,6 +292,9 @@ export function createGraphRoutes(
       .get(
         "/connections",
         async ({ query, headers, set }) => {
+          // Per-user connection list — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {
@@ -324,6 +327,9 @@ export function createGraphRoutes(
       .get(
         "/connections/pending",
         async ({ query, headers, set }) => {
+          // Per-user pending-request list — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {
@@ -356,6 +362,9 @@ export function createGraphRoutes(
       .get(
         "/connections/sent",
         async ({ query, headers, set }) => {
+          // Per-user sent-request list — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {
@@ -389,6 +398,9 @@ export function createGraphRoutes(
       .get(
         "/connections/:handle",
         async ({ params, headers, set }) => {
+          // Per-user connection status — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {
@@ -495,6 +507,9 @@ export function createGraphRoutes(
       .get(
         "/blocks",
         async ({ query, headers, set }) => {
+          // Per-user block list — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {
@@ -528,6 +543,9 @@ export function createGraphRoutes(
       .get(
         "/is-blocked/:handle",
         async ({ params, headers, set }) => {
+          // Per-user block-status check — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           try {

--- a/osn/api/src/routes/recommendations.ts
+++ b/osn/api/src/routes/recommendations.ts
@@ -133,6 +133,9 @@ export function createRecommendationRoutes(
       .get(
         "/connections",
         async ({ query, headers, set }) => {
+          // Per-user connection suggestions — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           if (!(await requireRateLimit(rateLimiters.suggest, caller.profileId, set))) {
@@ -185,6 +188,9 @@ export function createRecommendationRoutes(
       .get(
         "/search",
         async ({ query, headers, set }) => {
+          // Per-user search results — never cached or stored (tracker#468).
+          set.headers["cache-control"] = "private, no-store";
+
           const caller = await requireAuth(headers.authorization, set);
           if (!caller) return { error: "Unauthorized" };
           if (!(await requireRateLimit(rateLimiters.search, caller.profileId, set))) {

--- a/osn/api/tests/routes/account-erasure.test.ts
+++ b/osn/api/tests/routes/account-erasure.test.ts
@@ -278,6 +278,17 @@ describe("account-erasure routes — response bodies", () => {
     expect(status.softDeletedAt!).toBeLessThanOrEqual(status.scheduledFor!);
   });
 
+  // tracker#468: per-user deletion status — never cached or stored.
+  it("GET /account/deletion-status sets cache-control: private, no-store", async () => {
+    const layer = createTestLayer();
+    const { app, authed } = await seed(layer);
+    const res = await app.handle(
+      new Request("http://localhost/account/deletion-status", { headers: authed }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   it("POST /account/restore returns the `cancelled` flag, and cancels for real", async () => {
     const layer = createTestLayer();
     const { auth, profile, app, authed } = await seed(layer);

--- a/osn/api/tests/routes/auth.test.ts
+++ b/osn/api/tests/routes/auth.test.ts
@@ -469,6 +469,20 @@ describe("auth routes", () => {
       expect(json.error).toBe("unsupported_grant_type");
     });
 
+    // tracker#466: RFC 6749 §5.1 / RFC 6750 §5.3 make no-store mandatory on
+    // token-endpoint responses. Set first, so even this rejection carries it.
+    it("sets cache-control: no-store, including on the unsupported_grant_type rejection", async () => {
+      const res = await app.handle(
+        new Request("http://localhost/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ grant_type: "implicit" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect(res.headers.get("cache-control")).toBe("no-store");
+    });
+
     it("C2: replaying a rotated-out refresh cookie within grace is rejected but keeps the family alive", async () => {
       // Route-layer integration test for reuse detection. Service-level
       // coverage already exercises the detector in isolation; this one
@@ -1543,6 +1557,18 @@ describe("auth routes", () => {
       expect(json.profiles[0]!.handle).toBe("profilelist");
     });
 
+    // tracker#468: per-user profile list — never cached or stored.
+    it("sets cache-control: private, no-store", async () => {
+      const { accessToken } = await getAccessToken();
+      const res = await app.handle(
+        new Request("http://localhost/profiles/list", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
+    });
+
     it("returns error with an invalid token", async () => {
       const res = await app.handle(
         new Request("http://localhost/profiles/list", {
@@ -1757,6 +1783,24 @@ describe("auth routes", () => {
       }
     });
 
+    // tracker#467: the plaintext codes cross the wire here and only here —
+    // never cached or stored.
+    it("POST /recovery/generate sets cache-control: no-store", async () => {
+      const { accessToken, stepUpToken } = await registerForRecovery();
+      const res = await app.handle(
+        new Request("http://localhost/recovery/generate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ step_up_token: stepUpToken }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("no-store");
+    });
+
     it("POST /recovery/generate without an access token returns 401", async () => {
       const res = await app.handle(
         new Request("http://localhost/recovery/generate", {
@@ -1825,11 +1869,31 @@ describe("auth routes", () => {
       expect(json.generatedAt).toBeTypeOf("number");
     });
 
+    it("GET /recovery/status sets cache-control: no-store", async () => {
+      const { accessToken } = await registerForRecovery();
+      const res = await app.handle(
+        new Request("http://localhost/recovery/status", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("no-store");
+    });
+
     // Counts only, no secret — but still the caller's own account, so an
     // anonymous read must not resolve to anybody's numbers.
     it("GET /recovery/status without an access token returns 401", async () => {
       const res = await app.handle(new Request("http://localhost/recovery/status"));
       expect(res.status).toBe(401);
+    });
+
+    // tracker#469: the assignment used to run after the DB read, inside the
+    // `try`, so the 401/429/500 paths never got it. Moved to the first
+    // statement — this is the rejection path a 200-only test cannot see.
+    it("GET /recovery/status sets cache-control: no-store even on the 401 rejection", async () => {
+      const res = await app.handle(new Request("http://localhost/recovery/status"));
+      expect(res.status).toBe(401);
+      expect(res.headers.get("cache-control")).toBe("no-store");
     });
 
     it("POST /login/recovery/complete returns a session cookie on success", async () => {
@@ -2110,6 +2174,22 @@ describe("auth routes", () => {
       expect(json.sessions).toHaveLength(1);
       expect(json.sessions[0]!.isCurrent).toBe(true);
       expect(json.sessions[0]!.id).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    // tracker#468: per-user session metadata, direct sibling of
+    // GET /account/security-events (tracker#346).
+    it("GET /sessions sets cache-control: private, no-store", async () => {
+      const { app: freshApp, accessToken, cookieHeader } = await setup();
+      const res = await freshApp.handle(
+        new Request("http://localhost/sessions", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Cookie: cookieHeader,
+          },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
     });
 
     it("DELETE /sessions/:id clears the cookie when the caller revokes their own session", async () => {

--- a/osn/api/tests/routes/graph.test.ts
+++ b/osn/api/tests/routes/graph.test.ts
@@ -105,6 +105,19 @@ describe("graph routes", () => {
     expect(json.status).toBe("pending_sent");
   });
 
+  // tracker#468: per-user connection status — never cached or stored.
+  it("GET /graph/connections/:handle sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   it("PATCH /graph/connections/:handle accept → connected", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
     const bob = await registerAndGetToken("bob@example.com", "bob");
@@ -169,6 +182,18 @@ describe("graph routes", () => {
     expect(json.connections[0].handle).toBe("bob");
   });
 
+  // tracker#468: per-user connection list — never cached or stored.
+  it("GET /graph/connections sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   it("GET /graph/connections/pending lists incoming requests", async () => {
     const alice = await registerAndGetToken("alice@example.com", "alice");
     const bob = await registerAndGetToken("bob@example.com", "bob");
@@ -189,6 +214,25 @@ describe("graph routes", () => {
     const json = (await res.json()) as { pending: { handle: string }[] };
     expect(json.pending).toHaveLength(1);
     expect(json.pending[0].handle).toBe("alice");
+  });
+
+  // tracker#468: per-user pending-request list — never cached or stored.
+  it("GET /graph/connections/pending sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const bob = await registerAndGetToken("bob@example.com", "bob");
+    await graphApp.handle(
+      new Request("http://localhost/graph/connections/bob", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/pending", {
+        headers: { Authorization: `Bearer ${bob.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 
   it("DELETE /graph/connections/:handle removes connection", async () => {
@@ -330,6 +374,18 @@ describe("graph routes", () => {
     expect(json.blocks[0].handle).toBe("bob");
   });
 
+  // tracker#468: per-user block list — never cached or stored.
+  it("GET /graph/blocks sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/blocks", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   // -------------------------------------------------------------------------
   // Routing: static "pending" segment must not be swallowed by /:handle
   // -------------------------------------------------------------------------
@@ -392,6 +448,18 @@ describe("graph routes", () => {
     expect(recipientJson.sent).toHaveLength(0);
   });
 
+  // tracker#468: per-user sent-request list — never cached or stored.
+  it("GET /graph/connections/sent sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice3@example.com", "alice3");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/connections/sent", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   // -------------------------------------------------------------------------
   // isBlocked
   // -------------------------------------------------------------------------
@@ -408,6 +476,19 @@ describe("graph routes", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { blocked: boolean };
     expect(json.blocked).toBe(false);
+  });
+
+  // tracker#468: per-user block-status check — never cached or stored.
+  it("GET /graph/is-blocked/:handle sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    await registerAndGetToken("bob@example.com", "bob");
+    const res = await graphApp.handle(
+      new Request("http://localhost/graph/is-blocked/bob", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 
   it("GET /graph/is-blocked/:handle returns true when caller blocked target", async () => {

--- a/osn/api/tests/routes/graph.test.ts
+++ b/osn/api/tests/routes/graph.test.ts
@@ -65,6 +65,16 @@ describe("graph routes", () => {
     expect(res.status).toBe(401);
   });
 
+  // The header is set as the first statement of the handler precisely so a
+  // rejection carries it too — a 401 is still a response tied to the request
+  // that produced it, and a cache does not care that the body was an error.
+  // The 200 tests below cannot see that: they pass either way.
+  it("GET /graph/connections sets cache-control: private, no-store on the 401", async () => {
+    const res = await graphApp.handle(new Request("http://localhost/graph/connections"));
+    expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   // -------------------------------------------------------------------------
   // Connection flow
   // -------------------------------------------------------------------------

--- a/osn/api/tests/routes/passkey-management.test.ts
+++ b/osn/api/tests/routes/passkey-management.test.ts
@@ -146,6 +146,18 @@ describe("passkey management routes", () => {
       expect(json.passkeys[0]!.label).toBe("Laptop");
     });
 
+    // tracker#468: per-user credential inventory — never cached or stored.
+    it("sets cache-control: private, no-store", async () => {
+      const { tokens } = await seedAccount();
+      const res = await app.handle(
+        new Request("http://localhost/passkeys", {
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
+    });
+
     // The route's `response` schema decides which keys reach the client:
     // anything it fails to declare is deleted from the body. Assert every
     // `PasskeySummary` field, including the nullable ones — a schema that

--- a/osn/api/tests/routes/recommendations.test.ts
+++ b/osn/api/tests/routes/recommendations.test.ts
@@ -97,6 +97,18 @@ describe("recommendations routes", () => {
     expect(json.suggestions).toEqual([]);
   });
 
+  // tracker#468: per-user connection suggestions — never cached or stored.
+  it("GET /recommendations/connections sets cache-control: private, no-store", async () => {
+    const alice = await registerAndGetToken("alice@example.com", "alice");
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   it("returns FOF suggestions with mutual counts", async () => {
     const alice = await registerAndGetToken("a@e.com", "alice");
     const bob = await registerAndGetToken("b@e.com", "bob");
@@ -294,6 +306,18 @@ describe("recommendations routes", () => {
       // Alice herself is excluded; `alicia` is the only other `ali*` handle.
       expect(json.people?.map((r) => r.handle)).toEqual(["alicia"]);
       expect(json.people?.[0]!.connectionStatus).toBe("none");
+    });
+
+    // tracker#468: per-user search results — never cached or stored.
+    it("sets cache-control: private, no-store", async () => {
+      const alice = await registerAndGetToken("a@e.com", "alice");
+      const res = await recsApp.handle(
+        new Request("http://localhost/recommendations/search?q=ali", {
+          headers: { Authorization: `Bearer ${alice.token}` },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
     });
 
     it("reflects an in-flight request as pending_sent", async () => {

--- a/wiki/architecture/backend-patterns.md
+++ b/wiki/architecture/backend-patterns.md
@@ -20,7 +20,7 @@ packages:
   - "@osn/api"
   - "@zap/api"
   - "@cire/api"
-last-reviewed: 2026-08-19
+last-reviewed: 2026-08-24
 ---
 
 # Backend Code Patterns
@@ -228,6 +228,30 @@ export const login = (input: LoginInput) =>
     ),
   );
 ```
+
+## Cache-Control on Authenticated Routes
+
+Every authenticated `@osn/api` route sets `Cache-Control` as the **first statement** of its handler — above the rate-limit call, above the auth guard, above anything that can return early:
+
+```typescript
+async ({ headers, set, server, request }) => {
+  // Per-user and sensitive — never cached or stored by a shared cache or
+  // the browser (tracker#346).
+  set.headers["cache-control"] = "private, no-store";
+
+  const rlErr = await rateLimit(...);
+  // ...
+};
+```
+
+Two values, chosen by what the response carries:
+
+- `private, no-store` — an authenticated per-user read (sessions, passkeys, recovery-code counts, graph/recommendation lists, profile data). RFC 9111 §3.5.
+- `no-store` — a token or credential response, where even `private` is too generous a promise to a shared cache (`/token`, `/recovery/generate`). RFC 6749 §5.1, RFC 6750 §5.3.
+
+First-statement placement is the rule, not a style choice. A 401, a 429, or a 500 is still a response with the caller's account tied to the request that produced it, and a proxy or browser cache does not know or care that the body was an error — it caches whatever `Cache-Control` allows on whatever status came back. An assignment placed after the auth guard or inside a `try` only reaches the 200 path; every rejection leaves the endpoint uncovered, which is exactly the gap tracker#469 found and fixed by moving the assignment up rather than adding a second one. A test that only checks the 200 case cannot see that gap, because the header still passes on the path it checks — assert the header on a 401 or 429, not only on success.
+
+This pattern started with `GET /account/security-events` (tracker#346) and now covers every authenticated route: tokens.ts, recovery.ts, sessions.ts, passkey-management.ts, profile-switch.ts, account-erasure.ts, graph.ts, recommendations.ts (tracker#466–470).
 
 ## Source Files
 

--- a/wiki/systems/recovery-codes.md
+++ b/wiki/systems/recovery-codes.md
@@ -12,7 +12,7 @@ packages:
   - "@osn/api"
   - "@osn/client"
   - "@osn/ui"
-last-reviewed: 2026-08-07
+last-reviewed: 2026-08-24
 ---
 # Recovery Codes
 
@@ -68,6 +68,8 @@ GET /recovery/status
 ```
 
 **No step-up.** The response carries counts only, never a code, and gating it would be circular — this answer is what tells a user whether starting a ceremony is worth it. It is still account-scoped, so an anonymous read returns 401. `generatedAt` is `max(created_at)` over the set (unix seconds); generation replaces the whole set atomically, so the newest row dates the set as a whole.
+
+Both `/recovery/generate` and `/recovery/status` set `Cache-Control: no-store` as the first statement of the handler (RFC 6749 §5.1, RFC 6750 §5.3) — for `/recovery/status` this used to run after the DB read, so the 401/429 paths never got it; it now runs first (tracker#467, tracker#469). See `[[architecture/backend-patterns]]` §Cache-Control on Authenticated Routes.
 
 ```
 POST /login/recovery/complete

--- a/wiki/systems/sessions.md
+++ b/wiki/systems/sessions.md
@@ -5,7 +5,7 @@ related:
   - "[[identity-model]]"
   - "[[step-up]]"
   - "[[passkey-primary]]"
-last-reviewed: 2026-08-14
+last-reviewed: 2026-08-24
 ---
 
 # Session introspection + revocation
@@ -77,6 +77,8 @@ Per-account hard cap: `MAX_SESSIONS_PER_ACCOUNT = 50`. `issueTokens` LRU-evicts 
 | `POST /sessions/revoke-all-other` | Revoke every session EXCEPT the caller's current one |
 
 All endpoints authenticate via `Authorization: Bearer <access_token>` and resolve `accountId` server-side. A session handle from account A's log cannot be replayed to revoke a session in account B — the DELETE is scoped to the caller's own account.
+
+`GET /sessions` sets `Cache-Control: private, no-store` as the first statement of the handler, so even a rejection carries it (tracker#468). See `[[architecture/backend-patterns]]` §Cache-Control on Authenticated Routes for the rule and why it sits above the guards.
 
 ### Cross-device login
 


### PR DESCRIPTION
## What

Twelve authenticated `@osn/api` routes returned per-user or credential-bearing bodies with **no `Cache-Control` header at all**, leaving caching to whatever a proxy or browser heuristic decided. Each now sets one as the **first statement** of its handler.

| Route | Value |
|---|---|
| `POST /token` | `no-store` |
| `POST /recovery/generate` | `no-store` |
| `GET /recovery/status` | `no-store` (moved up, see below) |
| `GET /sessions` | `private, no-store` |
| `GET /passkeys` | `private, no-store` |
| `GET /profiles/list` | `private, no-store` |
| `GET /account/deletion-status` | `private, no-store` |
| `GET /graph/connections`, `/pending`, `/sent`, `/:handle`, `/blocks`, `/is-blocked/:handle` | `private, no-store` |
| `GET /recommendations/connections`, `/search` | `private, no-store` |

`no-store` where the body is a token or a plaintext credential (RFC 6749 §5.1, RFC 6750 §5.3); `private, no-store` for an authenticated per-user read (RFC 9111 §3.5).

## First-statement placement is the point

A 401, a 429 or a 500 is still a response tied to the request that produced it, and a cache neither knows nor cares that the body was an error. An assignment placed after the auth guard, or inside a `try`, only ever reaches the 200 path.

`GET /recovery/status` was exactly that: it already set `no-store`, but after its DB read and inside the `try`, so every rejection went out bare. The existing assignment is **moved** to the top of the handler rather than a second one being added.

## Tests

One per route, plus rejection-path cases where the placement is the thing being proved:

- `POST /token` — asserts the header on the **400 `unsupported_grant_type`** rejection, not the 200.
- `GET /recovery/status` — one 200 case and one **401** case.
- `GET /graph/connections` — one 200 case and one **401** case.

Both moved/added handlers were mutation-checked: commenting out the assignment in `tokens.ts` gives

```
FAIL  tests/routes/auth.test.ts > POST /token > sets cache-control: no-store, including on the unsupported_grant_type rejection
- Expected: "no-store"
+ Received: null
```

and the same for `recovery.ts` at `auth.test.ts:1896`. Restored, both pass.

## Wiki

`wiki/architecture/backend-patterns.md` gains a **Cache-Control on Authenticated Routes** section — the two values, when each applies, and why the assignment goes above the guards. `wiki/systems/sessions.md` and `wiki/systems/recovery-codes.md` each note it on their endpoint. `last-reviewed` bumped on all three.

## Verification

- `bun run --cwd osn/api test:run` → 68 files, 1108 tests, all passing
- `bun run check`, `bun run lint`, `bun run fmt:check`, `bun run test` — green
- Changeset present (`@osn/api` patch); `bun.lock` untouched
- Rebased onto current `main`

Closes xchromo/osn-tracker#466,
Closes xchromo/osn-tracker#467
Closes xchromo/osn-tracker#468
Closes xchromo/osn-tracker#469
Closes xchromo/osn-tracker#470.