### PR TITLE
test(osn-api): cover the /authorize error page copy and its own-property guard

### DIFF
--- a/.changeset/authorize-error-page-copy-tests.md
+++ b/.changeset/authorize-error-page-copy-tests.md
@@ -1,0 +1,14 @@
+---
+"@osn/api": patch
+---
+
+Cover the `/authorize` error page's copy and its own-property guard with
+tests: each known error code now has its rendered wording pinned, an
+unrecognised code is checked against its fallback text, a code named after a
+built-in `Object.prototype` member (`constructor`) is checked against
+leaking that built-in's own string form, a property planted on
+`Object.prototype` is checked against being read as copy, and the
+`rate_limited` variant is now exercised end to end through the route when
+its rate limiter denies a request. `renderAuthorizeErrorPage` is exported
+from `oidc.ts` so the unit-level cases can call it directly; its behaviour
+is unchanged.

--- a/osn/api/src/routes/auth/oidc.ts
+++ b/osn/api/src/routes/auth/oidc.ts
@@ -96,7 +96,7 @@ const AUTHORIZE_ERROR_COPY = {
 const hasAuthorizeErrorCopy = (code: string): code is keyof typeof AUTHORIZE_ERROR_COPY =>
   Object.hasOwn(AUTHORIZE_ERROR_COPY, code);
 
-const renderAuthorizeErrorPage = (code: string): string => {
+export const renderAuthorizeErrorPage = (code: string): string => {
   const message = hasAuthorizeErrorCopy(code)
     ? AUTHORIZE_ERROR_COPY[code]
     : AUTHORIZE_ERROR_COPY.invalid_request;

--- a/osn/api/tests/routes/oidc.test.ts
+++ b/osn/api/tests/routes/oidc.test.ts
@@ -17,10 +17,12 @@ import { makeLogEmailLive } from "@shared/email";
 import { Layer } from "effect";
 import { describe, it, expect, beforeAll } from "vitest";
 
+import { createDefaultAuthRateLimiters } from "../../src/routes/auth/limiters";
+import { renderAuthorizeErrorPage } from "../../src/routes/auth/oidc";
 import { makeTestAuthConfig } from "../helpers/auth-config";
 import { createTestLayerWithSqlite } from "../helpers/db";
 // S-M34: wrapped factory (trust XFF under app.handle). See helpers/routes.
-import { createAuthRoutes } from "../helpers/routes";
+import { createAuthRoutes, type AuthRateLimiters } from "../helpers/routes";
 
 const REDIRECT_URI = "https://rp.example.com/callback";
 const VERIFIER = "test-code-verifier-0123456789abcdefghijklmnopqrstuvwxyz";
@@ -330,6 +332,75 @@ describe("GET /authorize", () => {
     const loc = new URL(res.headers.get("location")!);
     expect(loc.origin + loc.pathname).toBe(REDIRECT_URI);
     expect(loc.searchParams.get("error")).toBe("invalid_request");
+  });
+
+  it("serves the rendered rate_limited error page when the oidcAuthorize limiter denies (#465)", async () => {
+    const { layer } = createTestLayerWithSqlite();
+    const rec = makeLogEmailLive();
+    const limiters: AuthRateLimiters = {
+      ...createDefaultAuthRateLimiters(),
+      oidcAuthorize: { check: async () => false },
+    };
+    const app = createAuthRoutes(config, Layer.merge(layer, rec.layer), undefined, limiters);
+
+    const res = await app.handle(new Request(authorizeUrl(goodParams)));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("Too many sign-in attempts");
+  });
+});
+
+describe("renderAuthorizeErrorPage", () => {
+  it("renders each known code's own copy (#492 item 1)", () => {
+    const invalidClient = renderAuthorizeErrorPage("invalid_client");
+    expect(invalidClient).toContain("We don't recognise the app that sent you here");
+    expect(invalidClient).toContain("<code>invalid_client</code>");
+    // The three codes are distinguishable, not three copies of one assertion.
+    expect(invalidClient).not.toContain("This sign-in link is malformed or has expired");
+
+    const invalidRequest = renderAuthorizeErrorPage("invalid_request");
+    expect(invalidRequest).toContain("This sign-in link is malformed or has expired");
+    expect(invalidRequest).toContain("<code>invalid_request</code>");
+
+    const rateLimited = renderAuthorizeErrorPage("rate_limited");
+    expect(rateLimited).toContain("Too many sign-in attempts");
+    expect(rateLimited).toContain("<code>rate_limited</code>");
+  });
+
+  it("falls back to the invalid_request copy for an unrecognised code (#492 item 2)", () => {
+    const html = renderAuthorizeErrorPage("server_error");
+    expect(html).toContain("This sign-in link is malformed or has expired");
+    expect(html).toContain("<code>server_error</code>");
+  });
+
+  it("does not leak the built-in Object.prototype.constructor (#464)", () => {
+    const html = renderAuthorizeErrorPage("constructor");
+    expect(html).toContain("This sign-in link is malformed or has expired");
+    expect(html).not.toContain("native code");
+  });
+
+  it("does not resolve a planted Object.prototype member as copy (#492 item 3)", () => {
+    // S-L3-shaped guard pin, matching the house form in
+    // osn/social/tests/components/AuthorizePage.test.tsx. Non-enumerable, so
+    // no unrelated `for...in` loop across the test run can see it, and
+    // removed again in `finally`.
+    const proto = Object.prototype as Record<string, unknown>;
+    expect(Object.hasOwn(proto, "plantedCopy")).toBe(false);
+    Object.defineProperty(proto, "plantedCopy", {
+      value: "Leaked copy",
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    try {
+      const html = renderAuthorizeErrorPage("plantedCopy");
+      expect(html).not.toContain("Leaked copy");
+      expect(html).toContain("This sign-in link is malformed or has expired");
+    } finally {
+      delete proto.plantedCopy;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The `/authorize` error page is what a stranded user reads when a sign-in cannot proceed, and until now nothing asserted a word of it. `renderAuthorizeErrorPage` picks its copy from a three-entry map and falls back to the `invalid_request` wording for anything it does not recognise, so a regression that collapsed all three messages into one — or that let an inherited `Object.prototype` member be read as copy — would have shipped green. This branch pins the copy and the guard with five tests.

Four of them call the renderer directly: one asserts each known code's own distinct wording (and asserts the three are distinguishable, rather than three copies of one assertion), one asserts the fallback wording for an unrecognised code, and two cover the prototype-chain hazard — `constructor`, which is a real `Object.prototype` member, and a property planted on `Object.prototype` for the length of the test. The fifth exercises the `rate_limited` page end to end through the route, by injecting a limiter that denies, which is the one variant no test reached before.

The only source change is one word:

- `renderAuthorizeErrorPage` at `osn/api/src/routes/auth/oidc.ts:99` is now exported, so the unit-level cases can call it without going through a route.
- No behaviour changes. The renderer, the copy map and the `Object.hasOwn` guard are untouched.
- The route test needs a `AuthRateLimiters` override, which `tests/helpers/routes.ts` already supports through its existing parameter list.

## Workspaces affected

| Workspace | What changed |
|---|---|
| `@osn/api` | `renderAuthorizeErrorPage` exported; five tests added to `tests/routes/oidc.test.ts` |

One changeset, `.changeset/authorize-error-page-copy-tests.md` (`@osn/api`: patch).

## Issues

**Closes**

| Issue | ID | What it asked for |
|---|---|---|
| xchromo/osn-tracker#464 | `T-U1` | Pin the error-page guard to own-property lookup |
| xchromo/osn-tracker#465 | `T-S1` | Render the `rate_limited` page in a test |
| xchromo/osn-tracker#492 | `T-U1` | Assert the copy the stranded user actually reads |

Closes xchromo/osn-tracker#464.
Closes xchromo/osn-tracker#465.
Closes xchromo/osn-tracker#492.

**Opened**

None.

## Decisions

### The planted property is removed in `finally` only, not also in an `afterEach` — `T-U1`

**Issue** — xchromo/osn-tracker#492's third item asks for the property planted on `Object.prototype` to be deleted "in a `finally` and again in an `afterEach`", as belt and braces against the planted value leaking into another test file.

**Why** — The stated rationale for the second cleanup is not true of this suite. `osn/api` runs vitest 4 with the default `forks` pool and `isolate: true`, so every test file runs in its own child process and no `Object.prototype` mutation can outlive the file that made it. The `finally` already covers the only real risk, which is a failing assertion inside the same file leaving the property behind for the tests after it.

**Solution** — Delete the property in `finally`, and leave it at that. The property is also defined non-enumerable, so no unrelated `for...in` anywhere in the file can see it even while it is planted.

**Rationale** — An `afterEach` whose stated reason is false is worse than no `afterEach`: the next person reads it as evidence that cross-file leakage is possible here and reasons from that. Deviating from the issue text is the smaller cost.

### The guard tests' honest counterfactual is not the `in` rewrite — `approach`

**Issue** — A test that pins a guard is only worth its runtime if some plausible edit makes it fail. The obvious candidate for these two — rewriting `Object.hasOwn(AUTHORIZE_ERROR_COPY, code)` as `code in AUTHORIZE_ERROR_COPY` — cannot reach CI at all.

**Why** — `house/no-in-operator-key-guard` (`tools/oxlint/house/rules/no-in-operator-key-guard.ts:52-61`) is an error with no test exemption, and it matches the narrowed parameter rather than the literal `keyof typeof` syntax, so the aliased predicate here is caught too. Lint would reject that rewrite before a test ever ran.

**Solution** — Keep both tests, on the counterfactual lint does not catch: replacing the guarded lookup with `AUTHORIZE_ERROR_COPY[code] ?? AUTHORIZE_ERROR_COPY.invalid_request`. That reads clean, passes lint, and leaks `Object`'s own `constructor` string for `code === "constructor"` and the planted value for `code === "plantedCopy"` — which is exactly what the two tests assert against.

**Rationale** — The lint rule and the tests guard different halves of the same hazard: the rule blocks one spelling, the tests block the behaviour whatever the spelling. Neither makes the other redundant.

### The 429 test goes through the test route wrapper, and that is load-bearing — `approach`

**Issue** — The `rate_limited` test asserts a 429 with an HTML body from `app.handle(...)`, with no Bun server behind it.

**Why** — Without a server, `server.requestIP` is unavailable, so the keying IP resolves to the `UNRESOLVED_IP` sentinel and every rate-limited request is denied before the handler runs — the test would pass for the wrong reason, and would keep passing if the render branch were deleted. `osn/api/tests/helpers/routes.ts` is what prevents that: it runs the routes with `{ trustedProxyCount: 1 }` and patches `.handle` to inject `x-forwarded-for: 127.0.0.1` on requests that set none.

**Solution** — Import `createAuthRoutes` from `tests/helpers/routes`, never the raw factory, and inject the denial through an `oidcAuthorize` limiter stub spread over `createDefaultAuthRateLimiters()` so the 429 comes from the limiter under test and not from an unresolved IP.

**Rationale** — Naming the wrapper here means the next person who moves this test to the raw factory knows why it starts passing vacuously.

## Test plan

| Gate | Result |
|---|---|
| `bun run fmt:check` | ✅ clean, 1426 files |
| `bun run lint` | ✅ exit 0 (only pre-existing warnings in `shared/dev-urls` and `cire/db/seed`) |
| `bun run check` | ✅ 37/37 |
| `bun run --cwd osn/api test:run` | ✅ 1117 pass, 68 files |
| `bun install --frozen-lockfile` | ✅ no change; `bun.lock` untouched |
| `bash scripts/validate-changesets.sh` | ✅ |

Checked and clear: `AUTHORIZE_ERROR_COPY` holds copy for `invalid_client`, `invalid_request` and `rate_limited`, while `OidcErrorCode` (`osn/api/src/services/auth/errors.ts:33-45`) has twelve members, which looks at first like ten codes rendering the wrong advice. It is not reachable. `renderAuthorizeErrorPage` has exactly two call sites: `osn/api/src/routes/auth/oidc.ts:265` passes the literal `"rate_limited"`, and `:303` passes `oidc.code` from the failure channel of `validateAuthorizeRequest`. That function fails with exactly two codes — `invalid_client` for an unknown client and `invalid_request` for an unregistered `redirect_uri` (`osn/api/src/services/auth/oidc.ts:1245` and `:1251`). Every other code it produces is a `kind: "error"` success that redirects back to the relying party rather than rendering, because by then a registered `redirect_uri` exists. The map covers the reachable set exactly, so no issue was filed.

**Not run:** no browser or manual exercise of the deployed page — the assertions are on the rendered HTML string, not on how it looks.

**Not run:** no test covers a `DatabaseError` reaching this route. That path goes to `handleError`, not to the error page, and is out of scope for these three issues.
