### PR TITLE
chore(issues): add needs:decision to the label script and conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ gh issue create --repo xchromo/osn --type Feature --label product:cire --title "
 
 `/new-feat` opens a well-formed issue; `/prep-pr` files findings at the end of a review. Label and type definitions, and the Project setup, are in `[[wiki/runbooks/github-issues-setup]]`; how a finding is filed is in `[[wiki/conventions/review-findings]]`.
 
+One label is orthogonal to all of that: **`needs:decision`**, on both repos. It means the next step needs a choice only the repo owner can make. An agent working the backlog writes what the issue is and what it proposes, applies the label, and moves to a different issue — one open question never parks the queue. See `[[wiki/conventions/review-findings]]` §When the fix needs a decision from the owner.
+
 **Never delete an issue — close it.** The history matters.
 
 **Every issue body stands on its own.** Someone opens it months later with nothing checked out. Name the file and line; state the concrete fix or the observable "done when"; spell out the acronyms. A body whose content is a pointer — "see the TODO", "per `wiki/todo/api.md`", "migrated from …" — is a bookmark, not an issue, and the 2026-08-15 migration deleted every page those pointers named. Where a wiki page adds real context, reference it by **repo path** (`wiki/systems/rate-limiting.md`) and restate the fact in the issue anyway: a `[[wikilink]]` does not resolve on GitHub.

--- a/scripts/todo-to-issues/labels.sh
+++ b/scripts/todo-to-issues/labels.sh
@@ -35,4 +35,11 @@ for repo in xchromo/osn xchromo/osn-tracker; do
   create "severity:info" "ededed" "Informational"
 
   create "epic" "3e4b9e" "Parent issue with sub-issues"
+
+  # Orthogonal to every label above: a state, not a category. An agent working
+  # the backlog applies it when the next step needs a choice only the repo
+  # owner can make, writes the choice up in the body, and moves to another
+  # issue rather than guessing. Its own colour, because sharing the security
+  # red would make a parked question look like a critical finding.
+  create "needs:decision" "e99695" "Blocked on a decision from the repo owner; do not action without one"
 done

--- a/wiki/conventions/contributing.md
+++ b/wiki/conventions/contributing.md
@@ -7,7 +7,7 @@ related:
   - "[[review-findings]]"
   - "[[stacked-prs]]"
   - "[[testing-patterns]]"
-last-reviewed: 2026-08-19
+last-reviewed: 2026-08-31
 ---
 
 # Contributing
@@ -93,8 +93,10 @@ Before opening a PR, verify:
 
 - [ ] Feature branch (not main)
 - [ ] Base branch correct -- `main`, or the parent branch if this PR is stacked, and the stack registered with `gh stack link` ([[stacked-prs]])
-- [ ] Changeset included (`bun run changeset`)
-- [ ] Changeset package names match workspace `name` fields
+- [ ] Changeset included, or the diff genuinely needs none -- `git diff --name-only origin/main...HEAD | ./scripts/changeset-required.sh` answers `required` or `skip`
+- [ ] Changeset valid (`./scripts/validate-changesets.sh`) -- package names match workspace `name` fields, and no changeset mixes ignored with versioned packages
+- [ ] Lockfile honest (`bun install --frozen-lockfile`) -- if `bun.lock` is in the diff, this must pass without rewriting it. An install on one machine prunes entries for every platform it is not running on; splice the entry by hand rather than committing that
+- [ ] Vitest DOM markers intact (`bun run check:jest-dom-markers`) -- every `vitest.config.ts` using `vite-plugin-solid` still names a `jest-dom` path in `setupFiles`
 - [ ] Tests pass (`bun run --cwd <package> test:run`)
 - [ ] Linting passes (`bun run lint`)
 - [ ] Formatting passes (`bun run fmt:check`)

--- a/wiki/conventions/review-findings.md
+++ b/wiki/conventions/review-findings.md
@@ -5,7 +5,7 @@ tags: [convention, review]
 related:
   - "[[contributing]]"
   - "[[stacked-prs]]"
-last-reviewed: 2026-08-19
+last-reviewed: 2026-08-31
 ---
 
 # Review Finding IDs
