### PR TITLE
feat(security): pin the access-token issuer in every downstream verifier

### DIFF
--- a/.changeset/shy-pumas-shave.md
+++ b/.changeset/shy-pumas-shave.md
@@ -1,0 +1,13 @@
+---
+"@shared/crypto": patch
+"@pulse/api": patch
+"@zap/api": patch
+---
+
+Enforce the access-token `issuer` claim in every downstream verifier.
+
+`@shared/osn-auth-client` has always accepted an expected `iss`, but every consumer left it unset — deliberately, because a verifier that pins the issuer rejects every token minted before osn-api started stamping one, and the rollout had to be verifier-first. Access tokens live five minutes, so that window closed long ago: every live token carries `iss`, and leaving the check off means a token from any other OSN deployment verifies here as long as it is signed by a key that deployment's JWKS vouches for.
+
+`cire/api`, `pulse/api` and `zap/api` now pass the expected issuer on every `extractClaims` call. In pulse and zap the JWKS URL and the issuer travel as one `OsnTokenVerification` value rather than two loose strings, so a call site cannot supply one and silently forget the other — which is the failure mode that left this unenforced, since an unset expected issuer is not an error, it is simply no check.
+
+`OSN_ISSUER_URL` is now required in a deployed tier and must equal osn-api's own value byte for byte; a mismatch 401s every authenticated request, so the two flip in the same deploy. `zap/api` gains the var, which it did not read before. `@shared/crypto/testing`'s signer stamps the local issuer by default, so a suite that injects a test key mints tokens its routes accept; pass a different origin, or `null`, to exercise the rejection paths.

--- a/.changeset/shy-pumas-shave.md
+++ b/.changeset/shy-pumas-shave.md
@@ -1,5 +1,7 @@
 ---
 "@shared/crypto": patch
+"@shared/osn-auth-client": patch
+"@shared/dev-urls": patch
 "@pulse/api": patch
 "@zap/api": patch
 ---
@@ -11,3 +13,5 @@ Enforce the access-token `issuer` claim in every downstream verifier.
 `cire/api`, `pulse/api` and `zap/api` now pass the expected issuer on every `extractClaims` call. In pulse and zap the JWKS URL and the issuer travel as one `OsnTokenVerification` value rather than two loose strings, so a call site cannot supply one and silently forget the other — which is the failure mode that left this unenforced, since an unset expected issuer is not an error, it is simply no check.
 
 `OSN_ISSUER_URL` is now required in a deployed tier and must equal osn-api's own value byte for byte; a mismatch 401s every authenticated request, so the two flip in the same deploy. `zap/api` gains the var, which it did not read before. `@shared/crypto/testing`'s signer stamps the local issuer by default, so a suite that injects a test key mints tokens its routes accept; pass a different origin, or `null`, to exercise the rejection paths.
+
+Three things fell out of reviewing it. `extractClaims` now treats an expected issuer that is present but **empty** as a configuration failure rather than as "no issuer check" — an unset env var reaching the verifier was the one way this could look configured while checking nothing. The comparison normalises a trailing slash on both sides, since six hand-maintained `wrangler.toml` values feed it and `jose` compares byte for byte. And `zap/api` gains `OSN_ISSUER_URL`/`OSN_JWKS_URL` in the portless devloop, which it never had — every bearer-authenticated zap route was 401ing locally, and pinning the issuer is what made that visible.

