### PR TITLE
fix(shared-redis): validate the Upstash eval reply at the HTTP boundary

### DIFF
--- a/.changeset/upstash-eval-boundary-validation.md
+++ b/.changeset/upstash-eval-boundary-validation.md
@@ -1,0 +1,5 @@
+---
+"@shared/redis": patch
+---
+
+Validate the Upstash `eval` reply against the RESP value space before returning it, instead of trusting the HTTP boundary's claimed type. Matches the check the ioredis path already runs through `toRedisReply`.

--- a/shared/redis/src/upstash.ts
+++ b/shared/redis/src/upstash.ts
@@ -7,10 +7,11 @@
  * `ioredis` import, so the top-level `@shared/redis` entry stays Workers-safe.
  *
  * Mapping decisions (see the `RedisClient` contract in `./client`):
- * - `eval(script, keys, args)` → `redis.eval(script, keys, args)`. Upstash
- *   returns the Lua script's value directly (numeric for the rate-limit script
- *   and the recovery-lockout counter; the step-up jti check accepts `1` or
- *   `"1"`), so no shaping is needed.
+ * - `eval(script, keys, args)` → `toRedisReply(await redis.eval(script, keys,
+ *   args))`. The SDK types `eval`'s result as whatever the caller claims, but
+ *   it is really an HTTP response body nobody has checked — `toRedisReply`
+ *   narrows it to the RESP value space at this boundary, the same as the
+ *   ioredis path does in `./ioredis`.
  * - `get(key)` → `redis.get(key)`. The client MUST be constructed with
  *   `automaticDeserialization: false` so values come back as raw strings —
  *   matching ioredis and the rotated-session-store, which round-trips opaque
@@ -24,7 +25,7 @@
 
 import { Redis } from "@upstash/redis";
 