@@ -97,6 +97,34 @@ Rules:
 - Several findings from one piece of work go on **stacked PRs**, one fix per PR, base of each set to the one below it -- see [[stacked-prs]].
 
 `T-*` test findings are not filed. They are coverage gaps, not defects -- `/prep-pr` Step 4 raises them and they get closed in the branch or waved through.
+
+## When the fix needs a decision from the owner
+
+Some issues cannot be closed by anyone but the repo owner: the fix is a choice between two defensible designs, or it costs money, or it changes a public contract. An agent working the backlog must not guess at those, and must not stop on them either -- one open question is not a reason for the other hundred issues to sit still.
+
+Label it and move on:
+
+```bash
+gh issue edit <n> --repo xchromo/osn-tracker --add-label "needs:decision"
+```
+
+`needs:decision` exists on both repos. It is orthogonal to `product:`, `area:` and `severity:` -- it says the issue is parked on a person, not what kind of work it is.
+
+Before the label goes on, the body has to carry exactly two things, in this order:
+
+1. **What the issue actually is** -- the file and line, the current behaviour, and why it is wrong. The same standard as any other body: someone opens it months later with nothing checked out.
+2. **A proposed solution, with the trade-off named** -- the option you would take, what it costs, and what the alternative buys instead. "Needs a decision" without a proposal hands the owner the whole problem back; the point of the label is that the thinking is done and only the choice is left.
+
+A body that says no more than "blocked, needs input" is not an issue, it is an interruption. Write the proposal first, then apply the label, then pick up a different issue.
+
+Filter for them when the owner sits down to clear the queue:
+
+```bash
+gh issue list --repo xchromo/osn --label needs:decision --state open --limit 1000
+gh issue list --repo xchromo/osn-tracker --label needs:decision --state open --limit 1000
+```
+
+Remove the label once the decision is recorded in a comment; the issue then goes back to being ordinary work.
 
 ## Usage in PR Comments
 

--- a/wiki/runbooks/github-issues-setup.md
+++ b/wiki/runbooks/github-issues-setup.md
@@ -4,7 +4,7 @@ tags: [runbooks, process, issues]
 related:
   - "[[review-findings]]"
   - "[[index]]"
-last-reviewed: 2026-08-18
+last-reviewed: 2026-08-31
 ---
 
 # GitHub Issues setup
