### PR TITLE
test(pulse-api): cover the /account session-cookie credential

### DIFF
--- a/.changeset/quiet-moons-tap.md
+++ b/.changeset/quiet-moons-tap.md
@@ -1,0 +1,9 @@
+---
+"@pulse/api": patch
+---
+
+Cover the `/account` routes' session-cookie credential, and stop the auth-gate cases building a database they never touch.
+
+`makeCallerResolver` accepts two credentials — a bearer access token and the `pulse_web_session` cookie — and every `/account` test used the bearer. Those are the DSAR-critical handlers (delete, restore, deletion-status) and the web app cannot present a bearer token, so if the routes stopped forwarding `headers["cookie"]`, or a handler read `headers.authorization` directly instead of going through `resolveCaller`, every web client would lose them with the suite still green. Three cases now exercise the cookie path, including a cookie that names no live session — without that negative, the positives would pass just as happily against a handler that authenticated nobody.
+
+The auth-gate block also built a fresh schema-applied in-memory database and a `ManagedRuntime` per case, for requests rejected inside `resolveCaller` before any handler runs. Those share one app now; the one case in the block that does reach a handler keeps its own.

--- a/pulse/api/tests/routes/account.test.ts
+++ b/pulse/api/tests/routes/account.test.ts
@@ -1,5 +1,6 @@
+import { Db } from "@pulse/db/service";
 import { makeAccessTokenSigner, type AccessTokenSigner } from "@shared/crypto/testing";
-import { Effect } from "effect";
+import { Effect, ManagedRuntime } from "effect";
 import { describe, it, expect, beforeAll, vi } from "vitest";
 
 import { createTestLayer } from "../helpers/db";
@@ -21,6 +22,7 @@ vi.mock("../../src/lib/osn-bridge", () => ({
 }));
 
 import { createAccountRoutes } from "../../src/routes/account";
+import { webSessionService, type WebIdentity } from "../../src/services/webSession";
 import { TEST_VERIFICATION } from "../helpers/verification";
 
 let signer: AccessTokenSigner;
@@ -37,7 +39,37 @@ function makeApp() {
   return createAccountRoutes(createTestLayer(), TEST_VERIFICATION, testPublicKey);
 }
 