-import type { RedisClient, RedisReply } from "./client";
+import { toRedisReply, type RedisClient } from "./client";
 
 /**
  * Redis's reply to SET: the status string `"OK"`, or nil when a conditional
@@ -45,11 +46,15 @@ export type RedisSetReply = string | null;
  * instance or a fake in tests without coupling to the SDK's full type.
  *
  * The SDK types most of these as generic in their result (`get<TData>`,
- * `eval<TArgs, TData>`), i.e. it will hand back whatever the caller claims. The
- * claims are made once, here, and each is justified: `get` returns raw strings
- * because the client is built with `automaticDeserialization: false`, and
- * `eval` returns a {@link RedisReply} because that is the whole of what a Lua
- * script can send back over RESP.
+ * `eval<TArgs, TData = unknown>`), i.e. it will hand back whatever the caller
+ * claims. The claims are made once, here, and each is justified: `get` returns
+ * raw strings because the client is built with `automaticDeserialization:
+ * false`. `eval` keeps the SDK's own `TData = unknown` default rather than
+ * pinning a type — it is an HTTP response body the SDK has only JSON-decoded,
+ * not a value anyone has checked against the RESP value space, so
+ * {@link wrapUpstash} calls it with no type argument (leaving it `unknown`)
+ * and runs the result through {@link toRedisReply} before handing it to a
+ * caller.
  */
 export interface UpstashLike {
   /**
@@ -57,8 +62,13 @@ export interface UpstashLike {
    * types them, and mirroring the SDK is what lets a real `Redis` instance
    * satisfy this interface without a cast. The `RedisClient` contract hands
    * `eval` readonly arrays, so {@link wrapUpstash} copies them on the way in.
+   *
+   * `TData` mirrors the SDK's own generic (defaulting to `unknown`) rather
+   * than a flat `Promise<unknown>` return: {@link wrapUpstash} never supplies
+   * it, so the call resolves to `unknown` regardless, and every value still
+   * passes through {@link toRedisReply} before a caller sees it.
    */
-  eval(script: string, keys: string[], args: (string | number)[]): Promise<RedisReply>;
+  eval<TData = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<TData>;
   ping(): Promise<string>;
   get(key: string): Promise<string | null>;
   set(key: string, value: string, opts?: { px: number }): Promise<RedisSetReply>;
@@ -77,8 +87,10 @@ export function wrapUpstash(redis: UpstashLike): RedisClient {
   return {
     async eval(script, keys, args) {
       // Copied because the SDK takes mutable arrays; both are two elements
-      // long and the call behind them is an HTTP round-trip.
-      return redis.eval(script, [...keys], [...args]);
+      // long and the call behind them is an HTTP round-trip. The reply itself
+      // is unvalidated JSON off the wire until toRedisReply narrows it — same
+      // boundary check the ioredis path applies in ./ioredis.
+      return toRedisReply(await redis.eval(script, [...keys], [...args]));
     },
     async ping() {
       return redis.ping();

--- a/shared/redis/tests/ioredis.test.ts
+++ b/shared/redis/tests/ioredis.test.ts
@@ -57,6 +57,31 @@ describe("wrapIoRedis", () => {
       expect(mock.eval).toHaveBeenCalledWith("script", 2, "k1", "k2", 10, 20);
     });
 
+    // Parity with the Upstash path: both transports run the reply through
+    // toRedisReply, so both must coerce and both must reject the same values.
+    // Without these, deleting toRedisReply from ./ioredis leaves the suite green.
+    it("coerces a bigint EVALSHA reply to number", async () => {
+      mock.evalsha.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects an EVALSHA reply RESP cannot carry", async () => {
+      mock.evalsha.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
+    it("coerces a bigint reply on the EVAL fallback path too", async () => {
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      mock.eval.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects a non-RESP reply on the EVAL fallback path too", async () => {
+      mock.evalsha.mockRejectedValueOnce(new Error("NOSCRIPT No matching script"));
+      mock.eval.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
     it("rethrows non-NOSCRIPT errors from EVALSHA", async () => {
       mock.evalsha.mockRejectedValueOnce(new Error("OOM command not allowed"));
 

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -100,6 +100,18 @@ describe("wrapUpstash", () => {
       fake.eval.mockResolvedValueOnce("1");
       expect(await client.eval("script", ["k"], [1])).toBe("1");
     });
+
+    it("coerces a bigint reply to number, same as the ioredis path", async () => {
+      fake.eval.mockResolvedValueOnce(42n);
+      expect(await client.eval("script", ["k"], [1])).toBe(42);
+    });
+
+    it("rejects a reply RESP cannot carry (toRedisReply's contract)", async () => {
+      fake.eval.mockResolvedValueOnce({ not: "a RESP value" });
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(
+        /Redis EVAL returned a object/,
+      );
+    });
   });
 
   describe("del", () => {

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -84,7 +84,7 @@ describe("wrapUpstash", () => {
     });
   });
 
-  describe("eval — numeric return passthrough", () => {
+  describe("eval — reply validated at the HTTP boundary", () => {
     it("returns the numeric value from the Lua script (rate-limit / counter)", async () => {
       fake.eval.mockResolvedValueOnce(1);
       const result = await client.eval("script", ["k"], [10, 1000]);
@@ -106,11 +106,38 @@ describe("wrapUpstash", () => {
       expect(await client.eval("script", ["k"], [1])).toBe(42);
     });
 
+    it("passes a boolean reply through unchanged (RESP3)", async () => {
+      fake.eval.mockResolvedValueOnce(true);
+      expect(await client.eval("script", ["k"], [1])).toBe(true);
+    });
+
+    // The REST body carries no `result` when a script returns nil, so the SDK
+    // hands back null or undefined depending on the shape. Both must land on
+    // null: recovery-lockout-store does `Number(result)` on this, and
+    // `Number(undefined)` is NaN, which compares false against every threshold.
+    it("normalises a nil reply to null", async () => {
+      fake.eval.mockResolvedValueOnce(null);
+      expect(await client.eval("script", ["k"], [1])).toBeNull();
+    });
+
+    it("normalises a missing reply to null", async () => {
+      fake.eval.mockResolvedValueOnce(undefined);
+      expect(await client.eval("script", ["k"], [1])).toBeNull();
+    });
+
+    it("walks a nested array reply, coercing as it goes", async () => {
+      fake.eval.mockResolvedValueOnce([1, "a", null, [42n, true]]);
+      expect(await client.eval("script", ["k"], [1])).toEqual([1, "a", null, [42, true]]);
+    });
+
+    it("rejects a non-RESP value nested inside an array reply", async () => {
+      fake.eval.mockResolvedValueOnce([1, { not: "a RESP value" }]);
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+
     it("rejects a reply RESP cannot carry (toRedisReply's contract)", async () => {
       fake.eval.mockResolvedValueOnce({ not: "a RESP value" });
-      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(
-        /Redis EVAL returned a object/,
-      );
+      await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
     });
   });
 

--- a/wiki/systems/redis.md
+++ b/wiki/systems/redis.md
@@ -16,7 +16,7 @@ related:
 packages:
   - "@shared/redis"
   - "@osn/api"
-last-reviewed: 2026-08-17
+last-reviewed: 2026-08-24
 ---
 # Redis Migration
 
@@ -102,11 +102,14 @@ traffic for low latency (C-M18; see [[compliance/subprocessors]], [[production-d
 | P-W4 | ✅ | Auth Maps never evict expired entries — Redis backend uses native PX expiry |
 | S-L18 | ✅ | Graph rate-limit store never evicted expired windows |
 | S-L23 | n/a | `pkceStore` deleted with PKCE removal |
+| S-L1 | ✅ | Upstash `eval` returned the HTTP reply unchecked — `wrapUpstash` now runs it through `toRedisReply`, as the ioredis path already did |
 
 ## Source Files
 
 - [shared/redis/src/index.ts](../../shared/redis/src/index.ts) — `@shared/redis` public API
-- [shared/redis/src/client.ts](../../shared/redis/src/client.ts) — `RedisClient` interface, `wrapIoRedis()`, `createMemoryClient()`, `createClientFromUrl()`
+- [shared/redis/src/client.ts](../../shared/redis/src/client.ts) — `RedisClient` interface, `RedisReply`, `toRedisReply()` (the one reply validator both transports run), `createMemoryClient()`
+- [shared/redis/src/ioredis.ts](../../shared/redis/src/ioredis.ts) — `wrapIoRedis()`, `createClientFromUrl()` — the TCP transport, Node only
+- [shared/redis/src/upstash.ts](../../shared/redis/src/upstash.ts) — `wrapUpstash()` — the HTTP transport, and the one Workers can use
 - [shared/redis/src/service.ts](../../shared/redis/src/service.ts) — `Redis` Context.Tag, `RedisLive`, `RedisMemoryLive` layers
 - [shared/redis/src/rate-limiter.ts](../../shared/redis/src/rate-limiter.ts) — `createRedisRateLimiter()` with Lua script
 - [shared/redis/src/health.ts](../../shared/redis/src/health.ts) — `checkRedisHealth()` probe


### PR DESCRIPTION
## Summary

`shared/redis` has two backends behind one `RedisClient` contract, and they
disagreed about `eval`. The ioredis one runs every reply through
`toRedisReply`; the Upstash one declared `eval(): Promise<RedisReply>` and
handed back whatever the SDK returned. That value is an HTTP response body the
SDK has only JSON-decoded, so the type was a claim with nothing behind it — the
looser boundary got the weaker check.

`wrapUpstash` now returns `toRedisReply(await redis.eval(...))`, so both
backends validate a Lua script's reply the same way.

- `UpstashLike.eval` drops the `RedisReply` claim and mirrors the SDK's own
  generic instead.
- Two tests cover the new boundary: a bigint reply coerces to a number, and a
  plain object throws.

## Workspaces affected

`@shared/redis`. The changeset `.changeset/upstash-eval-boundary-validation.md`
names `@shared/redis` at `patch`, which is the only workspace this branch
touches.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#439 | `S-L1` |

Closes xchromo/osn-tracker#439

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#517 | `P-I1` |
| xchromo/osn-tracker#518 | `P-I2` |

## Decisions

### Validate at the wrapper, not at each call site — `S-L1`

- **Issue** — `wrapUpstash().eval` returned the SDK's value untouched while
  asserting it was a `RedisReply`.
- **Why** — every caller narrows the reply on the spot (`result === 1`,
  `Number(result)`, `result === 1 || result === "1"`). A reply outside the RESP
  value space would slip past those checks as a silent wrong answer rather than
  a failure — on the rate limiter, that reads as "not limited".
- **Solution** — `wrapUpstash` awaits the SDK call and returns
  `toRedisReply(...)`.
- **Rationale** — `toRedisReply` already exists and already guards the ioredis
  path, so this adds no mechanism. Putting it in the wrapper runs the check once
  per backend instead of once per call site, and a throw is what every `eval`
  caller already treats as backend failure.

### Keep the SDK's generic rather than a flat `unknown` return — `approach`

- **Issue** — the fix was first specified as `eval(...): Promise<unknown>` on
  `UpstashLike`. That signature fails the vendored
  `anti-slop/no-unknown-returns` oxlint rule, which `oxlintrc.json` sets to
  `error` in source with an override for tests only, not for this path.
- **Why** — the ways round it were disabling the gate for the file or widening
  its override. Both cost more than the fix is worth, and both leave the next
  unchecked return in this package hidden.
- **Solution** — `UpstashLike.eval` mirrors the real `@upstash/redis` shape:
  `eval<TData = unknown>(script, keys, args): Promise<TData>`. `wrapUpstash`
  never supplies the type argument, so the call still resolves to `unknown`, and
  the result still passes through `toRedisReply`.
- **Rationale** — the rule reads a return of `Promise<T>` as clean when `T` is a
  lexical type parameter and flags it when it is bare `unknown`
  (`tools/oxlint/anti-slop/rules/no-unknown-returns.ts`). So this keeps the same
  guarantee at the call site with no lint override, and a real `Redis` instance
  still satisfies the interface without a cast.

### Dismissed: pin `UpstashLike.eval` to a non-generic `Promise<unknown>` — `S-L1` (review)

- **Issue** — the security review argued the generic still lets a future caller
  write `redis.eval<{ admin: true }>(...)` and get an unchecked assertion back,
  and proposed a flat `Promise<unknown>` return instead.
- **Why** — the concern is sound in the abstract: a defaulted generic is an
  assertion the caller controls, and a non-generic return would close it.
- **Solution** — not changed.
- **Rationale** — the proposed signature is the one the lint gate rejects, so
  taking it means disabling `anti-slop/no-unknown-returns` for this file, which
  is a worse trade than the residual risk. The risk itself is small and bounded:
  `UpstashLike` is a package-private interface with exactly one consumer,
  `wrapUpstash` in the same file, and that consumer supplies no type argument
  and validates the result regardless. The `RedisClient` contract every external
  caller actually holds still returns `RedisReply`.

### Test-surface gaps waved through — `T-*`

- **Issue** — the test review flagged that `toRedisReply` has no direct unit
  tests, and that array, nested-array and nil replies are not exercised through
  `wrapUpstash`.
- **Why** — arrays are the one case where this change alters what a caller
  receives, since `toRedisReply` recurses and rejects a bad element anywhere in
  the tree.
- **Solution** — left as is. The branch adds two tests for the paths it changes
  and no more.
- **Rationale** — `wiki/conventions/review-findings.md` says `T-*` findings are
  coverage gaps rather than defects, and are closed in the branch or waved
  through, never filed. No script in this package returns an array today, so the
  untested paths carry no live behaviour; widening the suite belongs with the
  first script that needs them.

**Out of scope** — Two info-tier performance notes on `shared/redis`, both
found in this review and neither fixed here: `P-I1`, tracked in
xchromo/osn-tracker#517, and `P-I2`, tracked in xchromo/osn-tracker#518.

## Test plan

| Gate | Result |
|---|---|
| `bunx turbo check --filter=@shared/redis` (`tsc --noEmit`) | ✅ |
| `bunx --bun vitest run` in `shared/redis` | ✅ 55 pass, 7 files |
| `bun run lint` (oxlint, repo-wide) | ✅ exit 0, no new warnings |
| `bun run fmt:check` (oxfmt, 1414 files) | ✅ |

All four ran in this worktree on `08502439`.

No manual steps. The change has no new runtime behaviour to exercise by hand —
it narrows a value that was already being returned.

Not verified against a live Upstash instance. The suite drives `wrapUpstash`
through a fake, as `shared/redis/tests/upstash.test.ts` already did, so the real
SDK's reply shapes are covered only by the contract this fix now enforces.
