### PR TITLE
perf(osn-api): fan out organisation co-members by id, and hydrate concurrently

### DIFF
--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -1,0 +1,11 @@
+---
+"@osn/api": patch
+---
+
+Halve the rows the connection-suggestion fan-out reads, and stop it labelling a suggestion with an organisation that no longer exists.
+
+`suggestConnections` fanned out to up to 2,000 organisation co-members and joined `organisations` on each row — a primary-key probe per membership row, so roughly 4,000 rows read where the query needed 2,000. D1 bills rows read. The fan-out now selects ids only, and the organisations that survive ranking (at most 50, usually far fewer) are hydrated in the same concurrent step as the profiles, so the request costs no extra round trip.
+
+The fan-out also gains `ORDER BY (organisation_id, profile_id)`. That pins what was left to the planner rather than fixing an observed problem: SQLite already walked `org_members_pair_idx` in exactly this order, so the plan is identical either way and no behaviour changes today. The index is UNIQUE on those two columns, so the ordering is its own and adds no sort.
+
+A candidate whose only basis was a shared organisation, and whose organisation has since been deleted, is now dropped rather than returned claiming `shared_organisation` with nothing to name — which is what the removed inner join used to do.

--- a/osn/api/src/services/recommendations.ts
+++ b/osn/api/src/services/recommendations.ts
@@ -68,8 +68,34 @@ const MAX_FOF_FANOUT_ROWS = 10_000;
  * Cap on the co-member fan-out from the caller's organisations. Same shape of
  * defence as MAX_FOF_FANOUT_ROWS: membership of one very large organisation
  * must not turn a suggestion request into an unbounded read.
+ *
+ * It is a budget for the whole fan-out, not per organisation, and the rows
+ * arrive ordered by `(organisation_id, profile_id)` — so a caller in one large
+ * organisation fills the budget from that organisation alone and never sees a
+ * co-member from any other. Organisation ids are random, so which one wins is
+ * a fixed draw per caller. Tracked as its own finding; the fix is a
+ * per-organisation budget rather than a bigger global one.
  */
 const MAX_ORG_COMEMBER_ROWS = 2_000;
