### PR TITLE
perf(turbo): scope test caches, and gate every lab story in CI

### DIFF
--- a/.changeset/lab-story-smoke-test.md
+++ b/.changeset/lab-story-smoke-test.md
@@ -1,0 +1,14 @@
+---
+"@tools/lab": patch
+---
+
+Gate every component-lab story in CI. `tools/lab/tests/stories.test.tsx` imports
+every file the registry globs match and renders each story that can run
+headless, so a bench that has silently stopped mounting fails the build instead
+of appearing as an error row in the sidebar that nobody opens. A story that
+needs a real browser opts out with `headless: false` in its `meta`; both
+three.js stories do.
+
+Also scope the Turborepo `test`, `test:d1` and `test:browser` caches with a
+subtractive `inputs` list, so a markdown-only edit no longer busts a package's
+test cache.

--- a/bun.lock
+++ b/bun.lock
@@ -659,6 +659,7 @@
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "@types/three": "^0.185.1",
+        "happy-dom": "^20.11.1",
         "typescript": "^6.0.3",
         "vite": "^8.1.5",
         "vite-plugin-solid": "^2.11.14",

--- a/scripts/check-jest-dom-markers.sh
+++ b/scripts/check-jest-dom-markers.sh
@@ -8,12 +8,11 @@
 # gate stays green and every Solid package pays for the matchers again.
 #
 # A grep, not a resolver: this job installs nothing, so the config is text. It
-# matches the import statement rather than the plugin's bare name, because
-# `tools/lab/vitest.config.ts` explains at length why it leaves the plugin out
-# and would otherwise be checked for a marker it must not have. Naming jest-dom
-# in a comment and nowhere else would still satisfy the second grep, which is
-# the price of not running a bundler here. It catches the deletion, which is the
-# way this actually regresses.
+# matches the import statement rather than the plugin's bare name, so a config
+# that only mentions the plugin in prose is not asked for a marker it does not
+# need. Naming jest-dom in a comment and nowhere else would still satisfy the
+# second grep, which is the price of not running a bundler here. It catches the
+# deletion, which is the way this actually regresses.
 set -euo pipefail
 
 root="${1:-$(git rev-parse --show-toplevel)}"

--- a/tools/lab/README.md
+++ b/tools/lab/README.md
@@ -99,6 +99,21 @@ export const meta = { title: "osn/ui/Button", layout: "centered" as const };
 `fullscreen` (no padding, for canvases). Without `title`, the sidebar name comes
 from the file path.
 
+`meta.headless` is the one flag with a gate behind it. `tests/stories.test.tsx`
+imports every story file and renders every story, so a bench that has quietly
+stopped mounting fails the build instead of showing up as a sidebar error row
+nobody sees. Set `headless: false` when the file cannot render outside a real
+browser — a `WebGLRenderer` needs a GPU context happy-dom does not have — and
+the smoke test stops at importing it:
+
+```tsx
+export const meta = { title: "lab/three", layout: "fullscreen" as const, headless: false };
+```
+
+It defaults to `true`, so a new story is gated unless its author says why it
+cannot be. Opting out describes the story's dependencies, not how finished it
+is.
+
 ## Where stories live
 
 Two homes, both auto-discovered:

--- a/tools/lab/package.json
+++ b/tools/lab/package.json
@@ -28,6 +28,7 @@
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "@types/three": "^0.185.1",
+    "happy-dom": "^20.11.1",
     "typescript": "^6.0.3",
     "vite": "^8.1.5",
     "vite-plugin-solid": "^2.11.14",

--- a/tools/lab/src/lab/registry.ts
+++ b/tools/lab/src/lab/registry.ts
@@ -100,6 +100,7 @@ export async function loadRegistry(): Promise<Registry> {
           file: path,
           story,
           layout: (story.layout ?? meta.layout ?? "centered") as StoryLayout,
+          headless: meta.headless !== false,
         });
       }
     }),

