### PR TITLE
perf(zap): fold chat and message write paths into fewer D1 round trips

### DIFF
--- a/.changeset/zap-write-hops.md
+++ b/.changeset/zap-write-hops.md
@@ -1,0 +1,52 @@
+---
+"@zap/api": patch
+---
+
+Fold Zap's per-chat write and membership paths from several round trips into one.
+
+`sendMessage`, `listMessages` and `sendC2bMessage` each used to run a `SELECT`
+for the chat row and then a separate `assertMember` query for membership,
+paying two round trips before doing anything. All three now run a single
+`LEFT JOIN` between `chats` and `chat_members` scoped to the caller's
+`profileId`, reading chat existence and membership off one row (`memberId ===
+null` is the new non-member signal, in place of `assertMember`'s empty
+result set).
+
+`createChat`, `provisionC2bChat` and `sendC2bMessage` batch their multi-row
+writes (`commitBatch` from `@shared/db-utils`) instead of several sequential
+`Effect.tryPromise` awaits — atomic on D1's `db.batch`, sequential-but-safe on
+bun:sqlite. Member-row inserts are chunked at `MAX_MEMBER_ROWS_PER_INSERT` (20
+rows/statement, new in `zap/api/src/lib/limits.ts`) to stay under D1's
+~100-bound-parameter ceiling per query on a chat created at the
+`MAX_CHAT_MEMBERS` (500) cap.
+
+`addMember`'s cap-plus-duplicate check is folded into one query
+(`count()` + a conditional `sum()` over `chat_members`, in place of a
+`COUNT(*)` followed by a separate indexed duplicate lookup), and the
+remaining concurrent-duplicate-add race — two adds of the same profile
+both passing the check before either inserts — is closed by catching the
+database's own unique-constraint failure on the follow-up INSERT and
+resolving it to `AlreadyMember` (409) instead of `DatabaseError` (500). The
+bounded `.cause`-chain walk this needs (`isUniqueConstraintFailure`, exported
+for its own unit tests) accounts for D1 wrapping every failure in
+`DrizzleQueryError` where bun:sqlite does not.
+
+`createChat` and `provisionC2bChat` now cap `memberProfileIds` at
+`MAX_CHAT_MEMBERS` — previously unbounded on `createChat`, so a caller could
+build a batched INSERT arbitrarily larger than D1 can execute in one
+invocation.
+
+The ARC-gated DSAR account-export route (`POST /internal/account-export`)
+gains an explicit cap: `profile_ids` over `MAX_EXPORT_PROFILE_IDS` (100, new
+limit) now returns 400 rather than letting the loaders' `IN (...)` clauses
+grow past D1's bound-parameter ceiling. Its c2b-message loader
+(`loadC2bMessages`) also replaces a two-query pair — c2b chat ids for the
+profiles, then messages by `inArray(messages.chatId, c2bChatIds)`, the second
+query's `IN` list unbounded in parameters — with a single three-table join
+scoped only by `profileIds`, and groups by `messages.id` rather than using
+`DISTINCT`: the join can duplicate a message row when two exported profiles
+share a chat, and the projection (`chatId`, `body`, `createdAt`) deliberately
+carries no `messages.id`, so a naive `DISTINCT` on the projected columns would
+collapse two genuinely different messages that share a body and the same
+second-resolution `createdAt` into one row and silently drop a message from a
+data subject's export.

--- a/bun.lock
+++ b/bun.lock
@@ -681,6 +681,7 @@
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
         "@shared/crypto": "workspace:*",
+        "@shared/db-utils": "workspace:*",
         "@shared/observability": "workspace:*",
         "@shared/osn-auth-client": "workspace:*",
         "@shared/rate-limit": "workspace:*",
@@ -692,7 +693,6 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
         "@effect/vitest": "^0.30.0",
-        "@shared/db-utils": "workspace:*",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "jose": "^6.2.4",

--- a/zap/api/package.json
+++ b/zap/api/package.json
@@ -29,6 +29,7 @@
     "@elysiajs/cors": "^1.4.2",
     "@elysiajs/eden": "^1.4.9",
     "@shared/crypto": "workspace:*",
+    "@shared/db-utils": "workspace:*",
     "@shared/observability": "workspace:*",
     "@shared/osn-auth-client": "workspace:*",
     "@shared/rate-limit": "workspace:*",
@@ -40,7 +41,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
     "@effect/vitest": "^0.30.0",
-    "@shared/db-utils": "workspace:*",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "jose": "^6.2.4",

--- a/zap/api/src/lib/limits.ts
+++ b/zap/api/src/lib/limits.ts
@@ -37,3 +37,18 @@ export const MAX_MEMBER_LIMIT = MAX_CHAT_MEMBERS;
 
 /** Max length of a server-visible c2b message body (plaintext chars). */
 export const MAX_BODY_LENGTH = 8_000;
+
+/**
+ * Maximum member rows per INSERT statement in a batched chat-creation write.
+ * A member row binds 5 parameters (id, chat_id, profile_id, role,
+ * joined_at) — 20 rows/statement keeps each INSERT at 100 bound parameters,
+ * D1's per-query ceiling.
+ */
+export const MAX_MEMBER_ROWS_PER_INSERT = 20;
+
+/**
+ * Maximum profile IDs accepted per DSAR export request. Each ID is one bound
+ * parameter in the `IN (...)` clauses the account-export loaders build —
+ * capped to stay under D1's ~100-bound-parameter ceiling per query.
+ */
+export const MAX_EXPORT_PROFILE_IDS = 100;

--- a/zap/api/src/routes/internal.ts
+++ b/zap/api/src/routes/internal.ts
@@ -11,6 +11,7 @@ import {
   requireArc,
   revokeServiceKey,
 } from "../lib/arc-middleware";
+import { MAX_CHAT_MEMBERS, MAX_EXPORT_PROFILE_IDS } from "../lib/limits";
 import { provisionC2bChat } from "../services/chats";
 import { sendC2bMessage, listC2bMessages } from "../services/messages";
 
