### PR TITLE
fix(cire-api): parallelise the paired R2 puts and stop a failed multi-delete fanning out

### DIFF
--- a/.changeset/cire-r2-followups.md
+++ b/.changeset/cire-r2-followups.md
@@ -1,0 +1,9 @@
+---
+"@cire/api": patch
+---
+
+Issue the two independent R2 puts in `storeBeforeImage` and `storeUpload` together instead of one after the other. Both write a fixed key with no dependency on the other, so awaiting them in sequence spent two round trips where one would do. They now go through `Promise.allSettled` and the first rejection is rethrown, which keeps the existing `R2Error` behaviour while making sure a second rejection is never left unhandled in a request context.
+
+Narrow the multi-key delete fallback in `reapR2Objects` to a synchronous throw. The array form of `delete` is a Cloudflare R2 feature that a single-key binding may not have, and the probe existed to detect that. It caught an asynchronous rejection too, so one failed multi-delete of a full chunk fanned out into up to 1000 single-key deletes against a bucket that had already refused the work. A binding that lacks the feature throws when called; a rejection means the delete itself failed, and is now counted as failed rather than retried per key.
+
+Cover the paths none of this had tests for: a bucket rejecting a delete, a put rejecting for one key of a pair, an asynchronous array-delete rejection not falling back to per-key deletes, and the dedupe, chunking and no-op behaviour of `reapR2Objects` itself.

--- a/cire/api/src/services/invite-assets.test.ts
+++ b/cire/api/src/services/invite-assets.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "bun:test";
 import { Effect } from "effect";
 
 import {
+  AssetR2Error,
   AssetsR2Service,
   createAssetsStub,
   deleteAsset,
@@ -61,6 +62,23 @@ describe("invite-assets R2 round-trip", () => {
       fetchAsset("assets/missing").pipe(Effect.provideService(AssetsR2Service, stub)),
     );
     expect(exit._tag).toBe("Failure");
+  });
+
+  it("fails deleteAsset with AssetR2Error when the delete rejects", async () => {
+    // A backend whose delete rejects — exercises the call sites in
+    // invite.ts / event-image.ts that catch this and log a warning instead
+    // of failing the request.
+    const failing = {
+      put: () => Promise.resolve(),
+      get: () => Promise.resolve(null),
+      delete: () => Promise.reject(new Error("delete failed")),
+    };
+    const error = await Effect.runPromise(
+      Effect.flip(deleteAsset("assets/whatever")).pipe(
+        Effect.provideService(AssetsR2Service, failing),
+      ),
+    );
+    expect(error).toBeInstanceOf(AssetR2Error);
   });
 });
 

