### PR TITLE
perf(cire): cut avoidable D1 round trips on four vendor read paths

### DIFF
--- a/.changeset/cire-vendor-read-paths.md
+++ b/.changeset/cire-vendor-read-paths.md
@@ -1,0 +1,19 @@
+---
+"@cire/api": patch
+"@cire/vendor": patch
+---
+
+Cut avoidable D1 round trips on three vendor read paths.
+
+`POST /api/vendor/enquiries/:id/quote` ran the vendor-name and
+wedding-currency lookups serially even though neither depends on the other;
+they now run together. `directoryService.getLiveListingById` and
+`consumeClaim` had the same shape — a row fetch followed by a category fetch
+keyed on an id already known before the row fetch returns — so both now run
+their two queries together as well.
+
+On the vendor portal, the claim happy path already gets the freshly-claimed
+listing back from `consumeClaim`, but the redirect to the editor is a full
+page navigation that drops it. The claim page now hands the listing forward
+through a single-use sessionStorage key; the editor seeds its resource from
+it when present and valid, and falls back to its normal fetch otherwise.

--- a/cire/api/src/routes/vendor-enquiries.ts
+++ b/cire/api/src/routes/vendor-enquiries.ts
@@ -279,25 +279,32 @@ export function createVendorEnquiriesRoutes(
               const body = yield* Schema.decodeUnknown(QuoteBody)(raw);
               const enquiry = yield* loadEnquiryForVendor(db, orgMembership, params.id, profileId);
               if (!enquiry) return yield* notFound(set);
-              // Resolve the CRM vendor's name for the quote email/chat body.
-              const [vendorRow] = yield* dbQuery(() =>
-                db
-                  .select({ name: vendors.name })
-                  .from(vendors)
-                  .where(eq(vendors.id, enquiry.vendorId))
-                  .all(),
+              // The vendor name and the wedding currency are independent single-row
+              // lookups — run them together instead of two serial round trips.
+              const [[vendorRow], [weddingRow]] = yield* Effect.all(
+                [
+                  // Resolve the CRM vendor's name for the quote email/chat body.
+                  dbQuery(() =>
+                    db
+                      .select({ name: vendors.name })
+                      .from(vendors)
+                      .where(eq(vendors.id, enquiry.vendorId))
+                      .all(),
+                  ),
+                  // The quote is formatted in the wedding's own currency (NOT NULL,
+                  // default 'AUD'); only the display string is affected — stored
+                  // `quoted_minor` is currency-agnostic integer cents.
+                  dbQuery(() =>
+                    db
+                      .select({ currency: weddings.currency })
+                      .from(weddings)
+                      .where(eq(weddings.id, enquiry.weddingId))
+                      .all(),
+                  ),
+                ],
+                { concurrency: "unbounded" },
               );
               const vendorName = (vendorRow as { name: string } | undefined)?.name ?? "Vendor";
-              // The quote is formatted in the wedding's own currency (NOT NULL,
-              // default 'AUD'); only the display string is affected — stored
-              // `quoted_minor` is currency-agnostic integer cents.
-              const [weddingRow] = yield* dbQuery(() =>
-                db
-                  .select({ currency: weddings.currency })
-                  .from(weddings)
-                  .where(eq(weddings.id, enquiry.weddingId))
-                  .all(),
-              );
               const currency = (weddingRow as { currency: string } | undefined)?.currency ?? "AUD";
               const quoteInput: QuoteEnquiryInput = {
                 enquiry,

--- a/cire/api/src/services/directory.ts
+++ b/cire/api/src/services/directory.ts
@@ -647,16 +647,22 @@ export function createDirectoryService(config: DirectoryServiceConfig = {}) {
             .run(),
         );
 
-        // Fetch updated listing + categories
-        const [updated] = yield* dbQuery(() =>
-          db
-            .select()
-            .from(directoryVendors)
-            .where(eq(directoryVendors.id, claimRow.directoryVendorId))
-            .all(),
+        // Fetch updated listing + categories — both keyed on the already-known
+        // directoryVendorId, so run them together instead of serially.
+        const [[updated], categories] = yield* Effect.all(
+          [
+            dbQuery(() =>
+              db
+                .select()
+                .from(directoryVendors)
+                .where(eq(directoryVendors.id, claimRow.directoryVendorId))
+                .all(),
+            ),
+            fetchCategories(claimRow.directoryVendorId),
+          ],
+          { concurrency: "unbounded" },
         );
         const dvRow = updated as DvRow;
-        const categories = yield* fetchCategories(dvRow.id);
         return toDto(dvRow, categories);
       }).pipe(Effect.withSpan("cire.directory.consumeClaim"));
     },
@@ -798,16 +804,23 @@ export function createDirectoryService(config: DirectoryServiceConfig = {}) {
     getLiveListingById(id: string): Effect.Effect<ListingDto | null, never, DbService> {
       return Effect.gen(function* () {
         const db = yield* DbService;
-        const [row] = yield* dbQuery(() =>
-          db
-            .select()
-            .from(directoryVendors)
-            .where(and(eq(directoryVendors.id, id), eq(directoryVendors.listed, "live")))
-            .all(),
+        // The row fetch and the category fetch are both keyed on `id` — no
+        // dependency between them — so run them together.
+        const [[row], categories] = yield* Effect.all(
+          [
+            dbQuery(() =>
+              db
+                .select()
+                .from(directoryVendors)
+                .where(and(eq(directoryVendors.id, id), eq(directoryVendors.listed, "live")))
+                .all(),
+            ),
+            fetchCategories(id),
+          ],
+          { concurrency: "unbounded" },
         );
         if (!row) return null;
         const dvRow = row as DvRow;
-        const categories = yield* fetchCategories(dvRow.id);
         return toDto(dvRow, categories);
       }).pipe(Effect.withSpan("cire.directory.getLiveListingById"));
     },

--- a/cire/vendor/src/components/ClaimApp.tsx
+++ b/cire/vendor/src/components/ClaimApp.tsx
@@ -4,7 +4,7 @@ import { createResource, createSignal, onCleanup, onMount, Show } from "solid-js
 import { haptic } from "../lib/haptics";
 import { CIRE_API_URL } from "../lib/osn";
 import { initTheme } from "../lib/theme";
-import { consumeClaim, fetchClaimPreview } from "../lib/vendor-store";
+import { consumeClaim, fetchClaimPreview, seedClaimedListing } from "../lib/vendor-store";
 import type { OrgSummary } from "../lib/vendor-store";
 import OrgPicker from "./OrgPicker";
 import Button from "./ui/Button";
@@ -48,7 +48,10 @@ function ClaimContent() {
   // Step 4: Consume the claim on org pick.
   const handleClaim = async (org: OrgSummary) => {
     try {
-      await consumeClaim(authFetch, token(), org.id);
+      const listing = await consumeClaim(authFetch, token(), org.id);
+      // Hand the listing forward across the full-page redirect below, so the
+      // editor doesn't re-fetch what this call already got back (VP-P-W2).
+      seedClaimedListing(org.id, listing);
       haptic("commit");
       sessionStorage.removeItem(CLAIM_TOKEN_KEY);
       window.location.href = "/#/orgs/" + org.id;

--- a/cire/vendor/src/components/ListingEditor.tsx
+++ b/cire/vendor/src/components/ListingEditor.tsx
@@ -5,7 +5,7 @@ import { createEffect, createMemo, createResource, createSignal, For, Show } fro
 import { friendlyError } from "../lib/api";
 import { haptic } from "../lib/haptics";
 import { categoryLabel, SERVICE_CATEGORIES } from "../lib/service-categories";
-import { fetchListing, putListing } from "../lib/vendor-store";
+import { fetchListing, putListing, takeSeededListing } from "../lib/vendor-store";
 import Button from "./ui/Button";
 import Card, { CardEyebrow } from "./ui/Card";
 import Chip from "./ui/Chip";
@@ -42,8 +42,15 @@ interface ListingEditorProps {
 export default function ListingEditor(props: ListingEditorProps) {
   const { authFetch } = useAuth();
 
-  // Load the listing (may be null for a brand-new org).
-  const [listing] = createResource(() => fetchListing(authFetch, props.orgId));
+  // Load the listing (may be null for a brand-new org). A claim that just
+  // redirected here may have left the listing seeded in sessionStorage
+  // (VP-P-W2) — use it once instead of re-fetching what consumeClaim already
+  // returned.
+  const [listing] = createResource(async () => {
+    const seeded = takeSeededListing(props.orgId);
+    if (seeded !== undefined) return seeded;
+    return fetchListing(authFetch, props.orgId);
+  });
 
   // ── Form signals ─────────────────────────────────────────────────────────
   const [name, setName] = createSignal("");

--- a/cire/vendor/src/lib/vendor-store.seed.test.ts
+++ b/cire/vendor/src/lib/vendor-store.seed.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+//
+// The claim-to-editor handoff is the one part of `vendor-store.ts` that needs a
+// DOM: it lives entirely in `sessionStorage`, which the package's default
+// `node` environment does not provide. Split into its own file rather than
+// switching the whole of `vendor-store.test.ts` over, so the fetch-shaped tests
+// there keep running in the environment they were written for.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type Listing, seedClaimedListing, takeSeededListing } from "./vendor-store";
+
+describe("claimed-listing handoff (VP-P-W2)", () => {
+  const CLAIMED_LISTING_KEY = "cire.vendor.claimed-listing";
+
+  const listing: Listing = {
+    id: "dv1",
+    ownerOrgId: "o1",
+    name: "Rosewood Barn",
+    description: null,
+    email: null,
+    phone: null,
+    website: null,
+    instagram: null,
+    locationText: null,
+    priceBand: null,
+    priceMinMinor: null,
+    priceMaxMinor: null,
+    listed: "live",
+    categories: ["venue"],
+    createdAt: 1,
+    updatedAt: 2,
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("round-trips a seeded listing for the org it was seeded under", () => {
+    seedClaimedListing("o1", listing);
+    expect(takeSeededListing("o1")).toEqual(listing);
+  });
+
+  it("consumes the key on read, so a second editor mount refetches", () => {
+    seedClaimedListing("o1", listing);
+    takeSeededListing("o1");
+    expect(takeSeededListing("o1")).toBeUndefined();
+    expect(sessionStorage.getItem(CLAIMED_LISTING_KEY)).toBeNull();
+  });
+
+  it("refuses a seed left by a different org, and consumes it anyway", () => {
+    seedClaimedListing("o1", listing);
+    expect(takeSeededListing("o2")).toBeUndefined();
+    // Consumed on the way out even on a mismatch, so a stale seed cannot sit
+    // waiting for the org it happens to name to be opened later.
+    expect(sessionStorage.getItem(CLAIMED_LISTING_KEY)).toBeNull();
+  });
+
+  it("returns undefined when nothing was seeded", () => {
+    expect(takeSeededListing("o1")).toBeUndefined();
+  });
+
+  it("returns undefined on unparseable JSON", () => {
+    sessionStorage.setItem(CLAIMED_LISTING_KEY, "{not json");
+    expect(takeSeededListing("o1")).toBeUndefined();
+  });
+
+  // S-L1: every field `Listing` declares as required and non-nullable is
+  // checked, because `ListingEditor` renders `listed` straight into the status
+  // chip — a seed without it would put the word "undefined" on screen.
+  it.each(["id", "name", "listed", "categories", "createdAt", "updatedAt"] as const)(
+    "rejects a seed missing the required field %s",
+    (field) => {
+      const partial: Record<string, unknown> = { ...listing };
+      delete partial[field];
+      sessionStorage.setItem(
+        CLAIMED_LISTING_KEY,
+        JSON.stringify({ orgId: "o1", listing: partial }),
+      );
+      expect(takeSeededListing("o1")).toBeUndefined();
+    },
+  );
+
+  it("rejects a seed whose categories are not all strings", () => {
+    sessionStorage.setItem(
+      CLAIMED_LISTING_KEY,
+      JSON.stringify({ orgId: "o1", listing: { ...listing, categories: ["venue", 7] } }),
+    );
+    expect(takeSeededListing("o1")).toBeUndefined();
+  });
+
+  it("keeps its nerve when sessionStorage throws on write", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => seedClaimedListing("o1", listing)).not.toThrow();
+  });
+
+  it("falls through to undefined when sessionStorage throws on read", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(takeSeededListing("o1")).toBeUndefined();
+  });
+
+  it("still returns the listing when only the removal throws", () => {
+    seedClaimedListing("o1", listing);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(takeSeededListing("o1")).toEqual(listing);
+  });
+});

--- a/cire/vendor/src/lib/vendor-store.ts
+++ b/cire/vendor/src/lib/vendor-store.ts
@@ -152,14 +152,24 @@ interface ClaimedListingSeed {
 }
 
 /**
- * The three fields {@link isValidListing} reads, each still `unknown` because
- * the value came out of a JSON.parse of a sessionStorage string, not the
- * network — same idiom as `CropCandidate` in `cire/api/src/schemas/invite.ts`.
+ * The fields {@link isValidListing} reads, each still `unknown` because the
+ * value came out of a JSON.parse of a sessionStorage string, not the network —
+ * same idiom as `CropCandidate` in `cire/api/src/schemas/invite.ts`.
+ *
+ * These are every field {@link Listing} declares as required and non-nullable.
+ * The nullable ones are deliberately left unchecked: `null` and absent are the
+ * same thing to every reader of them, so a seed missing one behaves exactly
+ * like a listing that never had it. The required ones are not so forgiving —
+ * `ListingEditor` renders `listed` straight into the status chip, so a seed
+ * without it puts the word "undefined" on screen (S-L1).
  */
 interface ListingCandidate {
   id?: unknown;
   name?: unknown;
+  listed?: unknown;
   categories?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
 }
 
 function isListingCandidate(value: unknown): value is ListingCandidate {
@@ -168,8 +178,16 @@ function isListingCandidate(value: unknown): value is ListingCandidate {
 
 function isValidListing(value: unknown): value is Listing {
   if (!isListingCandidate(value)) return false;
-  const { id, name, categories } = value;
-  return typeof id === "string" && typeof name === "string" && Array.isArray(categories);
+  const { id, name, listed, categories, createdAt, updatedAt } = value;
+  return (
+    typeof id === "string" &&
+    typeof name === "string" &&
+    typeof listed === "string" &&
+    Array.isArray(categories) &&
+    categories.every((entry) => typeof entry === "string") &&
+    typeof createdAt === "number" &&
+    typeof updatedAt === "number"
+  );
 }
 
 /**

--- a/cire/vendor/src/lib/vendor-store.ts
+++ b/cire/vendor/src/lib/vendor-store.ts
@@ -136,3 +136,83 @@ export async function consumeClaim(
   if (!body?.listing) throw new Error("Invalid response consuming claim");
   return body.listing;
 }
+
+// ── Claim → editor handoff (VP-P-W2) ────────────────────────────────────────
+// `consumeClaim` already returns the listing, but the claim page redirects
+// with a full document navigation (`window.location.href`), which drops
+// everything in memory. sessionStorage crosses that gap the same way
+// CLAIM_TOKEN_KEY crosses the sign-in redirect in ClaimApp. The key is read
+// once: `takeSeededListing` deletes it on the way out, whether or not the
+// value turns out usable, so it can never leak into a later, unrelated load.
+const CLAIMED_LISTING_KEY = "cire.vendor.claimed-listing";
+
+interface ClaimedListingSeed {
+  orgId: string;
+  listing: Listing;
+}
+
+/**
+ * The three fields {@link isValidListing} reads, each still `unknown` because
+ * the value came out of a JSON.parse of a sessionStorage string, not the
+ * network — same idiom as `CropCandidate` in `cire/api/src/schemas/invite.ts`.
+ */
+interface ListingCandidate {
+  id?: unknown;
+  name?: unknown;
+  categories?: unknown;
+}
+
+function isListingCandidate(value: unknown): value is ListingCandidate {
+  return typeof value === "object" && value !== null;
+}
+
+function isValidListing(value: unknown): value is Listing {
+  if (!isListingCandidate(value)) return false;
+  const { id, name, categories } = value;
+  return typeof id === "string" && typeof name === "string" && Array.isArray(categories);
+}
+
+/**
+ * Stash the listing `consumeClaim` just returned, keyed to the org it
+ * belongs to, so the editor can seed from it instead of re-fetching.
+ * Best-effort: sessionStorage can throw (private mode, blocked site data);
+ * a failure here just means the editor falls back to its normal fetch.
+ */
+export function seedClaimedListing(orgId: string, listing: Listing): void {
+  try {
+    sessionStorage.setItem(CLAIMED_LISTING_KEY, JSON.stringify({ orgId, listing }));
+  } catch {
+    // No seed, no problem.
+  }
+}
+
+/**
+ * Take the listing seeded by a just-completed claim, if any, for `orgId`.
+ * Returns `undefined` on every failure mode — key absent, unparseable JSON,
+ * a mismatched org, a shape that doesn't look like `Listing`, or
+ * sessionStorage throwing on read — so the caller always has a clean
+ * fall-through to fetchListing.
+ */
+export function takeSeededListing(orgId: string): Listing | undefined {
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(CLAIMED_LISTING_KEY);
+  } catch {
+    return undefined;
+  }
+  if (raw === null) return undefined;
+  try {
+    sessionStorage.removeItem(CLAIMED_LISTING_KEY);
+  } catch {
+    // Read succeeded but removal failed — proceed anyway; a stale key left
+    // behind gets rejected below on org mismatch or bad shape at worst.
+  }
+  try {
+    const seed = JSON.parse(raw) as ClaimedListingSeed;
+    if (seed.orgId !== orgId) return undefined;
+    if (!isValidListing(seed.listing)) return undefined;
+    return seed.listing;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Four vendor read paths were doing more work than they needed to. Three of them
issued two independent single-row D1 lookups one after the other, when neither
depended on the other; they now run together. The fourth threw away a listing
the server had already returned and fetched it again over the wire.

The fourth is the interesting one. `consumeClaim` hands back the freshly
claimed listing, but the claim page reaches the editor through
`window.location.href` — a full document navigation, which drops everything in
memory. The listing now crosses that gap through a single-use `sessionStorage`
key: written on the claim side, taken and deleted on the first read, validated
before it is trusted, and falling through to the normal fetch on every failure.

- `#109` needed no code at all. It asked whether a partial unique index serves
  a correlated `EXISTS` probe, and it does — see the Decisions section for the
  plan, taken off the real D1 driver rather than inferred.
- The security review of this branch found the seed guard too loose; the second
  commit tightens it and adds the tests the handoff was missing.

## Workspaces affected

`cire/api`, `cire/vendor`. `.changeset/cire-vendor-read-paths.md` names
`@cire/api` and `@cire/vendor`, both `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#108 | `VP-P-W2` |
| xchromo/osn-tracker#121 | `ENQ-P-W1` |
| xchromo/osn-tracker#111 | `VD-P-I2` |
| xchromo/osn-tracker#109 | `VD-P-W2` |

Closes xchromo/osn-tracker#108.
Closes xchromo/osn-tracker#121.
Closes xchromo/osn-tracker#111.
Closes xchromo/osn-tracker#109.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#584 | `S-L2` |
| xchromo/osn-tracker#585 | `P-I1` |

## Decisions

### The partial index does serve the probe — `VD-P-W2`

- **Issue** — `#109` asked whether the `inWedding` correlated `EXISTS` in
  `directory.ts` is served by the partial unique index
  `vendors_wedding_directory_uniq`, or whether it degrades to a scan.
- **Why** — the answer decides whether a plain non-partial index is needed. An
  index nobody needs is write amplification on every insert; a scan nobody
  noticed is a directory browse that gets slower with the table.
- **Solution** — ran `EXPLAIN QUERY PLAN` on both engines, and got the same
  plan from each: `SEARCH v USING COVERING INDEX
  vendors_wedding_directory_uniq (wedding_id=? AND directory_vendor_id=?)`.
  No code changed.
- **Rationale** — partial-index usability is a property of the engine version,
  so a local `bun:sqlite` answer alone would only have been indicative. The
  same query was run against Miniflare/workerd D1 — the driver dev, staging and
  production actually use — which makes this evidence rather than inference.
  SQLite proves the equality terms imply the index's `IS NOT NULL` predicate,
  so the partial index applies.

### The claim listing crosses a document navigation, so it goes through storage — `VP-P-W2`

- **Issue** — the claim page discarded the listing `consumeClaim` returned and
  the editor fetched it again.
- **Why** — one avoidable warm-edge round trip on the welcome flow, which is
  the first thing a new vendor sees.
- **Solution** — a single-use `sessionStorage` key, `cire.vendor.claimed-listing`,
  holding `{ orgId, listing }`. `takeSeededListing` deletes the key on any
  non-null read, checks the org before trusting the value, validates the shape,
  and returns `undefined` on every failure so the caller falls through to
  `fetchListing`.
- **Rationale** — the redirect is `window.location.href`, so an in-memory
  handoff cannot work and would have been a variable that quietly did nothing.
  The finding's other suggestion, a `Cache-Control: max-age` on the listing
  `GET`, was rejected: that response is per-vendor authenticated data, and a
  cache header is the riskier of the two options. Deleting the key before
  validating rather than after means a seed that fails validation cannot sit
  waiting for a later mount to match it.

### The seed guard checks every required field, not three of them — `S-L1`

- **Issue** — the first draft of `isValidListing` checked `id`, `name` and
  `categories`, then passed the object off as a full `Listing`.
- **Why** — `ListingEditor` renders `listed` straight into the status chip, so
  a seed without it puts the word "undefined" on screen. Not a privilege
  problem: every request the editor makes is keyed on `props.orgId` from the
  route, never on a field read out of the seed, so a malformed seed cannot
  reach another org's data.
- **Solution** — the guard now checks every field `Listing` declares required
  and non-nullable, and that the categories are all strings rather than merely
  an array. The handoff also has tests now; it had none.
- **Rationale** — the nullable fields stay unchecked on purpose. `null` and
  absent read the same to everything downstream, so a seed missing one behaves
  exactly like a listing that never had it, and checking them would be
  ceremony. The tests live in their own file because the handoff is the one
  part of `vendor-store.ts` that needs a DOM, and the fetch-shaped tests beside
  it were written for the `node` environment.

### `getListingByOrg` keeps its serial pair — `VD-P-I2`

- **Issue** — three of the four call sites named in the findings pair a row
  fetch with a category fetch. Only two of them are really independent.
- **Why** — parallelising a genuine data dependency is a bug, not an
  optimisation.
- **Solution** — `getLiveListingById` and `consumeClaim` were parallelised;
  `getListingByOrg` was left alone.
- **Rationale** — `getListingByOrg` is keyed on `orgId`, and the id
  `fetchCategories` needs only exists once the row comes back. `consumeClaim`
  looks the same but is not: its id comes from the token lookup, well before
  either read. Its burn-then-bind writes stay strictly sequential — that
  ordering is what makes a claim single-use.

**Out of scope**

- `getLiveListingById` now costs two D1 reads on a miss where it cost one, because
  `fetchCategories` fires unconditionally. Bounded by auth and a per-user rate
  limiter on its only caller, and concurrent so it adds no latency — xchromo/osn-tracker#585.
- A failed `sessionStorage.removeItem` leaves the seed behind for the tab's
  life. The org check still bounds it — xchromo/osn-tracker#584.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1432 files |
| `bun run test` | ✅ 1695 pass, 0 fail |
| `bun run test:d1` | ✅ 9 pass (`cire/api`), forced past the turbo cache |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run test:scripts` | ✅ 61 pass |
| `bun run check:jest-dom-markers` | ✅ 14 configs |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |

`bun run test:d1` is the gate that matters here — these are query-shape changes
on the asynchronous D1 driver, and the default `bun run test` never reaches
those files. It was run with `--force`, because a cached pass would have proved
nothing about this branch.

Nothing here alters a route's request or response contract, so no OpenAPI
document moves.

Not covered by any gate: the claim-to-editor handoff has unit tests over
`sessionStorage`, but nobody has walked the real flow in a browser — claim a
listing, watch the redirect, confirm the editor paints without a second
`GET .../listing` in the network panel. Worth doing once on the preview before
merge.
