### PR TITLE
fix(shared/redis): narrow Upstash replies, cache EVALSHA, reuse clean arrays

### DIFF
--- a/.changeset/tidy-pandas-smile.md
+++ b/.changeset/tidy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"@shared/redis": patch
+---
+
+Narrow Upstash GET, PING and DEL replies at the HTTP boundary so a wrapper that hands back a non-string or non-integer fails with a message naming the adapter, command and arriving type instead of a TypeError further downstream. Send EVALSHA after the first EVAL of a script, keeping the digest per client and reloading the body only on NOSCRIPT. Skip rebuilding an EVAL array reply when every element is already a RESP value.

--- a/shared/redis/src/client.ts
+++ b/shared/redis/src/client.ts
@@ -50,6 +50,32 @@ export function toRedisReply(value: unknown): RedisReply {
 }
 
 /**
+ * Narrow a driver's answer to the bulk string (or nil) that a Redis GET is
+ * defined to return.
+ *
+ * Unlike `eval`, whose result shape is script-defined and unknowable here,
+ * GET's reply is fixed by the protocol — a bulk string or nil — so a wrapper
+ * that hands back anything else (an SDK-side JSON parse, say) is a bug the
+ * caller needs to see named, not a `TypeError` two call sites downstream.
+ */
+export function toRedisString(value: unknown, command: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  throw new Error(`Redis ${command} returned a ${typeof value}, expected a string or nil.`);
+}
+
+/**
+ * Narrow a driver's answer to the integer that DEL is defined to return.
+ * Accepts `bigint` for the same reason `toRedisReply` does — some drivers
+ * surface large counts that way — and requires a finite `number` otherwise.
+ */
+export function toRedisInteger(value: unknown, command: string): number {
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  throw new Error(`Redis ${command} returned a ${typeof value}, expected an integer.`);
+}
+
+/**
  * Backend-agnostic Redis client contract. Node/Bun production uses ioredis via
  * `wrapIoRedis()`; Workers uses `wrapUpstash()`; dev/test uses
  * `createMemoryClient()`.

--- a/shared/redis/src/client.ts
+++ b/shared/redis/src/client.ts
@@ -25,6 +25,20 @@ import { RATE_LIMIT_SCRIPT } from "./rate-limiter";
 export type RedisReply = string | number | boolean | null | readonly RedisReply[];
 
 /**
+ * True when `value` is already inside the RESP value space, so it needs no
+ * rebuild.
+ *
+ * Recursive, because an array is only clean when every element is: one
+ * `bigint` nested three levels down still has to be converted.
+ */
+function isRedisReply(value: unknown): value is RedisReply {
+  if (value === null) return true;
+  const kind = typeof value;
+  if (kind === "string" || kind === "number" || kind === "boolean") return true;
+  return Array.isArray(value) && value.every(isRedisReply);
+}
+
+/**
  * Narrow a driver's untyped EVAL result to a {@link RedisReply}.
  *
  * ioredis types every `eval`/`evalsha` result as `unknown`, so the check has to
@@ -42,7 +56,14 @@ export function toRedisReply(value: unknown): RedisReply {
   // ioredis surfaces very large integers as BigInt on some servers; the counter
   // scripts only ever produce small ones, so narrowing loses nothing real.
   if (typeof value === "bigint") return Number(value);
-  if (Array.isArray(value)) return value.map(toRedisReply);
+  if (Array.isArray(value)) {
+    // Already in the value space — hand back the original rather than an
+    // identical copy. Only `bigint`, `undefined` and nested arrays holding
+    // either need a rebuild, and a reply built entirely of clean values is
+    // the common case on every hot path.
+    if (value.every(isRedisReply)) return value;
+    return value.map(toRedisReply);
+  }
   throw new Error(
     `Redis EVAL returned a ${typeof value}, which is not a RESP value. A Lua script must ` +
       "return a string, integer, boolean, nil or an array of those.",

--- a/shared/redis/src/upstash.ts
+++ b/shared/redis/src/upstash.ts
@@ -19,6 +19,11 @@
  *   JSON-parsed them. `get`'s own type is generic (`get<TData>`), the same
  *   unchecked-claim shape as `eval`, so the reply is narrowed at this
  *   boundary rather than trusted from the SDK's type.
+ *   Subsequent calls for the same script body try `EVALSHA` first and fall
+ *   back to a full `EVAL` on `NOSCRIPT` (P-I1) — see the doc comment on
+ *   `eval` in {@link wrapUpstash} for why this is safe over HTTP/REST
+ *   specifically, where a naive port of the ioredis retry-loop pattern would
+ *   double-retry.
  * - `set(key, value, pxMs?)` → `redis.set(key, value, { px })`.
  * - `del(...keys)` → `toRedisInteger(await redis.del(...keys), "DEL")`.
  * - `ping()` → `toRedisString(await redis.ping(), "PING") ?? ""`. PING never
@@ -85,6 +90,18 @@ export interface UpstashLike {
    * passes through {@link toRedisReply} before a caller sees it.
    */
   eval<TData = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<TData>;
