### PR TITLE
fix(swift): one retrying transport behind every authenticated OSNAuth call

### DIFF
--- a/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
+++ b/shared/swift/OSNShared/Sources/MusubiFeature/MusubiAccountView.swift
@@ -83,6 +83,10 @@ public struct MusubiAccountView: View {
 @MainActor
 func fetchPasskeys(session: OSNSession) async throws -> [PasskeySummary] {
     try await session.ensureFreshAccessToken()
-    let client = PasskeyManagementClient(session: session.urlSession, environment: session.environment)
+    let client = PasskeyManagementClient(
+        session: session.urlSession,
+        environment: session.environment,
+        tokenRefresher: session.tokenRefresher
+    )
     return try await client.list()
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/AuthenticatedTransport.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/AuthenticatedTransport.swift
@@ -1,6 +1,34 @@
 import Foundation
 import OSNKit
 
+/// Refuses to carry a request across hosts.
+///
+/// Foundation follows a 3xx on its own and re-applies the original request's
+/// headers to the redirected one, `Authorization` included, whatever host it
+/// points at. None of the five routes these clients call ever redirects, so
+/// declining outright costs nothing and means an open redirect on the API
+/// host — or a mistyped `Environment.baseURL` — cannot hand a third-party
+/// origin the account's access token. Returning `nil` surfaces the 3xx as
+/// the response instead of following it, which `body(_:_:)` then reports as
+/// a request failure.
+private final class SameHostRedirectGuard: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let host: String?
+
+    init(host: String?) {
+        self.host = host
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest
+    ) async -> URLRequest? {
+        guard let host, request.url?.host == host else { return nil }
+        return request
+    }
+}
+
 /// The single path every Bearer-authenticated `OSNAuth` request takes.
 ///
 /// Each client used to repeat the same five steps — build the request, paste
@@ -14,20 +42,38 @@ import OSNKit
 /// three that carry a single-use `X-Step-Up-Token`. Each route resolves the
 /// bearer principal and returns 401 *before* it verifies the step-up token
 /// (`osn/api/src/routes/auth/passkey-management.ts:81` and `:140`,
-/// `passkey-enroll.ts:46`), so a request rejected for a stale access token
-/// has not consumed its step-up jti and the same step-up token is still good
-/// on the retry.
+/// `passkey-enroll.ts:46`), and `lib/public-error.ts` maps no tagged error to
+/// 401, so a 401 on these routes has exactly one source: that pre-auth check.
+/// The first attempt therefore consumed neither the step-up jti nor the
+/// WebAuthn challenge, and both are still good on the retry.
 ///
-/// Non-isolated, so the remaining Keychain read happens on the cooperative
-/// pool even when the caller is `@MainActor`: `SecItemCopyMatching` is a
-/// synchronous IPC to `securityd`, and on the main actor that is a hitch.
+/// What this does **not** do is decide who the caller is. It authenticates as
+/// whatever the shared Keychain slot holds, which a sibling app in the same
+/// App Group can rotate to a different account's token between one call and
+/// the next. Reconciling that against what is on screen stays with
+/// `OSNSession.ensureFreshAccessToken()` (S-H1), and a screen that shows or
+/// acts on identity still calls it first.
+///
+/// The request-time Keychain read runs on the concurrent executor rather
+/// than the caller's actor. That was already true of the per-client reads
+/// this replaced — they sat in `nonisolated async` methods too — so the
+/// value here is not that it moved, but that `AccessTokenProvider` now pins
+/// it with `@concurrent` instead of leaving it to the current default for
+/// `nonisolated async`, which a language-mode bump would flip.
 struct AuthenticatedTransport: Sendable {
+    /// One decoder for every response in the package. It carries no per-call
+    /// state, so the per-request allocation each client used to make bought
+    /// nothing.
+    private static let decoder = JSONDecoder()
+
     private let session: URLSession
     private let tokens: AccessTokenProvider
+    private let redirectGuard: SameHostRedirectGuard
 
-    init(session: URLSession, tokenRefresher: TokenRefresher) {
+    init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
         self.session = session
         self.tokens = AccessTokenProvider(tokenRefresher: tokenRefresher)
+        self.redirectGuard = SameHostRedirectGuard(host: environment.baseURL.host)
     }
 
     /// Sends `request` with a bearer token resolved from one Keychain read
@@ -39,24 +85,29 @@ struct AuthenticatedTransport: Sendable {
     /// never retried: `TokenRefresher` is the only thing that can mint a
     /// token, and it has already had its turn.
     ///
+    /// A token minted during this very call is not retried either. The server
+    /// rejecting a token it issued moments ago will reject its replacement
+    /// too, so the retry would buy one more round trip and one more session
+    /// cookie rotation for nothing.
+    ///
     /// Throws `.accessTokenMissing` rather than sending an unauthenticated
     /// request that the server would 401 anyway.
     func data(for request: URLRequest) async throws -> Data {
-        guard let token = try await tokens.storedSessionBearerToken() else {
+        guard let resolved = try await tokens.storedSessionBearerToken() else {
             throw OSNAuthError.accessTokenMissing
         }
         var request = request
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(resolved.token)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request, delegate: redirectGuard)
         let http = try Self.httpResponse(response)
-        guard http.statusCode == 401, Self.isReplayable(request) else {
+        guard http.statusCode == 401, !resolved.wasJustMinted, Self.isReplayable(request) else {
             return try Self.body(data, http)
         }
 
-        let freshToken = try await tokens.refreshedBearerToken()
+        let freshToken = try await tokens.refreshedBearerToken(replacing: resolved.token)
         request.setValue("Bearer \(freshToken)", forHTTPHeaderField: "Authorization")
-        let (retryData, retryResponse) = try await session.data(for: request)
+        let (retryData, retryResponse) = try await session.data(for: request, delegate: redirectGuard)
         let retryHTTP = try Self.httpResponse(retryResponse)
         return try Self.body(retryData, retryHTTP)
     }
@@ -66,7 +117,7 @@ struct AuthenticatedTransport: Sendable {
     /// the call reached the server and the server agreed to it.
     func decode<T: Decodable>(_ type: T.Type, from request: URLRequest) async throws -> T {
         let data = try await data(for: request)
-        guard let decoded = try? JSONDecoder().decode(type, from: data) else {
+        guard let decoded = try? Self.decoder.decode(type, from: data) else {
             throw OSNAuthError.responseMalformed(status: 200)
         }
         return decoded

--- a/shared/swift/OSNShared/Sources/OSNAuth/AuthenticatedTransport.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/AuthenticatedTransport.swift
@@ -1,0 +1,97 @@
+import Foundation
+import OSNKit
+
+/// The single path every Bearer-authenticated `OSNAuth` request takes.
+///
+/// Each client used to repeat the same five steps — build the request, paste
+/// on whatever token the Keychain held, send it, check the status, decode —
+/// and the paste step had no expiry check and no retry. A screen left open
+/// past the access token's five-minute TTL (`wiki/systems/identity-model.md`)
+/// therefore just failed, and every new call site had to remember to call
+/// `OSNSession.ensureFreshAccessToken()` first; forgetting was silent.
+///
+/// Retrying a 401 is safe on every route these clients call, including the
+/// three that carry a single-use `X-Step-Up-Token`. Each route resolves the
+/// bearer principal and returns 401 *before* it verifies the step-up token
+/// (`osn/api/src/routes/auth/passkey-management.ts:81` and `:140`,
+/// `passkey-enroll.ts:46`), so a request rejected for a stale access token
+/// has not consumed its step-up jti and the same step-up token is still good
+/// on the retry.
+///
+/// Non-isolated, so the remaining Keychain read happens on the cooperative
+/// pool even when the caller is `@MainActor`: `SecItemCopyMatching` is a
+/// synchronous IPC to `securityd`, and on the main actor that is a hitch.
+struct AuthenticatedTransport: Sendable {
+    private let session: URLSession
+    private let tokens: AccessTokenProvider
+
+    init(session: URLSession, tokenRefresher: TokenRefresher) {
+        self.session = session
+        self.tokens = AccessTokenProvider(tokenRefresher: tokenRefresher)
+    }
+
+    /// Sends `request` with a bearer token resolved from one Keychain read
+    /// and returns the 200 body.
+    ///
+    /// On a 401 — the server rejected a token that looked fresh here, which
+    /// is what a clock difference or a sibling app's sign-out produces — it
+    /// refreshes once and sends the request again. A second 401 is reported,
+    /// never retried: `TokenRefresher` is the only thing that can mint a
+    /// token, and it has already had its turn.
+    ///
+    /// Throws `.accessTokenMissing` rather than sending an unauthenticated
+    /// request that the server would 401 anyway.
+    func data(for request: URLRequest) async throws -> Data {
+        guard let token = try await tokens.storedSessionBearerToken() else {
+            throw OSNAuthError.accessTokenMissing
+        }
+        var request = request
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+        let http = try Self.httpResponse(response)
+        guard http.statusCode == 401, Self.isReplayable(request) else {
+            return try Self.body(data, http)
+        }
+
+        let freshToken = try await tokens.refreshedBearerToken()
+        request.setValue("Bearer \(freshToken)", forHTTPHeaderField: "Authorization")
+        let (retryData, retryResponse) = try await session.data(for: request)
+        let retryHTTP = try Self.httpResponse(retryResponse)
+        return try Self.body(retryData, retryHTTP)
+    }
+
+    /// `data(for:)` plus the decode every caller does with the result. A 200
+    /// that doesn't decode is `.responseMalformed`, not a request failure —
+    /// the call reached the server and the server agreed to it.
+    func decode<T: Decodable>(_ type: T.Type, from request: URLRequest) async throws -> T {
+        let data = try await data(for: request)
+        guard let decoded = try? JSONDecoder().decode(type, from: data) else {
+            throw OSNAuthError.responseMalformed(status: 200)
+        }
+        return decoded
+    }
+
+    /// A body already streamed to the server cannot be sent a second time,
+    /// so a request carrying one gets its 401 handed back instead of a retry
+    /// that would send nothing. Every request these clients build sets
+    /// `httpBody` — plain `Data`, replayable — or carries no body at all;
+    /// the guard is for the hand-built request that doesn't.
+    private static func isReplayable(_ request: URLRequest) -> Bool {
+        request.httpBodyStream == nil
+    }
+
+    private static func body(_ data: Data, _ http: HTTPURLResponse) throws -> Data {
+        guard http.statusCode == 200 else {
+            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
+        }
+        return data
+    }
+
+    private static func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse else {
+            throw OSNAuthError.responseMalformed(status: -1)
+        }
+        return http
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -211,32 +211,45 @@ public final class OSNSession {
         }
     }
 
-    /// Loads the Keychain-stored access token and refreshes it if it's
-    /// missing or expires within the next 30 seconds; otherwise does
-    /// nothing. `RequestHelpers.applyBearerAccessToken` pastes whatever
-    /// token is currently in the Keychain onto a request with no expiry
-    /// check and no 401-retry, so a caller that skips this and waits out
-    /// the 5-minute access-token TTL (`wiki/systems/identity-model.md`)
-    /// 401s on its next request — e.g. the Musubi account screen's
-    /// `PasskeyManagementClient.list()`. `TokenRefresher.refresh()` already
-    /// persists the refreshed token to the Keychain; this method never
-    /// writes to it directly.
+    /// Reconciles the on-screen identity against the access token in the
+    /// Keychain, refreshing that token first when it is missing or within
+    /// `AccessTokenProvider.expirySkew` of expiry.
+    ///
+    /// This is the S-H1 hook, not the request-auth hook: the `OSNAuth`
+    /// clients go through `AuthenticatedTransport`, which resolves and
+    /// refreshes a token of its own and retries a 401, so no call site has
+    /// to remember to call this first to make its request authenticate. What
+    /// it still owns is the identity check — a sibling app sharing this
+    /// Keychain slot may have rotated the token to a *different* user's, and
+    /// a screen about to show or act on identity-bearing data wants that
+    /// caught before it renders.
+    ///
+    /// One Keychain read on both paths: the loaded token is handed straight
+    /// to `reconcileIdentity(token:)` rather than read a second time, and on
+    /// the refresh path the grant's own token is used.
+    /// `TokenRefresher.refresh()` persists it to the Keychain; this method
+    /// never writes there directly.
     public func ensureFreshAccessToken() async throws {
         let stored = try KeychainAccessTokenStore.load()
-        let isFresh = stored.map { $0.expiresAt.timeIntervalSinceNow > 30 } ?? false
-        guard !isFresh else {
-            reconcileIdentity()
+        if let stored, stored.expiresAt.timeIntervalSinceNow > AccessTokenProvider.expirySkew {
+            reconcileIdentity(token: stored.token)
             return
         }
-        try await tokenRefresher.refresh()
-        reconcileIdentity()
+        let grant = try await tokenRefresher.refresh()
+        reconcileIdentity(token: grant.accessToken)
     }
 
-    /// S-H1: every authenticated call goes through `ensureFreshAccessToken()`,
-    /// so reconciling here on both the already-fresh and just-refreshed paths
-    /// closes the hole — a sibling app rotating the shared Keychain token to a
-    /// different user's is caught on the very next call this app makes, not
-    /// just at launch.
+    /// S-H1: reconciling on both the already-fresh and the just-refreshed
+    /// path means a sibling app rotating the shared Keychain token to a
+    /// different user's is caught on the next call that goes through
+    /// `ensureFreshAccessToken()`, not just at launch.
+    ///
+    /// `AuthenticatedTransport` resolves its own token and does *not*
+    /// reconcile — it is a transport, and it has no view of `state`. So a
+    /// screen that shows or acts on identity still calls
+    /// `ensureFreshAccessToken()` first; dropping that call now costs the
+    /// identity check rather than the request's authentication, which is a
+    /// quieter failure and worth knowing before deleting one.
     ///
     /// Loads whatever access token is in the Keychain right now, decodes its
     /// claims (`AccessTokenClaims`, not signature-verified — see its doc),
@@ -248,9 +261,17 @@ public final class OSNSession {
     /// when the reconciled profile equals the cached one, so `@Observable`
     /// doesn't churn on every call.
     private func reconcileIdentity() {
+        reconcileIdentity(token: (try? KeychainAccessTokenStore.load())?.token)
+    }
+
+    /// The same reconciliation against a token the caller already holds, so
+    /// a call that has just read or just been handed one does not pay for a
+    /// second `SecItemCopyMatching` — a synchronous IPC to `securityd`, and
+    /// a hitch when it happens on the main actor. `nil` means "no token",
+    /// which `reconciledProfile` fails closed on.
+    private func reconcileIdentity(token: String?) {
         guard case .signedIn(let cached) = state else { return }
-        let stored = try? KeychainAccessTokenStore.load()
-        let claims = stored.flatMap { AccessTokenClaims(jwt: $0.token) }
+        let claims = token.flatMap { AccessTokenClaims(jwt: $0) }
         let reconciled = reconciledProfile(cached: cached, claims: claims)
         guard reconciled != cached else { return }
         state = .signedIn(reconciled)

--- a/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/OSNSession.swift
@@ -130,9 +130,9 @@ public final class OSNSession {
     public func restore() async {
         state = .restoring
         do {
-            try await tokenRefresher.refresh()
+            let grant = try await tokenRefresher.refresh()
             state = .signedIn(nil)
-            reconcileIdentity()
+            reconcileIdentity(token: grant.accessToken)
         } catch {
             state = .signedOut
         }
@@ -230,7 +230,12 @@ public final class OSNSession {
     /// `TokenRefresher.refresh()` persists it to the Keychain; this method
     /// never writes there directly.
     public func ensureFreshAccessToken() async throws {
-        let stored = try KeychainAccessTokenStore.load()
+        // `AccessTokenProvider.storedAccessToken()` rather than
+        // `KeychainAccessTokenStore.load()` directly: this class is
+        // `@MainActor`, and the load is a synchronous IPC to `securityd`.
+        // The provider's accessor is `@concurrent`, so the read runs on the
+        // cooperative pool and only the state write below lands back here.
+        let stored = try await AccessTokenProvider.storedAccessToken()
         if let stored, stored.expiresAt.timeIntervalSinceNow > AccessTokenProvider.expirySkew {
             reconcileIdentity(token: stored.token)
             return

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyEnrollmentClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyEnrollmentClient.swift
@@ -4,11 +4,14 @@ import OSNKit
 
 /// `POST /passkey/register/begin` + `/complete` (brief §3).
 public final class PasskeyEnrollmentClient: Sendable {
-    private let session: URLSession
+    private let transport: AuthenticatedTransport
     private let environment: Environment
 
-    public init(session: URLSession, environment: Environment) {
-        self.session = session
+    /// - Parameter tokenRefresher: the session's own refresher — see
+    ///   `PasskeyManagementClient.init` for why a second one on the same
+    ///   cookie jar revokes the session family.
+    public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
+        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
         self.environment = environment
     }
 
@@ -80,7 +83,6 @@ public final class PasskeyEnrollmentClient: Sendable {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("passkey/register/begin"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        try RequestHelpers.applyBearerAccessToken(to: &request)
         if let stepUpToken {
             request.setValue(stepUpToken, forHTTPHeaderField: "X-Step-Up-Token")
         }
@@ -88,15 +90,7 @@ public final class PasskeyEnrollmentClient: Sendable {
             RegisterBeginRequestBody(profileId: profileId, step_up_token: nil)
         )
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(PublicKeyCredentialCreationOptionsJSON.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded
+        return try await transport.decode(PublicKeyCredentialCreationOptionsJSON.self, from: request)
     }
 
     private func completeRegistration(
@@ -106,26 +100,10 @@ public final class PasskeyEnrollmentClient: Sendable {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("passkey/register/complete"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        try RequestHelpers.applyBearerAccessToken(to: &request)
         request.httpBody = try JSONEncoder().encode(
             RegisterCompleteRequestBody(profileId: profileId, attestation: attestation)
         )
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(PasskeyEnrollmentResult.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded
-    }
-
-    private static func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
-        guard let http = response as? HTTPURLResponse else {
-            throw OSNAuthError.responseMalformed(status: -1)
-        }
-        return http
+        return try await transport.decode(PasskeyEnrollmentResult.self, from: request)
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyEnrollmentClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyEnrollmentClient.swift
@@ -11,7 +11,11 @@ public final class PasskeyEnrollmentClient: Sendable {
     ///   `PasskeyManagementClient.init` for why a second one on the same
     ///   cookie jar revokes the session family.
     public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
-        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
+        self.transport = AuthenticatedTransport(
+            session: session,
+            environment: environment,
+            tokenRefresher: tokenRefresher
+        )
         self.environment = environment
     }
 
@@ -76,7 +80,9 @@ public final class PasskeyEnrollmentClient: Sendable {
         return try await completeRegistration(profileId: profileId, attestation: attestation)
     }
 
-    private func beginRegistration(
+    /// `internal`, not `private`, so a test can assert the conditional
+    /// `X-Step-Up-Token` header without running a real passkey ceremony.
+    func beginRegistration(
         profileId: String,
         stepUpToken: String?
     ) async throws -> PublicKeyCredentialCreationOptionsJSON {
@@ -93,7 +99,8 @@ public final class PasskeyEnrollmentClient: Sendable {
         return try await transport.decode(PublicKeyCredentialCreationOptionsJSON.self, from: request)
     }
 
-    private func completeRegistration(
+    /// `internal` for the same reason as `beginRegistration`.
+    func completeRegistration(
         profileId: String,
         attestation: RegistrationResponseJSON
     ) async throws -> PasskeyEnrollmentResult {

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyManagementClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyManagementClient.swift
@@ -21,7 +21,11 @@ public final class PasskeyManagementClient: Sendable {
     ///   whole session family. `OSNSession.tokenRefresher` is public for
     ///   exactly this.
     public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
-        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
+        self.transport = AuthenticatedTransport(
+            session: session,
+            environment: environment,
+            tokenRefresher: tokenRefresher
+        )
         self.environment = environment
     }
 

--- a/shared/swift/OSNShared/Sources/OSNAuth/PasskeyManagementClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/PasskeyManagementClient.swift
@@ -10,28 +10,25 @@ import OSNKit
 /// delete"). This is intentional server behavior to mirror, not a bug to
 /// "fix" to a separate `passkey_rename` purpose.
 public final class PasskeyManagementClient: Sendable {
-    private let session: URLSession
+    private let transport: AuthenticatedTransport
     private let environment: Environment
 
-    public init(session: URLSession, environment: Environment) {
-        self.session = session
+    /// - Parameter tokenRefresher: the session's own refresher, never a
+    ///   freshly built one. `TokenRefresher` coalesces concurrent `/token`
+    ///   requests per instance, and every grant rotates the session cookie,
+    ///   so two refreshers sharing one cookie jar race and the loser replays
+    ///   a rotated-out cookie — which trips reuse detection and revokes the
+    ///   whole session family. `OSNSession.tokenRefresher` is public for
+    ///   exactly this.
+    public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
+        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
         self.environment = environment
     }
 
     public func list() async throws -> [PasskeySummary] {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("passkeys"))
         request.httpMethod = "GET"
-        try RequestHelpers.applyBearerAccessToken(to: &request)
-
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(PasskeyListResponse.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded.passkeys
+        return try await transport.decode(PasskeyListResponse.self, from: request).passkeys
     }
 
     /// `stepUpToken` must have been minted via `StepUpPasskeyClient` with
@@ -47,17 +44,11 @@ public final class PasskeyManagementClient: Sendable {
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(stepUpToken, forHTTPHeaderField: "X-Step-Up-Token")
-        try RequestHelpers.applyBearerAccessToken(to: &request)
         request.httpBody = try JSONEncoder().encode(RenameRequestBody(label: label))
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(PasskeyRenameResult.self, from: data),
-              decoded.success else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
+        let result = try await transport.decode(PasskeyRenameResult.self, from: request)
+        guard result.success else {
+            throw OSNAuthError.responseMalformed(status: 200)
         }
     }
 
@@ -67,23 +58,7 @@ public final class PasskeyManagementClient: Sendable {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("passkeys/\(id)"))
         request.httpMethod = "DELETE"
         request.setValue(stepUpToken, forHTTPHeaderField: "X-Step-Up-Token")
-        try RequestHelpers.applyBearerAccessToken(to: &request)
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(PasskeyDeleteResult.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded
-    }
-
-    private static func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
-        guard let http = response as? HTTPURLResponse else {
-            throw OSNAuthError.responseMalformed(status: -1)
-        }
-        return http
+        return try await transport.decode(PasskeyDeleteResult.self, from: request)
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/RequestHelpers.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/RequestHelpers.swift
@@ -7,17 +7,13 @@ struct ServerErrorBody: Decodable {
     let message: String?
 }
 
+/// What is left of the per-client request plumbing once
+/// `AuthenticatedTransport` owns the authenticated path: the response
+/// mapping and the ceremony helpers that both authenticated and
+/// unauthenticated clients share. Applying the bearer token lived here too
+/// until the transport took it over — it pasted on whatever the Keychain
+/// held, with no expiry check and no retry.
 enum RequestHelpers {
-    /// Sets `Authorization: Bearer …` from the Keychain-stored access token.
-    /// Throws `.accessTokenMissing` rather than sending an unauthenticated
-    /// request that the server would just 401/403 anyway.
-    static func applyBearerAccessToken(to request: inout URLRequest) throws {
-        guard let stored = try KeychainAccessTokenStore.load() else {
-            throw OSNAuthError.accessTokenMissing
-        }
-        request.setValue("Bearer \(stored.token)", forHTTPHeaderField: "Authorization")
-    }
-
     /// Trap 6 / brief §2 — verifies the session cookie actually landed in
     /// the shared jar after a successful `/login/passkey/complete`, mirroring
     /// `TokenRefresher.verifySessionCookiePersisted()` in `OSNKit` exactly

--- a/shared/swift/OSNShared/Sources/OSNAuth/StepUpPasskeyClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/StepUpPasskeyClient.swift
@@ -7,11 +7,14 @@ import OSNKit
 /// OTP step-up (`step-up.ts:105`, `:135`) is web-only fallback and out of
 /// scope here (brief §4).
 public final class StepUpPasskeyClient: Sendable {
-    private let session: URLSession
+    private let transport: AuthenticatedTransport
     private let environment: Environment
 
-    public init(session: URLSession, environment: Environment) {
-        self.session = session
+    /// - Parameter tokenRefresher: the session's own refresher — see
+    ///   `PasskeyManagementClient.init` for why a second one on the same
+    ///   cookie jar revokes the session family.
+    public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
+        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
         self.environment = environment
     }
 
@@ -64,17 +67,8 @@ public final class StepUpPasskeyClient: Sendable {
     private func begin() async throws -> StepUpPasskeyBeginResponse {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("step-up/passkey/begin"))
         request.httpMethod = "POST"
-        try RequestHelpers.applyBearerAccessToken(to: &request)
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(StepUpPasskeyBeginResponse.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded
+        return try await transport.decode(StepUpPasskeyBeginResponse.self, from: request)
     }
 
     private func complete(
@@ -84,26 +78,10 @@ public final class StepUpPasskeyClient: Sendable {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("step-up/passkey/complete"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        try RequestHelpers.applyBearerAccessToken(to: &request)
         request.httpBody = try JSONEncoder().encode(
             StepUpPasskeyCompleteRequestBody(assertion: assertion, purpose: purpose)
         )
 
-        let (data, response) = try await session.data(for: request)
-        let http = try Self.httpResponse(response)
-        guard http.statusCode == 200 else {
-            throw RequestHelpers.opaqueFailure(status: http.statusCode, data: data)
-        }
-        guard let decoded = try? JSONDecoder().decode(StepUpPasskeyCompleteResponse.self, from: data) else {
-            throw OSNAuthError.responseMalformed(status: http.statusCode)
-        }
-        return decoded
-    }
-
-    private static func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
-        guard let http = response as? HTTPURLResponse else {
-            throw OSNAuthError.responseMalformed(status: -1)
-        }
-        return http
+        return try await transport.decode(StepUpPasskeyCompleteResponse.self, from: request)
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNAuth/StepUpPasskeyClient.swift
+++ b/shared/swift/OSNShared/Sources/OSNAuth/StepUpPasskeyClient.swift
@@ -14,7 +14,11 @@ public final class StepUpPasskeyClient: Sendable {
     ///   `PasskeyManagementClient.init` for why a second one on the same
     ///   cookie jar revokes the session family.
     public init(session: URLSession, environment: Environment, tokenRefresher: TokenRefresher) {
-        self.transport = AuthenticatedTransport(session: session, tokenRefresher: tokenRefresher)
+        self.transport = AuthenticatedTransport(
+            session: session,
+            environment: environment,
+            tokenRefresher: tokenRefresher
+        )
         self.environment = environment
     }
 
@@ -64,14 +68,18 @@ public final class StepUpPasskeyClient: Sendable {
         return try await complete(assertion: assertion, purpose: purpose)
     }
 
-    private func begin() async throws -> StepUpPasskeyBeginResponse {
+    /// `internal`, not `private`, so a test can assert the request shape
+    /// without running a real passkey ceremony — `mintStepUpToken` cannot run
+    /// headless, and this is the half that talks to the server.
+    func begin() async throws -> StepUpPasskeyBeginResponse {
         var request = URLRequest(url: environment.baseURL.appendingPathComponent("step-up/passkey/begin"))
         request.httpMethod = "POST"
 
         return try await transport.decode(StepUpPasskeyBeginResponse.self, from: request)
     }
 
-    private func complete(
+    /// `internal` for the same reason as `begin()`.
+    func complete(
         assertion: AuthenticationResponseJSON,
         purpose: StepUpPurpose
     ) async throws -> StepUpPasskeyCompleteResponse {

--- a/shared/swift/OSNShared/Sources/OSNKit/AccessTokenProvider.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/AccessTokenProvider.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The one place that decides when a stored access token is too near expiry
+/// to send, and the one path that fetches a fresh one.
+///
+/// Both authenticated request paths in this package resolve their bearer
+/// token here — `AuthenticatedTransport` behind the `OSNAuth` clients, and
+/// `BearerTokenMiddleware` in front of the generated Pulse client — so the
+/// skew allowance is written once instead of once per path, and each path
+/// performs exactly one Keychain read per request.
+///
+/// Nothing is cached in memory, deliberately. The Keychain item is the only
+/// copy: a token held in a property outlives the item it came from, and a
+/// sibling app rotating that item to a different user's token is the S-H1
+/// bug class that `OSNSession.reconcileIdentity()` exists to close.
+public struct AccessTokenProvider: Sendable {
+    /// A stored token within this many seconds of its `expiresAt` counts as
+    /// already gone, so one is never sent moments before the server would
+    /// reject it mid-flight. Access tokens live five minutes
+    /// (`wiki/systems/identity-model.md`), so this is a clock-skew
+    /// allowance, not a refresh schedule.
+    public static let expirySkew: TimeInterval = 30
+
+    private let tokenRefresher: TokenRefresher
+
+    public init(tokenRefresher: TokenRefresher) {
+        self.tokenRefresher = tokenRefresher
+    }
+
+    /// The bearer token for one outgoing request, from exactly one Keychain
+    /// read, treating an empty Keychain as a cold start: nothing is stored
+    /// yet, but the session cookie may well be good, so refresh and carry
+    /// on. `BearerTokenMiddleware`'s case — the Pulse client is built once at
+    /// launch and its first call routinely mints the process's first access
+    /// token.
+    public func bearerTokenRefreshingWhenAbsent() async throws -> String {
+        guard let stored = try KeychainAccessTokenStore.load() else {
+            return try await tokenRefresher.refresh().accessToken
+        }
+        return try await token(replacing: stored)
+    }
+
+    /// The same single read, treating an empty Keychain as the signed-out
+    /// state: `nil`, rather than a `/token` round trip with no session
+    /// cookie to present. The `OSNAuth` clients' case, which surface it as
+    /// `OSNAuthError.accessTokenMissing`.
+    ///
+    /// A token that *is* stored but sits within `expirySkew` of expiry is
+    /// refreshed on this path too — being signed out and holding a stale
+    /// token are different states and only the first is reported.
+    public func storedSessionBearerToken() async throws -> String? {
+        guard let stored = try KeychainAccessTokenStore.load() else { return nil }
+        return try await token(replacing: stored)
+    }
+
+    /// The 401 path: refresh unconditionally and return the new token.
+    ///
+    /// Deliberately reads no Keychain first — whatever is stored is exactly
+    /// what the server just rejected. `TokenRefresher.refresh()` already
+    /// coalesces concurrent callers onto a single `/token` request, so
+    /// several requests failing at once still rotate the session cookie
+    /// once; a second coalescer here would reintroduce the replayed-cookie
+    /// reuse detection that PR #289 fixed on the web client.
+    public func refreshedBearerToken() async throws -> String {
+        try await tokenRefresher.refresh().accessToken
+    }
+
+    private func token(replacing stored: KeychainAccessTokenStore.StoredAccessToken) async throws -> String {
+        if stored.expiresAt.timeIntervalSinceNow > Self.expirySkew {
+            return stored.token
+        }
+        return try await tokenRefresher.refresh().accessToken
+    }
+}

--- a/shared/swift/OSNShared/Sources/OSNKit/AccessTokenProvider.swift
+++ b/shared/swift/OSNShared/Sources/OSNKit/AccessTokenProvider.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+/// An access token resolved for one outgoing request, plus where it came
+/// from.
+///
+/// `wasJustMinted` is not bookkeeping: a token that arrived from a `/token`
+/// grant milliseconds ago and is then rejected will be rejected again, so a
+/// refresh-and-retry on it buys a second round trip and a second session-cookie
+/// rotation for nothing. Callers use it to skip the retry in exactly that case.
+public struct ResolvedAccessToken: Sendable, Equatable {
+    public let token: String
+    /// `true` when resolving this request minted the token, `false` when it
+    /// came out of the Keychain.
+    public let wasJustMinted: Bool
+
+    public init(token: String, wasJustMinted: Bool) {
+        self.token = token
+        self.wasJustMinted = wasJustMinted
+    }
+}
+
 /// The one place that decides when a stored access token is too near expiry
 /// to send, and the one path that fetches a fresh one.
 ///
@@ -13,6 +32,14 @@ import Foundation
 /// copy: a token held in a property outlives the item it came from, and a
 /// sibling app rotating that item to a different user's token is the S-H1
 /// bug class that `OSNSession.reconcileIdentity()` exists to close.
+///
+/// Every method here is `@concurrent`, so the synchronous
+/// `SecItemCopyMatching` inside runs on the concurrent executor even when
+/// the caller is `@MainActor`. Without the attribute this holds only by the
+/// current default for `nonisolated async` (SE-0338); turning on
+/// `NonisolatedNonsendingByDefault`, or moving to a later language mode,
+/// would silently put every Keychain read back on the main thread with the
+/// whole suite still green.
 public struct AccessTokenProvider: Sendable {
     /// A stored token within this many seconds of its `expiresAt` counts as
     /// already gone, so one is never sent moments before the server would
@@ -27,17 +54,29 @@ public struct AccessTokenProvider: Sendable {
         self.tokenRefresher = tokenRefresher
     }
 
+    /// One Keychain read, off the caller's actor. `nil` means nothing is
+    /// stored, which is the signed-out state and not an error.
+    ///
+    /// Exposed so `OSNSession` can make its own freshness decision without
+    /// reading the Keychain on the main actor and without a second copy of
+    /// the skew allowance.
+    @concurrent
+    public static func storedAccessToken() async throws -> KeychainAccessTokenStore.StoredAccessToken? {
+        try KeychainAccessTokenStore.load()
+    }
+
     /// The bearer token for one outgoing request, from exactly one Keychain
     /// read, treating an empty Keychain as a cold start: nothing is stored
     /// yet, but the session cookie may well be good, so refresh and carry
     /// on. `BearerTokenMiddleware`'s case — the Pulse client is built once at
     /// launch and its first call routinely mints the process's first access
     /// token.
-    public func bearerTokenRefreshingWhenAbsent() async throws -> String {
+    @concurrent
+    public func bearerTokenRefreshingWhenAbsent() async throws -> ResolvedAccessToken {
         guard let stored = try KeychainAccessTokenStore.load() else {
-            return try await tokenRefresher.refresh().accessToken
+            return ResolvedAccessToken(token: try await tokenRefresher.refresh().accessToken, wasJustMinted: true)
         }
-        return try await token(replacing: stored)
+        return try await resolve(stored)
     }
 
     /// The same single read, treating an empty Keychain as the signed-out
@@ -48,27 +87,41 @@ public struct AccessTokenProvider: Sendable {
     /// A token that *is* stored but sits within `expirySkew` of expiry is
     /// refreshed on this path too — being signed out and holding a stale
     /// token are different states and only the first is reported.
-    public func storedSessionBearerToken() async throws -> String? {
+    @concurrent
+    public func storedSessionBearerToken() async throws -> ResolvedAccessToken? {
         guard let stored = try KeychainAccessTokenStore.load() else { return nil }
-        return try await token(replacing: stored)
+        return try await resolve(stored)
     }
 
-    /// The 401 path: refresh unconditionally and return the new token.
+    /// The 401 path: a replacement for the token the server just rejected.
     ///
-    /// Deliberately reads no Keychain first — whatever is stored is exactly
-    /// what the server just rejected. `TokenRefresher.refresh()` already
-    /// coalesces concurrent callers onto a single `/token` request, so
-    /// several requests failing at once still rotate the session cookie
-    /// once; a second coalescer here would reintroduce the replayed-cookie
-    /// reuse detection that PR #289 fixed on the web client.
-    public func refreshedBearerToken() async throws -> String {
-        try await tokenRefresher.refresh().accessToken
-    }
-
-    private func token(replacing stored: KeychainAccessTokenStore.StoredAccessToken) async throws -> String {
-        if stored.expiresAt.timeIntervalSinceNow > Self.expirySkew {
+    /// Reads the Keychain once first, and hands back what it finds when that
+    /// is a *different*, still-fresh token — a concurrent request that
+    /// already refreshed has written the good one there, and reusing it
+    /// avoids a second `/token` grant. Only when the stored token is still
+    /// the rejected one does this refresh.
+    ///
+    /// That matters because every grant rotates the session cookie
+    /// (`TokenRefresher`), and `refresh()` coalesces only calls that overlap
+    /// in flight — several requests failing in a stagger would otherwise
+    /// rotate the cookie once each. No second coalescer lives here: two of
+    /// them racing on one cookie jar is the replayed-cookie reuse detection
+    /// that PR #289 fixed on the web client.
+    @concurrent
+    public func refreshedBearerToken(replacing rejected: String) async throws -> String {
+        if let stored = try KeychainAccessTokenStore.load(),
+            stored.token != rejected,
+            stored.expiresAt.timeIntervalSinceNow > Self.expirySkew
+        {
             return stored.token
         }
         return try await tokenRefresher.refresh().accessToken
+    }
+
+    private func resolve(_ stored: KeychainAccessTokenStore.StoredAccessToken) async throws -> ResolvedAccessToken {
+        if stored.expiresAt.timeIntervalSinceNow > Self.expirySkew {
+            return ResolvedAccessToken(token: stored.token, wasJustMinted: false)
+        }
+        return ResolvedAccessToken(token: try await tokenRefresher.refresh().accessToken, wasJustMinted: true)
     }
 }

--- a/shared/swift/OSNShared/Sources/OSNTesting/RequestRecorder.swift
+++ b/shared/swift/OSNShared/Sources/OSNTesting/RequestRecorder.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A `MockURLProtocol` handler is `@Sendable`, so a plain captured `var` is a
+/// data race under strict concurrency even where every call is sequential.
+/// Route the capture through an actor instead.
+public actor Recorder<Value: Sendable> {
+    public private(set) var values: [Value] = []
+
+    public init() {}
+
+    public func record(_ value: Value) { values.append(value) }
+    public var count: Int { values.count }
+    public var last: Value? { values.last }
+}
+
+/// One request as a test sees it: the path plus the two headers the
+/// authenticated-transport suites assert on. Kept here rather than in one
+/// test file because three test files need it, and a `URLProtocol` fixture
+/// does not cross SPM test targets — the same reason `MockURLProtocol` lives
+/// in this target.
+public struct SeenRequest: Sendable, Equatable {
+    public let path: String
+    public let authorization: String?
+    public let stepUpToken: String?
+    public let body: Data?
+
+    public init(_ request: URLRequest) {
+        self.path = request.url?.path ?? ""
+        self.authorization = request.value(forHTTPHeaderField: "Authorization")
+        self.stepUpToken = request.value(forHTTPHeaderField: "X-Step-Up-Token")
+        // `URLProtocol` strips `httpBody` off the request it hands the
+        // subclass and exposes it as a stream instead, so read it back from
+        // there — otherwise every recorded body is `nil`.
+        self.body = request.httpBody ?? request.httpBodyStream.map(Self.drain)
+    }
+
+    private static func drain(_ stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            guard read > 0 else { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}
+
+public func record(_ request: URLRequest, into recorder: Recorder<SeenRequest>) async {
+    await recorder.record(SeenRequest(request))
+}

--- a/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
@@ -10,15 +10,14 @@ import OSNKit
 /// backstop, a 401 from Pulse despite a fresh-looking cached token triggers
 /// one refresh-and-retry — never a loop.
 public struct BearerTokenMiddleware: ClientMiddleware {
-    private let tokenRefresher: TokenRefresher
-
-    /// A cached token within this many seconds of its `expiresAt` is treated
-    /// as already gone, so one is never sent moments before the server
-    /// would reject it mid-flight.
-    private static let expirySkew: TimeInterval = 30
+    /// The skew allowance and the refresh path both live in
+    /// `AccessTokenProvider`, shared with `AuthenticatedTransport` behind the
+    /// `OSNAuth` clients. This middleware used to declare its own `30`, and a
+    /// change to one silently diverged from the other.
+    private let tokens: AccessTokenProvider
 
     public init(tokenRefresher: TokenRefresher) {
-        self.tokenRefresher = tokenRefresher
+        self.tokens = AccessTokenProvider(tokenRefresher: tokenRefresher)
     }
 
     public func intercept(
@@ -45,17 +44,12 @@ public struct BearerTokenMiddleware: ClientMiddleware {
             return (response, responseBody)
         }
 
-        let freshToken = try await tokenRefresher.refresh().accessToken
+        let freshToken = try await tokens.refreshedBearerToken()
         request.headerFields[.authorization] = "Bearer \(freshToken)"
         return try await next(request, body, baseURL)
     }
 
     private func validToken() async throws -> String {
-        if let cached = try KeychainAccessTokenStore.load(),
-            cached.expiresAt.timeIntervalSinceNow > Self.expirySkew
-        {
-            return cached.token
-        }
-        return try await tokenRefresher.refresh().accessToken
+        try await tokens.bearerTokenRefreshingWhenAbsent()
     }
 }

--- a/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
+++ b/shared/swift/OSNShared/Sources/PulseAPI/BearerTokenMiddleware.swift
@@ -28,10 +28,15 @@ public struct BearerTokenMiddleware: ClientMiddleware {
         next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
     ) async throws -> (HTTPResponse, HTTPBody?) {
         var request = request
-        request.headerFields[.authorization] = "Bearer \(try await validToken())"
+        let resolved = try await tokens.bearerTokenRefreshingWhenAbsent()
+        request.headerFields[.authorization] = "Bearer \(resolved.token)"
 
         let (response, responseBody) = try await next(request, body, baseURL)
-        guard response.status.code == 401 else {
+        // A token minted moments ago inside this very call is not worth
+        // retrying: the server rejecting one it just issued will reject its
+        // replacement too, and the second `/token` grant rotates the session
+        // cookie again for nothing.
+        guard response.status.code == 401, !resolved.wasJustMinted else {
             return (response, responseBody)
         }
 
@@ -44,12 +49,8 @@ public struct BearerTokenMiddleware: ClientMiddleware {
             return (response, responseBody)
         }
 
-        let freshToken = try await tokens.refreshedBearerToken()
+        let freshToken = try await tokens.refreshedBearerToken(replacing: resolved.token)
         request.headerFields[.authorization] = "Bearer \(freshToken)"
         return try await next(request, body, baseURL)
-    }
-
-    private func validToken() async throws -> String {
-        try await tokens.bearerTokenRefreshingWhenAbsent()
     }
 }

--- a/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
+++ b/shared/swift/OSNShared/Tests/MusubiFeatureTests/MusubiFeatureTests.swift
@@ -128,4 +128,68 @@ struct FetchPasskeysTests {
 
         try KeychainAccessTokenStore.delete()
     }
+
+    /// `fetchPasskeys` resolves a token twice — once in
+    /// `ensureFreshAccessToken()` for the S-H1 identity check, once inside
+    /// `AuthenticatedTransport` for the request itself. Both read the skew
+    /// allowance from `AccessTokenProvider`, so the second must find the
+    /// token the first just persisted and refresh nothing.
+    ///
+    /// Worth pinning because the failure is silent and expensive: if the two
+    /// ever disagree, this screen fires two `/token` grants back to back, and
+    /// every grant rotates the session cookie the whole App Group shares.
+    @Test func loadingTheScreenSpendsExactlyOneTokenGrant() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let osnSession = makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+
+        // Signed in with a token inside the skew allowance, so
+        // `ensureFreshAccessToken()` is forced down its refresh branch.
+        MockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"at-restored","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-3; Path=/"],
+                Data(body.utf8)
+            )
+        }
+        await osnSession.restore()
+        #expect(osnSession.state == .signedIn(nil))
+        try KeychainAccessTokenStore.save("at-about-to-expire", expiresIn: 5)
+
+        let tokenGrants = Counter()
+        MockURLProtocol.handler = { request in
+            if request.url?.path.hasSuffix("/token") == true {
+                await tokenGrants.increment()
+                let body = """
+                {"access_token":"at-refreshed","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+                """
+                return (
+                    200,
+                    ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-4; Path=/"],
+                    Data(body.utf8)
+                )
+            }
+            let body = """
+            {"passkeys":[{"id":"pk-1","label":"iPhone","aaguid":null,"transports":null,"backupEligible":null,"backupState":null,"createdAt":1,"lastUsedAt":null}]}
+            """
+            return (200, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+
+        _ = try await fetchPasskeys(session: osnSession)
+
+        #expect(await tokenGrants.value == 1)
+
+        try KeychainAccessTokenStore.delete()
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
 }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/AuthenticatedTransportTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/AuthenticatedTransportTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import OSNKit
+import OSNTesting
+import Testing
+
+@testable import OSNAuth
+
+/// `MockURLProtocol.handler` is `@Sendable`, so a plain captured `var` is a
+/// data race under strict concurrency even where every call is sequential.
+/// Same shape as `PulseAPITests`' recorder.
+private actor Recorder<Value: Sendable> {
+    private(set) var values: [Value] = []
+    func record(_ value: Value) { values.append(value) }
+    var count: Int { values.count }
+    var last: Value? { values.last }
+}
+
+/// One recorded request, reduced to the two headers this suite asserts on.
+private struct SeenRequest: Sendable, Equatable {
+    let path: String
+    let authorization: String?
+    let stepUpToken: String?
+}
+
+private func record(_ request: URLRequest, into recorder: Recorder<SeenRequest>) async {
+    await recorder.record(
+        SeenRequest(
+            path: request.url?.path ?? "",
+            authorization: request.value(forHTTPHeaderField: "Authorization"),
+            stepUpToken: request.value(forHTTPHeaderField: "X-Step-Up-Token")
+        )
+    )
+}
+
+private let tokenGrantBody = #"""
+{"access_token":"rotated-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+"""#
+
+private func tokenGrantResponse() -> (Int, [String: String], Data) {
+    (
+        200,
+        ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-1; Path=/"],
+        Data(tokenGrantBody.utf8)
+    )
+}
+
+private let passkeyListBody = #"""
+{"passkeys":[{"id":"pk_0123456789ab","label":"iPhone","aaguid":null,"transports":null,
+ "backupEligible":null,"backupState":null,"createdAt":1,"lastUsedAt":null}]}
+"""#
+
+/// The 401-retry, the single Keychain read and the shared skew allowance, all
+/// driven through a real client rather than the transport directly — the point
+/// of the change is that every `OSNAuth` client gets this without asking, and a
+/// test that reached past them could not show that.
+///
+/// Touches the real Keychain, so it carries `.keychainSerializing` like every
+/// other suite that drives `MockURLProtocol` — see that type's doc.
+@Suite(.serialized, .keychainSerializing)
+struct AuthenticatedTransportTests {
+    @Test func aRejectedAccessTokenIsRefreshedAndTheRequestRetriedOnce() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let client = PasskeyManagementClient(
+            session: session,
+            environment: environment,
+            tokenRefresher: TokenRefresher(session: session, environment: environment)
+        )
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/token") {
+                return tokenGrantResponse()
+            }
+            let attempts = await seen.values.filter { $0.path.hasSuffix("/passkeys") }.count
+            if attempts == 1 {
+                return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+            }
+            return (200, ["Content-Type": "application/json"], Data(passkeyListBody.utf8))
+        }
+
+        let passkeys = try await client.list()
+
+        #expect(passkeys.map(\.id) == ["pk_0123456789ab"])
+        #expect(
+            await seen.values.map(\.path) == ["/passkeys", "/token", "/passkeys"],
+            "a 401 refreshes once, then replays the same request"
+        )
+        #expect(await seen.values.map(\.authorization) == [
+            "Bearer looks-fresh", nil, "Bearer rotated-token",
+        ])
+        #expect(try KeychainAccessTokenStore.load()?.token == "rotated-token")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func aSecondUnauthorizedIsReportedRatherThanRetriedAgain() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let client = PasskeyManagementClient(
+            session: session,
+            environment: environment,
+            tokenRefresher: TokenRefresher(session: session, environment: environment)
+        )
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            if request.url?.path.hasSuffix("/token") == true {
+                return tokenGrantResponse()
+            }
+            return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+        }
+
+        await #expect(throws: OSNAuthError.requestFailed(status: 401, error: "unauthorized")) {
+            _ = try await client.list()
+        }
+        #expect(
+            await seen.values.map(\.path) == ["/passkeys", "/token", "/passkeys"],
+            "exactly one retry — `TokenRefresher` is the only thing that can mint a token and it has had its turn"
+        )
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// The retry resends the single-use `X-Step-Up-Token`, which is only safe
+    /// because the server resolves the bearer principal and 401s *before* it
+    /// verifies step-up (`osn/api/src/routes/auth/passkey-management.ts:140`),
+    /// so the first attempt never consumed the token's jti.
+    @Test func theStepUpTokenIsResentUnchangedOnTheRetry() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let client = PasskeyManagementClient(
+            session: session,
+            environment: environment,
+            tokenRefresher: TokenRefresher(session: session, environment: environment)
+        )
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/token") {
+                return tokenGrantResponse()
+            }
+            let attempts = await seen.values.filter { $0.path.contains("pk_") }.count
+            if attempts == 1 {
+                return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+            }
+            return (
+                200,
+                ["Content-Type": "application/json"],
+                Data(#"{"success":true,"remaining":2}"#.utf8)
+            )
+        }
+
+        let result = try await client.delete(id: "pk_0123456789ab", stepUpToken: "step-up-1")
+
+        #expect(result == PasskeyDeleteResult(success: true, remaining: 2))
+        #expect(await seen.values.compactMap(\.stepUpToken) == ["step-up-1", "step-up-1"])
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func nothingStoredIsReportedWithoutSendingARequest() async throws {
+        try KeychainAccessTokenStore.delete()
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let client = PasskeyManagementClient(
+            session: session,
+            environment: environment,
+            tokenRefresher: TokenRefresher(session: session, environment: environment)
+        )
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (200, [:], Data())
+        }
+
+        await #expect(throws: OSNAuthError.accessTokenMissing) {
+            _ = try await client.list()
+        }
+        #expect(
+            await seen.count == 0,
+            "signed out is not a cold start: no `/token` round trip with no session cookie to spend"
+        )
+    }
+
+    /// The other half of the fix: a stored token inside the skew allowance is
+    /// replaced *before* the request, so the 401 path is a backstop rather than
+    /// the normal way an expiring token gets renewed. `expirySkew` is 30s and
+    /// lives in one place now — `BearerTokenMiddleware` reads the same value.
+    @Test func aTokenInsideTheSkewAllowanceIsRefreshedBeforeTheRequest() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save(
+            "about-to-expire",
+            expiresIn: AccessTokenProvider.expirySkew - 5
+        )
+
+        let environment = Environment.local
+        let session = makeMockSession()
+        let client = PasskeyManagementClient(
+            session: session,
+            environment: environment,
+            tokenRefresher: TokenRefresher(session: session, environment: environment)
+        )
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            if request.url?.path.hasSuffix("/token") == true {
+                return tokenGrantResponse()
+            }
+            return (200, ["Content-Type": "application/json"], Data(passkeyListBody.utf8))
+        }
+
+        _ = try await client.list()
+
+        #expect(await seen.values.map(\.path) == ["/token", "/passkeys"])
+        #expect(await seen.last?.authorization == "Bearer rotated-token")
+
+        try KeychainAccessTokenStore.delete()
+    }
+}

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/AuthenticatedTransportTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/AuthenticatedTransportTests.swift
@@ -5,33 +5,6 @@ import Testing
 
 @testable import OSNAuth
 
-/// `MockURLProtocol.handler` is `@Sendable`, so a plain captured `var` is a
-/// data race under strict concurrency even where every call is sequential.
-/// Same shape as `PulseAPITests`' recorder.
-private actor Recorder<Value: Sendable> {
-    private(set) var values: [Value] = []
-    func record(_ value: Value) { values.append(value) }
-    var count: Int { values.count }
-    var last: Value? { values.last }
-}
-
-/// One recorded request, reduced to the two headers this suite asserts on.
-private struct SeenRequest: Sendable, Equatable {
-    let path: String
-    let authorization: String?
-    let stepUpToken: String?
-}
-
-private func record(_ request: URLRequest, into recorder: Recorder<SeenRequest>) async {
-    await recorder.record(
-        SeenRequest(
-            path: request.url?.path ?? "",
-            authorization: request.value(forHTTPHeaderField: "Authorization"),
-            stepUpToken: request.value(forHTTPHeaderField: "X-Step-Up-Token")
-        )
-    )
-}
-
 private let tokenGrantBody = #"""
 {"access_token":"rotated-token","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
 """#
@@ -49,10 +22,18 @@ private let passkeyListBody = #"""
  "backupEligible":null,"backupState":null,"createdAt":1,"lastUsedAt":null}]}
 """#
 
-/// The 401-retry, the single Keychain read and the shared skew allowance, all
-/// driven through a real client rather than the transport directly — the point
-/// of the change is that every `OSNAuth` client gets this without asking, and a
-/// test that reached past them could not show that.
+private func makeClient(_ session: URLSession, _ environment: Environment) -> PasskeyManagementClient {
+    PasskeyManagementClient(
+        session: session,
+        environment: environment,
+        tokenRefresher: TokenRefresher(session: session, environment: environment)
+    )
+}
+
+/// The 401 retry, the single Keychain read, the error mapping and the shared
+/// skew allowance, all driven through a real client rather than the transport
+/// directly — the point of the change is that every `OSNAuth` client gets this
+/// without asking, and a test that reached past them could not show that.
 ///
 /// Touches the real Keychain, so it carries `.keychainSerializing` like every
 /// other suite that drives `MockURLProtocol` — see that type's doc.
@@ -62,19 +43,13 @@ struct AuthenticatedTransportTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
 
-        let environment = Environment.local
         let session = makeMockSession()
-        let client = PasskeyManagementClient(
-            session: session,
-            environment: environment,
-            tokenRefresher: TokenRefresher(session: session, environment: environment)
-        )
+        let client = makeClient(session, .local)
 
         let seen = Recorder<SeenRequest>()
         MockURLProtocol.handler = { request in
             await record(request, into: seen)
-            let path = request.url?.path ?? ""
-            if path.hasSuffix("/token") {
+            if request.url?.path.hasSuffix("/token") == true {
                 return tokenGrantResponse()
             }
             let attempts = await seen.values.filter { $0.path.hasSuffix("/passkeys") }.count
@@ -103,13 +78,8 @@ struct AuthenticatedTransportTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
 
-        let environment = Environment.local
         let session = makeMockSession()
-        let client = PasskeyManagementClient(
-            session: session,
-            environment: environment,
-            tokenRefresher: TokenRefresher(session: session, environment: environment)
-        )
+        let client = makeClient(session, .local)
 
         let seen = Recorder<SeenRequest>()
         MockURLProtocol.handler = { request in
@@ -139,30 +109,20 @@ struct AuthenticatedTransportTests {
         try KeychainAccessTokenStore.delete()
         try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
 
-        let environment = Environment.local
         let session = makeMockSession()
-        let client = PasskeyManagementClient(
-            session: session,
-            environment: environment,
-            tokenRefresher: TokenRefresher(session: session, environment: environment)
-        )
+        let client = makeClient(session, .local)
 
         let seen = Recorder<SeenRequest>()
         MockURLProtocol.handler = { request in
             await record(request, into: seen)
-            let path = request.url?.path ?? ""
-            if path.hasSuffix("/token") {
+            if request.url?.path.hasSuffix("/token") == true {
                 return tokenGrantResponse()
             }
             let attempts = await seen.values.filter { $0.path.contains("pk_") }.count
             if attempts == 1 {
                 return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
             }
-            return (
-                200,
-                ["Content-Type": "application/json"],
-                Data(#"{"success":true,"remaining":2}"#.utf8)
-            )
+            return (200, ["Content-Type": "application/json"], Data(#"{"success":true,"remaining":2}"#.utf8))
         }
 
         let result = try await client.delete(id: "pk_0123456789ab", stepUpToken: "step-up-1")
@@ -173,16 +133,71 @@ struct AuthenticatedTransportTests {
         try KeychainAccessTokenStore.delete()
     }
 
+    /// A token minted inside this very call is not worth retrying: a server
+    /// that rejects the token it just issued will reject its replacement too.
+    @Test func aTokenMintedDuringThisCallIsNotRetried() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("about-to-expire", expiresIn: 5)
+
+        let session = makeMockSession()
+        let client = makeClient(session, .local)
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            if request.url?.path.hasSuffix("/token") == true {
+                return tokenGrantResponse()
+            }
+            return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+        }
+
+        await #expect(throws: OSNAuthError.requestFailed(status: 401, error: "unauthorized")) {
+            _ = try await client.list()
+        }
+        #expect(
+            await seen.values.map(\.path) == ["/token", "/passkeys"],
+            "one refresh to resolve the expiring token, then no second one for the 401 it still got"
+        )
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// A concurrent request that already refreshed has written the good token
+    /// to the Keychain, so the 401 path reuses it rather than spending another
+    /// `/token` grant — every grant rotates the shared session cookie.
+    @Test func aNewerStoredTokenIsReusedInsteadOfRefreshingAgain() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let client = makeClient(session, .local)
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            let attempts = await seen.count
+            if attempts == 1 {
+                // Stand in for a sibling request that refreshed between our
+                // resolve and our 401.
+                try KeychainAccessTokenStore.save("someone-elses-refresh", expiresIn: 300)
+                return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+            }
+            return (200, ["Content-Type": "application/json"], Data(passkeyListBody.utf8))
+        }
+
+        _ = try await client.list()
+
+        #expect(await seen.values.map(\.path) == ["/passkeys", "/passkeys"], "no `/token` request at all")
+        #expect(await seen.last?.authorization == "Bearer someone-elses-refresh")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
     @Test func nothingStoredIsReportedWithoutSendingARequest() async throws {
         try KeychainAccessTokenStore.delete()
 
-        let environment = Environment.local
         let session = makeMockSession()
-        let client = PasskeyManagementClient(
-            session: session,
-            environment: environment,
-            tokenRefresher: TokenRefresher(session: session, environment: environment)
-        )
+        let client = makeClient(session, .local)
 
         let seen = Recorder<SeenRequest>()
         MockURLProtocol.handler = { request in
@@ -200,23 +215,20 @@ struct AuthenticatedTransportTests {
     }
 
     /// The other half of the fix: a stored token inside the skew allowance is
-    /// replaced *before* the request, so the 401 path is a backstop rather than
-    /// the normal way an expiring token gets renewed. `expirySkew` is 30s and
-    /// lives in one place now — `BearerTokenMiddleware` reads the same value.
-    @Test func aTokenInsideTheSkewAllowanceIsRefreshedBeforeTheRequest() async throws {
-        try KeychainAccessTokenStore.delete()
-        try KeychainAccessTokenStore.save(
-            "about-to-expire",
-            expiresIn: AccessTokenProvider.expirySkew - 5
-        )
+    /// replaced *before* the request, so the 401 path is a backstop rather
+    /// than the normal way an expiring token gets renewed.
+    ///
+    /// Fixtures are absolute, and the constant is asserted outright. Writing
+    /// them as `expirySkew - 5` would move with the constant and pass even at
+    /// `expirySkew = 0`, which is the value the allowance exists to rule out.
+    @Test func theSkewAllowanceIsThirtySecondsAndBracketsTheDecision() async throws {
+        #expect(AccessTokenProvider.expirySkew == 30)
 
-        let environment = Environment.local
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("about-to-expire", expiresIn: 25)
+
         let session = makeMockSession()
-        let client = PasskeyManagementClient(
-            session: session,
-            environment: environment,
-            tokenRefresher: TokenRefresher(session: session, environment: environment)
-        )
+        let client = makeClient(session, .local)
 
         let seen = Recorder<SeenRequest>()
         MockURLProtocol.handler = { request in
@@ -228,9 +240,130 @@ struct AuthenticatedTransportTests {
         }
 
         _ = try await client.list()
-
-        #expect(await seen.values.map(\.path) == ["/token", "/passkeys"])
+        #expect(await seen.values.map(\.path) == ["/token", "/passkeys"], "25s is inside the allowance")
         #expect(await seen.last?.authorization == "Bearer rotated-token")
+
+        // 45s is outside it: the stored token goes out untouched.
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("still-good", expiresIn: 45)
+        let secondSeen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: secondSeen)
+            return (200, ["Content-Type": "application/json"], Data(passkeyListBody.utf8))
+        }
+
+        _ = try await client.list()
+        #expect(await secondSeen.values.map(\.path) == ["/passkeys"], "45s is outside the allowance")
+        #expect(await secondSeen.last?.authorization == "Bearer still-good")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// The two codes the management endpoints document by name, plus the
+    /// catch-all. Each asserts one request as well, since only a 401 retries.
+    @Test(arguments: [
+        (403, #"{"error":"step_up_required"}"#, OSNAuthError.stepUpRequired),
+        (409, #"{"error":"session_stale","message":"Re-authenticate and try again."}"#,
+         OSNAuthError.sessionStale(message: "Re-authenticate and try again.")),
+        (500, #"{"error":"server_error"}"#, OSNAuthError.requestFailed(status: 500, error: "server_error")),
+    ])
+    func aNon401FailureIsMappedAndNeverRetried(status: Int, body: String, expected: OSNAuthError) async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let client = makeClient(session, .local)
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (status, ["Content-Type": "application/json"], Data(body.utf8))
+        }
+
+        await #expect(throws: expected) {
+            _ = try await client.delete(id: "pk_0123456789ab", stepUpToken: "step-up-1")
+        }
+        #expect(await seen.count == 1, "only a 401 is retried")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func aTwoHundredThatDoesNotDecodeIsMalformedNotAFailure() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let client = makeClient(session, .local)
+
+        MockURLProtocol.handler = { _ in
+            (200, ["Content-Type": "application/json"], Data("not json".utf8))
+        }
+
+        await #expect(throws: OSNAuthError.responseMalformed(status: 200)) {
+            _ = try await client.list()
+        }
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// `rename` is the one method where a successful HTTP call can still
+    /// throw — the server answers a bare `{ "success": … }`, so a `false`
+    /// there is the only signal that the rename did not take.
+    @Test func renameSendsTheLabelAndReportsAnUnsuccessfulBody() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let client = makeClient(session, .local)
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (200, ["Content-Type": "application/json"], Data(#"{"success":true}"#.utf8))
+        }
+
+        try await client.rename(id: "pk_0123456789ab", label: "Work phone", stepUpToken: "step-up-1")
+        #expect(await seen.last?.stepUpToken == "step-up-1")
+        #expect(await seen.last.flatMap(\.body).map { String(decoding: $0, as: UTF8.self) } == #"{"label":"Work phone"}"#)
+
+        MockURLProtocol.handler = { _ in
+            (200, ["Content-Type": "application/json"], Data(#"{"success":false}"#.utf8))
+        }
+        await #expect(throws: OSNAuthError.responseMalformed(status: 200)) {
+            try await client.rename(id: "pk_0123456789ab", label: "Work phone", stepUpToken: "step-up-1")
+        }
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// Parity with `BearerTokenMiddlewareTests.doesNotRetryWhenTheBodyCannotBeReplayed`:
+    /// a streamed body is consumed by the first attempt, so the 401 comes
+    /// back rather than a retry that would send nothing.
+    @Test func aStreamedBodyIsNotReplayed() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let transport = AuthenticatedTransport(
+            session: session,
+            environment: .local,
+            tokenRefresher: TokenRefresher(session: session, environment: .local)
+        )
+
+        var request = URLRequest(url: Environment.local.baseURL.appendingPathComponent("passkeys"))
+        request.httpMethod = "POST"
+        request.httpBodyStream = InputStream(data: Data("{}".utf8))
+
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+        }
+
+        await #expect(throws: OSNAuthError.requestFailed(status: 401, error: "unauthorized")) {
+            _ = try await transport.data(for: request)
+        }
+        #expect(await seen.count == 1)
 
         try KeychainAccessTokenStore.delete()
     }

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/OSNSessionTests.swift
@@ -212,6 +212,72 @@ struct OSNSessionTests {
 
         try KeychainAccessTokenStore.delete()
     }
+
+    /// Third S-H1 case, and the one the refresh branch owns: the stored token
+    /// is *expiring*, so `ensureFreshAccessToken()` refreshes rather than
+    /// reading the stored token, and must reconcile against the token the
+    /// grant returned.
+    ///
+    /// Three distinct JWTs, so the assertion can only pass for the right
+    /// reason: A is what restore left on screen, B is what sits in the
+    /// Keychain, C is what `/token` hands back. Reconciling against the
+    /// stored token would land on B, and against nothing would land on
+    /// `.signedIn(nil)`.
+    @Test func ensureFreshAccessTokenReconcilesAgainstTheGrantOnTheRefreshPath() async throws {
+        try KeychainAccessTokenStore.delete()
+        let environment = Environment.local
+        let session = makeMockSession()
+        let tokenRefresher = TokenRefresher(session: session, environment: environment)
+
+        let jwtA = makeJWT(sub: "profile-a", email: "a@example.com", handle: "alice", displayName: "Alice")
+        MockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"\(jwtA)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-a3; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        let osnSession = await makeOSNSession(environment: environment, session: session, tokenRefresher: tokenRefresher)
+        await osnSession.restore()
+        guard case .signedIn(let profileA) = osnSession.state, profileA?.id == "profile-a" else {
+            Issue.record("expected .signedIn(profile-a) after restore, got \(osnSession.state)")
+            try KeychainAccessTokenStore.delete()
+            return
+        }
+
+        // In the Keychain: B, and expiring, so the skew allowance forces a
+        // refresh instead of a read.
+        let jwtB = makeJWT(sub: "profile-b", email: "b@example.com", handle: "bob", displayName: "Bob")
+        try KeychainAccessTokenStore.save(jwtB, expiresIn: 5)
+
+        // What `/token` answers with: C.
+        let jwtC = makeJWT(sub: "profile-c", email: "c@example.com", handle: "carol", displayName: "Carol")
+        MockURLProtocol.handler = { _ in
+            let body = """
+            {"access_token":"\(jwtC)","token_type":"Bearer","expires_in":300,"scope":"openid profile"}
+            """
+            return (
+                200,
+                ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-c; Path=/"],
+                Data(body.utf8)
+            )
+        }
+
+        try await osnSession.ensureFreshAccessToken()
+
+        guard case .signedIn(let reconciled) = osnSession.state else {
+            Issue.record("expected .signedIn after ensureFreshAccessToken, got \(osnSession.state)")
+            try KeychainAccessTokenStore.delete()
+            return
+        }
+        #expect(reconciled?.id == "profile-c")
+
+        try KeychainAccessTokenStore.delete()
+    }
 }
 
 private actor Counter {

--- a/shared/swift/OSNShared/Tests/OSNAuthTests/StepUpAndEnrollmentClientTests.swift
+++ b/shared/swift/OSNShared/Tests/OSNAuthTests/StepUpAndEnrollmentClientTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import OSNKit
+import OSNTesting
+import Testing
+
+@testable import OSNAuth
+
+/// Neither `StepUpPasskeyClient.mintStepUpToken` nor
+/// `PasskeyEnrollmentClient.register` can run here — both drive a real
+/// `ASAuthorization` ceremony, which needs a presentation anchor and a user.
+/// What is testable, and what this branch rewrote, is the half that talks to
+/// the server: these suites drive those methods directly.
+@Suite(.serialized, .keychainSerializing)
+struct StepUpPasskeyClientTests {
+    private static let beginBody = #"""
+    {"options":{"challenge":"Y2g","timeout":60000,"rpId":"musubi.social",
+     "allowCredentials":[{"id":"aWQ","type":"public-key"}],"userVerification":"required"}}
+    """#
+
+    private func makeClient(_ session: URLSession) -> StepUpPasskeyClient {
+        StepUpPasskeyClient(
+            session: session,
+            environment: .local,
+            tokenRefresher: TokenRefresher(session: session, environment: .local)
+        )
+    }
+
+    @Test func beginPostsToTheStepUpRouteWithTheBearerToken() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (200, ["Content-Type": "application/json"], Data(Self.beginBody.utf8))
+        }
+
+        let response = try await makeClient(session).begin()
+
+        #expect(response.options.rpId == "musubi.social")
+        #expect(response.options.userVerification == "required")
+        #expect(await seen.last?.path == "/step-up/passkey/begin")
+        #expect(await seen.last?.authorization == "Bearer looks-fresh")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func completeSendsThePurposeAndReturnsTheMintedToken() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (
+                200,
+                ["Content-Type": "application/json"],
+                Data(#"{"step_up_token":"su-1","expires_in":300}"#.utf8)
+            )
+        }
+
+        let assertion = AuthenticationResponseJSON(
+            id: "id",
+            rawId: "rawId",
+            authenticatorAttachment: "platform",
+            response: AuthenticatorAssertionResponseJSON(
+                clientDataJSON: "clientData",
+                authenticatorData: "authData",
+                signature: "sig",
+                userHandle: nil
+            )
+        )
+        let response = try await makeClient(session).complete(assertion: assertion, purpose: .passkeyDelete)
+
+        #expect(response == StepUpPasskeyCompleteResponse(stepUpToken: "su-1", expiresIn: 300))
+        #expect(await seen.last?.path == "/step-up/passkey/complete")
+        let body = try #require(await seen.last?.body)
+        #expect(String(decoding: body, as: UTF8.self).contains(#""purpose":"passkey_delete""#))
+
+        try KeychainAccessTokenStore.delete()
+    }
+}
+
+@Suite(.serialized, .keychainSerializing)
+struct PasskeyEnrollmentClientTests {
+    private static let optionsBody = #"""
+    {"rp":{"id":"musubi.social","name":"Musubi"},
+     "user":{"id":"dTE","name":"alice","displayName":"Alice"},
+     "challenge":"Y2g","pubKeyCredParams":[{"type":"public-key","alg":-7}],
+     "timeout":60000,"excludeCredentials":null,"authenticatorSelection":null,"attestation":null}
+    """#
+
+    private func makeClient(_ session: URLSession) -> PasskeyEnrollmentClient {
+        PasskeyEnrollmentClient(
+            session: session,
+            environment: .local,
+            tokenRefresher: TokenRefresher(session: session, environment: .local)
+        )
+    }
+
+    /// The only conditional header in the package: present for a later
+    /// passkey, absent for the account's first, where the server bypasses the
+    /// step-up gate itself because no ceremony is reachable pre-credential.
+    @Test(arguments: [("su-1", "su-1" as String?), (nil, nil)] as [(String?, String?)])
+    func theStepUpHeaderIsSetOnlyWhenATokenIsSupplied(supplied: String?, expected: String?) async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (200, ["Content-Type": "application/json"], Data(Self.optionsBody.utf8))
+        }
+
+        let options = try await makeClient(session)
+            .beginRegistration(profileId: "profile-a", stepUpToken: supplied)
+
+        #expect(options.rp.id == "musubi.social")
+        #expect(await seen.last?.path == "/passkey/register/begin")
+        #expect(await seen.last?.stepUpToken == expected)
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    /// Both enrollment calls are Bearer-authed, and the same 401 retry covers
+    /// them — including carrying the step-up header through unchanged.
+    @Test func aRejectedTokenRetriesTheRegistrationBeginWithTheHeaderIntact() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            if request.url?.path.hasSuffix("/token") == true {
+                return (
+                    200,
+                    ["Content-Type": "application/json", "Set-Cookie": "osn_session=rotated-e; Path=/"],
+                    Data(#"{"access_token":"rotated-token","token_type":"Bearer","expires_in":300,"scope":"openid"}"#.utf8)
+                )
+            }
+            let attempts = await seen.values.filter { $0.path.hasSuffix("/begin") }.count
+            if attempts == 1 {
+                return (401, ["Content-Type": "application/json"], Data(#"{"error":"unauthorized"}"#.utf8))
+            }
+            return (200, ["Content-Type": "application/json"], Data(Self.optionsBody.utf8))
+        }
+
+        _ = try await makeClient(session).beginRegistration(profileId: "profile-a", stepUpToken: "su-1")
+
+        #expect(await seen.values.map(\.path) == [
+            "/passkey/register/begin", "/token", "/passkey/register/begin",
+        ])
+        #expect(await seen.values.compactMap(\.stepUpToken) == ["su-1", "su-1"])
+        #expect(await seen.last?.authorization == "Bearer rotated-token")
+
+        try KeychainAccessTokenStore.delete()
+    }
+
+    @Test func completeRegistrationReturnsTheNewCredentialId() async throws {
+        try KeychainAccessTokenStore.delete()
+        try KeychainAccessTokenStore.save("looks-fresh", expiresIn: 300)
+
+        let session = makeMockSession()
+        let seen = Recorder<SeenRequest>()
+        MockURLProtocol.handler = { request in
+            await record(request, into: seen)
+            return (200, ["Content-Type": "application/json"], Data(#"{"passkeyId":"pk_0123456789ab"}"#.utf8))
+        }
+
+        let attestation = RegistrationResponseJSON(
+            id: "id",
+            rawId: "rawId",
+            authenticatorAttachment: "platform",
+            response: AuthenticatorAttestationResponseJSON(
+                clientDataJSON: "clientData",
+                attestationObject: "attestation"
+            )
+        )
+        let result = try await makeClient(session)
+            .completeRegistration(profileId: "profile-a", attestation: attestation)
+
+        #expect(result == PasskeyEnrollmentResult(passkeyId: "pk_0123456789ab"))
+        #expect(await seen.last?.path == "/passkey/register/complete")
+
+        try KeychainAccessTokenStore.delete()
+    }
+}

--- a/shared/swift/OSNShared/a3-notes.md
+++ b/shared/swift/OSNShared/a3-notes.md
@@ -77,6 +77,12 @@
   `RequestHelpers.applyBearerAccessToken`'s no-expiry-check/no-401-retry
   behavior. A load failure surfaces inline in the view (error text + Retry
   button) and never touches `session.state`.
+  **Superseded 2026-08-30** (tracker#532, tracker#533):
+  `applyBearerAccessToken` is gone, and `AuthenticatedTransport` resolves and
+  refreshes the token for every `OSNAuth` client and retries a 401, so the
+  call no longer has to come first for the request to authenticate. It stays
+  in `MusubiAccountView` as the S-H1 identity check, which is a different
+  job.
 - `osn/ios/` mirrors `pulse/ios/` (`project.yml`, `Sources/App.swift`):
   bundle id `social.musubi.app`, same team/App-Group/associated-domain
   entitlements. AASA
@@ -254,4 +260,7 @@ lie.
   whatever it reads), per-app request attribution (S-L1), the 30s-skew
   literal and 401-retry behaviour (P-W2), the hard-coded `Environment.local`
   in the test helpers above, and moving the mock `URLProtocol` into
-  `OSNTesting`.
+  `OSNTesting`. Of those, the mock has since moved to `OSNTesting`, and the
+  skew literal plus the missing 401 retry were filed as tracker#533 with the
+  duplicate Keychain read (P-W1) as tracker#532 and closed together on
+  2026-08-30 by `AccessTokenProvider` and `AuthenticatedTransport`.


### PR DESCRIPTION
## Summary

Every authenticated `OSNAuth` request used to paste on whatever access token the Keychain happened to hold, with no expiry check and no retry. A screen left open past the token's five-minute TTL simply failed, and each new call site had to remember to call `OSNSession.ensureFreshAccessToken()` first — forgetting was silent, and the number of call sites is growing. Only the Pulse side had the 401 backstop, and it kept its own copy of the 30-second clock-skew allowance.

There is now one seam. `AccessTokenProvider` (OSNKit) owns the skew and the refresh; both request paths resolve their bearer token through it. `AuthenticatedTransport` (OSNAuth) sits behind the seven authenticated call sites across `PasskeyManagementClient`, `StepUpPasskeyClient` and `PasskeyEnrollmentClient`: one Keychain read per request, a refresh when what it finds is inside the allowance, and one refresh-and-retry on a 401.

- Nothing is cached in memory. A token held in a property outlives the Keychain item it came from, which is the S-H1 bug class.
- `ensureFreshAccessToken()` keeps its job as the identity check rather than the request-auth hook, and now reads the Keychain once instead of twice.
- The three clients take the session's own `TokenRefresher` rather than building one — refresh coalescing is per instance, and two refreshers on one cookie jar race until the loser replays a rotated-out cookie and the server revokes the session family.

## Workspaces affected

`shared/swift/OSNShared` (targets `OSNKit`, `OSNAuth`, `PulseAPI`, `OSNTesting`, `MusubiFeature`), plus one annotation to `shared/swift/OSNShared/a3-notes.md`.

No changeset. `shared/swift/` is on the allowlist in `scripts/changeset-required.sh`, which prints `skip` for this diff — there is no versioned package here to name.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#532 | `P-I` |
| xchromo/osn-tracker#533 | `P-I` |

Closes xchromo/osn-tracker#532.
Closes xchromo/osn-tracker#533.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#563 | `S-M` |
| xchromo/osn-tracker#564 | `S-M` |
| xchromo/osn-tracker#565 | `S-L` |

## Decisions

### One transport, not one middleware — `approach`

- **Issue** — the two authenticated paths speak different type languages. `BearerTokenMiddleware` intercepts OpenAPIRuntime's `HTTPRequest`/`HTTPBody`; the `OSNAuth` clients build `URLRequest` and call `URLSession`. A literally single transport would mean dragging the OpenAPI runtime into `OSNKit`, which every consumer imports.
- **Why** — the finding asks for "one retrying transport shared by both paths", and taking that literally would push a package dependency down into the base module to satisfy a wording.
- **Solution** — share the *policy*, not the plumbing. `AccessTokenProvider` holds the skew allowance, the resolve-once rule and the refresh; both paths are thin adapters over it.
- **Rationale** — the duplication the finding names is the skew literal and the missing retry, and both are gone. The remaining difference between the two adapters is genuine: one has a replayable `Data` body, the other has to check `iterationBehavior` first.

### Retrying a request that carries a single-use step-up token — `S-*`

- **Issue** — `rename`, `delete` and `passkey/register/begin` send an `X-Step-Up-Token` that the server consumes by jti. A blind refresh-and-retry resends it, and a token whose jti was already burned is worthless.
- **Why** — if the first attempt could consume the jti, the retry would fail with a confusing "step-up required" on a ceremony the user had just completed, and the fix would be worse than the bug.
- **Solution** — verified against the routes rather than assumed. Every one resolves the bearer principal and returns 401 *before* any step-up verification (`passkey-management.ts:39`, `:81`, `:140`; `passkey-enroll.ts:46`, `:106`; `step-up.ts:36`, `:78`), and `lib/public-error.ts` maps no tagged error to 401 — so a 401 on these routes has exactly one source, and it is upstream of the jti. A test asserts the header goes out unchanged on both attempts.
- **Rationale** — the alternative, excluding step-up-bearing requests from the retry, would have left the three routes that need the backstop most without one, on a hazard that does not exist.

### Not retrying a token minted moments earlier — `P-W`

- **Issue** — resolving a request can itself mint a token. If that request then 401s, the retry refreshed again, unconditionally.
- **Why** — two `/token` grants for one user action, where the second is provably useless: a server rejecting the token it just issued will reject its replacement. Each grant also rotates the session cookie the whole App Group shares.
- **Solution** — the provider reports whether it minted, and both adapters skip the retry in that case.
- **Rationale** — every case the retry was written for — clock difference, a sibling app's sign-out, a stale-looking-fresh cached token — presupposes the token came from the Keychain, not from a `/token` response received milliseconds ago.

### Reusing a concurrent request's refresh — `P-I` / `S-L`

- **Issue** — `TokenRefresher` coalesces only calls that overlap in flight. Requests that 401 in a stagger — the normal case, since responses arrive staggered — would each post their own `/token`.
- **Why** — one cookie rotation per failed request rather than one per expiry, and the replayed-rotated-cookie case is the family revocation PR #289 fixed on the web client. New exposure, since the `OSNAuth` clients made no refresh calls at all before.
- **Solution** — the 401 path reads the Keychain once and uses what it finds when that is a different, still-fresh token.
- **Rationale** — the one extra read lands only on the rare 401 path, and a second coalescer at the transport layer is exactly the thing that must not exist here.

### Refusing cross-host redirects — `S-L`

- **Issue** — Foundation follows a 3xx itself and re-applies the original request's headers to the redirected one, `Authorization` included, whatever host it points at.
- **Why** — an open redirect on the API host, or a mistyped `Environment.baseURL`, would hand a third-party origin the account's access token. Not a regression — the deleted helper behaved identically — but the transport is now the only place the header is applied, so it is the only place a guard is needed.
- **Solution** — a `URLSessionTaskDelegate` that returns `nil` when the redirect target's host differs from the environment's.
- **Rationale** — none of these five routes legitimately redirects, so refusing outright has no behavioural cost and covers every current and future client at once.

### Pinning the off-actor Keychain read with `@concurrent` — `P-W`

- **Issue** — `SecItemCopyMatching` is a synchronous IPC to `securityd`, and on the main actor that is a hitch. The reads stay off it only because `nonisolated async` does not currently inherit the caller's actor.
- **Why** — that is a default, not a guarantee. Turning on `NonisolatedNonsendingByDefault` — a routine forward-compat step — puts every one of these reads back on the main thread with the suite still green.
- **Solution** — `@concurrent` on the provider's methods, and `ensureFreshAccessToken()` reads through it rather than calling the store directly.
- **Rationale** — states the requirement in the code instead of inferring it from a package-level default, means the same thing under both isolation regimes, and costs nothing today because it is already what the compiler picks.

### Two clients' request methods made `internal` — `T-M`

- **Issue** — `StepUpPasskeyClient` and `PasskeyEnrollmentClient` were rewritten wholesale here and had no tests, because their public entry points run a real `ASAuthorization` ceremony that cannot run headless.
- **Why** — `beginRegistration` sets the only conditional header in the package, and nothing checked it was present when a token was supplied and absent when it was not.
- **Solution** — drop `private` from the four request methods, with a comment saying why, and test the half that talks to the server directly.
- **Rationale** — the untestable part is the ceremony, not the request shaping; widening four methods to module scope is a smaller price than leaving a rewritten client uncovered.

**Out of scope**

- The transport authenticates as whatever the shared Keychain holds and never reconciles that against `OSNSession.state` — xchromo/osn-tracker#563.
- `OSNKitError.refreshSessionInvalid` raised outside `revalidate()` never reaches `.signedOut` — xchromo/osn-tracker#564. Predates this branch; the branch adds a second path to the same gap.
- The retry spends two tokens from a pre-auth per-IP rate-limit bucket — xchromo/osn-tracker#565.
- `AuthenticatedTransport`'s `responseMalformed(status: -1)` branch stays untested: reaching a non-`HTTPURLResponse` needs a second `URLProtocol`, which is more harness than the branch is worth.

## Test plan

| Gate | Result |
|---|---|
| `swift build` (`shared/swift/OSNShared`) | ✅ |
| `swift test` (`shared/swift/OSNShared`) | ✅ 147 pass, 21 suites (129 on `main`) |
| `xcodebuild -scheme Musubi` (generic iOS Simulator) | ✅ |
| `xcodebuild -scheme Pulse` (generic iOS Simulator) | ✅ |
| `scripts/changeset-required.sh` | ✅ `skip` |
| `bun run lint` / `bun run typecheck` | n/a — no TypeScript in the diff |

Every new assertion was checked by mutating the source and confirming the suite goes red: dropping the retry kills three tests; `expirySkew = 0` kills seven; removing the just-minted guard, removing the newer-stored-token reuse, and treating 403/409 as success each kill their own; `reconcileIdentity(token: nil)` on the refresh path kills the new S-H1 test.

**Not run:** no device or simulator run of either app — both were built, not launched, so nothing here has been exercised against a real `securityd` or a real Keychain access group. The two-app rotation this guards against (a sibling app swapping the shared token mid-session) is still only reachable by hand; `swift test` on one package cannot stage it. The 401 retry has not been seen against the deployed API — the server-side reasoning is read from the routes, not observed.
