### PR TITLE
fix(test-config): stop vite-plugin-solid injecting jest-dom into every setupFiles

### DIFF
--- a/.changeset/jest-dom-setup.md
+++ b/.changeset/jest-dom-setup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stop `vite-plugin-solid` injecting `@testing-library/jest-dom/vitest` into every Vitest project's setup files; matcher-using tests import it themselves, and a shared marker file suppresses the plugin's default.

--- a/cire/host/src/components/BudgetView.test.tsx
+++ b/cire/host/src/components/BudgetView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetBudgetCache, type BudgetSnapshot, setCachedBudget } from "../lib/budget-store";

--- a/cire/host/src/components/ChecklistView.test.tsx
+++ b/cire/host/src/components/ChecklistView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetTasksCache, setCachedTasks, type TaskRow } from "../lib/tasks-store";

--- a/cire/host/src/components/DirectoryBrowseView.test.tsx
+++ b/cire/host/src/components/DirectoryBrowseView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const authFetch = vi.fn();

--- a/cire/host/src/components/EnquireDialog.test.tsx
+++ b/cire/host/src/components/EnquireDialog.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EnquiryListItem } from "../lib/enquiries-store";

--- a/cire/host/src/components/EnquiriesView.test.tsx
+++ b/cire/host/src/components/EnquiriesView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EnquiryListItem, EnquiryMessage } from "../lib/enquiries-store";

--- a/cire/host/src/components/EnquiryInbox.test.tsx
+++ b/cire/host/src/components/EnquiryInbox.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EnquiryListItem } from "../lib/enquiries-store";

--- a/cire/host/src/components/EnquiryThread.test.tsx
+++ b/cire/host/src/components/EnquiryThread.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EnquiryListItem, EnquiryMessage } from "../lib/enquiries-store";

--- a/cire/host/src/components/InviteBuilder.test.tsx
+++ b/cire/host/src/components/InviteBuilder.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { derivePalette, PALETTE_PRESETS, typographyVar } from "@cire/theme";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**

--- a/cire/host/src/components/Overview.agenda.test.tsx
+++ b/cire/host/src/components/Overview.agenda.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetBudgetCache, setCachedBudget } from "../lib/budget-store";

--- a/cire/host/src/components/Overview.budget.test.tsx
+++ b/cire/host/src/components/Overview.budget.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetBudgetCache, type BudgetSnapshot, setCachedBudget } from "../lib/budget-store";

--- a/cire/host/src/components/Overview.checklist.test.tsx
+++ b/cire/host/src/components/Overview.checklist.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetBudgetCache } from "../lib/budget-store";

--- a/cire/host/src/components/Overview.test.tsx
+++ b/cire/host/src/components/Overview.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**

--- a/cire/host/src/components/RegistryImageField.test.tsx
+++ b/cire/host/src/components/RegistryImageField.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/cire/host/src/components/RegistryView.test.tsx
+++ b/cire/host/src/components/RegistryView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/cire/host/src/components/SettingsPanel.test.tsx
+++ b/cire/host/src/components/SettingsPanel.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**

--- a/cire/host/src/components/VendorsView.test.tsx
+++ b/cire/host/src/components/VendorsView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetVendorsCache, setCachedVendors, type VendorRow } from "../lib/vendors-store";

--- a/cire/host/src/components/invite/PreviewModal.test.tsx
+++ b/cire/host/src/components/invite/PreviewModal.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PreviewModal from "./PreviewModal";

--- a/cire/host/src/components/ui/ui.test.tsx
+++ b/cire/host/src/components/ui/ui.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/cire/host/src/test-support/vitest-dom.d.ts
+++ b/cire/host/src/test-support/vitest-dom.d.ts
@@ -1,7 +1,0 @@
-// Vitest 4 ships the jest-dom matchers (`toBeInTheDocument`, `toHaveClass`,
-// `toHaveAttribute`, …) in its own `expect`, so the tests call them without a
-// setup file. It does not ship their *types*, so `astro check` saw 135
-// "property does not exist on type Assertion" errors across the test tier.
-// `@testing-library/jest-dom` carries the matching declarations and nothing
-// else here loads them — this is a types-only import, no runtime effect.
-import "@testing-library/jest-dom/vitest";

