### PR TITLE
fix(ci): stop the anti-slop guard failing on every local commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,14 @@ jobs:
       - name: Verify vendored anti-slop matches its checksums
         run: bash scripts/verify-vendored-anti-slop.sh
 
+      # The guard's own tests, beside the run that uses it. They exercise it in
+      # throwaway git repos rather than this checkout, and one case exports
+      # GIT_DIR the way git does for every hook — the state that once made the
+      # guard list the whole repo instead of the vendored subtree and blocked
+      # every local commit.
+      - name: Test the vendored anti-slop guard
+        run: bash scripts/verify-vendored-anti-slop.test.sh
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version

--- a/scripts/verify-vendored-anti-slop.sh
+++ b/scripts/verify-vendored-anti-slop.sh
@@ -15,6 +15,15 @@
 # `bun install` — the CI callers run before or without one.
 set -euo pipefail
 
+# Git exports GIT_DIR to every hook it runs, and with GIT_DIR set and no
+# GIT_WORK_TREE, `git ls-files` bases itself on the work-tree root whatever the
+# working directory is. Under lefthook's pre-commit that made the listing below
+# return all ~1800 tracked files instead of the vendored subtree's dozen, so the
+# diff failed and no commit touching a .js/.ts file could be made without
+# LEFTHOOK=0. Clearing the inherited variables puts discovery back on the
+# working directory, which is what every other git call here assumes.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 cd "$(dirname "$0")/.."
 
 cd tools/oxlint/anti-slop

