### PR TITLE
fix(osn-client): widen auth-fetch signatures, dedupe qs(), add sideEffects flag and tests

### DIFF
--- a/.changeset/osn-client-polish.md
+++ b/.changeset/osn-client-polish.md
@@ -1,0 +1,5 @@
+---
+"@osn/client": patch
+---
+
+Widens `authPost`/`authPatch`/`authDelete`/`authDeleteVoid` to accept an optional `AuthFetchOptions` with an abort signal, matching `authGet`. Also marks the package `sideEffects: false` so bundlers can tree-shake it, and moves the duplicated pagination query builder into `auth-fetch.ts`.

--- a/osn/client/package.json
+++ b/osn/client/package.json
@@ -3,6 +3,7 @@
   "version": "2.13.3",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
     "./solid": "./src/solid/index.ts"

--- a/osn/client/src/auth-fetch.ts
+++ b/osn/client/src/auth-fetch.ts
@@ -38,18 +38,28 @@ export function safeErrorMessage(value: unknown, status: number): string {
   return value.length > 200 ? `${value.slice(0, 200)}…` : value;
 }
 
-export interface AuthFetchers {
-  authGet<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T>;
-  authPost<T>(url: string, token: string, body?: unknown): Promise<T>;
-  authPatch<T>(url: string, token: string, body: unknown): Promise<T>;
-  /** For endpoints that return a JSON body on success (e.g. `{ ok: true }`). */
-  authDelete<T>(url: string, token: string): Promise<T>;
-  /** For callers that want no body back. Parses JSON only on the error path, so a
-   * success response that is empty or unparseable still resolves. */
-  authDeleteVoid(url: string, token: string): Promise<void>;
+/** Shared `?limit=&offset=` pagination query builder for the package's list endpoints. */
+export function qs(options?: { limit?: number; offset?: number }): string {
+  if (!options) return "";
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  const str = params.toString();
+  return str ? `?${str}` : "";
 }
 
-/** Build the four `auth*` helpers, parameterised on the error class each caller throws. */
+export interface AuthFetchers {
+  authGet<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T>;
+  authPost<T>(url: string, token: string, body?: unknown, options?: AuthFetchOptions): Promise<T>;
+  authPatch<T>(url: string, token: string, body: unknown, options?: AuthFetchOptions): Promise<T>;
+  /** For endpoints that return a JSON body on success (e.g. `{ ok: true }`). */
+  authDelete<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T>;
+  /** For callers that want no body back. Parses JSON only on the error path, so a
+   * success response that is empty or unparseable still resolves. */
+  authDeleteVoid(url: string, token: string, options?: AuthFetchOptions): Promise<void>;
+}
+
+/** Build the five `auth*` helpers, parameterised on the error class each caller throws. */
 export function createAuthFetchers(ErrorCtor: new (message: string) => Error): AuthFetchers {
   async function authGet<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T> {
     const res = await fetch(url, {
@@ -66,7 +76,12 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
     return json;
   }
 
-  async function authPost<T>(url: string, token: string, body?: unknown): Promise<T> {
+  async function authPost<T>(
+    url: string,
+    token: string,
+    body?: unknown,
+    options?: AuthFetchOptions,
+  ): Promise<T> {
     const res = await fetch(url, {
       method: "POST",
       headers: {
@@ -74,6 +89,7 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
         "Content-Type": "application/json",
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: options?.signal,
     });
     const json = await safeJson<T>(res);
     if (!res.ok) {
@@ -85,7 +101,12 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
     return json;
   }
 
-  async function authPatch<T>(url: string, token: string, body: unknown): Promise<T> {
+  async function authPatch<T>(
+    url: string,
+    token: string,
+    body: unknown,
+    options?: AuthFetchOptions,
+  ): Promise<T> {
     const res = await fetch(url, {
       method: "PATCH",
       headers: {
@@ -93,6 +114,7 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
+      signal: options?.signal,
     });
     const json = await safeJson<T>(res);
     if (!res.ok) {
@@ -104,10 +126,11 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
     return json;
   }
 
-  async function authDelete<T>(url: string, token: string): Promise<T> {
+  async function authDelete<T>(url: string, token: string, options?: AuthFetchOptions): Promise<T> {
     const res = await fetch(url, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${token}` },
+      signal: options?.signal,
     });
     const json = await safeJson<T>(res);
     if (!res.ok) {
@@ -119,10 +142,15 @@ export function createAuthFetchers(ErrorCtor: new (message: string) => Error): A
     return json;
   }
 
-  async function authDeleteVoid(url: string, token: string): Promise<void> {
+  async function authDeleteVoid(
+    url: string,
+    token: string,
+    options?: AuthFetchOptions,
+  ): Promise<void> {
     const res = await fetch(url, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${token}` },
+      signal: options?.signal,
     });
     if (!res.ok) {
       const json = await safeJson<{ error?: string }>(res);

--- a/osn/client/src/graph.ts
+++ b/osn/client/src/graph.ts
@@ -4,7 +4,7 @@
  * Bearer token auth.
  */
 
-import { createAuthFetchers } from "./auth-fetch";
+import { createAuthFetchers, qs } from "./auth-fetch";
 
 export interface GraphClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
@@ -47,19 +47,6 @@ export class GraphClientError extends Error {
     super(message);
     this.name = "GraphClientError";
   }
-}
-
-// ---------------------------------------------------------------------------
-// Query string helper
-// ---------------------------------------------------------------------------
-
-function qs(options?: { limit?: number; offset?: number }): string {
-  if (!options) return "";
-  const params = new URLSearchParams();
-  if (options.limit !== undefined) params.set("limit", String(options.limit));
-  if (options.offset !== undefined) params.set("offset", String(options.offset));
-  const str = params.toString();
-  return str ? `?${str}` : "";
 }
 
 // ---------------------------------------------------------------------------

--- a/osn/client/src/organisations.ts
+++ b/osn/client/src/organisations.ts
@@ -4,7 +4,7 @@
  * Bearer token auth.
  */
 
-import { createAuthFetchers } from "./auth-fetch";
+import { createAuthFetchers, qs } from "./auth-fetch";
 
 export interface OrgClientConfig {
   /** OSN issuer base URL, e.g. http://localhost:4000 */
@@ -38,19 +38,6 @@ export class OrgClientError extends Error {
     super(message);
     this.name = "OrgClientError";
   }
-}
-
-// ---------------------------------------------------------------------------
-// Query string helper
-// ---------------------------------------------------------------------------
-
-function qs(options?: { limit?: number; offset?: number }): string {
-  if (!options) return "";
-  const params = new URLSearchParams();
-  if (options.limit !== undefined) params.set("limit", String(options.limit));
-  if (options.offset !== undefined) params.set("offset", String(options.offset));
-  const str = params.toString();
-  return str ? `?${str}` : "";
 }
 
 // ---------------------------------------------------------------------------

--- a/osn/client/tests/auth-fetch.test.ts
+++ b/osn/client/tests/auth-fetch.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAuthFetchers, safeErrorMessage, safeJson } from "../src/auth-fetch";
+import * as barrel from "../src/index";
+
+class FakeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FakeError";
+  }
+}
+
+const { authGet, authPost, authPatch, authDelete, authDeleteVoid } = createAuthFetchers(FakeError);
+
+const url = "https://osn.example.com/thing";
+const TOKEN = "test-token";
+
+function mockFetch(response: { ok: boolean; status?: number; json: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+}
+
+function headersOf(call: Parameters<typeof fetch>) {
+  return (call[1] as RequestInit).headers as Record<string, string>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createAuthFetchers — Authorization header", () => {
+  it("authGet sends Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authGet(url, TOKEN);
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("authPost sends Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPost(url, TOKEN, { a: 1 });
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("authPatch sends Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPatch(url, TOKEN, { a: 1 });
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("authDelete sends Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authDelete(url, TOKEN);
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("authDeleteVoid sends Bearer auth", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve(null) });
+    await authDeleteVoid(url, TOKEN);
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+});
+
+describe("createAuthFetchers — Content-Type", () => {
+  it("authPost sends application/json", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPost(url, TOKEN, { a: 1 });
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!)["Content-Type"]).toBe("application/json");
+  });
+
+  it("authPatch sends application/json", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPatch(url, TOKEN, { a: 1 });
+    expect(headersOf(vi.mocked(fetch).mock.calls[0]!)["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("createAuthFetchers — authPost body handling", () => {
+  it('sends body: undefined, not the string "undefined", when called with no body', async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPost(url, TOKEN);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.body).toBeUndefined();
+  });
+
+  it("JSON-stringifies a provided body", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    await authPost(url, TOKEN, { a: 1 });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.body).toBe(JSON.stringify({ a: 1 }));
+  });
+});
+
+describe("createAuthFetchers — Invalid response on ok-but-unparseable body", () => {
+  it("authGet throws Invalid response: <status>", async () => {
+    mockFetch({ ok: true, status: 200, json: () => Promise.reject(new Error("bad json")) });
+    await expect(authGet(url, TOKEN)).rejects.toThrow("Invalid response: 200");
+  });
+
+  it("authPost throws Invalid response: <status>", async () => {
+    mockFetch({ ok: true, status: 200, json: () => Promise.reject(new Error("bad json")) });
+    await expect(authPost(url, TOKEN, { a: 1 })).rejects.toThrow("Invalid response: 200");
+  });
+
+  it("authPatch throws Invalid response: <status>", async () => {
+    mockFetch({ ok: true, status: 200, json: () => Promise.reject(new Error("bad json")) });
+    await expect(authPatch(url, TOKEN, { a: 1 })).rejects.toThrow("Invalid response: 200");
+  });
+
+  it("authDelete throws Invalid response: <status>", async () => {
+    mockFetch({ ok: true, status: 200, json: () => Promise.reject(new Error("bad json")) });
+    await expect(authDelete(url, TOKEN)).rejects.toThrow("Invalid response: 200");
+  });
+});
+
+describe("createAuthFetchers — authDeleteVoid", () => {
+  it("resolves on an empty/unparseable success body", async () => {
+    mockFetch({ ok: true, json: () => Promise.reject(new Error("bad json")) });
+    await expect(authDeleteVoid(url, TOKEN)).resolves.toBeUndefined();
+  });
+
+  it("throws on non-2xx", async () => {
+    mockFetch({ ok: false, json: () => Promise.resolve({ error: "boom" }) });
+    await expect(authDeleteVoid(url, TOKEN)).rejects.toBeInstanceOf(FakeError);
+  });
+});
+
+describe("safeErrorMessage", () => {
+  it("falls back to Request failed: <status> on a missing key", async () => {
+    expect(safeErrorMessage(undefined, 404)).toBe("Request failed: 404");
+  });
+
+  it("falls back to Request failed: <status> on an empty string", async () => {
+    expect(safeErrorMessage("", 404)).toBe("Request failed: 404");
+  });
+
+  it("falls back to Request failed: <status> on a non-string value", async () => {
+    expect(safeErrorMessage({ code: 1 }, 404)).toBe("Request failed: 404");
+  });
+
+  it("truncates a string longer than 200 characters to 200 chars + U+2026", async () => {
+    const long = "x".repeat(250);
+    const result = safeErrorMessage(long, 500);
+    expect(result).toBe(`${"x".repeat(200)}…`);
+    expect(result.length).toBe(201);
+  });
+
+  it("passes through a short string unchanged", async () => {
+    expect(safeErrorMessage("boom", 400)).toBe("boom");
+  });
+});
+
+describe("safeJson", () => {
+  it("returns the parsed value for valid JSON", async () => {
+    const res = { json: () => Promise.resolve({ a: 1 }) } as Response;
+    await expect(safeJson(res)).resolves.toEqual({ a: 1 });
+  });
+
+  it("returns null when json() rejects", async () => {
+    const res = { json: () => Promise.reject(new Error("bad json")) } as Response;
+    await expect(safeJson(res)).resolves.toBeNull();
+  });
+});
+
+describe("createAuthFetchers — signal forwarding", () => {
+  it("authGet forwards the abort signal", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    const controller = new AbortController();
+    await authGet(url, TOKEN, { signal: controller.signal });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("authPost forwards the abort signal", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    const controller = new AbortController();
+    await authPost(url, TOKEN, { a: 1 }, { signal: controller.signal });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("authPatch forwards the abort signal", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    const controller = new AbortController();
+    await authPatch(url, TOKEN, { a: 1 }, { signal: controller.signal });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("authDelete forwards the abort signal", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    const controller = new AbortController();
+    await authDelete(url, TOKEN, { signal: controller.signal });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("authDeleteVoid forwards the abort signal", async () => {
+    mockFetch({ ok: true, json: () => Promise.resolve(null) });
+    const controller = new AbortController();
+    await authDeleteVoid(url, TOKEN, { signal: controller.signal });
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+});
+
+describe("barrel", () => {
+  it("does not re-export createAuthFetchers", () => {
+    expect(Object.keys(barrel)).not.toContain("createAuthFetchers");
+  });
+});

--- a/osn/client/tests/graph.test.ts
+++ b/osn/client/tests/graph.test.ts
@@ -123,6 +123,23 @@ describe("createGraphClient — connection mutations", () => {
     await client.sendConnectionRequest(TOKEN, "alice bob");
     expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(`${base}/connections/alice%20bob`);
   });
+
+  it("removeConnection throws on a 204 with no body, unlike organisations' void deletes", async () => {
+    // graph's DELETE /graph/connections/:handle answers 200 { ok: true } today
+    // (osn/api/src/routes/graph.ts:256); removeConnection uses authDelete, which
+    // parses the success body. If that route ever regressed to a bodyless 204,
+    // this would catch it before organisations.ts's void-returning pattern got
+    // copied here by mistake.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        json: () => Promise.reject(new SyntaxError("Unexpected end of JSON")),
+      } as Response),
+    );
+    await expect(client.removeConnection(TOKEN, "alice")).rejects.toThrow("Invalid response: 204");
+  });
 });
 
 describe("createGraphClient — blocks", () => {


### PR DESCRIPTION
Four small `@osn/client` findings, all in `osn/client/src/auth-fetch.ts` and its callers.

## What changed

**Abort signals on the write verbs (tracker#526).** `authGet` already took an
`AuthFetchOptions` with a `signal`; the other four helpers did not, so a caller
that wanted to cancel a POST/PATCH/DELETE had no way to say so. All four now take
the same optional trailing `options` argument and forward `signal` into `fetch`.
The argument is optional and last, so every existing call site is untouched. No
default timeout was added — a timeout is a caller's policy, not the SDK's.

**One `qs()` instead of two (tracker#525).** `graph.ts` and `organisations.ts`
each carried a byte-identical `?limit=&offset=` builder. It now lives beside
`safeJson`/`safeErrorMessage` in `auth-fetch.ts` and is imported by both. It is
deliberately *not* re-exported from the package barrel: `auth-fetch` is internal
plumbing, and nothing outside the package should build these query strings.

**`"sideEffects": false` (tracker#506).** No module in the package does
import-time work, so bundlers can drop what a consumer does not import.

**Tests for the shared helpers (tracker#505).** `auth-fetch.ts` was the only
module in the package with no test file of its own — it was covered only
indirectly, through whichever client happened to exercise a verb. New
`osn/client/tests/auth-fetch.test.ts` covers the bearer header on all five
verbs, `Content-Type` on the two that send a body, the body-omitted arm of
`authPost`, the `Invalid response: <status>` path on all four body-parsing
verbs, `authDeleteVoid` resolving on an empty body, `safeErrorMessage`'s four
fallbacks and its 200-char truncation, `safeJson` directly, signal forwarding on
all five verbs, and one assertion that the barrel does not leak
`createAuthFetchers`.

One deviation from tracker#526 as written: it asks for a test that aborts a
controller mid-flight and asserts the promise rejects. With `fetch` replaced by
`vi.stubGlobal`, the stub ignores the signal, so such a test would assert
something about the mock rather than about this code. The tests assert
*forwarding* instead — the same shape `recommendations.test.ts:93` already uses.

`graph.test.ts` gains one case: `removeConnection` uses the body-parsing
`authDelete`, so a bodyless 204 from `GET/DELETE /graph/connections/:handle`
(`osn/api/src/routes/graph.ts:256`) would throw. The route answers
`200 { ok: true }` today; the test pins that assumption.

## Verification

Gates re-run in the worktree, not taken on trust: `check`, `lint`, `fmt:check`,
`test` (227 passing across 21 files in `@osn/client`), and
`scripts/validate-changesets.sh`.

Three gate-bite checks, each restored with `git checkout --` afterwards:

| Break | Result |
|---|---|
| Delete the `Authorization` header from `authPost` | 1 test fails |
| Delete `signal: options?.signal` from `authPatch` | 1 test fails |
| Make `authPost`'s `body:` an unconditional `JSON.stringify(body)` | **passes** — see below |

The third does not bite, and that is correct rather than a gap:
`JSON.stringify(undefined)` returns `undefined`, not the string `"undefined"`,
so the two forms are behaviourally identical. The test asserts the observable
contract (`init.body` is `undefined` when no body is given) and no implementation
that satisfies it can send the string.

Closes xchromo/osn-tracker#505
Closes xchromo/osn-tracker#506
Closes xchromo/osn-tracker#525
Closes xchromo/osn-tracker#526.
