### PR TITLE
fix(social,api): guard GRID_COLS with Object.hasOwn, harden the OIDC pollution test

### DIFF
--- a/.changeset/hasown-map-guard-polish.md
+++ b/.changeset/hasown-map-guard-polish.md
@@ -2,11 +2,12 @@
 "@osn/social": patch
 ---
 
-S-491 — `MobileNav`'s column-count lookup now guards `GRID_COLS` with
+`MobileNav`'s column-count lookup now guards `GRID_COLS` with
 `Object.hasOwn` instead of the `in` operator, so a polluted
 `Object.prototype` can no longer redirect the fallback class through an
-inherited property. Also adds test hygiene to `osn/api`'s OIDC confusable-fold
-prototype-pollution test (tracker#493, T-S1/T-S2): an `afterEach` that clears
+inherited property (tracker#491). Also adds test hygiene to `osn/api`'s OIDC
+confusable-fold prototype-pollution test (tracker#493, T-S1 and T-S2): an
+`afterEach` that clears
 the polluted key on every exit path (not just the happy one), and a
 pre-pollution baseline assertion so the post-pollution assertion is evidence
 that pollution changed nothing.

--- a/.changeset/hasown-map-guard-polish.md
+++ b/.changeset/hasown-map-guard-polish.md
@@ -1,0 +1,12 @@
+---
+"@osn/social": patch
+---
+
+S-491 — `MobileNav`'s column-count lookup now guards `GRID_COLS` with
+`Object.hasOwn` instead of the `in` operator, so a polluted
+`Object.prototype` can no longer redirect the fallback class through an
+inherited property. Also adds test hygiene to `osn/api`'s OIDC confusable-fold
+prototype-pollution test (tracker#493, T-S1/T-S2): an `afterEach` that clears
+the polluted key on every exit path (not just the happy one), and a
+pre-pollution baseline assertion so the post-pollution assertion is evidence
+that pollution changed nothing.

--- a/osn/api/tests/services/auth/oidc.test.ts
+++ b/osn/api/tests/services/auth/oidc.test.ts
@@ -15,10 +15,10 @@ import { clientNameSkeleton } from "../../../src/services/auth/oidc";
  * prove the guard checks OWN membership rather than trusting on that absence.
  */
 afterEach(() => {
-  // S-L2 lesson (see AuthorizePage.test.tsx:128-135): a `finally` does not
-  // run when vitest abandons a timed-out test body, so one hang would leak
-  // `Object.prototype.δ` into every later test in this file. This runs on
-  // every exit path; the `try`/`finally` below stays too, keeping the
+  // Same reason as the guard in AuthorizePage.test.tsx:127-135: a `finally`
+  // does not run when vitest abandons a timed-out test body, so one hang
+  // would leak `Object.prototype.δ` into every later test in this file. This
+  // runs on every exit path; the `try`/`finally` below stays too, keeping the
   // pollution window as short as it is today.
   delete (Object.prototype as Record<string, unknown>).δ;
 });

--- a/osn/api/tests/services/auth/oidc.test.ts
+++ b/osn/api/tests/services/auth/oidc.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { clientNameSkeleton } from "../../../src/services/auth/oidc";
 
@@ -14,11 +14,24 @@ import { clientNameSkeleton } from "../../../src/services/auth/oidc";
  * the test pollutes the prototype itself with a single-character property to
  * prove the guard checks OWN membership rather than trusting on that absence.
  */
+afterEach(() => {
+  // S-L2 lesson (see AuthorizePage.test.tsx:128-135): a `finally` does not
+  // run when vitest abandons a timed-out test body, so one hang would leak
+  // `Object.prototype.δ` into every later test in this file. This runs on
+  // every exit path; the `try`/`finally` below stays too, keeping the
+  // pollution window as short as it is today.
+  delete (Object.prototype as Record<string, unknown>).δ;
+});
+
 describe("clientNameSkeleton", () => {
   it("does not fold a character that is only an inherited property", () => {
     const proto = Object.prototype as Record<string, string>;
     // "δ" (Greek delta) is not a key CONFUSABLE_FOLD owns.
     expect(Object.hasOwn(proto, "δ")).toBe(false);
+    // Baseline, taken before the prototype is polluted: proves the
+    // post-pollution assertion below is evidence that pollution changed
+    // nothing, not merely a description of the function's normal output.
+    expect(clientNameSkeleton("aδb")).toBe("ab");
     // Non-enumerable, so no `for...in` anywhere in the realm can see it while
     // the test holds it. Removed again in the `finally`.
     Object.defineProperty(proto, "δ", {

--- a/osn/social/src/components/MobileNav.tsx
+++ b/osn/social/src/components/MobileNav.tsx
@@ -15,7 +15,8 @@ const GRID_COLS: GridColumnClasses = {
   5: "grid-cols-5",
 };
 
-const gridCols = (count: number): string => (count in GRID_COLS ? GRID_COLS[count] : "grid-cols-4");
+const gridCols = (count: number): string =>
+  Object.hasOwn(GRID_COLS, count) ? GRID_COLS[count] : "grid-cols-4";
 
 /**
  * The mobile shell's primary navigation: a fixed bottom tab bar, rendered


### PR DESCRIPTION
## Summary

Two small hardening fixes to code that already defends against a polluted `Object.prototype`, in places where the defence had a hole.

`MobileNav` picks a Tailwind grid class from a count with `count in GRID_COLS`. The `in` operator walks the prototype chain, so `Object.prototype[3] = "grid-cols-99"` makes the lookup take the inherited value instead of the `grid-cols-4` fallback. `Object.hasOwn` asks the question the code meant to ask.

`osn/api`'s OIDC test deliberately pollutes `Object.prototype.δ` to prove `clientNameSkeleton` ignores inherited confusable entries. It cleaned up in a `finally`, which does not run when Vitest abandons a timed-out test body — one hang would leak the key into every later test in the file. It also asserted only the post-pollution output, which on its own reads as a description of what the function returns rather than evidence that pollution changed nothing.

## Workspaces affected

| Package | Change |
|---|---|
| `@osn/social` | `src/components/MobileNav.tsx` |
| `@osn/api` | `tests/services/auth/oidc.test.ts` (test hygiene only, no source change) |

## Issues

**Closes**

| Issue | What it asked for |
|---|---|
| xchromo/osn-tracker#491 | Guard the `GRID_COLS` lookup with `Object.hasOwn` so a polluted prototype cannot redirect the fallback class |

Closes xchromo/osn-tracker#491.

Partly addresses xchromo/osn-tracker#493 — T-S1 (the `finally`-only cleanup) and T-S2 (the missing pre-pollution baseline) are fixed here. T-S3 in that issue is a decision, not a fix, so #493 stays open; a comment there says what is left.

**Opened** None.

## Decisions

### Keep the `try`/`finally` as well as the new `afterEach`

**Issue** The `afterEach` deletes the polluted key on every exit path, which is a superset of what the `finally` does.

**Why** Deleting the `finally` as redundant would widen the window in which `Object.prototype.δ` exists — from "the rest of this test body" to "the rest of this test body plus every hook Vitest runs between the body and `afterEach`".

**Solution** Both stay. The `finally` keeps the window as short as it is today; the `afterEach` is the backstop for the path the `finally` cannot cover.

**Rationale** The two are not the same guard. One is scope-tight, one is exhaustive, and the cost of keeping both is three lines.

### `#493` gets a reference, not a closing keyword

**Issue** Two of that issue's three findings land in this PR.

**Why** A `Closes` line would auto-close it on merge and lose T-S3, which asks whether the confusable-fold source scan should be a test (shaped like `scripts/changeset-required.test.sh`) or stay documentation. That is a call for the repo owner.

**Solution** Referenced above without a keyword; a comment on #493 records what landed.

**Rationale** Closing an issue whose open question is untouched is how a decision gets lost.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | pass |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run test` | pass |
| Changeset validation | pass |

The OIDC test asserts the new baseline (`clientNameSkeleton("aδb") === "ab"` before the prototype is touched) and still asserts `Object.hasOwn(proto, "δ") === false` inside the fold.

**Not run:** `bun run test:d1`, `bun run test:browser`, `bun run build`. `MobileNav`'s change is a one-line predicate swap with no rendered or layout effect, there is no D1 access, and the `osn/api` change is test-only. CI runs all three.