@@ -62,12 +62,19 @@ gh api repos/xchromo/osn-tracker/contents/.github/ISSUE_TEMPLATE/review-finding.
 ./scripts/todo-to-issues/labels.sh
 ```
 
-18 labels per repo: 6 `product:`, 6 `area:`, 5 `severity:`, and `epic`. The
-script uses `--force`, so re-running it is how a colour or description is
-changed. Every issue carries exactly one `product:` and at most one `area:`;
-only a finding carries a `severity:`, taken from the tier letter in its ID.
-The migration enforced that with a gate over its manifest; now that issues are
-filed by hand, `/prep-pr` and `/new-feat` carry the rule.
+19 labels per repo: 6 `product:`, 6 `area:`, 5 `severity:`, `epic`, and
+`needs:decision`. The script uses `--force`, so re-running it is how a colour
+or description is changed. Every issue carries exactly one `product:` and at
+most one `area:`; only a finding carries a `severity:`, taken from the tier
+letter in its ID. The migration enforced that with a gate over its manifest;
+now that issues are filed by hand, `/prep-pr` and `/new-feat` carry the rule.
+
+`needs:decision` is the one label that says nothing about what an issue *is*.
+It is a state: the next step needs a choice only the repo owner can make. It
+combines with any product, area or severity, and it is the mechanism that keeps
+one open question from stalling a backlog — see
+`wiki/conventions/review-findings.md` for what the body must say before the
+label goes on.
 
 **There is no `area:feature`.** An issue with no `area:` is ordinary product
 work, and its type already says `Feature` — a label repeating it would be a


### PR DESCRIPTION
## Summary

An agent working the issue backlog regularly reaches an issue whose next step is a choice only the repo owner can make — two defensible designs, a cost, a change to a public contract. It must not guess, and it must not stop either: one open question is not a reason for the other hundred issues to sit still. `needs:decision` is the label that parks such an issue on a person while the queue keeps moving.

The label was created by hand on both `xchromo/osn` and `xchromo/osn-tracker` and existed in no file. `scripts/todo-to-issues/labels.sh` is the source of truth for the label set and runs with `--force`, so a fresh run would have left the label unmanaged and its colour and description unowned. This adds it there and writes down the workflow it belongs to.

- The colour changes from `B60205` to `e99695`. `B60205` is already `area:security` and `severity:critical`, so a parked question rendered exactly like a critical security finding. Running `labels.sh` recolours the existing label on both repos; no issue loses the label.
- The PR checklist in `wiki/conventions/contributing.md` gained the three repo gates that already fail CI but were never listed, plus the lockfile check.

## Workspaces affected

None. The diff is `scripts/`, `wiki/` and the root `CLAUDE.md` — all on the allowlist in `scripts/changeset-required.sh`, which answers `skip` for this file list. No changeset, because no versioned package ships any of it.

## Issues

**Closes**

None.

**Opened**

None.

## Decisions

### The label carries a proposal, not a question — `approach`

- **Issue** — a label alone lets an agent mark an issue "someone else's problem" and move on, which converts a backlog of work into a backlog of unanswered questions.
- **Why** — the owner then has to reconstruct each issue from scratch before they can decide anything, which is most of the work and all of the context-switching. The point of running the backlog through an agent is that the thinking arrives done.
- **Solution** — `wiki/conventions/review-findings.md` now requires the body to carry exactly two things before the label goes on: what the issue actually is (file, line, current behaviour, why it is wrong), and a proposed solution with the trade-off named — the option the agent would take, what it costs, what the alternative buys.
- **Rationale** — that leaves the owner a choice rather than a problem, which is a minute's work instead of an hour's. A body reading "blocked, needs input" is explicitly called out as not an issue.

### Its own colour rather than the security red — `approach`

- **Issue** — the hand-created label used `B60205`, which `labels.sh` already assigns to both `area:security` and `severity:critical`.
- **Why** — the issue list is scanned by colour before it is read. Three different meanings in one red makes a parked design question look like an unpatched vulnerability, and makes a real critical finding easier to skim past.
- **Solution** — `e99695`, a lighter red: still reads as "wants attention", not confusable with the critical/security red.
- **Rationale** — `labels.sh` uses `--force`, so the recolour is what running the script does, and the runbook already documents that as the way a colour is changed. Nothing else in the label set uses `e99695`.

### `needs:decision` is a state, not a category — `approach`

- **Issue** — every other label in the set answers "what is this issue about": one `product:`, at most one `area:`, a `severity:` on findings only.
- **Why** — filing `needs:decision` under those rules would mean either forcing it into the `area:` slot (crowding out `security`/`ops`/`docs` on the issues most likely to need them) or writing an exception into the one-of-each rule.
- **Solution** — documented as orthogonal to all three axes in `wiki/runbooks/github-issues-setup.md` §3 and in `CLAUDE.md`. It combines with any product, area or severity, and it is removed once the decision is recorded in a comment.
- **Rationale** — it describes where the issue is in its life, not what kind of work it is, so it does not compete with the classification labels and needs no change to the one-of-each rule the manifest gate enforced.

**Out of scope** — the label is not yet applied to any existing issue; that happens as the backlog is worked. No workflow or automation reads it, so nothing enforces the two-part body — the convention page is the only gate, same as every other body rule in this repo.

## Test plan

| Gate | Result |
|---|---|
| `bash -n scripts/todo-to-issues/labels.sh` | ✅ |
| `git diff --name-only \| ./scripts/changeset-required.sh` | ✅ `skip` — no changeset required |
| wikilink resolution over changed `wiki/` pages | ✅ no real breaks (4 hits, all the documented false positives: three TOML `[[env.*.d1_databases]]` headers inside code fences, and the literal `[[wikilink]]` example) |

**Not run**, and why:

- `bun run lint`, `bun run fmt:check`, `bun run check` — structurally cannot see this diff. `fmt:check` globs `osn pulse zap shared cire tools/lab tools/oxlint/house` with `!**/*.md`, and the diff is entirely markdown plus one file under `scripts/`; `lint` and `check` act on TypeScript, of which the diff contains none.
- `scripts/todo-to-issues/labels.sh` itself — running it creates and recolours labels on both live repos. It is left for whoever merges this; the change is one `create` line following the same form as the eighteen above it.
- The performance and security review agents — the diff adds no code path, no route and no dependency.