+  /**
+   * Same generic shape as `eval`, for the same reason: the reply is an
+   * unvalidated HTTP body until {@link wrapUpstash} narrows it through
+   * {@link toRedisReply}.
+   *
+   * No `scriptLoad` alongside this: a script the server has never seen fails
+   * `EVALSHA` with `NOSCRIPT`, and the fallback below is a full `EVAL` —
+   * which loads the script as a side effect of running it. A separate
+   * `SCRIPT LOAD` would only spend a second round trip to do the same thing
+   * `EVAL` already does for free.
+   */
+  evalsha<TData = unknown>(sha1: string, keys: string[], args: (string | number)[]): Promise<TData>;
   ping(): Promise<string>;
   /**
    * `TData` mirrors `eval`'s generic default for the same reason: the SDK's
@@ -97,6 +114,12 @@ export interface UpstashLike {
   del(...keys: string[]): Promise<number>;
 }
 
+/** Compute a script's SHA-1 digest the way Redis identifies it for EVALSHA. */
+async function computeSha(script: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-1", new TextEncoder().encode(script));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 /**
  * Adapt an `@upstash/redis` client (or structural equivalent) as a
  * `RedisClient`.
@@ -106,13 +129,59 @@ export interface UpstashLike {
  * returns raw strings rather than JSON-parsed values.
  */
 export function wrapUpstash(redis: UpstashLike): RedisClient {
+  // Per-client cache, mirroring `wrapIoRedis`'s `scriptShas` in ./ioredis. No
+  // lock around a concurrent first call for the same script: computeSha is a
+  // pure function of the script body, so two callers racing here at worst
+  // hash the same string twice — wasted work, not a correctness issue.
+  const scriptShas = new Map<string, string>();
+
   return {
     async eval(script, keys, args) {
       // Copied because the SDK takes mutable arrays; both are two elements
-      // long and the call behind them is an HTTP round-trip. The reply itself
-      // is unvalidated JSON off the wire until toRedisReply narrows it — same
-      // boundary check the ioredis path applies in ./ioredis.
-      return toRedisReply(await redis.eval(script, [...keys], [...args]));
+      // long and the call behind them is an HTTP round-trip.
+      const keysCopy = [...keys];
+      const argsCopy = [...args];
+
+      const sha = scriptShas.get(script);
+
+      // First sight of this script body: this adapter has no SHA to try, and
+      // there is nothing to gain by computing one up front only to still send
+      // the full script — a fresh Upstash REST connection has no notion of
+      // "the server already has this loaded" the way a long-lived ioredis TCP
+      // connection might. So the first call is always a full EVAL, which
+      // loads the script on the server as a side effect; only once that has
+      // actually succeeded is the SHA cached for later calls to use.
+      if (sha === undefined) {
+        const reply = await redis.eval(script, keysCopy, argsCopy);
+        scriptShas.set(script, await computeSha(script));
+        return toRedisReply(reply);
+      }
+
+      // Every later call for this script tries EVALSHA first (P-I1), saving
+      // the HTTP body weight of the full script on every request.
+      //
+      // The retry here is intentionally narrower than ioredis's TCP-level
+      // NOSCRIPT handling in ./ioredis: `@upstash/redis`'s own transport
+      // already retries a *transport* failure internally (chunk-2X4SLXT7.mjs
+      // lines 168–188, honoring `this.retry.attempts`/`backoff`), and a
+      // non-2xx REST response is turned into a thrown `UpstashError` whose
+      // message is built from the server's own error body (line 203) — or,
+      // for the streaming path, from the deserialized `error` field (line
+      // 386). NOSCRIPT is a server-side "I don't have this script" answer,
+      // not a transport hiccup, so it always surfaces as exactly one thrown
+      // error with that text; nothing upstream of this catch would already
+      // have retried it. Any other error (bad arguments, a real network
+      // failure that exhausted the SDK's own retries) is not this adapter's
+      // to paper over, so it propagates unchanged.
+      try {
+        return toRedisReply(await redis.evalsha(sha, keysCopy, argsCopy));
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        if (!/NOSCRIPT/i.test(message)) throw cause;
+        // The server evicted the script (e.g. a restart, or a FLUSHALL).
+        // Re-send the body, which reloads it for next time.
+        return toRedisReply(await redis.eval(script, keysCopy, argsCopy));
+      }
     },
     async ping() {
       return toRedisString(await redis.ping(), "PING") ?? "";

--- a/shared/redis/src/upstash.ts
+++ b/shared/redis/src/upstash.ts
@@ -12,20 +12,25 @@
  *   it is really an HTTP response body nobody has checked — `toRedisReply`
  *   narrows it to the RESP value space at this boundary, the same as the
  *   ioredis path does in `./ioredis`.
- * - `get(key)` → `redis.get(key)`. The client MUST be constructed with
- *   `automaticDeserialization: false` so values come back as raw strings —
- *   matching ioredis and the rotated-session-store, which round-trips opaque
- *   `familyId` strings and would break if Upstash JSON-parsed them.
+ * - `get(key)` → `toRedisString(await redis.get(key), "GET")`. The client MUST
+ *   be constructed with `automaticDeserialization: false` so values come back
+ *   as raw strings — matching ioredis and the rotated-session-store, which
+ *   round-trips opaque `familyId` strings and would break if Upstash
+ *   JSON-parsed them. `get`'s own type is generic (`get<TData>`), the same
+ *   unchecked-claim shape as `eval`, so the reply is narrowed at this
+ *   boundary rather than trusted from the SDK's type.
  * - `set(key, value, pxMs?)` → `redis.set(key, value, { px })`.
- * - `del(...keys)` → `redis.del(...keys)` (returns the count removed).
- * - `ping()` → `redis.ping()`.
+ * - `del(...keys)` → `toRedisInteger(await redis.del(...keys), "DEL")`.
+ * - `ping()` → `toRedisString(await redis.ping(), "PING") ?? ""`. PING never
+ *   actually replies nil, but the fallback keeps the return type `string`
+ *   rather than `string | null` for a case that cannot occur.
  * - `quit()` → no-op: the REST transport is stateless, there is no socket to
  *   close.
  */
 
 import { Redis } from "@upstash/redis";
 
-import { toRedisReply, type RedisClient } from "./client";
+import { toRedisReply, toRedisString, toRedisInteger, type RedisClient } from "./client";
 
 /**
  * Redis's reply to SET: the status string `"OK"`, or nil when a conditional
@@ -47,14 +52,25 @@ export type RedisSetReply = string | null;
  *
  * The SDK types most of these as generic in their result (`get<TData>`,
  * `eval<TArgs, TData = unknown>`), i.e. it will hand back whatever the caller
- * claims. The claims are made once, here, and each is justified: `get` returns
- * raw strings because the client is built with `automaticDeserialization:
- * false`. `eval` keeps the SDK's own `TData = unknown` default rather than
- * pinning a type — it is an HTTP response body the SDK has only JSON-decoded,
- * not a value anyone has checked against the RESP value space, so
- * {@link wrapUpstash} calls it with no type argument (leaving it `unknown`)
- * and runs the result through {@link toRedisReply} before handing it to a
- * caller.
+ * claims. The claims are made once, here, and each is justified: `eval` keeps
+ * the SDK's own `TData = unknown` default rather than pinning a type — it is
+ * an HTTP response body the SDK has only JSON-decoded, not a value anyone has
+ * checked against the RESP value space, so {@link wrapUpstash} calls it with
+ * no type argument (leaving it `unknown`) and runs the result through
+ * {@link toRedisReply} before handing it to a caller. `get` mirrors the same
+ * shape (`get<TData = unknown>`) for the same reason: the client is built
+ * with `automaticDeserialization: false`, but that is a runtime configuration
+ * choice the SDK's own type cannot see, so {@link wrapUpstash} narrows the
+ * reply through {@link toRedisString} rather than trusting `TData`.
+ *
+ * `ping` and `del` stay concretely typed (`Promise<string>` /
+ * `Promise<number>`) rather than adopting the same generic escape hatch:
+ * `anti-slop/no-unknown-returns` is an error under `src/`, and only `eval`
+ * and `get` have a generic default to fall back on — `ping`/`del` would
+ * widen to a bare `Promise<unknown>`, which the rule forbids. Each is still
+ * narrowed at the call site below ({@link toRedisString}, {@link
+ * toRedisInteger}) so an SDK that returns something else is caught, not
+ * assumed.
  */
 export interface UpstashLike {
   /**
@@ -70,7 +86,13 @@ export interface UpstashLike {
    */
   eval<TData = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<TData>;
   ping(): Promise<string>;
-  get(key: string): Promise<string | null>;
+  /**
+   * `TData` mirrors `eval`'s generic default for the same reason: the SDK's
+   * declared reply type is a caller-supplied claim, not a checked value.
+   * {@link wrapUpstash} never supplies it, so this resolves to `unknown` and
+   * is narrowed through {@link toRedisString} before a caller sees it.
+   */
+  get<TData = unknown>(key: string): Promise<TData | null>;
   set(key: string, value: string, opts?: { px: number }): Promise<RedisSetReply>;
   del(...keys: string[]): Promise<number>;
 }
@@ -93,17 +115,17 @@ export function wrapUpstash(redis: UpstashLike): RedisClient {
       return toRedisReply(await redis.eval(script, [...keys], [...args]));
     },
     async ping() {
-      return redis.ping();
+      return toRedisString(await redis.ping(), "PING") ?? "";
     },
     async get(key) {
-      return redis.get(key);
+      return toRedisString(await redis.get(key), "GET");
     },
     async set(key, value, pxMs) {
       await redis.set(key, value, pxMs !== undefined ? { px: pxMs } : undefined);
     },
     async del(...keys) {
       if (keys.length === 0) return 0;
-      return redis.del(...keys);
+      return toRedisInteger(await redis.del(...keys), "DEL");
     },
     async quit() {
       // Stateless HTTP/REST transport — nothing to tear down.

--- a/shared/redis/tests/client.test.ts
+++ b/shared/redis/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { createMemoryClient } from "../src/client";
+import { createMemoryClient, toRedisReply } from "../src/client";
 import { RATE_LIMIT_SCRIPT } from "../src/rate-limiter";
 
 describe("createMemoryClient — sweep (P-W2)", () => {
@@ -43,5 +43,42 @@ describe("createMemoryClient — eval script guard (X5)", () => {
     await expect(client.eval(evilDelete, ["k1"], [1, 1000])).rejects.toThrow(
       /cannot execute arbitrary Lua/,
     );
+  });
+});
+
+describe("toRedisReply — array replies are not rebuilt when already clean (P-I2)", () => {
+  it("hands back the same array when every element is already a RESP value", () => {
+    const input = [1, "a", true, null];
+    expect(toRedisReply(input)).toBe(input);
+  });
+
+  it("hands back the same array when a nested array is clean too", () => {
+    const input = [1, ["a", [true, null]], "b"];
+    expect(toRedisReply(input)).toBe(input);
+  });
+
+  it("rebuilds an array holding a bigint, coercing it to a number", () => {
+    const input = [1, 42n];
+    const result = toRedisReply(input);
+    expect(result).not.toBe(input);
+    expect(result).toEqual([1, 42]);
+  });
+
+  it("rebuilds an array holding undefined, normalising it to null", () => {
+    const input = [1, undefined];
+    const result = toRedisReply(input);
+    expect(result).not.toBe(input);
+    expect(result).toEqual([1, null]);
+  });
+
+  it("rebuilds an outer array whose nested array needs coercing", () => {
+    const input = [1, [42n]];
+    const result = toRedisReply(input);
+    expect(result).not.toBe(input);
+    expect(result).toEqual([1, [42]]);
+  });
+
+  it("still throws on a value RESP cannot carry, however deeply nested", () => {
+    expect(() => toRedisReply([1, [{ not: "a RESP value" }]])).toThrow(/not a RESP value/);
   });
 });

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -14,10 +14,11 @@ import { wrapUpstash } from "../src/upstash";
  * member still comes from the real interface, so a shape drift in `set` (the
  * one member still statically checked here) is still caught.
  */
-type FakeUpstash = Omit<UpstashLike, "get" | "ping" | "del" | "eval"> & {
+type FakeUpstash = Omit<UpstashLike, "get" | "ping" | "del" | "eval" | "evalsha"> & {
   store: Map<string, string>;
   set: Mock;
   eval: Mock;
+  evalsha: Mock;
   get: Mock;
   ping: Mock;
   del: Mock;
@@ -39,6 +40,9 @@ function createFakeUpstash(): FakeUpstash {
   const evalFn = vi.fn(
     async (_script: string, _keys: readonly string[], _args: readonly (string | number)[]) => 1,
   );
+  const evalshaFn = vi.fn(
+    async (_sha1: string, _keys: readonly string[], _args: readonly (string | number)[]) => 1,
+  );
   const get = vi.fn(async (key: string) => (store.has(key) ? store.get(key)! : null));
   const ping = vi.fn(async () => "PONG");
   const del = vi.fn(async (...keys: string[]) => {
@@ -52,6 +56,7 @@ function createFakeUpstash(): FakeUpstash {
     store,
     set,
     eval: evalFn,
+    evalsha: evalshaFn,
     get,
     ping,
     del,
@@ -158,6 +163,82 @@ describe("wrapUpstash", () => {
     it("rejects a reply RESP cannot carry (toRedisReply's contract)", async () => {
       fake.eval.mockResolvedValueOnce({ not: "a RESP value" });
       await expect(client.eval("script", ["k"], [1])).rejects.toThrow(/not a RESP value/);
+    });
+  });
+
+  describe("eval — EVALSHA after the first call (P-I1)", () => {
+    const SHA_HEX = /^[0-9a-f]{40}$/;
+
+    it("sends a full EVAL the first time it sees a script", async () => {
+      const result = await client.eval("first-sight", ["k"], [1]);
+      expect(result).toBe(1);
+      expect(fake.eval).toHaveBeenCalledTimes(1);
+      expect(fake.evalsha).not.toHaveBeenCalled();
+    });
+
+    it("sends EVALSHA on every later call for the same script", async () => {
+      await client.eval("cached", ["k"], [1]);
+      await client.eval("cached", ["k"], [2]);
+      await client.eval("cached", ["k"], [3]);
+      // The full body went over the wire exactly once, on the cold call.
+      expect(fake.eval).toHaveBeenCalledTimes(1);
+      expect(fake.evalsha).toHaveBeenCalledTimes(2);
+    });
+
+    it("passes a stable 40-character lowercase hex SHA to EVALSHA", async () => {
+      await client.eval("stable", ["k"], [1]);
+      await client.eval("stable", ["k"], [2]);
+      await client.eval("stable", ["k"], [3]);
+      const shas = fake.evalsha.mock.calls.map((call) => call[0]);
+      expect(shas).toHaveLength(2);
+      for (const sha of shas) {
+        expect(sha).toMatch(SHA_HEX);
+      }
+      expect(shas[0]).toBe(shas[1]);
+    });
+
+    it("forwards keys and args to EVALSHA unchanged", async () => {
+      await client.eval("forwarding", ["k1", "k2"], [10, 1000]);
+      await client.eval("forwarding", ["k1", "k2"], [10, 1000]);
+      const call = fake.evalsha.mock.calls[0];
+      expect(call?.[1]).toEqual(["k1", "k2"]);
+      expect(call?.[2]).toEqual([10, 1000]);
+    });
+
+    it("caches each script body separately", async () => {
+      await client.eval("script-a", ["k"], [1]);
+      await client.eval("script-b", ["k"], [1]);
+      await client.eval("script-a", ["k"], [2]);
+      await client.eval("script-b", ["k"], [2]);
+      // Two cold EVALs, one per body; then one EVALSHA each, with two
+      // different digests.
+      expect(fake.eval).toHaveBeenCalledTimes(2);
+      expect(fake.evalsha).toHaveBeenCalledTimes(2);
+      const [shaA, shaB] = fake.evalsha.mock.calls.map((call) => call[0]);
+      expect(shaA).toMatch(SHA_HEX);
+      expect(shaB).toMatch(SHA_HEX);
+      expect(shaA).not.toBe(shaB);
+    });
+
+    it("falls back to a full EVAL when the server has evicted the script", async () => {
+      await client.eval("evicted", ["k"], [1]);
+      fake.evalsha.mockRejectedValueOnce(
+        new Error("NOSCRIPT No matching script. Please use EVAL."),
+      );
+      fake.eval.mockResolvedValueOnce(7);
+      expect(await client.eval("evicted", ["k"], [2])).toBe(7);
+      // Cold call plus the reload — the reload is what puts the script back
+      // in the server's cache.
+      expect(fake.eval).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates a non-NOSCRIPT EVALSHA failure without re-running the script", async () => {
+      await client.eval("failing", ["k"], [1]);
+      fake.evalsha.mockRejectedValueOnce(new Error("ERR max daily request limit exceeded"));
+      await expect(client.eval("failing", ["k"], [2])).rejects.toThrow(/max daily request/);
+      // Only the cold call. Retrying here would double-execute a script that
+      // may already have run server-side — an extra INCR on the rate limiter.
+      expect(fake.eval).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/shared/redis/tests/upstash.test.ts
+++ b/shared/redis/tests/upstash.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 
 import type { UpstashLike } from "../src/upstash";
 import { wrapUpstash } from "../src/upstash";
+
+/**
+ * `eval`/`get` are declared generic on `UpstashLike` (mirroring the SDK's own
+ * `<TData = unknown>` escape hatch — see `upstash.ts`), and a concrete mock
+ * function cannot satisfy a generic call signature: assignability requires
+ * validity for an arbitrary `TData`, which a mock resolving to one fixed
+ * type is not. The fake's `eval`/`get`/`ping`/`del` are typed as plain `Mock`s
+ * instead of through `UpstashLike` for exactly this reason; every other
+ * member still comes from the real interface, so a shape drift in `set` (the
+ * one member still statically checked here) is still caught.
+ */
+type FakeUpstash = Omit<UpstashLike, "get" | "ping" | "del" | "eval"> & {
+  store: Map<string, string>;
+  set: Mock;
+  eval: Mock;
+  get: Mock;
+  ping: Mock;
+  del: Mock;
+};
 
 /**
  * Fake `@upstash/redis` client. Backed by a real `Map` so the contract tests
@@ -10,11 +30,7 @@ import { wrapUpstash } from "../src/upstash";
  * Constructed as if `automaticDeserialization: false`, i.e. values are stored
  * and returned verbatim as strings.
  */
-function createFakeUpstash(): UpstashLike & {
-  store: Map<string, string>;
-  set: ReturnType<typeof vi.fn>;
-  eval: ReturnType<typeof vi.fn>;
-} {
+function createFakeUpstash(): FakeUpstash {
   const store = new Map<string, string>();
   const set = vi.fn(async (key: string, value: string, _opts?: { px: number }) => {
     store.set(key, value);
@@ -23,23 +39,22 @@ function createFakeUpstash(): UpstashLike & {
   const evalFn = vi.fn(
     async (_script: string, _keys: readonly string[], _args: readonly (string | number)[]) => 1,
   );
+  const get = vi.fn(async (key: string) => (store.has(key) ? store.get(key)! : null));
+  const ping = vi.fn(async () => "PONG");
+  const del = vi.fn(async (...keys: string[]) => {
+    let count = 0;
+    for (const key of keys) {
+      if (store.delete(key)) count++;
+    }
+    return count;
+  });
   return {
     store,
     set,
     eval: evalFn,
-    async get(key) {
-      return store.has(key) ? store.get(key)! : null;
-    },
-    async ping() {
-      return "PONG";
-    },
-    async del(...keys) {
-      let count = 0;
-      for (const key of keys) {
-        if (store.delete(key)) count++;
-      }
-      return count;
-    },
+    get,
+    ping,
+    del,
   };
 }
 
@@ -69,6 +84,11 @@ describe("wrapUpstash", () => {
 
     it("returns null for a missing key", async () => {
       expect(await client.get("absent")).toBeNull();
+    });
+
+    it("rejects a non-string GET reply naming the command", async () => {
+      fake.get.mockResolvedValueOnce(42);
+      await expect(client.get("k")).rejects.toThrow(/GET/);
     });
   });
 
@@ -154,11 +174,21 @@ describe("wrapUpstash", () => {
       await client.set("b", "2");
       expect(await client.del("a", "b", "missing")).toBe(2);
     });
+
+    it("rejects a non-numeric DEL reply naming the command", async () => {
+      fake.del.mockResolvedValueOnce("not a count");
+      await expect(client.del("a")).rejects.toThrow(/DEL/);
+    });
   });
 
   describe("ping / quit", () => {
     it("delegates ping", async () => {
       expect(await client.ping()).toBe("PONG");
+    });
+
+    it("maps a nil ping reply to an empty string rather than null", async () => {
+      fake.ping.mockResolvedValueOnce(null);
+      expect(await client.ping()).toBe("");
     });
 
     it("quit is a no-op for the stateless REST transport", async () => {

--- a/shared/redis/tsconfig.json
+++ b/shared/redis/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@shared/typescript-config/node.json",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Three findings against `@shared/redis`, all in the Upstash HTTP adapter and the
reply narrowing it shares with the ioredis path. The adapter handed back the
`@upstash/redis` SDK's declared reply types unchecked — and those types are
caller-supplied generics, not values anyone had validated — so a wrong runtime
shape surfaced as a `TypeError` two call sites downstream instead of an error
naming the command. It also re-sent the full Lua script body on every `eval`,
and `toRedisReply` rebuilt every array reply element by element even when the
array was already inside the RESP value space.

This is an operability and type-honesty fix, not a closed security hole. Both
call sites that consume an unchecked `get` — `osn/api/src/lib/rotated-session-store.ts:199`
(`raw.lastIndexOf(":")`) and `osn/api/src/lib/ceremony-store.ts:208`
(`JSON.parse(raw)`) — already catch and return `null`, so they fail open today.
Narrowing replaces an opaque throw with a message naming the adapter, the
command and the type that actually arrived.

- No behaviour change on any correct reply: the narrowings are identity
  functions for the shapes Redis is defined to return.
- `EVALSHA` is a wire-weight saving only; the script semantics are unchanged.

## Workspaces affected

`shared/redis`. One changeset, `.changeset/tidy-pandas-smile.md`, naming
`@shared/redis` at `patch`. It is the only versioned workspace in the diff.

## Issues

**Closes**

| Issue | Finding |
|---|---|
| xchromo/osn-tracker#472 | `S-L25` |
| xchromo/osn-tracker#517 | `P-I1` |
| xchromo/osn-tracker#518 | `P-I2` |

Closes xchromo/osn-tracker#472.
Closes xchromo/osn-tracker#517.
Closes xchromo/osn-tracker#518.

**Opened**

None.

## Decisions

### Narrow GET, PING and DEL at the HTTP boundary — `S-L25`

- **Issue** — `wrapUpstash` returned `redis.get(key)`, `redis.ping()` and
  `redis.del(...)` straight through. The SDK types `get` as `get<TData>`, a
  claim the caller makes rather than a value the SDK checked, and the raw-string
  behaviour the adapter depends on comes from a runtime option
  (`automaticDeserialization: false`) that no type can see.
- **Why** — if that option is ever lost, or a proxy sits in front of the REST
  endpoint, a JSON-parsed object reaches a caller typed `string | null`. The
  failure then lands as `raw.lastIndexOf is not a function` inside the
  session store, with nothing in the message pointing at Redis.
- **Solution** — added `toRedisString(value, command)` and
  `toRedisInteger(value, command)` to `shared/redis/src/client.ts`, widened
  `UpstashLike.get` to the SDK's own `get<TData = unknown>` shape, and routed
  `ping`/`get`/`del` through the narrowings.
- **Rationale** — the check belongs where the untyped HTTP body enters the
  process, which is the same place `toRedisReply` already guards `eval`. Pinning
  `get` to `Promise<string | null>` on `UpstashLike` was rejected: it would state
  a guarantee the SDK does not make and would move the lie one file over rather
  than removing it. `ping` and `del` stay concretely typed on the interface
  because `anti-slop/no-unknown-returns` is an error under `src/` and neither has
  a generic default to widen into — each is still narrowed at the call site.

### Send EVALSHA after the first EVAL, and only fall back on NOSCRIPT — `P-I1`

- **Issue** — every `eval` sent the whole Lua script body over HTTP. The
  rate-limit script runs on every authenticated request.
- **Why** — pure wire weight on the hottest path in the API, paid per request
  for a script the server already has loaded.
- **Solution** — a per-client `Map<script, sha>` inside `wrapUpstash`. The first
  call for a script body is always a full `EVAL`; the digest is computed with
  `crypto.subtle.digest("SHA-1", …)` and cached only after that call succeeds.
  Later calls send `EVALSHA`, falling back to a full `EVAL` on a `/NOSCRIPT/i`
  message and on nothing else.
- **Rationale** — cold `EVAL` first rather than `SCRIPT LOAD` first: `EVAL`
  loads the script as a side effect of running it, so a separate load would
  spend a second round trip to achieve the same state. The fallback is
  deliberately narrower than the ioredis path's: `@upstash/redis` already
  retries a transport failure five times internally, and a non-2xx REST response
  becomes a thrown `UpstashError` carrying the server's own error text. A
  broader `catch`-and-retry would re-run a script that may already have executed
  server-side — an extra `INCR` against the rate limiter for every transient
  error. `NOSCRIPT` is the one answer that proves the script did not run.

### Reuse an array reply that is already a RESP value — `P-I2`

- **Issue** — `toRedisReply`'s array branch always ran `value.map(toRedisReply)`,
  allocating a fresh array (and a fresh array per nesting level) even when every
  element was already a string, number, boolean, `null` or a clean array.
- **Why** — the common case on every hot path is a reply that needs no
  conversion at all, so the allocation buys nothing.
- **Solution** — a recursive `isRedisReply` type guard; when `value.every(isRedisReply)`
  the original array is returned unchanged. Only `bigint`, `undefined` and nested
  arrays holding either trigger a rebuild.
- **Rationale** — the guard has to recurse, because one `bigint` three levels
  down still has to be coerced; a shallow check would hand back an array
  containing a `bigint` typed as `RedisReply`. Throwing on a non-RESP value stays
  in the rebuild path, so a bad reply still fails loud however deeply it is
  nested.

**Out of scope** — none. Every finding in this batch is fixed here.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd shared/redis check` | ✅ clean |
| `bun run --cwd shared/redis test:run` | ✅ 7 files, 80 tests |
| `bun run --cwd osn/api check` | ✅ clean |
| `bun run --cwd osn/api test:run` | ✅ 68 files, 1136 tests |
| `bun run --cwd pulse/api check` | ✅ clean |
| `bun run --cwd pulse/api test:run` | ✅ 42 files, 637 tests |
| `bun run lint` | ✅ exit 0 |
| `bun run fmt:check` | ✅ 1429 files |
| `scripts/validate-changesets.sh` | ✅ pass |

`shared/redis/tsconfig.json` now includes `tests/**/*`, so the package's own
`check` typechecks the test files as well — they were previously unchecked.

Not run: nothing exercises this against a real Upstash endpoint. The `EVALSHA`
path and the `NOSCRIPT` fallback are covered by a fake client only, so the
first live confirmation is the dev-tier deploy — worth watching `wrangler tail`
on `osn-api` for a `NOSCRIPT` after the first request following a deploy.
