### PR TITLE
fix(osn-api): stop unique-constraint errors masking real DB faults in email flows

### DIFF
--- a/.changeset/tame-otters-listen.md
+++ b/.changeset/tame-otters-listen.md
@@ -1,0 +1,6 @@
+---
+"@osn/api": patch
+"@osn/db": patch
+---
+
+Email change and registration now correctly tell a real database fault apart from a genuine duplicate-address conflict, and a rate-capped account can no longer learn whether an email address is taken by watching which check fails first.

--- a/osn/api/src/d1-integration.test.ts
+++ b/osn/api/src/d1-integration.test.ts
@@ -14,11 +14,12 @@ import {
 import * as schema from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 import { createSchemaSql } from "@osn/db/testing";
-import { createD1Db } from "@shared/db-utils";
+import { commitBatch, createD1Db } from "@shared/db-utils";
 import { eq } from "drizzle-orm";
 import { Effect, Layer } from "effect";
 import { Miniflare } from "miniflare";
 
+import { UNIQUE_CONSTRAINT_ERROR } from "./lib/unique-constraint";
 import { cancelErasure, getDeletionStatus, requestErasure } from "./services/account-erasure";
 
 // Integration tests against a REAL (workerd-backed) D1 database via Miniflare.
@@ -111,5 +112,49 @@ describe("osn/api account erasure over real D1 (Miniflare)", () => {
     const acct = await rawDb.select().from(accounts).where(eq(accounts.id, ACCOUNT_ID));
     expect(acct[0]!.deletedAt).toBeNull();
     expect((await run(getDeletionStatus(ACCOUNT_ID))).scheduled).toBe(false);
+  });
+});
+
+describe("UNIQUE_CONSTRAINT_ERROR over real D1 (Miniflare)", () => {
+  it("matches a duplicate-email conflict raised through commitBatch", async () => {
+    const ts = new Date();
+    let threw = false;
+    try {
+      await commitBatch(rawDb, [
+        rawDb.insert(accounts).values({
+          id: "acc_d1test_dup",
+          email: "d1@example.com", // already seeded on ACCOUNT_ID
+          passkeyUserId: crypto.randomUUID(),
+          createdAt: ts,
+          updatedAt: ts,
+        }),
+      ]);
+    } catch (e) {
+      threw = true;
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(UNIQUE_CONSTRAINT_ERROR.test(msg)).toBe(true);
+    }
+    expect(threw).toBe(true);
+  });
+
+  it("does not match a foreign-key violation raised through commitBatch", async () => {
+    const ts = new Date();
+    let threw = false;
+    try {
+      await commitBatch(rawDb, [
+        rawDb.insert(users).values({
+          id: "usr_d1test_orphan",
+          accountId: "acc_does_not_exist",
+          handle: "orphan",
+          createdAt: ts,
+          updatedAt: ts,
+        }),
+      ]);
+    } catch (e) {
+      threw = true;
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(UNIQUE_CONSTRAINT_ERROR.test(msg)).toBe(false);
+    }
+    expect(threw).toBe(true);
   });
 });

--- a/osn/api/src/lib/unique-constraint.ts
+++ b/osn/api/src/lib/unique-constraint.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared narrowing for "was this write failure a uniqueness conflict?".
+ *
+ * Both `completeRegistration` and `completeEmailChange` write through
+ * `commitBatch` (`@shared/db-utils`), and neither driver path wraps the
+ * failure: D1's `db.batch(...)` and bun:sqlite's sequential fallback both
+ * leave the raw SQLite text in `e.message` at the top level, so no `.cause`
+ * walk is needed or wanted here.
+ *
+ * Only a uniqueness violation is a genuine caller-facing conflict (another
+ * account already claimed the address/handle). NOT NULL / FOREIGN KEY /
+ * CHECK constraint failures are DB faults, not user races — they must
+ * surface as DatabaseError, never get mapped to a benign "someone else got
+ * there first" outcome.
+ *
+ * Both spellings are accepted because the two drivers do not agree:
+ * bun:sqlite raises `UNIQUE constraint failed: accounts.email`, and a driver
+ * that reports the SQLite result code instead would carry
+ * `SQLITE_CONSTRAINT_UNIQUE`. Neither spelling can match a NOT NULL, FOREIGN
+ * KEY or CHECK failure, so the narrowing holds.
+ */
+export const UNIQUE_CONSTRAINT_ERROR = /UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i;

--- a/osn/api/src/services/auth/email-change.ts
+++ b/osn/api/src/services/auth/email-change.ts
@@ -11,6 +11,7 @@ import { type EmailError, EmailService } from "@shared/email";
 import { and, count as countFn, eq, gte, ne } from "drizzle-orm";
 import { Effect, Schema } from "effect";
 
