### PR TITLE
chore(ci): verify vendored anti-slop before it executes

### DIFF
--- a/.changeset/vendored-anti-slop-gate.md
+++ b/.changeset/vendored-anti-slop-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: verify the vendored anti-slop oxlint plugin before it executes rather than in a parallel CI job, via a shared `scripts/verify-vendored-anti-slop.sh` called from the `lint` job and chained ahead of oxlint in the pre-commit hook.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This is the job that runs `bun run lint` below, which executes the
+      # vendored anti-slop plugin (oxlintrc.json's jsPlugins). `script-tests`
+      # runs this same check, but in parallel with this job — so it verifies
+      # the tree independently of, not before, the run that matters. This
+      # copy has to come before oxlint actually runs it, hence first step
+      # after checkout, before install.
+      - name: Verify vendored anti-slop matches its checksums
+        run: bash scripts/verify-vendored-anti-slop.sh
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
@@ -180,25 +189,22 @@ jobs:
   script-tests:
     name: Scripts
     runs-on: ubuntu-latest
+    # The backstop under this job's own checks. Without it the job's ceiling
+    # is GitHub's six hours — and because the aggregate `ci` job `needs` it,
+    # and `CI` is a required check, a wedged runner here holds the merge gate
+    # open for that long. Five minutes is generous: the job does a checkout,
+    # a shasum, and `bun test ./scripts/` with no install.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
-      # tools/oxlint/anti-slop is excluded from oxfmt and ignored by oxlint (see
-      # its README), specifically so a re-vendor stays a plain copy with no
-      # formatting noise. That also means an edit to the vendored tree passes
-      # every other gate unnoticed — this is the one check that would catch it.
-      # No bun needed, so it runs right after checkout.
-      #
-      # `shasum -c` only verifies the paths SHA256SUMS lists — a file ADDED to
-      # the tree isn't in that list, so it has nothing to check it against and
-      # passes silently. The diff catches that half: it fails if the tracked
-      # file set drifts from SHA256SUMS in either direction, added or removed.
+      # No bun needed, so it runs right after checkout. The `lint` job runs
+      # this same script too, and that copy is the one that matters for
+      # ordering (see the comment there). This one stays because `script-tests`
+      # is the job that owns everything under scripts/, and a shasum costs
+      # nothing.
       - name: Verify vendored anti-slop matches its checksums
-        run: |
-          cd tools/oxlint/anti-slop
-          shasum -c SHA256SUMS
-          diff <(sed 's/^[0-9a-f]*  //' SHA256SUMS | sort) \
-               <(find . -type f ! -name SHA256SUMS | sed 's|^\./||' | sort)
+        run: bash scripts/verify-vendored-anti-slop.sh
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,11 @@ pre-commit:
   commands:
     lint:
       glob: "*.{js,jsx,ts,tsx}"
-      run: bunx --bun oxlint -c oxlintrc.json {staged_files}
+      # Chained, not a sibling command: `pre-commit` runs `parallel: true`, so
+      # a separate command gives no ordering guarantee against oxlint, and the
+      # vendored anti-slop plugin (oxlintrc.json's jsPlugins) could execute
+      # unverified anyway. `&&` is the only way this hook enforces order.
+      run: bash scripts/verify-vendored-anti-slop.sh && bunx --bun oxlint -c oxlintrc.json {staged_files}
     format:
       glob: "*.{js,jsx,ts,tsx}"
       # Vendored upstream source is left byte-identical so re-vendoring a newer

--- a/scripts/verify-vendored-anti-slop.sh
+++ b/scripts/verify-vendored-anti-slop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# tools/oxlint/anti-slop is excluded from oxfmt and ignored by oxlint (see its
+# README), specifically so a re-vendor stays a plain copy with no formatting
+# noise. That also means an edit to the vendored tree passes every other gate
+# unnoticed — this is the one check that would catch it.
+#
+# `shasum -c` only verifies the paths SHA256SUMS lists — a file ADDED to the
+# tree isn't in that list, so it has nothing to check it against and passes
+# silently. The diff catches that half: it fails if the tracked file set
+# drifts from SHA256SUMS in either direction, added or removed.
+#
+# `git ls-files`, not `find`: it reads the tracked/staged set, which is what
+# this check claims to cover; it lists symlinks (`find -type f` silently
+# skips them); it needs no `sed` to strip a `./` prefix; and it works with no
+# `bun install` — the CI callers run before or without one.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+cd tools/oxlint/anti-slop
+shasum -c SHA256SUMS
+diff <(sed 's/^[0-9a-f]*  //' SHA256SUMS | sort) \
+     <(git ls-files | grep -v '^SHA256SUMS$' | sort)


### PR DESCRIPTION
## What

The oxlint plugin at `tools/oxlint/anti-slop` is a verbatim upstream copy, excluded from oxfmt and ignored by oxlint so a re-vendor stays a plain file copy. `oxlintrc.json` loads it as a JS plugin, so it executes on every `bun run lint` — including the pre-commit hook on a developer machine.

The check that verifies the vendored tree lived in the `script-tests` CI job, which runs *in parallel* with `lint`. It verified the tree independently of, not before, the run that executes it. On a dev machine there was no verification at all: `lefthook.yml`'s pre-commit ran oxlint straight.

This moves the check into a script and calls it from the places that matter:

- **`scripts/verify-vendored-anti-slop.sh`** (new) — `shasum -c SHA256SUMS`, plus a `diff` of the tracked file set against the paths `SHA256SUMS` lists, so an *added* file fails too (`shasum -c` can only check paths the list names).
- **`.github/workflows/ci.yml`** — called as the first step of the `lint` job, after checkout and before install, so it runs before oxlint executes the plugin. The `script-tests` copy stays and now calls the same script.
- **`lefthook.yml`** — chained ahead of oxlint with `&&` inside the existing `lint` command. A sibling command would give no ordering guarantee: `pre-commit` runs `parallel: true`.
- **`.github/workflows/ci.yml`** — `timeout-minutes: 5` on `script-tests`. The aggregate `ci` job `needs` it and `CI` is a required check, so without a timeout a wedged runner holds the merge gate open for GitHub's six-hour default.

The file list moved from `find . -type f ! -name SHA256SUMS` to `git ls-files`. `find` reads the worktree; the check's own comment and CLAUDE.md's "Vendored trees" row both describe the *tracked* set. `git ls-files` also lists symlinks (`find -type f` silently skips them), needs no `sed` to strip `./`, reads the index — right for a pre-commit hook — and works with no `bun install`, which both new callers require.

`tools/oxlint/anti-slop/README.md` is deliberately untouched: its re-vendor recipe runs before files are staged, so it must keep using `find`.

## Verification

Gates: `check`, `lint`, `fmt:check`, `test`, `test:scripts`, `validate-changesets.sh` — all pass. Both YAML files parse.

Proved the gate bites, in the worktree:

| Tamper | Result |
|---|---|
| Append a line to `tools/oxlint/anti-slop/index.ts` | exit 1 — `shasum: WARNING: 1 computed checksum did NOT match` |
| Add and stage `tools/oxlint/anti-slop/sneaky.ts` | exit 1 — `diff` reports `21a22 > sneaky.ts` |
| `git rm` a vendored file | exit 1 — `shasum: WARNING: 1 listed file could not be read` |
| Clean tree | exit 0 |

Also runs correctly from a subdirectory, and the file is mode `100755`.

## Issues

Closes xchromo/osn-tracker#494 (S-H1)
Closes xchromo/osn-tracker#489 (P-I2)
Closes xchromo/osn-tracker#490 (P-I3).