--- a/tools/lab/src/lab/types.ts
+++ b/tools/lab/src/lab/types.ts
@@ -55,6 +55,16 @@ export interface StoryMeta {
   /** Overrides the path-derived sidebar title, e.g. `"osn/ui/Button"`. */
   title?: string;
   layout?: StoryLayout;
+  /**
+   * Set `false` when the file cannot render outside a real browser — a WebGL
+   * canvas is the case that exists today. The smoke test then stops at
+   * importing the file instead of rendering its stories.
+   *
+   * Defaults to `true`, so a new story is gated unless its author says why it
+   * cannot be. Opting out is a statement about the story's dependencies, not
+   * about how finished it is.
+   */
+  headless?: boolean;
 }
 
 /**
@@ -76,4 +86,6 @@ export interface StoryEntry {
   file: string;
   story: Story;
   layout: StoryLayout;
+  /** False when the story needs a real browser — see `StoryMeta.headless`. */
+  headless: boolean;
 }

--- a/tools/lab/src/stories/html-in-canvas.story.tsx
+++ b/tools/lab/src/stories/html-in-canvas.story.tsx
@@ -13,7 +13,10 @@ import {
 import { Canvas2D, CSS3DObject, htmlToCanvas, htmlToTexture, ThreeCanvas } from "../lab/three.tsx";
 import type { Story, StoryArgs } from "../lab/types.ts";
 
-export const meta = { title: "lab/html-in-canvas", layout: "fullscreen" as const };
+// `headless: false` — every story here builds a `WebGLRenderer`, which needs a
+// GPU context no headless DOM provides. The smoke test imports the file and
+// stops there.
+export const meta = { title: "lab/html-in-canvas", layout: "fullscreen" as const, headless: false };
 
 /**
  * The card markup all three stories rasterise. Written as strict XHTML —

--- a/tools/lab/src/stories/three-cube.story.tsx
+++ b/tools/lab/src/stories/three-cube.story.tsx
@@ -12,7 +12,10 @@ import {
 import { ThreeCanvas } from "../lab/three.tsx";
 import type { Story, StoryArgs } from "../lab/types.ts";
 
-export const meta = { title: "lab/three", layout: "fullscreen" as const };
+// `headless: false` — every story here builds a `WebGLRenderer`, which needs a
+// GPU context no headless DOM provides. The smoke test imports the file and
+// stops there.
+export const meta = { title: "lab/three", layout: "fullscreen" as const, headless: false };
 
 interface SpinArgs extends StoryArgs {
   figure: "cube" | "knot";

--- a/tools/lab/tests/registry.test.ts
+++ b/tools/lab/tests/registry.test.ts
@@ -1,10 +1,11 @@
 /**
  * The lab's pure helpers.
  *
- * Stories themselves carry no gate — nothing in CI renders one, by design. But
- * `titleFromPath` names every row in the sidebar and `inferControl` picks every
- * editor in the args panel, and both fail quietly: a wrong title still renders,
- * a wrong control still accepts input. Those are worth pinning.
+ * Stories are gated next door, in `stories.test.tsx`, which imports every one
+ * of them and renders the ones that can run headless. This file covers the two
+ * helpers that fail quietly instead: `titleFromPath` names every row in the
+ * sidebar and `inferControl` picks every editor in the args panel, and a wrong
+ * title still renders while a wrong control still accepts input.
  */
 import { describe, expect, it } from "vitest";
 

--- a/tools/lab/tests/stories.test.tsx
+++ b/tools/lab/tests/stories.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+//
+// The lab's own smoke test: every story file in the monorepo must import, and
+// every story that claims to work headless must render. It is the only thing
+// standing between a renamed export in `pulse/web` and a sidebar row that
+// throws when someone clicks it — the lab has no other consumer to break.
+//
+// This file asks for `happy-dom` by pragma rather than in the config, so the
+// pure-function tests beside it keep running in `node`.
+import { render } from "solid-js/web";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { Registry } from "../src/lab/registry.ts";
+import { loadRegistry, storyFileCount } from "../src/lab/registry.ts";
+
+describe("the story registry", () => {
+  // Loaded once. Every story file in the monorepo goes through Vite's
+  // transform on the first call, which is seconds on a cold cache — paying
+  // that per test is what makes this file look slow and flaky.
+  let registry: Registry;
+
+  beforeAll(async () => {
+    registry = await loadRegistry();
+  }, 120_000);
+
+  it("finds story files at all", () => {
+    // Zero means the globs in `registry.ts` stopped matching — a moved
+    // workspace, a renamed directory — and every assertion below would then
+    // pass over an empty list.
+    expect(storyFileCount).toBeGreaterThan(0);
+  });
+
+  it("imports every story file without throwing", () => {
+    // Named rather than counted, so the failure output says which file and why.
+    expect(registry.failures.map((f) => `${f.file}: ${f.error}`)).toEqual([]);
+  });
+
+  it("gives every entry a usable shape", () => {
+    const { entries } = registry;
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const entry of entries) {
+      expect(entry.id, `${entry.file} has an empty id`).not.toBe("");
+      expect(entry.title, `${entry.id} has an empty title`).not.toBe("");
+      expect(entry.name, `${entry.id} has an empty name`).not.toBe("");
+      expect(
+        entry.id.startsWith(entry.title),
+        `${entry.id} does not start with its own title`,
+      ).toBe(true);
+      expect(["centered", "padded", "fullscreen"]).toContain(entry.layout);
+      expect(typeof entry.story.render, `${entry.id} has no render function`).toBe("function");
+      expect(typeof entry.headless, `${entry.id} has no headless flag`).toBe("boolean");
+    }
+  });
+
+  it("gives every entry a unique id", () => {
+    const ids = registry.entries.map((e) => e.id);
+    // `loadRegistry` disambiguates a collision by appending the file path, so a
+    // duplicate here means that fix regressed and the sidebar would open the
+    // wrong story.
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("renders every story that claims to work headless", () => {
+    const headless = registry.entries.filter((e) => e.headless);
+    expect(headless.length).toBeGreaterThan(0);
+
+    for (const entry of headless) {
+      const host = document.createElement("div");
+      document.body.append(host);
+      let dispose: (() => void) | undefined;
+      try {
+        dispose = render(() => entry.story.render(entry.story.args ?? {}), host);
+      } catch (error) {
+        throw new Error(
+          `${entry.id} (${entry.file}) threw while rendering. Set \`headless: false\` in its ` +
+            "`meta` if it genuinely needs a real browser.",
+          { cause: error },
+        );
+      } finally {
+        dispose?.();
+        host.remove();
+      }
+    }
+  });
+});

--- a/tools/lab/vitest.config.ts
+++ b/tools/lab/vitest.config.ts
@@ -1,17 +1,29 @@
+import solid from "vite-plugin-solid";
 import { defineConfig } from "vitest/config";
 
 // Its own config, not `vite.config.ts`: that one is the dev server's, and the
 // tests here need none of it.
 //
-// Deliberately without `vite-plugin-solid`, unlike every other Solid package in
-// the repo. The plugin adds `@testing-library/jest-dom/vitest` to `setupFiles`
-// for any test run, which fails outright unless the package carries that
-// dependency — and a dev tool testing two pure functions has no reason to pull
-// in a DOM matcher library. The cost is that nothing here can import a `.tsx`
-// file, which is why `inferControl` lives in its own module.
+// `vite-plugin-solid` is here so the story smoke test can import `.tsx` story
+// files and render them. The plugin also prepends
+// `@testing-library/jest-dom/vitest` to `setupFiles` unless an existing entry's
+// path already contains `jest-dom`, which is what the marker file is for: this
+// package tests two pure functions and a render pass, and has no use for a DOM
+// matcher library.
 export default defineConfig({
+  plugins: [solid()],
+  // Bun installs solid-js into each workspace's own node_modules rather than
+  // hoisting it, so a story imported from `pulse/web` resolves a *second* copy
+  // of the runtime. Two Solid instances do not share a reactive graph, and a
+  // story that renders fine in the dev server then throws here. Same dedupe as
+  // `vite.config.ts`, for the same reason.
+  resolve: { dedupe: ["solid-js", "solid-js/web", "solid-js/store"] },
   test: {
+    // Node by default; the story smoke test asks for `happy-dom` with a
+    // first-line `// @vitest-environment` pragma, so the pure-function tests
+    // keep paying nothing for a DOM they never touch.
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["../../shared/test-config/no-jest-dom.ts"],
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -26,19 +26,43 @@
     "lint": {},
     "fmt": {},
     "check": {},
+    // `inputs` below is *subtractive*, not an allowlist. Turborepo's default is
+    // "every non-gitignored file in the package", and naming any input replaces
+    // that default outright — so a hand-written list is a promise that nothing
+    // outside it can change a test result, and a wrong promise shows up as a
+    // stale green run rather than a loud failure. Three packages keep tests
+    // outside `src/` and `tests/` (`cire/api/scripts`, `cire/db/seed`,
+    // `pulse/landing/functions`), and `osn/db`, `pulse/db` and `zap/db` read
+    // `drizzle/*.sql` off disk while testing, so an allowlist missing either
+    // would report a migration change as already-passing. `$TURBO_DEFAULT$`
+    // keeps the default set and subtracts from it, which puts the risk the
+    // other way round: the worst a wrong exclusion does is re-run a suite that
+    // did not need re-running.
     "test": {
       "dependsOn": [
         "^build"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md"
       ]
     },
     "test:d1": {
       "dependsOn": [
         "^build"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md"
       ]
     },
     "test:browser": {
       "dependsOn": [
         "^build"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md"
       ],
       "passThroughEnv": [
         "VITEST_BROWSER_EXECUTABLE_PATH",

--- a/wiki/conventions/component-lab.md
+++ b/wiki/conventions/component-lab.md
@@ -7,7 +7,7 @@ related:
   - "[[frontend-patterns]]"
   - "[[commands]]"
   - "[[devloop-urls]]"
-last-reviewed: 2026-08-28
+last-reviewed: 2026-08-31
 ---
 
 # Component Lab
@@ -119,21 +119,45 @@ import into the lab depends on this.
 `export const Thing = () => <div />` work with no config. It also means an
 exported helper shows up in the sidebar — keep helpers unexported.
 
-**Stories are not tests and carry no gate.** Nothing in CI renders a story.
-`check` typechecks the lab, `lint` and `fmt:check` cover it. A component whose
-behaviour matters still needs a real test — see [[testing-patterns]].
+**Stories are not tests, but they do carry a gate.** `tools/lab/tests/stories.test.tsx`
+imports every file the registry globs match and renders every story that can run
+headless, asserting only that nothing throws and `loadRegistry()` reports no
+failures. It says nothing about how a story looks — that is the thing a bench
+exists for and the thing no assertion can reach. A component whose *behaviour*
+matters still needs a real test — see [[testing-patterns]].
 
-The `test` script that does exist covers two pure helpers, `titleFromPath` and
+The gate exists because a bench that has silently stopped mounting is worse than
+no bench: you reach for it precisely when you are changing what it exercises,
+and a story that throws on import becomes a `LoadFailure` row in the sidebar
+rather than a red build. `@shared/toast` and `@shared/sortable` are the case
+that made it necessary — their co-located benches are the only coverage of drag
+feel, the shift/settle animation and toast enter/leave.
+
+**A story that cannot run headless opts out**, in its own `meta`:
+
+```tsx
+export const meta = { layout: "fullscreen" as const, headless: false };
+```
+
+The smoke test then imports the file and stops there. `headless` defaults to
+`true`, so a new story is gated unless its author says why it cannot be, and
+opting out is a statement about the story's dependencies — a `WebGLRenderer`
+needs a GPU context no headless DOM provides — not about how finished it is.
+Both three.js stories in `src/stories/` carry it.
+
+The `test` script also covers two pure helpers, `titleFromPath` and
 `inferControl`, because both fail quietly: a wrong title still renders a row, a
-wrong control still accepts input. Its config leaves out `vite-plugin-solid`,
-which every other Solid package here uses. The plugin adds a
-`@testing-library/jest-dom` setup file to any test run and the run dies without
-that dependency, which a tool testing two pure functions should not carry. Every
-other Solid package suppresses that injection with a marker in `setupFiles`
-instead — see [[testing-patterns]] — but a lab that imports no `.tsx` file has
-nothing to gain from the plugin either way. The price is that no test here can
-import a `.tsx` file, and it is why `inferControl` sits in `infer-control.ts`
-rather than beside the panel it feeds.
+wrong control still accepts input.
+
+Rendering `.tsx` needs `vite-plugin-solid`, which every other Solid package here
+uses and which the lab's config used to leave out. The plugin prepends a
+`@testing-library/jest-dom` setup file to any test run unless an existing
+`setupFiles` entry already has `jest-dom` in its path; `shared/test-config/no-jest-dom.ts`
+is that entry — the same marker every other Solid package uses, see
+[[testing-patterns]]. The DOM itself is per-file: the config's `environment`
+stays `node`, and `stories.test.tsx` asks for `happy-dom` with a first-line
+`// @vitest-environment happy-dom` pragma, so the pure-helper tests keep paying
+nothing for a DOM they never touch.
 
 ## HTML in canvas
 


### PR DESCRIPTION
## Summary

Two cache-and-coverage gaps in the same corner of the repo. Turborepo's `test`, `test:d1` and `test:browser` tasks declared no `inputs`, so every non-gitignored file in a package fed the hash and a README line re-ran the suite. And nothing in CI rendered a component-lab story, which stopped being acceptable once `@shared/toast` and `@shared/sortable` gained co-located benches that are the only coverage of drag feel, the shift/settle animation and toast enter/leave.

- The cache scoping is **subtractive** — `["$TURBO_DEFAULT$", "!**/*.md"]` — not the allowlist the issue proposed. Reasoning under Decisions.
- The story gate is one file, `tools/lab/tests/stories.test.tsx`. It imports every story file and renders every story that can run headless. It asserts nothing about appearance.
- Stories that need a real browser opt out with `headless: false` in their `meta`. Both three.js stories do.

## Workspaces affected

`@tools/lab`. One changeset, `.changeset/lab-story-smoke-test.md`, naming `@tools/lab` at `patch`. `turbo.json` and `bun.lock` are both outside every workspace directory and `scripts/changeset-required.sh` answers `required` for them, which the same changeset satisfies.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#524 | `P-I4` |
| xchromo/osn-tracker#458 | `T-U1` |

Closes xchromo/osn-tracker#524.

Closes xchromo/osn-tracker#458.

**Opened**

None.

## Decisions

### Subtract from turbo's default inputs rather than list them — `P-I4`

- **Issue** — the issue proposed an explicit `inputs` allowlist: `src/**`, `tests/**`, `vitest.config.*`, `package.json`, `tsconfig.json`.
- **Why** — naming any input **replaces** turbo's default hashing outright. An allowlist is therefore a promise that nothing outside it can change a test result, and a wrong promise does not fail loudly: it returns a cached green run for code that was never tested.
- **Solution** — `["$TURBO_DEFAULT$", "!**/*.md"]` on all three test tasks, with the reasoning written into `turbo.json` above them.
- **Rationale** — that exact allowlist would already have been wrong here twice. `cire/api/scripts`, `cire/db/seed` and `pulse/landing/functions` keep tests outside `src/` and `tests/`; `osn/db`, `pulse/db` and `zap/db` read `drizzle/*.sql` off disk while testing, so a migration change would have hashed as already-passing. Subtracting inverts the risk — the worst a wrong exclusion does is re-run a suite that did not need it. Confirmed with `turbo run test --dry=json`: `@osn/db#test` resolves 25 input files, zero markdown, six `.sql` still hashed.

### A per-story `headless` flag rather than a path exclusion — `T-U1`

- **Issue** — the three.js stories build a `WebGLRenderer`, which needs a GPU context happy-dom does not provide. They cannot be rendered by the gate.
- **Why** — excluding them by path or by glob puts the exception somewhere the story's author never looks, so the next WebGL bench silently either breaks the suite or gets excluded by someone editing a config they do not own.
- **Solution** — `headless?: boolean` on `StoryMeta`, defaulting to `true`. `headless: false` makes the smoke test stop at importing the file. Both three.js stories carry it with a comment saying why.
- **Rationale** — the flag lives next to the reason for it, and the default gates a new story unless its author states why it cannot be. It is a claim about the story's dependencies, not about how finished it is, which is the distinction that keeps it from becoming a to-do marker.

### The gate asserts mounting, not appearance — `T-U1`

- **Issue** — a smoke test over benches is easy to over-specify into a snapshot suite.
- **Why** — benches exist for what no assertion reaches: drag feel, animation, hover and focus styling, contrast. A test that pinned any of that would fail on every intentional change and get deleted.
- **Solution** — the assertions are that `storyFileCount > 0`, that `loadRegistry()` reports zero failures, that every entry has a non-empty id/title/name, a known layout, a callable `render` and a boolean `headless`, that ids are unique, and that every headless-capable story mounts and disposes without throwing.
- **Rationale** — it targets the actual failure mode, a bench that no longer mounts, and nothing else. The id-uniqueness case guards a real fix in `loadRegistry` — a duplicate id makes the sidebar open the wrong story.

### The registry loads once, in `beforeAll` — `approach`

- **Issue** — the first version called `loadRegistry()` in each test. It passed standalone and timed out under `turbo run test`.
- **Why** — the first load transforms every story file in the monorepo. Standalone that is under a second; with 37 other turbo tasks competing for the CPU it went past Vitest's 5s default and reported as a flaky timeout rather than as slowness.
- **Solution** — one `beforeAll` with a 120s hook timeout, shared by the five assertions.
- **Rationale** — the work was always meant to happen once; doing it five times was the whole cost. A generous hook timeout is right for a step whose duration is a function of how many story files the monorepo has.

### Adding `vite-plugin-solid` to the lab's Vitest config — `approach`

- **Issue** — the config deliberately omitted the plugin, so nothing there could import a `.tsx` file. Rendering a story requires it.
- **Why** — the plugin prepends `@testing-library/jest-dom/vitest` to `setupFiles` unless an entry's path already matches `jest-dom`, and the run dies without that dependency.
- **Solution** — the plugin is in, with `shared/test-config/no-jest-dom.ts` as the marker (the same one every other Solid package uses) and a `solid-js`/`solid-js/web`/`solid-js/store` dedupe. `environment` stays `node`; the smoke test asks for happy-dom with a first-line `// @vitest-environment` pragma.
- **Rationale** — the marker is the established pattern here and `bun run check:jest-dom-markers` covers it. Keeping the environment per-file means the pure-helper tests next door still pay nothing for a DOM. The dedupe is not optional: Bun installs `solid-js` per workspace instead of hoisting, so a story imported from another package resolves a second copy of the runtime, and two Solid instances do not share a reactive graph.

**Out of scope** — `scripts/check-jest-dom-markers.sh` carried a comment saying `tools/lab/vitest.config.ts` explains why it leaves the plugin out; that is no longer true and the comment is corrected here, but the script's logic is unchanged. `tools/lab/tests/registry.test.ts` had the same stale claim in its header and is corrected the same way. Nothing else was found while reading the diff, so no follow-up issues were filed.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd tools/lab test:run` | ✅ 13 pass, 2 files |
| `bun run test` (whole monorepo, turbo) | ✅ 38 tasks successful |
| `bun run check` | ✅ 37 tasks successful |
| `bun run lint` | ✅ no errors |
| `bun run fmt:check` | ✅ 1430 files |
| `bun run check:jest-dom-markers` | ✅ 14 Solid vitest configs checked |
| `./scripts/validate-changesets.sh` | ✅ |
| `git diff --name-only \| ./scripts/changeset-required.sh` | ✅ `required`, and one is present |
| `bun install --frozen-lockfile` | ✅ no changes — the `bun.lock` line was spliced by hand |
| `turbo run test --dry=json` | ✅ 63 test tasks resolve; `@osn/db#test` has 25 inputs, 0 markdown, 6 `.sql` |

By hand, and worth a reviewer's eye:

- The gate does not prove a story still *looks* right, and cannot. Both three.js stories are imported and never rendered, so a WebGL bench that has broken visually still passes.
- `bun run test:browser` was not run; the Chromium project needs a browser this environment has no executable for. The `inputs` key added to it is the same three lines as the other two tasks, and `turbo run test --dry=json` confirms the config parses.