+
+/**
+ * The organisation label on a suggestion card, or `null`.
+ *
+ * `null` for a candidate with no shared organisation, and also for one whose
+ * organisation row is missing — an organisation deleted between the fan-out
+ * and the hydration. Dropping the label is the right answer there: the
+ * suggestion itself still stands on its mutual connections, and a card that
+ * names an organisation that no longer exists is worse than one that names
+ * none.
+ */
+function hydrateOrganisation(
+  organisationId: string | null,
+  organisationMap: Map<string, { handle: string; name: string }>,
+): { handle: string; name: string } | null {
+  if (organisationId === null) return null;
+  const organisation = organisationMap.get(organisationId);
+  return organisation ? { handle: organisation.handle, name: organisation.name } : null;
+}
 
 /**
  * Minimum query length for search, full stop. One character is enough because
@@ -488,23 +514,38 @@ export function createRecommendationService() {
                 catch: (cause) => new DatabaseError({ cause }),
               }),
           myOrgIds.length === 0
-            ? Effect.succeed(
-                [] as { profileId: string; organisationHandle: string; organisationName: string }[],
-              )
+            ? Effect.succeed([] as { profileId: string; organisationId: string }[])
             : Effect.tryPromise({
+                // Ids only. This reads up to MAX_ORG_COMEMBER_ROWS rows and at
+                // most `safeLimit` candidates survive ranking, so joining
+                // `organisations` here re-serialised a handle and a name for
+                // every row to throw away roughly forty out of forty-one of
+                // them. The surviving organisations are hydrated in step 5,
+                // alongside the profiles, from a set that is already small.
+                //
+                // The ORDER BY pins what was left to the planner. Without
+                // one the row order under the LIMIT is unspecified — in
+                // practice SQLite already walked `org_members_pair_idx` in
+                // this order, so `EXPLAIN QUERY PLAN` is identical either way
+                // and no behaviour changes today. What it buys is that the
+                // slice stays the same slice if the planner ever chooses
+                // differently, which matters because org-only candidates all
+                // tie at `mutualCount: 0` and are separated only by the id
+                // tiebreak in step 4. It costs nothing: the index is UNIQUE
+                // on exactly (organisation_id, profile_id), so this is its own
+                // order and adds no sort.
+                //
+                // What the ordering does NOT fix is which organisations the
+                // cap reaches — see the note on MAX_ORG_COMEMBER_ROWS.
                 try: () =>
                   db
                     .select({
                       profileId: organisationMembers.profileId,
-                      organisationHandle: organisations.handle,
-                      organisationName: organisations.name,
+                      organisationId: organisationMembers.organisationId,
                     })
                     .from(organisationMembers)
-                    .innerJoin(
-                      organisations,
-                      eq(organisations.id, organisationMembers.organisationId),
-                    )
                     .where(inArray(organisationMembers.organisationId, myOrgIds))
+                    .orderBy(organisationMembers.organisationId, organisationMembers.profileId)
                     .limit(MAX_ORG_COMEMBER_ROWS),
                 catch: (cause) => new DatabaseError({ cause }),
               }),
@@ -516,7 +557,8 @@ export function createRecommendationService() {
       interface Candidate {
         mutualCount: number;
         organisationCount: number;
-        sharedOrganisation: { handle: string; name: string } | null;
+        /** Hydrated to a handle and a name in step 5, for survivors only. */
+        sharedOrganisationId: string | null;
       }
       const candidates = new Map<string, Candidate>();
       const candidateFor = (id: string): Candidate => {
@@ -525,7 +567,7 @@ export function createRecommendationService() {
         const fresh: Candidate = {
           mutualCount: 0,
           organisationCount: 0,
-          sharedOrganisation: null,
+          sharedOrganisationId: null,
         };
         candidates.set(id, fresh);
         return fresh;
@@ -551,16 +593,18 @@ export function createRecommendationService() {
         candidate.organisationCount += 1;
         // First organisation wins as the label — one is all a card can show,
         // and `organisationCount` already carries the "how many" signal.
-        candidate.sharedOrganisation ??= {
-          handle: row.organisationHandle,
-          name: row.organisationName,
-        };
+        // "First" is now well defined: the fan-out is ordered by
+        // (organisation_id, profile_id), so the same caller gets the same
+        // organisation on the card every time.
+        candidate.sharedOrganisationId ??= row.organisationId;
       }
 
       if (candidates.size === 0) return [];
 
-      // Step 4: rank. Mutual connections outrank shared organisations; handle
-      // breaks ties so the list is stable between requests.
+      // Step 4: rank. Mutual connections outrank shared organisations; the
+      // profile id breaks ties so the list is stable between requests. The id,
+      // not the handle — ids are unique outright, and the comparison below has
+      // always used them whatever this comment said.
       const sorted = [...candidates.entries()]
         .toSorted(
           ([idA, a], [idB, b]) =>
@@ -571,31 +615,76 @@ export function createRecommendationService() {
         .slice(0, safeLimit);
 
       const candidateIds = sorted.map(([id]) => id);
+      const survivingOrgIds = [
+        ...new Set(sorted.map(([, c]) => c.sharedOrganisationId).filter((id) => id !== null)),
+      ];
 
-      // Step 5: hydrate. The accounts join drops candidates whose account is
-      // tombstoned (Art. 17 erasure pending) so a mid-deletion profile is
-      // never suggested.
-      const profiles = yield* Effect.tryPromise({
-        try: () =>
-          db
-            .select({
-              id: users.id,
-              handle: users.handle,
-              displayName: users.displayName,
-              avatarUrl: users.avatarUrl,
-            })
-            .from(users)
-            .innerJoin(accounts, eq(users.accountId, accounts.id))
-            .where(and(inArray(users.id, candidateIds), isNull(accounts.deletedAt))),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
+      // Step 5: hydrate the survivors — profiles and organisation labels.
+      //
+      // Both reads depend only on `sorted`, so they run concurrently. Running
+      // the organisations query after the profiles one would add a fourth
+      // serial wave: on D1 every statement is a network round trip, worth
+      // milliseconds, while the row-building this change avoids is worth tens
+      // of microseconds. A serial hydration would have spent the saving
+      // several times over on latency for every caller.
+      //
+      // The accounts join drops candidates whose account is tombstoned
+      // (Art. 17 erasure pending) so a mid-deletion profile is never
+      // suggested. At most `safeLimit` candidates reach here and they share
+      // organisations, so `survivingOrgIds` is a handful of ids — the set the
+      // fan-out used to read thousands of `organisations` rows to produce.
+      const [profiles, organisationRows] = yield* Effect.all(
+        [
+          Effect.tryPromise({
+            try: () =>
+              db
+                .select({
+                  id: users.id,
+                  handle: users.handle,
+                  displayName: users.displayName,
+                  avatarUrl: users.avatarUrl,
+                })
+                .from(users)
+                .innerJoin(accounts, eq(users.accountId, accounts.id))
+                .where(and(inArray(users.id, candidateIds), isNull(accounts.deletedAt))),
+            catch: (cause) => new DatabaseError({ cause }),
+          }),
+          survivingOrgIds.length === 0
+            ? Effect.succeed([] as { id: string; handle: string; name: string }[])
+            : Effect.tryPromise({
+                try: () =>
+                  db
+                    .select({
+                      id: organisations.id,
+                      handle: organisations.handle,
+                      name: organisations.name,
+                    })
+                    .from(organisations)
+                    .where(inArray(organisations.id, survivingOrgIds)),
+                catch: (cause) => new DatabaseError({ cause }),
+              }),
+        ],
+        { concurrency: "unbounded" },
+      );
 
       const profileMap = new Map(profiles.map((p) => [p.id, p]));
+      const organisationMap = new Map(organisationRows.map((o) => [o.id, o]));
 
       return sorted
         .map(([id, candidate]) => {
           const p = profileMap.get(id);
           if (!p) return null;
+          const sharedOrganisation = hydrateOrganisation(
+            candidate.sharedOrganisationId,
+            organisationMap,
+          );
+          // A candidate whose only basis was a shared organisation, and whose
+          // organisation no longer exists, has no basis left — drop them
+          // rather than assert `shared_organisation` and name nothing. This
+          // restores exactly what the fan-out's old inner join to
+          // `organisations` did, at the point where both facts are already in
+          // hand and without paying for the join.
+          if (candidate.mutualCount === 0 && sharedOrganisation === null) return null;
           return {
             handle: p.handle,
             displayName: p.displayName,
@@ -605,7 +694,7 @@ export function createRecommendationService() {
               candidate.mutualCount > 0
                 ? ("mutual_connections" as const)
                 : ("shared_organisation" as const),
-            sharedOrganisation: candidate.sharedOrganisation,
+            sharedOrganisation,
           };
         })
         .filter((s): s is Suggestion => s !== null);

--- a/osn/api/tests/routes/recommendations.test.ts
+++ b/osn/api/tests/routes/recommendations.test.ts
@@ -144,6 +144,37 @@ describe("recommendations routes", () => {
     expect(json.suggestions[0]!.sharedOrganisation).toBeNull();
   });
 
+  // The hydrated organisation label is built after ranking and then has to
+  // survive the route's TypeBox `response` schema. Every other card in these
+  // tests carries `sharedOrganisation: null`, so a shape drift in the
+  // non-null branch would surface as a 500 in production rather than a red
+  // test.
+  it("serialises a non-null sharedOrganisation through the response schema", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const bob = await registerAndGetToken("b@e.com", "bob");
+    const org = await runWithLayer(
+      createOrganisationService().createOrganisation(alice.profileId, "acme", "Acme Inc"),
+    );
+    await runWithLayer(
+      createOrganisationService().addMember(org.id, alice.profileId, bob.profileId, "member"),
+    );
+
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { suggestions: Array<Record<string, unknown>> };
+    expect(json.suggestions).toHaveLength(1);
+    expect(json.suggestions[0]!.handle).toBe("bob");
+    expect(json.suggestions[0]!.reason).toBe("shared_organisation");
+    expect(json.suggestions[0]!.sharedOrganisation).toEqual({
+      handle: "acme",
+      name: "Acme Inc",
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Limit parsing (T-S1)
   // -------------------------------------------------------------------------

--- a/osn/api/tests/services/recommendations.test.ts
+++ b/osn/api/tests/services/recommendations.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, describe } from "@effect/vitest";
-import { accounts } from "@osn/db/schema";
+import { accounts, organisations } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
@@ -279,6 +279,36 @@ describe("suggestConnections", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
+  // The fan-out selects ids only and hydrates the surviving organisations
+  // afterwards, so the label has to survive that round trip — and be the same
+  // label on two identical requests. Without the ORDER BY the LIMIT took an
+  // arbitrary slice, so which organisation labelled a co-member could differ
+  // between calls.
+  it.effect("labels a co-member with the same organisation on repeated calls", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      // bob shares three organisations with alice, so there is something to be
+      // arbitrary about.
+      const acme = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
+      const beta = yield* orgs.createOrganisation(alice.id, "beta", "Beta Ltd");
+      const gamma = yield* orgs.createOrganisation(alice.id, "gamma", "Gamma Co");
+      yield* orgs.addMember(acme.id, alice.id, bob.id, "member");
+      yield* orgs.addMember(beta.id, alice.id, bob.id, "member");
+      yield* orgs.addMember(gamma.id, alice.id, bob.id, "member");
+
+      const first = yield* recs.suggestConnections(alice.id);
+      const second = yield* recs.suggestConnections(alice.id);
+
+      expect(first).toHaveLength(1);
+      expect(first[0]!.handle).toBe("bob");
+      expect(first[0]!.sharedOrganisation).not.toBeNull();
+      expect(second[0]!.sharedOrganisation).toEqual(first[0]!.sharedOrganisation);
+      // Whichever one it is, it is one alice actually shares with bob.
+      expect(["acme", "beta", "gamma"]).toContain(first[0]!.sharedOrganisation!.handle);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
   it.effect("never suggests a friend-of-friend whose account is tombstoned", () =>
     Effect.gen(function* () {
       // Art. 17 erasure is pending on dana's account — she must not resurface
@@ -296,6 +326,61 @@ describe("suggestConnections", () => {
           .set({ deletedAt: 1_700_000_000 })
           .where(eq(accounts.id, dana.accountId)),
       );
+
+      expect(yield* recs.suggestConnections(alice.id)).toEqual([]);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // Hydration happens after ranking, so an organisation can disappear between
+  // the fan-out reading its membership row and the lookup reading its name.
+  // The suggestion has to survive that with no label rather than vanish or
+  // carry a stale one.
+  //
+  // The state is reached by deleting the row directly, because the service
+  // layer cannot produce it: `deleteOrganisation` removes the membership rows
+  // and the organisation in one batch. This pins the defensive branch, not a
+  // reachable bug — which also means dropping the old `innerJoin(organisations)`
+  // from the fan-out changed no candidate that a real database can hold.
+  it.effect("drops the label, not the suggestion, when the organisation is gone", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      // dana is a friend-of-friend as well as a co-member, so the suggestion
+      // still stands on its mutual connection once the label is gone.
+      yield* connect(alice.id, bob.id);
+      yield* connect(bob.id, dana.id);
+      const org = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
+      yield* orgs.addMember(org.id, alice.id, dana.id, "member");
+
+      const { db } = yield* Db;
+      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, org.id)));
+
+      const result = yield* recs.suggestConnections(alice.id);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.handle).toBe("dana");
+      expect(result[0]!.reason).toBe("mutual_connections");
+      expect(result[0]!.sharedOrganisation).toBeNull();
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // The other side of the same branch: with no mutual connection, a shared
+  // organisation that no longer exists leaves the candidate with no basis at
+  // all. Asserting `shared_organisation` while naming nothing is worse than
+  // not suggesting them, and this is exactly what the fan-out's old inner
+  // join to `organisations` used to do.
+  it.effect("drops an organisation-only candidate whose organisation is gone", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const org = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
+      yield* orgs.addMember(org.id, alice.id, bob.id, "member");
+
+      // bob is suggested while the organisation exists.
+      expect((yield* recs.suggestConnections(alice.id)).map((x) => x.handle)).toEqual(["bob"]);
+
+      const { db } = yield* Db;
+      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, org.id)));
 
       expect(yield* recs.suggestConnections(alice.id)).toEqual([]);
     }).pipe(Effect.provide(createTestLayer())),

--- a/osn/api/tests/services/recommendations.test.ts
+++ b/osn/api/tests/services/recommendations.test.ts
@@ -279,33 +279,63 @@ describe("suggestConnections", () => {
     }).pipe(Effect.provide(createTestLayer())),
   );
 
-  // The fan-out selects ids only and hydrates the surviving organisations
-  // afterwards, so the label has to survive that round trip — and be the same
-  // label on two identical requests. Without the ORDER BY the LIMIT took an
-  // arbitrary slice, so which organisation labelled a co-member could differ
-  // between calls.
-  it.effect("labels a co-member with the same organisation on repeated calls", () =>
+  // The hydration is a keyed lookup into a map built after ranking, which the
+  // old inner join could not get wrong. Two candidates in two different live
+  // organisations is the smallest case that tells a keyed lookup from an
+  // unkeyed one: with only one organisation in the map, returning "whatever is
+  // in there" and returning "the right one" are the same answer, and a card
+  // wearing another organisation's name would ship green.
+  it.effect("labels each candidate with the organisation it actually shares", () =>
     Effect.gen(function* () {
       const alice = yield* auth.registerProfile("a@e.com", "alice");
       const bob = yield* auth.registerProfile("b@e.com", "bob");
-      // bob shares three organisations with alice, so there is something to be
-      // arbitrary about.
+      const cara = yield* auth.registerProfile("c@e.com", "cara");
       const acme = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
       const beta = yield* orgs.createOrganisation(alice.id, "beta", "Beta Ltd");
-      const gamma = yield* orgs.createOrganisation(alice.id, "gamma", "Gamma Co");
       yield* orgs.addMember(acme.id, alice.id, bob.id, "member");
-      yield* orgs.addMember(beta.id, alice.id, bob.id, "member");
-      yield* orgs.addMember(gamma.id, alice.id, bob.id, "member");
+      yield* orgs.addMember(beta.id, alice.id, cara.id, "member");
 
-      const first = yield* recs.suggestConnections(alice.id);
-      const second = yield* recs.suggestConnections(alice.id);
+      const result = yield* recs.suggestConnections(alice.id);
+      const byHandle = new Map(result.map((x) => [x.handle, x.sharedOrganisation]));
 
-      expect(first).toHaveLength(1);
-      expect(first[0]!.handle).toBe("bob");
-      expect(first[0]!.sharedOrganisation).not.toBeNull();
-      expect(second[0]!.sharedOrganisation).toEqual(first[0]!.sharedOrganisation);
-      // Whichever one it is, it is one alice actually shares with bob.
-      expect(["acme", "beta", "gamma"]).toContain(first[0]!.sharedOrganisation!.handle);
+      expect(byHandle.get("bob")).toEqual({ handle: "acme", name: "Acme Inc" });
+      expect(byHandle.get("cara")).toEqual({ handle: "beta", name: "Beta Ltd" });
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // The same lookup when the map is only partly populated: one label survives,
+  // one candidate loses its organisation but keeps its mutual connection, and
+  // a third loses the only basis it had.
+  it.effect("hydrates a partial map without borrowing another candidate's label", () =>
+    Effect.gen(function* () {
+      const alice = yield* auth.registerProfile("a@e.com", "alice");
+      const bob = yield* auth.registerProfile("b@e.com", "bob");
+      const cara = yield* auth.registerProfile("c@e.com", "cara");
+      const dana = yield* auth.registerProfile("d@e.com", "dana");
+      const erin = yield* auth.registerProfile("e@e.com", "erin");
+
+      const acme = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
+      const beta = yield* orgs.createOrganisation(alice.id, "beta", "Beta Ltd");
+      yield* orgs.addMember(acme.id, alice.id, bob.id, "member");
+      yield* orgs.addMember(beta.id, alice.id, cara.id, "member");
+      yield* orgs.addMember(beta.id, alice.id, erin.id, "member");
+      // dana is a friend-of-friend, so she survives losing her label.
+      yield* connect(alice.id, cara.id);
+      yield* connect(cara.id, dana.id);
+
+      const { db } = yield* Db;
+      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, beta.id)));
+
+      const result = yield* recs.suggestConnections(alice.id);
+      const byHandle = new Map(result.map((x) => [x.handle, x.sharedOrganisation]));
+
+      // bob keeps the organisation he actually shares — not beta's name, and
+      // not a label borrowed from the one entry left in the map.
+      expect(byHandle.get("bob")).toEqual({ handle: "acme", name: "Acme Inc" });
+      // dana stands on the mutual connection, with no label.
+      expect(byHandle.get("dana")).toBeNull();
+      // erin's only basis was beta, which is gone.
+      expect(byHandle.has("erin")).toBe(false);
     }).pipe(Effect.provide(createTestLayer())),
   );
 
@@ -336,11 +366,12 @@ describe("suggestConnections", () => {
   // The suggestion has to survive that with no label rather than vanish or
   // carry a stale one.
   //
-  // The state is reached by deleting the row directly, because the service
-  // layer cannot produce it: `deleteOrganisation` removes the membership rows
-  // and the organisation in one batch. This pins the defensive branch, not a
-  // reachable bug — which also means dropping the old `innerJoin(organisations)`
-  // from the fan-out changed no candidate that a real database can hold.
+  // The state is reached by deleting the row directly. It cannot persist —
+  // `deleteOrganisation` removes the membership rows and the organisation in
+  // one batch, and D1 enforces the foreign key besides (this harness does not;
+  // see the pragma finding). What it can be is a read race: the fan-out and
+  // the hydration are two statements now rather than one join, so an
+  // organisation deleted between them lands exactly here.
   it.effect("drops the label, not the suggestion, when the organisation is gone", () =>
     Effect.gen(function* () {
       const alice = yield* auth.registerProfile("a@e.com", "alice");


### PR DESCRIPTION
## Summary

`suggestConnections` fanned out to up to 2,000 organisation co-members and joined `organisations` on every row — one primary-key probe per membership row, so roughly 4,000 rows read to answer a query that needs 2,000. D1 bills rows read. Only the first organisation per candidate is ever used as a label and at most 50 candidates survive ranking, so nearly all of that work was discarded.

The fan-out now selects ids only, and the organisations that survive ranking are hydrated in the same step as the profiles and concurrently with them. That last part is the bit that needed care: both reads depend only on the ranked list, and doing them in sequence would have added a fourth serial wave. On D1 a round trip costs milliseconds while the row-building this avoids costs tens of microseconds, so a serial hydration would have spent the saving several times over on latency for every caller below the cap — which is nearly all of them.

- The fan-out gains a deterministic `ORDER BY (organisation_id, profile_id)`, which pins what was previously left to the planner.
- A candidate whose only basis was a shared organisation that has since been deleted is now dropped rather than returned asserting `shared_organisation` with nothing to name.

## Workspaces affected

`@osn/api`. `.changeset/olive-moons-shake.md` names it at `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#285 | `P-W` |

Closes xchromo/osn-tracker#285.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#574 | `P-W` |
| xchromo/osn-tracker#575 | `S-M` |
| xchromo/osn-tracker#576 | `C-M` |

## Decisions

### Hydrating concurrently, not serially — `P-W`

- **Issue** — the first version of this change ran the new organisations query after the profiles query, in its own wave.
- **Why** — measured in-process, the row-building it removes is worth 0.074 ms at the 2,000-row cap and 0.028 ms in the typical case. A D1 round trip is worth milliseconds. Serial hydration would have made this a net wall-clock regression for every caller not at the cap.
- **Solution** — both reads depend only on `sorted`, so they run under one `Effect.all({ concurrency: "unbounded" })`, exactly as steps 1 and 2 already do. Same number of round-trip waves as before the change.
- **Rationale** — the durable win here is rows read, not CPU. Framing it as a CPU saving is what made the extra round trip look free; naming it correctly is what stops the next person making the same trade somewhere it does not pay.

### What the `ORDER BY` actually buys — `approach`

- **Issue** — the fan-out had no `ORDER BY` under its `LIMIT`.
- **Why** — the row order was unspecified, and organisation-only candidates all tie at `mutualCount: 0`, so the ranking's tiebreak was ordering whatever the planner happened to return.
- **Solution** — order by `(organisation_id, profile_id)`, which `org_members_pair_idx` is UNIQUE on, so it is the index's own order and adds no sort.
- **Rationale** — this pins an accident rather than fixing an observed fault: `EXPLAIN QUERY PLAN` is identical with and without it, because SQLite already walked that index in that order. Worth doing on its own terms, and the commit and changeset say so rather than claiming a flake that never happened.

### Dropping a candidate with no remaining basis — `S-L`

- **Issue** — removing the inner join to `organisations` means a membership row pointing at a deleted organisation no longer disappears; it produces a candidate whose card asserts `shared_organisation` while naming none.
- **Why** — not reachable today: `deleteOrganisation` removes the membership rows and the organisation in one batch, so the intermediate state is "organisation with no members", never the reverse. But the defensive branch exists either way and may as well be right.
- **Solution** — when the label hydrates to `null` and there is no mutual connection, drop the candidate. When there is a mutual connection, keep the suggestion and drop only the label.
- **Rationale** — restores exactly what the inner join did, at the point where both facts are already in hand and without paying for the join. A card naming an organisation that no longer exists is worse than one naming none; a card whose only stated reason has evaporated should not be there at all.

### The tiebreak comment was wrong — `P-I`

- **Issue** — the ranking comment said "handle breaks ties"; the comparison has always used the profile id.
- **Why** — a reader trusting it would expect handle-alphabetical output and could "fix" a non-bug.
- **Solution** — corrected the comment. No behaviour change.
- **Rationale** — ids are the right tiebreak: unique outright, where handles are only unique per namespace, and already in the candidate map.

**Out of scope**

- The global 2,000-row budget is filled by the lowest-id organisations, so a caller in 50 organisations sees co-members from about 8 of them, permanently — xchromo/osn-tracker#574. Pre-existing; this change makes the bias deterministic rather than incidental, which is why it is now worth fixing.
- `bun:sqlite` runs without `PRAGMA foreign_keys = ON`, so tests and local development accept writes D1 rejects — xchromo/osn-tracker#575. It is why the new deleted-organisation test can construct its state at all.
- The recommender's main parameters are not disclosed anywhere, which DSA Art. 27 requires — xchromo/osn-tracker#576.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd osn/api test:run` | ✅ 1122 pass, 68 files (1117 on `main`) |
| `bun run test` (full monorepo) | ✅ 38 tasks |
| `bun run check` | ✅ 37 packages |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `scripts/validate-changesets.sh` | ✅ |

Five tests added, all mutation-checked against the exact line they cover:

| Mutation | Result |
|---|---|
| hydration ignores its map key and returns any organisation | 2 red |
| hydration always returns `null` | 3 red |
| a missing organisation yields a stale label instead of `null` | 1 red |
| the basis-less-candidate guard is removed | 1 red |

The keyed-lookup case is the one worth naming. The first version of these tests never put two live organisations in the map at once, so a mutant that ignored the key and returned whichever organisation came first passed all 1120 tests — a card wearing another organisation's name, shipping green. Two candidates in two different organisations is the smallest case that tells a keyed lookup from an unkeyed one; a third test covers the partly hydrated map, where one label survives, one candidate keeps its mutual connection but loses its label, and one loses the only basis it had.

That replaced a repeat-call test whose distinguishing assertion could not fail: the label is the minimum organisation id on both calls whatever the ordering code says.

The route suite also gains its first card carrying a non-null `sharedOrganisation`. Every other one asserts `null`, so a shape drift in the hydrated object would have surfaced as a 500 against the TypeBox response schema in production rather than as a red test.

**Not run:** the `ORDER BY` is not covered by a test and deliberately stays that way. Deleting the line leaves the whole suite green, and four separate experiments say no useful test exists: the plan is byte-identical with and without it; raw SQL over 10,000 rows returns the same order either way, before and after `ANALYZE`; through the service across 30 fresh databases the label was the minimum-`organisation_id` organisation 30 times out of 30; and in the cap-crossing case — the only one where ordering can change which rows survive — the surviving set matched the prediction 10/10 both with and without the clause. A behaviour test here would assert what the engine already guarantees, so it could only ever pass. The source comment says what the clause is for instead.

The concurrent hydration is likewise unpinned: `bun:sqlite` is synchronous, so `{ concurrency: 1 }` is indistinguishable from `{ concurrency: "unbounded" }` in this lane. The property only exists against D1, and `osn/api/src/d1-integration.test.ts` has no recommendations coverage today.

`EXPLAIN QUERY PLAN` evidence is from `bun:sqlite` (SQLite 3.51.0) against 100,000 membership rows across 400 organisations with a 50-organisation `IN` list, with and without `ANALYZE`: `SEARCH organisation_members USING COVERING INDEX org_members_pair_idx (organisation_id=?)`, no `USE TEMP B-TREE FOR ORDER BY`. That shares SQLite's planner but not D1's storage, and nothing here has been measured against a deployed Worker.
