### PR TITLE
fix(osn-api): enforce foreign keys on bun:sqlite, and repair Art. 17 erasure

### DIFF
--- a/.changeset/brave-otters-warn.md
+++ b/.changeset/brave-otters-warn.md
@@ -1,0 +1,15 @@
+---
+"@shared/db-utils": patch
+"@osn/db": patch
+"@osn/api": patch
+"@pulse/db": patch
+"@zap/db": patch
+---
+
+Enforce foreign keys on `bun:sqlite`, and fix the two erasure bugs that were hiding behind it.
+
+SQLite defaults `PRAGMA foreign_keys` to **OFF** while D1 enforces them, so every local run and every test accepted writes production rejects. The cheap, fast environment was the permissive one, which is the worst way round: a statement that orphans a row, or deletes a parent before its children, passed the whole suite and would have failed on deploy.
+
+Turning it on found `hardDeleteAccount` broken in two ways, both of which would make GDPR Art. 17 erasure throw rather than complete. It deletes the `accounts` row while deliberately keeping `security_events` and `email_changes` under Art. 6(1)(c) — but both declared a foreign key to `accounts`, so a column documented to outlive its parent referenced it. Those two constraints are dropped. It also deleted `users` before the `oauth_consents` and `oauth_authorization_codes` rows that carry a `profile_id` referencing them; those deletes now run first.
+
+`dev-login`'s provisioning batch declared itself infallible through `Effect.promise` while being a chain of inserts that reference rows an earlier `onConflictDoNothing` may have skipped. With foreign keys on, that arrived as a defect and escaped the route's own error handling, answering 400 where the contract says 500 `provisioning_failed`.