--- a/cire/api/src/services/r2-cleanup.test.ts
+++ b/cire/api/src/services/r2-cleanup.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "bun:test";
+
+import { Effect } from "effect";
+
+import { reapR2Objects, type DeletableBucket } from "./r2-cleanup";
+
+function createRecordingBucket(): DeletableBucket & { calls: string[][] } {
+  const calls: string[][] = [];
+  return {
+    calls,
+    delete(keys: string | string[]) {
+      calls.push(Array.isArray(keys) ? keys : [keys]);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("reapR2Objects", () => {
+  it("dedupes duplicate keys before deleting", async () => {
+    const bucket = createRecordingBucket();
+    await Effect.runPromise(reapR2Objects(bucket, "sheets", ["a", "b", "a", "b", "c"]));
+    expect(bucket.calls.length).toBe(1);
+    expect(bucket.calls[0]?.toSorted()).toEqual(["a", "b", "c"]);
+  });
+
+  it("is a no-op for an empty key list", async () => {
+    const bucket = createRecordingBucket();
+    await Effect.runPromise(reapR2Objects(bucket, "sheets", [null, undefined, ""]));
+    expect(bucket.calls.length).toBe(0);
+  });
+
+  it("warns and does not throw when the bucket binding is absent", async () => {
+    await expect(
+      Effect.runPromise(reapR2Objects(undefined, "assets", ["a", "b"])),
+    ).resolves.toBeUndefined();
+  });
+
+  it("chunks a key list larger than CHUNK_SIZE into multiple delete calls", async () => {
+    const bucket = createRecordingBucket();
+    const keys = Array.from({ length: 1001 }, (_, i) => `key-${i}`);
+    await Effect.runPromise(reapR2Objects(bucket, "sheets", keys));
+    expect(bucket.calls.length).toBe(2);
+    expect(bucket.calls[0]?.length).toBe(1000);
+    expect(bucket.calls[1]?.length).toBe(1);
+  });
+});

--- a/cire/api/src/services/r2-cleanup.ts
+++ b/cire/api/src/services/r2-cleanup.ts
@@ -23,7 +23,9 @@ import { metricR2ObjectsSwept } from "../metrics";
  *  - **Bounded.** Keys are deduped and chunked so a purge touching many objects
  *    respects the Worker CPU/subrequest budget; each chunk is one `delete([...])`
  *    multi-key call where the binding supports it (Cloudflare R2), falling back
- *    to per-key deletes (the in-memory test stub / any single-key binding).
+ *    to per-key deletes only when a binding rejects the array form
+ *    *synchronously* — an asynchronous rejection is a real delete failure, not
+ *    a feature gap, so it is counted as failed rather than retried per-key.
  *  - **Metric.** Emits the bounded-cardinality `cire.r2.objects.swept` counter
  *    (`bucket` ∈ sheets|assets, `result` ∈ ok|error) — count is the number of
  *    keys in the request, so the sum tracks reclaimed objects per bucket.
@@ -36,7 +38,10 @@ export type R2BucketLabel = "sheets" | "assets";
  * Minimal delete-only R2 surface. Cloudflare's `R2Bucket` satisfies this
  * structurally and additionally accepts `string[]` for a single multi-key
  * delete; the in-memory test stubs implement only the single-key form. We
- * feature-detect the array form at call time so both work.
+ * feature-detect the array form at call time so both work — but only a
+ * *synchronous* throw from `bucket.delete(batch)` is treated as "form not
+ * supported"; a rejected promise is a genuine delete failure and is not
+ * retried per-key.
  *
  * The result is `Promise<void> | void`, matching the real backend: R2's
  * `delete` resolves `Promise<void>` (the ambient `R2Bucket` from
@@ -98,12 +103,19 @@ export function reapR2Objects(
         try: async () => {
           // Cloudflare R2's `delete` accepts `string[]` (one multi-key request);
           // the in-memory test stub / any single-key binding may not. Attempt the
-          // array form first, fall back to per-key deletes if it throws.
+          // array form first, fall back to per-key deletes only when the call
+          // throws synchronously — an async rejection is a real failure, not a
+          // feature gap, and must not be masked by a per-key retry.
+          let pending: Promise<void> | undefined;
           try {
-            await bucket.delete(batch);
-            return;
+            pending = Promise.resolve(bucket.delete(batch));
           } catch {
-            // Binding rejected the array form — fall through to per-key deletes.
+            // Binding rejected the array form synchronously — fall through to per-key.
+            pending = undefined;
+          }
+          if (pending) {
+            await pending;
+            return;
           }
           for (const key of batch) {
             // eslint-disable-next-line no-await-in-loop

--- a/cire/api/src/services/r2-imports.test.ts
+++ b/cire/api/src/services/r2-imports.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect } from "bun:test";
 
 import { Effect, Layer } from "effect";
 
-import { R2Service, createR2Stub, fetchUpload, storeUpload, R2Error } from "./r2-imports";
+import {
+  R2Service,
+  createR2Stub,
+  fetchUpload,
+  storeBeforeImage,
+  storeUpload,
+  R2Error,
+} from "./r2-imports";
 
 describe("R2Service (in-memory stub)", () => {
   it("stores and fetches an uploaded events.csv + guests.csv pair", async () => {
@@ -31,6 +38,42 @@ describe("R2Service (in-memory stub)", () => {
 
     const error = await Effect.runPromise(
       Effect.flip(fetchUpload("imports/missing/events.csv")).pipe(Effect.provide(layer)),
+    );
+    expect(error).toBeInstanceOf(R2Error);
+  });
+
+  it("fails storeUpload with R2Error when one of the two puts rejects", async () => {
+    // Only one of the pair rejects — exercises the Promise.allSettled path
+    // that throws the first rejection rather than adopting Promise.all's.
+    const partiallyFailing = {
+      put: (key: string) =>
+        key.endsWith("guests.csv") ? Promise.reject(new Error("put failed")) : Promise.resolve(),
+      get: () => Promise.resolve(null),
+      delete: () => Promise.resolve(),
+    };
+    const layer = Layer.succeed(R2Service, partiallyFailing);
+
+    const error = await Effect.runPromise(
+      Effect.flip(storeUpload("events,csv\n", "guests,csv\n", "import-fail")).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(error).toBeInstanceOf(R2Error);
+  });
+
+  it("fails storeBeforeImage with R2Error when one of the two puts rejects", async () => {
+    const partiallyFailing = {
+      put: (key: string) =>
+        key.endsWith("events.csv") ? Promise.reject(new Error("put failed")) : Promise.resolve(),
+      get: () => Promise.resolve(null),
+      delete: () => Promise.resolve(),
+    };
+    const layer = Layer.succeed(R2Service, partiallyFailing);
+
+    const error = await Effect.runPromise(
+      Effect.flip(storeBeforeImage("events,csv\n", "guests,csv\n", "import-fail")).pipe(
+        Effect.provide(layer),
+      ),
     );
     expect(error).toBeInstanceOf(R2Error);
   });

--- a/cire/api/src/services/r2-imports.ts
+++ b/cire/api/src/services/r2-imports.ts
@@ -76,8 +76,8 @@ export function storeBeforeImage(
 
     yield* Effect.tryPromise({
       try: async () => {
-        await r2.put(ek, eventsCsv);
-        await r2.put(gk, guestsCsv);
+        const results = await Promise.allSettled([r2.put(ek, eventsCsv), r2.put(gk, guestsCsv)]);
+        for (const r of results) if (r.status === "rejected") throw r.reason;
       },
       catch: (cause) => new R2Error({ reason: "before-image store failed", cause }),
     });
@@ -98,8 +98,8 @@ export function storeUpload(
 
     yield* Effect.tryPromise({
       try: async () => {
-        await r2.put(ek, eventsCsv);
-        await r2.put(gk, guestsCsv);
+        const results = await Promise.allSettled([r2.put(ek, eventsCsv), r2.put(gk, guestsCsv)]);
+        for (const r of results) if (r.status === "rejected") throw r.reason;
       },
       catch: (cause) => new R2Error({ reason: "store failed", cause }),
     });

--- a/cire/api/src/services/retention.test.ts
+++ b/cire/api/src/services/retention.test.ts
@@ -27,11 +27,13 @@ const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
  * In-memory delete-only R2 stub recording every key passed to `.delete()`.
  * Supports BOTH the single-key and the array (multi-key) delete form so the
  * reaper's array-first/per-key-fallback path is exercised. `failKeys` forces a
- * throw for the named keys (best-effort path); `arrayOnly: false` simulates a
- * binding that rejects the array form (the test-stub case).
+ * throw for the named keys (best-effort path); `rejectArray` simulates a
+ * binding that throws synchronously on the array form (falls back to
+ * per-key); `rejectArrayAsync` simulates a binding whose array form rejects
+ * asynchronously (a real delete failure — no per-key fallback).
  */
 function createDeleteStub(
-  opts: { failKeys?: Set<string>; rejectArray?: boolean } = {},
+  opts: { failKeys?: Set<string>; rejectArray?: boolean; rejectArrayAsync?: boolean } = {},
 ): DeletableBucket & {
   deleted: Set<string>;
 } {
@@ -46,6 +48,7 @@ function createDeleteStub(
     delete(keys: string | string[]) {
       if (Array.isArray(keys)) {
         if (opts.rejectArray) throw new Error("array delete unsupported");
+        if (opts.rejectArrayAsync) return Promise.reject(new Error("array delete failed"));
         for (const k of keys) removeOne(k);
       } else {
         removeOne(keys);
@@ -537,6 +540,39 @@ describe("retentionService.sweepExpiredGuestData", () => {
         const sheets = createDeleteStub({ rejectArray: true });
         yield* retentionService.sweepExpiredGuestData(now, { sheets });
         for (const k of sheetKeys) expect(sheets.deleted.has(k)).toBe(true);
+      }),
+    ),
+  );
+
+  it(
+    "does not fall back to per-key delete when the array form rejects asynchronously",
+    withDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const now = new Date("2026-06-17T04:00:00.000Z");
+        const { weddingId, guestId, sheetKeys } = yield* makeWedding({
+          eventDates: ["2024-06-01"],
+          withImport: true,
+        });
+        // rejectArrayAsync ⇒ the array delete rejects after being called — a
+        // real delete failure, not a feature gap, so there is no per-key retry.
+        const sheets = createDeleteStub({ rejectArrayAsync: true });
+
+        // The sweep still resolves (best-effort) and the D1 rows are gone.
+        const deleted = yield* retentionService.sweepExpiredGuestData(now, { sheets });
+        expect(deleted).toBeGreaterThanOrEqual(1);
+        expect(
+          (yield* dbQuery(() => db.select().from(guests).where(eq(guests.id, guestId)).all()))
+            .length,
+        ).toBe(0);
+        expect(
+          (yield* dbQuery(() =>
+            db.select().from(imports).where(eq(imports.weddingId, weddingId)).all(),
+          )).length,
+        ).toBe(0);
+        // No per-key fallback ran, so nothing was recorded as deleted.
+        for (const k of sheetKeys) expect(sheets.deleted.has(k)).toBe(false);
+        expect(sheets.deleted.size).toBe(0);
       }),
     ),
   );


### PR DESCRIPTION
## Summary

Three follow-ups on the cire/api R2 paths, all found while reviewing the R2 typing work in #823.

`storeBeforeImage` and `storeUpload` each write two objects — an events CSV and a guests CSV — under two fixed keys, with no dependency between them. Both awaited the first put before starting the second, so every import spent two sequential round trips to R2 where one would do. They now issue both together through `Promise.allSettled` and rethrow the first rejection. `allSettled` rather than `all` on purpose: with `Promise.all`, a second rejection arriving after the first has already settled the race becomes an unhandled rejection, which on workerd can take down the request context that is already handling the error.

`reapR2Objects` probes for R2's multi-key `delete(string[])` and falls back to per-key deletes when the binding does not support it. The probe caught an asynchronous rejection as well as a synchronous throw, so a real failed multi-delete — a bucket erroring, throttling, or losing its connection — was read as "this binding lacks the feature" and retried as up to 1000 single-key deletes against a bucket that had just refused the whole chunk. The fallback is now reached only when the call throws synchronously, which is what a binding without the feature actually does. A rejection is a delete failure and is counted as one.

Neither R2 service had a test for a failing bucket, and `reapR2Objects` had no direct tests at all. Both gaps are closed here.

## Workspaces affected

`@cire/api`

## Issues

**Closes**

| Issue | Title |
| --- | --- |
| xchromo/osn-tracker#475 | P-I1 — Two independent R2 puts awaited serially in storeBeforeImage / storeUpload |
| xchromo/osn-tracker#476 | P-I2 — Multi-delete probe repeats per chunk, so an async R2 failure fans out to 1000 single-key deletes |
| xchromo/osn-tracker#478 | T-S/T-E/T-M (series) — R2 write and delete paths: no test can catch a dropped await, and no test covers an R2 rejection |

Closes xchromo/osn-tracker#475
Closes xchromo/osn-tracker#476
Closes xchromo/osn-tracker#478

**Opened**

None.

## Decisions

### `Promise.allSettled` rather than `Promise.all` for the paired puts

**Issue** — Two independent `r2.put` calls were awaited one after the other, doubling the latency of every import for no ordering reason.

**Why** — `Promise.all` rejects as soon as one member rejects, and abandons the others. If the second put then rejects too, nothing is attached to it, and workerd reports an unhandled rejection against a request that is already unwinding through the `R2Error` path.

**Solution** — `await Promise.allSettled([...])`, then loop the results and `throw r.reason` for the first `rejected` entry.

**Rationale** — Every settlement is observed, so no rejection is left floating, and the error surfaced to the caller is unchanged: the same `R2Error` with the same `reason`, built from the same `cause`.

### The multi-delete fallback fires only on a synchronous throw

**Issue** — `reapR2Objects` wrapped `bucket.delete(batch)` in a `try`/`catch` that also caught asynchronous rejections, so any R2-side delete failure was treated as a missing feature and retried key by key.

**Why** — A binding that does not implement the array form fails when the call is made, not when its promise settles. A rejection means the delete was attempted and failed. Retrying a failed chunk one key at a time is up to 1000 extra requests, and the sweep runs on the request path via `routes/registry.ts:114`.

**Solution** — Call `bucket.delete(batch)` inside a bare `try` that only records whether a promise came back, `await` it outside that block, and fall through to the per-key loop only when the call itself threw.

**Rationale** — The probe still detects the case it was written for — the in-memory test stub and any single-key binding both throw synchronously — while a genuine failure now propagates and the chunk is counted into `failed` like any other delete failure.

**Out of scope**

Two behaviours in the new tests are asserted indirectly. The async-rejection test proves the per-key fallback does not run (no sheet key is deleted) but does not assert the chunk lands in the `failed` counter, and the absent-bucket test does not assert the `error` metric. `failed` is only observable through `metricR2ObjectsSwept`, cire/api's metric instruments are no-ops on workerd, and no test in the package uses `spyOn` or `mock.module` against a metric — so asserting either one means building metric-spy infrastructure that does not exist yet. That is worth doing, but not inside a fix for the delete-fanout bug.

## Test plan

| Gate | Result |
| --- | --- |
| `bun run lint` | pass |
| `bun run fmt:check` | pass |
| `bun run check` | pass |
| `bun run build` | pass |
| `bun run test` | pass |
| `bash scripts/validate-changesets.sh` | pass |

New tests, all in `@cire/api`:

- `r2-cleanup.test.ts` (new file) — dedupes repeated keys into one call, no-ops on a list of only null/undefined/empty keys, resolves when no bucket is bound, and chunks 1001 keys into calls of 1000 and 1.
- `retention.test.ts` — a stub whose array `delete` rejects asynchronously: the sweep still resolves, the D1 rows are gone, and no per-key delete reached the bucket. Fails against the old code, which deleted every key individually.
- `r2-imports.test.ts` — `storeUpload` and `storeBeforeImage` each fail with `R2Error` when one put of the pair rejects.
- `invite-assets.test.ts` — `deleteAsset` fails with `AssetR2Error` when the bucket's `delete` rejects.

**Not run:** `bun run test:d1` and `bun run test:browser`. Neither tier reaches these files — the D1 lane covers the async D1 driver and the browser lane covers CSS and layout; the R2 services are exercised by the default `test` lane only.

Stacked on #823 — the diff above is against `chore/cire-api-test-typecheck`, which carries the R2 interface types this builds on.