--- a/cire/host/vitest.config.ts
+++ b/cire/host/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
           // NODE process, and a browser test's `Intl` reads the browser's zone,
           // not the runner's — see the note on the browser project below.
           env: { TZ: "Australia/Sydney" },
+          setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
         },
       },
       {

--- a/cire/invites/vitest.config.ts
+++ b/cire/invites/vitest.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
           transformMode: { web: [/\.[jt]sx?$/] },
           passWithNoTests: true,
           exclude: ["**/node_modules/**", "**/dist/**", "**/*.browser.test.{ts,tsx}"],
+          setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
         },
       },
       {

--- a/cire/landing/vitest.config.ts
+++ b/cire/landing/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: "jsdom",
     transformMode: { web: [/\.[jt]sx?$/] },
     passWithNoTests: true,
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/cire/vendor/src/components/ClaimApp.test.tsx
+++ b/cire/vendor/src/components/ClaimApp.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import type { JSX } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/cire/vendor/src/components/ListingEditor.test.tsx
+++ b/cire/vendor/src/components/ListingEditor.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { AuthProvider } from "@shared/rp-auth/solid";
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { type JSX } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/cire/vendor/src/components/OrgPicker.test.tsx
+++ b/cire/vendor/src/components/OrgPicker.test.tsx
@@ -1,5 +1,6 @@
 import { AuthProvider } from "@shared/rp-auth/solid";
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 // @vitest-environment happy-dom
 import { type JSX } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/cire/vendor/src/components/ProfileMenu.test.tsx
+++ b/cire/vendor/src/components/ProfileMenu.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import ProfileMenu from "./ProfileMenu";

--- a/cire/vendor/src/components/TopBar.test.tsx
+++ b/cire/vendor/src/components/TopBar.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import TopBar from "./TopBar";

--- a/cire/vendor/src/components/VendorApp.test.tsx
+++ b/cire/vendor/src/components/VendorApp.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mutable session value so each test can control what useAuth() returns.

--- a/cire/vendor/src/components/VendorEnquiryInbox.test.tsx
+++ b/cire/vendor/src/components/VendorEnquiryInbox.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────

--- a/cire/vendor/src/components/VendorEnquiryThread.test.tsx
+++ b/cire/vendor/src/components/VendorEnquiryThread.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────

--- a/cire/vendor/src/components/ui/ui.test.tsx
+++ b/cire/vendor/src/components/ui/ui.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen } from "@solidjs/testing-library";
+import "@testing-library/jest-dom/vitest";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/cire/vendor/src/test-setup.ts
+++ b/cire/vendor/src/test-setup.ts
@@ -1,1 +1,0 @@
-import "@testing-library/jest-dom/vitest";

--- a/cire/vendor/vitest.config.ts
+++ b/cire/vendor/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
-    setupFiles: ["./src/test-setup.ts"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/osn/client/vitest.config.ts
+++ b/osn/client/vitest.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [solid()],
-  test: { environment: "node", include: ["tests/**/*.test.{ts,tsx}"] },
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
+  },
 });

--- a/osn/landing/vitest.config.ts
+++ b/osn/landing/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: "jsdom",
     transformMode: { web: [/\.[jt]sx?$/] },
     passWithNoTests: true,
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/osn/social/vitest.config.ts
+++ b/osn/social/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
     coverage: {
       provider: "istanbul",
       include: ["src/**/*.{ts,tsx}"],

--- a/osn/ui/vitest.config.ts
+++ b/osn/ui/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/pulse/landing/vitest.config.ts
+++ b/pulse/landing/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: "jsdom",
     transformMode: { web: [/\.[jt]sx?$/] },
     passWithNoTests: true,
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/pulse/web/vitest.config.ts
+++ b/pulse/web/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
     // Allow async event handlers to throw unhandled rejections without failing
     // the suite — this mirrors real browser behaviour where onSubmit rejection
     // is silently swallowed. Required to test the `if (error) throw error` path

--- a/shared/rp-auth/vitest.config.ts
+++ b/shared/rp-auth/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/shared/sortable/vitest.config.ts
+++ b/shared/sortable/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/shared/test-config/no-jest-dom.ts
+++ b/shared/test-config/no-jest-dom.ts
@@ -1,0 +1,11 @@
+// A marker, not a setup file. `vite-plugin-solid` prepends
+// `@testing-library/jest-dom/vitest` to `setupFiles` for every Vitest run unless
+// some entry's path already matches /jest-dom/ — see `getJestDomExport` in the
+// plugin's `dist/esm/index.mjs`. Naming this file so the path matches is what
+// suppresses that, and it is worth several seconds of setup per package.
+//
+// Never put real setup code here. It belongs to no package, so turbo's `test`
+// task inputs do not hash it and editing it would invalidate nobody's cache.
+// A test that needs a jest-dom matcher imports
+// `@testing-library/jest-dom/vitest` itself.
+export {};

--- a/shared/toast/vitest.config.ts
+++ b/shared/toast/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });


### PR DESCRIPTION
## Summary

`vite-plugin-solid` prepends `@testing-library/jest-dom/vitest` to `setupFiles` on **every** Vitest project it configures, unless one of that project's existing `setupFiles` entries has a path matching `/jest-dom/`. Nothing in this repo opted in — the plugin's `getJestDomExport` does it by default — so all 13 Vitest projects were loading the whole jest-dom matcher bundle once per worker, including the ten packages that never call a jest-dom matcher.

This branch makes the repo's stance explicit instead of inherited:

- Adds `shared/test-config/no-jest-dom.ts`, a marker file whose *path* is what suppresses the injection. It is `export {};` plus a comment block; it is deliberately not a setup file and must never grow setup code (it belongs to no package, so turbo's `test` inputs do not hash it).
- Wires it as `setupFiles` in all 13 `vitest.config.ts` files.
- Adds an explicit `import "@testing-library/jest-dom/vitest";` to the 27 test files that actually use a jest-dom matcher.
- Deletes `cire/vendor/src/test-setup.ts` (its entire body was that one import) and `cire/host/src/test-support/vitest-dom.d.ts` (its comment claimed Vitest 4 ships the matchers, which is not true; `bun run --cwd cire/host check` is `0 errors, 0 warnings` without it).

## Workspaces affected

| Package | Path |
|---|---|
| `@cire/host` | `cire/host` |
| `@cire/invites` | `cire/invites` |
| `@cire/landing` | `cire/landing` |
| `@cire/vendor` | `cire/vendor` |
| `@osn/client` | `osn/client` |
| `@osn/landing` | `osn/landing` |
| `@osn/social` | `osn/social` |
| `@osn/ui` | `osn/ui` |
| `@pulse/landing` | `pulse/landing` |
| `@pulse/web` | `pulse/web` |
| `@shared/rp-auth` | `shared/rp-auth` |
| `@shared/sortable` | `shared/sortable` |
| `@shared/toast` | `shared/toast` |

## Issues

### Closes

| Issue | Finding |
|---|---|
| `xchromo/osn-tracker#516` | `P-W1` |
| `xchromo/osn-tracker#500` | `P-I2` |

Closes xchromo/osn-tracker#516.
Closes xchromo/osn-tracker#500.

### Opened

| Issue | What |
|---|---|
| `xchromo/osn#791` | Ten packages list `@testing-library/jest-dom` in `devDependencies` with zero importers; safe to drop only once this injection is gone. |
| `xchromo/osn-tracker#530` | `P-I1` — the marker file sits outside every package's turbo `test` input hash, so nothing but its own comment stops it growing real setup code. |

## Decisions

### A marker file, not thirteen inline suppressions

**Issue:** The plugin's opt-out is "some `setupFiles` path matches `/jest-dom/`". Any path satisfies it, including a per-package stub.
**Why:** Thirteen stubs is thirteen files that each look like a setup file and will eventually be treated as one.
**Solution:** One shared file at `shared/test-config/no-jest-dom.ts`, referenced by relative path from each config.
**Rationale:** The suppression is a repo-wide property of how we use the plugin, so it lives in one place, with the explanation attached to it. The comment in that file states plainly that the *name* is the mechanism and that real setup code must not go there.

### Matcher-using tests import jest-dom themselves

**Issue:** Once the injection stops, the matchers have to come from somewhere.
**Why:** A global `setupFiles` entry that loads them for every package reproduces the problem this branch removes, just with our name on it.
**Solution:** 27 test files gained `import "@testing-library/jest-dom/vitest";`.
**Rationale:** Cost lands where the dependency is. A reader of one of those files can now see why `toBeInTheDocument` resolves.

### Out of scope

- **Dropping the unused `devDependencies`.** Filed as `xchromo/osn#791` rather than done here, so a regression in either half is attributable. Also worth knowing before doing it: the plugin's probe uses `require.resolve` from the *plugin's* module context, not the package under test, so bun hoisting can keep a green run green after a package drops the dependency — a passing suite is not proof.
- **A guard that stops a jest-dom-only setup file coming back.** `xchromo/osn-tracker#504`, next PR in this stack. It will also carry the fix for `xchromo/osn-tracker#530`, since both walk the same 13 configs.
- **`tools/lab/vitest.config.ts:7-10`** carries a comment describing the pre-marker world. Stale prose, not a bug; left for whoever next edits that file.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run test` | pass — 37/37 tasks, `@cire/api` 1684 tests across 103 files |
| `bash scripts/validate-changesets.sh` | pass |
| `bash scripts/changeset-required.sh` | pass |

Per-workspace `vitest run` across all 13 touched packages, all green: `@cire/host` 85 files / 1147 tests, `@cire/invites` 64 / 958, `@cire/vendor` 19 / 249, `@osn/client` 20 / 198, `@osn/ui` 17 / 143, `@osn/social` 19 / 147, `@shared/sortable` 2 / 36, `@shared/toast` 2 / 28, `@shared/rp-auth` 2 / 43, `@cire/landing` 7 / 35, `@pulse/landing` 3 / 11, `@osn/landing` 2 / 7.

Repo-wide grep over all 575 test files for the full jest-dom matcher list found exactly 28 files using a matcher, and all 28 carry the explicit import — the 27 in this diff plus `pulse/web/tests/explore/ExploreNav.test.tsx`, which already had it. The reverse check is also clean: no file gained an import it does not use. Without that property the failure mode is loud, not silent — `Invalid Chai property: toBeInTheDocument`.

### Timings, and what they do and do not show

Paired before/after on the same machine, back to back so both halves saw identical background load. "Before" reverts only the `vitest.config.ts` (injection back on); the explicit imports stay, and tests pass either way.

| Suite | Before | After |
|---|---|---|
| `cire/host --project unit`, 83 files | 6.43s / 5.94s — setup **10.34s / 9.10s**, import 17.90s / 17.64s | 6.20s / 5.62s — setup **1.24s / 1.16s**, import 23.60s / 20.56s |
| `pulse/web`, 41 files | 2.63s / 2.95s — setup **4.65s / 5.19s**, import 9.11s / 9.72s | 3.10s / 3.04s — setup **1.04s / 627ms**, import 14.35s / 14.87s |
| `osn/client`, 20 files, zero matchers | 1.58s / 1.55s — setup **2.22s / 2.36s**, import 2.21s / 1.89s | 1.37s / 1.47s — setup **141ms / 267ms**, import 2.09s / 2.57s |

The honest reading: the `setup` bucket falls by an order of magnitude everywhere, but in packages that actually use matchers most of that cost simply moves into the `import` bucket — `pulse/web` import goes 9.1s → 14.4s — so wall clock there is flat, and only slightly better on `cire/host`. The unambiguous win is the third row and the nine packages like it: `osn/client` stops loading jest-dom altogether, with nothing moving to `import`.

So the claim is not "the test suite got faster". It is: this removes work that was never needed, and makes the work that is needed visible at the point of use.

### Deliberately not exercised

The `browser` Vitest projects in `cire/host` and `cire/invites` did not get the marker and did not need it — the plugin skips injection entirely when `browser.enabled`, because browser mode bundles its own jest-dom assertions. Those projects are unchanged and unrun here; they were never injected into, so there is nothing for this change to have broken.