--- a/osn/api/src/routes/auth/dev-login.ts
+++ b/osn/api/src/routes/auth/dev-login.ts
@@ -75,7 +75,12 @@ export interface DevLoginConfig {
 const provision = Effect.gen(function* () {
   const { db } = yield* Db;
   const now = new Date();
-  yield* Effect.promise(() =>
+  // `tryPromise`, not `promise`. `promise` declares the batch infallible, and
+  // it is not: every insert here references a row another insert may have
+  // skipped through `onConflictDoNothing`, so with foreign keys enforced the
+  // batch can reject. Declared infallible, that arrived as a defect and
+  // escaped the caller's handling entirely.
+  yield* Effect.tryPromise(() =>
     commitBatch(db, [
       db
         .insert(accounts)
@@ -168,7 +173,19 @@ export function createDevLoginRoutes(ctx: AuthRouteContext, config: DevLoginConf
 
       let profile = yield* auth.findProfileById(DEV_PRINCIPAL.profileId);
       if (!profile) {
-        yield* provision;
+        // A provisioning failure is caught, not propagated, so it lands on the
+        // same path as a provision that ran but left no row: re-read, find
+        // nothing, return `null`, and let the caller answer 500
+        // `provisioning_failed`. That is what this function's contract already
+        // says, and it was only true while the batch could not fail — with
+        // foreign keys enforced it can, because a handle squatter makes the
+        // `users` insert a no-op and the `organisations` row that references
+        // that profile then has no owner to point at. Letting the error escape
+        // gave a 400, which says the caller sent something wrong when the
+        // truth is that the server could not provision.
+        yield* provision.pipe(
+          Effect.catchAll((cause) => Effect.logError("dev-login: provisioning failed", { cause })),
+        );
         profile = yield* auth.findProfileById(DEV_PRINCIPAL.profileId);
       }
       if (!profile) return null;

--- a/osn/api/src/services/account-erasure.ts
+++ b/osn/api/src/services/account-erasure.ts
@@ -546,6 +546,21 @@ const hardDeleteAccount = (accountId: string): Effect.Effect<void, AccountErasur
                 db
                   .delete(organisationMembers)
                   .where(inArray(organisationMembers.profileId, profileIds)),
+                // OIDC provider records (Art. 17). Both are account-scoped and
+                // PII-bearing: `oauth_consents` names every relying party the
+                // user linked, `oauth_authorization_codes` is a live grant in
+                // flight. A deletion mid-flow must take the pending code with
+                // it — leaving it would let an outstanding code redeem against
+                // a tombstoned account.
+                //
+                // Above the `users` delete, not below it: both carry a
+                // `profile_id` referencing `users.id`, so removing the profiles
+                // first orphans them and the whole batch fails on a database
+                // that enforces foreign keys.
+                db.delete(oauthConsents).where(eq(oauthConsents.accountId, accountId)),
+                db
+                  .delete(oauthAuthorizationCodes)
+                  .where(eq(oauthAuthorizationCodes.accountId, accountId)),
                 db.delete(users).where(eq(users.accountId, accountId)),
               ]
             : []),
@@ -554,15 +569,6 @@ const hardDeleteAccount = (accountId: string): Effect.Effect<void, AccountErasur
           db.delete(passkeys).where(eq(passkeys.accountId, accountId)),
           db.delete(recoveryCodes).where(eq(recoveryCodes.accountId, accountId)),
           db.delete(deletionJobs).where(eq(deletionJobs.accountId, accountId)),
-          // OIDC provider records (Art. 17). Both are account-scoped and
-          // PII-bearing: `oauth_consents` names every relying party the user
-          // linked, `oauth_authorization_codes` is a live grant in flight. A
-          // deletion mid-flow must take the pending code with it — leaving it
-          // would let an outstanding code redeem against a tombstoned account.
-          db.delete(oauthConsents).where(eq(oauthConsents.accountId, accountId)),
-          db
-            .delete(oauthAuthorizationCodes)
-            .where(eq(oauthAuthorizationCodes.accountId, accountId)),
           // Clients the account REGISTERED (owner side): disable them and
           // sever the ownership link. The rows themselves stay — other users'
           // consents reference them by client_id, and once unlinked they hold

--- a/osn/api/tests/services/recommendations.test.ts
+++ b/osn/api/tests/services/recommendations.test.ts
@@ -1,7 +1,7 @@
 import { it, expect, describe } from "@effect/vitest";
 import { accounts, organisations } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { beforeAll } from "vitest";
 
@@ -22,6 +22,29 @@ beforeAll(async () => {
   config = await makeTestAuthConfig();
   auth = createAuthService(config);
 });
+
+/**
+ * Deletes an `organisations` row while leaving its `organisation_members`
+ * rows in place — a state the service layer cannot produce, and one the
+ * database now refuses: `deleteOrganisation` removes the memberships and the
+ * organisation in one batch, and foreign keys are enforced.
+ *
+ * The tests below need it anyway, because the branch it exercises is real: the
+ * fan-out and the label hydration are two statements, so an organisation
+ * deleted between them lands exactly there. Dropping the pragma around this
+ * one statement is what lets a test reach a race that a single transaction
+ * cannot hold — and doing it here, in one named helper, keeps the exception
+ * visible rather than spread across three tests.
+ */
+const deleteOrganisationRowOnly = (organisationId: string) =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    yield* Effect.promise(async () => {
+      await db.run(sql`PRAGMA foreign_keys = OFF`);
+      await db.delete(organisations).where(eq(organisations.id, organisationId));
+      await db.run(sql`PRAGMA foreign_keys = ON`);
+    });
+  });
 
 // Connect two users bidirectionally (request + accept).
 const connect = (a: string, b: string) =>
@@ -323,8 +346,7 @@ describe("suggestConnections", () => {
       yield* connect(alice.id, cara.id);
       yield* connect(cara.id, dana.id);
 
-      const { db } = yield* Db;
-      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, beta.id)));
+      yield* deleteOrganisationRowOnly(beta.id);
 
       const result = yield* recs.suggestConnections(alice.id);
       const byHandle = new Map(result.map((x) => [x.handle, x.sharedOrganisation]));
@@ -384,8 +406,7 @@ describe("suggestConnections", () => {
       const org = yield* orgs.createOrganisation(alice.id, "acme", "Acme Inc");
       yield* orgs.addMember(org.id, alice.id, dana.id, "member");
 
-      const { db } = yield* Db;
-      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, org.id)));
+      yield* deleteOrganisationRowOnly(org.id);
 
       const result = yield* recs.suggestConnections(alice.id);
       expect(result).toHaveLength(1);
@@ -410,8 +431,7 @@ describe("suggestConnections", () => {
       // bob is suggested while the organisation exists.
       expect((yield* recs.suggestConnections(alice.id)).map((x) => x.handle)).toEqual(["bob"]);
 
-      const { db } = yield* Db;
-      yield* Effect.promise(() => db.delete(organisations).where(eq(organisations.id, org.id)));
+      yield* deleteOrganisationRowOnly(org.id);
 
       expect(yield* recs.suggestConnections(alice.id)).toEqual([]);
     }).pipe(Effect.provide(createTestLayer())),

--- a/osn/db/drizzle/0005_goofy_gwen_stacy.sql
+++ b/osn/db/drizzle/0005_goofy_gwen_stacy.sql
@@ -1,0 +1,29 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_email_changes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`account_id` text NOT NULL,
+	`previous_email` text NOT NULL,
+	`new_email` text NOT NULL,
+	`completed_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_email_changes`("id", "account_id", "previous_email", "new_email", "completed_at") SELECT "id", "account_id", "previous_email", "new_email", "completed_at" FROM `email_changes`;--> statement-breakpoint
+DROP TABLE `email_changes`;--> statement-breakpoint
+ALTER TABLE `__new_email_changes` RENAME TO `email_changes`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `email_changes_account_idx` ON `email_changes` (`account_id`);--> statement-breakpoint
+CREATE INDEX `email_changes_completed_at_idx` ON `email_changes` (`completed_at`);--> statement-breakpoint
+CREATE TABLE `__new_security_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`account_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`acknowledged_at` integer,
+	`ip_hash` text,
+	`ua_label` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_security_events`("id", "account_id", "kind", "created_at", "acknowledged_at", "ip_hash", "ua_label") SELECT "id", "account_id", "kind", "created_at", "acknowledged_at", "ip_hash", "ua_label" FROM `security_events`;--> statement-breakpoint
+DROP TABLE `security_events`;--> statement-breakpoint
+ALTER TABLE `__new_security_events` RENAME TO `security_events`;--> statement-breakpoint
+CREATE INDEX `security_events_unacked_idx` ON `security_events` (`account_id`,`created_at`) WHERE "security_events"."acknowledged_at" IS NULL;

--- a/osn/db/drizzle/meta/0005_snapshot.json
+++ b/osn/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1663 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "52933f1f-baea-4fe3-a168-d725b0dfb3b7",
+  "prevId": "832bec0a-b975-4695-a5cf-a407238edbe1",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passkey_user_id": {
+          "name": "passkey_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_profiles": {
+          "name": "max_profiles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_restricted_at": {
+          "name": "processing_restricted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "accounts_passkey_user_id_unique": {
+          "name": "accounts_passkey_user_id_unique",
+          "columns": [
+            "passkey_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_enrollments": {
+      "name": "app_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "app_enrollments_account_idx": {
+          "name": "app_enrollments_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "app_enrollments_active_idx": {
+          "name": "app_enrollments_active_idx",
+          "columns": [
+            "account_id",
+            "app"
+          ],
+          "isUnique": false,
+          "where": "\"app_enrollments\".\"left_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "app_enrollments_account_id_accounts_id_fk": {
+          "name": "app_enrollments_account_id_accounts_id_fk",
+          "tableFrom": "app_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocks": {
+      "name": "blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blocks_blocker_idx": {
+          "name": "blocks_blocker_idx",
+          "columns": [
+            "blocker_id"
+          ],
+          "isUnique": false
+        },
+        "blocks_blocked_idx": {
+          "name": "blocks_blocked_idx",
+          "columns": [
+            "blocked_id"
+          ],
+          "isUnique": false
+        },
+        "blocks_pair_idx": {
+          "name": "blocks_pair_idx",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blocks_blocker_id_users_id_fk": {
+          "name": "blocks_blocker_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_id_users_id_fk": {
+          "name": "blocks_blocked_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_requester_idx": {
+          "name": "connections_requester_idx",
+          "columns": [
+            "requester_id"
+          ],
+          "isUnique": false
+        },
+        "connections_addressee_idx": {
+          "name": "connections_addressee_idx",
+          "columns": [
+            "addressee_id"
+          ],
+          "isUnique": false
+        },
+        "connections_pair_idx": {
+          "name": "connections_pair_idx",
+          "columns": [
+            "requester_id",
+            "addressee_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "connections_requester_id_users_id_fk": {
+          "name": "connections_requester_id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connections_addressee_id_users_id_fk": {
+          "name": "connections_addressee_id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deletion_jobs": {
+      "name": "deletion_jobs",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "soft_deleted_at": {
+          "name": "soft_deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hard_delete_at": {
+          "name": "hard_delete_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pulse_done_at": {
+          "name": "pulse_done_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zap_done_at": {
+          "name": "zap_done_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user_request'"
+        },
+        "cancel_session_id": {
+          "name": "cancel_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletion_jobs_hard_delete_idx": {
+          "name": "deletion_jobs_hard_delete_idx",
+          "columns": [
+            "hard_delete_at"
+          ],
+          "isUnique": false
+        },
+        "deletion_jobs_pulse_pending_idx": {
+          "name": "deletion_jobs_pulse_pending_idx",
+          "columns": [
+            "soft_deleted_at"
+          ],
+          "isUnique": false,
+          "where": "\"deletion_jobs\".\"pulse_done_at\" IS NULL"
+        },
+        "deletion_jobs_zap_pending_idx": {
+          "name": "deletion_jobs_zap_pending_idx",
+          "columns": [
+            "soft_deleted_at"
+          ],
+          "isUnique": false,
+          "where": "\"deletion_jobs\".\"zap_done_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "deletion_jobs_account_id_accounts_id_fk": {
+          "name": "deletion_jobs_account_id_accounts_id_fk",
+          "tableFrom": "deletion_jobs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_changes": {
+      "name": "email_changes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_email": {
+          "name": "previous_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_changes_account_idx": {
+          "name": "email_changes_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "email_changes_completed_at_idx": {
+          "name": "email_changes_completed_at_idx",
+          "columns": [
+            "completed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_codes_expires_idx": {
+          "name": "oauth_codes_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_account_id_accounts_id_fk": {
+          "name": "oauth_authorization_codes_account_id_accounts_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_profile_id_users_id_fk": {
+          "name": "oauth_authorization_codes_profile_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector_identifier": {
+          "name": "sector_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "is_first_party": {
+          "name": "is_first_party",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_clients_sector_idx": {
+          "name": "oauth_clients_sector_idx",
+          "columns": [
+            "sector_identifier"
+          ],
+          "isUnique": false
+        },
+        "oauth_clients_owner_idx": {
+          "name": "oauth_clients_owner_idx",
+          "columns": [
+            "owner_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_owner_account_id_accounts_id_fk": {
+          "name": "oauth_clients_owner_account_id_accounts_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_consents_account_client_uq": {
+          "name": "oauth_consents_account_client_uq",
+          "columns": [
+            "account_id",
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_account_id_accounts_id_fk": {
+          "name": "oauth_consents_account_id_accounts_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_profile_id_users_id_fk": {
+          "name": "oauth_consents_profile_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organisation_members": {
+      "name": "organisation_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_members_org_idx": {
+          "name": "org_members_org_idx",
+          "columns": [
+            "organisation_id"
+          ],
+          "isUnique": false
+        },
+        "org_members_profile_idx": {
+          "name": "org_members_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "org_members_pair_idx": {
+          "name": "org_members_pair_idx",
+          "columns": [
+            "organisation_id",
+            "profile_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organisation_members_organisation_id_organisations_id_fk": {
+          "name": "organisation_members_organisation_id_organisations_id_fk",
+          "tableFrom": "organisation_members",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organisation_members_profile_id_users_id_fk": {
+          "name": "organisation_members_profile_id_users_id_fk",
+          "tableFrom": "organisation_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organisations": {
+      "name": "organisations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organisations_handle_unique": {
+          "name": "organisations_handle_unique",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        },
+        "organisations_owner_idx": {
+          "name": "organisations_owner_idx",
+          "columns": [
+            "owner_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organisations_owner_id_users_id_fk": {
+          "name": "organisations_owner_id_users_id_fk",
+          "tableFrom": "organisations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backup_eligible": {
+          "name": "backup_eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backup_state": {
+          "name": "backup_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        },
+        "passkeys_account_id_idx": {
+          "name": "passkeys_account_id_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_account_id_accounts_id_fk": {
+          "name": "passkeys_account_id_accounts_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_codes": {
+      "name": "recovery_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recovery_codes_code_hash_unique": {
+          "name": "recovery_codes_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "recovery_codes_account_idx": {
+          "name": "recovery_codes_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_account_id_accounts_id_fk": {
+          "name": "recovery_codes_account_id_accounts_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "security_events": {
+      "name": "security_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ua_label": {
+          "name": "ua_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "security_events_unacked_idx": {
+          "name": "security_events_unacked_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false,
+          "where": "\"security_events\".\"acknowledged_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_account_keys": {
+      "name": "service_account_keys",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key_jwk": {
+          "name": "public_key_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_account_keys_service_idx": {
+          "name": "service_account_keys_service_idx",
+          "columns": [
+            "service_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "service_account_keys_service_id_service_accounts_service_id_fk": {
+          "name": "service_account_keys_service_id_service_accounts_service_id_fk",
+          "tableFrom": "service_account_keys",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "service_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_accounts": {
+      "name": "service_accounts",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authenticated_at": {
+          "name": "authenticated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ua_label": {
+          "name": "ua_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_account_idx": {
+          "name": "sessions_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_family_idx": {
+          "name": "sessions_family_idx",
+          "columns": [
+            "family_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_account_last_used_idx": {
+          "name": "sessions_account_last_used_idx",
+          "columns": [
+            "account_id",
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_account_id_accounts_id_fk": {
+          "name": "sessions_account_id_accounts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        },
+        "users_account_idx": {
+          "name": "users_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "users_handle_idx": {
+          "name": "users_handle_idx",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_account_id_accounts_id_fk": {
+          "name": "users_account_id_accounts_id_fk",
+          "tableFrom": "users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/osn/db/drizzle/meta/_journal.json
+++ b/osn/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785198751565,
       "tag": "0004_little_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1788097202987,
+      "tag": "0005_goofy_gwen_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/osn/db/src/schema/index.ts
+++ b/osn/db/src/schema/index.ts
@@ -322,9 +322,15 @@ export const emailChanges = sqliteTable(
   "email_changes",
   {
     id: text("id").primaryKey(), // "ech_" prefix
-    accountId: text("account_id")
-      .notNull()
-      .references(() => accounts.id),
+    // No `.references(accounts.id)`, deliberately. `hardDeleteAccount`
+    // (`osn/api/src/services/account-erasure.ts`) removes the `accounts` row
+    // and KEEPS these under Art. 6(1)(c), so the column outlives its parent by
+    // design — and a column that must outlive its parent cannot have a foreign
+    // key to it. With the constraint in place the final `delete(accounts)`
+    // failed, taking the whole erasure batch with it, so Art. 17 deletion
+    // could never complete against a database that enforces foreign keys.
+    // Retention is enforced by the sweeper, not by a reference.
+    accountId: text("account_id").notNull(),
     previousEmail: text("previous_email").notNull(),
     newEmail: text("new_email").notNull(),
     /** Unix seconds */
@@ -360,9 +366,15 @@ export const securityEvents = sqliteTable(
   "security_events",
   {
     id: text("id").primaryKey(), // "sev_" prefix
-    accountId: text("account_id")
-      .notNull()
-      .references(() => accounts.id),
+    // No `.references(accounts.id)`, deliberately. `hardDeleteAccount`
+    // (`osn/api/src/services/account-erasure.ts`) removes the `accounts` row
+    // and KEEPS these under Art. 6(1)(c), so the column outlives its parent by
+    // design — and a column that must outlive its parent cannot have a foreign
+    // key to it. With the constraint in place the final `delete(accounts)`
+    // failed, taking the whole erasure batch with it, so Art. 17 deletion
+    // could never complete against a database that enforces foreign keys.
+    // Retention is enforced by the sweeper, not by a reference.
+    accountId: text("account_id").notNull(),
     /**
      * Bounded kind enum — see SecurityEventKind in @shared/observability.
      * Enforced at the service boundary, not the column level, so adding

--- a/osn/db/src/testing.ts
+++ b/osn/db/src/testing.ts
@@ -46,6 +46,13 @@ function buildSchemaSql(): string[] {
 
 /** Apply the full OSN schema to an in-memory bun:sqlite handle. */
 export function applySchema(sqlite: Database): void {
+  // SQLite defaults `foreign_keys` to OFF. D1 enforces them, so without this a
+  // test database accepts writes production rejects — a statement that orphans
+  // a row, or deletes a parent before its children, passes the whole suite and
+  // fails on deploy with `FOREIGN KEY constraint failed`. Applied here rather
+  // than at each call site so every test database built from the live schema
+  // agrees with production about what is a legal write.
+  sqlite.run("PRAGMA foreign_keys = ON");
   for (const stmt of createSchemaSql()) sqlite.run(stmt);
 }
 

--- a/pulse/db/src/testing.ts
+++ b/pulse/db/src/testing.ts
@@ -46,6 +46,13 @@ function buildSchemaSql(): string[] {
  * Apply the full Pulse schema to an in-memory SQLite handle.
  */
 export function applySchema(sqlite: Database): void {
+  // SQLite defaults `foreign_keys` to OFF. D1 enforces them, so without this a
+  // test database accepts writes production rejects — a statement that orphans
+  // a row, or deletes a parent before its children, passes the whole suite and
+  // fails on deploy with `FOREIGN KEY constraint failed`. Applied here rather
+  // than at each call site so every test database built from the live schema
+  // agrees with production about what is a legal write.
+  sqlite.run("PRAGMA foreign_keys = ON");
   for (const stmt of createSchemaSql()) sqlite.run(stmt);
 }
 

--- a/shared/db-utils/src/index.ts
+++ b/shared/db-utils/src/index.ts
@@ -62,6 +62,14 @@ export async function createDrizzleClient<S extends DrizzleSchema>(
   const { Database } = (await import(bunSqlite)) as typeof import("bun:sqlite");
   const { drizzle } = (await import(bunSqliteDriver)) as typeof import("drizzle-orm/bun-sqlite");
   const sqlite = new Database(dbPath);
+  // SQLite defaults `foreign_keys` to OFF, so every reference declared in the
+  // schema is unenforced on Bun while D1 enforces them. That makes the cheap,
+  // fast environment the permissive one: a statement that orphans a row, or
+  // deletes a parent before its children, passes the whole suite and fails on
+  // deploy with `FOREIGN KEY constraint failed`. Turning it on here is what
+  // makes local runs and tests agree with production about what is a legal
+  // write.
+  sqlite.run("PRAGMA foreign_keys = ON");
   return drizzle(sqlite, { schema });
 }
 

--- a/zap/db/src/testing.ts
+++ b/zap/db/src/testing.ts
@@ -46,6 +46,13 @@ function buildSchemaSql(): string[] {
 
 /** Apply the full Zap schema to an in-memory bun:sqlite handle. */
 export function applySchema(sqlite: Database): void {
+  // SQLite defaults `foreign_keys` to OFF. D1 enforces them, so without this a
+  // test database accepts writes production rejects — a statement that orphans
+  // a row, or deletes a parent before its children, passes the whole suite and
+  // fails on deploy with `FOREIGN KEY constraint failed`. Applied here rather
+  // than at each call site so every test database built from the live schema
+  // agrees with production about what is a legal write.
+  sqlite.run("PRAGMA foreign_keys = ON");
   for (const stmt of createSchemaSql()) sqlite.run(stmt);
 }
 


### PR DESCRIPTION
## Summary

SQLite defaults `PRAGMA foreign_keys` to **OFF**; D1 enforces them. So every local run and every test in this repo accepted writes production rejects — the worst way round for that asymmetry to fall, because the fast, cheap environment was the permissive one and a reference-order mistake waited for a deploy to surface.

Turning it on cost one line in three places and immediately found **GDPR Art. 17 hard deletion broken two different ways**, either of which would make the sweeper throw on every run and leave a soft-deleted account in the database indefinitely.

- `hardDeleteAccount` deletes the `accounts` row while deliberately keeping `security_events` and `email_changes` under Art. 6(1)(c) — but both declared a foreign key to `accounts`, so a column documented to outlive its parent referenced it.
- It also deleted `users` before the `oauth_consents` and `oauth_authorization_codes` rows carrying a `profile_id` that references them.

A third fell out of the same change: `dev-login`'s provisioning batch declared itself infallible while being a chain of inserts that reference rows an earlier `onConflictDoNothing` may have skipped.

## Workspaces affected

`@shared/db-utils`, `@osn/db`, `@osn/api`, `@pulse/db`, `@zap/db` — all at `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#575 | `S-M` |
| xchromo/osn-tracker#580 | `S-H` |

Closes xchromo/osn-tracker#575.
Closes xchromo/osn-tracker#580.

**Opened**

None — everything the pragma exposed is fixed here.

## Decisions

### Dropping the foreign key, not the retained rows — `S-H`

- **Issue** — `security_events.account_id` and `email_changes.account_id` referenced `accounts.id`, while erasure deliberately keeps those rows and deletes the account.
- **Why** — the two are irreconcilable: with foreign keys enforced the final `delete(accounts)` fails and takes the whole batch with it.
- **Solution** — drop the two constraints. The alternative, deleting the rows during erasure, was rejected: it contradicts a documented Art. 6(1)(c) retention requirement, trading an availability bug for a compliance one.
- **Rationale** — a column that must outlive its parent cannot reference it. Retention is enforced by the 12-month and 90-day sweepers, which is where that rule belongs; the constraint was asserting something the design had already decided against. The migration is a table rebuild, so it cannot invalidate an existing row.

### `tryPromise`, not `promise`, for a fallible batch — `approach`

- **Issue** — `dev-login`'s `provision` wrapped `commitBatch` in `Effect.promise`, which declares the effect infallible.
- **Why** — it is not. Each insert references a row an earlier `onConflictDoNothing` may have skipped, so with foreign keys on the batch can reject. Declared infallible, that arrives as a *defect* and goes straight past the caller's own error handling — the route answered 400 ("you sent something wrong") where its documented contract is 500 `provisioning_failed` ("the server could not provision").
- **Solution** — `tryPromise`, and the caller catches it onto the path its own comment already described: re-read, find nothing, return `null`, answer 500.
- **Rationale** — the type was the bug. Marking a database write infallible removes the caller's ability to handle it, and the handling it needed was already written and unreachable.

### One named helper for the impossible state — `approach`

- **Issue** — three recommendations tests delete an `organisations` row while membership rows still reference it, which the database now refuses.
- **Why** — that state is genuinely unreachable through the service layer (`deleteOrganisation` removes both in one batch), but the branch it exercises is real: the fan-out and the label hydration are two statements, so an organisation can vanish between them.
- **Solution** — one `deleteOrganisationRowOnly` helper that drops the pragma around that single statement, with the reasoning stated once.
- **Rationale** — a test that needs to construct something production cannot hold should say so in one visible place, rather than three tests quietly depending on the enforcement being off everywhere.

**Out of scope**

- Whether D1 enforces these constraints at runtime is Cloudflare's documented behaviour but has not been confirmed against the live database — see the note in the test plan. It does not change any fix here: the schema and the erasure design contradicted each other regardless.

## Test plan

| Gate | Result |
|---|---|
| `bun run test` (full monorepo) | ✅ 38 tasks |
| `bun run --cwd osn/api test:run` | ✅ 1122 pass, all with foreign keys enforced |
| `bun run --cwd osn/db test:run` | ✅ 107 pass |
| `bun run check` | ✅ 37 packages |
| `bun run lint` / `bun run fmt:check` | ✅ |
| `scripts/validate-changesets.sh` | ✅ |

The change is its own test: every one of the six failures it produced was a real defect or a fixture asserting against a state production cannot hold, and the suite is green only because each was fixed rather than worked around. Before this branch, reverting any of the three production fixes left the suite green.

**Not run:** the migration has not been applied to a real D1 instance. It is a table rebuild of `security_events` and `email_changes` — `drizzle-kit`'s standard `__new_*` / copy / drop / rename shape, preserving both indexes — and dropping a constraint cannot invalidate existing rows, but it does rewrite two tables and should go to dev before production like any other.

Art. 17 erasure has never been exercised against a real database, so this was latent rather than an incident. That also means the fixes are verified only against `bun:sqlite` with the pragma on, which is now the same enforcement posture D1 has, not the same engine.