--- a/cire/api/src/app.ts
+++ b/cire/api/src/app.ts
@@ -307,6 +307,14 @@ export interface AppOptions {
   images?: ImagesBindingLike;
   /** JWKS endpoint of the OSN issuer that signs organiser access tokens. */
   osnJwksUrl?: string;
+  /**
+   * Expected `iss` on organiser access tokens — the issuer's origin, exactly
+   * as osn-api mints it. The JWKS says a key is genuine; this says the token
+   * was minted by the deployment we expect rather than another OSN install
+   * sharing the curve. `index.ts` supplies it from `OSN_ISSUER_URL`, which
+   * must equal osn-api's own value byte for byte.
+   */
+  osnIssuerUrl?: string;
   /** Expected `aud` claim on organiser access tokens. */
   osnAudience?: string;
   /** Test-only: inject the verifying key and skip the JWKS fetch. */
@@ -479,6 +487,8 @@ export function createApp(db: Db, options: AppOptions = {}) {
     assets,
     images,
     osnJwksUrl = "http://localhost:4000/.well-known/jwks.json",
+    // Matches osn-api's own local default (`osn/api/src/build-deps.ts`).
+    osnIssuerUrl = "http://localhost:4000",
     osnAudience = "osn-access",
     osnTestKey,
     oidc = null,
@@ -558,6 +568,7 @@ export function createApp(db: Db, options: AppOptions = {}) {
   // browser authenticates now that the passkey ceremony lives on musubi.social.
   const osnAuthOptions = {
     jwksUrl: osnJwksUrl,
+    issuer: osnIssuerUrl,
     audience: osnAudience,
     _testKey: osnTestKey,
     db,

--- a/cire/api/src/index.test.ts
+++ b/cire/api/src/index.test.ts
@@ -40,6 +40,7 @@ const BASE_ENV = {
   OSN_ENV: "production",
   WEB_ORIGIN: "https://app.example.com",
   OSN_JWKS_URL: "https://id.example.com/.well-known/jwks.json",
+  OSN_ISSUER_URL: "https://id.example.com",
   OSN_AUDIENCE: "osn-access",
   // Deployed-tier boots now REQUIRE the claim rate-limit binding (fail-closed);
   // supply it so these tests exercise the happy boot path, not the guard.
@@ -127,6 +128,7 @@ describe("Worker boot (no bootstrap-owner config)", () => {
       DB,
       OSN_ENV: BASE_ENV.OSN_ENV,
       OSN_JWKS_URL: BASE_ENV.OSN_JWKS_URL,
+      OSN_ISSUER_URL: BASE_ENV.OSN_ISSUER_URL,
       OSN_AUDIENCE: BASE_ENV.OSN_AUDIENCE,
       CLAIM_RATE_LIMITER: fakeRateLimiter,
     } as unknown as Parameters<NonNullable<typeof handler.fetch>>[1];

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -55,6 +55,9 @@ export interface Env {
   WEB_ORIGIN: string;
   OSN_JWKS_URL: string;
   OSN_AUDIENCE: string;
+  // `OSN_ISSUER_URL` is both the expected `iss` on organiser access tokens
+  // and the OIDC issuer origin — one value, two uses, and it must equal
+  // osn-api's own `OSN_ISSUER_URL` byte for byte.
   // Organiser sign-in over OIDC. `OSN_ISSUER_URL` is the issuer origin
   // (`https://id.musubi.social`) and must equal the `iss` claim byte-for-byte;
   // `CIRE_API_ORIGIN` is this Worker's own public origin, used to build the
@@ -63,7 +66,7 @@ export interface Env {
   // the four missing ⇒ `/api/auth/oidc/*` answers 503 and nobody can sign in;
   // the guest invite site keeps working, so this is scoped to the routes that
   // genuinely cannot function, not the whole Worker.
-  OSN_ISSUER_URL?: string;
+  OSN_ISSUER_URL: string;
   CIRE_API_ORIGIN?: string;
   CIRE_OIDC_CLIENT_ID?: string;
   CIRE_OIDC_CLIENT_SECRET?: string;
@@ -181,6 +184,11 @@ const handler: ExportedHandler<Env> = {
       !env.DB && "DB",
       !env.WEB_ORIGIN && "WEB_ORIGIN",
       !env.OSN_JWKS_URL && "OSN_JWKS_URL",
+      // Required, not optional-with-a-default. The default is the localhost
+      // issuer, so an unset value in a deployed tier would expect
+      // `http://localhost:4000` and reject every real token — a total outage
+      // whose cause is invisible in the 401. Failing at startup names it.
+      !env.OSN_ISSUER_URL && "OSN_ISSUER_URL",
       !env.OSN_AUDIENCE && "OSN_AUDIENCE",
     ].filter(Boolean);
     if (missing.length > 0 || !env.DB) {
@@ -401,6 +409,7 @@ const handler: ExportedHandler<Env> = {
         assets: env.ASSETS,
         images: env.IMAGES,
         osnJwksUrl: env.OSN_JWKS_URL,
+        osnIssuerUrl: env.OSN_ISSUER_URL,
         osnAudience: env.OSN_AUDIENCE,
         oidc,
         // Back-channel revoke endpoint: enabled only when the shared secret is

--- a/cire/api/src/local.ts
+++ b/cire/api/src/local.ts
@@ -44,6 +44,7 @@ const app = createApp(db, {
   r2,
   assets,
   osnJwksUrl: process.env.OSN_JWKS_URL,
+  osnIssuerUrl: process.env.OSN_ISSUER_URL,
   osnAudience: process.env.OSN_AUDIENCE,
 });
 

--- a/cire/api/src/routes/organiser-weddings.test.ts
+++ b/cire/api/src/routes/organiser-weddings.test.ts
@@ -110,6 +110,18 @@ describe("GET /api/organiser/weddings", () => {
     expect(res.status).toBe(401);
   });
 
+  // `iss` is pinned, so a token minted by a different OSN deployment is
+  // rejected even though its signature and audience are both fine. Signed with
+  // this suite's own key so the issuer is the only thing that differs — the
+  // wrong-key path is a separate case and would pass for the wrong reason.
+  it("returns 401 for a token from a different issuer", async () => {
+    const { app } = buildApp();
+    const res = await appRequest(app, "/api/organiser/weddings", {
+      headers: { Authorization: `Bearer ${await auth.signAsOtherIssuer(BOOTSTRAP_OWNER)}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
   it("lists only the caller's weddings", async () => {
     const { app } = buildApp();
     const res = await get(app, "/api/organiser/weddings", BOOTSTRAP_OWNER);

--- a/cire/api/src/test-helpers/osn-token.ts
+++ b/cire/api/src/test-helpers/osn-token.ts
@@ -1,16 +1,29 @@
 import { makeAccessTokenSigner } from "@shared/crypto/testing";
 
+/**
+ * The issuer these test tokens claim, matching `createApp`'s `osnIssuerUrl`
+ * default and osn-api's own local default (`osn/api/src/build-deps.ts`).
+ *
+ * It has to be stated somewhere now that `iss` is enforced: a token minted
+ * without one, or with another origin, is rejected — which is the point. A
+ * suite testing that rejection signs with a different value and expects a 401.
+ */
+export const OSN_TEST_ISSUER = "http://localhost:4000";
+
 export type OsnTestAuth = {
   /** Public verifying key — pass as `osnTestKey` to `createApp`. */
   key: CryptoKey;
   /** Mints a 5-minute ES256 access token (`aud: "osn-access"`) for `profileId`. */
   sign(profileId: string): Promise<string>;
+  /** Mints one claiming a different issuer, for the rejection path. */
+  signAsOtherIssuer(profileId: string): Promise<string>;
 };
 
 /**
  * Test-only stand-in for the OSN issuer: generates an ES256 key pair and
  * exposes the public key (for `osnTestKey` injection, skipping the JWKS
- * fetch) plus a signer that mints access tokens shaped like osn/api's.
+ * fetch) plus a signer that mints access tokens shaped like osn/api's —
+ * including the `iss` claim, which every verifier now pins.
  *
  * Thin adapter over `@shared/crypto/testing`'s `makeAccessTokenSigner` — the
  * single implementation shared with the pulse and zap route suites. The
@@ -20,6 +33,9 @@ export async function makeOsnTestAuth(): Promise<OsnTestAuth> {
   const signer = await makeAccessTokenSigner();
   return {
     key: signer.publicKey,
-    sign: (profileId: string) => signer.sign(profileId, { expiresIn: "5m" }),
+    sign: (profileId: string) =>
+      signer.sign(profileId, { expiresIn: "5m", issuer: OSN_TEST_ISSUER }),
+    signAsOtherIssuer: (profileId: string) =>
+      signer.sign(profileId, { expiresIn: "5m", issuer: "https://id.evil.invalid" }),
   };
 }

--- a/osn/api/wrangler.toml
+++ b/osn/api/wrangler.toml
@@ -46,7 +46,14 @@ OSN_ENV = "local"
 OSN_RP_ID = "localhost"
 OSN_RP_NAME = "OSN"
 OSN_ORIGIN = "http://localhost:1422,http://localhost:1420,http://localhost:4322,http://localhost:5173,http://localhost:4326,http://localhost:4321"
-OSN_ISSUER_URL = "http://localhost:8787"
+# 4000, not wrangler's default 8787. Every consumer's local expectation is
+# `http://localhost:4000` — cire's and pulse's wrangler dev blocks, all three
+# `DEFAULT_ISSUER_URL`s, `build-deps.ts`'s own fallback and the shared test
+# signer. Now that access-token verification pins the issuer, a `wrangler dev`
+# minting 8787 would 401 every cross-service call with nothing in the response
+# to say why. Run this loop as `wrangler dev --port 4000` so the URL agrees
+# with the claim.
+OSN_ISSUER_URL = "http://localhost:4000"
 OSN_CORS_ORIGIN = "http://localhost:1422,http://localhost:1420,http://localhost:4322,http://localhost:4326,http://localhost:4321"
 # Where `GET /dev/login?return_to=…` may redirect. Its own list, NOT the CORS
 # one: a redirect target need not be an origin that fetches this Worker with

--- a/pulse/api/src/app.ts
+++ b/pulse/api/src/app.ts
@@ -7,6 +7,7 @@ import type { ClientIpOptions } from "@shared/rate-limit";
 import type { Layer } from "effect";
 import { Elysia } from "elysia";
 
+import type { OsnTokenVerification } from "./lib/jwks";
 import { originGuard } from "./lib/origin-guard";
 import { makeMemoryRateLimiters, type PulseRateLimiters } from "./redis";
 import { createAccountRoutes } from "./routes/account";
@@ -29,7 +30,7 @@ export interface AppOptions {
    */
   dbLayer?: Layer.Layer<Db>;
   /** JWKS endpoint of the OSN issuer that signs access tokens. */
-  jwksUrl?: string;
+  verification?: OsnTokenVerification;
   /**
    * Rate limiter backends (W4). The composition root (`local.ts` long-lived
    * Bun host, or the per-isolate `index.ts` Worker) builds these from Redis
@@ -92,7 +93,7 @@ export interface AppOptions {
 export function createApp(options: AppOptions = {}) {
   const {
     dbLayer = DbLive,
-    jwksUrl,
+    verification,
     rateLimiters = makeMemoryRateLimiters(),
     clientIpConfig = {},
     corsOrigins,
@@ -166,7 +167,7 @@ export function createApp(options: AppOptions = {}) {
     .use(
       createEventsRoutes(
         dbLayer,
-        jwksUrl,
+        verification,
         undefined,
         discovery,
         share,
@@ -182,16 +183,16 @@ export function createApp(options: AppOptions = {}) {
       ),
     )
     .use(
-      createSeriesRoutes(dbLayer, jwksUrl, undefined, {
+      createSeriesRoutes(dbLayer, verification, undefined, {
         seriesCreate: write.series_create,
         seriesUpdate: write.series_update,
       }),
     )
-    .use(createVenuesRoutes(dbLayer, jwksUrl))
-    .use(createSettingsRoutes(dbLayer, jwksUrl))
-    .use(createCloseFriendsRoutes(dbLayer, jwksUrl, undefined, write.close_friend_mutate))
-    .use(createOnboardingRoutes(dbLayer, jwksUrl))
-    .use(createAccountRoutes(dbLayer, jwksUrl))
+    .use(createVenuesRoutes(dbLayer, verification))
+    .use(createSettingsRoutes(dbLayer, verification))
+    .use(createCloseFriendsRoutes(dbLayer, verification, undefined, write.close_friend_mutate))
+    .use(createOnboardingRoutes(dbLayer, verification))
+    .use(createAccountRoutes(dbLayer, verification))
     .use(createInternalRoutes(dbLayer));
 }
 

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect";
 
 import { createApp, type App, type AppOptions } from "./app";
 import { assertCorsOriginsConfigured, resolveCorsOrigins } from "./lib/cors-config";
+import { DEFAULT_ISSUER_URL, DEFAULT_JWKS_URL } from "./lib/jwks";
 import { buildPulseOidcConfig } from "./lib/oidc";
 import { makeMemoryRateLimiters, type PulseRateLimiters } from "./redis";
 
@@ -98,6 +99,16 @@ function buildApp(env: Env): App {
     throw new Error("OSN_JWKS_URL must be set and use HTTPS in non-local environments");
   }
 
+  // The JWKS proves a key is genuine; `iss` proves the token was minted for
+  // this deployment rather than another OSN install. Required in a deployed
+  // env for the same reason the JWKS URL is: an unset expected issuer is not
+  // a soft default, it is the check not running. It must equal osn-api's own
+  // `OSN_ISSUER_URL` byte for byte, so the two flip in the same deploy.
+  const issuerUrl = env.OSN_ISSUER_URL;
+  if (secure && (!issuerUrl || issuerUrl.startsWith("http://"))) {
+    throw new Error("OSN_ISSUER_URL must be set and use HTTPS in non-local environments");
+  }
+
   // CORS allowlist — fail closed in non-local envs where PULSE_CORS_ORIGIN is
   // unset (an empty allowlist in a secure env is a misconfiguration).
   const corsOrigins = resolveCorsOrigins({ PULSE_CORS_ORIGIN: env.PULSE_CORS_ORIGIN }, secure);
@@ -120,7 +131,10 @@ function buildApp(env: Env): App {
 
   const options: AppOptions = {
     dbLayer: makeDbD1Live(env.DB as D1Database),
-    jwksUrl,
+    verification: {
+      jwksUrl: jwksUrl ?? DEFAULT_JWKS_URL,
+      issuer: issuerUrl ?? DEFAULT_ISSUER_URL,
+    },
     rateLimiters,
     clientIpConfig: resolveClientIpConfig(env),
     corsOrigins,

--- a/pulse/api/src/index.ts
+++ b/pulse/api/src/index.ts
@@ -104,8 +104,13 @@ function buildApp(env: Env): App {
   // env for the same reason the JWKS URL is: an unset expected issuer is not
   // a soft default, it is the check not running. It must equal osn-api's own
   // `OSN_ISSUER_URL` byte for byte, so the two flip in the same deploy.
-  const issuerUrl = env.OSN_ISSUER_URL;
-  if (secure && (!issuerUrl || issuerUrl.startsWith("http://"))) {
+  // `||`, not `??`: an empty `OSN_ISSUER_URL` var is a misconfiguration, and
+  // `??` would carry the empty string straight through to the verifier. The
+  // presence check is ungated for the same reason as zap's — a tier that
+  // reads as local because its env block is incomplete must still not run
+  // with the check off.
+  const issuerUrl = env.OSN_ISSUER_URL || DEFAULT_ISSUER_URL;
+  if (secure && (!env.OSN_ISSUER_URL || issuerUrl.startsWith("http://"))) {
     throw new Error("OSN_ISSUER_URL must be set and use HTTPS in non-local environments");
   }
 
@@ -131,10 +136,7 @@ function buildApp(env: Env): App {
 
   const options: AppOptions = {
     dbLayer: makeDbD1Live(env.DB as D1Database),
-    verification: {
-      jwksUrl: jwksUrl ?? DEFAULT_JWKS_URL,
-      issuer: issuerUrl ?? DEFAULT_ISSUER_URL,
-    },
+    verification: { jwksUrl: jwksUrl || DEFAULT_JWKS_URL, issuer: issuerUrl },
     rateLimiters,
     clientIpConfig: resolveClientIpConfig(env),
     corsOrigins,

--- a/pulse/api/src/lib/caller.ts
+++ b/pulse/api/src/lib/caller.ts
@@ -5,6 +5,7 @@ import { Effect, type ManagedRuntime } from "effect";
 import { metricCallerAuth } from "../metrics";
 import { webSessionService } from "../services/webSession";
 import { parseWebSessionToken } from "./cookie";
+import type { OsnTokenVerification } from "./jwks";
 
 /**
  * Resolve the caller of a Pulse request from either credential.
@@ -33,22 +34,26 @@ export interface CallerResolverOptions {
   /** The route factory's own runtime — the cookie lookup needs `Db`. */
   runtime: ManagedRuntime.ManagedRuntime<Db, never>;
   /** JWKS endpoint of the OSN issuer that signs access tokens. */
-  jwksUrl: string;
+  verification: OsnTokenVerification;
   /** Injected verifying key for tests (skips the JWKS fetch). */
   testKey?: CryptoKey | undefined;
 }
 
 export function makeCallerResolver({
   runtime,
-  jwksUrl,
+  verification,
   testKey,
 }: CallerResolverOptions): ResolveCaller {
   return async (headers) => {
     const authorization = headers["authorization"];
     if (authorization) {
-      const claims = await extractClaims(authorization, jwksUrl, {
+      const claims = await extractClaims(authorization, verification.jwksUrl, {
         testKey: testKey as CryptoKey,
         audience: "osn-access",
+        // Enforced, not optional. A token signed by a different OSN
+        // deployment verifies against its own JWKS perfectly well; `iss` is
+        // the only claim that says it was minted for this one.
+        issuer: verification.issuer,
       });
       metricCallerAuth("bearer", claims ? "ok" : "rejected");
       return claims;

--- a/pulse/api/src/lib/jwks.ts
+++ b/pulse/api/src/lib/jwks.ts
@@ -1,2 +1,31 @@
+/**
+ * Where the access-token signing keys live, and who must have signed them.
+ *
+ * The two travel together because neither is sufficient alone: the JWKS says a
+ * key is genuine, `iss` says the token came from the deployment we expect
+ * rather than any other OSN install sharing the curve. Bundling them means a
+ * call site cannot supply one and silently forget the other — the failure mode
+ * that kept `iss` unenforced, since an unset expected issuer is not an error,
+ * it is simply no check at all.
+ */
+export interface OsnTokenVerification {
+  /** Full JWKS URL of the OSN issuer. */
+  readonly jwksUrl: string;
+  /** Expected `iss` claim — the issuer's origin, exactly as osn-api mints it. */
+  readonly issuer: string;
+}
+
 export const DEFAULT_JWKS_URL =
   process.env.OSN_JWKS_URL ?? "http://localhost:4000/.well-known/jwks.json";
+
+/**
+ * Must match `AuthConfig.issuerUrl` in the osn-api this verifies against,
+ * byte for byte. The default matches osn-api's own local default
+ * (`osn/api/src/build-deps.ts`); a deployed environment always sets it.
+ */
+export const DEFAULT_ISSUER_URL = process.env.OSN_ISSUER_URL ?? "http://localhost:4000";
+
+export const DEFAULT_VERIFICATION: OsnTokenVerification = {
+  jwksUrl: DEFAULT_JWKS_URL,
+  issuer: DEFAULT_ISSUER_URL,
+};

--- a/pulse/api/src/local.ts
+++ b/pulse/api/src/local.ts
@@ -28,6 +28,14 @@ if (nonLocal && jwksUrl.startsWith("http://")) {
   throw new Error("OSN_JWKS_URL must use HTTPS in non-local environments");
 }
 
+// Same treatment for the expected `iss`: pinning it is what stops a token
+// from another OSN deployment verifying here, and a plaintext issuer in a
+// deployed tier is the same misconfiguration as a plaintext JWKS URL.
+const issuerUrl = process.env.OSN_ISSUER_URL ?? "http://localhost:4000";
+if (nonLocal && issuerUrl.startsWith("http://")) {
+  throw new Error("OSN_ISSUER_URL must use HTTPS in non-local environments");
+}
+
 // ---------------------------------------------------------------------------
 // Redis composition root — env-driven backend selection (mirrors osn/api).
 // `REDIS_URL` set → Redis-backed limiters (shared across processes, survives
@@ -91,7 +99,7 @@ if (nonLocal && !oidc) {
 }
 
 const appOptions: AppOptions = {
-  jwksUrl,
+  verification: { jwksUrl, issuer: issuerUrl },
   rateLimiters,
   clientIpConfig,
   corsOrigins,

--- a/pulse/api/src/routes/account.ts
+++ b/pulse/api/src/routes/account.ts
@@ -3,7 +3,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { makeCallerResolver } from "../lib/caller";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { notifyAppLeft, verifyStepUp } from "../lib/osn-bridge";
 import {
   metricPulseAccountDeletionRequested,
@@ -30,12 +30,12 @@ import * as accountErasure from "../services/accountErasure";
  */
 export const createAccountRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   return new Elysia({ prefix: "/account" })
     .delete(
       "",

--- a/pulse/api/src/routes/closeFriends.ts
+++ b/pulse/api/src/routes/closeFriends.ts
@@ -4,7 +4,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { makeCallerResolver } from "../lib/caller";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { checkWriteRateLimit, createDefaultWriteRateLimiter } from "../lib/rate-limit";
 import {
   addCloseFriend,
@@ -30,7 +30,7 @@ import { getConnectionIds, getProfileDisplays } from "../services/graphBridge";
  */
 export const createCloseFriendsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
   /**
    * Per-USER limiter (keyed on `claims.profileId`) shared by the add +
@@ -41,7 +41,7 @@ export const createCloseFriendsRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   return new Elysia({ prefix: "/close-friends" })
     .get(
       "/",

--- a/pulse/api/src/routes/events.ts
+++ b/pulse/api/src/routes/events.ts
@@ -13,7 +13,7 @@ import { Elysia, t } from "elysia";
 import { validateBbox } from "../lib/bbox";
 import { makeCallerResolver } from "../lib/caller";
 import { MAX_PRICE_MAJOR } from "../lib/currency";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { MAX_EVENT_GUESTS } from "../lib/limits";
 import { checkWriteRateLimit, createDefaultWriteRateLimiter } from "../lib/rate-limit";
 import { shareSourceTypeBox, type ShareSource } from "../lib/shareSource";
@@ -309,7 +309,7 @@ export function createDefaultExposureRateLimiter(): RateLimiterBackend {
 
 export const createEventsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
   /**
    * Per-IP rate limiter for `GET /events/discover`. Defaults to the in-memory
@@ -356,7 +356,7 @@ export const createEventsRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   const eventCreateLimiter =
     writeRateLimiters.eventCreate ?? createDefaultWriteRateLimiter("event_create");
   const eventUpdateLimiter =

--- a/pulse/api/src/routes/onboarding.ts
+++ b/pulse/api/src/routes/onboarding.ts
@@ -4,7 +4,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { makeCallerResolver } from "../lib/caller";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import {
   completeOnboarding,
   getOnboardingStatus,
@@ -115,14 +115,14 @@ const toWire = (status: OnboardingStatus): OnboardingStatusWire => ({
  */
 export const createOnboardingRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
   completeRateLimiter: RateLimiterBackend = createDefaultOnboardingCompleteRateLimiter(),
   statusRateLimiter: RateLimiterBackend = createDefaultOnboardingStatusRateLimiter(),
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   return new Elysia({ prefix: "/me/onboarding" })
     .get(
       "/",

--- a/pulse/api/src/routes/series.ts
+++ b/pulse/api/src/routes/series.ts
@@ -5,7 +5,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { makeCallerResolver } from "../lib/caller";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { checkWriteRateLimit, createDefaultWriteRateLimiter } from "../lib/rate-limit";
 import { canViewEvent } from "../services/eventAccess";
 import {
@@ -87,7 +87,7 @@ const rruleInvalidReasonEnum = t.Union([
 
 export const createSeriesRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
   /**
    * Per-USER write limiters keyed on `claims.profileId` (W4). Defaults are
@@ -100,7 +100,7 @@ export const createSeriesRoutes = (
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   const seriesCreateLimiter =
     writeRateLimiters.seriesCreate ?? createDefaultWriteRateLimiter("series_create");
   const seriesUpdateLimiter =

--- a/pulse/api/src/routes/settings.ts
+++ b/pulse/api/src/routes/settings.ts
@@ -3,7 +3,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { makeCallerResolver } from "../lib/caller";
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { metricSettingsUpdated } from "../metrics";
 import { updateSettings } from "../services/pulseUsers";
 
@@ -16,12 +16,12 @@ import { updateSettings } from "../services/pulseUsers";
  */
 export const createSettingsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
 ) => {
   // Layer graph built once per factory (convention: see osn/api/src/lib/route-runtime.ts) — not per request.
   const runtime = ManagedRuntime.make(dbLayer);
-  const resolveCaller = makeCallerResolver({ runtime, jwksUrl, testKey: _testKey });
+  const resolveCaller = makeCallerResolver({ runtime, verification, testKey: _testKey });
   return new Elysia({ prefix: "/me" }).patch(
     "/settings",
     async ({ body, headers, set }) => {

--- a/pulse/api/src/routes/venues.ts
+++ b/pulse/api/src/routes/venues.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
 import { validateBbox } from "../lib/bbox";
+import type { OsnTokenVerification } from "../lib/jwks";
 import { metricEventAccessDenied } from "../metrics";
 import { loadVisibleEvent } from "../services/eventAccess";
 import { getVenue, listAllVenues, listEventLineup, listVenueEvents } from "../services/venues";
@@ -163,7 +164,9 @@ export const createVenuesRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
   // Auth params kept for symmetry with sibling route factories — venue
   // surfaces are public so we don't currently extract claims.
-  _jwksUrl: string = "",
+  // Unused: venues has no authenticated route. Kept so every route
+  // factory in this package has the same positional shape.
+  _verification: OsnTokenVerification | string = "",
   _testKey?: CryptoKey,
   /**
    * Per-IP rate limiter for the /venues group. Defaults to the in-memory

--- a/pulse/api/src/routes/venues.ts
+++ b/pulse/api/src/routes/venues.ts
@@ -166,7 +166,7 @@ export const createVenuesRoutes = (
   // surfaces are public so we don't currently extract claims.
   // Unused: venues has no authenticated route. Kept so every route
   // factory in this package has the same positional shape.
-  _verification: OsnTokenVerification | string = "",
+  _verification?: OsnTokenVerification,
   _testKey?: CryptoKey,
   /**
    * Per-IP rate limiter for the /venues group. Defaults to the in-memory

--- a/pulse/api/tests/helpers/verification.ts
+++ b/pulse/api/tests/helpers/verification.ts
@@ -1,0 +1,21 @@
+import { LOCAL_TEST_ISSUER } from "@shared/crypto/testing";
+
+/**
+ * The token-verification config the route suites hand their factories.
+ *
+ * A literal, deliberately — not `DEFAULT_VERIFICATION` from `src/lib/jwks.ts`,
+ * whose issuer is `process.env.OSN_ISSUER_URL` read at module load. Under
+ * `dev-env` that variable is exported, so importing the production default
+ * would make these suites expect the portless issuer while
+ * `makeAccessTokenSigner` stamps the local one: every authenticated test 401s,
+ * and the ones asserting 401 pass for entirely the wrong reason. A test that
+ * cannot fail is worse than no test when the rejection path is the point.
+ *
+ * `jwksUrl` is empty because every suite injects a verifying key and never
+ * fetches. The issuer is the half that matters, and it matches what the shared
+ * signer mints by default.
+ */
+export const TEST_VERIFICATION = {
+  jwksUrl: "",
+  issuer: LOCAL_TEST_ISSUER,
+} as const;

--- a/pulse/api/tests/lib/caller.test.ts
+++ b/pulse/api/tests/lib/caller.test.ts
@@ -1,5 +1,9 @@
 import type { Db } from "@pulse/db/service";
-import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/testing";
+import {
+  LOCAL_TEST_ISSUER,
+  makeAccessTokenSigner,
+  type AccessTokenSigner,
+} from "@shared/crypto/testing";
 import { ManagedRuntime } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -8,7 +12,12 @@ import { webSessionService, type WebIdentity } from "../../src/services/webSessi
 import { createTestLayer } from "../helpers/db";
 
 // The JWKS URL is never fetched: every verify path here is given `testKey`.
-const JWKS_URL = "http://localhost:4000/.well-known/jwks.json";
+const VERIFICATION = {
+  jwksUrl: "http://localhost:4000/.well-known/jwks.json",
+  // Matches what `makeAccessTokenSigner` stamps by default, so a
+  // token minted here is one these routes accept.
+  issuer: LOCAL_TEST_ISSUER,
+};
 
 const identity: WebIdentity = {
   osnProfileId: "usr_alice",
@@ -33,7 +42,7 @@ beforeEach(() => {
   runtime = ManagedRuntime.make(createTestLayer());
   resolveCaller = makeCallerResolver({
     runtime,
-    jwksUrl: JWKS_URL,
+    verification: VERIFICATION,
     testKey: signer.publicKey,
   });
 });

--- a/pulse/api/tests/routes/account.test.ts
+++ b/pulse/api/tests/routes/account.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../src/lib/osn-bridge", () => ({
   notifyAppLeft: vi.fn(() => Effect.succeed({ closed: true } as const)),
 }));
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createAccountRoutes } from "../../src/routes/account";
 
 let signer: AccessTokenSigner;
@@ -33,7 +34,7 @@ beforeAll(async () => {
 const makeToken = (profileId: string) => signer.sign(profileId);
 
 function makeApp() {
-  return createAccountRoutes(createTestLayer(), "http://unused.test/jwks", testPublicKey);
+  return createAccountRoutes(createTestLayer(), TEST_VERIFICATION, testPublicKey);
 }
 
 describe("account routes — auth gates", () => {

--- a/pulse/api/tests/routes/account.test.ts
+++ b/pulse/api/tests/routes/account.test.ts
@@ -20,8 +20,8 @@ vi.mock("../../src/lib/osn-bridge", () => ({
   notifyAppLeft: vi.fn(() => Effect.succeed({ closed: true } as const)),
 }));
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createAccountRoutes } from "../../src/routes/account";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
 let testPublicKey: CryptoKey;

--- a/pulse/api/tests/routes/attendees.test.ts
+++ b/pulse/api/tests/routes/attendees.test.ts
@@ -2,10 +2,10 @@ import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/te
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { canViewAttendees } from "../../src/services/eventAccess";
 import { createTestLayer, seedEvent } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
 let testPublicKey: CryptoKey;

--- a/pulse/api/tests/routes/attendees.test.ts
+++ b/pulse/api/tests/routes/attendees.test.ts
@@ -2,6 +2,7 @@ import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/te
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { canViewAttendees } from "../../src/services/eventAccess";
 import { createTestLayer, seedEvent } from "../helpers/db";
@@ -39,7 +40,7 @@ describe("GET /events/:id/rsvps — additive canViewAttendees flag", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     const event = await Effect.runPromise(
       seedEvent({
         title: "Public",

--- a/pulse/api/tests/routes/calendar.test.ts
+++ b/pulse/api/tests/routes/calendar.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(),
 }));
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
@@ -82,7 +83,7 @@ describe("GET /events/calendar", () => {
     vi.mocked(bridge.getProfileDisplays).mockReturnValue(
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
-    app = createEventsRoutes(createTestLayer(), "", testPublicKey);
+    app = createEventsRoutes(createTestLayer(), TEST_VERIFICATION, testPublicKey);
     meToken = await makeToken("usr_me");
     aliceToken = await makeToken("usr_alice");
   });
@@ -141,7 +142,7 @@ describe("GET /events/calendar", () => {
   });
 
   it("returns 500 when the calendar query fails", async () => {
-    const brokenApp = createEventsRoutes(brokenLayer(), "", testPublicKey);
+    const brokenApp = createEventsRoutes(brokenLayer(), TEST_VERIFICATION, testPublicKey);
     const res = await get(brokenApp, "/events/calendar", meToken);
     expect(res.status).toBe(500);
   });

--- a/pulse/api/tests/routes/calendar.test.ts
+++ b/pulse/api/tests/routes/calendar.test.ts
@@ -24,8 +24,8 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(),
 }));
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
 const LATER = "2030-06-02T10:00:00.000Z";

--- a/pulse/api/tests/routes/closeFriends.test.ts
+++ b/pulse/api/tests/routes/closeFriends.test.ts
@@ -14,8 +14,8 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(() => Effect.succeed(new Map())),
 }));
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
 let testPublicKey: CryptoKey;

--- a/pulse/api/tests/routes/closeFriends.test.ts
+++ b/pulse/api/tests/routes/closeFriends.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(() => Effect.succeed(new Map())),
 }));
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
 
 let signer: AccessTokenSigner;
@@ -54,7 +55,7 @@ describe("close-friends routes", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    app = createCloseFriendsRoutes(layer, "", testPublicKey);
+    app = createCloseFriendsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     vi.mocked(bridge.getConnectionIds).mockReturnValue(Effect.succeed(new Set()));
     vi.mocked(bridge.getProfileDisplays).mockReturnValue(Effect.succeed(new Map()));

--- a/pulse/api/tests/routes/discover.test.ts
+++ b/pulse/api/tests/routes/discover.test.ts
@@ -3,6 +3,7 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
 
@@ -47,7 +48,7 @@ describe("GET /events/discover", () => {
     layer = createTestLayer();
     app = createEventsRoutes(
       layer,
-      "",
+      TEST_VERIFICATION,
       testPublicKey,
       allowAllLimiter,
       undefined,
@@ -130,7 +131,7 @@ describe("GET /events/discover", () => {
     const blockingLimiter: RateLimiterBackend = { check: () => false };
     const blockedApp = createEventsRoutes(
       layer,
-      "",
+      TEST_VERIFICATION,
       testPublicKey,
       blockingLimiter,
       undefined,
@@ -151,7 +152,7 @@ describe("GET /events/discover", () => {
     };
     const failedApp = createEventsRoutes(
       layer,
-      "",
+      TEST_VERIFICATION,
       testPublicKey,
       failingLimiter,
       undefined,

--- a/pulse/api/tests/routes/discover.test.ts
+++ b/pulse/api/tests/routes/discover.test.ts
@@ -3,9 +3,9 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 /**
  * Permissive rate limiter for tests — never trips. Real per-IP limiter

--- a/pulse/api/tests/routes/events.new.test.ts
+++ b/pulse/api/tests/routes/events.new.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(),
 }));
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
@@ -82,7 +83,7 @@ describe("events routes — new config fields", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -186,7 +187,7 @@ describe("RSVP routes", () => {
       ),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
     const res = await post(app, "/events", { title: "Party", startTime: FUTURE }, aliceToken);
@@ -322,9 +323,18 @@ describe("Share-attribution routes", () => {
     // `app.handle(...)` there is no socket peer, so we declare a single
     // trusted proxy and feed a stable `x-forwarded-for` so the limiter can
     // resolve a keying IP (matches the osn/api auth-route test convention).
-    app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, undefined, {
-      trustedProxyCount: 1,
-    });
+    app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        trustedProxyCount: 1,
+      },
+    );
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
     const res = await post(app, "/events", { title: "Party", startTime: FUTURE }, aliceToken);
@@ -414,7 +424,7 @@ describe("ICS route", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -556,7 +566,7 @@ describe("Comms routes", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
     const res = await post(
@@ -647,7 +657,7 @@ describe("Private event visibility gate", () => {
       ),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
 
@@ -802,7 +812,7 @@ describe("Event text field length caps (S-M3)", () => {
       Effect.succeed(new Map<string, ProfileDisplay>()),
     );
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -854,7 +864,7 @@ describe("PATCH /me/settings", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    settingsApp = createSettingsRoutes(layer, "", testPublicKey);
+    settingsApp = createSettingsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 

--- a/pulse/api/tests/routes/events.new.test.ts
+++ b/pulse/api/tests/routes/events.new.test.ts
@@ -16,8 +16,8 @@ vi.mock("../../src/services/graphBridge", () => ({
   getProfileDisplays: vi.fn(),
 }));
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
 

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -2,9 +2,9 @@ import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/te
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 const FUTURE = "2030-06-01T10:00:00.000Z";
 

--- a/pulse/api/tests/routes/events.test.ts
+++ b/pulse/api/tests/routes/events.test.ts
@@ -2,6 +2,7 @@ import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/te
 import { Effect } from "effect";
 import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
 
@@ -65,7 +66,7 @@ describe("events routes", () => {
 
   beforeEach(async () => {
     layer = createTestLayer();
-    app = createEventsRoutes(layer, "", testPublicKey);
+    app = createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
   });
 
@@ -88,6 +89,24 @@ describe("events routes", () => {
 
   it("POST /events returns 401 when not authenticated", async () => {
     const res = await post(app, "/events", { title: "Concert", startTime: FUTURE });
+    expect(res.status).toBe(401);
+  });
+
+  // `iss` is pinned, so a token minted by a different OSN deployment is
+  // rejected even though its signature and audience are both fine — signed
+  // with this suite's own key so the issuer is the only difference.
+  it("POST /events returns 401 for a token from a different issuer", async () => {
+    const foreign = await signer.sign("usr_alice", { issuer: "https://id.evil.invalid" });
+    const res = await post(app, "/events", { title: "Concert", startTime: FUTURE }, foreign);
+    expect(res.status).toBe(401);
+  });
+
+  // The pre-enforcement shape: tokens minted before osn-api stamped `iss`.
+  // Every one of those expired within five minutes of that rollout, so a
+  // token arriving without one today is a forgery or a misconfiguration.
+  it("POST /events returns 401 for a token carrying no issuer", async () => {
+    const noIssuer = await signer.sign("usr_alice", { issuer: null });
+    const res = await post(app, "/events", { title: "Concert", startTime: FUTURE }, noIssuer);
     expect(res.status).toBe(401);
   });
 

--- a/pulse/api/tests/routes/onboarding.test.ts
+++ b/pulse/api/tests/routes/onboarding.test.ts
@@ -25,8 +25,8 @@ vi.mock("../../src/lib/osn-bridge", () => ({
   notifyAppJoined: vi.fn(() => Effect.succeed({ enrolled: true } as const)),
 }));
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
 let testPublicKey: CryptoKey;

--- a/pulse/api/tests/routes/onboarding.test.ts
+++ b/pulse/api/tests/routes/onboarding.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../src/lib/osn-bridge", () => ({
   notifyAppJoined: vi.fn(() => Effect.succeed({ enrolled: true } as const)),
 }));
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import * as bridge from "../../src/services/graphBridge";
 
 let signer: AccessTokenSigner;
@@ -75,7 +76,7 @@ describe("onboarding routes", () => {
 
   beforeEach(async () => {
     const layer = createTestLayer();
-    app = createOnboardingRoutes(layer, "", testPublicKey);
+    app = createOnboardingRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     vi.mocked(bridge.getAccountIdForProfile).mockReturnValue(Effect.succeed("acc_alice"));
   });
@@ -241,7 +242,7 @@ describe("onboarding routes", () => {
       check: () => Promise.resolve(false),
       reset: () => Promise.resolve(),
     };
-    const denyApp = createOnboardingRoutes(layer, "", testPublicKey, denyAll);
+    const denyApp = createOnboardingRoutes(layer, TEST_VERIFICATION, testPublicKey, denyAll);
     const res = await post(denyApp, "/me/onboarding/complete", validBody, aliceToken);
     expect(res.status).toBe(429);
   });
@@ -250,7 +251,13 @@ describe("onboarding routes", () => {
     const layer = createTestLayer();
     const allowAll = { check: () => Promise.resolve(true), reset: () => Promise.resolve() };
     const denyAll = { check: () => Promise.resolve(false), reset: () => Promise.resolve() };
-    const denyApp = createOnboardingRoutes(layer, "", testPublicKey, allowAll, denyAll);
+    const denyApp = createOnboardingRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      allowAll,
+      denyAll,
+    );
     const res = await get(denyApp, "/me/onboarding", aliceToken);
     expect(res.status).toBe(429);
   });
@@ -262,7 +269,13 @@ describe("onboarding routes", () => {
       check: () => Promise.reject(new Error("backend down")),
       reset: () => Promise.resolve(),
     };
-    const failApp = createOnboardingRoutes(layer, "", testPublicKey, allowAll, throwing);
+    const failApp = createOnboardingRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      allowAll,
+      throwing,
+    );
     const res = await get(failApp, "/me/onboarding", aliceToken);
     expect(res.status).toBe(429);
   });

--- a/pulse/api/tests/routes/series.test.ts
+++ b/pulse/api/tests/routes/series.test.ts
@@ -1,6 +1,7 @@
 import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/testing";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createSeriesRoutes } from "../../src/routes/series";
 import { createTestLayer } from "../helpers/db";
 
@@ -56,7 +57,7 @@ describe("series routes", () => {
 
   beforeEach(async () => {
     const layer = createTestLayer();
-    app = createSeriesRoutes(layer, "", testPublicKey);
+    app = createSeriesRoutes(layer, TEST_VERIFICATION, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
   });

--- a/pulse/api/tests/routes/series.test.ts
+++ b/pulse/api/tests/routes/series.test.ts
@@ -1,9 +1,9 @@
 import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/testing";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createSeriesRoutes } from "../../src/routes/series";
 import { createTestLayer } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
 let testPublicKey: CryptoKey;

--- a/pulse/api/tests/routes/shareExposureRateLimit.test.ts
+++ b/pulse/api/tests/routes/shareExposureRateLimit.test.ts
@@ -3,6 +3,7 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
 
@@ -61,7 +62,8 @@ const buildApp = (
   layer: ReturnType<typeof createTestLayer>,
   share: RateLimiterBackend,
   exposure: RateLimiterBackend,
-) => createEventsRoutes(layer, "", testPublicKey, allow, share, exposure, {}, PROXIED);
+) =>
+  createEventsRoutes(layer, TEST_VERIFICATION, testPublicKey, allow, share, exposure, {}, PROXIED);
 
 describe("P4 — per-IP share / exposure rate limiting", () => {
   let layer: ReturnType<typeof createTestLayer>;

--- a/pulse/api/tests/routes/shareExposureRateLimit.test.ts
+++ b/pulse/api/tests/routes/shareExposureRateLimit.test.ts
@@ -3,9 +3,9 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createTestLayer, seedEvent } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 /**
  * P4: per-IP rate limiting on the unauthenticated share / exposure pings,

--- a/pulse/api/tests/routes/venues.test.ts
+++ b/pulse/api/tests/routes/venues.test.ts
@@ -525,7 +525,7 @@ describe("venue routes", () => {
   it("returns 429 once the per-IP rate limit is exhausted", async () => {
     const layer = createTestLayer();
     const limiter = createRateLimiter({ maxRequests: 2, windowMs: 60_000 });
-    app = createVenuesRoutes(layer, "", undefined, limiter);
+    app = createVenuesRoutes(layer, undefined, undefined, limiter);
 
     expect((await get(app, "/venues")).status).toBe(200);
     expect((await get(app, "/venues")).status).toBe(200);

--- a/pulse/api/tests/routes/writeRateLimit.test.ts
+++ b/pulse/api/tests/routes/writeRateLimit.test.ts
@@ -3,11 +3,11 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createCloseFriendsRoutes } from "../../src/routes/closeFriends";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createSeriesRoutes } from "../../src/routes/series";
 import { createTestLayer, seedEvent } from "../helpers/db";
+import { TEST_VERIFICATION } from "../helpers/verification";
 
 const block: RateLimiterBackend = { check: () => false };
 const throws: RateLimiterBackend = {

--- a/pulse/api/tests/routes/writeRateLimit.test.ts
+++ b/pulse/api/tests/routes/writeRateLimit.test.ts
@@ -3,6 +3,7 @@ import type { RateLimiterBackend } from "@shared/rate-limit";
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_VERIFICATION as TEST_VERIFICATION } from "../../src/lib/jwks";
 import { createCloseFriendsRoutes } from "../../src/routes/closeFriends";
 import { createEventsRoutes } from "../../src/routes/events";
 import { createSeriesRoutes } from "../../src/routes/series";
@@ -55,17 +56,33 @@ describe("per-user write rate limiting → 429", () => {
   });
 
   it("event create returns 429 when the limiter blocks", async () => {
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      eventCreate: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        eventCreate: block,
+      },
+    );
     const res = await send(app, "POST", "/events", token, { title: "X", startTime: FUTURE });
     expect(res.status).toBe(429);
   });
 
   it("event create fails closed (429) when the limiter throws", async () => {
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      eventCreate: throws,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        eventCreate: throws,
+      },
+    );
     const res = await send(app, "POST", "/events", token, { title: "X", startTime: FUTURE });
     expect(res.status).toBe(429);
   });
@@ -76,9 +93,17 @@ describe("per-user write rate limiting → 429", () => {
         Effect.provide(layer),
       ),
     );
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      eventUpdate: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        eventUpdate: block,
+      },
+    );
     const res = await send(app, "PATCH", `/events/${event.id}`, token, { title: "Y" });
     expect(res.status).toBe(429);
   });
@@ -87,9 +112,17 @@ describe("per-user write rate limiting → 429", () => {
     const event = await Effect.runPromise(
       seedEvent({ title: "E", startTime: FUTURE }).pipe(Effect.provide(layer)),
     );
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      rsvpUpsert: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        rsvpUpsert: block,
+      },
+    );
     const res = await send(app, "POST", `/events/${event.id}/rsvps`, token, { status: "going" });
     expect(res.status).toBe(429);
   });
@@ -100,9 +133,17 @@ describe("per-user write rate limiting → 429", () => {
         Effect.provide(layer),
       ),
     );
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      eventInvite: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        eventInvite: block,
+      },
+    );
     const res = await send(app, "POST", `/events/${event.id}/invite`, token, {
       profileIds: ["usr_bob"],
     });
@@ -115,9 +156,17 @@ describe("per-user write rate limiting → 429", () => {
         Effect.provide(layer),
       ),
     );
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      commsBlast: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        commsBlast: block,
+      },
+    );
     const res = await send(app, "POST", `/events/${event.id}/comms/blasts`, token, {
       channels: ["email"],
       body: "hi",
@@ -126,7 +175,9 @@ describe("per-user write rate limiting → 429", () => {
   });
 
   it("series create returns 429 when the limiter blocks", async () => {
-    const app = createSeriesRoutes(layer, "", testPublicKey, { seriesCreate: block });
+    const app = createSeriesRoutes(layer, TEST_VERIFICATION, testPublicKey, {
+      seriesCreate: block,
+    });
     const res = await send(app, "POST", "/series", token, {
       title: "S",
       rrule: "FREQ=WEEKLY;COUNT=3",
@@ -136,27 +187,37 @@ describe("per-user write rate limiting → 429", () => {
   });
 
   it("series patch returns 429 when the limiter blocks", async () => {
-    const app = createSeriesRoutes(layer, "", testPublicKey, { seriesUpdate: block });
+    const app = createSeriesRoutes(layer, TEST_VERIFICATION, testPublicKey, {
+      seriesUpdate: block,
+    });
     const res = await send(app, "PATCH", "/series/ser_nope", token, { title: "T" });
     expect(res.status).toBe(429);
   });
 
   it("close-friend add returns 429 when the limiter blocks", async () => {
-    const app = createCloseFriendsRoutes(layer, "", testPublicKey, block);
+    const app = createCloseFriendsRoutes(layer, TEST_VERIFICATION, testPublicKey, block);
     const res = await send(app, "POST", "/close-friends/usr_bob", token);
     expect(res.status).toBe(429);
   });
 
   it("close-friend remove fails closed (429) when the limiter throws", async () => {
-    const app = createCloseFriendsRoutes(layer, "", testPublicKey, throws);
+    const app = createCloseFriendsRoutes(layer, TEST_VERIFICATION, testPublicKey, throws);
     const res = await send(app, "DELETE", "/close-friends/usr_bob", token);
     expect(res.status).toBe(429);
   });
 
   it("does not rate-limit before authenticating (401 wins for anon)", async () => {
-    const app = createEventsRoutes(layer, "", testPublicKey, undefined, undefined, undefined, {
-      eventCreate: block,
-    });
+    const app = createEventsRoutes(
+      layer,
+      TEST_VERIFICATION,
+      testPublicKey,
+      undefined,
+      undefined,
+      undefined,
+      {
+        eventCreate: block,
+      },
+    );
     const res = await app.handle(
       new Request("http://localhost/events", {
         method: "POST",

--- a/pulse/api/wrangler.toml
+++ b/pulse/api/wrangler.toml
@@ -39,9 +39,11 @@ migrations_dir = "../db/drizzle"
 
 [env.staging.vars]
 OSN_ENV = "staging"
-# TODO: real OSN issuer origin before staging deploy
-OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
-OSN_ISSUER_URL = "https://osn-api.example.com"
+# Mirrors osn-api's own staging value, which is itself a placeholder until the
+# staging tier is real. Both move together: the verifier's expected issuer has
+# to equal what osn-api mints or every authenticated request 401s.
+OSN_JWKS_URL = "https://api.staging.osn.example/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://api.staging.osn.example"
 # TODO: set once the Pulse domain is chosen. Must be same-site with the Pulse
 # web origin (`api.<pulse-domain>`) — the session cookie is host-scoped and
 # `SameSite=Lax`, so a cross-site API host is never sent one.
@@ -59,9 +61,12 @@ migrations_dir = "../db/drizzle"
 
 [env.production.vars]
 OSN_ENV = "production"
-# TODO: real OSN issuer origin before prod deploy
-OSN_JWKS_URL = "https://osn-api.example.com/.well-known/jwks.json"
-OSN_ISSUER_URL = "https://osn-api.example.com"
+# The OSN issuer is known regardless of which domain Pulse itself ends up on,
+# so these are real, not placeholders. OSN_ISSUER_URL must equal osn-api's own
+# value byte for byte — access-token verification pins it, and a mismatch 401s
+# every authenticated request — so the two flip in the same deploy.
+OSN_JWKS_URL = "https://id.musubi.social/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://id.musubi.social"
 # TODO: set once the Pulse domain is chosen. Must be same-site with the Pulse
 # web origin (`api.<pulse-domain>`) — the session cookie is host-scoped and
 # `SameSite=Lax`, so a cross-site API host is never sent one.

--- a/shared/crypto/src/testing.ts
+++ b/shared/crypto/src/testing.ts
@@ -17,6 +17,16 @@ import { generateArcKeyPair } from "./jwk";
  * `@shared/crypto/testing`.
  */
 
+/**
+ * The `iss` these tokens carry unless a caller says otherwise.
+ *
+ * Matches osn-api's own local default (`osn/api/src/build-deps.ts`) and the
+ * default every downstream verifier falls back to, so a suite that injects a
+ * test key and leaves the verification config alone mints tokens its routes
+ * accept. Deployed tiers set both sides from `OSN_ISSUER_URL`.
+ */
+export const LOCAL_TEST_ISSUER = "http://localhost:4000";
+
 /** Claims a caller can vary per token. Everything else is fixed by the verifier contract. */
 export interface AccessTokenClaims {
   /** Optional `email` claim — some routes read it for profile bootstrapping. */
@@ -30,8 +40,14 @@ export interface AccessTokenClaims {
    * ±30s `clockTolerance`) to exercise the expired-token reject path.
    */
   expiresIn?: string;
-  /** Set an `iss` claim — cire pins the issuer, other verifiers ignore it. */
-  issuer?: string;
+  /**
+   * Override the `iss` claim. Defaults to `LOCAL_TEST_ISSUER`, because every
+   * downstream verifier now pins the issuer and a token minted without one is
+   * rejected — which is the whole point. Pass a different origin to exercise
+   * that rejection; pass `null` for a token carrying no `iss` at all, the
+   * shape that existed before osn-api stamped it.
+   */
+  issuer?: string | null;
   /** Override the `kid` header to exercise key-mismatch paths. */
   kid?: string;
 }
@@ -67,7 +83,8 @@ export async function makeAccessTokenSigner(): Promise<AccessTokenSigner> {
         .setIssuedAt()
         .setExpirationTime(claims.expiresIn ?? "5m");
 
-      if (claims.issuer !== undefined) jwt = jwt.setIssuer(claims.issuer);
+      const issuer = claims.issuer === undefined ? LOCAL_TEST_ISSUER : claims.issuer;
+      if (issuer !== null) jwt = jwt.setIssuer(issuer);
 
       return jwt.sign(privateKey);
     },

--- a/shared/crypto/tests/testing.test.ts
+++ b/shared/crypto/tests/testing.test.ts
@@ -1,7 +1,7 @@
 import { decodeProtectedHeader, jwtVerify } from "jose";
 import { describe, expect, it } from "vitest";
 
-import { makeAccessTokenSigner } from "../src/testing";
+import { LOCAL_TEST_ISSUER, makeAccessTokenSigner } from "../src/testing";
 
 // The pulse, zap and cire route suites all authenticate through this one
 // signer. If it stopped setting `aud`, or put `sub` in the header instead of
@@ -79,6 +79,38 @@ describe("makeAccessTokenSigner", () => {
     expect(await codeOf(jwtVerify(stepUp, signer.publicKey, { audience: AUD }))).toBe(
       "ERR_JWT_CLAIM_VALIDATION_FAILED",
     );
+  });
+
+  // Every downstream suite's tokens are accepted because of this default —
+  // pulse, zap and the sixteen cire suites all mint without naming an issuer
+  // and verify against a config expecting the local one. A change to the
+  // sentinel below would mint tokens no verifier accepts, and be diagnosed as
+  // a route bug in four packages.
+  it("stamps the local issuer by default, so downstream verifiers accept it", async () => {
+    const signer = await makeAccessTokenSigner();
+    const token = await signer.sign("usr_alice");
+
+    const { payload } = await jwtVerify(token, signer.publicKey, {
+      audience: AUD,
+      issuer: LOCAL_TEST_ISSUER,
+    });
+    expect(payload.iss).toBe(LOCAL_TEST_ISSUER);
+  });
+
+  // `null`, not `undefined`: the pre-enforcement shape, for driving the
+  // rejection path a verifier that pins the issuer must take.
+  it("mints no iss at all when the issuer is null", async () => {
+    const signer = await makeAccessTokenSigner();
+    const token = await signer.sign("usr_alice", { issuer: null });
+
+    const { payload } = await jwtVerify(token, signer.publicKey, { audience: AUD });
+    expect(payload.iss).toBeUndefined();
+
+    expect(
+      await codeOf(
+        jwtVerify(token, signer.publicKey, { audience: AUD, issuer: LOCAL_TEST_ISSUER }),
+      ),
+    ).toBe("ERR_JWT_CLAIM_VALIDATION_FAILED");
   });
 
   it("honours an issuer override so cire's issuer pinning is reachable", async () => {

--- a/shared/dev-urls/src/app-env.ts
+++ b/shared/dev-urls/src/app-env.ts
@@ -71,6 +71,14 @@ export const DEV_ENV = {
   "@zap/api": (urls: Urls, self: DevAppId, env: DevEnv) => ({
     // Zap's graph bridge calls osn-api server-to-server.
     OSN_API_URL: urls["@osn/api"],
+    // Where the access-token keys are and who must have minted the token.
+    // Both were missing, so zap fell back to its `http://localhost:4000`
+    // defaults while osn-api under portless mints
+    // `https://<prefix>id.musubi.localhost` — every bearer-authenticated zap
+    // route 401'd in the devloop. The JWKS half was already wrong before the
+    // issuer was pinned; the pin is what made it visible.
+    OSN_ISSUER_URL: urls["@osn/api"],
+    OSN_JWKS_URL: `${urls["@osn/api"]}/.well-known/jwks.json`,
     // Browsers that reach zap directly: pulse event chats, and the account app.
     ZAP_CORS_ORIGIN: devOriginList(["@pulse/web", "@osn/social"], self, env),
   }),

--- a/shared/dev-urls/tests/app-env.test.ts
+++ b/shared/dev-urls/tests/app-env.test.ts
@@ -53,9 +53,14 @@ describe("buildDevEnv", () => {
     });
   });
 
-  it("gives @zap/api its CORS allowlist and S2S URL", () => {
+  it("gives @zap/api its CORS allowlist, S2S URL and token verification", () => {
     expect(buildDevEnv("@zap/api", urlFor("@zap/api"))).toEqual({
       OSN_API_URL: "https://id.musubi.localhost",
+      // Both halves of access-token verification. Without them zap kept its
+      // `http://localhost:4000` defaults while osn-api minted under the
+      // portless host, so every bearer-authenticated route 401'd.
+      OSN_ISSUER_URL: "https://id.musubi.localhost",
+      OSN_JWKS_URL: "https://id.musubi.localhost/.well-known/jwks.json",
       ZAP_CORS_ORIGIN: "https://pulse.localhost,https://musubi.localhost",
     });
   });

--- a/shared/osn-auth-client/src/verify.ts
+++ b/shared/osn-auth-client/src/verify.ts
@@ -76,6 +76,20 @@ type VerifyOutcome =
    */
   | { kind: "terminal" };
 
+/**
+ * Drops one trailing `/`.
+ *
+ * `jose` compares `iss` byte for byte, so `https://id.musubi.social/` and
+ * `https://id.musubi.social` are different issuers. Six `wrangler.toml` blocks
+ * carry that value by hand, and a stray slash in any of them would 401 every
+ * authenticated request with nothing else to show for it. Normalising both
+ * sides removes the typo class — the same treatment CORS origins already get
+ * in `zap/api/src/lib/cors-config.ts`.
+ */
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
 async function verifyTokenWithKey(
   token: string,
   key: CryptoKey,
@@ -94,9 +108,27 @@ async function verifyTokenWithKey(
       // than a token that never ages out.
       requiredClaims: ["exp"],
     };
-    // Unset issuer ⇒ omit the option ⇒ jose does not enforce `iss` (X2).
-    if (issuer) verifyOptions.issuer = issuer;
+    // Three states, not two. Omitting `issuer` entirely means the caller has
+    // not asked for the check — the rollout-safety posture the option shipped
+    // with. Supplying one enforces it. Supplying an EMPTY one is a
+    // misconfiguration, and the one case that must not resolve to "no check":
+    // an expected issuer read from an unset env var is exactly how a
+    // half-configured deployment would end up accepting tokens from any OSN
+    // install while looking configured. `extractClaims` rejects that before
+    // reaching here; this is the second half of the same guard.
+    if (issuer === "") return { kind: "terminal" };
     const { payload } = await jwtVerify(token, key, verifyOptions);
+    // `iss` is compared here rather than handed to `jose`, so both sides can
+    // be normalised. One check, not two: a token carrying no `iss` — or a
+    // non-string one — reduces to `""`, which never equals an expected issuer,
+    // since the empty case is rejected above. Adding `iss` to `requiredClaims`
+    // as well would be a second mechanism for the same rejection.
+    if (issuer !== undefined) {
+      const claimed = typeof payload.iss === "string" ? payload.iss : "";
+      if (stripTrailingSlash(claimed) !== stripTrailingSlash(issuer)) {
+        return { kind: "terminal" };
+      }
+    }
     const profileId = typeof payload.sub === "string" ? payload.sub : null;
     if (!profileId) return { kind: "terminal" };
     return {
@@ -127,6 +159,16 @@ export async function extractClaims(
   const token = authHeader.slice(7);
   const audience = options?.audience;
   const issuer = options?.issuer;
+
+  // An issuer asked for but empty is a configuration failure, not a request
+  // for no check. Fail closed here rather than silently verifying nothing —
+  // see `verifyTokenWithKey`.
+  //
+  // `=== ""` rather than `"issuer" in options`: a caller that spreads its
+  // config passes the key explicitly set to `undefined`, which `in` treats as
+  // present. Only the empty string is the misconfiguration; `undefined` is
+  // still the honest "not asking for this check".
+  if (options?.issuer === "") return null;
 
   let header: { kid?: string; alg?: string };
   try {

--- a/shared/osn-auth-client/tests/verify.test.ts
+++ b/shared/osn-auth-client/tests/verify.test.ts
@@ -286,6 +286,84 @@ describe("extractClaims — negative + rotation paths", () => {
     expect(fetchCount).toBe(1); // resolve only, no rotation retry
   });
 
+  // The third state, and the one that matters most: an expected issuer that is
+  // present but EMPTY. That is what an unset `OSN_ISSUER_URL` var reaching the
+  // verifier looks like, and treating it as "no check" would let a
+  // half-configured deployment accept tokens from any OSN install while
+  // looking configured. It fails closed instead.
+  // The comparison is normalised on both sides, so an operator's stray slash
+  // in one of six hand-maintained wrangler blocks is not a silent outage.
+  it("tolerates a trailing slash on either side of the issuer", async () => {
+    const withSlash = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: kidA })
+      .setSubject("usr_a")
+      .setIssuer(`${ISS}/`)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(keyA.signKey);
+
+    // Slash on the token only.
+    expect((await extractClaims(`Bearer ${withSlash}`, JWKS_URL, { issuer: ISS }))?.profileId).toBe(
+      "usr_a",
+    );
+    // Slash on the expected value only.
+    const plain = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: kidA })
+      .setSubject("usr_a")
+      .setIssuer(ISS)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(keyA.signKey);
+    expect(
+      (await extractClaims(`Bearer ${plain}`, JWKS_URL, { issuer: `${ISS}/` }))?.profileId,
+    ).toBe("usr_a");
+  });
+
+  // Normalising a slash must not soften the check itself: a token with no
+  // `iss` at all is rejected whenever one is expected.
+  it("issuer set + token carrying no iss → null", async () => {
+    const noIssuer = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: kidA })
+      .setSubject("usr_a")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(keyA.signKey);
+
+    expect(await extractClaims(`Bearer ${noIssuer}`, JWKS_URL, { issuer: ISS })).toBeNull();
+  });
+
+  it("issuer set to an empty string → null, and never reaches the network", async () => {
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: kidA })
+      .setSubject("usr_a")
+      .setIssuer(ISS)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(keyA.signKey);
+
+    const before = fetchCount;
+    const result = await extractClaims(`Bearer ${token}`, JWKS_URL, { issuer: "" });
+    expect(result).toBeNull();
+    // Rejected on the config, before any JWKS fetch — a misconfigured
+    // verifier should not also stampede the issuer.
+    expect(fetchCount).toBe(before);
+  });
+
+  it("issuer explicitly undefined → treated as unset, not as empty", async () => {
+    // A caller that spreads its config passes the key present-but-undefined.
+    // That is still the honest "not asking for this check", unlike "".
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: kidA })
+      .setSubject("usr_a")
+      .setIssuer("https://anything.example.com")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(keyA.signKey);
+
+    const result = await extractClaims(`Bearer ${token}`, JWKS_URL, { issuer: undefined });
+    expect(result?.profileId).toBe("usr_a");
+  });
+
   it("issuer UNSET → any iss accepted (rollout safety: pre-O1 tokens verify)", async () => {
     // Token with an arbitrary iss, verified WITHOUT an expected issuer.
     const token = await new SignJWT({})

--- a/wiki/runbooks/production-deploy.md
+++ b/wiki/runbooks/production-deploy.md
@@ -12,7 +12,7 @@ related:
   - "[[cire-vendors]]"
   - "[[musubi-identity-migration]]"
   - "[[dev-environment]]"
-last-reviewed: 2026-08-15
+last-reviewed: 2026-08-30
 ---
 
 # Production Deploy Runbook — osn + cire
@@ -368,6 +368,31 @@ bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|producti
 | `OSN_ACCESS_TOKEN_TTL` / `OSN_REFRESH_TOKEN_TTL` | `[env.<env>.vars]` | Optional | Defaults 300s / 2592000s. |
 | `PULSE_API_URL` / `ZAP_API_URL` | `[env.<env>.vars]` | Optional | Outbound ARC key registration for account-erasure fan-out. |
 
+### 3.1b Access-token issuer pinning (all downstream Workers)
+
+Since 2026-08-30 every service that verifies an OSN access token pins the
+`iss` claim, not just the signature and audience. A token minted by a
+different OSN deployment verifies fine against its own JWKS; `iss` is the only
+claim that says which deployment minted it.
+
+That makes `OSN_ISSUER_URL` a **paired** value: the verifier's copy must equal
+what osn-api mints, byte for byte, so **the two flip in the same deploy**. A
+mismatch 401s every authenticated request, and the 401 is indistinguishable
+from an expired token — there is nothing in the response to say the issuer is
+wrong.
+
+| Worker | Var | Required? | Prod value |
+|---|---|---|---|
+| osn-api | `OSN_ISSUER_URL` | **Yes** | `https://id.musubi.social` — the value every row below must match |
+| cire-api | `OSN_ISSUER_URL` | **Yes — 503 without it** | `https://id.musubi.social` |
+| pulse-api | `OSN_ISSUER_URL` | **Yes** | `https://id.musubi.social` (no deploy job yet) |
+| zap-api | `OSN_ISSUER_URL` | **Yes** | `https://id.musubi.social` (prod D1 unprovisioned; deploy job skips) |
+
+A trailing slash on either side is tolerated — the comparison normalises both
+— but nothing else is. An **empty** value is rejected outright rather than
+read as "no issuer check": a half-configured tier fails closed instead of
+quietly accepting tokens from anywhere.
+
 ### 3.2 cire-api (Cloudflare Worker)
 
 | Name | How to set | Required? | Notes |
@@ -375,7 +400,7 @@ bunx wrangler secret put OTEL_EXPORTER_OTLP_HEADERS  --env <dev|staging|producti
 | D1 `database_id` | `wrangler.toml` (top-level + `[env.production]`) | **Yes** | §2.1 — `6e835474-e0a7-4db9-8883-3247c3c891cd`, already set. |
 | `WEB_ORIGIN` | `wrangler.toml` `[env.production.vars]` | **Yes** | Comma-sep allowlist; must include the guest, organiser **and** vendor origins. Each entry must be `https://…` or the Worker fails closed at the edge (`src/index.ts:59-74`). Prod = **`https://invite.cireweddings.com,https://host.cireweddings.com,https://vendor.cireweddings.com`**. |
 | `OSN_JWKS_URL` | `wrangler.toml` `[env.production.vars]` | **Yes** | Deployed osn-api JWKS URL (`<OSN_ISSUER_URL>/.well-known/jwks.json`). Prod = **`https://id.musubi.social/.well-known/jwks.json`**. |
-| `OSN_ISSUER_URL` | `wrangler.toml` `[env.production.vars]` | **Yes** | Deployed osn-api origin; must equal osn-api's own `OSN_ISSUER_URL`, since it is the `iss` claim cire checks. Prod = **`https://id.musubi.social`**. |
+| `OSN_ISSUER_URL` | `wrangler.toml` `[env.production.vars]` | **Yes — Worker answers 503 without it** | Deployed osn-api origin; must equal osn-api's own `OSN_ISSUER_URL`, since it is the `iss` claim cire checks. Since 2026-08-30 it is on the edge required-vars list (`cire/api/src/index.ts`), so an unset value takes the Worker down rather than falling back to the localhost default and 401ing every request with nothing to say why. Prod = **`https://id.musubi.social`**. |
 | `OSN_AUDIENCE` | `wrangler.toml` `[env.production.vars]` | **Yes** | `osn-access` (the user access-token audience). |
 | `CIRE_API_ARC_PRIVATE_KEY` | `wrangler secret put CIRE_API_ARC_PRIVATE_KEY` | **Conditional** | ES256 JWK (string). Only if guest account-linking is enabled (§6.2). Absent ⇒ linking `POST` answers 503 (`src/index.ts:78-85`, `services/osn-bridge.ts:99-113`). |
 | `CIRE_API_ARC_KEY_ID` | `wrangler secret put CIRE_API_ARC_KEY_ID` | **Conditional** | `kid` matching the public key registered in osn-api `service_accounts` for serviceId `cire-api`. §6.2 |

--- a/zap/api/src/app.ts
+++ b/zap/api/src/app.ts
@@ -4,7 +4,7 @@ import { DbLive, type Db } from "@zap/db/service";
 import type { Layer } from "effect";
 import { Elysia } from "elysia";
 
-import { DEFAULT_JWKS_URL } from "./lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "./lib/jwks";
 import {
   createChatsRoutes,
   createDefaultZapRateLimiters,
@@ -22,12 +22,13 @@ export interface AppOptions {
    */
   dbLayer?: Layer.Layer<Db>;
   /**
-   * JWKS endpoint of the OSN issuer that signs access tokens (W1/W2 — ES256
-   * verification via `@shared/osn-auth-client`). Workers supply it from the
-   * `OSN_JWKS_URL` binding; the local dev server falls back to
-   * `DEFAULT_JWKS_URL`.
+   * Where the OSN issuer's access-token signing keys live, and the `iss` its
+   * tokens must carry (W1/W2 — ES256 verification via
+   * `@shared/osn-auth-client`). Workers supply both from the `OSN_JWKS_URL`
+   * and `OSN_ISSUER_URL` bindings; the local dev server falls back to
+   * `DEFAULT_VERIFICATION`.
    */
-  jwksUrl?: string;
+  verification?: OsnTokenVerification;
   /**
    * Per-IP write limiters (Cloudflare-keyed, S-H1). Defaults to in-memory
    * counters; a deployment that needs a globally-shared throttle wires a
@@ -50,7 +51,7 @@ export interface AppOptions {
 export function createApp(options: AppOptions = {}) {
   const {
     dbLayer = DbLive,
-    jwksUrl = DEFAULT_JWKS_URL,
+    verification = DEFAULT_VERIFICATION,
     rateLimiters = createDefaultZapRateLimiters(),
     corsOrigins,
   } = options;
@@ -63,7 +64,7 @@ export function createApp(options: AppOptions = {}) {
       .use(observabilityPlugin({ serviceName: SERVICE_NAME }))
       .use(healthRoutes({ serviceName: SERVICE_NAME }))
       .get("/", () => ({ status: "ok", service: SERVICE_NAME }))
-      .use(createChatsRoutes(dbLayer, jwksUrl, undefined, rateLimiters))
+      .use(createChatsRoutes(dbLayer, verification, undefined, rateLimiters))
       .use(createInternalRoutes(dbLayer))
   );
 }

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -26,6 +26,8 @@ export interface Env {
    * token verification unanchored.
    */
   OSN_JWKS_URL?: string;
+  /** Expected `iss` on access tokens — osn-api's own `OSN_ISSUER_URL`. */
+  OSN_ISSUER_URL?: string;
   /** CORS allowlist (S-M2), comma-separated. */
   ZAP_CORS_ORIGIN?: string;
   /** Environment discriminator — `local` vs anything else. */
@@ -54,6 +56,16 @@ function buildApp(env: Env): App {
     throw new Error("OSN_JWKS_URL must be set and use HTTPS in non-local environments");
   }
 
+  // The JWKS proves a key is genuine; `iss` proves the token was minted for
+  // this deployment rather than another OSN install. Required in a deployed
+  // env for the same reason the JWKS URL is: an unset expected issuer is not
+  // a soft default, it is the check not running. It must match osn-api's own
+  // `OSN_ISSUER_URL` byte for byte, so the two flip in the same deploy.
+  const issuer = env.OSN_ISSUER_URL;
+  if (nonLocal && (!issuer || issuer.startsWith("http://"))) {
+    throw new Error("OSN_ISSUER_URL must be set and use HTTPS in non-local environments");
+  }
+
   // S-M2: restrict CORS to a known origin allowlist instead of the open
   // reflect-any default. Fail closed in non-local envs (empty allowlist throws).
   const corsOrigins = resolveCorsOrigins({ ZAP_CORS_ORIGIN: env.ZAP_CORS_ORIGIN });
@@ -61,7 +73,7 @@ function buildApp(env: Env): App {
 
   return createApp({
     dbLayer: makeDbD1Live(env.DB as D1Database),
-    jwksUrl,
+    verification: { jwksUrl: jwksUrl!, issuer: issuer! },
     corsOrigins,
   });
 }

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -4,6 +4,7 @@ import { Effect, Logger } from "effect";
 
 import { createApp, SERVICE_NAME, type App } from "./app";
 import { assertCorsOriginsConfigured, isNonLocalEnv, resolveCorsOrigins } from "./lib/cors-config";
+import { DEFAULT_ISSUER_URL, DEFAULT_JWKS_URL } from "./lib/jwks";
 import { registerWithOsnApi } from "./services/zapGraphBridge";
 
 // Re-export the Eden treaty type so `@zap/api` consumers and `./client` keep
@@ -61,8 +62,13 @@ function buildApp(env: Env): App {
   // env for the same reason the JWKS URL is: an unset expected issuer is not
   // a soft default, it is the check not running. It must match osn-api's own
   // `OSN_ISSUER_URL` byte for byte, so the two flip in the same deploy.
-  const issuer = env.OSN_ISSUER_URL;
-  if (nonLocal && (!issuer || issuer.startsWith("http://"))) {
+  // Presence is checked unconditionally; only the HTTPS requirement is
+  // gated on the tier. A Worker whose env block sets neither `ZAP_ENV` nor
+  // `OSN_ENV` reads as local, so gating presence too would let a publicly
+  // reachable deployment run with no expected issuer at all — the check
+  // silently off, which is the state this whole change exists to end.
+  const issuer = env.OSN_ISSUER_URL || DEFAULT_ISSUER_URL;
+  if (nonLocal && (!env.OSN_ISSUER_URL || issuer.startsWith("http://"))) {
     throw new Error("OSN_ISSUER_URL must be set and use HTTPS in non-local environments");
   }
 
@@ -73,7 +79,7 @@ function buildApp(env: Env): App {
 
   return createApp({
     dbLayer: makeDbD1Live(env.DB as D1Database),
-    verification: { jwksUrl: jwksUrl!, issuer: issuer! },
+    verification: { jwksUrl: jwksUrl ?? DEFAULT_JWKS_URL, issuer },
     corsOrigins,
   });
 }

--- a/zap/api/src/lib/jwks.ts
+++ b/zap/api/src/lib/jwks.ts
@@ -1,2 +1,31 @@
+/**
+ * Where the access-token signing keys live, and who must have signed them.
+ *
+ * The two travel together because neither is sufficient alone: the JWKS says a
+ * key is genuine, `iss` says the token came from the deployment we expect
+ * rather than any other OSN install sharing the curve. Bundling them means a
+ * call site cannot supply one and silently forget the other — the failure mode
+ * that kept `iss` unenforced, since an unset expected issuer is not an error,
+ * it is simply no check at all.
+ */
+export interface OsnTokenVerification {
+  /** Full JWKS URL of the OSN issuer. */
+  readonly jwksUrl: string;
+  /** Expected `iss` claim — the issuer's origin, exactly as osn-api mints it. */
+  readonly issuer: string;
+}
+
 export const DEFAULT_JWKS_URL =
   process.env.OSN_JWKS_URL ?? "http://localhost:4000/.well-known/jwks.json";
+
+/**
+ * Must match `AuthConfig.issuerUrl` in the osn-api this verifies against,
+ * byte for byte. The default matches osn-api's own local default
+ * (`osn/api/src/build-deps.ts`); a deployed environment always sets it.
+ */
+export const DEFAULT_ISSUER_URL = process.env.OSN_ISSUER_URL ?? "http://localhost:4000";
+
+export const DEFAULT_VERIFICATION: OsnTokenVerification = {
+  jwksUrl: DEFAULT_JWKS_URL,
+  issuer: DEFAULT_ISSUER_URL,
+};

--- a/zap/api/src/local.ts
+++ b/zap/api/src/local.ts
@@ -3,7 +3,7 @@ import { Effect, Logger } from "effect";
 
 import { createApp, SERVICE_NAME } from "./app";
 import { assertCorsOriginsConfigured, isNonLocalEnv, resolveCorsOrigins } from "./lib/cors-config";
-import { DEFAULT_JWKS_URL } from "./lib/jwks";
+import { DEFAULT_JWKS_URL, DEFAULT_VERIFICATION } from "./lib/jwks";
 import { registerWithOsnApi } from "./services/zapGraphBridge";
 
 // `local` environment entry point: long-lived Bun.serve process backed by
@@ -24,7 +24,7 @@ if (nonLocal && DEFAULT_JWKS_URL.startsWith("http://")) {
 const corsOrigins = resolveCorsOrigins(process.env);
 assertCorsOriginsConfigured(corsOrigins, nonLocal);
 
-const app = createApp({ jwksUrl: DEFAULT_JWKS_URL, corsOrigins });
+const app = createApp({ verification: DEFAULT_VERIFICATION, corsOrigins });
 
 const port = process.env.PORT || 3002;
 

--- a/zap/api/src/routes/chats.ts
+++ b/zap/api/src/routes/chats.ts
@@ -9,7 +9,7 @@ import { DbLive, type Db } from "@zap/db/service";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { Elysia, t } from "elysia";
 
-import { DEFAULT_JWKS_URL } from "../lib/jwks";
+import { DEFAULT_VERIFICATION, type OsnTokenVerification } from "../lib/jwks";
 import { MAX_CHAT_MEMBERS, MAX_CIPHERTEXT_LENGTH, MAX_NONCE_LENGTH } from "../lib/limits";
 import { metricAccessDenied } from "../metrics";
 import {
@@ -46,12 +46,16 @@ const ACCESS_AUDIENCE = "osn-access";
  */
 async function resolveProfileId(
   authHeader: string | undefined,
-  jwksUrl: string,
+  verification: OsnTokenVerification,
   testKey: CryptoKey | undefined,
 ): Promise<{ profileId: string } | null> {
-  const claims = await extractClaims(authHeader, jwksUrl, {
+  const claims = await extractClaims(authHeader, verification.jwksUrl, {
     testKey: testKey as CryptoKey,
     audience: ACCESS_AUDIENCE,
+    // Enforced, not optional. A token signed by a different OSN deployment
+    // verifies against its own JWKS perfectly well; `iss` is the only claim
+    // that says it was minted for this one.
+    issuer: verification.issuer,
   });
   if (!claims) return null;
   if (!claims.profileId.startsWith("usr_")) return null;
@@ -78,7 +82,7 @@ export function createDefaultZapRateLimiters(): ZapRateLimiters {
 
 export const createChatsRoutes = (
   dbLayer: Layer.Layer<Db> = DbLive,
-  jwksUrl: string = DEFAULT_JWKS_URL,
+  verification: OsnTokenVerification = DEFAULT_VERIFICATION,
   _testKey?: CryptoKey,
   rateLimiters: ZapRateLimiters = createDefaultZapRateLimiters(),
 ) => {
@@ -90,7 +94,7 @@ export const createChatsRoutes = (
       .get(
         "/",
         async ({ query, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -124,7 +128,7 @@ export const createChatsRoutes = (
       .get(
         "/:id",
         async ({ params, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -161,7 +165,7 @@ export const createChatsRoutes = (
             set.status = 429;
             return { message: "Too many requests" } as const;
           }
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -205,7 +209,7 @@ export const createChatsRoutes = (
       .patch(
         "/:id",
         async ({ params, body, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -247,7 +251,7 @@ export const createChatsRoutes = (
       .get(
         "/:id/members",
         async ({ params, query, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -291,7 +295,7 @@ export const createChatsRoutes = (
             set.status = 429;
             return { message: "Too many requests" } as const;
           }
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -348,7 +352,7 @@ export const createChatsRoutes = (
       .delete(
         "/:id/members/:profileId",
         async ({ params, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -397,7 +401,7 @@ export const createChatsRoutes = (
             set.status = 429;
             return { message: "Too many requests" } as const;
           }
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;
@@ -440,7 +444,7 @@ export const createChatsRoutes = (
       .get(
         "/:id/messages",
         async ({ params, query, headers, set }) => {
-          const claims = await resolveProfileId(headers["authorization"], jwksUrl, _testKey);
+          const claims = await resolveProfileId(headers["authorization"], verification, _testKey);
           if (!claims) {
             set.status = 401;
             return { message: "Unauthorized" } as const;

--- a/zap/api/tests/routes/chats.test.ts
+++ b/zap/api/tests/routes/chats.test.ts
@@ -15,7 +15,14 @@ beforeAll(async () => {
   testPublicKey = signer.publicKey;
 });
 
-const makeToken = (profileId: string) => signer.sign(profileId);
+/**
+ * The issuer these tests mint with, and the one the routes are told to expect.
+ * Both halves have to name it: a token whose `iss` does not match is rejected,
+ * which is the point of pinning it.
+ */
+const TEST_ISSUER = "https://id.test.invalid";
+
+const makeToken = (profileId: string) => signer.sign(profileId, { issuer: TEST_ISSUER });
 
 const json = (body: unknown) => JSON.stringify(body);
 
@@ -57,7 +64,7 @@ describe("chats routes", () => {
     // (which has its own dedicated suite below). Each test resets it.
     setConsentGate(() => Promise.resolve(true));
     layer = createTestLayer();
-    app = createChatsRoutes(layer, "", testPublicKey);
+    app = createChatsRoutes(layer, { jwksUrl: "", issuer: TEST_ISSUER }, testPublicKey);
     aliceToken = await makeToken("usr_alice");
     bobToken = await makeToken("usr_bob");
   });
@@ -102,6 +109,30 @@ describe("chats routes", () => {
       .setAudience("osn-access")
       .sign(new TextEncoder().encode("dev-secret-change-in-prod"));
     const res = await req(app, "GET", "/chats", { token: hs256 });
+    expect(res.status).toBe(401);
+  });
+
+  // The whole point of pinning `iss`. A different OSN deployment signs with a
+  // key its own JWKS vouches for, so the signature check passes and the
+  // audience matches — `iss` is the only claim that says which deployment
+  // minted it. Signed with THIS suite's key so nothing but the issuer differs.
+  it("GET /chats returns 401 for a token from a different issuer", async () => {
+    const otherIssuer = await signer.sign("usr_alice", { issuer: "https://id.evil.invalid" });
+    const res = await req(app, "GET", "/chats", { token: otherIssuer });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /chats returns 401 for a token with no issuer at all", async () => {
+    // The pre-enforcement shape: tokens minted before osn-api stamped `iss`.
+    // Every one of those expired within five minutes of the rollout, so a
+    // token arriving without one today is not a legacy token, it is a forgery
+    // or a misconfiguration — either way, not ours.
+    const noIssuer = await new SignJWT({ sub: "usr_alice" })
+      .setProtectedHeader({ alg: "ES256", kid: "test-kid" })
+      .setAudience("osn-access")
+      .setExpirationTime("5m")
+      .sign(signer.privateKey);
+    const res = await req(app, "GET", "/chats", { token: noIssuer });
     expect(res.status).toBe(401);
   });
 

--- a/zap/api/wrangler.toml
+++ b/zap/api/wrangler.toml
@@ -47,12 +47,16 @@ database_name = "zap-db-prod"
 database_id = "9b75f81a-7439-412a-9aad-cf47836bca07"
 migrations_dir = "../db/drizzle"
 
-# Production vars: OSN identity issuer for access-token JWKS verification.
-# OSN_JWKS_URL is the only env var zap-api reads from `Env` for JWT verification
-# (src/index.ts + src/lib/jwks.ts). Mirrors the prod origin used by cire-api
-# and osn-api (id.musubi.social). Set before first deploy.
+# Production vars: OSN identity issuer for access-token verification.
+# Two vars, both read in src/index.ts (and defaulted in src/lib/jwks.ts):
+# OSN_JWKS_URL says which keys are genuine, OSN_ISSUER_URL says which
+# deployment minted the token. Both mirror the prod origin cire-api and
+# osn-api use (id.musubi.social), and OSN_ISSUER_URL MUST equal osn-api's own
+# OSN_ISSUER_URL byte for byte — a mismatch 401s every authenticated request,
+# so the two flip in the same deploy. Set before first deploy.
 [env.production.vars]
 OSN_JWKS_URL = "https://id.musubi.social/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://id.musubi.social"
 # zapGraphBridge validates OSN_API_URL is https at module load in production
 # (it sends ARC tokens to osn-api's graph). osn-api serves on id.musubi.social.
 OSN_API_URL = "https://id.musubi.social"

--- a/zap/api/wrangler.toml
+++ b/zap/api/wrangler.toml
@@ -16,6 +16,20 @@ compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 # local D1) and deployed (`wrangler deploy --env dev`).
 
 # ── dev ────────────────────────────────────────────────────────────────────
+# `dev` is runnable locally (`wrangler dev --env dev`) as well as deployed, so
+# these point at a local osn-api — the same posture, and the same reasoning, as
+# `pulse/api/wrangler.toml`'s dev block. `ZAP_ENV` is deliberately NOT set:
+# setting it would flip `isNonLocalEnv` and fail-close CORS, breaking the local
+# run. Point both at the deployed dev origin in the same commit that gives this
+# env real https origins.
+#
+# They are here at all because access-token verification now pins the issuer.
+# An env block with no vars used to mean "no expected issuer", which the
+# verifier read as "no issuer check" — the state this pinning exists to end.
+[env.dev.vars]
+OSN_JWKS_URL = "http://localhost:4000/.well-known/jwks.json"
+OSN_ISSUER_URL = "http://localhost:4000"
+
 [[env.dev.d1_databases]]
 binding = "DB"
 database_name = "zap-db"
@@ -23,6 +37,15 @@ database_id = "placeholder-replace-after-d1-create"
 migrations_dir = "../db/drizzle"
 
 # ── staging ──────────────────────────────────────────────────────────────────
+# Mirrors osn-api's own staging value (`osn/api/wrangler.toml`), which is itself
+# a placeholder until the staging tier is real. Both move together — a
+# verifier whose expected issuer disagrees with what osn-api mints 401s every
+# authenticated request.
+[env.staging.vars]
+ZAP_ENV = "staging"
+OSN_JWKS_URL = "https://api.staging.osn.example/.well-known/jwks.json"
+OSN_ISSUER_URL = "https://api.staging.osn.example"
+
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "zap-db-staging"


### PR DESCRIPTION
## Summary

`@shared/osn-auth-client` has always accepted an expected `iss`, and every consumer left it unset. That was right once — pinning the issuer rejects tokens minted before osn-api stamped one, so the rollout had to be verifier-first, and the option shipped optional to make that ordering safe. Access tokens live five minutes, so the window closed within five minutes of that deploy.

What remained is a verifier that accepts a token from **any** OSN deployment, provided it is signed by a key that deployment's JWKS vouches for. The signature is genuine and the audience matches; `iss` is the only claim that says which install minted it. cire, pulse and zap now pass the expected issuer on every `extractClaims` call.

In pulse and zap the JWKS URL and the issuer travel as one `OsnTokenVerification` value rather than two loose strings threaded separately through eight route factories. That shape is the point: an unset expected issuer is not an error, it is the check silently not running, which is how this stayed unenforced. The compiler found all twenty call sites for me.

## Workspaces affected

`@shared/osn-auth-client`, `@shared/crypto`, `@shared/dev-urls`, `@cire/api`, `@pulse/api`, `@zap/api`. The changeset names the five versioned ones at `patch` (`@cire/*` is version-less).

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#177 | Enforce access-token issuer in downstream verifiers |

Closes xchromo/osn-tracker#177.

**Opened**

None.

## Decisions

### Three states for the expected issuer, not two — `S-H`

- **Issue** — `verify.ts` read `if (issuer) verifyOptions.issuer = issuer`, so an **empty** expected issuer omitted the option and jose enforced nothing.
- **Why** — that is exactly what an unset `OSN_ISSUER_URL` reaching the verifier looks like: a deployment that appears configured and accepts tokens from anywhere. The first version of this branch could deliver it — zap asserted `issuer!` behind a guard that only ran when the tier read as non-local, and zap's `dev`/`staging` blocks set no vars at all, so a publicly reachable Worker took the local branch; pulse used `??`, which does not catch `""`.
- **Solution** — empty is rejected outright, `undefined` still means "not asking for this check". Presence is now checked unconditionally at both entry points; only the HTTPS requirement stays gated on the tier, and the non-null assertions are gone.
- **Rationale** — a config value that is missing should fail closed, not resolve to the permissive default. Keeping `undefined` distinct preserves the rollout-safety posture the option was designed for, and is what a caller spreading a config with the key present actually passes.

### Comparing `iss` here rather than in jose — `S-L`

- **Issue** — `jose` compares `iss` byte for byte. Six `wrangler.toml` blocks carry this value by hand.
- **Why** — a stray trailing slash in any one of them would 401 every authenticated request, with nothing in the response to say why. The repo already normalises trailing slashes on CORS origins for this reason.
- **Solution** — verify without jose's `issuer` option, then compare both sides normalised.
- **Rationale** — one mechanism, not two: a token carrying no `iss`, or a non-string one, reduces to `""` and never matches an expected issuer, since the empty case is rejected before this point. Adding `iss` to `requiredClaims` as well would be a second path to the same rejection — a mutation confirmed it changed nothing, so it is not there.

### `OSN_ISSUER_URL` becomes required in a deployed tier — `approach`

- **Issue** — the var was optional everywhere, and zap did not read it at all.
- **Why** — an unset value falls back to the localhost issuer, so a deployed tier would expect `http://localhost:4000` and reject every real token: a total outage whose cause is invisible in the 401.
- **Solution** — cire adds it to the edge required-vars list (503 with the var named); pulse and zap throw at startup, beside the identical check the JWKS URL already gets.
- **Rationale** — it is now an auth input, so it earns the same fail-closed treatment as the other one. Failing with the variable's name beats serving with the wrong expectation.

### Config that pointed at the wrong issuer — `S-M`

- **Issue** — three environments would have broken on first deploy, and one local loop already did.
- **Why** — all four were inert while nothing checked `iss`; pinning it arms them.
- **Solution** — `osn/api`'s bare `wrangler dev` minted `http://localhost:8787` while all six consumer defaults expect `4000` (now 4000, with the port the loop should use written down). pulse's staging and production were `https://osn-api.example.com` placeholders (now the real origins). zap had no vars outside production, and no issuer or JWKS URL in the portless devloop — so every bearer-authenticated zap route was **already** 401ing locally before this branch; the pin is what made it visible.
- **Rationale** — a comment reading "TODO: real OSN issuer origin before prod deploy" is not a gate. The values are knowable now, and the devloop has to exercise the check or a regression reaches a deployed tier unnoticed.

### Test tokens carry an issuer by default — `T-M`

- **Issue** — sixteen cire suites, twelve pulse suites and zap's all mint through `@shared/crypto/testing`, which stamped no `iss`.
- **Solution** — the signer stamps `LOCAL_TEST_ISSUER` unless told otherwise; `issuer: null` mints none, for the rejection path.
- **Rationale** — one edit rather than thirty, and it matches reality: the helper is a stand-in for osn-api, which always sets `iss`. Both new behaviours have their own tests, because four packages' auth suites now rest on them.

**Out of scope**

- `wiki/compliance/access-control.md` is not updated with a row for the new verification gate. The deploy runbook covers the operational half (new §3.1b, plus the cire row marked 503-without-it); the compliance matrix is a separate sweep.

## Test plan

| Gate | Result |
|---|---|
| `bun run test` (full monorepo) | ✅ 38 tasks |
| `bun run --cwd shared/osn-auth-client test:run` | ✅ 94 pass (86 on `main`) |
| `bun run --cwd shared/crypto test:run` | ✅ 84 pass (82 on `main`) |
| `bun run --cwd shared/dev-urls test:run` | ✅ 57 pass |
| `bun run --cwd cire/api test` | ✅ 1695 pass (1694 on `main`) |
| `bun run --cwd pulse/api test:run` | ✅ 637 pass (635 on `main`) |
| `bun run --cwd zap/api test:run` | ✅ 146 pass (144 on `main`) |
| `bun run check` | ✅ 37 packages |
| `bun run lint` / `bun run fmt:check` | ✅ |
| `scripts/validate-changesets.sh` | ✅ |

Each of the three services has a token-from-another-issuer rejection test, signed with that suite's **own** key so the issuer is the only thing that differs — the wrong-key path would have passed for the wrong reason.

Every guard was mutation-checked: removing the empty-issuer rejection, the issuer comparison, or the slash normalisation each turns `osn-auth-client` red; dropping `issuer:` from cire's, pulse's or zap's `extractClaims` call turns that service red; removing the signer's default issuer turns `shared/crypto` red.

**Not run:** nothing here has been exercised against a deployed Worker. The issuer matrix was checked by reading all four `wrangler.toml` files and `@shared/dev-urls` per environment, not by deploying — and this is fail-closed, so a value that does not byte-match what osn-api mints 401s every authenticated request. **cire dev and prod, and zap prod, match today.** pulse has no deploy job at all, and zap prod skips while its D1 is unprovisioned, so no live tier changes behaviour on merge.
