### PR TITLE
feat(swift): resolve the API environment from the build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,10 @@ wiki/business/
 # block in `project.yml`, same as it writes the `.xcodeproj` — the committed
 # source of truth is the YAML, not the generated plist.
 */ios/*.entitlements
+# Same deal for the Info.plist: XcodeGen writes it from the `info.properties`
+# block in `project.yml`, which is where the per-configuration tier and hosts
+# are declared. Committing the output would let it drift from that source.
+*/ios/*-Info.plist
 .build/
 DerivedData/
 .swiftpm/

--- a/osn/ios/Sources/App.swift
+++ b/osn/ios/Sources/App.swift
@@ -1,6 +1,7 @@
 import AuthenticationServices
 import MusubiFeature
 import OSNAuth
+import OSNKit
 import SwiftUI
 import UIKit
 
@@ -23,7 +24,10 @@ struct MusubiApp: App {
             .task {
                 guard session == nil, sessionError == nil else { return }
                 do {
-                    session = try OSNSession()
+                    // The identity host comes from this build's configuration,
+                    // via `OSNTier` in Info.plist — never a `.local` default,
+                    // which would ship a release pointed at localhost.
+                    session = try OSNSession(environment: Environment.resolve())
                 } catch {
                     sessionError = String(describing: error)
                 }

--- a/osn/ios/project.yml
+++ b/osn/ios/project.yml
@@ -34,9 +34,31 @@ targets:
         DEVELOPMENT_TEAM: FV59Y8RSUH
         CODE_SIGN_STYLE: Automatic
         TARGETED_DEVICE_FAMILY: "1"
-        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
-        GENERATE_INFOPLIST_FILE: "YES"
         SWIFT_VERSION: "6.2"
+      configs:
+        # Read by `DeploymentTier.resolve()` through the Info.plist keys below.
+        # There is no default anywhere in the Swift code: a build that does not
+        # set these fails loudly rather than talking to localhost in release.
+        Debug:
+          OSN_TIER: local
+          OSN_ISSUER_URL: http://localhost:4000
+        Release:
+          OSN_TIER: production
+          # `production` resolves to the fixed id.musubi.social host in
+          # `Environment`, so this is unused there — kept for a dev/staging
+          # build, which has no fixed host.
+          OSN_ISSUER_URL: ""
+    # XcodeGen writes this plist, the same way it writes the entitlements file
+    # and the .xcodeproj — all three are gitignored. It replaces
+    # GENERATE_INFOPLIST_FILE because `INFOPLIST_KEY_*` build settings only
+    # cover Apple's own documented keys; a custom one like `OSNTier` cannot be
+    # injected that way, and the Swift side needs to read it at launch.
+    info:
+      path: Musubi-Info.plist
+      properties:
+        UILaunchScreen: {}
+        OSNTier: $(OSN_TIER)
+        OSNIssuerURL: $(OSN_ISSUER_URL)
     # The App Group `group.social.musubi.session` is registered under team
     # FV59Y8RSUH, so the shared cookie jar resolves and every OSN app signs in
     # once. The string must stay in step with

--- a/pulse/ios/Sources/App.swift
+++ b/pulse/ios/Sources/App.swift
@@ -1,5 +1,7 @@
 import AuthenticationServices
 import OSNAuth
+import OSNKit
+import PulseAPI
 import PulseFeature
 import SwiftUI
 import UIKit
@@ -23,7 +25,15 @@ struct PulseApp: App {
             .task {
                 guard session == nil, sessionError == nil else { return }
                 do {
-                    session = try PulseSession()
+                    // Both hosts come from this build's configuration, via
+                    // `OSNTier` in Info.plist — never a `.local` default, which
+                    // would ship a release pointed at localhost. A build that
+                    // cannot answer the question throws, and the `sessionError`
+                    // branch below says so instead of showing an empty feed.
+                    session = try PulseSession(
+                        environment: Environment.resolve(),
+                        pulseEnvironment: PulseEnvironment.resolve()
+                    )
                 } catch {
                     sessionError = String(describing: error)
                 }

--- a/pulse/ios/project.yml
+++ b/pulse/ios/project.yml
@@ -34,9 +34,38 @@ targets:
         DEVELOPMENT_TEAM: FV59Y8RSUH
         CODE_SIGN_STYLE: Automatic
         TARGETED_DEVICE_FAMILY: "1"
-        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
-        GENERATE_INFOPLIST_FILE: "YES"
         SWIFT_VERSION: "6.2"
+      configs:
+        # Read by `DeploymentTier.resolve()` through the Info.plist keys below.
+        # There is no default anywhere in the Swift code: a build that does not
+        # set these fails loudly rather than talking to localhost in release.
+        Debug:
+          OSN_TIER: local
+          OSN_ISSUER_URL: http://localhost:4000
+          PULSE_API_URL: http://localhost:3001
+        Release:
+          OSN_TIER: production
+          # `production` resolves to the fixed id.musubi.social host in
+          # `Environment`, so this is unused there — kept for a dev/staging
+          # build, which has no fixed host.
+          OSN_ISSUER_URL: ""
+          # No Pulse API host is deployed at any tier yet. Left empty on
+          # purpose: `PulseEnvironment.resolve()` throws rather than falling
+          # back to localhost, and the app surfaces that instead of an empty
+          # feed. Fill it in when the API ships.
+          PULSE_API_URL: ""
+    # XcodeGen writes this plist, the same way it writes the entitlements file
+    # and the .xcodeproj — all three are gitignored. It replaces
+    # GENERATE_INFOPLIST_FILE because `INFOPLIST_KEY_*` build settings only
+    # cover Apple's own documented keys; a custom one like `OSNTier` cannot be
+    # injected that way, and the Swift side needs to read it at launch.
+    info:
+      path: Pulse-Info.plist
+      properties:
+        UILaunchScreen: {}
+        OSNTier: $(OSN_TIER)
+        OSNIssuerURL: $(OSN_ISSUER_URL)
+        PulseAPIURL: $(PULSE_API_URL)
     # The App Group `group.social.musubi.session` is registered under team
     # FV59Y8RSUH, so the shared cookie jar resolves and every OSN app signs in
     # once. The string must stay in step with

--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
@@ -83,6 +83,6 @@ public struct MusubiAccountView: View {
 @MainActor
 func fetchPasskeys(session: OSNSession) async throws -> [PasskeySummary] {
     try await session.ensureFreshAccessToken()
-    let client = PasskeyManagementClient(session: session.urlSession, environment: .local)
+    let client = PasskeyManagementClient(session: session.urlSession, environment: session.environment)
     return try await client.list()
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -60,6 +60,12 @@ public final class OSNSession {
 
     public private(set) var state: SessionState = .restoring
 
+    /// The identity host this session talks to. Held so a caller building
+    /// its own OSNAuth client (e.g. Musubi's passkey list) uses the same one
+    /// rather than reaching for a literal — `MusubiAccountView` hardcoded
+    /// `.local` before this existed.
+    public let environment: Environment
+
     /// Shared cookie-jar-backed session and token refresher — every
     /// app-specific API client (e.g. `makePulseClient`) is built from these
     /// so it shares the same cookie jar and refresh-in-flight coalescing.
@@ -74,15 +80,20 @@ public final class OSNSession {
     /// a mock `URLSession` through it. This lets `OSNAuthTests` construct an
     /// `OSNSession` wired to `OSNTesting`'s `MockURLProtocol` and assert deterministically
     /// on its behaviour instead of depending on a real network call failing.
-    init(urlSession: URLSession, tokenRefresher: TokenRefresher, loginClient: PasskeyLoginClient) {
+    init(
+        environment: Environment,
+        urlSession: URLSession,
+        tokenRefresher: TokenRefresher,
+        loginClient: PasskeyLoginClient
+    ) {
+        self.environment = environment
         self.urlSession = urlSession
         self.tokenRefresher = tokenRefresher
         self.loginClient = loginClient
     }
 
     /// - Parameter environment: identity host for passkey ceremonies + token
-    ///   refresh. Defaults to `.local` — no deployed Pulse API host exists
-    ///   yet, so this is development-oriented, not a hardcoded prod value.
+    ///   refresh.
     /// - Throws: whatever `SharedCookieJar.makeSession()` throws
     ///   (`OSNKitError.appGroupContainerUnavailable` when the App Group
     ///   container doesn't resolve — the group is registered, so this means
@@ -90,11 +101,20 @@ public final class OSNSession {
     ///   see `pulse/ios/project.yml`). That is an infrastructure/build-config
     ///   failure, not a session state — there is no working `URLSession` to
     ///   hand out if it happens, so it isn't folded into `SessionState`.
-    public convenience init(environment: Environment = .local) throws {
+    ///
+    /// `environment` has no default. It defaulted to `.local`, which meant a
+    /// release build silently talked to `localhost`; app targets now derive it
+    /// from the build configuration via `Environment.resolve(info:)`.
+    public convenience init(environment: Environment) throws {
         let session = try SharedCookieJar.makeSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
         let loginClient = PasskeyLoginClient(session: session, environment: environment)
-        self.init(urlSession: session, tokenRefresher: tokenRefresher, loginClient: loginClient)
+        self.init(
+            environment: environment,
+            urlSession: session,
+            tokenRefresher: tokenRefresher,
+            loginClient: loginClient
+        )
     }
 
     /// Silent restore on launch. A throw from `TokenRefresher.refresh()`

--- a/shared/swift/OSNShared/Sources/OSNKit/DeploymentTier.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/DeploymentTier.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// How a tier resolver reads the app's `Info.plist`.
+///
+/// A closure rather than a `Bundle`, for the same reason
+/// `SharedCookieJar.makeConfiguration` takes a `containerURLProvider`: a test
+/// cannot construct a `Bundle` with an arbitrary info dictionary, so without
+/// this seam none of the failure branches below could be reached from
+/// `swift test`. Production callers use `.main` and never pass anything.
+public struct InfoDictionaryLookup: Sendable {
+    private let read: @Sendable (String) -> Any?
+
+    public init(_ read: @escaping @Sendable (String) -> Any?) {
+        self.read = read
+    }
+
+    public func callAsFunction(_ key: String) -> Any? { read(key) }
+
+    /// The running app's own `Info.plist`.
+    public static let main = InfoDictionaryLookup { Bundle.main.object(forInfoDictionaryKey: $0) }
+
+    /// A fixed dictionary — for tests, and for nothing else.
+    public static func fixture(_ values: [String: String]) -> InfoDictionaryLookup {
+        InfoDictionaryLookup { values[$0] }
+    }
+}
+
+/// Which deployed tier this build talks to. Mirrors `DeploymentEnvironment` in
+/// `@shared/observability`, so the four names mean the same thing on both
+/// sides of the wire.
+///
+/// The value comes from the app's `Info.plist`, written per build
+/// configuration by XcodeGen (`OSNTier` in each app's `project.yml`). It is
+/// read once, at the point a session is built — nothing caches it.
+public enum DeploymentTier: String, Sendable, Equatable, CaseIterable {
+    case local
+    case dev
+    case staging
+    case production
+
+    /// The `Info.plist` key each app's `project.yml` writes.
+    public static let infoPlistKey = "OSNTier"
+
+    /// - Throws: `OSNKitError.deploymentTierMissing` when the key is absent —
+    ///   which means the app target was built without the per-configuration
+    ///   setting, not that the user did anything wrong — or
+    ///   `OSNKitError.deploymentTierUnknown` when it holds something outside
+    ///   the four names above.
+    ///
+    ///   Deliberately no default. A build whose tier cannot be read must fail
+    ///   loudly: the quiet alternative is a release that talks to `localhost`,
+    ///   which is the exact bug this type exists to prevent.
+    public static func resolve(info: InfoDictionaryLookup = .main) throws -> DeploymentTier {
+        guard let raw = info(infoPlistKey) as? String, !raw.isEmpty else {
+            throw OSNKitError.deploymentTierMissing(key: infoPlistKey)
+        }
+        guard let tier = DeploymentTier(rawValue: raw) else {
+            throw OSNKitError.deploymentTierUnknown(value: raw)
+        }
+        return tier
+    }
+}
+
+/// Reads a required URL out of the app's `Info.plist`.
+///
+/// Shared by `Environment` and `PulseEnvironment` — which live in different
+/// modules — so both spell "this tier needs a host and the build did not
+/// supply one" the same way.
+public func osnRequiredURL(forInfoDictionaryKey key: String, in info: InfoDictionaryLookup = .main) throws -> URL {
+    guard let raw = info(key) as? String, !raw.isEmpty else {
+        throw OSNKitError.environmentURLMissing(key: key)
+    }
+    guard let url = URL(string: raw), url.scheme != nil, url.host != nil else {
+        throw OSNKitError.environmentURLInvalid(key: key, value: raw)
+    }
+    return url
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/Environment.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/Environment.swift
@@ -24,4 +24,33 @@ public enum Environment: Sendable, Equatable {
             return URL(string: "https://id.musubi.social")!
         }
     }
+
+    /// The `Info.plist` key carrying the issuer host for tiers that have no
+    /// fixed one.
+    public static let issuerURLInfoPlistKey = "OSNIssuerURL"
+
+    /// Builds the environment this app was compiled for, from the `OSNTier`
+    /// its build configuration wrote into `Info.plist`.
+    ///
+    /// `local` and `production` resolve to their fixed hosts. `dev` and
+    /// `staging` have no deployed osn-api host, so they take theirs from
+    /// `OSNIssuerURL` and throw when the build did not supply one.
+    ///
+    /// - Throws: `OSNKitError.deploymentTierMissing` / `.deploymentTierUnknown`
+    ///   / `.environmentURLMissing` / `.environmentURLInvalid`. All four are
+    ///   build-configuration faults, and all four are deliberately loud — the
+    ///   alternative is a release build quietly talking to `localhost`, which
+    ///   is what this method exists to make impossible.
+    public static func resolve(info: InfoDictionaryLookup = .main) throws -> Environment {
+        switch try DeploymentTier.resolve(info: info) {
+        case .local:
+            return .local
+        case .dev:
+            return .dev(baseURL: try osnRequiredURL(forInfoDictionaryKey: issuerURLInfoPlistKey, in: info))
+        case .staging:
+            return .staging(baseURL: try osnRequiredURL(forInfoDictionaryKey: issuerURLInfoPlistKey, in: info))
+        case .production:
+            return .production
+        }
+    }
 }

--- a/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/OSNKitError.swift
@@ -41,6 +41,30 @@ public enum OSNKitError: Error, Sendable, Equatable {
     /// all. Never treat an unrecognized response as success.
     case refreshResponseMalformed(status: Int)
 
+    /// The app's `Info.plist` carries no `OSNTier`. The value is written per
+    /// build configuration by XcodeGen from each app's `project.yml`, so this
+    /// means the target was built without that setting — a build-configuration
+    /// fault, not anything the user did.
+    ///
+    /// There is deliberately no default. A build whose tier cannot be read
+    /// must fail loudly, because the quiet alternative is a release that talks
+    /// to `localhost`.
+    case deploymentTierMissing(key: String)
+
+    /// `OSNTier` holds something outside `local` / `dev` / `staging` /
+    /// `production` — a typo in `project.yml`, which would otherwise resolve
+    /// to a silent fallback.
+    case deploymentTierUnknown(value: String)
+
+    /// This tier needs a host supplied by the build and none was. `dev` and
+    /// `staging` have no fixed osn-api host, and **no Pulse API host is
+    /// deployed at any tier**, so a Pulse build outside `local` has to be told
+    /// where its API lives.
+    case environmentURLMissing(key: String)
+
+    /// The build supplied a host, but it isn't a usable absolute URL.
+    case environmentURLInvalid(key: String, value: String)
+
     /// `SecItemAdd` failed while storing an access token.
     case keychainWriteFailed(status: OSStatus)
 
@@ -69,6 +93,14 @@ extension OSNKitError: CustomStringConvertible {
             return "POST /token returned invalid_grant: \(message). The session is gone; sign the user out."
         case .refreshResponseMalformed(let status):
             return "POST /token returned an unrecognized response (status \(status)). Refusing to treat it as success."
+        case .deploymentTierMissing(let key):
+            return "No \(key) in Info.plist. Each app's project.yml writes it per build configuration; this build has none, so there is no way to tell which tier it should talk to. Refusing to guess."
+        case .deploymentTierUnknown(let value):
+            return "Info.plist names an unknown tier: \(value). Expected one of \(DeploymentTier.allCases.map(\.rawValue).joined(separator: ", "))."
+        case .environmentURLMissing(let key):
+            return "No \(key) in Info.plist, and this tier has no fixed host to fall back to. Set it in the app's project.yml for this build configuration."
+        case .environmentURLInvalid(let key, let value):
+            return "\(key) in Info.plist is not a usable absolute URL: \(value)."
         case .keychainWriteFailed(let status):
             return "Keychain write failed (OSStatus \(status)) while storing the access token."
         case .keychainReadFailed(let status):

--- a/shared/swift/OSNShared/Sources/PulseAPI/PulseEnvironment.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/PulseEnvironment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSNKit
 
 /// Pulse's own base URL — a separate question from osn-api's `Environment`.
 /// There is no deployed Pulse API host yet, so only `.local` may hardcode a
@@ -15,4 +16,33 @@ public enum PulseEnvironment: Sendable, Equatable {
         case .dev(let baseURL), .staging(let baseURL), .production(let baseURL): return baseURL
         }
     }
+
+    /// The `Info.plist` key carrying the Pulse API host.
+    public static let apiURLInfoPlistKey = "PulseAPIURL"
+
+    /// Builds the Pulse environment this app was compiled for, from the same
+    /// `OSNTier` key `Environment.resolve` reads.
+    ///
+    /// Only `local` has a fixed host. **No Pulse API host is deployed at any
+    /// tier**, so every other tier takes its base URL from `PulseAPIURL` and
+    /// throws when the build did not supply one.
+    ///
+    /// That throw is the point. Before this existed, `PulseSession.init`
+    /// defaulted to `.local`, so a release build silently pointed at
+    /// `http://localhost:3001` and simply never loaded anything. Failing here
+    /// surfaces "Pulse has no server yet" through the app's existing
+    /// `Text(sessionError)` path instead of hiding it as an empty feed.
+    public static func resolve(info: InfoDictionaryLookup = .main) throws -> PulseEnvironment {
+        switch try DeploymentTier.resolve(info: info) {
+        case .local:
+            return .local
+        case .dev:
+            return .dev(baseURL: try osnRequiredURL(forInfoDictionaryKey: apiURLInfoPlistKey, in: info))
+        case .staging:
+            return .staging(baseURL: try osnRequiredURL(forInfoDictionaryKey: apiURLInfoPlistKey, in: info))
+        case .production:
+            return .production(baseURL: try osnRequiredURL(forInfoDictionaryKey: apiURLInfoPlistKey, in: info))
+        }
+    }
+
 }

--- a/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
+++ b/shared/swift/OSNShared/Sources/PulseFeature/PulseSession.swift
@@ -27,12 +27,14 @@ public final class PulseSession {
     public let api: any APIProtocol
 
     /// - Parameters:
-    ///   - environment: identity host for passkey ceremonies + token
-    ///     refresh. Defaults to `.local` — no deployed Pulse API host exists
-    ///     yet, so this is development-oriented, not a hardcoded prod value.
-    ///   - pulseEnvironment: Pulse API host for `api`. Defaults to `.local`
-    ///     for the same reason.
-    public init(environment: Environment = .local, pulseEnvironment: PulseEnvironment = .local) throws {
+    ///   - environment: identity host for passkey ceremonies + token refresh.
+    ///   - pulseEnvironment: Pulse API host for `api`.
+    ///
+    /// Neither has a default. They used to default to `.local`, which meant a
+    /// release build silently talked to `localhost` — see
+    /// `Environment.resolve(info:)`, which the app target calls to derive
+    /// both from the build configuration.
+    public init(environment: Environment, pulseEnvironment: PulseEnvironment) throws {
         let auth = try OSNSession(environment: environment)
         self.auth = auth
         self.api = makePulseClient(environment: pulseEnvironment, session: auth.urlSession, tokenRefresher: auth.tokenRefresher)

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
@@ -8,6 +8,7 @@ import Testing
 @MainActor
 private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
     OSNSession(
+        environment: environment,
         urlSession: session,
         tokenRefresher: tokenRefresher,
         loginClient: PasskeyLoginClient(session: session, environment: environment)

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -21,6 +21,7 @@ private func makeJWT(sub: String, email: String, handle: String, displayName: St
 @MainActor
 private func makeOSNSession(environment: Environment, session: URLSession, tokenRefresher: TokenRefresher) -> OSNSession {
     OSNSession(
+        environment: environment,
         urlSession: session,
         tokenRefresher: tokenRefresher,
         loginClient: PasskeyLoginClient(session: session, environment: environment)

--- a/shared/swift/OSNShared/Tests/OSNKitTests/EnvironmentTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/EnvironmentTests.swift
@@ -19,3 +19,74 @@ import Testing
     let url = URL(string: "https://staging.example.internal")!
     #expect(Environment.staging(baseURL: url).baseURL == url)
 }
+
+// MARK: - Resolution from the build configuration
+//
+// Every branch below is reachable only because `resolve` takes an
+// `InfoDictionaryLookup` rather than a `Bundle` — a test cannot build a
+// `Bundle` with an arbitrary info dictionary. Same seam, same reason, as
+// `SharedCookieJar.makeConfiguration`'s `containerURLProvider`.
+
+@Test func resolveReadsLocalTier() throws {
+    let env = try Environment.resolve(info: .fixture(["OSNTier": "local"]))
+    #expect(env == .local)
+}
+
+@Test func resolveReadsProductionTierWithoutNeedingAURL() throws {
+    // `production` has a fixed host, so a build that supplies no OSNIssuerURL
+    // still resolves — this is what a Release build of either app does.
+    let env = try Environment.resolve(info: .fixture(["OSNTier": "production"]))
+    #expect(env == .production)
+    #expect(env.baseURL == URL(string: "https://id.musubi.social")!)
+}
+
+@Test func resolveTakesTheSuppliedHostForDevAndStaging() throws {
+    let dev = try Environment.resolve(
+        info: .fixture(["OSNTier": "dev", "OSNIssuerURL": "https://id.dev.musubi.social"])
+    )
+    #expect(dev.baseURL == URL(string: "https://id.dev.musubi.social")!)
+
+    let staging = try Environment.resolve(
+        info: .fixture(["OSNTier": "staging", "OSNIssuerURL": "https://id.staging.musubi.social"])
+    )
+    #expect(staging.baseURL == URL(string: "https://id.staging.musubi.social")!)
+}
+
+/// The whole point of the type: no tier means no guess. A silent `.local`
+/// fallback here is what shipped a release pointing at localhost.
+@Test func resolveThrowsRatherThanDefaultingWhenTheTierIsAbsent() {
+    #expect(throws: OSNKitError.deploymentTierMissing(key: "OSNTier")) {
+        try Environment.resolve(info: .fixture([:]))
+    }
+}
+
+@Test func resolveThrowsOnAnEmptyTier() {
+    // An unset xcconfig variable expands to the empty string, not to nothing —
+    // so this is the shape a missing build setting actually takes.
+    #expect(throws: OSNKitError.deploymentTierMissing(key: "OSNTier")) {
+        try Environment.resolve(info: .fixture(["OSNTier": ""]))
+    }
+}
+
+@Test func resolveThrowsOnAnUnknownTier() {
+    #expect(throws: OSNKitError.deploymentTierUnknown(value: "prod")) {
+        try Environment.resolve(info: .fixture(["OSNTier": "prod"]))
+    }
+}
+
+@Test func resolveThrowsWhenADevBuildSuppliesNoIssuerHost() {
+    #expect(throws: OSNKitError.environmentURLMissing(key: "OSNIssuerURL")) {
+        try Environment.resolve(info: .fixture(["OSNTier": "dev"]))
+    }
+}
+
+@Test func resolveThrowsOnAHostThatIsNotAnAbsoluteURL() {
+    #expect(throws: OSNKitError.environmentURLInvalid(key: "OSNIssuerURL", value: "id.musubi.social")) {
+        try Environment.resolve(info: .fixture(["OSNTier": "dev", "OSNIssuerURL": "id.musubi.social"]))
+    }
+}
+
+@Test func everyTierNameRoundTrips() {
+    // Guards the strings in both project.yml files against a rename here.
+    #expect(DeploymentTier.allCases.map(\.rawValue) == ["local", "dev", "staging", "production"])
+}

--- a/shared/swift/OSNShared/Tests/PulseAPITests/PulseEnvironmentTests.swift
+++ b/shared/swift/OSNShared/Tests/PulseAPITests/PulseEnvironmentTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSNKit
 import Testing
 @testable import PulseAPI
 
@@ -19,4 +20,38 @@ import Testing
 @Test func productionPassesThroughCallerSuppliedURL() {
     let url = URL(string: "https://production.example.internal")!
     #expect(PulseEnvironment.production(baseURL: url).baseURL == url)
+}
+
+// MARK: - Resolution from the build configuration
+
+/// Pulse's asymmetry with `Environment`: **no Pulse API host is deployed at
+/// any tier**, so only `local` has one to fall back on. Every other tier must
+/// be told, and throws when it isn't — which is what stops a Release build
+/// silently pointing at `http://localhost:3001`.
+@Test func pulseResolveReadsLocalTier() throws {
+    let env = try PulseEnvironment.resolve(info: .fixture(["OSNTier": "local"]))
+    #expect(env == .local)
+    #expect(env.baseURL == URL(string: "http://localhost:3001")!)
+}
+
+@Test func pulseResolveThrowsForProductionWithNoHostConfigured() {
+    // This is the current state of the Release configuration in
+    // pulse/ios/project.yml: PULSE_API_URL is deliberately empty, because
+    // there is nothing to point it at yet.
+    #expect(throws: OSNKitError.environmentURLMissing(key: "PulseAPIURL")) {
+        try PulseEnvironment.resolve(info: .fixture(["OSNTier": "production"]))
+    }
+}
+
+@Test func pulseResolveTakesTheSuppliedHostOnceThereIsOne() throws {
+    let env = try PulseEnvironment.resolve(
+        info: .fixture(["OSNTier": "production", "PulseAPIURL": "https://api.pulse.example"])
+    )
+    #expect(env.baseURL == URL(string: "https://api.pulse.example")!)
+}
+
+@Test func pulseResolveThrowsRatherThanDefaultingWhenTheTierIsAbsent() {
+    #expect(throws: OSNKitError.deploymentTierMissing(key: "OSNTier")) {
+        try PulseEnvironment.resolve(info: .fixture([:]))
+    }
 }


### PR DESCRIPTION
Closes #795. Also closes the finding it was filed from, xchromo/osn-tracker#450.

**Now targets `main`.** This was stacked on #814, which has since been squash-merged — so this branch was rebased `--onto origin/main` and retargeted, and the diff below is only this change. #816 is still stacked on top of it.

## The bug

Both iOS apps hardcoded their hosts, so a release build talks to `localhost`:

- `Environment` / `PulseEnvironment` resolve `.local` to `http://localhost:4000` and `http://localhost:3001`.
- `OSNSession.init` and `PulseSession.init` both defaulted `environment` to `.local`, and both `App.swift` files took the defaults.
- `MusubiAccountView.fetchPasskeys` built a `PasskeyManagementClient(… environment: .local)` from a literal — so even a correctly configured session listed passkeys from localhost.

It is also a hard prerequisite for ever running a real passkey ceremony: a native app can only claim an RP ID named in that domain's AASA, and local `osn-api` defaults to `rpId: "localhost"` (`osn/api/src/build-deps.ts:306`), which no app can claim.

## The shape

`DeploymentTier` (`local` / `dev` / `staging` / `production`, mirroring `DeploymentEnvironment` in `@shared/observability`) plus `Environment.resolve` and `PulseEnvironment.resolve`, reading the tier — and any host that tier needs — from the app's Info.plist. Both `init`s lose their defaults, both app targets call `resolve()`, and `OSNSession` now carries its `environment` so a caller building its own OSNAuth client uses the same one instead of a literal.

**No fallback anywhere.** A build that cannot answer "which tier am I" throws, and both apps already render that through their existing `Text(sessionError)` branch. A default is precisely the bug being fixed.

## The two tiers are asymmetric, and the config says so

| | osn-api | Pulse API |
|---|---|---|
| Debug | `http://localhost:4000` | `http://localhost:3001` |
| Release | fixed `id.musubi.social`, no URL needed | **empty on purpose** |

There is no deployed Pulse API host at any tier. So `PULSE_API_URL` is deliberately blank in Release and `PulseEnvironment.resolve()` throws there — surfacing "Pulse has no server yet" instead of hiding it as a feed that silently never loads. There is a test pinning exactly that, and it flips to a passing host the day the API ships.

## Info.plist, not INFOPLIST_KEY

Both `project.yml` files move from `GENERATE_INFOPLIST_FILE` to XcodeGen's `info:` block. `INFOPLIST_KEY_*` build settings only cover Apple's own documented keys — a custom key like `OSNTier` cannot be injected that way, and the Swift side has to read it at launch. `UILaunchScreen: {}` replaces `INFOPLIST_KEY_UILaunchScreen_Generation`.

The generated plist is gitignored alongside the entitlements file and the `.xcodeproj`, for the same reason already written next to those rules: the YAML is the source of truth and a committed copy would drift from it.

## Testability

`resolve` takes an `InfoDictionaryLookup` closure rather than a `Bundle`, because a test cannot construct a `Bundle` with an arbitrary info dictionary — without that seam none of the failure branches would be reachable from `swift test`. Same pattern and the same stated reason as `SharedCookieJar.makeConfiguration`'s `containerURLProvider`.

13 tests across `EnvironmentTests` and `PulseEnvironmentTests` cover every branch: each tier, a missing tier, an **empty** tier (the shape an unset build setting actually takes — `$(FOO)` expands to `""`, not to nothing), an unknown tier, a missing host, a non-absolute host, and Pulse's throw-in-Release.

## Verification

This container has no Swift toolchain and no Xcode, so nothing was compiled locally — the macOS Swift CI lane is the check. **It has now passed on this change**: `swift test`, plus `xcodegen generate` + `xcodebuild build` for both Pulse and Musubi. That lane is what exercises the Info.plist restructure, which was the part I most wanted CI's opinion on.

Also verified locally:

- Both `project.yml` files parse, and the `info` / `configs` blocks contain exactly the intended keys (checked with a YAML load, not by eye).
- `scripts/changeset-required.sh` → `skip`.
- `grep` confirms no `.local` literal survives outside the enum definitions and the Debug configuration.
- After the rebase, the diff is unchanged at 16 files / +385 −18 — nothing dropped or duplicated by replaying onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CcTJau43jEocATsNXHmqd