### PR TITLE
fix(cire-api): clear every type error in the package's own source

### DIFF
--- a/.changeset/cire-api-source-typecheck.md
+++ b/.changeset/cire-api-source-typecheck.md
@@ -1,0 +1,25 @@
+---
+"@cire/api": patch
+---
+
+Fix every type error in `cire/api`'s own source. The package was never
+type-checked — it has no `check` script, so `bun run check` skipped it and
+about a hundred errors accumulated behind the gap.
+
+Most were narrow: enum tuples typed as `[string, ...string[]]` instead of the
+union they carry, missing fields on a declared return shape, an error union
+that omitted a failure the code could actually raise, `Bun.Server` named
+without its type argument. Three are worth naming:
+
+- Session rotation had a hand-rolled `.batch()` feature-detect. It now calls
+  `commitBatch`, the shared helper the importer and directory writes already
+  use, with the same insert-before-delete ordering.
+- The organiser write routes drop a `.guard()` wrapper in favour of a second
+  `.group()` on the same prefix — the form `organiser-hosts.ts` already uses,
+  and the only way to run two gates over one path. The editor and owner gates
+  still cover exactly the routes they covered before; `budget.test.ts` pins
+  both directions (an editor creates items, an editor gets 403 on the cap).
+- The importer's RSVP warning filtered on `status !== "pending"`, but the
+  column's enum is `attending | declined | maybe` and it is `NOT NULL` — "no
+  answer yet" is the absence of a row. The check was always true, so it is
+  gone.

--- a/.changeset/shared-crypto-generate-keypair.md
+++ b/.changeset/shared-crypto-generate-keypair.md
@@ -1,0 +1,8 @@
+---
+"@shared/crypto": patch
+---
+
+Narrow `generateArcKeyPair`'s return instead of leaning on the caller's
+tsconfig. `crypto.subtle.generateKey` is typed `CryptoKey | CryptoKeyPair`
+because it serves symmetric algorithms too; ECDSA always yields the pair, so
+the function now checks for `privateKey` and returns the narrowed value.

