### PR TITLE
fix(osn-api): filter primitives at push, use a cursor for the _tag walk

### DIFF
--- a/.changeset/error-tag-walk-budget-and-quadratic-dequeue.md
+++ b/.changeset/error-tag-walk-budget-and-quadratic-dequeue.md
@@ -1,0 +1,5 @@
+---
+"@osn/api": patch
+---
+
+Fix `publicError`'s `_tag` walk to stop charging the 512-node traversal budget for primitive property values, so a wide chain of string fields no longer exhausts the budget before a real tagged error is found and misreported as a 400. Also replace the queue's `Array#shift()` with a read cursor, so the walk is linear in the number of nodes visited instead of quadratic.

--- a/osn/api/src/lib/public-error.ts
+++ b/osn/api/src/lib/public-error.ts
@@ -21,7 +21,7 @@ export function publicError(
   const CAUSE_TAGS = new Set(["Fail", "Die", "Interrupt", "Sequential", "Parallel", "Empty"]);
   const tag = (() => {
     const seen = new Set<unknown>();
-    const queue: unknown[] = [e];
+    const queue: object[] = e && typeof e === "object" ? [e] : [];
     // P-I1: bound the traversal. A tagged error's `_tag` sits within a few hops
     // of the root (the instance itself, or a FiberFailure → Cause → Fail node),
     // so a small budget never truncates a real lookup — but it guarantees
@@ -29,9 +29,10 @@ export function publicError(
     // (which falls through to the generic default) references a large object
     // graph (DB layer, fiber state) via a `Die` cause.
     let budget = 512;
-    while (queue.length && budget-- > 0) {
-      const node = queue.shift();
-      if (!node || typeof node !== "object" || seen.has(node)) continue;
+    let head = 0;
+    while (head < queue.length && budget-- > 0) {
+      const node = queue[head++];
+      if (seen.has(node)) continue;
       seen.add(node);
       const tag_value = (node as { _tag?: unknown })._tag;
       if (typeof tag_value === "string" && !CAUSE_TAGS.has(tag_value)) return tag_value;
@@ -54,7 +55,7 @@ export function publicError(
         } catch {
           continue; // a throwing getter is not a tag carrier
         }
-        queue.push(v);
+        if (v && typeof v === "object") queue.push(v);
       }
     }
     return null;

--- a/osn/api/tests/lib/public-error.test.ts
+++ b/osn/api/tests/lib/public-error.test.ts
@@ -90,4 +90,29 @@ describe("publicError", () => {
     for (let i = 0; i < 600; i++) node = { next: node };
     expect(publicError(node)).toEqual({ status: 400, body: { error: "invalid_request" } });
   });
+
+  // tracker#473: a wide-but-shallow cause chain (many string fields per hop)
+  // must not spend the 512-node budget on primitives. Against the unfixed
+  // walk — which dequeues (and so charges budget for) every pushed value,
+  // primitives included — this chain exhausts the budget before reaching the
+  // tagged node and falls through to 400; that is the bug this test pins.
+  it("reaches a tagged error past a wide chain of primitive fields", () => {
+    let node: Record<string, unknown> = { _tag: "DatabaseError" };
+    for (let hop = 0; hop < 10; hop++) {
+      const wide: Record<string, unknown> = { cause: node };
+      for (let f = 0; f < 60; f++) wide[`field${f}`] = `value${f}`;
+      node = wide;
+    }
+    expect(publicError(node)).toEqual({ status: 500, body: { error: "internal_error" } });
+  });
+
+  // The #473 seed narrowing's regression test: a primitive `e` must not reach
+  // `Reflect.ownKeys`, which throws on a primitive in strict mode.
+  it.each([["a string error"], [null]])(
+    "falls through for a primitive %p without throwing",
+    (e) => {
+      expect(() => publicError(e)).not.toThrow();
+      expect(publicError(e)).toEqual({ status: 400, body: { error: "invalid_request" } });
+    },
+  );
 });


### PR DESCRIPTION
## Summary

`publicError` walks an unknown thrown value looking for an Effect error's `_tag`, so it can map a tagged domain error onto its real HTTP status instead of the generic 400. Two things were wrong with that walk.

It pushed every property value onto the queue, primitives included, and charged the 512-node budget for each one at dequeue — before the object guard. A cause chain with many string fields per hop therefore spent the whole budget on strings and fell through to the default 400 arm without ever reaching the tagged node, turning a 500 into a 400.

It also dequeued with `Array#shift()`, which is O(n) in the length of the queue, making the walk quadratic in the number of nodes visited.

The push site now filters to objects, and the dequeue is a read cursor. The queue is seeded from a narrowed `e` and typed `object[]`, so the per-node "is this an object" check disappears from the loop body rather than moving elsewhere — no assertion is needed anywhere, because the ternary seed and the push filter both narrow.

## Workspaces affected

| Package | Change |
|---|---|
| `@osn/api` | `src/lib/public-error.ts`, plus two tests in `tests/lib/public-error.test.ts` |

## Issues

**Closes**

| Issue | What it asked for |
|---|---|
| xchromo/osn-tracker#473 | Stop primitive property values consuming the traversal budget, so a wide cause chain still reaches a real `_tag` |
| xchromo/osn-tracker#474 | Replace the O(n) `shift()` dequeue, which made the bounded walk quadratic |

Closes xchromo/osn-tracker#473.
Closes xchromo/osn-tracker#474.

**Opened** None.

## Decisions

### Seed the queue narrowed and type it `object[]`

**Issue** The queue was `unknown[]`, seeded `[e]` from an unchecked `e: unknown`, and each iteration re-established "this is an object" in the dequeue guard. Removing the primitives at the push site leaves that guard doing nothing except narrowing the type.

**Why** With the guard gone the loop body hands `node` straight to `Reflect.ownKeys`, which does not accept `unknown` under `strict: true` — so the shape has to be settled at the seed, not patched at the use.

**Solution** `const queue: object[] = e && typeof e === "object" ? [e] : [];`, and the dequeue keeps only the `seen` check.

**Rationale** The ternary narrows the seed and the push filter narrows `v`, so `queue[head++]` types as `object` with no assertion — `noUncheckedIndexedAccess` is not set (`shared/typescript-config/base.json:8`). The alternative, keeping `unknown[]` and the old guard, compiles equally well but leaves a runtime check whose only remaining job is to satisfy the type system.

### Fall through, do not throw, for a primitive `e`

**Issue** The narrowed seed changes what happens when someone throws a string or `null`: the queue is empty, the walk does not run at all.

**Why** Previously the same value went into the queue and was skipped by the dequeue guard on the first iteration. The outcome was identical; the new shape reaches it one step earlier.

**Solution** Kept the behaviour and pinned it — a parameterised test asserts a string `e` and a `null` `e` both return the default 400 arm and do not throw.

**Rationale** `Reflect.ownKeys` throws on a primitive in strict mode, so the seed guard is the only thing standing between a stringly-thrown error and a 500 from the error handler itself. That deserves a regression test rather than a comment.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run test` | pass |
| Changeset validation | pass |

Two tests added. The budget test builds a ten-hop cause chain with sixty string fields per hop and asserts the tagged node's 500; it was run against the unfixed walk first and failed there with the 400 the bug produces, so it bites. The primitive test covers the seed guard.

**Not run:** `bun run test:d1`, `bun run test:browser` and `bun run build` — this change touches one pure function in `osn/api` and its unit tests, no D1 access, no rendered component, no build output. CI runs all three.