--- a/scripts/verify-vendored-anti-slop.test.sh
+++ b/scripts/verify-vendored-anti-slop.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for verify-vendored-anti-slop.sh. Plain-bash assertions (no bats
+# dependency), matching the sibling shell tests under scripts/.
+#
+# The guard has no injection point — it hardcodes `scripts/..` and
+# `tools/oxlint/anti-slop` — so each case builds a throwaway git repo with that
+# same shape, copies the real script in, and runs it there. That also means the
+# cases never touch the repo's own vendored tree.
+#
+# Run: bash scripts/verify-vendored-anti-slop.test.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+guard="$here/verify-vendored-anti-slop.sh"
+pass=0
+fail=0
+
+# A repo whose vendored tree matches its SHA256SUMS exactly.
+make_fixture() {
+  local root="$1"
+  mkdir -p "$root/scripts" "$root/tools/oxlint/anti-slop/rules"
+  cp "$guard" "$root/scripts/verify-vendored-anti-slop.sh"
+  printf 'export const plugin = {};\n' > "$root/tools/oxlint/anti-slop/index.ts"
+  printf 'MIT\n' > "$root/tools/oxlint/anti-slop/LICENSE"
+  printf 'export const rule = {};\n' > "$root/tools/oxlint/anti-slop/rules/no-any.ts"
+  (cd "$root/tools/oxlint/anti-slop" \
+    && shasum -a 256 index.ts LICENSE rules/no-any.ts > SHA256SUMS)
+  git -C "$root" init -q
+  git -C "$root" add -A
+  git -C "$root" -c user.email=t@t -c user.name=t commit -qm init
+}
+
+# $3 is the expected exit status; $4, when "gitdir", exports GIT_DIR the way git
+# does for every hook it runs — the state that broke the cwd-relative listing.
+run_case() {
+  local name="$1" root="$2" want="$3" mode="${4:-clean}" got
+  if [ "$mode" = "gitdir" ]; then
+    GIT_DIR="$root/.git" bash "$root/scripts/verify-vendored-anti-slop.sh" >/dev/null 2>&1
+  else
+    bash "$root/scripts/verify-vendored-anti-slop.sh" >/dev/null 2>&1
+  fi
+  got=$?
+  if [ "$got" -eq "$want" ]; then
+    echo "ok   - $name (exit $got)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $name (got exit $got, want $want)"
+    fail=$((fail + 1))
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Baseline: an untouched vendored tree passes.
+c="$tmp/clean"
+make_fixture "$c"
+run_case "matching tree passes" "$c" 0
+
+# The regression. Git exports GIT_DIR to hooks, and with it set the guard used
+# to list every tracked file in the repo rather than the vendored subtree, so
+# the diff failed and lefthook blocked every commit staging a .js/.ts file.
+run_case "matching tree passes with GIT_DIR set" "$c" 0 gitdir
+
+# An edit to a vendored file is what the checksums exist to catch.
+m="$tmp/modified"
+make_fixture "$m"
+printf 'export const plugin = { tampered: true };\n' > "$m/tools/oxlint/anti-slop/index.ts"
+run_case "modified vendored file fails" "$m" 1
+
+# ...and it must still be caught under GIT_DIR, so the fix above does not
+# trade a false failure for a false pass.
+run_case "modified vendored file fails with GIT_DIR set" "$m" 1 gitdir
+
+# A file added to the tree is absent from SHA256SUMS, so `shasum -c` has
+# nothing to check it against. Only the file-set diff catches this half.
+a="$tmp/added"
+make_fixture "$a"
+printf 'export const rule = {};\n' > "$a/tools/oxlint/anti-slop/rules/smuggled.ts"
+git -C "$a" add -A
+git -C "$a" -c user.email=t@t -c user.name=t commit -qm add
+run_case "added tracked file fails" "$a" 1
+run_case "added tracked file fails with GIT_DIR set" "$a" 1 gitdir
+
+# The other direction: a file SHA256SUMS lists that is no longer tracked.
+d="$tmp/deleted"
+make_fixture "$d"
+git -C "$d" rm -q tools/oxlint/anti-slop/rules/no-any.ts
+git -C "$d" -c user.email=t@t -c user.name=t commit -qm rm
+run_case "removed tracked file fails" "$d" 1
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

`scripts/verify-vendored-anti-slop.sh` has been failing for everyone locally since it landed, on every commit that stages a `.js`, `.jsx`, `.ts` or `.tsx` file — the only way past it was `LEFTHOOK=0` or `--no-verify`, which turns off oxlint and oxfmt too, the checks the guard was chained ahead of to protect. Git exports `GIT_DIR` into every hook's environment, and with `GIT_DIR` set and no `GIT_WORK_TREE` a `git ls-files` bases itself on the work-tree root whatever the working directory is, so the guard's `cd tools/oxlint/anti-slop; git ls-files` listed all ~1800 tracked files instead of the vendored subtree's 21 and the diff against `SHA256SUMS` failed. Clearing the inherited variables before the `cd` puts repository discovery back on the working directory, which is what every other git call in these scripts already assumes.

CI never saw it: a workflow step has no `GIT_DIR` in its environment, so both callers passed throughout. That gap is the second half of this PR — a test file for the guard, exercising it with `GIT_DIR` exported the way git sets it.

- `shasum -c` was never the broken half. Every file reported `OK` even while the hook failed; only the file-set diff was wrong.
- `GIT_INDEX_FILE` is unset alongside the other two. Nothing sets it on the pre-commit path today, but it redirects the same listing and belongs with its siblings rather than as a later surprise.

## Workspaces affected

None. `scripts/` and `.github/` ship inside no versioned package, so `scripts/changeset-required.sh` returns `skip` for this file list and no changeset is needed.

## Issues

**Closes**

| Issue | What |
|---|---|
| #820 | `verify-vendored-anti-slop.sh` fails on every local commit (GIT_DIR) |

Closes xchromo/osn#820.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#820 | Filed during this branch, fixed by it |

## Decisions

### Clear the inherited git variables rather than re-anchor the listing — `approach`

- **Issue** — the guard's `git ls-files` runs from inside `tools/oxlint/anti-slop` and relies on the working directory to scope it, which `GIT_DIR` overrides.
- **Why** — under lefthook that scoping silently inverted: the check that exists to catch a tampered vendored file instead blocked every commit in the repo, and pushed people towards `--no-verify`, which disables the lint the guard protects.
- **Solution** — `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE` at the top of the script, before the `cd`. The rest of the script is unchanged.
- **Rationale** — the alternative was to list from the repo root with an explicit pathspec and strip the prefix with `sed`, which works but leaves the script the only one in `scripts/` that cannot trust plain repository discovery. Unsetting fixes the cause once and lets the existing three lines stand as written. It cannot mask a real tamper: the two failure cases are re-asserted under `GIT_DIR` in the tests below and both still fail.

### Test the guard in throwaway repos, not this checkout — `approach`

- **Issue** — the guard hardcodes `scripts/..` and `tools/oxlint/anti-slop` with no injection point, so there is nowhere to hand it a fixture.
- **Why** — a test that mutated this repo's own vendored tree to assert the failure cases would leave the working tree dirty on any early exit, and would be checking the same files the guard is meant to protect.
- **Solution** — each case builds a `git init` repo with the same `scripts/` + `tools/oxlint/anti-slop/` shape, copies the real script in, and runs it there.
- **Rationale** — matches `scripts/validate-changesets.test.sh`, which builds fixture workspaces for the same reason. Plain-bash assertions, no bats dependency, consistent with both existing shell tests.

### Prove the test is not vacuous — `approach`

- **Issue** — a regression test written after the fix can pass for the wrong reason.
- **Why** — the specific risk here is a fix that stops the false failure by making the guard blind, which a test that only checks the happy path would wave through.
- **Solution** — the `GIT_DIR`-clean case was run against the previous version of the script and fails there; the modified-file and added-file cases were run under `GIT_DIR` both before and after the fix and pass in both.
- **Rationale** — that pair is what distinguishes "the guard now works under `GIT_DIR`" from "the guard now finds nothing under `GIT_DIR`".

**Out of scope** — none.

## Test plan

| Gate | Result |
|---|---|
| `bash scripts/verify-vendored-anti-slop.sh` (clean env) | ✅ 21 files `OK`, no diff |
| `bash scripts/verify-vendored-anti-slop.sh` with `GIT_DIR` set | ✅ passes; failed before this change |
| `bash scripts/verify-vendored-anti-slop.test.sh` | ✅ 7 passed, 0 failed |
| Same test against the pre-fix script | ✅ 6 passed, 1 failed — the `GIT_DIR`-clean case |
| `bash scripts/changeset-required.sh` on this file list | ✅ `skip` |
| `bash -n` on both shell files | ✅ |
| `bunx --bun oxfmt --check .github/workflows/ci.yml` | ✅ |
| YAML parse of `.github/workflows/ci.yml` | ✅ |

Exercised by hand as well: a probe `.ts` file was staged and committed in this worktree with hooks live. The `lint` command — which chains this guard ahead of oxlint — reported `✔️ lint (1.00 seconds)` and the commit succeeded. That commit was then dropped with `git reset --hard`; it is not in this branch.

Not covered by any gate: the `GIT_INDEX_FILE` unset. No hook on the pre-commit path sets that variable today, so there is no state in which the tests can tell it apart from the other two.