+import { UNIQUE_CONSTRAINT_ERROR } from "../../lib/unique-constraint";
 import {
   metricAuthOtpSent,
   metricSessionSecurityInvalidation,
@@ -81,29 +82,12 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
         return yield* Effect.fail(new AuthError({ message: "New email matches current email" }));
       }
 
-      // S-H2: silently succeed on collisions — an authenticated caller
-      // must not learn whether another account owns an email. Registration
-      // treats this as first-class (see the `beginRegistration` comment);
-      // email change must match. The UNIQUE(email) constraint at `complete`
-      // is the real defence against a race-winning swap.
-      const collision = yield* Effect.tryPromise({
-        // P-I1: projecting the indexed column alone lets UNIQUE(email) answer
-        // the probe from the index without reading the account row.
-        try: () =>
-          db
-            .select({ email: accounts.email })
-            .from(accounts)
-            .where(eq(accounts.email, normalised))
-            .limit(1),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-      if (collision.length > 0) {
-        return { sent: true };
-      }
-
       // P-W3: 2-per-7-days cap uses an indexed aggregate instead of a full
-      // history fetch. `email_changes_completed_at_idx` + the account filter
-      // serve the predicate.
+      // history fetch. `email_changes_account_completed_at_idx` serves the
+      // predicate (accountId + completedAt range) in one scan. This runs
+      // BEFORE the collision probe below (S-H2): a capped caller must not be
+      // able to tell a taken address from a free one by watching which check
+      // fails first.
       const windowStart = Math.floor(Date.now() / 1000) - EMAIL_CHANGE_WINDOW_SECONDS;
       const recentCount = yield* Effect.tryPromise({
         try: async () => {
@@ -124,6 +108,26 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
         return yield* Effect.fail(
           new AuthError({ message: "Email change limit reached (2 per 7 days)" }),
         );
+      }
+
+      // S-H2: silently succeed on collisions — an authenticated caller
+      // must not learn whether another account owns an email. Registration
+      // treats this as first-class (see the `beginRegistration` comment);
+      // email change must match. The UNIQUE(email) constraint at `complete`
+      // is the real defence against a race-winning swap.
+      const collision = yield* Effect.tryPromise({
+        // P-I1: projecting the indexed column alone lets UNIQUE(email) answer
+        // the probe from the index without reading the account row.
+        try: () =>
+          db
+            .select({ email: accounts.email })
+            .from(accounts)
+            .where(eq(accounts.email, normalised))
+            .limit(1),
+        catch: (cause) => new DatabaseError({ cause }),
+      });
+      if (collision.length > 0) {
+        return { sent: true };
       }
 
       const code = genOtpCode();
@@ -289,17 +293,10 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             // Only a uniqueness violation is a genuine caller-facing conflict
-            // (another account already claimed the address). NOT NULL / FOREIGN
-            // KEY / CHECK constraint failures are DB faults, not user races —
-            // they must surface as DatabaseError, not get mapped to a benign
-            // "someone else got there first" outcome.
-            //
-            // Both spellings are accepted because the two drivers do not agree:
-            // bun:sqlite raises `UNIQUE constraint failed: accounts.email`, and
-            // a driver that reports the SQLite result code instead would carry
-            // `SQLITE_CONSTRAINT_UNIQUE`. Neither spelling can match a NOT NULL,
-            // FOREIGN KEY or CHECK failure, so the narrowing holds.
-            if (/UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i.test(msg)) {
+            // (another account already claimed the address); see
+            // `UNIQUE_CONSTRAINT_ERROR` for the full justification, shared
+            // with `registration.ts`.
+            if (UNIQUE_CONSTRAINT_ERROR.test(msg)) {
               return { ok: false as const, reason: "conflict" as const };
             }
             throw e;

--- a/osn/api/src/services/auth/registration.ts
+++ b/osn/api/src/services/auth/registration.ts
@@ -12,6 +12,7 @@ import { eq, sql } from "drizzle-orm";
 import { unionAll } from "drizzle-orm/sqlite-core";
 import { Effect, Schema } from "effect";
 
+import { UNIQUE_CONSTRAINT_ERROR } from "../../lib/unique-constraint";
 import { metricAuthHandleCheck, metricAuthOtpSent, withAuthRegister } from "../../metrics";
 import { MAX_OTP_ATTEMPTS, MIN_AGE_YEARS, RESERVED_HANDLES } from "./constants";
 import type { AuthContext } from "./context";
@@ -299,8 +300,9 @@ export function createRegistrationModule(
    *    race against another insert (TOCTOU) leaves the pending entry intact
    *    so the user can retry without burning their OTP (S-H4).
    *  - Insert relies on the DB-level UNIQUE constraint on email/handle as
-   *    the source of truth, mapping constraint violations to a clean
-   *    AuthError instead of leaking driver text (S-H4 / S-H5).
+   *    the source of truth, mapping *uniqueness* violations to a clean
+   *    AuthError instead of leaking driver text (S-H4 / S-H5). Any other
+   *    constraint failure surfaces as DatabaseError.
    */
   const completeRegistration = (
     email: string,
@@ -352,9 +354,12 @@ export function createRegistrationModule(
 
       // Insert account + profile. The DB-level UNIQUE constraints on `email`
       // and `handle` are the source of truth for race-free uniqueness; a
-      // constraint violation here means another registration won the race
-      // (or the legacy `/register` endpoint was called concurrently). We
-      // surface that as a clean AuthError without leaking driver text.
+      // UNIQUE violation here means another registration won the race (or
+      // the legacy `/register` endpoint was called concurrently), and we
+      // surface that as a clean AuthError without leaking driver text. Any
+      // other constraint failure (NOT NULL / FOREIGN KEY / CHECK) is a DB
+      // fault, not a user race, and surfaces as DatabaseError instead — see
+      // `UNIQUE_CONSTRAINT_ERROR` for why the match is narrowed this way.
       const inserted = yield* Effect.tryPromise({
         try: async () => {
           try {
@@ -380,7 +385,7 @@ export function createRegistrationModule(
             return { ok: true as const };
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
-            if (/UNIQUE|constraint/i.test(msg)) {
+            if (UNIQUE_CONSTRAINT_ERROR.test(msg)) {
               return { ok: false as const, reason: "conflict" };
             }
             throw e;

--- a/osn/api/tests/helpers/db.ts
+++ b/osn/api/tests/helpers/db.ts
@@ -12,9 +12,12 @@ export function createTestLayer() {
 }
 
 /**
- * Same layer, plus the raw SQLite handle behind it. Tests that need to seed a
- * table with no route to write it — the OAuth client registry, for one — insert
- * through this handle rather than through a fixture the service does not have.
+ * Same layer, plus the raw SQLite handle behind it and the email recorder
+ * used to build it. Tests that need to seed a table with no route to write
+ * it — the OAuth client registry, for one — insert through `sqlite` rather
+ * than through a fixture the service does not have; tests that need to
+ * assert on captured sends read `email.recorded()` rather than building a
+ * second email layer to merge in.
  */
 export function createTestLayerWithSqlite() {
   const sqlite = new Database(":memory:");
@@ -24,23 +27,8 @@ export function createTestLayerWithSqlite() {
   applySchema(sqlite);
   const db = drizzle(sqlite, { schema });
   const dbLayer = Layer.succeed(Db, { db });
-  const emailLayer = makeLogEmailLive().layer;
-  return { layer: Layer.merge(dbLayer, emailLayer), sqlite, db };
-}
-
-/**
- * Variant of `createTestLayer()` that exposes the email recorder so
- * tests can assert on captured sends. Replaces the old pattern of
- * setting a `sendEmail` callback in `AuthConfig`.
- */
-export function createTestLayerWithEmailRecorder() {
-  const inner = createTestLayer();
   const email = makeLogEmailLive();
-  return {
-    layer: Layer.merge(inner, email.layer),
-    recorded: email.recorded,
-    reset: email.reset,
-  };
+  return { layer: Layer.merge(dbLayer, email.layer), sqlite, db, email };
 }
 
 // Re-export for tests that want to build their own capture recorder.

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -8,7 +8,7 @@ import { beforeAll } from "vitest";
 import { createInMemoryRotatedSessionStore } from "../../src/lib/rotated-session-store";
 import { createAuthService } from "../../src/services/auth";
 import { makeTestAuthConfig } from "../helpers/auth-config";
-import { createTestLayer } from "../helpers/db";
+import { createTestLayer, createTestLayerWithSqlite } from "../helpers/db";
 
 /**
  * Build a fresh auth service + OTP-capturing email recorder + merged
@@ -436,6 +436,69 @@ describe("beginRegistration + completeRegistration", () => {
       expect(err.message).toContain("already registered");
     }).pipe(Effect.provide(layer));
   });
+
+  // #557: a non-uniqueness constraint failure at the write must surface as
+  // DatabaseError, never get folded into the generic "already registered"
+  // AuthError the genuine-conflict path returns. `completeRegistration`
+  // builds its own accounts+users insert with internally-consistent foreign
+  // keys, so a FK violation can't be induced through the service itself — a
+  // trigger stands in for "some other constraint failed", raising a
+  // constraint-worded message that does not contain "UNIQUE", which is
+  // exactly the string the old `/UNIQUE|constraint/i` pattern matched by
+  // mistake.
+  it.effect("surfaces a non-uniqueness constraint failure as DatabaseError", () => {
+    const email = makeLogEmailLive();
+    const { layer: dbLayer, sqlite } = createTestLayerWithSqlite();
+    const layer = Layer.merge(dbLayer, email.layer);
+    const svc = createAuthService(config);
+    const latestCode = (): string | undefined => {
+      const all = email.recorded();
+      for (let i = all.length - 1; i >= 0; i--) {
+        const m = all[i].text.match(/code is: (\d{6})/);
+        if (m) return m[1];
+      }
+      return undefined;
+    };
+    return Effect.gen(function* () {
+      yield* svc.beginRegistration("regfault@example.com", "regfaultuser", "1990-01-01");
+      const code = latestCode();
+      sqlite.run(`
+        CREATE TRIGGER reject_users_insert_regfault BEFORE INSERT ON users
+        BEGIN SELECT RAISE(ABORT, 'CHECK constraint failed: users'); END;
+      `);
+      const err = yield* Effect.flip(svc.completeRegistration("regfault@example.com", code!));
+      expect(err._tag).toBe("DatabaseError");
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #557: pins the *direction* of the narrowed match — a genuine duplicate
+  // must still land on the caller-facing AuthError (not DatabaseError), and
+  // the pending entry must survive so a retry is possible (registration.ts
+  // :393-396). Distinct from the S-H4 test above: that one only asserts the
+  // error class and message; this one proves survival by re-driving the
+  // exact same code and observing the same conflict again, rather than the
+  // "Invalid or expired code" a wiped pending entry would produce instead.
+  it.effect(
+    "a genuine duplicate email still resolves to AuthError, and the pending entry survives for retry",
+    () => {
+      const { svc, captured, layer } = makeAuth();
+      return Effect.gen(function* () {
+        yield* svc.beginRegistration("realdup@example.com", "realdupuser", "1990-01-01");
+        const code = captured.code;
+        // Someone else wins the race for the SAME email via the legacy path
+        // before our OTP is redeemed.
+        yield* svc.registerProfile("realdup@example.com", "otherhandle");
+        const first = yield* Effect.flip(svc.completeRegistration("realdup@example.com", code!));
+        expect(first._tag).toBe("AuthError");
+        expect(first.message).toContain("already registered");
+        // Retried with the same code: if the pending entry had been wiped,
+        // this would fail "Invalid or expired code" instead.
+        const retry = yield* Effect.flip(svc.completeRegistration("realdup@example.com", code!));
+        expect(retry._tag).toBe("AuthError");
+        expect(retry.message).toContain("already registered");
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.effect(
     "T-M2: begin fails with AuthError (not EmailError) when email transport rejects",

--- a/osn/api/tests/services/email-change.test.ts
+++ b/osn/api/tests/services/email-change.test.ts
@@ -1,7 +1,6 @@
 import { it, expect, describe } from "@effect/vitest";
 import { Db } from "@osn/db/service";
-import { makeLogEmailLive } from "@shared/email";
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { beforeAll } from "vitest";
 
 import { createAuthService } from "../../src/services/auth";
@@ -17,10 +16,9 @@ import { createTestLayerWithSqlite } from "../helpers/db";
  * fault-injection trigger the service layer has no route to create.
  */
 function makeEmailCapture() {
-  const email = makeLogEmailLive();
-  const { layer: dbLayer, sqlite } = createTestLayerWithSqlite();
+  const { layer, sqlite, email } = createTestLayerWithSqlite();
   return {
-    layer: Layer.merge(dbLayer, email.layer),
+    layer,
     sqlite,
     captured: {
       codes: () =>
@@ -313,9 +311,12 @@ describe("beginEmailChange + completeEmailChange", () => {
 
   // Regression pin for S1: a non-uniqueness constraint failure at the write
   // must surface as DatabaseError, never get folded into the same generic
-  // AuthError the OTP-mismatch/UNIQUE-conflict paths return. No FK
-  // enforcement exists anywhere in this tree to trigger a real one, so a
-  // fault-injection trigger stands in for "some other constraint failed".
+  // AuthError the OTP-mismatch/UNIQUE-conflict paths return. FK enforcement
+  // is on in this tree (`PRAGMA foreign_keys = ON`, see `@osn/db/testing`),
+  // but `email_changes.accountId` deliberately carries no FK reference (see
+  // the schema comment on that column), so no real FK violation is reachable
+  // through this table — a fault-injection trigger stands in for "some other
+  // constraint failed".
   it.effect("surfaces a non-uniqueness constraint failure as DatabaseError", () => {
     const { layer, captured, sqlite } = makeEmailCapture();
     return Effect.gen(function* () {
@@ -522,6 +523,51 @@ describe("beginEmailChange + completeEmailChange", () => {
       const err = yield* Effect.flip(performChange("ec-cap-3@example.com"));
       expect(err._tag).toBe("AuthError");
       expect(err.message).toMatch(/limit reached/i);
+    }).pipe(Effect.provide(layer));
+  });
+
+  // #559 S-H2: the 7-day cap check must run BEFORE the collision probe, so a
+  // capped caller can't tell a taken address from a free one by comparing
+  // which failure they get. Drives the cap directly via raw rows (cheaper
+  // than two full ceremonies) rather than reusing "enforces 2-per-7-days
+  // cap" above.
+  it.effect("caps identically regardless of whether the target address is taken", () => {
+    const { layer, captured, sqlite } = makeEmailCapture();
+    return Effect.gen(function* () {
+      const { auth, profile } = yield* setup(
+        "ec-capcollision@example.com",
+        "eccapcollision",
+        captured,
+      );
+      // Another account already owns this address.
+      yield* auth.registerProfile("ec-capcollision-taken@example.com", "eccapcollisiontaken");
+
+      const nowSec = Math.floor(Date.now() / 1000);
+      for (const suffix of ["1", "2"]) {
+        sqlite
+          .query(
+            `INSERT INTO email_changes (id, account_id, previous_email, new_email, completed_at)
+             VALUES (?, ?, ?, ?, ?)`,
+          )
+          .run(
+            `ech_capcollision_${suffix}`,
+            profile.accountId,
+            "ec-capcollision-old@example.com",
+            `ec-capcollision-new-${suffix}@example.com`,
+            nowSec,
+          );
+      }
+
+      const takenErr = yield* Effect.flip(
+        auth.beginEmailChange(profile.accountId, "ec-capcollision-taken@example.com"),
+      );
+      const freeErr = yield* Effect.flip(
+        auth.beginEmailChange(profile.accountId, "ec-capcollision-free@example.com"),
+      );
+      expect(takenErr._tag).toBe("AuthError");
+      expect(freeErr._tag).toBe("AuthError");
+      expect(takenErr.message).toMatch(/limit reached/i);
+      expect(freeErr.message).toBe(takenErr.message);
     }).pipe(Effect.provide(layer));
   });
 });

--- a/osn/db/drizzle/0006_burly_lucky_pierre.sql
+++ b/osn/db/drizzle/0006_burly_lucky_pierre.sql
@@ -1,0 +1,2 @@
+DROP INDEX `email_changes_account_idx`;--> statement-breakpoint
+CREATE INDEX `email_changes_account_completed_at_idx` ON `email_changes` (`account_id`,`completed_at`);

--- a/osn/db/drizzle/meta/0006_snapshot.json
+++ b/osn/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1664 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dd78f1c7-39d5-43cb-b456-8e8e92560095",
+  "prevId": "52933f1f-baea-4fe3-a168-d725b0dfb3b7",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passkey_user_id": {
+          "name": "passkey_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_profiles": {
+          "name": "max_profiles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_restricted_at": {
+          "name": "processing_restricted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "accounts_passkey_user_id_unique": {
+          "name": "accounts_passkey_user_id_unique",
+          "columns": [
+            "passkey_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_enrollments": {
+      "name": "app_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "app_enrollments_account_idx": {
+          "name": "app_enrollments_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "app_enrollments_active_idx": {
+          "name": "app_enrollments_active_idx",
+          "columns": [
+            "account_id",
+            "app"
+          ],
+          "isUnique": false,
+          "where": "\"app_enrollments\".\"left_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "app_enrollments_account_id_accounts_id_fk": {
+          "name": "app_enrollments_account_id_accounts_id_fk",
+          "tableFrom": "app_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocks": {
+      "name": "blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blocks_blocker_idx": {
+          "name": "blocks_blocker_idx",
+          "columns": [
+            "blocker_id"
+          ],
+          "isUnique": false
+        },
+        "blocks_blocked_idx": {
+          "name": "blocks_blocked_idx",
+          "columns": [
+            "blocked_id"
+          ],
+          "isUnique": false
+        },
+        "blocks_pair_idx": {
+          "name": "blocks_pair_idx",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blocks_blocker_id_users_id_fk": {
+          "name": "blocks_blocker_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_id_users_id_fk": {
+          "name": "blocks_blocked_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_requester_idx": {
+          "name": "connections_requester_idx",
+          "columns": [
+            "requester_id"
+          ],
+          "isUnique": false
+        },
+        "connections_addressee_idx": {
+          "name": "connections_addressee_idx",
+          "columns": [
+            "addressee_id"
+          ],
+          "isUnique": false
+        },
+        "connections_pair_idx": {
+          "name": "connections_pair_idx",
+          "columns": [
+            "requester_id",
+            "addressee_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "connections_requester_id_users_id_fk": {
+          "name": "connections_requester_id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connections_addressee_id_users_id_fk": {
+          "name": "connections_addressee_id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deletion_jobs": {
+      "name": "deletion_jobs",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "soft_deleted_at": {
+          "name": "soft_deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hard_delete_at": {
+          "name": "hard_delete_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pulse_done_at": {
+          "name": "pulse_done_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zap_done_at": {
+          "name": "zap_done_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user_request'"
+        },
+        "cancel_session_id": {
+          "name": "cancel_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletion_jobs_hard_delete_idx": {
+          "name": "deletion_jobs_hard_delete_idx",
+          "columns": [
+            "hard_delete_at"
+          ],
+          "isUnique": false
+        },
+        "deletion_jobs_pulse_pending_idx": {
+          "name": "deletion_jobs_pulse_pending_idx",
+          "columns": [
+            "soft_deleted_at"
+          ],
+          "isUnique": false,
+          "where": "\"deletion_jobs\".\"pulse_done_at\" IS NULL"
+        },
+        "deletion_jobs_zap_pending_idx": {
+          "name": "deletion_jobs_zap_pending_idx",
+          "columns": [
+            "soft_deleted_at"
+          ],
+          "isUnique": false,
+          "where": "\"deletion_jobs\".\"zap_done_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "deletion_jobs_account_id_accounts_id_fk": {
+          "name": "deletion_jobs_account_id_accounts_id_fk",
+          "tableFrom": "deletion_jobs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_changes": {
+      "name": "email_changes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_email": {
+          "name": "previous_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_changes_account_completed_at_idx": {
+          "name": "email_changes_account_completed_at_idx",
+          "columns": [
+            "account_id",
+            "completed_at"
+          ],
+          "isUnique": false
+        },
+        "email_changes_completed_at_idx": {
+          "name": "email_changes_completed_at_idx",
+          "columns": [
+            "completed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_codes_expires_idx": {
+          "name": "oauth_codes_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_account_id_accounts_id_fk": {
+          "name": "oauth_authorization_codes_account_id_accounts_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_profile_id_users_id_fk": {
+          "name": "oauth_authorization_codes_profile_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector_identifier": {
+          "name": "sector_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "is_first_party": {
+          "name": "is_first_party",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_clients_sector_idx": {
+          "name": "oauth_clients_sector_idx",
+          "columns": [
+            "sector_identifier"
+          ],
+          "isUnique": false
+        },
+        "oauth_clients_owner_idx": {
+          "name": "oauth_clients_owner_idx",
+          "columns": [
+            "owner_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_owner_account_id_accounts_id_fk": {
+          "name": "oauth_clients_owner_account_id_accounts_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_consents_account_client_uq": {
+          "name": "oauth_consents_account_client_uq",
+          "columns": [
+            "account_id",
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_account_id_accounts_id_fk": {
+          "name": "oauth_consents_account_id_accounts_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_profile_id_users_id_fk": {
+          "name": "oauth_consents_profile_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organisation_members": {
+      "name": "organisation_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_members_org_idx": {
+          "name": "org_members_org_idx",
+          "columns": [
+            "organisation_id"
+          ],
+          "isUnique": false
+        },
+        "org_members_profile_idx": {
+          "name": "org_members_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "org_members_pair_idx": {
+          "name": "org_members_pair_idx",
+          "columns": [
+            "organisation_id",
+            "profile_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organisation_members_organisation_id_organisations_id_fk": {
+          "name": "organisation_members_organisation_id_organisations_id_fk",
+          "tableFrom": "organisation_members",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organisation_members_profile_id_users_id_fk": {
+          "name": "organisation_members_profile_id_users_id_fk",
+          "tableFrom": "organisation_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organisations": {
+      "name": "organisations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organisations_handle_unique": {
+          "name": "organisations_handle_unique",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        },
+        "organisations_owner_idx": {
+          "name": "organisations_owner_idx",
+          "columns": [
+            "owner_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organisations_owner_id_users_id_fk": {
+          "name": "organisations_owner_id_users_id_fk",
+          "tableFrom": "organisations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backup_eligible": {
+          "name": "backup_eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backup_state": {
+          "name": "backup_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        },
+        "passkeys_account_id_idx": {
+          "name": "passkeys_account_id_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_account_id_accounts_id_fk": {
+          "name": "passkeys_account_id_accounts_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_codes": {
+      "name": "recovery_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recovery_codes_code_hash_unique": {
+          "name": "recovery_codes_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "recovery_codes_account_idx": {
+          "name": "recovery_codes_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_account_id_accounts_id_fk": {
+          "name": "recovery_codes_account_id_accounts_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "security_events": {
+      "name": "security_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ua_label": {
+          "name": "ua_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "security_events_unacked_idx": {
+          "name": "security_events_unacked_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false,
+          "where": "\"security_events\".\"acknowledged_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_account_keys": {
+      "name": "service_account_keys",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key_jwk": {
+          "name": "public_key_jwk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_account_keys_service_idx": {
+          "name": "service_account_keys_service_idx",
+          "columns": [
+            "service_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "service_account_keys_service_id_service_accounts_service_id_fk": {
+          "name": "service_account_keys_service_id_service_accounts_service_id_fk",
+          "tableFrom": "service_account_keys",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "service_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_accounts": {
+      "name": "service_accounts",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authenticated_at": {
+          "name": "authenticated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ua_label": {
+          "name": "ua_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_account_idx": {
+          "name": "sessions_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_family_idx": {
+          "name": "sessions_family_idx",
+          "columns": [
+            "family_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_account_last_used_idx": {
+          "name": "sessions_account_last_used_idx",
+          "columns": [
+            "account_id",
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_account_id_accounts_id_fk": {
+          "name": "sessions_account_id_accounts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        },
+        "users_account_idx": {
+          "name": "users_account_idx",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "users_handle_idx": {
+          "name": "users_handle_idx",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_account_id_accounts_id_fk": {
+          "name": "users_account_id_accounts_id_fk",
+          "tableFrom": "users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/osn/db/drizzle/meta/_journal.json
+++ b/osn/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788097202987,
       "tag": "0005_goofy_gwen_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1788103572019,
+      "tag": "0006_burly_lucky_pierre",
+      "breakpoints": true
     }
   ]
 }

--- a/osn/db/src/schema/index.ts
+++ b/osn/db/src/schema/index.ts
@@ -337,7 +337,12 @@ export const emailChanges = sqliteTable(
     completedAt: integer("completed_at").notNull(),
   },
   (t) => [
-    index("email_changes_account_idx").on(t.accountId),
+    // Serves the 2-per-7-days cap predicate (accountId filter + completedAt
+    // range) as a single index scan instead of an accountId-only scan
+    // followed by a filter.
+    index("email_changes_account_completed_at_idx").on(t.accountId, t.completedAt),
+    // Kept for a future retention sweeper (not yet built) that will need to
+    // find rows past the retention window irrespective of account.
     index("email_changes_completed_at_idx").on(t.completedAt),
   ],
 );


### PR DESCRIPTION
## Summary

Five findings on the OSN email-change and registration flows, all in the same two service files, fixed together.

The one that matters is the constraint-error narrowing. `completeRegistration` matched `/UNIQUE|constraint/i` against the driver's error text and treated every hit as "another account won the race". That word `constraint` also appears in `NOT NULL constraint failed`, `FOREIGN KEY constraint failed` and `CHECK constraint failed` — real database faults, which the flow was answering with a clean `AuthError` telling the user their handle or email was taken. A genuine schema or data fault therefore looked, to the caller and to the logs, like ordinary contention.

The narrowing now lives in one place, `osn/api/src/lib/unique-constraint.ts`, shared by both flows, and matches only `UNIQUE constraint` or `SQLITE_CONSTRAINT_UNIQUE`. Anything else rethrows and surfaces as `DatabaseError`.

Alongside it: the 7-day email-change cap now runs *before* the address-collision probe (it ran after, so a rate-capped caller could tell a taken address from a free one by which error came back first), the cap predicate gets a composite index instead of an account-only one, and the email-change tests stop building two `EmailService` layers and discarding one.

## Workspaces affected

| Workspace | Change |
|---|---|
| `@osn/api` | New `src/lib/unique-constraint.ts`; narrowed matching in `registration.ts` and `email-change.ts`; cap/probe order swapped; test helper returns the email recorder |
| `@osn/db` | `email_changes` index replaced with a composite `(account_id, completed_at)`; migration `0006_burly_lucky_pierre.sql` |

## Issues

| Issue | Finding | What it was |
|---|---|---|
| 557 | S-M1 | `/UNIQUE\|constraint/i` in `registration.ts` mapped every constraint failure to a benign conflict |
| 558 | S-L2 | Nothing pinned the constraint-error text D1 actually raises |
| 559 | S-L4 | The 7-day cap was checked after the collision probe, giving an address-enumeration oracle |
| 560 | P-I2 | The cap query had no composite `(account_id, completed_at)` index |
| 561 | P-I4 | Every email-change test built two `EmailService` layers and discarded one |

Closes xchromo/osn-tracker#557.
Closes xchromo/osn-tracker#558.
Closes xchromo/osn-tracker#559.
Closes xchromo/osn-tracker#560.
Closes xchromo/osn-tracker#561.

## Decisions

### No `.cause` walk on the caught error

**Issue** — 557 and 558 both hinge on reading the SQLite error text out of a failed write. Drizzle 0.45.2 wraps some failures in a `DrizzleQueryError` whose real message sits on `.cause`, so a naive `e.message` test can read the wrapper's text and miss the constraint name entirely.

**Why** — Getting this wrong is invisible: the match silently stops firing, every duplicate email starts surfacing as a 500 instead of a conflict, and no test that only exercises bun:sqlite would notice.

**Solution** — Both call sites write through `commitBatch` (`shared/db-utils/src/index.ts:166`), and neither driver path wraps. Drizzle constructs `DrizzleQueryError` inside `queryWithCache` (`sqlite-core/session.js:38`) only; the D1 driver's `async batch(queries)` calls `this.client.batch(...)` raw at `d1/session.js:51`, bypassing it, and the bun-sqlite session has no `queryWithCache` call site at all. So the raw SQLite text is on `e.message` at the top level on both drivers, and `UNIQUE_CONSTRAINT_ERROR.test(msg)` is correct as written.

**Rationale** — The reasoning is recorded in the doc comment on `unique-constraint.ts` so the next person to touch it does not have to re-derive it. A single-statement D1 write *does* wrap (`d1/session.js:119,128,152,180`) and would need the `.cause` walk — the comment says which shape is which, because the difference is not guessable from the call site.

**Out of scope** — Adding a `.cause` walk defensively "in case". It would be dead code today and would hide the day the batch path starts wrapping, which is exactly when we want a loud failure.

### The pinning test runs against real D1, not bun:sqlite

**Issue** — 558 asks for the constraint-error text to be pinned by a test. A test on bun:sqlite would pin bun's spelling, which is not the spelling production raises.

**Solution** — Two cases added to `osn/api/src/d1-integration.test.ts`, which runs against a workerd-backed D1 through Miniflare: one asserting a duplicate email raised through `commitBatch` matches `UNIQUE_CONSTRAINT_ERROR`, and one asserting a foreign-key violation raised the same way does **not** match. The negative case is the one that would have caught the original bug.

**Rationale** — That file runs on `bun:test`, not vitest — it is excluded by `osn/api/vitest.config.ts` and driven by the `test:d1` script, wired into CI at `.github/workflows/ci.yml:153` and `deploy.yml:192`. So the pin runs on every PR against the same engine production uses.

### The old account-only index is dropped, not kept alongside

**Issue** — 560 wants a composite `(account_id, completed_at)` for the cap predicate. `email_changes_account_idx` on `account_id` alone was already there.

**Solution** — Replaced it. A composite index leads with `account_id`, so every query the old index could serve, the new one serves too. Keeping both would cost a second write on every email change to serve nothing.

**Rationale** — `email_changes_completed_at_idx` (on `completed_at` alone) stays, because it answers a different question — rows past the retention window irrespective of account — that the composite cannot serve from its leading column.

## Test plan

| Gate | Result |
|---|---|
| `bun run lint` | Pass — no new warnings; the pre-existing `no-console` warnings in `shared/dev-urls/src/cli.ts` are untouched |
| `bun run fmt:check` | Pass — 1430 files |
| `bun run check` | Pass — 37/37 |
| `bun run test` | Pass — 38/38 tasks |
| `bun run --cwd osn/api test:d1` | Pass — 4 tests, including the two new D1 constraint-text pins |
| `osn/db` ddl-lockstep | Pass — migration `0006` matches the schema |

**Not run:** no deployed-tier verification. The new migration has not been applied to dev or production; it runs on the next deploy through the normal migration step.

**Not run:** no load or timing measurement of the new composite index. The change is judged on the predicate shape (`account_id` equality + `completed_at` range served by one scan instead of an account-only scan plus a filter), not on a benchmark — the table holds at most a handful of rows per account by construction of the cap itself.
