### PR TITLE
refactor(swift): move the mock URLProtocol into OSNTesting

### DIFF
--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -72,7 +72,7 @@ public final class OSNSession {
     /// `containerURLProvider` parameter: the public initializer always builds
     /// real dependencies from `environment`, and there is no way to swap in
     /// a mock `URLSession` through it. This lets `OSNAuthTests` construct an
-    /// `OSNSession` wired to `LoginMockURLProtocol` and assert deterministically
+    /// `OSNSession` wired to `OSNTesting`'s `MockURLProtocol` and assert deterministically
     /// on its behaviour instead of depending on a real network call failing.
     init(urlSession: URLSession, tokenRefresher: TokenRefresher, loginClient: PasskeyLoginClient) {
         self.urlSession = urlSession

--- a/shared/swift/OSNShared/Sources/OSNTesting/MockURLProtocol.swift
+++ b/shared/swift/OSNShared/Sources/OSNTesting/MockURLProtocol.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// A `URLProtocol` that answers every request from a handler you set, so a
+/// test can drive a real `URLSession` (real cookie jar, real header handling)
+/// without a network.
+///
+/// This is the one copy. Until it moved here it was duplicated, near enough
+/// line for line, in five test files — `LoginMockURLProtocol`,
+/// `MockURLProtocol`, `MiddlewareMockURLProtocol`, `MusubiMockURLProtocol` —
+/// because a `URLProtocol` subclass is not shared across SPM test targets and
+/// each target needed one. `OSNTesting` is a *source* target every test
+/// target already depends on, which is the seam that was missing.
+///
+/// ## `handler` is global, and that is only safe because of the lock
+///
+/// One shared class means one shared `handler`, where five classes meant five.
+/// Swift Testing runs suites — and whole test targets — concurrently, so this
+/// would be a race if the suites using it could overlap.
+///
+/// They cannot: every suite that touches this mock also carries
+/// `.keychainSerializing`, which serialises against every other test carrying
+/// it across suites *and* targets. That covers `OSNAuthTests`'
+/// `OSNSessionTests` and `PasskeyLoginClientTests`, `OSNKitTests`'
+/// `KeychainSerialTests` (which `TokenRefresherTests` extends),
+/// `PulseAPITests`' `BearerTokenMiddlewareTests`, and `MusubiFeatureTests`'
+/// `FetchPasskeysTests`. They all drive HTTP that ends in a Keychain write, so
+/// they needed the lock anyway and the mock rides along on it.
+///
+/// **If you use this mock from a new suite, give that suite
+/// `.keychainSerializing` too** — even if it never touches the Keychain.
+/// Without it the suite can run concurrently with another that is mid-request
+/// and overwrite `handler` underneath it.
+public final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    /// Answers one request. Set it synchronously before the call under test.
+    public nonisolated(unsafe) static var handler: (
+        @Sendable (URLRequest) async throws -> (Int, [String: String], Data)
+    )?
+
+    /// Where `Set-Cookie` headers are deposited.
+    ///
+    /// A custom `URLProtocol`'s `didReceive` callback does not run the real
+    /// transport's `Set-Cookie` extraction — Foundation only populates
+    /// `httpCookieStorage` for actual network responses. Point this at the
+    /// test session's own cookie storage so the mock does that step by hand,
+    /// matching what a genuine `/token` round trip would leave behind.
+    /// `TokenRefresher` and `PasskeyLoginClient` both verify the rotated
+    /// session cookie actually landed in the jar, so without this they fail
+    /// against a mock that otherwise looks correct.
+    public nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
+
+    override public class func canInit(with request: URLRequest) -> Bool { true }
+
+    override public class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override public func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        Task {
+            do {
+                let (status, headers, data) = try await handler(request)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                if let url = request.url {
+                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
+                    if !cookies.isEmpty {
+                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
+                    }
+                }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override public func stopLoading() {}
+}
+
+/// An ephemeral `URLSession` wired to `MockURLProtocol`, with its cookie jar
+/// registered so `Set-Cookie` in a mocked response lands where the code under
+/// test looks for it.
+public func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    configuration.httpShouldSetCookies = true
+    configuration.httpCookieAcceptPolicy = .always
+    MockURLProtocol.cookieStorage = configuration.httpCookieStorage
+    return URLSession(configuration: configuration)
+}

--- a/shared/swift/OSNShared/Sources/OSNTesting/OSNTesting.swift
+++ b/shared/swift/OSNShared/Sources/OSNTesting/OSNTesting.swift
@@ -1,3 +1,8 @@
-// OSNTesting: fixtures/fakes for the app test targets. Empty in A0 — depends
-// on OSNKit since fakes here stand in for its API client/session types.
+// OSNTesting: fixtures, fakes and traits shared by the app test targets.
+//
+// A source target rather than a test target, because SwiftPM shares source
+// targets across test targets and shares nothing between test targets — which
+// is why `MockURLProtocol` lived in five copies before it moved here.
+//
+// Depends on OSNKit since fakes here stand in for its client/session types.
 import OSNKit

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
@@ -5,58 +5,6 @@ import Testing
 @testable import MusubiFeature
 @testable import OSNAuth
 
-/// Intercepts requests for one `URLSession` at a time — mirrors
-/// `OSNAuthTests/PasskeyLoginClientTests.swift`'s `LoginMockURLProtocol`.
-/// Each test target needs its own copy since `URLProtocol` subclasses
-/// aren't shared across SPM targets (see the comment there).
-final class MusubiMockURLProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
-    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        Task {
-            do {
-                let (status, headers, data) = try await handler(request)
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: status,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: headers
-                )!
-                if let url = request.url {
-                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
-                    if !cookies.isEmpty {
-                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
-                    }
-                }
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: data)
-                client?.urlProtocolDidFinishLoading(self)
-            } catch {
-                client?.urlProtocol(self, didFailWithError: error)
-            }
-        }
-    }
-
-    override func stopLoading() {}
-}
-
-private func makeMockSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MusubiMockURLProtocol.self]
-    configuration.httpShouldSetCookies = true
-    configuration.httpCookieAcceptPolicy = .always
-    MusubiMockURLProtocol.cookieStorage = configuration.httpCookieStorage
-    return URLSession(configuration: configuration)
-}
-
 @MainActor
 private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
     OSNSession(
@@ -112,7 +60,7 @@ struct FetchPasskeysTests {
         let session = makeMockSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
-        MusubiMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"access_token":"at-fresh-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
             """
@@ -127,7 +75,7 @@ struct FetchPasskeysTests {
         await osnSession.restore()
         #expect(osnSession.state == .signedIn(nil))
 
-        MusubiMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"passkeys":[{"id":"pk-1","label":"iPhone","aaguid":null,"transports":null,"backupEligible":null,"backupState":null,"createdAt":1,"lastUsedAt":null}]}
             """
@@ -150,7 +98,7 @@ struct FetchPasskeysTests {
         let session = makeMockSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
-        MusubiMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"access_token":"at-fresh-2","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
             """
@@ -165,7 +113,7 @@ struct FetchPasskeysTests {
         await osnSession.restore()
         #expect(osnSession.state == .signedIn(nil))
 
-        MusubiMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = #"{"error":"server_error","message":"boom"}"#
             return (500, ["Content-Type": "application/json"], Data(body.utf8))
         }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -18,15 +18,6 @@ private func makeJWT(sub: String, email: String, handle: String, displayName: St
     return "\(header).\(payload).\(signature)"
 }
 
-private func makeMockSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [LoginMockURLProtocol.self]
-    configuration.httpShouldSetCookies = true
-    configuration.httpCookieAcceptPolicy = .always
-    LoginMockURLProtocol.cookieStorage = configuration.httpCookieStorage
-    return URLSession(configuration: configuration)
-}
-
 @MainActor
 private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
     OSNSession(
@@ -49,7 +40,7 @@ struct OSNSessionTests {
         let session = makeMockSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = #"{"error":"invalid_grant","message":"session expired"}"#
             return (400, ["Content-Type": "application/json"], Data(body.utf8))
         }
@@ -67,7 +58,7 @@ struct OSNSessionTests {
         let session = makeMockSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             (200, [:], Data())
         }
 
@@ -85,7 +76,7 @@ struct OSNSessionTests {
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
         let requestCount = Counter()
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             await requestCount.increment()
             let body = """
             {"access_token":"at-fresh-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
@@ -118,7 +109,7 @@ struct OSNSessionTests {
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
         let requestCount = Counter()
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             await requestCount.increment()
             return (200, [:], Data())
         }
@@ -143,7 +134,7 @@ struct OSNSessionTests {
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
         let jwtA = makeJWT(sub: "profile-a", email: "a@example.com", handle: "alice", displayName: "Alice")
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"access_token":"\(jwtA)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
             """
@@ -193,7 +184,7 @@ struct OSNSessionTests {
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
 
         let jwtA = makeJWT(sub: "profile-a", email: "a@example.com", handle: "alice", displayName: "Alice")
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"access_token":"\(jwtA)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
             """

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/PasskeyLoginClientTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/PasskeyLoginClientTests.swift
@@ -4,58 +4,6 @@ import OSNTesting
 import Testing
 @testable import OSNAuth
 
-/// Intercepts requests for one `URLSession` at a time — mirrors
-/// `OSNKitTests/TokenRefresherTests.swift`'s `MockURLProtocol`. Each test
-/// target needs its own copy since `URLProtocol` subclasses aren't shared
-/// across SPM targets.
-final class LoginMockURLProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
-    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        Task {
-            do {
-                let (status, headers, data) = try await handler(request)
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: status,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: headers
-                )!
-                if let url = request.url {
-                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
-                    if !cookies.isEmpty {
-                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
-                    }
-                }
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: data)
-                client?.urlProtocolDidFinishLoading(self)
-            } catch {
-                client?.urlProtocol(self, didFailWithError: error)
-            }
-        }
-    }
-
-    override func stopLoading() {}
-}
-
-private func makeTestSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [LoginMockURLProtocol.self]
-    configuration.httpShouldSetCookies = true
-    configuration.httpCookieAcceptPolicy = .always
-    LoginMockURLProtocol.cookieStorage = configuration.httpCookieStorage
-    return URLSession(configuration: configuration)
-}
-
 private func fixtureAssertion() -> AuthenticationResponseJSON {
     AuthenticationResponseJSON(
         id: "id",
@@ -79,10 +27,10 @@ struct PasskeyLoginClientCompleteTests {
     @Test func successfulCompletePersistsAccessTokenAndVerifiesCookie() async throws {
         try KeychainAccessTokenStore.delete()
         let environment = Environment.local
-        let session = makeTestSession()
+        let session = makeMockSession()
         let client = PasskeyLoginClient(session: session, environment: environment)
 
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"session":{"access_token":"at-passkey-1","token_type":"Bearer","expires_in":300,"scope":"openid profile"},
              "profile":{"id":"u1","handle":"someone","email":"someone@example.com","displayName":null,"avatarUrl":null}}
@@ -107,10 +55,10 @@ struct PasskeyLoginClientCompleteTests {
     @Test func completeWithoutRotatedCookieThrowsAndDoesNotPersist() async throws {
         try KeychainAccessTokenStore.delete()
         let environment = Environment.local
-        let session = makeTestSession()
+        let session = makeMockSession()
         let client = PasskeyLoginClient(session: session, environment: environment)
 
-        LoginMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = """
             {"session":{"access_token":"at-passkey-2","token_type":"Bearer","expires_in":300,"scope":"openid profile"},
              "profile":{"id":"u1","handle":"someone","email":"someone@example.com","displayName":null,"avatarUrl":null}}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/TokenRefresherTests.swift
@@ -1,67 +1,7 @@
 import Foundation
+import OSNTesting
 import Testing
 @testable import OSNKit
-
-/// Intercepts requests for one `URLSession` at a time. All `TokenRefresher`
-/// scenarios below share `Environment.local`'s fixed host, so — like
-/// `KeychainAccessTokenStoreTests` — they run as ordered steps inside a
-/// single `@Test` function rather than as separate concurrent ones.
-final class MockURLProtocol: URLProtocol, @unchecked Sendable {
-    // Set synchronously, then only ever read after the setting call's own
-    // `await` has already suspended — every scenario below is one sequential
-    // test body, never concurrent test functions racing this property.
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
-
-    // A custom URLProtocol's `didReceive` callback does not run the real
-    // transport's Set-Cookie extraction — Foundation only populates
-    // `httpCookieStorage` for actual network responses. Point this at the
-    // test session's own cookie storage so the mock can do that step by
-    // hand, matching what a genuine `/token` round trip would leave behind.
-    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        Task {
-            do {
-                let (status, headers, data) = try await handler(request)
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: status,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: headers
-                )!
-                if let url = request.url {
-                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
-                    if !cookies.isEmpty {
-                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
-                    }
-                }
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: data)
-                client?.urlProtocolDidFinishLoading(self)
-            } catch {
-                client?.urlProtocol(self, didFailWithError: error)
-            }
-        }
-    }
-
-    override func stopLoading() {}
-}
-
-private func makeTestSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MockURLProtocol.self]
-    configuration.httpShouldSetCookies = true
-    configuration.httpCookieAcceptPolicy = .always
-    MockURLProtocol.cookieStorage = configuration.httpCookieStorage
-    return URLSession(configuration: configuration)
-}
 
 extension KeychainSerialTests {
     // Also saves/deletes the real Keychain item (via TokenRefresher's calls
@@ -70,7 +10,7 @@ extension KeychainSerialTests {
     @Test func tokenRefresherScenarios() async throws {
     try KeychainAccessTokenStore.delete()
     let environment = Environment.local
-    let session = makeTestSession()
+    let session = makeMockSession()
     let refresher = TokenRefresher(session: session, environment: environment)
 
     // 1. Success: decodes the grant, persists the rotated cookie, saves the

--- a/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseAPITests/BearerTokenMiddlewareTests.swift
@@ -7,64 +7,6 @@ import Testing
 
 @testable import PulseAPI
 
-/// Self-contained copy of `OSNKitTests`' `MockURLProtocol` pattern — this
-/// test target can't import `OSNKitTests` (separate test target), and the
-/// mock is small enough that duplicating it beats a shared-infra refactor.
-final class MiddlewareMockURLProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (Int, [String: String], Data))?
-
-    // A custom URLProtocol's `didReceive` callback does not run the real
-    // transport's Set-Cookie extraction — Foundation only populates
-    // `httpCookieStorage` for actual network responses. Point this at the
-    // test session's own cookie storage so the mock can do that step by
-    // hand, matching what a genuine `/token` round trip would leave behind
-    // (TokenRefresher checks the cookie actually landed in the jar).
-    nonisolated(unsafe) static var cookieStorage: HTTPCookieStorage?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        Task {
-            do {
-                let (status, headers, data) = try await handler(request)
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: status,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: headers
-                )!
-                if let url = request.url {
-                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
-                    if !cookies.isEmpty {
-                        Self.cookieStorage?.setCookies(cookies, for: url, mainDocumentURL: nil)
-                    }
-                }
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: data)
-                client?.urlProtocolDidFinishLoading(self)
-            } catch {
-                client?.urlProtocol(self, didFailWithError: error)
-            }
-        }
-    }
-
-    override func stopLoading() {}
-}
-
-private func makeTestSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MiddlewareMockURLProtocol.self]
-    configuration.httpShouldSetCookies = true
-    configuration.httpCookieAcceptPolicy = .always
-    MiddlewareMockURLProtocol.cookieStorage = configuration.httpCookieStorage
-    return URLSession(configuration: configuration)
-}
-
 private actor Counter {
     private(set) var value = 0
     func increment() { value += 1 }
@@ -89,11 +31,11 @@ struct BearerTokenMiddlewareTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("stale-token", expiresIn: -10)
 
-        let session = makeTestSession()
+        let session = makeMockSession()
         let refresher = TokenRefresher(session: session, environment: .local)
         let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
 
-        MiddlewareMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = #"{"access_token":"fresh-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
             return (
                 200,
@@ -123,13 +65,13 @@ struct BearerTokenMiddlewareTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("valid-token", expiresIn: 300)
 
-        let session = makeTestSession()
+        let session = makeMockSession()
         let refresher = TokenRefresher(session: session, environment: .local)
         let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
 
         // No handler installed — a refresh call would crash the test by
         // hitting `didFailWithError`, proving the cached token was used.
-        MiddlewareMockURLProtocol.handler = nil
+        MockURLProtocol.handler = nil
 
         let seenAuthorization = Recorder<String?>()
         _ = try await middleware.intercept(
@@ -149,11 +91,11 @@ struct BearerTokenMiddlewareTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("looks-valid", expiresIn: 300)
 
-        let session = makeTestSession()
+        let session = makeMockSession()
         let refresher = TokenRefresher(session: session, environment: .local)
         let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
 
-        MiddlewareMockURLProtocol.handler = { _ in
+        MockURLProtocol.handler = { _ in
             let body = #"{"access_token":"rotated-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}"#
             return (
                 200,
@@ -188,7 +130,7 @@ struct BearerTokenMiddlewareTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("looks-valid", expiresIn: 300)
 
-        let session = makeTestSession()
+        let session = makeMockSession()
         let refresher = TokenRefresher(session: session, environment: .local)
         let middleware = BearerTokenMiddleware(tokenRefresher: refresher)
 


### PR DESCRIPTION
Closes #794. Also closes the finding it was filed from, xchromo/osn-tracker#451.

Bottom of a three-PR stack off the Pulse iOS auth epic (#793). The two above it are environment selection (#795) and the shared Keychain item (#798); each is based on the one below.

## What

A `URLProtocol` subclass that answers requests from a settable handler was duplicated, near enough line for line, across five test files — `LoginMockURLProtocol` (`OSNAuthTests`, used by two suites), `MockURLProtocol` (`OSNKitTests`), `MiddlewareMockURLProtocol` (`PulseAPITests`) and `MusubiMockURLProtocol` (`MusubiFeatureTests`). Each copy was deliberate, and each carried a comment pointing at the others: SwiftPM shares nothing between test targets.

But `OSNTesting` is a **source** target, and all five test targets already depend on it. That was the seam that was missing — no `Package.swift` change is needed here.

One copy now lives in `Sources/OSNTesting/MockURLProtocol.swift`, with the `makeMockSession()` helper the five files each spelled identically (they differed only in the class name).

Net **−254 / +23** across the five test files.

## Two things worth reviewing

**The cookie capture is load-bearing and carried over verbatim.** A custom `URLProtocol`'s `didReceive` does not run the real transport's `Set-Cookie` extraction — Foundation only populates `httpCookieStorage` for actual network responses — so the mock does that step by hand. Both `TokenRefresher.verifySessionCookiePersisted()` and `PasskeyLoginClient.complete` check that the rotated session cookie actually landed in the jar, so dropping this would fail them against a mock that otherwise looks correct.

**Five statics become one, and that is only safe because of a lock that already exists.** Swift Testing runs suites — and whole test targets — concurrently, so one shared `handler` would be a race if its users could overlap. They cannot: every suite touching the mock already carries `.keychainSerializing`, which serialises across suites *and* targets. Checked rather than assumed:

| Suite | Trait |
|---|---|
| `OSNAuthTests.OSNSessionTests` | `.serialized, .keychainSerializing` |
| `OSNAuthTests.PasskeyLoginClientTests` | `.serialized, .keychainSerializing` |
| `PulseAPITests.BearerTokenMiddlewareTests` | `.serialized, .keychainSerializing` |
| `MusubiFeatureTests.FetchPasskeysTests` | `.serialized, .keychainSerializing` |
| `OSNKitTests.TokenRefresherTests` | extends `KeychainSerialTests`, which declares it |

They all drive HTTP that ends in a Keychain write, so they needed the lock anyway and the mock rides along on it. The requirement — **a new suite using this mock must carry `.keychainSerializing` even if it never touches the Keychain** — is written into the mock's own doc comment rather than left implicit.

`MusubiFeatureTests`' other suite, `ShouldRestoreTests`, is un-serialised and stays that way: it touches neither the network nor the Keychain, and every mock reference in that file sits inside the serialised suite (verified by line number).

## Also

- `OSNSession.swift`'s doc comment named `LoginMockURLProtocol`, which no longer exists — repointed at `OSNTesting`'s.
- `OSNTesting.swift`'s header still described the target as "Empty in A0"; it now says what the target is for and why it is a source target.

## Verification

Honest statement of what was and was not run: **this container has no Swift toolchain and no Xcode**, so nothing here has been compiled locally. The macOS Swift CI lane is the check — `swift test`, then `xcodegen generate` + `xcodebuild build` for both Pulse and Musubi. I am not claiming it compiles until that lane says so, and I will drive it to green.

What was verified locally:

- `scripts/changeset-required.sh` → `skip`; every changed path is on the allowlist.
- No dangling references: `grep -rn "LoginMockURLProtocol\|MiddlewareMockURLProtocol\|MusubiMockURLProtocol\|makeTestSession" Sources/ Tests/` returns nothing but the deliberate mentions in the new file's doc comment.
- Each of the five diffs read by hand to confirm only the mock class and its session helper were removed.

No production behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CcTJau43jEocATsNXHmqd

---
_Generated by [Claude Code](https://claude.ai/code/session_014CcTJau43jEocATsNXHmqd)_