### PR TITLE
fix(osn-api): only a uniqueness violation is an email-change conflict

### DIFF
--- a/.changeset/email-change-conflict-hardening.md
+++ b/.changeset/email-change-conflict-hardening.md
@@ -1,0 +1,20 @@
+---
+"@osn/api": patch
+"@shared/observability": patch
+---
+
+Hardened the email-change ceremony against a race where two accounts complete
+a change to the same address at once. The database-uniqueness check now only
+catches a genuine UNIQUE-constraint violation, so any other write failure
+correctly surfaces as a database error instead of being folded into the same
+generic message. When a change loses that race, its now-stale pending entry
+is deleted rather than left behind. The write path's pre-check now reads
+only the one column it needs from the account.
+
+Metrics gained a `metricResult` override: an error can now name its own
+outcome bucket directly, taking precedence over the usual message-keyword
+classification. This lets the email-change conflict path report as
+`conflict` instead of `validation_error`. `@shared/observability` exports its
+`RESULT_VALUES` runtime tuple alongside the existing `Result` type so
+downstream packages can build this kind of override without redefining the
+set of allowed outcomes.

--- a/osn/api/src/metrics.ts
+++ b/osn/api/src/metrics.ts
@@ -282,14 +282,21 @@ const isResult = (v: unknown): v is Result => typeof v === "string" && RESULT_SE
 export const classifyError = (err: unknown): Result => {
   if (!err || typeof err !== "object") return "error";
 
-  // An explicit override beats every inference below — set where the
-  // caller-facing message is deliberately vague and the true outcome
-  // would otherwise be unobservable (see AuthError.metricResult).
-  const override = (err as { metricResult?: unknown }).metricResult;
-  if (isResult(override)) return override;
-
   // Effect tagged errors expose `_tag`.
   const tag = (err as { _tag?: unknown })._tag;
+
+  // An explicit override beats every inference below — set where the
+  // caller-facing message is deliberately vague and the true outcome would
+  // otherwise be unobservable (see AuthError.metricResult). Only error
+  // classes declared in this repo may steer a metric bucket, so the override
+  // is read off a known tag rather than off any object: an error rebuilt from
+  // an upstream JSON body must not be able to reclassify itself. Add a tag
+  // here when another class declares the field.
+  if (tag === "AuthError") {
+    const override = (err as { metricResult?: unknown }).metricResult;
+    if (isResult(override)) return override;
+  }
+
   if (typeof tag === "string") {
     if (tag === "NotFoundError" || tag === "EventNotFound") return "not_found";
     if (tag === "ValidationError") return "validation_error";

--- a/osn/api/src/metrics.ts
+++ b/osn/api/src/metrics.ts
@@ -13,6 +13,7 @@ import {
   createHistogram,
   createUpDownCounter,
   LATENCY_BUCKETS_SECONDS,
+  RESULT_VALUES,
 } from "@shared/observability/metrics";
 import type {
   AppEnrollmentApp,
@@ -275,8 +276,17 @@ const safeErrorSummary = (err: unknown): SafeErrorSummary => {
  * error taxonomy grows. Matches are best-effort and intentionally conservative
  * — unknown error shapes collapse to `"error"`.
  */
+const RESULT_SET: ReadonlySet<string> = new Set(RESULT_VALUES);
+const isResult = (v: unknown): v is Result => typeof v === "string" && RESULT_SET.has(v);
+
 export const classifyError = (err: unknown): Result => {
   if (!err || typeof err !== "object") return "error";
+
+  // An explicit override beats every inference below — set where the
+  // caller-facing message is deliberately vague and the true outcome
+  // would otherwise be unobservable (see AuthError.metricResult).
+  const override = (err as { metricResult?: unknown }).metricResult;
+  if (isResult(override)) return override;
 
   // Effect tagged errors expose `_tag`.
   const tag = (err as { _tag?: unknown })._tag;

--- a/osn/api/src/services/auth/email-change.ts
+++ b/osn/api/src/services/auth/email-change.ts
@@ -199,7 +199,7 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
       const preflight = yield* Effect.tryPromise({
         try: async () => {
           const [acct] = await db
-            .select()
+            .select({ email: accounts.email })
             .from(accounts)
             .where(eq(accounts.id, accountId))
             .limit(1);
@@ -263,7 +263,12 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
             return { ok: true as const, email: pending.newEmail };
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
-            if (/UNIQUE|constraint/i.test(msg)) {
+            // Only a uniqueness violation is a genuine caller-facing conflict
+            // (another account already claimed the address). NOT NULL / FOREIGN
+            // KEY / CHECK constraint failures are DB faults, not user races —
+            // they must surface as DatabaseError, not get mapped to a benign
+            // "someone else got there first" outcome.
+            if (/UNIQUE constraint/i.test(msg)) {
               return { ok: false as const, reason: "conflict" as const };
             }
             throw e;
@@ -276,7 +281,16 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
         // Only "conflict" can come out of the narrowed TX (preflight
         // already rejected not_found / rate_limit). Map to a generic
         // error that matches the begin-path enumeration posture.
-        return yield* Effect.fail(new AuthError({ message: "Invalid or expired code" }));
+        //
+        // The pending change is deleted here, not just left to expire: a
+        // conflicted pending change can never complete (the UNIQUE
+        // constraint will reject every retry against the same claimed
+        // address), so keeping it around only holds the OTP-attempts
+        // counter open for no reason. Matches the lockout branch above.
+        yield* Effect.promise(() => stores.pendingEmailChanges.delete(accountId));
+        return yield* Effect.fail(
+          new AuthError({ message: "Invalid or expired code", metricResult: "conflict" }),
+        );
       }
 
       yield* Effect.promise(() => stores.pendingEmailChanges.delete(accountId));

--- a/osn/api/src/services/auth/email-change.ts
+++ b/osn/api/src/services/auth/email-change.ts
@@ -29,6 +29,16 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
   const EMAIL_CHANGE_LIMIT = 2;
   const EMAIL_CHANGE_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 
+  /**
+   * Drop a pending change on a path that is already failing. The store is a
+   * network hop in production, and `Effect.promise` would turn a blip there
+   * into a defect — a 500 in place of the 4xx the caller has earned, and the
+   * outcome bucket the caller-facing failure was meant to record. The entry
+   * carries a TTL, so losing the delete costs nothing but the wait.
+   */
+  const dropPending = (accountId: string) =>
+    Effect.tryPromise(() => stores.pendingEmailChanges.delete(accountId)).pipe(Effect.ignore);
+
   const beginEmailChange = (
     accountId: string,
     newEmail: string,
@@ -55,7 +65,12 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
       }
 
       const currentAccount = yield* Effect.tryPromise({
-        try: () => db.select().from(accounts).where(eq(accounts.id, accountId)).limit(1),
+        try: () =>
+          db
+            .select({ email: accounts.email })
+            .from(accounts)
+            .where(eq(accounts.id, accountId))
+            .limit(1),
         catch: (cause) => new DatabaseError({ cause }),
       });
       const account = currentAccount[0];
@@ -72,7 +87,14 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
       // email change must match. The UNIQUE(email) constraint at `complete`
       // is the real defence against a race-winning swap.
       const collision = yield* Effect.tryPromise({
-        try: () => db.select().from(accounts).where(eq(accounts.email, normalised)).limit(1),
+        // P-I1: projecting the indexed column alone lets UNIQUE(email) answer
+        // the probe from the index without reading the account row.
+        try: () =>
+          db
+            .select({ email: accounts.email })
+            .from(accounts)
+            .where(eq(accounts.email, normalised))
+            .limit(1),
         catch: (cause) => new DatabaseError({ cause }),
       });
       if (collision.length > 0) {
@@ -175,7 +197,7 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
         // O3: persist the attempt bump + carry remaining TTL (store doesn't alias).
         const attempts = pending.attempts + 1;
         if (attempts >= MAX_OTP_ATTEMPTS) {
-          yield* Effect.promise(() => stores.pendingEmailChanges.delete(accountId));
+          yield* dropPending(accountId);
         } else {
           yield* Effect.promise(() =>
             stores.pendingEmailChanges.set(
@@ -236,7 +258,10 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
             // Atomic batch on D1, sequential on bun:sqlite. A half-applied
             // change would leave a potentially-compromised session alive with a
             // stale email claim, so the email swap + audit row + session wipe
-            // commit together.
+            // commit together. The guarantee is D1's, not this function's — on
+            // the local bun:sqlite driver the statements run one after another
+            // and a mid-chain failure can leave the swap applied without the
+            // audit row or the session wipe.
             await commitBatch(db, [
               db
                 .update(accounts)
@@ -268,7 +293,13 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
             // KEY / CHECK constraint failures are DB faults, not user races —
             // they must surface as DatabaseError, not get mapped to a benign
             // "someone else got there first" outcome.
-            if (/UNIQUE constraint/i.test(msg)) {
+            //
+            // Both spellings are accepted because the two drivers do not agree:
+            // bun:sqlite raises `UNIQUE constraint failed: accounts.email`, and
+            // a driver that reports the SQLite result code instead would carry
+            // `SQLITE_CONSTRAINT_UNIQUE`. Neither spelling can match a NOT NULL,
+            // FOREIGN KEY or CHECK failure, so the narrowing holds.
+            if (/UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i.test(msg)) {
               return { ok: false as const, reason: "conflict" as const };
             }
             throw e;
@@ -282,12 +313,14 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
         // already rejected not_found / rate_limit). Map to a generic
         // error that matches the begin-path enumeration posture.
         //
-        // The pending change is deleted here, not just left to expire: a
-        // conflicted pending change can never complete (the UNIQUE
-        // constraint will reject every retry against the same claimed
-        // address), so keeping it around only holds the OTP-attempts
-        // counter open for no reason. Matches the lockout branch above.
-        yield* Effect.promise(() => stores.pendingEmailChanges.delete(accountId));
+        // The pending change is deleted here, not just left to expire. The
+        // address is claimed by another account, so every retry of this
+        // ceremony fails the same way; holding the entry only keeps the
+        // OTP-attempts counter open against a target the caller cannot have.
+        // (Not an absolute impossibility — the winner could later move off the
+        // address — but then a fresh `begin` is the honest way back in.)
+        // Matches the lockout branch above.
+        yield* dropPending(accountId);
         return yield* Effect.fail(
           new AuthError({ message: "Invalid or expired code", metricResult: "conflict" }),
         );

--- a/osn/api/src/services/auth/errors.ts
+++ b/osn/api/src/services/auth/errors.ts
@@ -1,3 +1,4 @@
+import type { Result } from "@shared/observability/metrics";
 import { Data } from "effect";
 
 // ---------------------------------------------------------------------------
@@ -6,6 +7,12 @@ import { Data } from "effect";
 
 export class AuthError extends Data.TaggedError("AuthError")<{
   readonly message: string;
+  /**
+   * Overrides the metric bucket `classifyError` would infer from the
+   * message. Set it where the caller-facing message is deliberately
+   * vague and the true outcome would otherwise be unobservable.
+   */
+  readonly metricResult?: Result;
 }> {}
 
 export class DatabaseError extends Data.TaggedError("DatabaseError")<{

--- a/osn/api/tests/metrics.test.ts
+++ b/osn/api/tests/metrics.test.ts
@@ -73,6 +73,21 @@ describe("classifyError", () => {
       const err = new AuthErrorLike({ message: "Invalid or expired code" });
       expect(classifyError(err)).toBe("validation_error");
     });
+
+    // Only error classes declared in this repo may steer a bucket. An error
+    // rebuilt from an upstream payload can carry any key it likes; if that
+    // were enough, a remote fault could report itself as a success.
+    it("ignores metricResult on an error this repo did not tag", () => {
+      const foreign = { _tag: "UpstreamFailure", message: "gateway blew up", metricResult: "ok" };
+      expect(classifyError(foreign)).toBe("error");
+      const untagged = { message: "gateway blew up", metricResult: "ok" };
+      expect(classifyError(untagged)).toBe("error");
+    });
+
+    it("ignores a metricResult that is not a member of RESULT_VALUES", () => {
+      const err = new AuthErrorLike({ message: "Invalid or expired code", metricResult: "banana" });
+      expect(classifyError(err)).toBe("validation_error");
+    });
   });
 
   describe("fallback", () => {

--- a/osn/api/tests/metrics.test.ts
+++ b/osn/api/tests/metrics.test.ts
@@ -18,6 +18,10 @@ class NotFoundError extends Data.TaggedError("NotFoundError")<{ message?: string
 class ValidationError extends Data.TaggedError("ValidationError")<{ cause?: unknown }> {}
 class EventNotFound extends Data.TaggedError("EventNotFound")<{ id: string }> {}
 class RandomTag extends Data.TaggedError("SomeUnknownTag")<{ message: string }> {}
+class AuthErrorLike extends Data.TaggedError("AuthError")<{
+  message: string;
+  metricResult?: string;
+}> {}
 
 describe("classifyError", () => {
   describe("effect tagged errors", () => {
@@ -47,6 +51,27 @@ describe("classifyError", () => {
       [new Error("handle taken"), "conflict"],
     ])("maps %o → %s", (err, expected) => {
       expect(classifyError(err)).toBe(expected);
+    });
+  });
+
+  describe("metricResult override", () => {
+    // Regression pin for S3: the message clearly matches the "invalid"
+    // substring rule (→ validation_error), but a caller-set metricResult
+    // must win — this is the whole point of the override.
+    it("an explicit metricResult beats the message-keyword match", () => {
+      const err = new AuthErrorLike({
+        message: "Invalid or expired code",
+        metricResult: "conflict",
+      });
+      expect(classifyError(err)).toBe("conflict");
+    });
+
+    // Precedence pin, not just an outcome pin: with no override present,
+    // the same tag/message combination must still fall through to the
+    // ordinary instanceof-Error / message-keyword path.
+    it("falls through to message classification when metricResult is absent", () => {
+      const err = new AuthErrorLike({ message: "Invalid or expired code" });
+      expect(classifyError(err)).toBe("validation_error");
     });
   });
 

--- a/osn/api/tests/services/email-change.test.ts
+++ b/osn/api/tests/services/email-change.test.ts
@@ -412,7 +412,7 @@ describe("beginEmailChange + completeEmailChange", () => {
   it.live("rejects completing after the pending change has expired", () => {
     const { layer, captured } = makeEmailCapture();
     return Effect.gen(function* () {
-      const auth = createAuthService({ ...baseConfig, otpTtl: 2 });
+      const auth = createAuthService({ ...baseConfig, otpTtl: 1 });
       const profile = yield* auth.registerProfile("ec-expired@example.com", "ecexpired");
       yield* auth.beginStepUpOtp(profile.accountId);
       const stepUpOtpCode = captured.latest()!;
@@ -424,8 +424,10 @@ describe("beginEmailChange + completeEmailChange", () => {
       yield* auth.beginEmailChange(profile.accountId, "ec-expired-new@example.com");
       const code = captured.latest()!;
 
-      // Real wall-clock sleep past the 2s otpTtl. CI slack on both ends.
-      yield* Effect.promise(() => new Promise((r) => setTimeout(r, 2500)));
+      // Real wall-clock sleep past the 1s otpTtl, with 500ms of CI slack.
+      // Kept as short as the margin allows: this is the only real sleep in the
+      // package and it is paid on every run.
+      yield* Effect.promise(() => new Promise((r) => setTimeout(r, 1500)));
 
       const err = yield* Effect.flip(
         auth.completeEmailChange(profile.accountId, code, stepUpToken, null),

--- a/osn/api/tests/services/email-change.test.ts
+++ b/osn/api/tests/services/email-change.test.ts
@@ -1,21 +1,27 @@
 import { it, expect, describe } from "@effect/vitest";
+import { Db } from "@osn/db/service";
 import { makeLogEmailLive } from "@shared/email";
 import { Effect, Layer } from "effect";
 import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
+import { createInMemoryAccountCap } from "../../src/services/auth/stores";
 import { makeTestAuthConfig } from "../helpers/auth-config";
-import { createTestLayer } from "../helpers/db";
+import { createTestLayerWithSqlite } from "../helpers/db";
 
 /**
  * Build a fresh email recorder + test layer. Tests that need to capture
  * sent codes destructure `captured` (a getter-backed array of codes)
- * and provide `layer` at `Effect.provide` time.
+ * and provide `layer` at `Effect.provide` time. Also exposes the raw
+ * SQLite handle behind the layer for tests that need to install a
+ * fault-injection trigger the service layer has no route to create.
  */
 function makeEmailCapture() {
   const email = makeLogEmailLive();
+  const { layer: dbLayer, sqlite } = createTestLayerWithSqlite();
   return {
-    layer: Layer.merge(createTestLayer(), email.layer),
+    layer: Layer.merge(dbLayer, email.layer),
+    sqlite,
     captured: {
       codes: () =>
         email
@@ -157,6 +163,7 @@ describe("beginEmailChange + completeEmailChange", () => {
   it.effect("rejects at complete time when another account wins the email in the meantime", () => {
     const { layer, captured } = makeEmailCapture();
     return Effect.gen(function* () {
+      const { db } = yield* Db;
       const a = yield* setup("ec-race-a@example.com", "ecracea", captured);
       const b = yield* setup("ec-race-b@example.com", "ecraceb", captured);
 
@@ -180,12 +187,305 @@ describe("beginEmailChange + completeEmailChange", () => {
       );
       expect(bResult.email).toBe(target);
 
+      // A refreshes before the failed complete — proves A's session is
+      // untouched by the collision, not just A's email.
+      const aTokens = yield* a.auth.issueTokens(
+        a.profile.id,
+        a.profile.accountId,
+        a.profile.email,
+        a.profile.handle,
+        a.profile.displayName,
+      );
+
       // A's write now collides for real: B already owns `target`.
       const err = yield* Effect.flip(
         a.auth.completeEmailChange(a.profile.accountId, codeA, a.stepUpToken, null),
       );
       expect(err._tag).toBe("AuthError");
       expect(err.message).toMatch(/invalid or expired code/i);
+      // Regression pin for S3: the conflict branch tags its metric bucket
+      // explicitly rather than leaving it to `classifyError`'s substring
+      // match (which would also fire here, but for the wrong reason).
+      expect(err).toMatchObject({ metricResult: "conflict" });
+
+      // Invariant pins, not half-applied-batch/rollback detectors: the
+      // first batch statement (the accounts update) is what throws the
+      // UNIQUE violation, so the emailChanges insert and sessions delete
+      // never execute. These assert nothing about A changed, not that a
+      // partial write was rolled back.
+      const [aAccount] = yield* Effect.promise(() =>
+        db.query.accounts.findMany({ where: (acc, { eq }) => eq(acc.id, a.profile.accountId) }),
+      );
+      expect(aAccount?.email).toBe("ec-race-a@example.com");
+      const [bAccount] = yield* Effect.promise(() =>
+        db.query.accounts.findMany({ where: (acc, { eq }) => eq(acc.id, b.profile.accountId) }),
+      );
+      expect(bAccount?.email).toBe(target);
+      const aEmailChanges = yield* Effect.promise(() =>
+        db.query.emailChanges.findMany({
+          where: (ec, { eq }) => eq(ec.accountId, a.profile.accountId),
+        }),
+      );
+      expect(aEmailChanges).toHaveLength(0);
+
+      // A's pre-existing session still verifies — the failed complete
+      // didn't touch sessions at all (S2's delete only removes the
+      // pending ceremony state, never a session).
+      yield* a.auth.verifyRefreshToken(aTokens.refreshToken);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // Positive control for the race test above: proves the ceremony still
+  // succeeds end-to-end when the target address really is free, on the
+  // same shared email recorder / call-ordering the race test relies on.
+  it.effect("succeeds completing a change to a free address (positive control)", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const c = yield* setup("ec-race-c@example.com", "ecracec", captured);
+      yield* c.auth.beginEmailChange(c.profile.accountId, "ec-race-c-new@example.com");
+      const codeC = captured.latest()!;
+      const result = yield* c.auth.completeEmailChange(
+        c.profile.accountId,
+        codeC,
+        c.stepUpToken,
+        null,
+      );
+      expect(result.email).toBe("ec-race-c-new@example.com");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("rejects an invalid new-email address", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile } = yield* setup("ec-badaddr@example.com", "ecbadaddr", captured);
+      const err = yield* Effect.flip(auth.beginEmailChange(profile.accountId, "not-an-email"));
+      expect(err._tag).toBe("ValidationError");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("rejects a change to the caller's own current email", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile } = yield* setup("ec-selfemail@example.com", "ecselfemail", captured);
+      const err = yield* Effect.flip(
+        auth.beginEmailChange(profile.accountId, "ec-selfemail@example.com"),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/matches current email/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("rejects a change to the caller's own email in a different case", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile } = yield* setup("ec-selfcase@example.com", "ecselfcase", captured);
+      // EmailSchema accepts uppercase (the guard normalises before comparing,
+      // so decode alone must not swallow this).
+      const err = yield* Effect.flip(
+        auth.beginEmailChange(profile.accountId, "EC-SELFCASE@EXAMPLE.COM"),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/matches current email/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #520: begin is capped per-account independently of the per-IP rate
+  // limiter. makeTestAuthConfig() sets no cap/TTL overrides, so exercising
+  // this requires building a service with an injected emailChangeBeginCap
+  // rather than relying on the shared test config.
+  it.effect("caps the number of email-change begins per account", () => {
+    const { layer } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const auth = createAuthService({
+        ...baseConfig,
+        emailChangeBeginCap: createInMemoryAccountCap(2, 60_000),
+      });
+      const profile = yield* auth.registerProfile("ec-begincap@example.com", "ecbegincap");
+      yield* auth.beginEmailChange(profile.accountId, "ec-begincap-1@example.com");
+      yield* auth.beginEmailChange(profile.accountId, "ec-begincap-2@example.com");
+      const err = yield* Effect.flip(
+        auth.beginEmailChange(profile.accountId, "ec-begincap-3@example.com"),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/too many email change attempts/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // Regression pin for S1: a non-uniqueness constraint failure at the write
+  // must surface as DatabaseError, never get folded into the same generic
+  // AuthError the OTP-mismatch/UNIQUE-conflict paths return. No FK
+  // enforcement exists anywhere in this tree to trigger a real one, so a
+  // fault-injection trigger stands in for "some other constraint failed".
+  it.effect("surfaces a non-uniqueness constraint failure as DatabaseError", () => {
+    const { layer, captured, sqlite } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile, stepUpToken } = yield* setup(
+        "ec-fault@example.com",
+        "ecfault",
+        captured,
+      );
+      yield* auth.beginEmailChange(profile.accountId, "ec-fault-new@example.com");
+      const code = captured.latest()!;
+
+      sqlite.exec(
+        `CREATE TRIGGER ec_force_fault BEFORE INSERT ON email_changes
+         BEGIN SELECT RAISE(ABORT, 'NOT NULL constraint failed: email_changes.new_email'); END;`,
+      );
+
+      const err = yield* Effect.flip(
+        auth.completeEmailChange(profile.accountId, code, stepUpToken, null),
+      );
+      expect(err._tag).toBe("DatabaseError");
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #512 T-E3 / #521: five wrong submissions lock out the pending change;
+  // the sixth, correct, submission still fails because the entry is gone.
+  // Step-up tokens are single-use (jti consumed on verify), so a naive test
+  // reusing one token across submissions dies at replay before reaching the
+  // OTP comparison — mint a fresh one per submission.
+  it.effect(
+    "locks out after MAX_OTP_ATTEMPTS wrong codes, even with a fresh token each time",
+    () => {
+      const { layer, captured } = makeEmailCapture();
+      return Effect.gen(function* () {
+        const auth = createAuthService(baseConfig);
+        const profile = yield* auth.registerProfile("ec-lockout@example.com", "eclockout");
+
+        const issueStepUp = Effect.gen(function* () {
+          yield* auth.beginStepUpOtp(profile.accountId);
+          const otpCode = captured.latest()!;
+          const { stepUpToken } = yield* auth.completeStepUpOtp(
+            profile.accountId,
+            otpCode,
+            "email_change",
+          );
+          return stepUpToken;
+        });
+
+        yield* issueStepUp; // burn one to keep the ceremony above honest — begin needs no step-up.
+        yield* auth.beginEmailChange(profile.accountId, "ec-lockout-new@example.com");
+
+        // Five wrong submissions, each with a fresh step-up token.
+        for (let i = 0; i < 5; i++) {
+          const stepUpToken = yield* issueStepUp;
+          const err = yield* Effect.flip(
+            auth.completeEmailChange(profile.accountId, "000000", stepUpToken, null),
+          );
+          expect(err._tag).toBe("AuthError");
+          expect(err.message).toMatch(/invalid or expired code/i);
+        }
+
+        // Sixth submission: correct code, but the pending entry was wiped by
+        // the fifth failed attempt hitting MAX_OTP_ATTEMPTS.
+        const correctCode = captured.latest()!;
+        const stepUpToken = yield* issueStepUp;
+        const err = yield* Effect.flip(
+          auth.completeEmailChange(profile.accountId, correctCode, stepUpToken, null),
+        );
+        expect(err._tag).toBe("AuthError");
+        expect(err.message).toMatch(/invalid or expired code/i);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect("rejects completing with no pending change", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile, stepUpToken } = yield* setup(
+        "ec-nopending@example.com",
+        "ecnopending",
+        captured,
+      );
+      const err = yield* Effect.flip(
+        auth.completeEmailChange(profile.accountId, "000000", stepUpToken, null),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/invalid or expired code/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #512 T-E3: expiry is wall-clock (`Date.now()` comparisons), so this must
+  // run on the real clock. it.effect's TestClock suspends Effect.sleep until
+  // manually advanced — it would hang here, and advancing it wouldn't help
+  // since the service never reads TestClock. it.live is required.
+  it.live("rejects completing after the pending change has expired", () => {
+    const { layer, captured } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const auth = createAuthService({ ...baseConfig, otpTtl: 2 });
+      const profile = yield* auth.registerProfile("ec-expired@example.com", "ecexpired");
+      yield* auth.beginStepUpOtp(profile.accountId);
+      const stepUpOtpCode = captured.latest()!;
+      const { stepUpToken } = yield* auth.completeStepUpOtp(
+        profile.accountId,
+        stepUpOtpCode,
+        "email_change",
+      );
+      yield* auth.beginEmailChange(profile.accountId, "ec-expired-new@example.com");
+      const code = captured.latest()!;
+
+      // Real wall-clock sleep past the 2s otpTtl. CI slack on both ends.
+      yield* Effect.promise(() => new Promise((r) => setTimeout(r, 2500)));
+
+      const err = yield* Effect.flip(
+        auth.completeEmailChange(profile.accountId, code, stepUpToken, null),
+      );
+      expect(err._tag).toBe("AuthError");
+      expect(err.message).toMatch(/invalid or expired code/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #484 / #514 P-I4: proves the S2 delete (removing a conflicted pending
+  // change) actually matters, rather than being dead code. Extends the race
+  // test's world: A's complete already lost the genuine UNIQUE race once
+  // (S2 fires, pending is gone). A second, non-uniqueness fault is then
+  // installed and A resubmits with a fresh token — with S2 in place this
+  // short-circuits at `!pending` (AuthError) rather than ever reaching the
+  // write and turning into a DatabaseError. Without S2 the pending entry
+  // would survive and this assertion would catch the regression.
+  it.effect("S2 delete: a conflicted pending change cannot be resurrected by retrying", () => {
+    const { layer, captured, sqlite } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const a = yield* setup("ec-s2-a@example.com", "ecs2a", captured);
+      const b = yield* setup("ec-s2-b@example.com", "ecs2b", captured);
+
+      const target = "ec-s2-target@example.com";
+
+      yield* a.auth.beginEmailChange(a.profile.accountId, target);
+      const codeA = captured.latest()!;
+
+      yield* b.auth.beginEmailChange(b.profile.accountId, target);
+      const codeB = captured.latest()!;
+      yield* b.auth.completeEmailChange(b.profile.accountId, codeB, b.stepUpToken, null);
+
+      // Genuine UNIQUE conflict must happen first — installing the second
+      // trigger before this would mask it.
+      const firstErr = yield* Effect.flip(
+        a.auth.completeEmailChange(a.profile.accountId, codeA, a.stepUpToken, null),
+      );
+      expect(firstErr._tag).toBe("AuthError");
+
+      sqlite.exec(
+        `CREATE TRIGGER ec_block_update BEFORE UPDATE ON accounts
+         BEGIN SELECT RAISE(ABORT, 'NOT NULL constraint failed: accounts.email'); END;`,
+      );
+
+      yield* a.auth.beginStepUpOtp(a.profile.accountId);
+      const stepUpOtpCode = captured.latest()!;
+      const { stepUpToken: freshStepUpToken } = yield* a.auth.completeStepUpOtp(
+        a.profile.accountId,
+        stepUpOtpCode,
+        "email_change",
+      );
+
+      const secondErr = yield* Effect.flip(
+        a.auth.completeEmailChange(a.profile.accountId, codeA, freshStepUpToken, null),
+      );
+      // With S2: the pending entry is already gone, so this short-circuits
+      // at `!pending` — AuthError. Without S2, the pending entry would
+      // survive and reach the write, where `ec_block_update` fires a
+      // non-UNIQUE message that S1 correctly re-throws as DatabaseError.
+      expect(secondErr._tag).toBe("AuthError");
     }).pipe(Effect.provide(layer));
   });
 

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -51,12 +51,12 @@
 
     "vitest/no-standalone-expect": [
       "error",
-      { "additionalTestBlockFunctions": ["it.effect", "effectIt.effect"] }
+      { "additionalTestBlockFunctions": ["it.effect", "effectIt.effect", "it.live"] }
     ],
     "vitest/expect-expect": [
       "error",
       {
-        "additionalTestBlockFunctions": ["it.effect", "effectIt.effect"],
+        "additionalTestBlockFunctions": ["it.effect", "effectIt.effect", "it.live"],
         "assertFunctionNames": ["expect", "expectFailsWith", "assertNoAccountId"]
       }
     ],

--- a/shared/observability/src/metrics/attrs.ts
+++ b/shared/observability/src/metrics/attrs.ts
@@ -10,16 +10,19 @@
  * existing union without thinking about cardinality impact.
  */
 
+export const RESULT_VALUES = [
+  "ok",
+  "error",
+  "unauthorized",
+  "forbidden",
+  "not_found",
+  "rate_limited",
+  "validation_error",
+  "conflict",
+] as const;
+
 /** Generic outcome for any operation. Keep the set small. */
-export type Result =
-  | "ok"
-  | "error"
-  | "unauthorized"
-  | "forbidden"
-  | "not_found"
-  | "rate_limited"
-  | "validation_error"
-  | "conflict";
+export type Result = (typeof RESULT_VALUES)[number];
 
 /** Auth methods supported by OSN Core. Passkey (incl. security keys) is the only primary login factor; recovery_code is the "lost device" escape hatch; refresh tracks token refresh cycles. */
 export type AuthMethod = "passkey" | "recovery_code" | "refresh";

--- a/shared/observability/src/metrics/index.ts
+++ b/shared/observability/src/metrics/index.ts
@@ -20,6 +20,8 @@ export {
   type HttpInFlightAttrs,
 } from "./http";
 
+export { RESULT_VALUES } from "./attrs";
+
 export {
   type Result,
   type AuthMethod,

--- a/wiki/observability/metrics.md
+++ b/wiki/observability/metrics.md
@@ -9,7 +9,7 @@ related:
   - "[[tracing]]"
   - "[[feature-checklist]]"
 packages: ["@shared/observability", "@osn/api", "@pulse/api", "@shared/crypto"]
-last-reviewed: 2026-07-22
+last-reviewed: 2026-08-30
 ---
 # Metrics
 
@@ -122,12 +122,39 @@ export const LATENCY_BUCKETS_S = [
 ### Shared attribute types (`shared/observability/src/metrics/attrs.ts`)
 
 ```typescript
-export type Result = "ok" | "error" | "unauthorized" | "rate_limited" | "not_found";
+// `Result` is derived from a runtime tuple so the type and the set that
+// `classifyError` validates against cannot drift apart.
+export const RESULT_VALUES = [
+  "ok", "error", "unauthorized", "forbidden",
+  "not_found", "rate_limited", "validation_error", "conflict",
+] as const;
+export type Result = (typeof RESULT_VALUES)[number];
+
 export type AuthMethod = "passkey" | "recovery_code" | "refresh";
 export type ArcVerifyResult =
   | "ok" | "expired" | "bad_signature" | "unknown_issuer"
   | "scope_denied" | "audience_mismatch";
 ```
+
+#### Overriding the inferred result
+
+`classifyError` (`osn/api/src/metrics.ts`) normally infers the `result` bucket
+from the error's tag and then from keywords in its message. That inference is
+wrong wherever the caller-facing message is deliberately vague, because the
+message no longer describes what happened.
+
+`AuthError` therefore carries an optional `metricResult`, and `classifyError`
+honours it ahead of every inference — but only on that tag, so an error rebuilt
+from an upstream JSON body cannot steer a bucket, and only when the value is a
+member of `RESULT_VALUES`, so the attribute stays bounded.
+
+The one use today: a `completeEmailChange` that loses the `UNIQUE(email)` race
+returns "Invalid or expired code" — byte-identical to a wrong OTP, so the
+endpoint does not confirm that an address is taken — and sets
+`metricResult: "conflict"`. **A `conflict` spike on the email-change dashboard
+means lost races, not validation errors, and the caller saw a 400 whose body
+says nothing about a conflict.** Set the field wherever a message is vague on
+purpose; do not set it to make an ordinary failure read better.
 
 ### Domain metrics (`osn/api/src/metrics.ts`)
 


### PR DESCRIPTION
## Summary

`completeEmailChange` mapped any database message matching `/UNIQUE|constraint/i` to a
caller-facing "conflict", so a `NOT NULL`, `FOREIGN KEY` or `CHECK` fault — a database
problem, not a user race — was reported to the caller as "someone else got there first"
and to the dashboards as a normal outcome. This narrows that match to the two spellings
the drivers actually use for a uniqueness violation, so every other constraint failure
surfaces as `DatabaseError` and is visible.

Two smaller corrections ride along. A pending change that loses the uniqueness race can
never complete — every retry hits the same constraint — so it is now deleted rather than
left to hold the OTP-attempt counter open until it expires. And because the caller-facing
message for a lost race is deliberately vague ("Invalid or expired code", identical to a
wrong OTP, so the endpoint does not confirm that an address is taken), the true outcome
was unobservable: `AuthError` now carries an optional `metricResult` that `classifyError`
honours ahead of every inference, so the dashboards see `conflict` while the caller still
sees nothing.

- Both begin-path selects on `accounts` project the one column they read, letting the
  UNIQUE index answer the collision probe without touching the row.
- `Result` in `@shared/observability` is now derived from a runtime `RESULT_VALUES` tuple,
  value-exported from the metrics index, so `classifyError` can validate an override
  against the union at runtime instead of trusting a cast.
- Nine of the eleven issues here are test-coverage items; the ceremony's rejection
  branches — invalid address, self-email, begin cap, OTP lockout, expiry, missing pending
  change — had no tests at all.

The second commit is a hardening pass over the first, closing the findings from security
and performance reviews of it: the override is gated on a tag this repo declares, the two
failure-path deletes no longer turn a store blip into a defect, and the constraint match
accepts both driver spellings. Each is a Decision below.

## Workspaces affected

`@osn/api`, `@shared/observability`. One changeset,
`.changeset/email-change-conflict-hardening.md`, names both at `patch`. Root
`oxlintrc.json` also changed (two allowlist entries) — it is not on the
`scripts/changeset-required.sh` allowlist, and is covered by the same changeset.
`wiki/observability/metrics.md` is updated in the same commit as the field it documents.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#481 | `S-L1` |
| xchromo/osn-tracker#482 | `S-L2` |
| xchromo/osn-tracker#483 | `S-L3` |
| xchromo/osn-tracker#484 | `S-I1` |
| xchromo/osn-tracker#508 | `S-L2` |
| xchromo/osn-tracker#511 | `S-L1` / `T-S1` / `T-S2` |
| xchromo/osn-tracker#512 | `T-E3` / `T-E4` |
| xchromo/osn-tracker#514 | `P-I4` / `P-I5` |
| xchromo/osn-tracker#519 | `T-E2` |
| xchromo/osn-tracker#520 | `T-E3` |
| xchromo/osn-tracker#521 | `T-E4` |

Closes xchromo/osn-tracker#481.
Closes xchromo/osn-tracker#482.
Closes xchromo/osn-tracker#483.
Closes xchromo/osn-tracker#484.
Closes xchromo/osn-tracker#508.
Closes xchromo/osn-tracker#511.
Closes xchromo/osn-tracker#512.
Closes xchromo/osn-tracker#514.
Closes xchromo/osn-tracker#519.
Closes xchromo/osn-tracker#520.
Closes xchromo/osn-tracker#521.

**Opened**

| Issue | Finding |
|---|---|
| xchromo/osn-tracker#557 | `S-M1` — registration's own catch still uses the loose pattern this PR narrows in email-change |
| xchromo/osn-tracker#558 | `S-L2` — nothing pins the constraint-error text D1 raises, so the two-spelling match is unverified against the production driver |
| xchromo/osn-tracker#559 | `S-L4` — the 7-day cap is checked after the collision probe, so a capped caller can tell a taken address from a free one |
| xchromo/osn-tracker#560 | `P-I2` — the cap query has no composite `(account_id, completed_at)` index |
| xchromo/osn-tracker#561 | `P-I4` — every email-change test builds two `EmailService` layers and discards one |

## Decisions

### Only a uniqueness violation is a conflict — `S-L2`

- **Issue** — the catch around the account-email update matched `/UNIQUE|constraint/i`.
  The bare `constraint` alternative matches `NOT NULL constraint failed`,
  `FOREIGN KEY constraint failed` and `CHECK constraint failed` as readily as it matches a
  uniqueness violation.
- **Why** — a genuine database fault was returned to the caller as a benign race and
  bucketed on the dashboards as an ordinary outcome. The one class of failure that means
  "the schema or the data is wrong" was the one class rendered invisible.
- **Solution** — narrow the test to `/UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i`.
  Everything else re-throws and surfaces as `DatabaseError`.
- **Rationale** — bun:sqlite words it `UNIQUE constraint failed: <table>.<col>`; the
  `SQLITE_CONSTRAINT_UNIQUE` form is the other spelling in circulation, and accepting both
  costs nothing because neither can match a NOT NULL, FOREIGN KEY or CHECK failure. A test
  pins the re-throw by installing a `RAISE(ABORT, 'NOT NULL constraint failed: …')`
  trigger, which the old pattern would have swallowed. What D1 itself raises is not pinned
  anywhere; that gap is filed as #558.

### A lost race deletes the pending change — `S-I1` / `P-I4`

- **Issue** — on a lost uniqueness race the pending change was left in place to expire.
- **Why** — it can never complete: the address is taken, so every retry hits the same
  constraint. Meanwhile it holds the per-account OTP-attempt counter open and keeps the
  ceremony in a state the user cannot exit except by waiting out the TTL.
- **Solution** — delete the pending change on the conflict branch, as the lockout branch
  directly above it already does.
- **Rationale** — it matches the neighbouring branch rather than adding a mechanism, and
  the caller-facing message is unchanged, so nothing new is disclosed. A test pins it by
  blocking the `accounts` update with a trigger after the race and re-submitting: the
  request short-circuits on the missing pending change instead of reaching the update.

### A cleanup on a failing path must not upgrade the failure into a defect — `review`

- **Issue** — both failure-path deletes of the pending change ran through
  `Effect.promise`, which treats a rejection as a defect.
- **Why** — the pending-change store is a network hop in production. A blip there would
  have become an unhandled defect: a 500 in place of the 4xx the caller had earned, and
  the loss of the very outcome bucket the failure was meant to record.
- **Solution** — a `dropPending` helper built on
  `Effect.tryPromise(...).pipe(Effect.ignore)`, used by both the lockout branch and the
  conflict branch.
- **Rationale** — the entry carries a TTL, so losing the delete costs nothing but the
  wait, while losing the caller's real error costs the caller their response and the
  operator their metric. The success-path delete at the end of `completeEmailChange` is
  deliberately left as `Effect.promise`: there the delete is the last step of a
  succeeding ceremony, and a store failure there is a real fault that should be loud.

### The metric result is overridden, not inferred — `S-L3`

- **Issue** — `classifyError` infers a metric bucket from the error message. A lost race
  and a wrong OTP share the message "Invalid or expired code" by design, so both were
  counted as `validation_error` and write-time conflicts could not be seen at all.
- **Why** — the vagueness is deliberate: telling the caller that the address is taken
  turns the endpoint into an account-existence oracle. But that left the operators with
  no way to distinguish a spike in conflicts from a spike in mistyped codes.
- **Solution** — an optional `metricResult` field on `AuthError`, checked by
  `classifyError` ahead of every inference, set to `"conflict"` on the race branch.
- **Rationale** — the field is metrics-only: it never reaches the HTTP body, and the
  caller-facing message is byte-identical to the wrong-OTP case. Overriding at the
  classifier keeps the one place that decides metric buckets as the one place to read.
  Rejected: a distinct message (an oracle) and a separate counter at the call site
  (the outcome would not appear on the shared result dimension at all).

### Only an error class this repo declares may steer a bucket — `review`

- **Issue** — the override was read off any object carrying a `metricResult` key.
- **Why** — errors are rebuilt from upstream JSON bodies elsewhere in the stack. An
  object shaped by a remote service could then choose its own metric bucket, and a remote
  fault could report itself as a success.
- **Solution** — the override is read only after `_tag === "AuthError"`, and the value is
  checked for membership in `RESULT_VALUES` before it is used. The comment at the check
  says to add a tag there when another class declares the field.
- **Rationale** — two independent guards, each cheap, and the failure mode of either is
  to fall through to the ordinary inference rather than to poison the dimension. Two
  regression tests pin them: a foreign `_tag` carrying `metricResult: "ok"`, and an
  `AuthError` carrying a value outside the tuple.

### `Result` is validated at runtime, not cast — `approach`

- **Issue** — `classifyError` receives `metricResult` off an `unknown` error object and
  has to decide whether it is a member of the `Result` union.
- **Why** — a `Result` is a metric dimension. An unbounded string reaching it is a
  cardinality problem, which is the thing `shared/observability/src/metrics/attrs.ts`
  exists to prevent.
- **Solution** — `RESULT_VALUES` is now a `const` tuple, `Result` is derived from it, and
  the metrics index value-exports it. `classifyError` checks membership in a `Set` built
  from that tuple.
- **Rationale** — one source of truth, and no cast: an override that is not a `Result`
  falls through to the normal inference instead of poisoning the dimension. The index
  previously re-exported `attrs` type-only, so the value export is the only structural
  change.

### #520's premise is false, and the test injects the capability instead — `T-E3`

- **Issue** — #520 asks for a test of the per-account `emailChangeBeginCap` and describes
  it as unreachable because `makeTestAuthConfig()` does not parameterise the limiter
  family.
- **Why** — that reading would make the cap untestable without first refactoring the
  shared test helper, which would touch every auth suite in the package.
- **Solution** — no helper change. `emailChangeBeginCap` is a field on `AuthConfig`
  (`osn/api/src/services/auth/config.ts:121`), defaulted in
  `osn/api/src/services/auth/context.ts:47` and read in
  `osn/api/src/services/auth/email-change.ts:62`, so the test spreads `baseConfig` and
  overrides that one field with `createInMemoryAccountCap(2, 60_000)`
  (`osn/api/src/services/auth/stores.ts:225`). The third `beginEmailChange` is rejected.
- **Rationale** — injecting per test keeps the window small enough to assert without a
  clock and leaves every other suite on the shared default. The issue's premise is
  recorded here rather than silently worked around.

### `it.live` added to the two vitest allowlists — `approach`

- **Issue** — the expiry test must read a real clock. `@effect/vitest` runs `it.effect`
  under `TestClock`, so a wall-clock wait inside one hangs; `it.live` is the runner that
  does not.
- **Why** — `vitest/no-standalone-expect` and `vitest/expect-expect` list the
  Effect-flavoured test functions explicitly, and neither listed `it.live`, so both fired
  as errors on a correct test.
- **Solution** — add `it.live` to `additionalTestBlockFunctions` in both rules in
  `oxlintrc.json`.
- **Rationale** — a config gap for a runner already in use, not a suppression: no
  `eslint-disable` is added and no rule is downgraded. The other entries in the same
  arrays are the same kind of declaration. `oxlintrc.json` is CODEOWNERS-protected
  (`.github/CODEOWNERS:16`), so this change carries a human owner's approval by the same
  act that merges the PR; it is called out here so that approval is a deliberate one.

### The one real sleep in the package is as short as the margin allows — `review`

- **Issue** — the expiry test slept 2500 ms against a 2 s `otpTtl`.
- **Why** — it is the only wall-clock wait in `osn/api`, and every run of the package pays
  it. `it.live` means it cannot be faked with `TestClock`.
- **Solution** — `otpTtl: 1` and a 1500 ms sleep: past expiry with 500 ms of slack for a
  loaded CI runner.
- **Rationale** — 1000 ms of the wait was buying nothing. Anything shorter starts trading
  the slack that keeps the test from flaking, which is a worse deal than a second.

**Out of scope** — #521 asks additionally that a re-stored pending change never extend the
original TTL. That is not observable from a service-level test; see the Test plan.

## Test plan

| Gate | Result |
|---|---|
| `bun run fmt:check` | ✅ |
| `bun run lint` | ✅ (only pre-existing warnings in `shared/dev-urls` and `cire/db/seed`) |
| `bun run check` | ✅ 37/37 |
| `bun run --cwd osn/api test:run` | ✅ 1126 pass, 68 files |
| `bun run --cwd shared/observability test:run` | ✅ 92 pass, 9 files |
| `bun install --frozen-lockfile` | ✅ no change; `bun.lock` untouched |
| `bash scripts/validate-changesets.sh` | ✅ |

The new cases cover: the full race (A and B both pending, B completes first, A's submission
fails with the wrong-OTP message and `metricResult: "conflict"`, A's account email unchanged,
A's pending row gone, A's pre-existing refresh token still valid); a positive control that a
free address still completes; invalid new address; self-email, in matching and differing case;
the begin cap; the OTP lockout at `MAX_OTP_ATTEMPTS`, minting a fresh step-up token per
submission because a step-up token is single-use; expiry, on the real clock via `it.live`;
completing with no pending change; the two constraint-fault pins described under Decisions;
and the two override guards — a foreign `_tag` and an out-of-tuple value.

**Not run:** #521's second ask — that a re-stored pending change never extends the original
TTL — has no assertion here. `beginEmailChange` re-stores with a fresh `expiresAt` computed
from `otpTtl`, and the service exposes neither the stored record nor its expiry, so nothing
at this level can distinguish an extended TTL from a preserved one; asserting it would need a
store-level test that reaches past the service boundary. The issue is closed for its other
three asks, and this one is stated here rather than left implied.

**Not run:** no test exercises real D1. The constraint match is verified against bun:sqlite
only, so the `SQLITE_CONSTRAINT_UNIQUE` alternative is reasoned about rather than observed.
Filed as #558.

**Not run:** no manual exercise of the deployed endpoint. Every claim above comes from the
suites in the table.