@@ -95,19 +96,21 @@ const loadC2bMessages = (
   Effect.gen(function* () {
     if (profileIds.length === 0) return [];
     const { db } = yield* Db;
-    // First find the c2b chat IDs this set of profiles belongs to.
-    const memberRows = yield* Effect.promise(
-      (): Promise<{ chatId: string }[]> =>
-        db
-          .select({ chatId: chatMembers.chatId })
-          .from(chatMembers)
-          .innerJoin(chats, and(eq(chats.id, chatMembers.chatId), eq(chats.class, "c2b")))
-          .where(inArray(chatMembers.profileId, [...profileIds])) as Promise<{ chatId: string }[]>,
-    );
-    if (memberRows.length === 0) return [];
-    const c2bChatIds = [...new Set(memberRows.map((r) => r.chatId))];
+    // Single 3-table join replaces the old two-query pair (c2b chat ids for
+    // the profiles, then messages by `inArray(messages.chatId, c2bChatIds)`)
+    // — the second query's `IN` list was unbounded in parameters, so a
+    // profile in more than ~100 c2b chats failed the export outright. Only
+    // `profileIds` is bound here.
     // Read only `body` — never `ciphertext` or `nonce`.
     // isNotNull(body): defence-in-depth — only c2b bodies, never a stray null.
+    // groupBy(messages.id), not DISTINCT: the join duplicates a message row
+    // when two exported profiles share a chat. DISTINCT applies to the
+    // *projected* columns, and the projection deliberately has no
+    // `messages.id` — two genuinely different messages in the same chat with
+    // the same body and the same second-resolution `createdAt` would collapse
+    // into one and the data subject would silently lose a message. Grouping
+    // by a non-projected column (the message's own primary key) is valid
+    // SQLite and keeps them apart.
     // orderBy + limit: bounds the fetch to keep the export within Worker memory/CPU.
     const msgRows = yield* Effect.promise(
       (): Promise<{ chatId: string; body: string; createdAt: Date }[]> =>
@@ -118,7 +121,10 @@ const loadC2bMessages = (
             createdAt: messages.createdAt,
           })
           .from(messages)
-          .where(and(inArray(messages.chatId, c2bChatIds), isNotNull(messages.body)))
+          .innerJoin(chatMembers, eq(chatMembers.chatId, messages.chatId))
+          .innerJoin(chats, and(eq(chats.id, messages.chatId), eq(chats.class, "c2b")))
+          .where(and(inArray(chatMembers.profileId, [...profileIds]), isNotNull(messages.body)))
+          .groupBy(messages.id)
           .orderBy(desc(messages.createdAt))
           .limit(MAX_EXPORT_C2B_MESSAGES) as Promise<
           { chatId: string; body: string; createdAt: Date }[]
@@ -234,6 +240,15 @@ export const createInternalRoutes = (dbLayer: Layer.Layer<DbType> = DbLive) => {
           );
           if (!caller) return { error: "Unauthorized" };
 
+          // Bound at the boundary rather than letting D1 fail the export: each
+          // profile id is one bound parameter in the `inArray(...)` clauses
+          // both loaders below build, so an unbounded list risks D1's
+          // ~100-bound-parameter ceiling per query.
+          if (body.profile_ids.length > MAX_EXPORT_PROFILE_IDS) {
+            set.status = 400;
+            return { error: `profile_ids exceeds max of ${MAX_EXPORT_PROFILE_IDS}` };
+          }
+
           const [membershipRecords, c2bMessageRecords] = await runtime.runPromise(
             Effect.all([loadChatMemberships(body.profile_ids), loadC2bMessages(body.profile_ids)]),
           );
@@ -295,7 +310,7 @@ export const createInternalRoutes = (dbLayer: Layer.Layer<DbType> = DbLive) => {
         },
         {
           body: t.Object({
-            memberProfileIds: t.Array(t.String(), { minItems: 2 }),
+            memberProfileIds: t.Array(t.String(), { minItems: 2, maxItems: MAX_CHAT_MEMBERS }),
             createdByProfileId: t.String({ minLength: 1 }),
             title: t.Optional(t.String()),
           }),

--- a/zap/api/src/services/chats.ts
+++ b/zap/api/src/services/chats.ts
@@ -1,7 +1,8 @@
+import { commitBatch } from "@shared/db-utils";
 import { chats, chatMembers } from "@zap/db/schema";
 import type { Chat, ChatMember } from "@zap/db/schema";
 import { Db } from "@zap/db/service";
-import { and, asc, count, desc, eq, lt, or } from "drizzle-orm";
+import { and, asc, count, desc, eq, lt, or, sql } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
 import {
@@ -11,6 +12,7 @@ import {
   MAX_CHAT_MEMBERS,
   MAX_CHAT_TITLE_LENGTH,
   MAX_MEMBER_LIMIT,
+  MAX_MEMBER_ROWS_PER_INSERT,
 } from "../lib/limits";
 import { storedNow } from "../lib/storedNow";
 import { metricChatCreated, metricMemberAdded, metricMemberRemoved } from "../metrics";
@@ -89,7 +91,10 @@ const ChatTypeEnum = Schema.Literal("dm", "group", "event");
 const TitleString = Schema.String.pipe(Schema.maxLength(MAX_CHAT_TITLE_LENGTH));
 
 const ProvisionC2bChatSchema = Schema.Struct({
-  memberProfileIds: Schema.Array(Schema.String).pipe(Schema.minItems(2)),
+  memberProfileIds: Schema.Array(Schema.String).pipe(
+    Schema.minItems(2),
+    Schema.maxItems(MAX_CHAT_MEMBERS),
+  ),
   createdByProfileId: Schema.String,
   title: Schema.optional(TitleString),
 });
@@ -98,12 +103,61 @@ const CreateChatSchema = Schema.Struct({
   type: ChatTypeEnum,
   title: Schema.optional(TitleString),
   eventId: Schema.optional(Schema.String),
-  memberProfileIds: Schema.optional(Schema.Array(Schema.String)),
+  memberProfileIds: Schema.optional(
+    Schema.Array(Schema.String).pipe(Schema.maxItems(MAX_CHAT_MEMBERS)),
+  ),
 });
 
 const UpdateChatSchema = Schema.Struct({
   title: Schema.optional(TitleString),
 });
+
+// ---------------------------------------------------------------------------
+// Write helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits an array of already-built row objects into chunks of at most
+ * `size`. Used to keep a single batched INSERT's bound-parameter count under
+ * D1's per-query ceiling — chunking rows, not pre-built statement groups, so
+ * this is a fresh, differently-shaped helper from `cire/api`'s
+ * `chunkGroups`, not a port of it.
+ */
+const chunkRows = <T>(rows: readonly T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) {
+    chunks.push(rows.slice(i, i + size));
+  }
+  return chunks;
+};
+
+/**
+ * Detects a SQLite unique-constraint failure by walking a bounded number of
+ * `.cause` levels (5) and testing each level's `message`.
+ *
+ * D1's session wraps every failure in `DrizzleQueryError`
+ * (`drizzle-orm/d1/session.js`): the top-level `.message` is `"Failed
+ * query: …"` and the driver error carrying `UNIQUE constraint failed:
+ * chat_members.chat_id, chat_members.profile_id` sits one level down in
+ * `.cause`. bun:sqlite's session does not wrap (no `queryWithCache` call in
+ * `drizzle-orm/bun-sqlite/session.js`), so locally the substring is already
+ * at the top level — walking still finds it there on the first iteration.
+ * Matches on the message substring only, never on the constraint name
+ * (`chat_members_pair_idx`), which never appears in the error text.
+ */
+export const isUniqueConstraintFailure = (error: unknown): boolean => {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5; depth++) {
+    if (!(current instanceof Error)) {
+      return false;
+    }
+    if (current.message.includes("UNIQUE constraint failed")) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+};
 
 // ---------------------------------------------------------------------------
 // Service functions
@@ -251,39 +305,46 @@ export const createChat = (
       updatedAt: now,
     };
 
-    yield* Effect.tryPromise({
-      try: () => db.insert(chats).values(row),
-      catch: (cause) => new DatabaseError({ cause }),
-    });
+    // Creator as admin, plus the already consent-checked + de-duped initial
+    // members — one row array, one batch, rather than three sequential
+    // round trips.
+    const creatorMemberRow = {
+      id: "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+      chatId: id,
+      profileId: creatorProfileId,
+      role: "admin" as const,
+      joinedAt: now,
+    };
+    const otherMemberRows = initialMembers.map((uid) => ({
+      id: "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+      chatId: id,
+      profileId: uid,
+      role: "member" as const,
+      joinedAt: now,
+    }));
+    const allMemberRows = [creatorMemberRow, ...otherMemberRows];
 
-    // Add creator as admin member.
-    const memberId = "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    // FK-first ordering: the chat row is inserted before any member row,
+    // which references it. Chunked at MAX_MEMBER_ROWS_PER_INSERT rows per
+    // INSERT to stay under D1's ~100-bound-parameter ceiling — up to
+    // MAX_CHAT_MEMBERS+1 (501) member rows here (the creator plus up to
+    // MAX_CHAT_MEMBERS others, the schema's cap on `memberProfileIds`)
+    // chunks into ceil(501/20) = 26 INSERTs, plus the chat INSERT itself =
+    // 27 statements — under D1's 50-queries-per-invocation Free-tier bound.
+    // Atomic on D1 (`db.batch`); on bun:sqlite `commitBatch` chains the
+    // statements sequentially with no rollback, which is not a regression
+    // versus the three separate awaits this replaces — no test may assert
+    // joint rollback there.
     yield* Effect.tryPromise({
       try: () =>
-        db.insert(chatMembers).values({
-          id: memberId,
-          chatId: id,
-          profileId: creatorProfileId,
-          role: "admin",
-          joinedAt: now,
-        }),
+        commitBatch(db, [
+          db.insert(chats).values(row),
+          ...chunkRows(allMemberRows, MAX_MEMBER_ROWS_PER_INSERT).map((chunk) =>
+            db.insert(chatMembers).values(chunk),
+          ),
+        ]),
       catch: (cause) => new DatabaseError({ cause }),
     });
-
-    // Batch-insert initial members (already consent-checked + de-duped).
-    if (initialMembers.length > 0) {
-      const memberRows = initialMembers.map((uid) => ({
-        id: "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12),
-        chatId: id,
-        profileId: uid,
-        role: "member" as const,
-        joinedAt: now,
-      }));
-      yield* Effect.tryPromise({
-        try: () => db.insert(chatMembers).values(memberRows),
-        catch: (cause) => new DatabaseError({ cause }),
-      });
-    }
 
     metricChatCreated(validated.type, "ok");
     // Returned from the values just written — see `provisionC2bChat`.
@@ -321,10 +382,38 @@ export const updateChat = (
     // update is gone. `storedNow()` is what makes that safe: Drizzle stores a
     // timestamp as whole seconds, and an untruncated `Date` here would make
     // the response disagree with every later read of the same row.
-    const chat = yield* getChat(id);
+    //
+    // One LEFT JOIN replaces the separate `getChat` + `assertAdmin` lookups —
+    // the nested `chat` projection carries the whole row (this function
+    // spreads `{ ...chat, ... }` below) and `role` says whether the
+    // requester is a member at all.
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<{ chat: Chat; role: ChatMember["role"] | null }[]> =>
+        db
+          .select({ chat: chats, role: chatMembers.role })
+          .from(chats)
+          .leftJoin(
+            chatMembers,
+            and(eq(chatMembers.chatId, chats.id), eq(chatMembers.profileId, requestingProfileId)),
+          )
+          .where(eq(chats.id, id))
+          .limit(1) as Promise<{ chat: Chat; role: ChatMember["role"] | null }[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (rows.length === 0) {
+      return yield* Effect.fail(new ChatNotFound({ id }));
+    }
+    const { chat, role } = rows[0]!;
 
-    // Check that the requesting user is an admin.
-    yield* assertAdmin(id, requestingProfileId);
+    // `role` null (no membership row) or a non-"admin" role both mean "not an
+    // admin" and must fail `NotChatAdmin`, never `NotChatMember` — the
+    // deleted `assertAdmin` filtered `role = 'admin'` in its WHERE clause, so
+    // a non-admin AND a non-member both fell through to `NotChatAdmin`. A
+    // "natural" fold that maps the null case to `NotChatMember` would
+    // silently change this route's status from 403 to 404.
+    if (role !== "admin") {
+      return yield* Effect.fail(new NotChatAdmin({ chatId: id }));
+    }
 
     // After the authorisation gate, not before — see `addMember`. A 409 "not
     // a c2c chat" reaching a caller with no standing in the chat would tell
@@ -377,8 +466,30 @@ export const addMember = (
 > =>
   Effect.gen(function* () {
     const { db } = yield* Db;
-    const chat = yield* getChat(chatId);
-    yield* assertAdmin(chatId, requestingProfileId);
+    // One LEFT JOIN replaces the separate `getChat` + `assertAdmin` lookups —
+    // see `updateChat` for the same fold and the same null-vs-non-admin note.
+    const chatRows = yield* Effect.tryPromise({
+      try: (): Promise<{ chat: Chat; role: ChatMember["role"] | null }[]> =>
+        db
+          .select({ chat: chats, role: chatMembers.role })
+          .from(chats)
+          .leftJoin(
+            chatMembers,
+            and(eq(chatMembers.chatId, chats.id), eq(chatMembers.profileId, requestingProfileId)),
+          )
+          .where(eq(chats.id, chatId))
+          .limit(1) as Promise<{ chat: Chat; role: ChatMember["role"] | null }[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (chatRows.length === 0) {
+      return yield* Effect.fail(new ChatNotFound({ id: chatId }));
+    }
+    const { chat, role } = chatRows[0]!;
+    // `role` null (no membership row) or a non-"admin" role both fail
+    // `NotChatAdmin`, never `NotChatMember` — see `updateChat`'s fold for why.
+    if (role !== "admin") {
+      return yield* Effect.fail(new NotChatAdmin({ chatId }));
+    }
 
     // After the authorisation gate, not before. `assertC2c` answers 409 "not a
     // c2c chat", which to a caller with no standing in the chat would say the
@@ -395,31 +506,31 @@ export const addMember = (
     // profile being added. Fail-closed on graph-unreachable.
     yield* checkConsent(requestingProfileId, profileId);
 
-    // P-W2: check the member count with COUNT(*) instead of loading every
-    // member row (up to MAX_CHAT_MEMBERS) into memory.
-    const countRows = yield* Effect.tryPromise({
-      try: (): Promise<{ value: number }[]> =>
+    // P-W2/cap+duplicate fold: one query over chat_members instead of a
+    // COUNT(*) followed by a separate indexed duplicate lookup. `sum()` from
+    // drizzle-orm 0.45.2 is typed `SQL<string | null>`
+    // (`sql\`sum(...)\`.mapWith(String)`), which does not typecheck against a
+    // numeric comparison — the raw `sql<number>` template is used instead.
+    // `sum` over zero matching rows is SQL NULL, hence the `dup ?? 0` guard;
+    // `count()` already maps with `Number`, so `total` needs no guard.
+    const capRows = yield* Effect.tryPromise({
+      try: (): Promise<{ total: number; dup: number | null }[]> =>
         db
-          .select({ value: count() })
+          .select({
+            total: count(),
+            dup: sql<number>`sum(${chatMembers.profileId} = ${profileId})`,
+          })
           .from(chatMembers)
-          .where(eq(chatMembers.chatId, chatId)) as Promise<{ value: number }[]>,
+          .where(eq(chatMembers.chatId, chatId)) as Promise<
+          { total: number; dup: number | null }[]
+        >,
       catch: (cause) => new DatabaseError({ cause }),
     });
-    if ((countRows[0]?.value ?? 0) >= MAX_CHAT_MEMBERS) {
+    const { total, dup } = capRows[0]!;
+    if (total >= MAX_CHAT_MEMBERS) {
       return yield* Effect.fail(new MemberLimitReached({ chatId }));
     }
-
-    // Check if already a member (single indexed lookup on the unique pair).
-    const duplicate = yield* Effect.tryPromise({
-      try: (): Promise<{ id: string }[]> =>
-        db
-          .select({ id: chatMembers.id })
-          .from(chatMembers)
-          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.profileId, profileId)))
-          .limit(1) as Promise<{ id: string }[]>,
-      catch: (cause) => new DatabaseError({ cause }),
-    });
-    if (duplicate.length > 0) {
+    if ((dup ?? 0) > 0) {
       return yield* Effect.fail(new AlreadyMember({ chatId, profileId }));
     }
 
@@ -435,15 +546,58 @@ export const addMember = (
       role: "member",
       joinedAt: now,
     };
+    // The cap/duplicate check above narrows the concurrent-duplicate window
+    // but cannot close it (P-I/TOCTOU) — two concurrent adds of the *same*
+    // profile can both pass it and both reach this INSERT. The unique
+    // constraint on (chat_id, profile_id) is the real guard: catch its
+    // failure and resolve to `AlreadyMember` (409) rather than `DatabaseError`
+    // (500). This fixes concurrent duplicate adds only — the member *cap* has
+    // a separate, pre-existing TOCTOU (two concurrent adds of *different*
+    // profiles can both read `total = 499` and both insert), which this does
+    // not close and is not a regression.
     yield* Effect.tryPromise({
       try: () => db.insert(chatMembers).values(row),
-      catch: (cause) => new DatabaseError({ cause }),
+      catch: (cause) =>
+        isUniqueConstraintFailure(cause)
+          ? new AlreadyMember({ chatId, profileId })
+          : new DatabaseError({ cause }),
     });
     metricMemberAdded("ok");
 
     // Returned from the values just written — see `provisionC2bChat`.
     return row;
   }).pipe(Effect.withSpan("zap.chats.add_member"));
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Still used by `removeMember` (admin-removing-another-member path) — not a
+// fold target in this plan, only `updateChat` and `addMember` are.
+const assertAdmin = (
+  chatId: string,
+  profileId: string,
+): Effect.Effect<void, NotChatAdmin | DatabaseError, Db> =>
+  Effect.gen(function* () {
+    const { db } = yield* Db;
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<ChatMember[]> =>
+        db
+          .select()
+          .from(chatMembers)
+          .where(
+            and(
+              eq(chatMembers.chatId, chatId),
+              eq(chatMembers.profileId, profileId),
+              eq(chatMembers.role, "admin"),
+            ),
+          ) as Promise<ChatMember[]>,
+      catch: (cause) => new DatabaseError({ cause }),
+    });
+    if (rows.length === 0) {
+      return yield* Effect.fail(new NotChatAdmin({ chatId }));
+    }
+  });
 
 export const removeMember = (
   chatId: string,
@@ -586,11 +740,6 @@ export const provisionC2bChat = (input: {
       updatedAt: now,
     };
 
-    yield* Effect.tryPromise({
-      try: () => db.insert(chats).values(row),
-      catch: (cause) => new DatabaseError({ cause }),
-    });
-
     // Insert all members (no role distinction — cire is the trusted authorizer).
     const memberRows = memberSet.map((profileId) => ({
       id: "cmem_" + crypto.randomUUID().replace(/-/g, "").slice(0, 12),
@@ -599,8 +748,24 @@ export const provisionC2bChat = (input: {
       role: "member" as const,
       joinedAt: now,
     }));
+
+    // FK-first ordering: the chat row is inserted before any member row,
+    // which references it. Chunked at MAX_MEMBER_ROWS_PER_INSERT rows per
+    // INSERT to stay under D1's ~100-bound-parameter ceiling — up to
+    // MAX_CHAT_MEMBERS (500) rows here chunks into ceil(500/20) = 25
+    // INSERTs, plus the chat INSERT itself = 26 statements — under D1's
+    // 50-queries-per-invocation Free-tier bound. Atomic on D1 (`db.batch`);
+    // on bun:sqlite `commitBatch` chains the statements sequentially with
+    // no rollback, which is not a regression versus the two separate awaits
+    // this replaces — no test may assert joint rollback there.
     yield* Effect.tryPromise({
-      try: () => db.insert(chatMembers).values(memberRows),
+      try: () =>
+        commitBatch(db, [
+          db.insert(chats).values(row),
+          ...chunkRows(memberRows, MAX_MEMBER_ROWS_PER_INSERT).map((chunk) =>
+            db.insert(chatMembers).values(chunk),
+          ),
+        ]),
       catch: (cause) => new DatabaseError({ cause }),
     });
 
@@ -632,34 +797,5 @@ export const assertMember = (
     });
     if (rows.length === 0) {
       return yield* Effect.fail(new NotChatMember({ chatId }));
-    }
-  });
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-const assertAdmin = (
-  chatId: string,
-  profileId: string,
-): Effect.Effect<void, NotChatAdmin | DatabaseError, Db> =>
-  Effect.gen(function* () {
-    const { db } = yield* Db;
-    const rows = yield* Effect.tryPromise({
-      try: (): Promise<ChatMember[]> =>
-        db
-          .select()
-          .from(chatMembers)
-          .where(
-            and(
-              eq(chatMembers.chatId, chatId),
-              eq(chatMembers.profileId, profileId),
-              eq(chatMembers.role, "admin"),
-            ),
-          ) as Promise<ChatMember[]>,
-      catch: (cause) => new DatabaseError({ cause }),
-    });
-    if (rows.length === 0) {
-      return yield* Effect.fail(new NotChatAdmin({ chatId }));
     }
   });

--- a/zap/api/src/services/messages.ts
+++ b/zap/api/src/services/messages.ts
@@ -1,5 +1,6 @@
+import { commitBatch } from "@shared/db-utils";
 import { chats, chatMembers, messages } from "@zap/db/schema";
-import type { Chat, ChatMember, Message } from "@zap/db/schema";
+import type { Chat, Message } from "@zap/db/schema";
 import { Db } from "@zap/db/service";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
@@ -67,19 +68,28 @@ export const sendMessage = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    // Verify chat exists.
-    const chatRows = yield* Effect.tryPromise({
-      try: (): Promise<Chat[]> =>
-        db.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+    // Verify chat exists and sender is a member in one LEFT JOIN, in place of
+    // the separate SELECT + assertMember round trips this used to make.
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<{ chat: Chat; memberId: string | null }[]> =>
+        db
+          .select({ chat: chats, memberId: chatMembers.id })
+          .from(chats)
+          .leftJoin(
+            chatMembers,
+            and(eq(chatMembers.chatId, chats.id), eq(chatMembers.profileId, senderProfileId)),
+          )
+          .where(eq(chats.id, chatId))
+          .limit(1) as Promise<{ chat: Chat; memberId: string | null }[]>,
       catch: (cause) => new DatabaseError({ cause }),
     });
-    if (chatRows.length === 0) {
+    if (rows.length === 0) {
       return yield* Effect.fail(new ChatNotFound({ id: chatId }));
     }
-    const chat = chatRows[0]!;
-
-    // Verify sender is a member.
-    yield* assertMember(chatId, senderProfileId);
+    const { chat, memberId } = rows[0]!;
+    if (memberId === null) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
 
     // Assert this is a c2c chat — the mirror of `sendC2bMessage`'s check.
     // Without it a member of a c2b chat could write ciphertext into it through
@@ -136,18 +146,28 @@ export const listMessages = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    // Verify chat exists.
-    const chatRows = yield* Effect.tryPromise({
-      try: (): Promise<Chat[]> =>
-        db.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+    // Verify chat exists and user is a member in one LEFT JOIN, in place of
+    // the separate SELECT + assertMember round trips this used to make.
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<{ chat: Chat; memberId: string | null }[]> =>
+        db
+          .select({ chat: chats, memberId: chatMembers.id })
+          .from(chats)
+          .leftJoin(
+            chatMembers,
+            and(eq(chatMembers.chatId, chats.id), eq(chatMembers.profileId, profileId)),
+          )
+          .where(eq(chats.id, chatId))
+          .limit(1) as Promise<{ chat: Chat; memberId: string | null }[]>,
       catch: (cause) => new DatabaseError({ cause }),
     });
-    if (chatRows.length === 0) {
+    if (rows.length === 0) {
       return yield* Effect.fail(new ChatNotFound({ id: chatId }));
     }
-
-    // Verify user is a member.
-    yield* assertMember(chatId, profileId);
+    const { chat, memberId } = rows[0]!;
+    if (memberId === null) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
 
     // The read half of the same rule the write path enforces. Without it the
     // public route serves a c2b chat's plaintext `body` column to any member,
@@ -156,7 +176,7 @@ export const listMessages = (
     // rows whose `ciphertext` and `nonce` are both null.
     //
     // After the membership check, for the reason `sendMessage` gives.
-    if (chatRows[0]!.class !== "c2c") {
+    if (chat.class !== "c2c") {
       return yield* Effect.fail(new NotC2cChat({ chatId }));
     }
 
@@ -223,24 +243,41 @@ export const sendC2bMessage = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    // Verify chat exists.
-    const chatRows = yield* Effect.tryPromise({
-      try: (): Promise<Chat[]> =>
-        db.select().from(chats).where(eq(chats.id, chatId)).limit(1) as Promise<Chat[]>,
+    // Verify chat exists and sender is a member in one LEFT JOIN, in place of
+    // the separate SELECT + assertMember round trips this used to make.
+    const rows = yield* Effect.tryPromise({
+      try: (): Promise<{ chat: Chat; memberId: string | null }[]> =>
+        db
+          .select({ chat: chats, memberId: chatMembers.id })
+          .from(chats)
+          .leftJoin(
+            chatMembers,
+            and(eq(chatMembers.chatId, chats.id), eq(chatMembers.profileId, senderProfileId)),
+          )
+          .where(eq(chats.id, chatId))
+          .limit(1) as Promise<{ chat: Chat; memberId: string | null }[]>,
       catch: (cause) => new DatabaseError({ cause }),
     });
-    if (chatRows.length === 0) {
+    if (rows.length === 0) {
       return yield* Effect.fail(new ChatNotFound({ id: chatId }));
     }
-    const chat = chatRows[0]!;
+    const { chat, memberId } = rows[0]!;
 
-    // Assert this is a c2b chat.
+    // Assert this is a c2b chat — BEFORE the membership check, the mirror
+    // image of `sendMessage`'s ordering. That route is public, so membership
+    // has to come first there or a stranger holding a chat id could tell a
+    // c2c chat from a c2b one. This route is ARC-gated and only cire calls
+    // it — there's no untrusted caller to withhold class from — so checking
+    // class first means a c2c chat id passed here by mistake comes back
+    // `NotC2bChat`, the real reason, instead of a manufactured `NotChatMember`
+    // that would send an integrator debugging the wrong thing.
     if (chat.class !== "c2b") {
       return yield* Effect.fail(new NotC2bChat({ chatId }));
     }
 
-    // Verify sender is a member.
-    yield* assertMember(chatId, senderProfileId);
+    if (memberId === null) {
+      return yield* Effect.fail(new NotChatMember({ chatId }));
+    }
 
     const validated = yield* Schema.decodeUnknown(SendC2bMessageSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
@@ -260,14 +297,16 @@ export const sendC2bMessage = (
       expiresAt: null,
     };
 
+    // One hop instead of two sequential writes. Atomic on D1 (`db.batch`); on
+    // bun:sqlite `commitBatch` chains the statements sequentially with no
+    // rollback, which is not a regression versus the two separate awaits this
+    // replaces — no test may assert joint rollback there.
     yield* Effect.tryPromise({
-      try: () => db.insert(messages).values(row),
-      catch: (cause) => new DatabaseError({ cause }),
-    });
-
-    // Bump chat's updatedAt.
-    yield* Effect.tryPromise({
-      try: () => db.update(chats).set({ updatedAt: now }).where(eq(chats.id, chatId)),
+      try: () =>
+        commitBatch(db, [
+          db.insert(messages).values(row),
+          db.update(chats).set({ updatedAt: now }).where(eq(chats.id, chatId)),
+        ]),
       catch: (cause) => new DatabaseError({ cause }),
     });
 
@@ -349,27 +388,3 @@ export const listC2bMessages = (
     metricMessagesListed(results.length);
     return results;
   }).pipe(Effect.withSpan("zap.messages.list_c2b"));
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-const assertMember = (
-  chatId: string,
-  profileId: string,
-): Effect.Effect<void, NotChatMember | DatabaseError, Db> =>
-  Effect.gen(function* () {
-    const { db } = yield* Db;
-    const rows = yield* Effect.tryPromise({
-      try: (): Promise<ChatMember[]> =>
-        db
-          .select()
-          .from(chatMembers)
-          .where(and(eq(chatMembers.chatId, chatId), eq(chatMembers.profileId, profileId)))
-          .limit(1) as Promise<ChatMember[]>,
-      catch: (cause) => new DatabaseError({ cause }),
-    });
-    if (rows.length === 0) {
-      return yield* Effect.fail(new NotChatMember({ chatId }));
-    }
-  });

--- a/zap/api/tests/routes/internal.test.ts
+++ b/zap/api/tests/routes/internal.test.ts
@@ -1,9 +1,9 @@
 import { exportKeyToJwk, generateArcKeyPair, signArcToken } from "@shared/crypto/jwk";
-import type { Chat } from "@zap/db/schema";
 import { Effect } from "effect";
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 
 import { _resetServiceKeysForTests } from "../../src/lib/arc-middleware";
+import { MAX_EXPORT_PROFILE_IDS } from "../../src/lib/limits";
 import { createInternalRoutes } from "../../src/routes/internal";
 import {
   createTestLayer,
@@ -338,6 +338,78 @@ describe("zap internal routes — ARC-gated account-export", () => {
     ).record;
     expect(firstRecord.body).toBe("msg-newest");
     expect(firstRecord.createdAt).toBe(t2.toISOString());
+  });
+
+  it("rejects profile_ids over the export cap with 400", async () => {
+    const app = createInternalRoutes(createTestLayer());
+    await post(app, "/internal/register-service", registerBody(), `Bearer ${SECRET}`);
+
+    const arc = await signArcToken(privateKey, {
+      iss: "osn-api",
+      aud: "zap-api",
+      scope: "account:export",
+      kid: KID,
+    });
+    const overCap = Array.from({ length: MAX_EXPORT_PROFILE_IDS + 1 }, (_, i) => `usr_${i}`);
+    const res = await post(
+      app,
+      "/internal/account-export",
+      { account_id: "acc_x", profile_ids: overCap },
+      `ARC ${arc}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: `profile_ids exceeds max of ${MAX_EXPORT_PROFILE_IDS}`,
+    });
+  });
+
+  it("keeps two distinct c2b messages that share a body and same-second createdAt (groupBy, not DISTINCT)", async () => {
+    const layer = createTestLayer();
+    const app = createInternalRoutes(layer);
+    await post(app, "/internal/register-service", registerBody(), `Bearer ${SECRET}`);
+
+    const c2bChat = await Effect.runPromise(
+      seedC2bChat({ type: "group" }).pipe(Effect.provide(layer)),
+    );
+    await Effect.runPromise(
+      seedMember(c2bChat.id, "usr_dup", "member").pipe(Effect.provide(layer)),
+    );
+
+    // Both timestamps round to the same integer second once stored (the
+    // `createdAt` column is second-resolution) — two genuinely different
+    // messages, same body, same stored second.
+    const first = new Date("2024-06-01T12:00:00.100Z");
+    const second = new Date("2024-06-01T12:00:00.900Z");
+    await Effect.runPromise(
+      seedC2bMessage(c2bChat.id, "usr_dup", "same body text", first).pipe(Effect.provide(layer)),
+    );
+    await Effect.runPromise(
+      seedC2bMessage(c2bChat.id, "usr_dup", "same body text", second).pipe(Effect.provide(layer)),
+    );
+
+    const arc = await signArcToken(privateKey, {
+      iss: "osn-api",
+      aud: "zap-api",
+      scope: "account:export",
+      kid: KID,
+    });
+    const res = await post(
+      app,
+      "/internal/account-export",
+      { account_id: "acc_dup", profile_ids: ["usr_dup"] },
+      `ARC ${arc}`,
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const c2bLines = text
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => (JSON.parse(l) as { section: string }).section === "zap.c2b_messages");
+
+    // A `.distinct()` on the projected {chatId, body, createdAt} columns
+    // would collapse these into one row, silently dropping a message from
+    // the DSAR export. `.groupBy(messages.id)` must keep both.
+    expect(c2bLines).toHaveLength(2);
   });
 });
 

--- a/zap/api/tests/services/chats.test.ts
+++ b/zap/api/tests/services/chats.test.ts
@@ -1,7 +1,15 @@
+import { Database } from "bun:sqlite";
+
 import { it } from "@effect/vitest";
+import * as schema from "@zap/db/schema";
+import { chats as chatsTable, chatMembers } from "@zap/db/schema";
+import { Db } from "@zap/db/service";
+import { applySchema } from "@zap/db/testing";
+import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Effect, Either } from "effect";
 import { describe, expect, beforeEach, afterEach } from "vitest";
 
+import { MAX_CHAT_MEMBERS } from "../../src/lib/limits";
 import {
   createChat,
   getChat,
@@ -11,6 +19,7 @@ import {
   removeMember,
   getChatMembers,
   provisionC2bChat,
+  isUniqueConstraintFailure,
 } from "../../src/services/chats";
 import { setConsentGate, resetConsentGate } from "../../src/services/consent";
 import { createTestLayer, seedC2bChat, seedChat, seedMember } from "../helpers/db";
@@ -842,4 +851,199 @@ describe("chats service", () => {
       expect(returned.createdAt.getTime() % 1000).toBe(0);
     }).pipe(Effect.provide(createTestLayer())),
   );
+
+  // ── over-cap rejection happens before any downstream call ───────────────
+
+  it.effect("createChat rejects memberProfileIds over the cap without ever checking consent", () =>
+    Effect.gen(function* () {
+      let consentCalls = 0;
+      setConsentGate(() => {
+        consentCalls++;
+        return Promise.resolve(true);
+      });
+      const overCap = Array.from({ length: MAX_CHAT_MEMBERS + 1 }, (_, i) => `usr_overflow_${i}`);
+      const result = yield* Effect.either(
+        createChat({ type: "group", memberProfileIds: overCap }, "usr_alice"),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe("ValidationError");
+      }
+      // Schema.maxItems rejects at decode time — checkConsent must never run.
+      expect(consentCalls).toBe(0);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect(
+    "provisionC2bChat rejects memberProfileIds over the cap without creating a chat row",
+    () =>
+      Effect.gen(function* () {
+        const overCap = Array.from({ length: MAX_CHAT_MEMBERS + 1 }, (_, i) => `usr_overflow_${i}`);
+        const result = yield* Effect.either(
+          provisionC2bChat({ memberProfileIds: overCap, createdByProfileId: "usr_a" }),
+        );
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("ValidationError");
+        }
+        // provisionC2bChat has no consent gate to count (cire-trusted path), so
+        // the proof that nothing downstream ran is that no chat row exists.
+        const { db } = yield* Db;
+        const rows = yield* Effect.promise(() => db.select().from(chatsTable));
+        expect(rows).toHaveLength(0);
+      }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── MAX_MEMBER_ROWS_PER_INSERT chunking (20 rows/statement) ──────────────
+
+  it.effect("createChat lands every member across more than one chunked INSERT", () =>
+    Effect.gen(function* () {
+      // 25 invited members + the creator = 26 rows, split by chunkRows into a
+      // 20-row batch and a 6-row batch. All 26 must land regardless of the
+      // chunk boundary.
+      const memberIds = Array.from({ length: 25 }, (_, i) => `usr_member_${i}`);
+      const chat = yield* createChat({ type: "group", memberProfileIds: memberIds }, "usr_alice");
+      const { members } = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(26);
+      const profileIds = new Set(members.map((m) => m.profileId));
+      expect(profileIds.has("usr_alice")).toBe(true);
+      for (const id of memberIds) expect(profileIds.has(id)).toBe(true);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  it.effect("provisionC2bChat lands every member across more than one chunked INSERT", () =>
+    Effect.gen(function* () {
+      const memberIds = Array.from({ length: 26 }, (_, i) => `usr_biz_${i}`);
+      const chat = yield* provisionC2bChat({
+        memberProfileIds: memberIds,
+        createdByProfileId: memberIds[0]!,
+      });
+      const { members } = yield* getChatMembers(chat.id);
+      expect(members).toHaveLength(26);
+      const profileIds = new Set(members.map((m) => m.profileId));
+      for (const id of memberIds) expect(profileIds.has(id)).toBe(true);
+    }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // ── addMember insert-level isUniqueConstraintFailure catch (TOCTOU) ──────
+
+  it.effect(
+    "concurrent addMember for the same profile yields exactly one success and one AlreadyMember",
+    () =>
+      Effect.gen(function* () {
+        const chat = yield* seedChat({ type: "group" });
+        yield* seedMember(chat.id, "usr_alice", "admin");
+
+        // Both fibers pass the pre-check's dup-count read before either
+        // inserts, so the real discriminator here is the insert's
+        // `isUniqueConstraintFailure` catch, not the P-W2 pre-check fold.
+        // Interleaving is scheduler-dependent, not guaranteed identical on
+        // every run — the assertion is on the aggregate outcome, not on
+        // which fiber hits the catch.
+        const [r1, r2] = yield* Effect.all(
+          [
+            Effect.either(addMember(chat.id, "usr_racer", "usr_alice")),
+            Effect.either(addMember(chat.id, "usr_racer", "usr_alice")),
+          ],
+          { concurrency: "unbounded" },
+        );
+        const outcomes = [r1, r2];
+        const rights = outcomes.filter(Either.isRight);
+        const lefts = outcomes.filter(Either.isLeft);
+        expect(rights).toHaveLength(1);
+        expect(lefts).toHaveLength(1);
+        expect(lefts[0]!.left._tag).toBe("AlreadyMember");
+
+        const { members } = yield* getChatMembers(chat.id);
+        expect(members).toHaveLength(2);
+        expect(members.filter((m) => m.profileId === "usr_racer")).toHaveLength(1);
+      }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  describe("isUniqueConstraintFailure", () => {
+    it("matches an unwrapped bun:sqlite-style top-level message", () => {
+      const error = new Error(
+        "UNIQUE constraint failed: chat_members.chat_id, chat_members.profile_id",
+      );
+      expect(isUniqueConstraintFailure(error)).toBe(true);
+    });
+
+    it("matches a D1-style error wrapped one level in .cause", () => {
+      const driverError = new Error(
+        "UNIQUE constraint failed: chat_members.chat_id, chat_members.profile_id",
+      );
+      const wrapped = new Error("Failed query: insert into chat_members ...", {
+        cause: driverError,
+      });
+      expect(isUniqueConstraintFailure(wrapped)).toBe(true);
+    });
+
+    it("matches at the deepest checked level (5 nested errors, depth 4)", () => {
+      const bottom = new Error(
+        "UNIQUE constraint failed: chat_members.chat_id, chat_members.profile_id",
+      );
+      const level3 = new Error("level3", { cause: bottom });
+      const level2 = new Error("level2", { cause: level3 });
+      const level1 = new Error("level1", { cause: level2 });
+      const top = new Error("top", { cause: level1 });
+      expect(isUniqueConstraintFailure(top)).toBe(true);
+    });
+
+    it("does not match past the 5-level bound", () => {
+      const bottom = new Error(
+        "UNIQUE constraint failed: chat_members.chat_id, chat_members.profile_id",
+      );
+      const level4 = new Error("level4", { cause: bottom });
+      const level3 = new Error("level3", { cause: level4 });
+      const level2 = new Error("level2", { cause: level3 });
+      const level1 = new Error("level1", { cause: level2 });
+      const top = new Error("top", { cause: level1 });
+      expect(isUniqueConstraintFailure(top)).toBe(false);
+    });
+
+    it("does not match a differently-shaped constraint failure", () => {
+      expect(isUniqueConstraintFailure(new Error("FOREIGN KEY constraint failed"))).toBe(false);
+    });
+
+    it("does not match a non-Error value", () => {
+      expect(isUniqueConstraintFailure("boom")).toBe(false);
+      expect(isUniqueConstraintFailure(undefined)).toBe(false);
+      expect(isUniqueConstraintFailure(null)).toBe(false);
+    });
+
+    it("matches a genuine bun:sqlite error from a real duplicate insert", async () => {
+      const sqlite = new Database(":memory:");
+      applySchema(sqlite);
+      const db = drizzle(sqlite, { schema });
+      const chatId = "chat_unique_test";
+      const now = new Date();
+      await db.insert(chatsTable).values({
+        id: chatId,
+        type: "group",
+        class: "c2c",
+        title: null,
+        eventId: null,
+        createdByProfileId: "usr_alice",
+        createdAt: now,
+        updatedAt: now,
+      });
+      const memberRow = {
+        id: "cmem_unique_test",
+        chatId,
+        profileId: "usr_bob",
+        role: "member" as const,
+        joinedAt: now,
+      };
+      await db.insert(chatMembers).values(memberRow);
+
+      let captured: unknown;
+      try {
+        await db.insert(chatMembers).values({ ...memberRow, id: "cmem_unique_test_2" });
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeDefined();
+      expect(isUniqueConstraintFailure(captured)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Four tracker findings, all in `@zap/api`, all the same shape: a write or read path that took several sequential D1 round trips, or built a bound-parameter list with no ceiling. This folds the round trips and puts a ceiling on every list.

- **Membership checks fold into the chat lookup.** `sendMessage`, `listMessages`, `sendC2bMessage`, `updateChat` and `addMember` each ran a `SELECT` for the chat and then a second `SELECT` for the caller's membership row. Each is now one `LEFT JOIN` on `chat_members` keyed to the calling profile. `assertMember` is gone; `assertAdmin` survives for `removeMember`, which this PR does not touch.
- **Multi-statement writes go through `commitBatch`.** `createChat` made three writes (chat, creator member, other members) and `provisionC2bChat` and `sendC2bMessage` made two each. Each is now a single `commitBatch` — atomic on D1, sequentially chained on `bun:sqlite`, which is what the separate awaits already did.
- **Member rows are chunked.** A member row binds five parameters, so a batched `INSERT` is split at `MAX_MEMBER_ROWS_PER_INSERT` (20) rows per statement to stay under D1's ~100-bound-parameter ceiling per query.
- **Member lists are capped.** `createChat` and `provisionC2bChat` both accept `memberProfileIds` with no upper bound. `MAX_CHAT_MEMBERS` (500) now applies at both the Effect Schema and the Elysia TypeBox layer, so an over-cap request is rejected at decode time and never reaches consent or the database.
- **The DSAR export is bounded and no longer loses messages.** `loadC2bMessages` ran two queries and fed the first's result into an unbounded `IN (...)`, so a profile in more than about a hundred c2b chats failed the export outright. It is now one three-table join binding only `profileIds`, and `POST /internal/account-export` rejects a `profile_ids` list longer than `MAX_EXPORT_PROFILE_IDS` (100) with a 400.
- **`addMember`'s cap and duplicate checks fold into one query,** and its `INSERT` now resolves a unique-constraint failure to `AlreadyMember` (409) instead of `DatabaseError` (500).

## Workspaces affected

| Workspace | Change |
| --- | --- |
| `@zap/api` | Service and route changes above; `@shared/db-utils` moves from `devDependencies` to `dependencies` because `commitBatch` is now imported in `src/` |

## Issues

| Issue | Finding |
| --- | --- |
| xchromo/osn-tracker#568 | P-W (zap) |
| xchromo/osn-tracker#569 | P-W (zap) |
| xchromo/osn-tracker#570 | P-W (zap) |
| xchromo/osn-tracker#579 | P-W (zap) |

Closes xchromo/osn-tracker#568.
Closes xchromo/osn-tracker#569.
Closes xchromo/osn-tracker#570.
Closes xchromo/osn-tracker#579.

## Decisions

### The folded membership check keeps `NotChatAdmin`, not `NotChatMember`

**Issue** — `updateChat` and `addMember` used to call `getChat` and then `assertAdmin`. `assertAdmin` filtered `role = 'admin'` inside its `WHERE`, so a non-admin member and a complete non-member both fell out the same way: `NotChatAdmin`, a 403.

**Why** — Folding the two lookups into one `LEFT JOIN` makes the two cases visibly distinct for the first time: `role` comes back `null` for a non-member and `"member"` for a non-admin. The natural-looking fold maps the `null` case to `NotChatMember`, which would silently change these routes from 403 to 404.

**Solution** — Both cases test `role !== "admin"` and fail `NotChatAdmin`. A comment at each site says why, because the shape invites the other reading.

**Rationale** — This is not a behaviour change and should not become one in a performance PR. If the two cases ought to answer differently, that is a separate decision about what a non-member is allowed to learn about a chat.

### `sendC2bMessage` checks chat class before membership; `sendMessage` checks it after

**Issue** — The two send paths order their class check and their membership check differently, which reads like an oversight.

**Why** — `sendMessage` serves a public route. A stranger holding a chat id must not be able to tell a c2c chat from a c2b one, so membership has to be established first and the class check has to come after.

**Solution** — `sendC2bMessage` keeps its class check first. That route is ARC-gated and only cire calls it.

**Rationale** — There is no untrusted caller to withhold the class from, and a c2c chat id passed here by mistake should come back `NotC2bChat` — the real reason — rather than a manufactured `NotChatMember` that sends an integrator debugging the wrong thing. Both orderings are deliberate and both are commented.

### The DSAR join groups by `messages.id` rather than using `DISTINCT`

**Issue** — The new three-table join duplicates a message row when two exported profiles are members of the same chat, so the duplicates have to be collapsed.

**Why** — `.distinct()` applies to the *projected* columns, and this projection deliberately carries no `messages.id` — it is `{chatId, body, createdAt}` and nothing more, because the export must never read `ciphertext` or `nonce`. Two genuinely different messages in one chat sharing a body and a second-resolution `createdAt` would collapse into one, and the data subject would silently lose a message from their export.

**Solution** — `.groupBy(messages.id)`. Grouping by a column outside the projection is valid SQLite, and every row in a group is the same message, so the projected values are identical within a group.

**Rationale** — A DSAR export that silently drops a record is a compliance problem, not a performance one. `zap/api/tests/routes/internal.test.ts` seeds exactly that collision and asserts both messages survive.

### `addMember`'s unique-constraint catch closes the duplicate race, not the cap race

**Issue** — The cap and duplicate pre-check is a read, so two concurrent adds can both pass it.

**Why** — Two concurrent adds of the *same* profile both passing the pre-check reach the `INSERT` and one hits the unique constraint on `(chat_id, profile_id)`, which used to surface as a 500.

**Solution** — The `INSERT`'s catch tests `isUniqueConstraintFailure` (a bounded five-level walk of the `.cause` chain, exported so it can be unit-tested against both the wrapped D1 shape and the unwrapped `bun:sqlite` one) and answers `AlreadyMember` — a 409.

**Out of scope** — The member *cap* has its own, pre-existing time-of-check/time-of-use gap: two concurrent adds of *different* profiles can both read `total = 499` and both insert. Nothing here closes it and nothing here makes it worse. It needs a different mechanism — a constraint or a conditional write — and belongs in its own issue.

## Test plan

| Gate | Command | Result |
| --- | --- | --- |
| Zap API tests | `bun run --cwd zap/api test:run` | Pass — 179 tests, 7 files |
| Zap DB tests | `bun run --cwd zap/db test:run` | Pass — 26 tests, 2 files |
| Typecheck | `bun run check` | Pass — 37 tasks |
| Lint | `bun run lint` | Pass — pre-existing `no-console` warnings only, none in this diff |
| Format | `bun run fmt:check` | Pass — 1429 files |
| Changesets | `bash scripts/validate-changesets.sh` | Pass |
| Lockfile | `bun install --frozen-lockfile` | Pass — no changes |

New coverage: over-cap rejection for both `createChat` and `provisionC2bChat` (proving consent is never called and no chat row is written), chunked-insert coverage that straddles the 20-row boundary in both batched creators, a concurrent `addMember` race asserting exactly one success and one `AlreadyMember`, seven `isUniqueConstraintFailure` cases including one driven by a real `bun:sqlite` duplicate insert, the export cap's 400, and the same-body/same-second DSAR collision.

**Not run:** no deploy and no D1 run. Every claim about D1 — batch atomicity, the ~100-bound-parameter ceiling, the 50-queries-per-invocation Free-tier bound — is reasoned from the documented limits and exercised locally against `bun:sqlite`, where `commitBatch` chains statements sequentially with no rollback. No test asserts joint rollback, because locally there is none to assert.