+/**
+ * An app plus a runtime over the SAME layer, so a session minted here is one
+ * the app's own `resolveCaller` can read. `makeApp()` builds its layer
+ * internally, which is right for a case that only needs isolation — but a
+ * cookie test needs to write a session row the app will then look up.
+ */
+function makeAppWithSharedDb() {
+  const layer = createTestLayer();
+  return {
+    app: createAccountRoutes(layer, TEST_VERIFICATION, testPublicKey),
+    runtime: ManagedRuntime.make(layer),
+  };
+}
+
+const identity: WebIdentity = {
+  osnProfileId: "usr_cookie",
+  osnSub: "pairwise-sub-for-pulse",
+  email: "cookie@example.com",
+  handle: "cookie",
+  displayName: "Cookie",
+  avatarUrl: null,
+};
+
 describe("account routes — auth gates", () => {
+  // One app for the cases rejected inside `resolveCaller`, which never reach a
+  // handler and so never touch the database — a fresh schema-applied in-memory
+  // DB and a `ManagedRuntime` per case bought isolation nothing needed, and
+  // left a sqlite handle open each time. The step-up case below is the
+  // exception and says so.
+  const app = makeApp();
+
   it.each([
     ["DELETE", "/account"],
     ["POST", "/account/restore"],
@@ -47,7 +79,7 @@ describe("account routes — auth gates", () => {
       method === "DELETE"
         ? { method, headers: { "content-type": "application/json" }, body: JSON.stringify({}) }
         : { method };
-    const res = await makeApp().handle(new Request(`http://localhost${path}`, init));
+    const res = await app.handle(new Request(`http://localhost${path}`, init));
     expect(res.status).toBe(401);
   });
 
@@ -57,7 +89,7 @@ describe("account routes — auth gates", () => {
     // `resolveCaller` lib layer (see caller.test.ts). Distinct from a
     // stale *cookie session* — this is a bearer token, no cookie involved.
     const expired = await signer.sign("usr_expired", { expiresIn: "-120s" });
-    const res = await makeApp().handle(
+    const res = await app.handle(
       new Request("http://localhost/account/deletion-status", {
         headers: { authorization: `Bearer ${expired}` },
       }),
@@ -67,6 +99,9 @@ describe("account routes — auth gates", () => {
 
   it("DELETE /account returns 403 without a step-up token", async () => {
     const token = await makeToken("usr_gate");
+    // Its own app: this is the one case in the block that gets PAST
+    // `resolveCaller` and reaches a handler, so it touches the database and
+    // wants isolation like the runtime-wiring cases below.
     const res = await makeApp().handle(
       new Request("http://localhost/account", {
         method: "DELETE",
@@ -76,6 +111,57 @@ describe("account routes — auth gates", () => {
     );
     expect(res.status).toBe(403);
     expect(((await res.json()) as { error: string }).error).toBe("step_up_required");
+  });
+});
+
+// `/account` holds the DSAR-critical handlers, and the web app cannot present
+// a bearer token — it authenticates with the `pulse_web_session` cookie that
+// `makeCallerResolver` accepts as the second credential. Every case in this
+// file used a bearer token, so if `createAccountRoutes` stopped forwarding
+// `headers["cookie"]`, or a handler read `headers.authorization` directly
+// instead of going through `resolveCaller`, every web client would lose
+// delete, restore and deletion-status while the suite stayed green.
+describe("account routes — cookie credential", () => {
+  const mintCookie = async (runtime: ManagedRuntime.ManagedRuntime<Db, never>) => {
+    const created = await runtime.runPromise(webSessionService.create(identity));
+    return `pulse_web_session=${created.token}`;
+  };
+
+  it("GET /account/deletion-status authenticates with the session cookie", async () => {
+    const { app, runtime } = makeAppWithSharedDb();
+    const res = await app.handle(
+      new Request("http://localhost/account/deletion-status", {
+        headers: { cookie: await mintCookie(runtime) },
+      }),
+    );
+    expect(res.status).toBe(200);
+    // The same body the bearer path returns — the credential decides who the
+    // caller is, not what they get back.
+    expect(await res.json()).toEqual({ scheduled: false });
+  });
+
+  it("POST /account/restore authenticates with the session cookie", async () => {
+    const { app, runtime } = makeAppWithSharedDb();
+    const res = await app.handle(
+      new Request("http://localhost/account/restore", {
+        method: "POST",
+        headers: { cookie: await mintCookie(runtime) },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  // The negative half: a cookie that names no live session is not a
+  // credential. Without this the two cases above would pass just as happily
+  // against a handler that ignored the cookie and authenticated nobody.
+  it("returns 401 for a session cookie that names no live session", async () => {
+    const { app } = makeAppWithSharedDb();
+    const res = await app.handle(
+      new Request("http://localhost/account/deletion-status", {
+        headers: { cookie: "pulse_web_session=not-a-real-token" },
+      }),
+    );
+    expect(res.status).toBe(401);
   });
 });
 


### PR DESCRIPTION
## Summary

`makeCallerResolver` in `pulse/api/src/lib/auth.ts` accepts two credentials — an `Authorization: Bearer` access token and a `pulse_web_session` cookie — and every existing `/account` test used the bearer one. The web app cannot present a bearer token: the cookie is how it authenticates, and `/account` holds the DSAR handlers (schedule deletion, restore, deletion status). So the three endpoints a data-subject request actually runs through had no test on the credential the only client uses.

Three cases now drive the cookie path. Two positive — deletion status and restore — and one negative: a `pulse_web_session` naming no live session must resolve to no credential at all, not to a caller. Without that third case the two positive ones would pass just as happily against a handler that ignored the cookie and authenticated nobody.

The auth-gate block above them was also building a fresh schema-applied in-memory database and a `ManagedRuntime` per case, including the cases rejected inside `resolveCaller` before any handler runs. Those need no isolation and each left a sqlite handle open. They share one app now; the single case in that block that does reach a handler keeps its own, with a comment saying why.

## Workspaces affected

| Package | Change |
|---|---|
| `@pulse/api` | Tests only — `tests/routes/account.test.ts`. No source change. |

## Issues

| Issue | Title |
|---|---|
| xchromo/osn-tracker#513 | T-M: no `/account` route test exercises the `pulse_web_session` cookie credential |
| xchromo/osn-tracker#515 | T-R: auth-gate tests build a schema-applied in-memory database they never touch |

Closes xchromo/osn-tracker#513.
Closes xchromo/osn-tracker#515.

## Decisions

### Adding a negative cookie case rather than only the two positive ones

**Issue** Two passing cookie requests do not prove the cookie was read. A resolver that dropped the cookie header entirely would return no caller, the handlers would 401, and the tests would fail — but a resolver that accepted *any* cookie value would pass both positive cases while authenticating an attacker.

**Why** The cookie is an opaque session token hashed at rest; the whole security property is that an unrecognised one resolves to nobody.

**Solution** A third case sends `pulse_web_session=not-a-real-token` and asserts 401.

**Rationale** Confirmed by mutation: making the resolver ignore `headers["cookie"]` turns four cases red, and making it accept an unresolvable session token turns three red. Neither mutant survives.

### Sharing one app across the auth-gate cases instead of one per case

**Issue** Each auth-gate case called the full test-layer builder — apply the schema to a new in-memory sqlite, build a `ManagedRuntime`, construct the routes — to send a request that `resolveCaller` rejects before a handler runs.

**Why** Nothing in those cases touches the database, so there is nothing for the per-case isolation to isolate. The cost is real: a schema application and an unclosed sqlite handle each time.

**Solution** One app hoisted for the block. `DELETE /account returns 403 without a step-up token` is the one case there that does reach a handler, so it keeps its own app and says so in a comment.

**Out of scope** The same pattern appears in other `pulse/api` route tests. This PR changes only the file the finding named; the rest is worth a sweep of its own.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd pulse/api test:run` | 640 pass (was 637) |
| `bun run test` (whole monorepo) | 38 packages successful |
| `bun run check` | 37 successful |
| `bun run lint` | clean |
| `bun run fmt:check` | clean |
| Changeset | `.changeset/quiet-moons-tap.md`, validated |
| Mutation check | 2 mutants, both killed (see Decisions) |

**Not run:** nothing deployed — this PR is tests only and touches no source file.
