### PR TITLE
fix(swift): end the session in every app on sign-out

### DIFF
--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -106,6 +106,10 @@ public final class OSNSession {
     /// release build silently talked to `localhost`; app targets now derive it
     /// from the build configuration via `Environment.resolve(info:)`.
     public convenience init(environment: Environment) throws {
+        // Before anything reads the Keychain: move a pre-group item into the
+        // shared access group, so an app updating from an older build keeps
+        // its signed-in state. A no-op on every later launch, and off iOS.
+        try? KeychainAccessTokenStore.migrateToSharedAccessGroup()
         let session = try SharedCookieJar.makeSession()
         let tokenRefresher = TokenRefresher(session: session, environment: environment)
         let loginClient = PasskeyLoginClient(session: session, environment: environment)
@@ -173,15 +177,38 @@ public final class OSNSession {
         }
     }
 
+    /// Ends the session everywhere it is recorded: on the server, in the
+    /// Keychain, and in the shared cookie jar.
+    ///
     /// `TokenRefresher.logout()` already deletes the Keychain access token
     /// internally on every path (even a failed network call). The explicit
     /// `KeychainAccessTokenStore.delete()` here is defensive — `delete()`
     /// treats "already gone" as success (`errSecItemNotFound`), so calling
     /// it after `logout()` is a no-op, not a race.
+    ///
+    /// The cookie needs clearing by hand for a reason worth stating: the
+    /// server ends a session by returning clearing cookies from `POST
+    /// /logout`, so a request that never *reached* the server clears nothing.
+    /// The jar is shared across every OSN app in the App Group, so a stale
+    /// cookie left there is not just this app's problem — the next sibling to
+    /// foreground would present it and look signed in.
     public func signOut() async {
         try? await tokenRefresher.logout()
         try? KeychainAccessTokenStore.delete()
+        clearSessionCookie()
         state = .signedOut
+    }
+
+    /// Removes the session cookie for this environment from the shared jar.
+    /// The name is derived exactly as the server derives it — see
+    /// `sessionCookieName(for:)`, which is the one place that decides between
+    /// the `__Host-` and bare spellings.
+    private func clearSessionCookie() {
+        guard let storage = urlSession.configuration.httpCookieStorage else { return }
+        let name = sessionCookieName(for: environment)
+        for cookie in storage.cookies(for: environment.baseURL) ?? [] where cookie.name == name {
+            storage.deleteCookie(cookie)
+        }
     }
 
     /// Loads the Keychain-stored access token and refreshes it if it's

--- a/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
@@ -9,6 +9,77 @@ public enum KeychainAccessTokenStore {
     private static let service = "OSNKit.accessToken"
     private static let account = "current"
 
+    /// The Keychain access group the item lives in, or `nil` for an
+    /// app-private item.
+    ///
+    /// Without a group each app gets its **own** item, so signing out of Pulse
+    /// left Musubi's copy of the access token working for the rest of its
+    /// ≤5-minute TTL even though the shared session was already dead. iOS
+    /// accepts an App Group identifier here given the App Groups entitlement
+    /// both targets already declare, so this needs no new entitlement and no
+    /// provisioning-profile regeneration.
+    ///
+    /// `nil` off iOS, and that is not a detail: `swift test` runs on an
+    /// unentitled macOS host, and an unentitled process that asks for an
+    /// access group gets `errSecMissingEntitlement` (−34018) on *every* call.
+    /// Four test targets write to the real Keychain, so a hardcoded group
+    /// would turn the whole suite red. It is a `var` so a test can force
+    /// either branch.
+    #if os(iOS)
+    public nonisolated(unsafe) static var accessGroup: String? = osnSessionAppGroupIdentifier
+    #else
+    public nonisolated(unsafe) static var accessGroup: String? = nil
+    #endif
+
+    /// Moves a pre-existing app-private item into the shared access group,
+    /// once.
+    ///
+    /// Called from `OSNSession`'s initializer, which is the one place every
+    /// app builds a session, so an app updating from a build that predates
+    /// group sharing keeps its signed-in state instead of being silently
+    /// logged out.
+    ///
+    /// Idempotent by construction: it reads the ungrouped item first and
+    /// returns immediately when there is none, so a second run does nothing
+    /// rather than raising `errSecDuplicateItem` (−25299). A no-op when
+    /// `accessGroup` is `nil` — there is nowhere to migrate to.
+    public static func migrateToSharedAccessGroup() throws {
+        guard accessGroup != nil else { return }
+
+        var query = query(accessGroup: nil)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecItemNotFound:
+            return
+        case errSecSuccess:
+            break
+        default:
+            throw OSNKitError.keychainReadFailed(status: status)
+        }
+        guard let data = result as? Data else {
+            throw OSNKitError.keychainReadFailed(status: status)
+        }
+
+        // Write the grouped copy before dropping the original: a failure
+        // halfway leaves the user signed in rather than signed out.
+        SecItemDelete(baseQuery() as CFDictionary)
+        var write = baseQuery()
+        write[kSecValueData as String] = data
+        write[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let writeStatus = SecItemAdd(write as CFDictionary, nil)
+        guard writeStatus == errSecSuccess else {
+            throw OSNKitError.keychainWriteFailed(status: writeStatus)
+        }
+
+        let deleteStatus = SecItemDelete(query(accessGroup: nil) as CFDictionary)
+        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+            throw OSNKitError.keychainDeleteFailed(status: deleteStatus)
+        }
+    }
+
     /// A cached access token plus the moment it expires, so callers can
     /// judge freshness without a second round trip to the server.
     public struct StoredAccessToken: Sendable, Equatable {
@@ -67,10 +138,18 @@ public enum KeychainAccessTokenStore {
     }
 
     private static func baseQuery() -> [String: Any] {
-        [
+        query(accessGroup: accessGroup)
+    }
+
+    private static func query(accessGroup: String?) -> [String: Any] {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
+        if let accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+        }
+        return query
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/KeychainAccessTokenStore.swift
@@ -46,11 +46,16 @@ public enum KeychainAccessTokenStore {
     public static func migrateToSharedAccessGroup() throws {
         guard accessGroup != nil else { return }
 
-        var query = query(accessGroup: nil)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        // Named `legacyQuery`, not `query`: a local called `query` would shadow
+        // the `query(accessGroup:)` above, and the later call to it would
+        // resolve to the dictionary instead of the function.
+        let legacyQuery = query(accessGroup: nil)
+
+        var readQuery = legacyQuery
+        readQuery[kSecReturnData as String] = true
+        readQuery[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = SecItemCopyMatching(readQuery as CFDictionary, &result)
         switch status {
         case errSecItemNotFound:
             return
@@ -74,7 +79,7 @@ public enum KeychainAccessTokenStore {
             throw OSNKitError.keychainWriteFailed(status: writeStatus)
         }
 
-        let deleteStatus = SecItemDelete(query(accessGroup: nil) as CFDictionary)
+        let deleteStatus = SecItemDelete(legacyQuery as CFDictionary)
         guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
             throw OSNKitError.keychainDeleteFailed(status: deleteStatus)
         }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -277,7 +277,9 @@ struct SignOutTests {
         let (osnSession, session) = await makeSignedInSession()
         seedSessionCookie(in: session)
 
-        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        MockURLProtocol.handler = { _ -> (Int, [String: String], Data) in
+            throw URLError(.notConnectedToInternet)
+        }
         await osnSession.signOut()
 
         #expect(sessionCookies(in: session).isEmpty)

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -218,3 +218,85 @@ private actor Counter {
     private(set) var value = 0
     func increment() { value += 1 }
 }
+
+/// Sign-out has to end the session in three places, not one: on the server,
+/// in the Keychain, and in the shared cookie jar.
+///
+/// What this suite can and cannot reach, stated plainly. The cookie and
+/// Keychain halves run here for real. The **access-group** half does not:
+/// `swift test` runs on an unentitled macOS host, where any query carrying
+/// `kSecAttrAccessGroup` fails with `errSecMissingEntitlement` (−34018), so
+/// `KeychainAccessTokenStore.accessGroup` is `nil` off iOS and the only branch
+/// reachable here is the no-op one. That two apps genuinely share one item is
+/// device-only behaviour and is checked by hand, not by this suite.
+@Suite(.serialized, .keychainSerializing)
+@MainActor
+struct SignOutTests {
+    private func makeSignedInSession() async -> (OSNSession, URLSession) {
+        let session = makeMockSession()
+        let refresher = TokenRefresher(session: session, environment: .local)
+        let osnSession = makeOSNSession(environment: .local, session: session, tokenRefresher: refresher)
+        return (osnSession, session)
+    }
+
+    private func seedSessionCookie(in session: URLSession) {
+        let cookie = HTTPCookie(properties: [
+            .name: sessionCookieName(for: .local),
+            .value: "ses_seeded",
+            .domain: Environment.local.baseURL.host!,
+            .path: "/",
+        ])!
+        session.configuration.httpCookieStorage?.setCookie(cookie)
+    }
+
+    private func sessionCookies(in session: URLSession) -> [HTTPCookie] {
+        (session.configuration.httpCookieStorage?.cookies(for: Environment.local.baseURL) ?? [])
+            .filter { $0.name == sessionCookieName(for: .local) }
+    }
+
+    @Test func signOutClearsTheSessionCookieFromTheSharedJar() async throws {
+        try KeychainAccessTokenStore.save("token", expiresIn: 300)
+        let (osnSession, session) = await makeSignedInSession()
+        seedSessionCookie(in: session)
+        #expect(sessionCookies(in: session).count == 1)
+
+        MockURLProtocol.handler = { _ in (200, [:], Data()) }
+        await osnSession.signOut()
+
+        #expect(sessionCookies(in: session).isEmpty)
+        #expect(try KeychainAccessTokenStore.load() == nil)
+        #expect(osnSession.state == .signedOut)
+    }
+
+    /// The case the manual `deleteCookie` exists for. The server ends a
+    /// session by returning clearing cookies, so a request that never reaches
+    /// it clears nothing — and the jar is shared, so the stale cookie would be
+    /// the *next app's* problem, not this one's.
+    @Test func signOutStillClearsEverythingWhenLogoutNeverReachesTheServer() async throws {
+        try KeychainAccessTokenStore.save("token", expiresIn: 300)
+        let (osnSession, session) = await makeSignedInSession()
+        seedSessionCookie(in: session)
+
+        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        await osnSession.signOut()
+
+        #expect(sessionCookies(in: session).isEmpty)
+        #expect(try KeychainAccessTokenStore.load() == nil)
+        #expect(osnSession.state == .signedOut)
+    }
+
+    /// After a sign-out the shared session is dead server-side, so a sibling
+    /// app's next refresh must fail rather than quietly succeed.
+    @Test func aRefreshAfterSignOutFails() async throws {
+        let (osnSession, _) = await makeSignedInSession()
+        MockURLProtocol.handler = { _ in (200, [:], Data()) }
+        await osnSession.signOut()
+
+        MockURLProtocol.handler = { _ in
+            let body = #"{"error":"invalid_grant","message":"session revoked"}"#
+            return (400, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+        await osnSession.restore()
+        #expect(osnSession.state == .signedOut)
+    }
+}

--- a/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNKitTests/KeychainAccessTokenStoreTests.swift
@@ -33,3 +33,30 @@ struct KeychainSerialTests {
         #expect(try KeychainAccessTokenStore.load() == nil)
     }
 }
+
+extension KeychainSerialTests {
+    /// The migration's reachable branch on this host.
+    ///
+    /// `accessGroup` is `nil` off iOS — an unentitled macOS process asking for
+    /// `kSecAttrAccessGroup` gets `errSecMissingEntitlement` (−34018) on every
+    /// call, which would turn all four Keychain-touching test targets red — so
+    /// the only branch `swift test` can execute is the early return. What it
+    /// does prove is that the migration is harmless where it cannot apply, and
+    /// that it never disturbs a stored token: the actual move between groups is
+    /// device-only and is verified by hand.
+    @Test func migrationIsANoOpWithNoAccessGroupConfigured() throws {
+        #expect(KeychainAccessTokenStore.accessGroup == nil, "off iOS this must stay nil, or the suite cannot run")
+
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("token-before", expiresIn: 300)
+
+        try KeychainAccessTokenStore.migrateToSharedAccessGroup()
+        #expect(try KeychainAccessTokenStore.load()?.token == "token-before")
+
+        // Idempotent: running it again changes nothing and raises nothing.
+        try KeychainAccessTokenStore.migrateToSharedAccessGroup()
+        #expect(try KeychainAccessTokenStore.load()?.token == "token-before")
+
+        try KeychainAccessTokenStore.delete()
+    }
+}


### PR DESCRIPTION
Closes #798. Closes xchromo/osn-tracker#449.

## Why this exists when #816 says "merged"

#816 carried this change but merged into `feat/swift-env-selection`, not `main`. #815 had already been **squash-merged** to `main` from commit `014c013`, so that branch is not an ancestor of `main` and the merge left this work stranded — `main` today has #814 and #815 and nothing of this change (`grep legacyQuery` on `origin/main` → 0 hits). #798 correctly stayed open, since GitHub only auto-closes on merges to the default branch.

This branch is that same work rebased cleanly onto current `main`: **4 files, +223 / −1**, with none of #815's diff duplicated. Content is identical to what #816 merged.

**Its CI has never actually passed.** #816's three runs were each superseded — the first failed on a real compile error, the second was cut short by a rebase, the third was still in flight when the PR was merged. So this PR is also the first genuine verification that the code compiles.

## The problem

Signing out of one OSN app did not reliably sign the others out. Three things are involved and only one of them held.

**1. The server session was already fine.** `POST /logout` invalidates it and returns clearing cookies (`osn/api/src/routes/auth/tokens.ts:84`), and `TokenRefresher.logout()` deletes the local access token on every path including a failed network call. Unchanged here.

**2. The shared cookie jar could keep a dead cookie.** The server ends a session by *returning* clearing cookies — so a request that never reached it clears nothing. The jar is shared across every app in the App Group, which makes a stale cookie not just this app's problem: the next sibling to foreground would present it and look signed in. `signOut()` now removes it explicitly, deriving the name through `sessionCookieName(for:)` rather than hardcoding either the `__Host-` or bare spelling.

**3. The sibling app's access token outlived the sign-out.** `baseQuery()` set no `kSecAttrAccessGroup`, so each app had its own Keychain item and `signOut()` deleted only the caller's. The sibling's bearer kept working for the rest of its ≤5-minute TTL against a session that was already dead.

## The access group

The item now lives in the App Group. iOS accepts an App Group identifier as a Keychain access group given the App Groups entitlement both targets already declare — so **no new entitlement and no provisioning-profile regeneration**, which matters because adding a capability invalidates every profile carrying that App ID. Worth confirming on device rather than taking on my word; it's on the manual checklist in #810.

`migrateToSharedAccessGroup()` moves a pre-existing app-private item across, so an app updating from a build that predates sharing keeps its signed-in state instead of being silently logged out. Two properties by construction:

- It writes the grouped copy **before** deleting the original, so a failure halfway leaves the user signed in rather than signed out.
- It returns early when there is no ungrouped item, so a second run does nothing rather than raising `errSecDuplicateItem` (−25299).

`OSNSession`'s initializer calls it — the one place every app builds a session, and before anything reads the token.

## Why the group is nil off iOS

Load-bearing, not tidiness. `swift test` runs on an **unentitled macOS host**, where any query carrying `kSecAttrAccessGroup` fails with `errSecMissingEntitlement` (−34018) — and four test targets (`OSNKitTests`, `OSNAuthTests`, `PulseAPITests`, `MusubiFeatureTests`) write to the real Keychain. That is why `KeychainSerializingTrait` exists in the first place. A hardcoded group would turn the entire suite red.

## What the tests prove, and what they don't

Written into the suites' own doc comments rather than left implied:

| | Covered here |
|---|---|
| Cookie cleared from the shared jar on sign-out | ✅ |
| Cookie **and** Keychain cleared when `/logout` never reaches the server | ✅ — the case the manual `deleteCookie` exists for |
| A refresh after sign-out fails rather than quietly succeeding | ✅ |
| Migration is harmless where it cannot apply, and idempotent | ✅ — the early-return branch |
| Two apps genuinely sharing one item | ❌ **device-only** |

The last row cannot be reached from `swift test` for the reason above, so it is checked by hand and listed in #810's device checklist. I'd rather say that than let a green suite imply the cross-app behaviour was proved.

## Verification

No Swift toolchain and no Xcode in this container, so nothing was compiled locally — the macOS CI lane is the check, and I'll drive it to green.

Verified locally: `scripts/changeset-required.sh` → `skip`; the diff against `main` is exactly the four intended files; and after each rebase I re-asserted that the fix survived (`legacyQuery` present at all four sites, the shadowed `SecItemDelete(query(accessGroup:))` form gone), because `wiki/conventions/stacked-prs.md` warns a rebase can drop a fix while the diff still reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CcTJau43jEocATsNXHmqd

---
_Generated by [Claude Code](https://claude.ai/code/session_014CcTJau43jEocATsNXHmqd)_