--- a/cire/api/src/local.ts
+++ b/cire/api/src/local.ts
@@ -49,7 +49,9 @@ const app = createApp(db, {
 
 const server = Bun.serve({
   port,
-  fetch(request: Request, srv: Bun.Server) {
+  // Both parameters are contextually typed by `Bun.serve`; naming `Bun.Server`
+  // here would need its WebSocket type argument, which this server has not got.
+  fetch(request, srv) {
     // Local dev has no Cloudflare edge, so `cf-connecting-ip` is absent and the
     // fail-closed rate limiter (W5) 429s every gated route (claim, preview-code,
     // account-link, invite writes). Inject the socket peer as the trusted client

--- a/cire/api/src/routes/budget.ts
+++ b/cire/api/src/routes/budget.ts
@@ -106,189 +106,186 @@ export const createBudgetReadRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =
 export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
   new Elysia({ prefix: "/api/organiser" })
     .use(osnAuth(osnAuthOptions))
+    // Editor writes. A second `.group` on the same path below carries the
+    // owner-only cap set — a gate is applied per group, so the only way to
+    // run two of them over the same prefix is two groups (mirrors
+    // createOrganiserHostsWriteRoutes).
     .group("/weddings/:weddingId", (group) =>
       group
-        // Editor writes.
-        .guard((write) =>
-          write
-            .use(weddingEditor(db))
-            .post(
-              "/budget/items",
-              async ({ weddingId, request, set }) => {
-                if (!weddingId) return internalSync(set);
-                const raw: unknown = await request.json().catch(() => null);
-                return runCire(
-                  Effect.gen(function* () {
-                    const body = yield* Schema.decodeUnknown(CreateBudgetItemBody)(raw);
-                    const item = yield* budgetService.createItem({ weddingId, ...body });
-                    return { item };
-                  }).pipe(
-                    Effect.provideService(DbService, db),
-                    Effect.catchTag("ParseError", () => badRequest(set)),
-                    Effect.catchAllDefect(() => internal(set)),
-                  ),
-                );
-              },
-              manualParse,
-            )
-            .patch(
-              "/budget/items/reorder",
-              async ({ weddingId, request, set }) => {
-                if (!weddingId) return internalSync(set);
-                const raw: unknown = await request.json().catch(() => null);
-                return runCire(
-                  Effect.gen(function* () {
-                    const body = yield* Schema.decodeUnknown(ReorderBudgetItemsBody)(raw);
-                    yield* budgetService.reorderItems(weddingId, body.category, body.orderedIds);
-                    return { ok: true as const };
-                  }).pipe(
-                    Effect.provideService(DbService, db),
-                    Effect.catchTag("ParseError", () => badRequest(set)),
-                    Effect.catchAllDefect(() => internal(set)),
-                  ),
-                );
-              },
-              manualParse,
-            )
-            .patch(
-              "/budget/items/:itemId",
-              async ({ weddingId, params, request, set }) => {
-                if (!weddingId) return internalSync(set);
-                const raw: unknown = await request.json().catch(() => null);
-                return runCire(
-                  Effect.gen(function* () {
-                    const body = yield* Schema.decodeUnknown(UpdateBudgetItemBody)(raw);
-                    const item = yield* budgetService.updateItem({
-                      weddingId,
-                      itemId: params.itemId,
-                      patch: body,
-                    });
-                    return { item };
-                  }).pipe(
-                    Effect.provideService(DbService, db),
-                    Effect.catchTag("ParseError", () => badRequest(set)),
-                    Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
-                    Effect.catchAllDefect(() => internal(set)),
-                  ),
-                );
-              },
-              manualParse,
-            )
-            .delete("/budget/items/:itemId", async ({ weddingId, params, set }) => {
-              if (!weddingId) return internalSync(set);
-              return runCire(
-                budgetService.removeItem(weddingId, params.itemId).pipe(
-                  Effect.map(() => ({ ok: true as const })),
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            })
-            .post(
-              "/budget/items/:itemId/payments",
-              async ({ weddingId, params, request, set }) => {
-                if (!weddingId) return internalSync(set);
-                const raw: unknown = await request.json().catch(() => null);
-                return runCire(
-                  Effect.gen(function* () {
-                    const body = yield* Schema.decodeUnknown(CreatePaymentBody)(raw);
-                    const payment = yield* budgetService.addPayment({
-                      weddingId,
-                      itemId: params.itemId,
-                      label: body.label,
-                      amountMinor: body.amountMinor,
-                      dueAt: body.dueAt,
-                    });
-                    return { payment };
-                  }).pipe(
-                    Effect.provideService(DbService, db),
-                    Effect.catchTag("ParseError", () => badRequest(set)),
-                    Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
-                    Effect.catchAllDefect(() => internal(set)),
-                  ),
-                );
-              },
-              manualParse,
-            )
-            .patch(
-              "/budget/items/:itemId/payments/:paymentId",
-              async ({ weddingId, params, request, set }) => {
-                if (!weddingId) return internalSync(set);
-                const raw: unknown = await request.json().catch(() => null);
-                return runCire(
-                  Effect.gen(function* () {
-                    const body = yield* Schema.decodeUnknown(UpdatePaymentBody)(raw);
-                    const payment = yield* budgetService.updatePayment({
-                      weddingId,
-                      itemId: params.itemId,
-                      paymentId: params.paymentId,
-                      patch: body,
-                    });
-                    return { payment };
-                  }).pipe(
-                    Effect.provideService(DbService, db),
-                    Effect.catchTag("ParseError", () => badRequest(set)),
-                    Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
-                    Effect.catchTag("PaymentNotInItem", () => paymentNotFound(set)),
-                    Effect.catchAllDefect(() => internal(set)),
-                  ),
-                );
-              },
-              manualParse,
-            )
-            .delete(
-              "/budget/items/:itemId/payments/:paymentId",
-              async ({ weddingId, params, set }) => {
-                if (!weddingId) return internalSync(set);
-                return runCire(
-                  budgetService
-                    .removePayment({
-                      weddingId,
-                      itemId: params.itemId,
-                      paymentId: params.paymentId,
-                    })
-                    .pipe(
-                      Effect.map(() => ({ ok: true as const })),
-                      Effect.provideService(DbService, db),
-                      Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
-                      Effect.catchTag("PaymentNotInItem", () => paymentNotFound(set)),
-                      Effect.catchAllDefect(() => internal(set)),
-                    ),
-                );
-              },
-            ),
+        .use(weddingEditor(db))
+        .post(
+          "/budget/items",
+          async ({ weddingId, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(CreateBudgetItemBody)(raw);
+                const item = yield* budgetService.createItem({ weddingId, ...body });
+                return { item };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
         )
-        // Owner-only cap set — delegates to the settings service (single writer
-        // of weddings.budget_total_minor).
-        .guard((own) =>
-          own.use(weddingOwner(db)).put(
-            "/budget/total",
-            async ({ weddingId, osnProfileId, request, set }) => {
-              if (!weddingId || !osnProfileId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(SetBudgetTotalBody)(raw);
-                  const settings = yield* weddingSettingsService.update(
-                    weddingId,
-                    { budgetTotalMinor: body.budgetTotalMinor },
-                    osnProfileId,
-                  );
-                  return { budgetTotalMinor: settings.budgetTotalMinor };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("WeddingNotFound", () => weddingNotFound(set)),
-                  Effect.catchTag("SettingsWriteError", () => internal(set)),
-                  // Unreachable: this patch never names the deadline. Handled so
-                  // the union stays total rather than falling to the defect arm.
-                  Effect.catchTag("RsvpDeadlineInPast", () => internal(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
+        .patch(
+          "/budget/items/reorder",
+          async ({ weddingId, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(ReorderBudgetItemsBody)(raw);
+                yield* budgetService.reorderItems(weddingId, body.category, body.orderedIds);
+                return { ok: true as const };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .patch(
+          "/budget/items/:itemId",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(UpdateBudgetItemBody)(raw);
+                const item = yield* budgetService.updateItem({
+                  weddingId,
+                  itemId: params.itemId,
+                  patch: body,
+                });
+                return { item };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .delete("/budget/items/:itemId", async ({ weddingId, params, set }) => {
+          if (!weddingId) return internalSync(set);
+          return runCire(
+            budgetService.removeItem(weddingId, params.itemId).pipe(
+              Effect.map(() => ({ ok: true as const })),
+              Effect.provideService(DbService, db),
+              Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
+              Effect.catchAllDefect(() => internal(set)),
+            ),
+          );
+        })
+        .post(
+          "/budget/items/:itemId/payments",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(CreatePaymentBody)(raw);
+                const payment = yield* budgetService.addPayment({
+                  weddingId,
+                  itemId: params.itemId,
+                  label: body.label,
+                  amountMinor: body.amountMinor,
+                  dueAt: body.dueAt,
+                });
+                return { payment };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .patch(
+          "/budget/items/:itemId/payments/:paymentId",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(UpdatePaymentBody)(raw);
+                const payment = yield* budgetService.updatePayment({
+                  weddingId,
+                  itemId: params.itemId,
+                  paymentId: params.paymentId,
+                  patch: body,
+                });
+                return { payment };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
+                Effect.catchTag("PaymentNotInItem", () => paymentNotFound(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .delete("/budget/items/:itemId/payments/:paymentId", async ({ weddingId, params, set }) => {
+          if (!weddingId) return internalSync(set);
+          return runCire(
+            budgetService
+              .removePayment({
+                weddingId,
+                itemId: params.itemId,
+                paymentId: params.paymentId,
+              })
+              .pipe(
+                Effect.map(() => ({ ok: true as const })),
+                Effect.provideService(DbService, db),
+                Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
+                Effect.catchTag("PaymentNotInItem", () => paymentNotFound(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+          );
+        }),
+    )
+    // Owner-only cap set — delegates to the settings service (single writer
+    // of weddings.budget_total_minor).
+    .group("/weddings/:weddingId", (group) =>
+      group.use(weddingOwner(db)).put(
+        "/budget/total",
+        async ({ weddingId, osnProfileId, request, set }) => {
+          if (!weddingId || !osnProfileId) return internalSync(set);
+          const raw: unknown = await request.json().catch(() => null);
+          return runCire(
+            Effect.gen(function* () {
+              const body = yield* Schema.decodeUnknown(SetBudgetTotalBody)(raw);
+              const settings = yield* weddingSettingsService.update(
+                weddingId,
+                { budgetTotalMinor: body.budgetTotalMinor },
+                osnProfileId,
               );
-            },
-            manualParse,
-          ),
-        ),
+              return { budgetTotalMinor: settings.budgetTotalMinor };
+            }).pipe(
+              Effect.provideService(DbService, db),
+              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("WeddingNotFound", () => weddingNotFound(set)),
+              Effect.catchTag("SettingsWriteError", () => internal(set)),
+              // Unreachable: this patch never names the deadline. Handled so
+              // the union stays total rather than falling to the defect arm.
+              Effect.catchTag("RsvpDeadlineInPast", () => internal(set)),
+              Effect.catchAllDefect(() => internal(set)),
+            ),
+          );
+        },
+        manualParse,
+      ),
     );

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -19,6 +19,7 @@ import {
   InviteTextBody,
   InviteThemeBody,
   isInviteImageSlot,
+  type InviteImageSlot,
 } from "../schemas/invite";
 import { entitlementService } from "../services/entitlements";
 import { eventImageService } from "../services/event-image";

--- a/cire/api/src/routes/organiser-weddings.ts
+++ b/cire/api/src/routes/organiser-weddings.ts
@@ -1,6 +1,7 @@
 import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect, Schema } from "effect";
 import { Elysia } from "elysia";
+import type { HTTPHeaders } from "elysia";
 
 import { DbService } from "../db";
 import type { Db } from "../db";
@@ -74,7 +75,7 @@ const rosterDefect = (set: { status?: number | string }, read: string, weddingId
   });
 
 /** Mark a claim-code-bearing JSON response uncacheable (see {@link rosterDefect}). */
-const noStore = (set: { headers: Record<string, string> }) => {
+const noStore = (set: { headers: HTTPHeaders }) => {
   set.headers["cache-control"] = "no-store";
 };
 

--- a/cire/api/src/routes/registry.ts
+++ b/cire/api/src/routes/registry.ts
@@ -215,173 +215,171 @@ export const createRegistryWriteRoutes = (
   new Elysia({ prefix: "/api/organiser" })
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
-      group.guard((write) =>
-        write
-          .use(weddingEditor(db))
-          .use(weddingEntitlement(db, "registry"))
-          .put(
-            "/registry/settings",
-            async ({ weddingId, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(UpdateRegistrySettingsBody)(raw);
-                  // The cash-gifts/Stripe invariant lives in the service (S-M3),
-                  // not here: this route used to load the WHOLE snapshot — items,
-                  // gift log, currency — to read one boolean off it (P-C2).
-                  const settings = yield* registryService.updateSettings(weddingId, body);
-                  return { settings };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("StripeNotReady", () => conflict(set, "stripe_not_ready")),
-                  Effect.tapDefect(logDefect(weddingId)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .post(
-            "/registry/items",
-            async ({ weddingId, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(CreateRegistryItemBody)(raw);
-                  const item = yield* registryService.createItem({ weddingId, ...body });
-                  yield* Effect.sync(() => metricRegistryItemWrite("create"));
-                  return { item };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("InvalidQuantity", () => badRequest(set)),
-                  Effect.catchTag("ImageKeyNotInWedding", () =>
-                    badRequestCode(set, "image_key_not_in_wedding"),
-                  ),
-                  Effect.catchTag("RegistryItemLimitReached", () =>
-                    conflict(set, "registry_item_limit_reached"),
-                  ),
-                  Effect.tapDefect(logDefect(weddingId)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .patch(
-            "/registry/items/reorder",
-            async ({ weddingId, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(ReorderRegistryItemsBody)(raw);
-                  yield* registryService.reorderItems(weddingId, body.orderedIds);
-                  return { ok: true as const };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.tapDefect(logDefect(weddingId)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .patch(
-            "/registry/items/:itemId",
-            async ({ weddingId, params, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(UpdateRegistryItemBody)(raw);
-                  const item = yield* registryService.updateItem({
-                    weddingId,
-                    itemId: params.itemId,
-                    patch: body,
-                  });
-                  yield* Effect.sync(() => metricRegistryItemWrite("update"));
-                  return { item };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("InvalidQuantity", () => badRequest(set)),
-                  Effect.catchTag("ImageKeyNotInWedding", () =>
-                    badRequestCode(set, "image_key_not_in_wedding"),
-                  ),
-                  Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
-                  Effect.tapDefect(logDefect(weddingId)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .delete("/registry/items/:itemId", async ({ weddingId, params, request, set }) => {
+      group
+        .use(weddingEditor(db))
+        .use(weddingEntitlement(db, "registry"))
+        .put(
+          "/registry/settings",
+          async ({ weddingId, request, set }) => {
             if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
             return runCire(
-              registryService.removeItem(weddingId, params.itemId).pipe(
-                Effect.tap(() => Effect.sync(() => metricRegistryItemWrite("remove"))),
-                // Nothing else references the object now, so it is an orphan.
-                // Reap it rather than leaving it to the 7-day reconcile sweep:
-                // the picture came off a shop page or the couple's camera roll,
-                // and a bucket with no lifecycle rule keeps it forever.
-                // Best-effort by contract — a failed delete logs and never turns
-                // a successful delete into an error the organiser has to see.
-                //
-                // `imageKeyOrphaned` is the service's verdict, taken with the
-                // delete: two items may name the same key, and reaping on the
-                // first delete would blank the survivor's picture (S-M1).
-                Effect.tap(({ imageKey, imageKeyOrphaned }) =>
-                  reapAfterResponse(request, assets, imageKeyOrphaned ? imageKey : null),
-                ),
-                Effect.map(() => ({ ok: true as const })),
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(UpdateRegistrySettingsBody)(raw);
+                // The cash-gifts/Stripe invariant lives in the service (S-M3),
+                // not here: this route used to load the WHOLE snapshot — items,
+                // gift log, currency — to read one boolean off it (P-C2).
+                const settings = yield* registryService.updateSettings(weddingId, body);
+                return { settings };
+              }).pipe(
                 Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("StripeNotReady", () => conflict(set, "stripe_not_ready")),
+                Effect.tapDefect(logDefect(weddingId)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .post(
+          "/registry/items",
+          async ({ weddingId, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(CreateRegistryItemBody)(raw);
+                const item = yield* registryService.createItem({ weddingId, ...body });
+                yield* Effect.sync(() => metricRegistryItemWrite("create"));
+                return { item };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("InvalidQuantity", () => badRequest(set)),
+                Effect.catchTag("ImageKeyNotInWedding", () =>
+                  badRequestCode(set, "image_key_not_in_wedding"),
+                ),
+                Effect.catchTag("RegistryItemLimitReached", () =>
+                  conflict(set, "registry_item_limit_reached"),
+                ),
+                Effect.tapDefect(logDefect(weddingId)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .patch(
+          "/registry/items/reorder",
+          async ({ weddingId, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(ReorderRegistryItemsBody)(raw);
+                yield* registryService.reorderItems(weddingId, body.orderedIds);
+                return { ok: true as const };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.tapDefect(logDefect(weddingId)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .patch(
+          "/registry/items/:itemId",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(UpdateRegistryItemBody)(raw);
+                const item = yield* registryService.updateItem({
+                  weddingId,
+                  itemId: params.itemId,
+                  patch: body,
+                });
+                yield* Effect.sync(() => metricRegistryItemWrite("update"));
+                return { item };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("InvalidQuantity", () => badRequest(set)),
+                Effect.catchTag("ImageKeyNotInWedding", () =>
+                  badRequestCode(set, "image_key_not_in_wedding"),
+                ),
                 Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
                 Effect.tapDefect(logDefect(weddingId)),
                 Effect.catchAllDefect(() => internal(set)),
               ),
             );
-          })
-          .post(
-            "/registry/gifts/:kind/:giftId/thanked",
-            async ({ weddingId, params, request, osnProfileId, set }) => {
-              if (!weddingId || !osnProfileId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(SetThankedBody)(raw);
-                  // The kind comes off the PATH, so it is validated as strictly
-                  // as a body field would be — an unknown value must 400, never
-                  // fall through to a table by coincidence.
-                  const kind = yield* Schema.decodeUnknown(GiftKindSchema)(params.kind);
-                  yield* registryService.setThanked({
-                    weddingId,
-                    kind,
-                    giftId: params.giftId,
-                    thanked: body.thanked,
-                    actorOsnProfileId: osnProfileId,
-                  });
-                  yield* Effect.sync(() =>
-                    metricRegistryGift(body.thanked ? "thanked" : "unthanked"),
-                  );
-                  return { ok: true as const };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("GiftNotInWedding", () => giftNotFound(set)),
-                  Effect.tapDefect(logDefect(weddingId)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          ),
-      ),
+          },
+          manualParse,
+        )
+        .delete("/registry/items/:itemId", async ({ weddingId, params, request, set }) => {
+          if (!weddingId) return internalSync(set);
+          return runCire(
+            registryService.removeItem(weddingId, params.itemId).pipe(
+              Effect.tap(() => Effect.sync(() => metricRegistryItemWrite("remove"))),
+              // Nothing else references the object now, so it is an orphan.
+              // Reap it rather than leaving it to the 7-day reconcile sweep:
+              // the picture came off a shop page or the couple's camera roll,
+              // and a bucket with no lifecycle rule keeps it forever.
+              // Best-effort by contract — a failed delete logs and never turns
+              // a successful delete into an error the organiser has to see.
+              //
+              // `imageKeyOrphaned` is the service's verdict, taken with the
+              // delete: two items may name the same key, and reaping on the
+              // first delete would blank the survivor's picture (S-M1).
+              Effect.tap(({ imageKey, imageKeyOrphaned }) =>
+                reapAfterResponse(request, assets, imageKeyOrphaned ? imageKey : null),
+              ),
+              Effect.map(() => ({ ok: true as const })),
+              Effect.provideService(DbService, db),
+              Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
+              Effect.tapDefect(logDefect(weddingId)),
+              Effect.catchAllDefect(() => internal(set)),
+            ),
+          );
+        })
+        .post(
+          "/registry/gifts/:kind/:giftId/thanked",
+          async ({ weddingId, params, request, osnProfileId, set }) => {
+            if (!weddingId || !osnProfileId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(SetThankedBody)(raw);
+                // The kind comes off the PATH, so it is validated as strictly
+                // as a body field would be — an unknown value must 400, never
+                // fall through to a table by coincidence.
+                const kind = yield* Schema.decodeUnknown(GiftKindSchema)(params.kind);
+                yield* registryService.setThanked({
+                  weddingId,
+                  kind,
+                  giftId: params.giftId,
+                  thanked: body.thanked,
+                  actorOsnProfileId: osnProfileId,
+                });
+                yield* Effect.sync(() =>
+                  metricRegistryGift(body.thanked ? "thanked" : "unthanked"),
+                );
+                return { ok: true as const };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("GiftNotInWedding", () => giftNotFound(set)),
+                Effect.tapDefect(logDefect(weddingId)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        ),
     );
 
 /** Options for {@link createRegistryLinkPreviewRoutes}. */

--- a/cire/api/src/routes/vendor-directory.ts
+++ b/cire/api/src/routes/vendor-directory.ts
@@ -4,7 +4,7 @@ import { Elysia } from "elysia";
 
 import { DbService } from "../db";
 import type { Db } from "../db";
-import { SERVICE_CATEGORIES } from "../lib/service-categories";
+import { isServiceCategory } from "../lib/service-categories";
 import { osnAuth } from "../middleware/osn-auth";
 import type { OsnAuthOptions } from "../middleware/osn-auth";
 import { rateLimitMiddlewareByUser } from "../middleware/rate-limit";
@@ -15,8 +15,6 @@ import { runCire } from "../observability";
 import { AddFromDirectoryBody } from "../schemas/vendors";
 import { directoryService } from "../services/directory";
 import { vendorsService } from "../services/vendors";
-
-const CATEGORY_KEYS = new Set(SERVICE_CATEGORIES.map((c) => c.key));
 
 function clampInt(raw: unknown, def: number, min: number, max: number): number {
   const n = typeof raw === "string" ? Number.parseInt(raw, 10) : NaN;
@@ -77,7 +75,7 @@ export const createVendorDirectoryReadRoutes = (
         .get("/directory", async ({ weddingId, query, set }) => {
           if (!weddingId) return internalSync(set);
           const q = query as Record<string, string | undefined>;
-          const category = q.category && CATEGORY_KEYS.has(q.category) ? q.category : null;
+          const category = q.category && isServiceCategory(q.category) ? q.category : null;
           return runCire(
             directoryService
               .browse(weddingId, {
@@ -107,53 +105,51 @@ export const createVendorDirectoryWriteRoutes = (
   new Elysia({ prefix: "/api/organiser" })
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
-      group.guard((write) =>
-        write
-          .use(weddingEditor(db))
-          .use(weddingEntitlement(db, "vendors"))
-          .use(rateLimitMiddlewareByUser(limiter))
-          .post(
-            "/directory/:directoryVendorId/add",
-            async ({ weddingId, params, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(AddFromDirectoryBody)(raw);
-                  const listing = yield* directoryService.getLiveListingById(
-                    params.directoryVendorId,
-                  );
-                  if (!listing) return yield* notFound(set);
-                  if (!listing.categories.includes(body.category)) return yield* badRequest(set);
-                  const already = yield* vendorsService.existsForDirectory(
-                    weddingId,
-                    params.directoryVendorId,
-                  );
-                  if (already) return yield* conflict(set);
-                  const vendor = yield* vendorsService.create({
-                    weddingId,
-                    name: listing.name,
-                    category: body.category,
-                    status: "researching",
-                    contactName: null,
-                    email: listing.email,
-                    phone: listing.phone,
-                    notes: null,
-                    quotedMinor: null,
-                    directoryVendorId: listing.id,
-                  });
-                  set.status = 201;
-                  return { vendor };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchAllDefect((d) =>
-                    isUniqueViolation(d) ? conflict(set) : internal(set),
-                  ),
+      group
+        .use(weddingEditor(db))
+        .use(weddingEntitlement(db, "vendors"))
+        .use(rateLimitMiddlewareByUser(limiter))
+        .post(
+          "/directory/:directoryVendorId/add",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(AddFromDirectoryBody)(raw);
+                const listing = yield* directoryService.getLiveListingById(
+                  params.directoryVendorId,
+                );
+                if (!listing) return yield* notFound(set);
+                if (!listing.categories.includes(body.category)) return yield* badRequest(set);
+                const already = yield* vendorsService.existsForDirectory(
+                  weddingId,
+                  params.directoryVendorId,
+                );
+                if (already) return yield* conflict(set);
+                const vendor = yield* vendorsService.create({
+                  weddingId,
+                  name: listing.name,
+                  category: body.category,
+                  status: "researching",
+                  contactName: null,
+                  email: listing.email,
+                  phone: listing.phone,
+                  notes: null,
+                  quotedMinor: null,
+                  directoryVendorId: listing.id,
+                });
+                set.status = 201;
+                return { vendor };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchAllDefect((d) =>
+                  isUniqueViolation(d) ? conflict(set) : internal(set),
                 ),
-              );
-            },
-            manualParse,
-          ),
-      ),
+              ),
+            );
+          },
+          manualParse,
+        ),
     );

--- a/cire/api/src/routes/vendors.ts
+++ b/cire/api/src/routes/vendors.ts
@@ -108,141 +108,139 @@ export const createVendorWriteRoutes = (
   return new Elysia({ prefix: "/api/organiser" })
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
-      group.guard((write) =>
-        write
-          .use(weddingEditor(db))
-          .use(weddingEntitlement(db, "vendors"))
-          .post(
-            "/vendors",
-            async ({ weddingId, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(CreateVendorBody)(raw);
-                  const vendor = yield* vendorsService.create({
-                    weddingId,
-                    name: body.name,
-                    category: body.category,
-                    status: body.status,
-                    contactName: body.contactName ?? null,
-                    email: body.email ?? null,
-                    phone: body.phone ?? null,
-                    notes: body.notes ?? null,
-                    quotedMinor: body.quotedMinor ?? null,
-                  });
-                  return { vendor };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          // Register literal /vendors/reorder BEFORE /vendors/:vendorId
-          .post(
-            "/vendors/reorder",
-            async ({ weddingId, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(ReorderVendorsBody)(raw);
-                  yield* vendorsService.reorder(weddingId, body.status, body.orderedIds);
-                  return { ok: true as const };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .patch(
-            "/vendors/:vendorId",
-            async ({ weddingId, params, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(UpdateVendorBody)(raw);
-                  const vendor = yield* vendorsService.update(weddingId, params.vendorId, {
-                    name: body.name,
-                    category: body.category,
-                    status: body.status,
-                    contactName: body.contactName,
-                    email: body.email,
-                    phone: body.phone,
-                    notes: body.notes,
-                    quotedMinor: body.quotedMinor,
-                  });
-                  return { vendor };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          )
-          .delete("/vendors/:vendorId", async ({ weddingId, params, set }) => {
+      group
+        .use(weddingEditor(db))
+        .use(weddingEntitlement(db, "vendors"))
+        .post(
+          "/vendors",
+          async ({ weddingId, request, set }) => {
             if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
             return runCire(
-              vendorsService.remove(weddingId, params.vendorId).pipe(
-                Effect.map(() => ({ ok: true as const })),
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(CreateVendorBody)(raw);
+                const vendor = yield* vendorsService.create({
+                  weddingId,
+                  name: body.name,
+                  category: body.category,
+                  status: body.status,
+                  contactName: body.contactName ?? null,
+                  email: body.email ?? null,
+                  phone: body.phone ?? null,
+                  notes: body.notes ?? null,
+                  quotedMinor: body.quotedMinor ?? null,
+                });
+                return { vendor };
+              }).pipe(
                 Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        // Register literal /vendors/reorder BEFORE /vendors/:vendorId
+        .post(
+          "/vendors/reorder",
+          async ({ weddingId, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(ReorderVendorsBody)(raw);
+                yield* vendorsService.reorder(weddingId, body.status, body.orderedIds);
+                return { ok: true as const };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        )
+        .patch(
+          "/vendors/:vendorId",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(UpdateVendorBody)(raw);
+                const vendor = yield* vendorsService.update(weddingId, params.vendorId, {
+                  name: body.name,
+                  category: body.category,
+                  status: body.status,
+                  contactName: body.contactName,
+                  email: body.email,
+                  phone: body.phone,
+                  notes: body.notes,
+                  quotedMinor: body.quotedMinor,
+                });
+                return { vendor };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
                 Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
                 Effect.catchAllDefect(() => internal(set)),
               ),
             );
-          })
-          .post(
-            "/vendors/:vendorId/list-in-directory",
-            async ({ weddingId, params, request, set }) => {
-              if (!weddingId) return internalSync(set);
-              const raw: unknown = await request.json().catch(() => null);
-              return runCire(
-                Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(SeedListingBody)(raw);
-                  const result = yield* directoryService.seedFromCrm(weddingId, params.vendorId, {
-                    name: body.name,
-                    email: body.email,
-                    description: body.description ?? null,
-                    phone: body.phone ?? null,
-                    website: body.website ?? null,
-                    instagram: body.instagram ?? null,
-                    locationText: body.locationText ?? null,
-                    priceBand: null,
-                    priceMinMinor: null,
-                    priceMaxMinor: null,
-                    categories: [...body.categories],
-                  });
-                  // Best-effort claim invite email — error channel is `never`,
-                  // so providing the layer and running cannot fail the response.
-                  yield* sendClaimInviteEmail({
-                    to: body.email,
-                    claimUrl: result.claimUrl,
-                    vendorName: body.name,
-                  }).pipe(Effect.provide(emailLayer));
-                  return {
-                    directoryVendorId: result.directoryVendorId,
-                    claimUrl: result.claimUrl,
-                  };
-                }).pipe(
-                  Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () => badRequest(set)),
-                  Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
-                  Effect.catchAllDefect(() => internal(set)),
-                ),
-              );
-            },
-            manualParse,
-          ),
-      ),
+          },
+          manualParse,
+        )
+        .delete("/vendors/:vendorId", async ({ weddingId, params, set }) => {
+          if (!weddingId) return internalSync(set);
+          return runCire(
+            vendorsService.remove(weddingId, params.vendorId).pipe(
+              Effect.map(() => ({ ok: true as const })),
+              Effect.provideService(DbService, db),
+              Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
+              Effect.catchAllDefect(() => internal(set)),
+            ),
+          );
+        })
+        .post(
+          "/vendors/:vendorId/list-in-directory",
+          async ({ weddingId, params, request, set }) => {
+            if (!weddingId) return internalSync(set);
+            const raw: unknown = await request.json().catch(() => null);
+            return runCire(
+              Effect.gen(function* () {
+                const body = yield* Schema.decodeUnknown(SeedListingBody)(raw);
+                const result = yield* directoryService.seedFromCrm(weddingId, params.vendorId, {
+                  name: body.name,
+                  email: body.email,
+                  description: body.description ?? null,
+                  phone: body.phone ?? null,
+                  website: body.website ?? null,
+                  instagram: body.instagram ?? null,
+                  locationText: body.locationText ?? null,
+                  priceBand: null,
+                  priceMinMinor: null,
+                  priceMaxMinor: null,
+                  categories: [...body.categories],
+                });
+                // Best-effort claim invite email — error channel is `never`,
+                // so providing the layer and running cannot fail the response.
+                yield* sendClaimInviteEmail({
+                  to: body.email,
+                  claimUrl: result.claimUrl,
+                  vendorName: body.name,
+                }).pipe(Effect.provide(emailLayer));
+                return {
+                  directoryVendorId: result.directoryVendorId,
+                  claimUrl: result.claimUrl,
+                };
+              }).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
+                Effect.catchAllDefect(() => internal(set)),
+              ),
+            );
+          },
+          manualParse,
+        ),
     );
 };

--- a/cire/api/src/schemas/budget.ts
+++ b/cire/api/src/schemas/budget.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect";
 
 import { SERVICE_CATEGORIES } from "../lib/service-categories";
+import type { ServiceCategory } from "../lib/service-categories";
 
 const MAX_NAME_CHARS = 200;
 const MAX_LABEL_CHARS = 80;
@@ -10,7 +11,10 @@ const MAX_NOTES_CHARS = 2000;
 const MAX_MINOR = 9_000_000_000_000;
 
 // The category enum, sourced from the single list so the two never drift.
-const categoryKeys = SERVICE_CATEGORIES.map((c) => c.key) as [string, ...string[]];
+const categoryKeys = SERVICE_CATEGORIES.map((c) => c.key) as [
+  ServiceCategory,
+  ...ServiceCategory[],
+];
 const CategorySchema = Schema.Literal(...categoryKeys);
 
 const Name = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_NAME_CHARS));

--- a/cire/api/src/schemas/tasks.ts
+++ b/cire/api/src/schemas/tasks.ts
@@ -1,12 +1,13 @@
 import { Schema } from "effect";
 
 import { TIMEFRAME_BUCKETS } from "../lib/checklist-buckets";
+import type { TimeframeBucket } from "../lib/checklist-buckets";
 
 const MAX_TITLE_CHARS = 200;
 const MAX_NOTES_CHARS = 2000;
 
 // The bucket enum, sourced from the single list so the two never drift.
-const bucketKeys = TIMEFRAME_BUCKETS.map((b) => b.key) as [string, ...string[]];
+const bucketKeys = TIMEFRAME_BUCKETS.map((b) => b.key) as [TimeframeBucket, ...TimeframeBucket[]];
 const TimeframeBucketSchema = Schema.Literal(...bucketKeys);
 
 const Title = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_TITLE_CHARS));

--- a/cire/api/src/services/claim.ts
+++ b/cire/api/src/services/claim.ts
@@ -253,7 +253,7 @@ function buildClaimResponse(family: FamilyRow): Effect.Effect<ClaimResponse, nev
               .all(),
           );
 
-    const eventList: ClaimResponse["events"] = [];
+    const eventList: Array<ClaimResponse["events"][number]> = [];
     for (const e of eventRows) {
       const { palette, malformed } = decodePalette(e.dressCodePalette);
       if (malformed) {
@@ -506,7 +506,9 @@ export const claimService = {
 
       const byGuest = new Map<
         string,
-        { -readonly [K in keyof OrganiserGuestRow]: OrganiserGuestRow[K] }
+        Omit<{ -readonly [K in keyof OrganiserGuestRow]: OrganiserGuestRow[K] }, "events"> & {
+          events: string[];
+        }
       >();
       for (const row of rows) {
         let entry = byGuest.get(row.guestId);

--- a/cire/api/src/services/hosts.ts
+++ b/cire/api/src/services/hosts.ts
@@ -185,7 +185,13 @@ export const hostsService = {
         ),
       );
 
-      return { id, osnProfileId: input.osnProfileId, role: input.role, createdAt: now };
+      return {
+        id,
+        osnProfileId: input.osnProfileId,
+        role: input.role,
+        createdAt: now,
+        addedByOsnProfileId: input.addedByOsnProfileId,
+      };
     }).pipe(Effect.withSpan("cire.host.add"));
   },
 
@@ -266,7 +272,11 @@ export const hostsService = {
                   eq(weddingHosts.osnProfileId, input.osnProfileId),
                 ),
               )
-              .returning({ id: weddingHosts.id, createdAt: weddingHosts.createdAt })
+              .returning({
+                id: weddingHosts.id,
+                createdAt: weddingHosts.createdAt,
+                addedByOsnProfileId: weddingHosts.addedByOsnProfileId,
+              })
               .all(),
           ),
         catch: (e) => new HostWriteError({ op: "update", reason: String(e) }),
@@ -284,6 +294,7 @@ export const hostsService = {
         osnProfileId: input.osnProfileId,
         role: input.role,
         createdAt: updated.createdAt,
+        addedByOsnProfileId: updated.addedByOsnProfileId,
       };
     }).pipe(Effect.withSpan("cire.host.setRole"));
   },

--- a/cire/api/src/services/import.ts
+++ b/cire/api/src/services/import.ts
@@ -697,9 +697,11 @@ export function diffAgainstDb(
         db.select().from(rsvps).where(inArray(rsvps.guestId, ids)).all(),
       );
       const lostFirst = new Map(guestsBeingLost.map((g) => [g.id, g.firstName]));
+      // Every row here is an explicit response — `rsvps.status` is a required
+      // enum of attending/declined/maybe; "no response yet" is the absence of a
+      // row, never a stored "pending" status. So every fetched row is meaningful
+      // by definition (the previous `status !== "pending"` check was always true).
       for (const r of rsvpRows) {
-        const isMeaningful = r.status !== "pending" || (r.dietary && r.dietary.length > 0);
-        if (!isMeaningful) continue;
         const firstName = lostFirst.get(r.guestId) ?? "(unknown)";
         warnings.push(
           `Removing guest ${firstName} would lose their RSVP: status=${r.status}, dietary=${r.dietary ?? ""}`,

--- a/cire/api/src/services/invite.ts
+++ b/cire/api/src/services/invite.ts
@@ -1,5 +1,6 @@
 import { families, weddingInviteCustomisations, weddings } from "@cire/db";
 import type {
+  FontChoice,
   FontStyleChoice,
   FontWeightChoice,
   HeadingSizeChoice,
@@ -15,7 +16,6 @@ import {
   decodeCrop,
   HERO_BLUR_DEFAULT,
   type CropScreen,
-  type FontChoice,
   type ImageCrop,
   type InviteImageSlot,
   type InviteTextBody,
@@ -809,7 +809,7 @@ export const inviteService = {
 
       yield* Effect.logInfo("invite image uploaded", { weddingId });
       yield* Effect.sync(() => metricInviteAssetUploaded("ok", bytes.byteLength));
-      return imagePath(slug, slot, now.getTime());
+      return imagePath(slug, slot, now.getTime().toString());
     }).pipe(
       Effect.tapError(() => Effect.sync(() => metricInviteAssetUploaded("error"))),
       Effect.withSpan("cire.invite.setImage"),

--- a/cire/api/src/services/revert.ts
+++ b/cire/api/src/services/revert.ts
@@ -7,6 +7,7 @@ import { DbService, dbQuery } from "../db";
 import { metricImportReverted } from "../metrics";
 import type { ChangeScope, ImportSummary, ParsedFamily } from "../schemas/import";
 import { currentEventsAsParsed } from "./changes";
+import { CapacityExceeded } from "./entitlements";
 import { applyImport, diffAgainstDb, ImportError } from "./import";
 import { R2Service, fetchUpload, R2Error } from "./r2-imports";
 import { parseEventsCsv, parseGuestsCsv } from "./spreadsheet";
@@ -19,7 +20,12 @@ export class RevertParseError extends Data.TaggedError("RevertParseError")<{
   readonly reason: string;
 }> {}
 
-export type RevertError = NoPriorImport | R2Error | RevertParseError | ImportError;
+export type RevertError =
+  | NoPriorImport
+  | R2Error
+  | RevertParseError
+  | ImportError
+  | CapacityExceeded;
 
 /**
  * Reconcile the wedding to the state described by a pair of snapshot CSVs:
@@ -46,7 +52,7 @@ function reconcileToSnapshot(
   eventsCsv: string,
   guestsCsv: string,
   finalize: BatchItem<"sqlite">[] = [],
-): Effect.Effect<ImportSummary, RevertParseError | ImportError, DbService> {
+): Effect.Effect<ImportSummary, RevertParseError | ImportError | CapacityExceeded, DbService> {
   return Effect.gen(function* () {
     const hasEvents = eventsCsv.trim().length > 0;
     const hasGuests = guestsCsv.trim().length > 0;

--- a/cire/api/src/services/session.ts
+++ b/cire/api/src/services/session.ts
@@ -2,10 +2,10 @@ import { sessions } from "@cire/db";
 import { generateToken, hashToken } from "@shared/crypto/tokens";
 import { rowsChanged } from "@shared/db-utils";
 import { eq, lte } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import { Effect, Data } from "effect";
 
-import { DbService, dbQuery } from "../db";
-import type { BatchableDb } from "../db";
+import { commitBatch, DbService, dbQuery } from "../db";
 import { metricSessionCreated, metricSessionSwept } from "../metrics";
 
 export class SessionInvalid extends Data.TaggedError("SessionInvalid")<{
@@ -123,28 +123,22 @@ export const sessionService = {
       const now = new Date();
       const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
 
-      const insertStmt = db.insert(sessions).values({
-        id: crypto.randomUUID(),
-        familyId,
-        token: newHash,
-        expiresAt,
-        createdAt: now,
-      });
-      const deleteStmt = db.delete(sessions).where(eq(sessions.token, oldHash));
+      // Insert before delete in the statement list — on the bun:sqlite
+      // sequential fallback (no `.batch()`) that keeps the family with a live
+      // session at every point, matching the previous by-hand ordering.
+      const statements: BatchItem<"sqlite">[] = [
+        db.insert(sessions).values({
+          id: crypto.randomUUID(),
+          familyId,
+          token: newHash,
+          expiresAt,
+          createdAt: now,
+        }),
+        db.delete(sessions).where(eq(sessions.token, oldHash)),
+      ];
 
       yield* Effect.tryPromise({
-        try: () => {
-          const batchable = db as BatchableDb;
-          if (typeof batchable.batch === "function") {
-            return batchable.batch([insertStmt, deleteStmt]);
-          }
-          // bun:sqlite (tests/local): no .batch(); run sequentially — insert
-          // before delete so the family always has a live session.
-          return (async () => {
-            await insertStmt;
-            await deleteStmt;
-          })();
-        },
+        try: () => commitBatch(db, statements),
         catch: (e) => new SessionWriteError({ op: "insert", reason: String(e) }),
       }).pipe(
         Effect.tapError((err) => Effect.logError("session rotate failed", { reason: err.reason })),

--- a/cire/api/src/services/weddings.ts
+++ b/cire/api/src/services/weddings.ts
@@ -178,23 +178,25 @@ export const weddingsService = {
         const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 6);
         const slug = `${base}-${suffix}`;
 
-        const result = yield* Effect.tryPromise({
-          try: () =>
-            Promise.resolve(
-              db
-                .insert(weddings)
-                .values({
-                  id,
-                  slug,
-                  displayName: trimmed,
-                  ownerOsnProfileId: osnProfileId,
-                  codeStyle,
-                  createdAt: now,
-                  updatedAt: now,
-                })
-                .run(),
-            ),
-        }).pipe(
+        // The one-argument form, not `{ try }` — that object overload also
+        // requires a `catch`, and the failure is handled by the `catchAll`
+        // below rather than at the boundary.
+        const result = yield* Effect.tryPromise(() =>
+          Promise.resolve(
+            db
+              .insert(weddings)
+              .values({
+                id,
+                slug,
+                displayName: trimmed,
+                ownerOsnProfileId: osnProfileId,
+                codeStyle,
+                createdAt: now,
+                updatedAt: now,
+              })
+              .run(),
+          ),
+        ).pipe(
           Effect.map(() => ({
             ok: true as const,
             summary: {

--- a/shared/crypto/src/jwk.ts
+++ b/shared/crypto/src/jwk.ts
@@ -33,11 +33,18 @@ export const ARC_ALG = "ES256";
  * Returns Web Crypto CryptoKeyPair with extractable keys suitable for JWK export.
  */
 export async function generateArcKeyPair(): Promise<CryptoKeyPair> {
-  return crypto.subtle.generateKey(
+  const key = await crypto.subtle.generateKey(
     { name: "ECDSA", namedCurve: "P-256" },
     true, // extractable — needed for JWK export
     ["sign", "verify"],
   );
+  // `generateKey` is typed as returning `CryptoKey | CryptoKeyPair` because it
+  // serves symmetric algorithms too. ECDSA always yields the pair, so this
+  // narrows rather than asserts — the throw is unreachable in practice.
+  if (!("privateKey" in key)) {
+    throw new TypeError("generateKey returned a single key for ECDSA P-256");
+  }
+  return key;
 }
 
 /**


### PR DESCRIPTION
Part one of osn#714. `cire/api` has no `check` script, so `bun run check` skips
the package and about a hundred type errors have accumulated in its own source.
This clears the source half; the test half and the `check` script itself follow
in a second PR, because the two error sets are unrelated and reviewing them
together would bury the three real behaviour changes below.

Nothing here changes what the API does, with one exception called out under
Decisions.

## What changed

Most of the 19 files are narrow type fixes: an enum tuple typed as
`[string, ...string[]]` instead of the union it actually carries, a missing
field on a declared return shape, an error union that omitted a failure the
code could raise, `Bun.Server` named without its type argument, `import type`
moved to the module that exports the symbol.

Three are worth reading properly.

### Session rotation now uses `commitBatch`

`services/session.ts` had a hand-rolled `.batch()` feature-detect behind a
`BatchableDb` cast — the cast is what the type error was. It now calls
`commitBatch`, the shared helper the importer and the directory writes already
use, with the same insert-before-delete ordering. On D1 that is one `.batch()`;
on the bun:sqlite fallback it is the same sequential pair the old code ran, so
the family keeps a live session at every point either way.

### The organiser write routes swap `.guard()` for a second `.group()`

`routes/budget.ts`, `routes/registry.ts`, `routes/vendors.ts` and
`routes/vendor-directory.ts` drop the `.guard((write) => write.use(...))`
wrapper in favour of applying the gates to the group directly. In `budget.ts`
that means two `.group("/weddings/:weddingId", ...)` calls on one instance —
an Elysia gate is applied per group, so two groups is the only way to run two
different gates over one prefix. It is the form `routes/organiser-hosts.ts`
already uses.

The gates cover exactly the routes they covered before: seven editor routes
plus the owner-only `PUT /budget/total`, which the doc comment at the top of
the file lists route by route. `budget.test.ts` pins both directions and is
unchanged — an editor creates items and adds payments, and an editor gets 403
on the cap while the owner gets 200.

### An always-true RSVP filter is gone

`services/import.ts` warned before dropping a guest who had answered, and
filtered the rows with `status !== "pending" || dietary.length > 0`. But
`rsvps.status` is `text("status", { enum: ["attending", "declined", "maybe"] })
.notNull()` (`cire/db/src/schema.ts:813-815`) — there is no `"pending"`, and
"no answer yet" is the absence of a row. The left side was always true, so the
filter never dropped anything. Removing it leaves the behaviour as it has
always run and stops the dead comparison reading like a real guard.

## Decisions

The RSVP filter is the one place where a reader might expect a behaviour
change and not get one. If the intent was ever "only warn about attending or
declined guests, not maybe", that intent has never been in effect — the check
could not fire. Restoring it would be a new feature, not a fix, so it is not
in this PR.

## Verification

Run in the worktree, all green:

```
check      lint      fmt:check      test      changesets
```

`bunx tsc --noEmit` in `cire/api` still reports the 504 test-file errors — that
is the second PR's scope, and is why the `check` script is not added here.

Refs osn#714.
