### PR TITLE
perf(cire): stop a fontless build from shipping, and fix four font-path findings

### DIFF
--- a/.changeset/cire-font-build-guard.md
+++ b/.changeset/cire-font-build-guard.md
@@ -1,0 +1,31 @@
+---
+"@cire/vendor": patch
+"@cire/host": patch
+"@cire/landing": patch
+---
+
+Five findings from a self-hosted-fonts follow-up (xchromo/osn-tracker#128,
+#129, #130, #131, #132):
+
+- `bun run build` now fails loudly instead of shipping a fontless site when
+  Astro's build-time Google Fonts fetch silently drops every font
+  (`scripts/check-astro-fonts.ts`, run after `astro build` in all three
+  packages). CI also caches Astro's font-metadata directory
+  (`node_modules/.astro`) so most runs never call `fonts.google.com` at all.
+- `<Font preload>` on `@cire/host`'s two page shells and `@cire/landing`'s two
+  layouts now names `subset: "latin"`, matching `@cire/vendor` — a bare
+  `preload` bypasses `unicode-range` and fetches every subset unconditionally.
+- `/_astro/*` gets `Cache-Control: public, max-age=31536000, immutable` in
+  `@cire/vendor` and `@cire/host`'s `_headers` (content-hashed paths, so a
+  year-long cache is safe; `@cire/landing` already had it).
+- `Textarea` (`@cire/host` and `@cire/vendor` `components/ui/Field.tsx`) takes
+  a `resize` prop, defaulting to the existing `resize-y` behaviour. Set to
+  `"none"` at the call sites inside an auto-sized `ModuleShell`/vendor-portal
+  frame (`ListingEditor`, `EnquiryThread`, `EventsEditor`, the invite
+  builder's `TextAreaField`) — dragging a `resize-y` grip at a fixed width
+  was tripping `createAutoSize()`'s reflow guard on every delivery.
+  `RegistryView.tsx` has the same bug and is deliberately left unfixed here
+  (locked against a separate open PR).
+- A stale comment on `ListingEditor.tsx`'s category-checked signal is
+  corrected: toggling one category recomputes all 14 rows, not just the
+  toggled one — cheap enough that it isn't worth a per-key signal split.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
             cire/vendor/node_modules/.astro
             cire/host/node_modules/.astro
             cire/landing/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,34 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-build-
 
+      # `@cire/vendor`, `@cire/host` and `@cire/landing` declare
+      # `provider: fontProviders.google()`, which makes `astro build` fetch
+      # `https://fonts.google.com/metadata/fonts` — Astro's own font
+      # metadata cache for that fetch lives at each package's default
+      # `cacheDir`, `node_modules/.astro` (xchromo/osn-tracker#128). None of
+      # this job's other caches cover it: the bun cache above only holds
+      # installed packages, and the turbo cache is keyed per-commit on
+      # purpose (see the `typecheck` job's comment on why) so it can't be
+      # the thing that survives across runs here. What decides whether this
+      # cache is still correct is which font families each config asks for,
+      # not the lockfile or the commit — so, following the same reasoning
+      # the other caches in this file use (key on whatever the cache's
+      # correctness actually depends on), this one is keyed on the three
+      # `astro.config.mjs` files. Restoring it turns most CI runs' font
+      # fetch into a cache hit, which is directly the fix for #128: a build
+      # that never has to call `fonts.google.com` can't be broken by that
+      # endpoint 403ing.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: |
+            cire/vendor/node_modules/.astro
+            cire/host/node_modules/.astro
+            cire/landing/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,7 +188,7 @@ jobs:
             cire/vendor/node_modules/.astro
             cire/host/node_modules/.astro
             cire/landing/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -567,7 +567,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/host/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/host/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/host/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -644,7 +644,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/host/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/host/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/host/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -714,7 +714,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/vendor/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/vendor/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -782,7 +782,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/vendor/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/vendor/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -849,7 +849,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/landing/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/landing/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/landing/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 
@@ -919,7 +919,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cire/landing/node_modules/.astro
-          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/landing/astro.config.mjs') }}
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('bun.lock', 'cire/landing/astro.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-astro-fonts-
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,6 +175,23 @@ jobs:
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
+      # See ci.yml's `build-test` job for why this is keyed on the three
+      # astro.config.mjs files rather than bun.lock or github.sha — Astro's
+      # font-metadata cache is a function of which families each config
+      # asks for, and restoring it here turns this workflow's own `bun run
+      # build` into a cache hit against fonts.google.com too
+      # (xchromo/osn-tracker#128).
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: |
+            cire/vendor/node_modules/.astro
+            cire/host/node_modules/.astro
+            cire/landing/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs', 'cire/host/astro.config.mjs', 'cire/landing/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 
@@ -539,6 +556,21 @@ jobs:
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
+      # See ci.yml's `build-test` job for the reasoning behind this key.
+      # `PUBLIC_CIRE_API_URL` differs between this dev build and the
+      # production one below, and turbo.json's `build` task hashes
+      # `PUBLIC_*` env vars as inputs — so this job's `bun run build` is
+      # always a turbo cache MISS against the `build` job above and really
+      # runs `astro build` again, hitting fonts.google.com again unless this
+      # restores what that fetch produced (xchromo/osn-tracker#128).
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/host/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/host/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 
@@ -606,6 +638,16 @@ jobs:
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
+      # See ci.yml's `build-test` job for the reasoning behind this key, and
+      # the dev job above for why this always misses turbo's own cache.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/host/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/host/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 
@@ -665,6 +707,17 @@ jobs:
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
+      # See ci.yml's `build-test` job for the reasoning behind this key, and
+      # the cire/host dev job above for why this always misses turbo's own
+      # cache.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/vendor/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 
@@ -722,6 +775,17 @@ jobs:
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
 
+      # See ci.yml's `build-test` job for the reasoning behind this key, and
+      # the cire/host dev job above for why this always misses turbo's own
+      # cache.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/vendor/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/vendor/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
+
       - name: Install dependencies
         run: bun install
 
@@ -777,6 +841,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
+
+      # See ci.yml's `build-test` job for the reasoning behind this key, and
+      # the cire/host dev job above for why this always misses turbo's own
+      # cache.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/landing/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/landing/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
 
       - name: Install dependencies
         run: bun install
@@ -836,6 +911,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-build-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-turbo-build-
+
+      # See ci.yml's `build-test` job for the reasoning behind this key, and
+      # the cire/host dev job above for why this always misses turbo's own
+      # cache.
+      - name: Cache Astro font metadata
+        uses: actions/cache@v4
+        with:
+          path: cire/landing/node_modules/.astro
+          key: ${{ runner.os }}-astro-fonts-${{ hashFiles('cire/landing/astro.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-fonts-
 
       - name: Install dependencies
         run: bun install

--- a/cire/host/package.json
+++ b/cire/host/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "portless",
     "dev:app": "dev-env astro dev",
-    "build": "astro build",
+    "build": "astro build && bun run ../../scripts/check-astro-fonts.ts dist",
     "preview": "astro preview",
     "test": "bunx --bun vitest --project unit",
     "test:run": "bunx --bun vitest run --project unit",

--- a/cire/host/public/_headers
+++ b/cire/host/public/_headers
@@ -7,6 +7,16 @@
   Reporting-Endpoints: csp-endpoint="https://api.cireweddings.com/api/csp-report"
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://api.cireweddings.com http://localhost:8787; connect-src 'self' https://api.cireweddings.com http://localhost:8787; frame-src 'none'; worker-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; report-uri https://api.cireweddings.com/api/csp-report; report-to csp-endpoint
 
+# Long-cache the immutable, content-hashed Astro bundles — this now includes
+# the self-hosted font files (Schibsted Grotesk, Cormorant Garamond), which
+# used to come from fonts.gstatic.com with this exact header and lost it on
+# the move to our own origin (xchromo/osn-tracker#131). Every path under
+# /_astro/ carries a content hash in the filename, so a year-long cache is
+# unconditionally safe: a changed file is a new URL, never the same one with
+# different bytes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
 # The organiser portal is a STATIC Astro build on Cloudflare Pages, so the asset
 # layer serves every response and this file covers all of them. (The guest site
 # can't do that — it's an SSR Worker, which is why cire/invites carries the same

--- a/cire/host/src/components/EnquiryThread.tsx
+++ b/cire/host/src/components/EnquiryThread.tsx
@@ -144,6 +144,12 @@ export default function EnquiryThread(props: EnquiryThreadProps) {
                 value={draft()}
                 onInput={(e) => setDraft(e.currentTarget.value)}
                 rows={3}
+                // Every module view renders inside `ModuleShell`'s
+                // auto-sized frame, whose reflow guard watches width only —
+                // dragging this box's own resize grip at a fixed width
+                // reads as a content change on every delivery
+                // (xchromo/osn-tracker#130).
+                resize="none"
               />
             )}
           </Field>

--- a/cire/host/src/components/EventsEditor.tsx
+++ b/cire/host/src/components/EventsEditor.tsx
@@ -842,6 +842,12 @@ function EventDrawer(props: {
                         e.currentTarget.value.length > 0 ? e.currentTarget.value : null,
                     })
                   }
+                  // This editor is a module view, and every module view
+                  // renders inside `ModuleShell`'s auto-sized frame, whose
+                  // reflow guard watches width only — dragging this box's
+                  // own resize grip at a fixed width reads as a content
+                  // change on every delivery (xchromo/osn-tracker#130).
+                  resize="none"
                 />
               )}
             </Field>

--- a/cire/host/src/components/invite/fields.tsx
+++ b/cire/host/src/components/invite/fields.tsx
@@ -100,6 +100,12 @@ export function TextAreaField(props: {
         value={props.value}
         maxlength={props.maxLength}
         onInput={(e) => props.onInput(e.currentTarget.value)}
+        // The invite builder is a module view, and every module view renders
+        // inside `ModuleShell`'s auto-sized frame, whose reflow guard
+        // watches width only — dragging this box's own resize grip at a
+        // fixed width reads as a content change on every delivery
+        // (xchromo/osn-tracker#130).
+        resize="none"
       />
       <Show when={props.hint}>
         <span class="font-body text-text-muted text-[0.72rem] italic">{props.hint}</span>

--- a/cire/host/src/components/ui/Field.tsx
+++ b/cire/host/src/components/ui/Field.tsx
@@ -74,14 +74,39 @@ export function Input(props: InputProps) {
   return <input type="text" {...rest} class={controlClass(own.size, own.class)} />;
 }
 
-export type TextareaProps = Omit<SafeProps<"textarea">, "size"> & { size?: ControlSize };
+export type TextareaResize = "y" | "none";
 
-/** A multi-line box. `resize-y` on purpose: sideways resize breaks the column
- *  it sits in, and no-resize takes away the one control a host has over a long
- *  note. */
+const TEXTAREA_RESIZE = {
+  y: "resize-y",
+  none: "resize-none",
+} satisfies Readonly<Record<TextareaResize, string>>;
+
+export type TextareaProps = Omit<SafeProps<"textarea">, "size"> & {
+  size?: ControlSize;
+  /** `"y"` (the default) on purpose: sideways resize breaks the column a
+   *  textarea sits in, and no-resize takes away the one control a host has
+   *  over a long note. `"none"` exists for the one place that default is
+   *  wrong — a textarea inside `ModuleShell`'s auto-sized frame
+   *  (`lib/auto-size.ts`). That observer's reflow guard watches width only;
+   *  dragging this textarea's own resize grip changes height at a fixed
+   *  width, which the guard reads as a content change on every delivery
+   *  (xchromo/osn-tracker#130). A caller cannot fix this by passing
+   *  `class="resize-none"`: this component appends its own resize class
+   *  after `own.class`, so both land on the element and Tailwind resolves
+   *  the conflict by the two utilities' order in the generated stylesheet,
+   *  not by attribute order — the caller's class does not reliably win. */
+  resize?: TextareaResize;
+};
+
+/** A multi-line box. */
 export function Textarea(props: TextareaProps) {
-  const [own, rest] = splitProps(props, ["size", "class"]);
-  return <textarea {...rest} class={`${controlClass(own.size, own.class)} resize-y`} />;
+  const [own, rest] = splitProps(props, ["size", "class", "resize"]);
+  return (
+    <textarea
+      {...rest}
+      class={`${controlClass(own.size, own.class)} ${TEXTAREA_RESIZE[own.resize ?? "y"]}`}
+    />
+  );
 }
 
 export type SelectProps = Omit<SafeProps<"select">, "size"> & { size?: ControlSize };

--- a/cire/host/src/components/ui/ui.test.tsx
+++ b/cire/host/src/components/ui/ui.test.tsx
@@ -451,6 +451,17 @@ describe("controls", () => {
     expect(getByRole("textbox").className).toContain("resize-y");
   });
 
+  it("turns off resize for a textarea sitting inside an auto-sized frame", () => {
+    // xchromo/osn-tracker#130: `createAutoSize()`'s reflow guard watches
+    // width only, so dragging a `resize-y` grip at a fixed width reads as a
+    // content change on every delivery. `resize="none"` is the escape hatch
+    // — and it has to win over the default class, not just add to it.
+    const { getByRole } = render(() => <Textarea aria-label="Description" resize="none" />);
+    const className = getByRole("textbox").className;
+    expect(className).toContain("resize-none");
+    expect(className).not.toContain("resize-y");
+  });
+
   it("passes a Select its options and its value", () => {
     const { getByRole } = render(() => (
       <Select aria-label="Status" value="booked">

--- a/cire/host/src/pages/index.astro
+++ b/cire/host/src/pages/index.astro
@@ -17,9 +17,13 @@ import { THEME_BOOT_SCRIPT } from '../lib/theme-boot'
     <script is:inline set:html={THEME_BOOT_SCRIPT}></script>
     <!-- Self-hosted; see the `fonts` block in astro.config.mjs. Both faces are
          preloaded because both are above the fold — the wordmark is Cormorant
-         and everything beside it is Schibsted. -->
-    <Font cssVariable="--font-ui" preload />
-    <Font cssVariable="--font-flair" preload />
+         and everything beside it is Schibsted. A bare `preload` ignores each
+         face's `unicode-range` and fetches every subset unconditionally —
+         `latin-ext` included, for a page that never renders a codepoint out
+         of `latin`. Naming the subset here keeps the preload to what the
+         page can actually use (xchromo/osn-tracker#129). -->
+    <Font cssVariable="--font-ui" preload={[{ subset: "latin" }]} />
+    <Font cssVariable="--font-flair" preload={[{ subset: "latin" }]} />
   </head>
   <body>
     <!--

--- a/cire/host/src/pages/login.astro
+++ b/cire/host/src/pages/login.astro
@@ -15,8 +15,11 @@ import { THEME_BOOT_SCRIPT } from '../lib/theme-boot'
          first page a host sees, and it is the one most likely to be opened at
          night. It must not paint a frame of the wrong theme. -->
     <script is:inline set:html={THEME_BOOT_SCRIPT}></script>
-    <Font cssVariable="--font-ui" preload />
-    <Font cssVariable="--font-flair" preload />
+    <!-- A bare `preload` ignores each face's `unicode-range` and fetches
+         every subset unconditionally — naming the subset keeps the preload
+         to what the page can actually use (xchromo/osn-tracker#129). -->
+    <Font cssVariable="--font-ui" preload={[{ subset: "latin" }]} />
+    <Font cssVariable="--font-flair" preload={[{ subset: "latin" }]} />
   </head>
   <body>
     <!-- Same `page-frame` gutters as the dashboard, with its own measure: a

--- a/cire/landing/package.json
+++ b/cire/landing/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "portless",
     "dev:app": "dev-env astro dev",
-    "build": "astro build",
+    "build": "astro build && bun run ../../scripts/check-astro-fonts.ts dist",
     "preview": "astro preview --port 4323",
     "check": "bunx --bun astro check",
     "test": "vitest run",

--- a/cire/landing/src/layouts/BaseLayout.astro
+++ b/cire/landing/src/layouts/BaseLayout.astro
@@ -52,9 +52,12 @@ const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : As
       <style is:inline>[data-reveal]{opacity:1 !important;transform:none !important}</style>
     </noscript>
     <!-- Both faces are above the fold — the wordmark is Cormorant, the copy beside
-         it is Lato — so both preload. -->
-    <Font cssVariable="--font-cormorant" preload />
-    <Font cssVariable="--font-lato" preload />
+         it is Lato — so both preload. A bare `preload` ignores each face's
+         `unicode-range` and fetches every subset unconditionally — naming
+         the subset keeps the preload to what the page can actually use
+         (xchromo/osn-tracker#129). -->
+    <Font cssVariable="--font-cormorant" preload={[{ subset: "latin" }]} />
+    <Font cssVariable="--font-lato" preload={[{ subset: "latin" }]} />
   </head>
   <body>
     <div class="page-root">

--- a/cire/landing/src/layouts/LegalLayout.astro
+++ b/cire/landing/src/layouts/LegalLayout.astro
@@ -17,9 +17,12 @@ const { title } = Astro.props
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>{title} — Cire</title>
     <!-- Both faces are above the fold — the wordmark is Cormorant, the copy beside
-         it is Lato — so both preload. -->
-    <Font cssVariable="--font-cormorant" preload />
-    <Font cssVariable="--font-lato" preload />
+         it is Lato — so both preload. A bare `preload` ignores each face's
+         `unicode-range` and fetches every subset unconditionally — naming
+         the subset keeps the preload to what the page can actually use
+         (xchromo/osn-tracker#129). -->
+    <Font cssVariable="--font-cormorant" preload={[{ subset: "latin" }]} />
+    <Font cssVariable="--font-lato" preload={[{ subset: "latin" }]} />
   </head>
   <body>
     <main class="legal">

--- a/cire/vendor/package.json
+++ b/cire/vendor/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "portless",
     "dev:app": "dev-env astro dev",
-    "build": "astro build",
+    "build": "astro build && bun run ../../scripts/check-astro-fonts.ts dist",
     "preview": "astro preview",
     "check": "bunx --bun astro check",
     "test": "bunx --bun vitest",

--- a/cire/vendor/public/_headers
+++ b/cire/vendor/public/_headers
@@ -10,6 +10,15 @@
 /claim*
   Referrer-Policy: no-referrer
 
+# Long-cache the immutable, content-hashed Astro bundles — this now includes
+# the self-hosted font files the comment above describes, which used to come
+# from fonts.gstatic.com with this exact header and lost it on the move to
+# our own origin (xchromo/osn-tracker#131). Every path under /_astro/ carries
+# a content hash in the filename, so a year-long cache is unconditionally
+# safe: a changed file is a new URL, never the same one with different bytes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
 # Landed with the organiser's policy (VP-S-L3 said do both together — the two
 # portals share a shape). Same staging: an ENFORCED line carrying only
 # directives that cannot break a working page, plus a REPORT-ONLY line carrying

--- a/cire/vendor/src/components/ListingEditor.tsx
+++ b/cire/vendor/src/components/ListingEditor.tsx
@@ -57,9 +57,13 @@ export default function ListingEditor(props: ListingEditorProps) {
   // Money: displayed in major units (dollars); "" means null (no value set).
   const [priceMin, setPriceMin] = createSignal("");
   const [priceMax, setPriceMax] = createSignal("");
-  // Per-key checked state: Record<categoryKey, boolean>.
-  // Reading `checked()[key]` inside <For> is isolated to that row — toggling one key
-  // only re-runs the expression for that checkbox (VP-P-W1).
+  // Per-key checked state: Record<categoryKey, boolean>, held as one signal.
+  // `toggleCategory` below spreads a fresh object on every toggle, so every
+  // row's `checked()[key]` read re-runs on every toggle, not just the one
+  // that changed — this is a single signal, not one per key, and SolidJS has
+  // no way to see that only one property moved. That recomputes 14 boolean
+  // lookups per toggle (`SERVICE_CATEGORIES` has 14 entries), which costs
+  // nothing worth a per-key signal split (xchromo/osn-tracker#132).
   const [checked, setChecked] = createSignal<Record<string, boolean>>({});
 
   const [seeded, setSeeded] = createSignal(false);
@@ -234,6 +238,11 @@ export default function ListingEditor(props: ListingEditorProps) {
                 onInput={(e) => setDescription(e.currentTarget.value)}
                 rows={3}
                 maxLength={2000}
+                // This form sits inside `createAutoSize()`'s frame, whose
+                // reflow guard watches width only — dragging this box's own
+                // resize grip at a fixed width reads as a content change on
+                // every delivery (xchromo/osn-tracker#130).
+                resize="none"
               />
             )}
           </Field>

--- a/cire/vendor/src/components/VendorEnquiryThread.tsx
+++ b/cire/vendor/src/components/VendorEnquiryThread.tsx
@@ -178,6 +178,12 @@ export default function VendorEnquiryThread(props: VendorEnquiryThreadProps) {
             <Textarea
               {...field}
               rows={3}
+              // Inside VendorApp's createAutoSize() panel, same as
+              // ListingEditor's description box: a fixed-width height drag
+              // reads as a content swap to the frame's `lastWidth !== width`
+              // guard and restarts a transition per observer delivery
+              // (osn-tracker#130).
+              resize="none"
               placeholder="Write a reply…"
               value={draft()}
               onInput={(e) => setDraft(e.currentTarget.value)}

--- a/cire/vendor/src/components/ui/Field.tsx
+++ b/cire/vendor/src/components/ui/Field.tsx
@@ -73,14 +73,40 @@ export function Input(props: InputProps) {
   return <input type="text" {...rest} class={controlClass(own.size, own.class)} />;
 }
 
-export type TextareaProps = Omit<SafeProps<"textarea">, "size"> & { size?: ControlSize };
+export type TextareaResize = "y" | "none";
 
-/** A multi-line box. `resize-y` on purpose: sideways resize breaks the column
- *  it sits in, and no-resize takes away the one control a vendor has over a long
- *  description. */
+const TEXTAREA_RESIZE = {
+  y: "resize-y",
+  none: "resize-none",
+} satisfies Readonly<Record<TextareaResize, string>>;
+
+export type TextareaProps = Omit<SafeProps<"textarea">, "size"> & {
+  size?: ControlSize;
+  /** `"y"` (the default) on purpose: sideways resize breaks the column a
+   *  textarea sits in, and no-resize takes away the one control a vendor has
+   *  over a long description. `"none"` exists for the one place that default
+   *  is wrong — a textarea inside the auto-sized frame `createAutoSize()`
+   *  wraps `ListingEditor` in (`lib/auto-size.ts`). That observer's reflow
+   *  guard watches width only; dragging this textarea's own resize grip
+   *  changes height at a fixed width, which the guard reads as a content
+   *  change on every delivery (xchromo/osn-tracker#130). A caller cannot fix
+   *  this by passing `class="resize-none"`: this component appends its own
+   *  resize class after `own.class`, so both land on the element and
+   *  Tailwind resolves the conflict by the two utilities' order in the
+   *  generated stylesheet, not by attribute order — the caller's class does
+   *  not reliably win. */
+  resize?: TextareaResize;
+};
+
+/** A multi-line box. */
 export function Textarea(props: TextareaProps) {
-  const [own, rest] = splitProps(props, ["size", "class"]);
-  return <textarea {...rest} class={`${controlClass(own.size, own.class)} resize-y`} />;
+  const [own, rest] = splitProps(props, ["size", "class", "resize"]);
+  return (
+    <textarea
+      {...rest}
+      class={`${controlClass(own.size, own.class)} ${TEXTAREA_RESIZE[own.resize ?? "y"]}`}
+    />
+  );
 }
 
 export type SelectProps = Omit<SafeProps<"select">, "size"> & { size?: ControlSize };

--- a/cire/vendor/src/components/ui/ui.test.tsx
+++ b/cire/vendor/src/components/ui/ui.test.tsx
@@ -245,6 +245,25 @@ describe("Field", () => {
     expect(screen.getByLabelText("Reply")).toBeInTheDocument();
   });
 
+  it("lets a long description grow downwards but not sideways by default", () => {
+    // Sideways resize breaks the column the textarea sits in; no resize at
+    // all takes away the one control a vendor has over a long description.
+    const { getByRole } = render(() => <Textarea aria-label="Description" />);
+    expect(getByRole("textbox").className).toContain("resize-y");
+  });
+
+  it("turns off resize for a textarea sitting inside an auto-sized frame", () => {
+    // xchromo/osn-tracker#130: `createAutoSize()`'s reflow guard (wrapping
+    // `ListingEditor`) watches width only, so dragging a `resize-y` grip at
+    // a fixed width reads as a content change on every delivery.
+    // `resize="none"` is the escape hatch — and it has to win over the
+    // default class, not just add to it.
+    const { getByRole } = render(() => <Textarea aria-label="Description" resize="none" />);
+    const className = getByRole("textbox").className;
+    expect(className).toContain("resize-none");
+    expect(className).not.toContain("resize-y");
+  });
+
   it("wires a select the same way", () => {
     render(() => (
       <Field label="Price band">

--- a/scripts/check-astro-fonts.cli.test.ts
+++ b/scripts/check-astro-fonts.cli.test.ts
@@ -1,0 +1,134 @@
+// S-H1 (see check-release-age-excludes.cli.test.ts for the pattern this
+// mirrors) — the pure-function tests in check-astro-fonts.test.ts import
+// `checkAstroFonts` directly and never exercise the `import.meta.main` CLI
+// block, so they prove nothing about the real binary CI actually runs
+// (`bun run ../../scripts/check-astro-fonts.ts dist` from inside each
+// package's `build` script). `bun test` sets `import.meta.main` to `false`
+// for every file it loads, so that block is dead code as far as the test
+// run above is concerned. These tests run the actual script file as a
+// subprocess against a synthetic `dist/`, the same way each package's
+// `build` script invokes it.
+
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = new URL("./check-astro-fonts.ts", import.meta.url).pathname;
+
+async function runCli(
+  cwd: string,
+  args: readonly string[],
+): Promise<{ readonly exitCode: number; readonly stdout: string; readonly stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", SCRIPT, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+async function makeFixture(packageName: string | undefined): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "check-astro-fonts-cli-"));
+  if (packageName !== undefined) {
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: packageName }));
+  }
+  return dir;
+}
+
+test("the real CLI exits 0 against a fixture dist with fonts and a @font-face rule", async () => {
+  const dir = await makeFixture("@cire/host");
+
+  try {
+    await mkdir(join(dir, "dist", "_astro", "fonts"), { recursive: true });
+    await writeFile(join(dir, "dist", "_astro", "fonts", "abc.woff2"), "fake");
+    await writeFile(
+      join(dir, "dist", "index.html"),
+      `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+    );
+
+    const { exitCode, stdout, stderr } = await runCli(dir, ["dist"]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("@cire/host shipped a real font build");
+    expect(exitCode).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the real CLI exits non-zero, naming the package, against an empty fonts dir", async () => {
+  const dir = await makeFixture("@cire/vendor");
+
+  try {
+    await mkdir(join(dir, "dist", "_astro", "fonts"), { recursive: true });
+    await writeFile(
+      join(dir, "dist", "index.html"),
+      `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+    );
+
+    const { exitCode, stdout, stderr } = await runCli(dir, ["dist"]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("@cire/vendor shipped a fontless build");
+    expect(stderr).toContain("is missing or empty");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the real CLI exits non-zero, naming the package, when no @font-face rule was emitted", async () => {
+  const dir = await makeFixture("@cire/landing");
+
+  try {
+    await mkdir(join(dir, "dist", "_astro", "fonts"), { recursive: true });
+    await writeFile(join(dir, "dist", "_astro", "fonts", "abc.woff2"), "fake");
+    await writeFile(join(dir, "dist", "index.html"), `<html><body>fontless</body></html>`);
+
+    const { exitCode, stdout, stderr } = await runCli(dir, ["dist"]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("@cire/landing shipped a fontless build");
+    expect(stderr).toContain('no "@font-face" rule found');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the real CLI exits non-zero when called with no dist argument", async () => {
+  const dir = await makeFixture("@cire/host");
+
+  try {
+    const { exitCode, stderr } = await runCli(dir, []);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("usage:");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the real CLI falls back to the cwd when package.json has no name field", async () => {
+  const dir = await makeFixture(undefined);
+
+  try {
+    await mkdir(join(dir, "dist", "_astro", "fonts"), { recursive: true });
+    await writeFile(join(dir, "dist", "_astro", "fonts", "abc.woff2"), "fake");
+    await writeFile(
+      join(dir, "dist", "index.html"),
+      `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+    );
+
+    const { exitCode, stdout } = await runCli(dir, ["dist"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("shipped a real font build");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-astro-fonts.test.ts
+++ b/scripts/check-astro-fonts.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { checkAstroFonts } from "./check-astro-fonts";
+import { checkAstroFonts, familyNamesFromAstroConfig } from "./check-astro-fonts";
 
 // Every test builds its own throwaway `dist/` under a fresh temp directory,
 // tracked here so `afterEach` can remove it even when a test fails partway
@@ -118,4 +118,104 @@ test("an @font-face rule nested under a subdirectory's .css file still counts", 
   );
 
   expect(await checkAstroFonts(distDir)).toEqual([]);
+});
+
+// The config shape all three packages use, trimmed to what the parser reads.
+const TWO_FAMILY_CONFIG = `
+export default defineConfig({
+  experimental: {
+    fonts: [
+      { name: "Schibsted Grotesk", cssVariable: "--font-ui", provider: fontProviders.google() },
+      { name: "Cormorant Garamond", cssVariable: "--font-flair", provider: fontProviders.google() },
+    ],
+  },
+});
+`;
+
+test("familyNamesFromAstroConfig reads every family in the fonts array", () => {
+  expect(familyNamesFromAstroConfig(TWO_FAMILY_CONFIG)).toEqual([
+    "Schibsted Grotesk",
+    "Cormorant Garamond",
+  ]);
+});
+
+test("familyNamesFromAstroConfig ignores a name: outside the fonts array", () => {
+  const config = `
+    export default defineConfig({
+      site: { name: "not a font" },
+      experimental: { fonts: [{ name: "Lato" }] },
+    });
+  `;
+  expect(familyNamesFromAstroConfig(config)).toEqual(["Lato"]);
+});
+
+test("familyNamesFromAstroConfig finds nothing when there is no fonts array", () => {
+  expect(familyNamesFromAstroConfig("export default defineConfig({});")).toEqual([]);
+});
+
+// S-M1 (found reviewing this branch): Astro drops a family whose metadata
+// fetch failed and CONTINUES — it emits neither a real @font-face nor even the
+// optimizedFallbacks rule for it. Every package here declares two families, so
+// a partial outage leaves the surviving family satisfying both whole-build
+// checks while the other silently vanishes.
+test("a build missing ONE of two declared families is caught", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir, TWO_FAMILY_CONFIG)).toEqual([
+    {
+      problem:
+        'font family "Cormorant Garamond" is declared in the astro config but appears nowhere in the built CSS or HTML — its metadata fetch failed and Astro dropped it',
+    },
+  ]);
+});
+
+test("a build carrying both declared families passes", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}@font-face{font-family:"Cormorant Garamond"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir, TWO_FAMILY_CONFIG)).toEqual([]);
+});
+
+// A guard that quietly stops guarding when its input changes shape is worse
+// than no guard, so an unparseable config fails rather than passes.
+test("a config the parser cannot read fails rather than passing", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+  );
+
+  const findings = await checkAstroFonts(distDir, "export default defineConfig({});");
+  expect(findings).toHaveLength(1);
+  expect(findings[0]!.problem).toContain("could not read any font family name");
+});
+
+// S-L1: a bare recursive readdir returns subdirectories too, so an empty
+// nested directory used to read as "fonts present".
+test("an empty subdirectory under _astro/fonts does not count as a font file", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts", "schibsted"), { recursive: true });
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"x"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir)).toEqual([
+    {
+      problem: `${join(distDir, "_astro", "fonts")} is missing or empty — no font files were emitted by the build`,
+    },
+  ]);
 });

--- a/scripts/check-astro-fonts.test.ts
+++ b/scripts/check-astro-fonts.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkAstroFonts } from "./check-astro-fonts";
+
+// Every test builds its own throwaway `dist/` under a fresh temp directory,
+// tracked here so `afterEach` can remove it even when a test fails partway
+// through building its fixture.
+let currentDir: string | undefined;
+
+afterEach(async () => {
+  if (currentDir) {
+    await rm(currentDir, { recursive: true, force: true });
+    currentDir = undefined;
+  }
+});
+
+async function makeDist(): Promise<string> {
+  currentDir = await mkdtemp(join(tmpdir(), "check-astro-fonts-"));
+  const distDir = join(currentDir, "dist");
+  await mkdir(distDir, { recursive: true });
+  return distDir;
+}
+
+test("a real build — non-empty fonts dir and an inlined @font-face — passes", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk";src:url(/_astro/fonts/abc123.woff2)}</style></head><body></body></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir)).toEqual([]);
+});
+
+test("a real build — non-empty fonts dir and a standalone @font-face stylesheet — passes", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await writeFile(
+    join(distDir, "_astro", "fonts.a1b2c3.css"),
+    `@font-face{font-family:"Schibsted Grotesk";src:url(/_astro/fonts/abc123.woff2)}`,
+  );
+  await writeFile(join(distDir, "index.html"), `<html><body></body></html>`);
+
+  expect(await checkAstroFonts(distDir)).toEqual([]);
+});
+
+test("failure mode 1 — no fonts dir at all — fails even with real @font-face CSS", async () => {
+  const distDir = await makeDist();
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir)).toEqual([
+    {
+      problem: `${join(distDir, "_astro", "fonts")} is missing or empty — no font files were emitted by the build`,
+    },
+  ]);
+});
+
+test("failure mode 1 — fonts dir exists but is empty — fails", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(
+    join(distDir, "index.html"),
+    `<html><head><style>@font-face{font-family:"Schibsted Grotesk"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir)).toEqual([
+    {
+      problem: `${join(distDir, "_astro", "fonts")} is missing or empty — no font files were emitted by the build`,
+    },
+  ]);
+});
+
+test("failure mode 2 — fonts dir has files but nothing emits @font-face — fails", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  // A stale file left behind by an unrelated step is not evidence of a real
+  // font build — the guard still requires the CSS half.
+  await writeFile(join(distDir, "_astro", "fonts", "leftover.woff2"), "stale-bytes");
+  await writeFile(join(distDir, "index.html"), `<html><body>no fonts here</body></html>`);
+
+  expect(await checkAstroFonts(distDir)).toEqual([
+    {
+      problem: `no "@font-face" rule found in any .css or .html file under ${distDir}`,
+    },
+  ]);
+});
+
+test("both failure modes at once report both findings", async () => {
+  const distDir = await makeDist();
+  await writeFile(join(distDir, "index.html"), `<html><body>fontless</body></html>`);
+
+  expect(await checkAstroFonts(distDir)).toEqual([
+    {
+      problem: `${join(distDir, "_astro", "fonts")} is missing or empty — no font files were emitted by the build`,
+    },
+    {
+      problem: `no "@font-face" rule found in any .css or .html file under ${distDir}`,
+    },
+  ]);
+});
+
+test("an @font-face rule nested under a subdirectory's .css file still counts", async () => {
+  const distDir = await makeDist();
+  await mkdir(join(distDir, "_astro", "fonts"), { recursive: true });
+  await writeFile(join(distDir, "_astro", "fonts", "abc123.woff2"), "fake-woff2-bytes");
+  await mkdir(join(distDir, "login"), { recursive: true });
+  await writeFile(
+    join(distDir, "login", "index.html"),
+    `<html><head><style>@font-face{font-family:"Cormorant Garamond"}</style></head></html>`,
+  );
+
+  expect(await checkAstroFonts(distDir)).toEqual([]);
+});

--- a/scripts/check-astro-fonts.ts
+++ b/scripts/check-astro-fonts.ts
@@ -59,32 +59,68 @@ export type Finding = {
  * as an empty one — no fonts were emitted — so both report `false`.
  */
 async function hasAnyFile(dir: string): Promise<boolean> {
-  let entries: string[];
   try {
-    entries = await readdir(dir, { recursive: true });
+    // `withFileTypes`, because a bare recursive `readdir` returns
+    // subdirectories as well as files with no way to tell them apart from the
+    // returned strings — an empty nested directory would then read as "fonts
+    // present" and defeat half this guard's contract. The three packages write
+    // font files flat today, so this is a latent false pass rather than a live
+    // one, and it costs nothing to close.
+    const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+    return entries.some((entry) => entry.isFile());
   } catch {
     return false;
   }
-  return entries.length > 0;
 }
 
 /**
- * True if any `.css` or `.html` file under `distDir` contains a literal
- * `@font-face` rule. This is a substring check, not a CSS parse — the same
- * shortcut `verify-vendored-anti-slop.sh`-style guards in this repo take,
- * and adequate here: nothing legitimate emits the literal text
- * `@font-face` other than a real font-face rule.
+ * The `name:` of every family in an Astro config's `fonts` array.
+ *
+ * Read out of the config's TEXT rather than by importing it: importing pulls
+ * in Astro's whole toolchain to answer a question a regex answers, and this
+ * guard runs at the end of every build in three packages.
+ *
+ * A parse that finds nothing is reported as a finding by the caller, never
+ * silently treated as "no families to check" — a guard that quietly stops
+ * guarding when its input changes shape is worse than no guard.
  */
-async function distContainsFontFace(distDir: string): Promise<boolean> {
-  const glob = new Glob("**/*.{css,html}");
-  for await (const relativePath of glob.scan({ cwd: distDir, dot: true })) {
-    const text = await Bun.file(join(distDir, relativePath)).text();
-    if (text.includes("@font-face")) return true;
+export function familyNamesFromAstroConfig(configText: string): readonly string[] {
+  const fontsBlock = /\bfonts\s*:\s*\[/.exec(configText);
+  if (!fontsBlock) return [];
+  const names: string[] = [];
+  // Slice from the `fonts:` array and scan forward. Deliberately NOT
+  // `namePattern.lastIndex = fontsBlock.index` on top of the slice — that
+  // starts `matchAll` a second `fontsBlock.index` characters in and skips
+  // every family, which is exactly the silent no-op this guard must not have.
+  const namePattern = /\bname\s*:\s*["'`]([^"'`]+)["'`]/g;
+  for (const match of configText.slice(fontsBlock.index).matchAll(namePattern)) {
+    const name = match[1];
+    if (name !== undefined && !names.includes(name)) names.push(name);
   }
-  return false;
+  return names;
 }
 
-export async function checkAstroFonts(distDir: string): Promise<readonly Finding[]> {
+/** Every `.css` and `.html` file under `distDir`, concatenated. */
+async function readBuiltText(distDir: string): Promise<string> {
+  const glob = new Glob("**/*.{css,html}");
+  const parts: string[] = [];
+  try {
+    for await (const relativePath of glob.scan({ cwd: distDir, dot: true })) {
+      parts.push(await Bun.file(join(distDir, relativePath)).text());
+    }
+  } catch {
+    // No dist at all — a missing directory reads the same as an empty one, and
+    // the caller turns that into the "no @font-face anywhere" finding rather
+    // than an unhandled ENOENT that says nothing about what went wrong.
+    return "";
+  }
+  return parts.join("\n");
+}
+
+export async function checkAstroFonts(
+  distDir: string,
+  configText?: string,
+): Promise<readonly Finding[]> {
   const findings: Finding[] = [];
 
   const fontsDir = join(distDir, "_astro", "fonts");
@@ -94,10 +130,37 @@ export async function checkAstroFonts(distDir: string): Promise<readonly Finding
     });
   }
 
-  if (!(await distContainsFontFace(distDir))) {
+  const built = await readBuiltText(distDir);
+  if (!built.includes("@font-face")) {
     findings.push({
       problem: `no "@font-face" rule found in any .css or .html file under ${distDir}`,
     });
+  }
+
+  // Per family, not just "at least one font somewhere". Astro drops a family
+  // whose metadata fetch failed and CONTINUES to the next one — it emits
+  // neither a real `@font-face` nor even the `optimizedFallbacks` rule for
+  // that family. Every package here declares two families, so a partial
+  // outage (one family's metadata served, the other's 403ing) would leave the
+  // surviving family satisfying both checks above while the wordmark and the
+  // couple's name fell back to a default serif. Same failure a reader sees,
+  // scoped to one family, and the whole-build checks cannot see it.
+  if (configText !== undefined) {
+    const families = familyNamesFromAstroConfig(configText);
+    if (families.length === 0) {
+      findings.push({
+        problem:
+          "could not read any font family name out of the astro config — this guard cannot " +
+          "check per-family coverage, and is failing rather than passing on an unknown shape",
+      });
+    }
+    for (const family of families) {
+      if (!built.includes(family)) {
+        findings.push({
+          problem: `font family "${family}" is declared in the astro config but appears nowhere in the built CSS or HTML — its metadata fetch failed and Astro dropped it`,
+        });
+      }
+    }
   }
 
   return findings;
@@ -131,7 +194,18 @@ if (import.meta.main) {
     // No readable package.json — fall back to the cwd already assigned above.
   }
 
-  const findings = await checkAstroFonts(distDir);
+  // The config sits beside the `package.json` read above — same cwd, because
+  // every package invokes this from its own directory.
+  let configText: string | undefined;
+  try {
+    configText = await Bun.file(join(process.cwd(), "astro.config.mjs")).text();
+  } catch {
+    // No config to read: the whole-build checks below still apply, the
+    // per-family ones are skipped. A package with no astro.config.mjs has no
+    // families to check.
+  }
+
+  const findings = await checkAstroFonts(distDir, configText);
 
   if (findings.length > 0) {
     console.error(`❌ check-astro-fonts: ${packageName} shipped a fontless build.`);

--- a/scripts/check-astro-fonts.ts
+++ b/scripts/check-astro-fonts.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env bun
+/**
+ * CI guard: fail the build if Astro's build-time Google Fonts fetch silently
+ * dropped every font.
+ *
+ * `@cire/vendor`, `@cire/host` and `@cire/landing` all declare fonts with
+ * `provider: fontProviders.google()`, which makes `GET
+ * https://fonts.google.com/metadata/fonts` a hard dependency of `astro
+ * build`. The failure is silent, three layers deep:
+ *
+ *   - unifont retries the fetch 3 times then throws;
+ *   - Astro constructs unifont with `throwOnError: false`, so unifont
+ *     `console.error`s the failure and drops the provider instead of
+ *     propagating it;
+ *   - Astro then finds zero fonts for the family, logs a `logger.warn("No
+ *     data found for font family …")`, and `continue`s to the next family.
+ *
+ * Result: an empty `dist/_astro/fonts/`, zero `@font-face` rules anywhere in
+ * the built output, zero font preloads, a `--font-ui`-shaped custom property
+ * pointing at a family nothing defines — and `astro build` exits 0. Nothing
+ * downstream of the build (`wrangler pages deploy dist`) would notice; the
+ * broken artefact ships on a green CI run. xchromo/osn-tracker#128.
+ *
+ * This guard takes a `dist` directory and fails unless BOTH hold:
+ *
+ *   1. `dist/_astro/fonts/` exists and holds at least one file — Astro's own
+ *      copy step writes the downloaded font files there, so an empty (or
+ *      missing) directory means nothing was ever fetched.
+ *   2. At least one `.css` or `.html` file under `dist` contains an
+ *      `@font-face` rule. Astro inlines the generated `@font-face` CSS into
+ *      each page's `<style>` block when it is small enough, and only spills
+ *      it into a standalone `_astro/*.css` file above that threshold — a
+ *      real build was observed doing the former, so this guard checks both
+ *      rather than assuming one.
+ *
+ * Turbo caches a package's `build` task only on a zero exit code (no
+ * `continueOnError`-shaped setting exists in the root `turbo.json`), and
+ * this guard runs as a second `&&`-chained command in that same `build`
+ * script — so a guard failure makes the whole task exit non-zero and turbo
+ * never caches the broken artefact as a success. A later run that DOES hit
+ * turbo's cache is replaying a build that passed this guard when it was
+ * created, which is why the guard does not need to run again on a cache hit.
+ */
+
+import { readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { Glob } from "bun";
+
+export type Finding = {
+  readonly problem: string;
+};
+
+/**
+ * True if `dir` exists and contains at least one regular file, checked
+ * recursively — Astro nests per-family subdirectories under some provider
+ * configurations, so a shallow `readdir` would miss a real, non-empty
+ * result. A missing directory is not an error here: it means the same thing
+ * as an empty one — no fonts were emitted — so both report `false`.
+ */
+async function hasAnyFile(dir: string): Promise<boolean> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir, { recursive: true });
+  } catch {
+    return false;
+  }
+  return entries.length > 0;
+}
+
+/**
+ * True if any `.css` or `.html` file under `distDir` contains a literal
+ * `@font-face` rule. This is a substring check, not a CSS parse — the same
+ * shortcut `verify-vendored-anti-slop.sh`-style guards in this repo take,
+ * and adequate here: nothing legitimate emits the literal text
+ * `@font-face` other than a real font-face rule.
+ */
+async function distContainsFontFace(distDir: string): Promise<boolean> {
+  const glob = new Glob("**/*.{css,html}");
+  for await (const relativePath of glob.scan({ cwd: distDir, dot: true })) {
+    const text = await Bun.file(join(distDir, relativePath)).text();
+    if (text.includes("@font-face")) return true;
+  }
+  return false;
+}
+
+export async function checkAstroFonts(distDir: string): Promise<readonly Finding[]> {
+  const findings: Finding[] = [];
+
+  const fontsDir = join(distDir, "_astro", "fonts");
+  if (!(await hasAnyFile(fontsDir))) {
+    findings.push({
+      problem: `${fontsDir} is missing or empty — no font files were emitted by the build`,
+    });
+  }
+
+  if (!(await distContainsFontFace(distDir))) {
+    findings.push({
+      problem: `no "@font-face" rule found in any .css or .html file under ${distDir}`,
+    });
+  }
+
+  return findings;
+}
+
+if (import.meta.main) {
+  const distArg = process.argv[2];
+
+  if (!distArg) {
+    console.error("❌ check-astro-fonts: usage: bun run check-astro-fonts.ts <dist-dir>");
+    process.exit(1);
+  }
+
+  // `resolve`, not `join` — an absolute `distArg` (the CLI test below passes
+  // one) must be used as-is rather than joined onto `cwd` as a relative
+  // path segment, which `join` would do silently.
+  const distDir = resolve(process.cwd(), distArg);
+
+  // The package name is read from the caller's own `package.json` rather
+  // than passed as a second argument, so the same invocation
+  // (`bun run ../../scripts/check-astro-fonts.ts dist`) works unchanged in
+  // every package's `build` script — the whole point of task #128's second
+  // half being "use the same invocation shape in all three".
+  let packageName = process.cwd();
+  try {
+    const pkg = (await Bun.file(join(process.cwd(), "package.json")).json()) as {
+      readonly name?: string;
+    };
+    if (typeof pkg.name === "string" && pkg.name.length > 0) packageName = pkg.name;
+  } catch {
+    // No readable package.json — fall back to the cwd already assigned above.
+  }
+
+  const findings = await checkAstroFonts(distDir);
+
+  if (findings.length > 0) {
+    console.error(`❌ check-astro-fonts: ${packageName} shipped a fontless build.`);
+    for (const { problem } of findings) console.error(`   ${problem}`);
+    console.error("");
+    console.error("   This is the failure mode in xchromo/osn-tracker#128: Astro's build-time");
+    console.error("   Google Fonts fetch failed and every layer between unifont and astro build");
+    console.error(
+      "   swallowed the error, so the build still exited 0 with no fonts in it. Re-run",
+    );
+    console.error("   the build with network access to fonts.google.com, or investigate why the");
+    console.error("   fetch failed before shipping this artefact.");
+    process.exit(1);
+  }
+
+  console.log(`✅ check-astro-fonts: ${packageName} shipped a real font build.`);
+}

--- a/wiki/architecture/frontend-patterns.md
+++ b/wiki/architecture/frontend-patterns.md
@@ -21,7 +21,7 @@ related:
 packages:
   - "@pulse/web"
   - "@osn/ui"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-08-31
 ---
 
 # Frontend Patterns
@@ -179,6 +179,31 @@ with a negative margin" trick inverts on a sticky element: a negative bottom mar
 A full-bleed sticky action bar must instead have the scroll container drop its own
 bottom padding and let the bar own the edge, plus its `env(safe-area-inset-bottom)`
 — the `flushBottom` prop on `AnimatedModal`, used by cire's `RsvpModal`.
+
+### A width-only reflow guard cannot see a drag that only changes height
+
+`createAutoSize()` (`cire/vendor/src/lib/auto-size.ts`, byte-identical in
+`cire/host`) animates a frame's height on a `ResizeObserver` delivery, and
+guards against animating a plain text reflow (a narrower window rewrapping
+the content) by comparing the observed width to the last one: unchanged width
+means real content changed, not layout. That guard has one blind spot —
+anything that changes height at a **fixed** width reads as a content change
+on every delivery, because the one signal the guard checks did not move.
+
+A `resize-y` `<textarea>` is exactly that case. Dragging its resize grip
+changes height continuously at a fixed width, so every delivery inside the
+frame's animation cap sets `overflow: hidden`, `contain: layout paint` and a
+fresh transition it never finishes, forcing a synchronous
+`getBoundingClientRect()` per frame — the reflow the guard exists to prevent,
+arriving through the one axis it does not watch. `Textarea`'s `resize` prop
+(`cire/host` and `cire/vendor` `components/ui/Field.tsx`, default `"y"`) is
+the fix: opt a textarea out of user-resize when it sits inside an
+auto-sized frame. Passing `class="resize-none"` at a call site does **not**
+work — `Field.tsx` appends its own resize class after the caller's, so both
+land on the element and Tailwind resolves the conflict by the two utilities'
+order in the generated stylesheet, not by attribute order. Reach for a real
+prop, not a class override, whenever a component appends its own class after
+the caller's (xchromo/osn-tracker#130).
 
 ## Source Files
 


### PR DESCRIPTION
## Summary

`astro build` fetched Google Fonts metadata, and when that fetch failed it
shipped a site with no fonts in it and exited 0. Three layers each swallowed the
error: unifont retried three times and threw, Astro had constructed it with
`throwOnError: false` so it logged and dropped the provider, and Astro then found
zero fonts for the family, warned, and continued. `deploy.yml` runs
`wrangler pages deploy dist` straight after the build with nothing in between,
so the broken artefact shipped on a green run.

This adds `scripts/check-astro-fonts.ts` to the end of each affected package's
own `build` script, so it fires locally and on deploy rather than only in CI. It
fails unless the build emitted font files, emitted `@font-face`, and — after the
security review of this branch — emitted every family the package's config
declares.

Four smaller findings ride along: the host portal's bare `<Font preload />`,
missing cache headers on first-party font assets, a textarea that made an
auto-size frame thrash, and a comment that described work the code was not doing.

- `@cire/landing` turned out to have the same unguarded font fetch as the other
  two. It is in scope; the plan had two packages, not three.

## Workspaces affected

`cire/vendor`, `cire/host`, `cire/landing`, plus root `scripts/` and
`.github/workflows/` (CI/infra-only). `.changeset/cire-font-build-guard.md`
names `@cire/vendor`, `@cire/host` and `@cire/landing`, all `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#128 | `VP-P-W5` / `VP-S-L5` |
| xchromo/osn-tracker#129 | `VP-P-W6` |
| xchromo/osn-tracker#131 | `VP-P-I6` |
| xchromo/osn-tracker#130 | `VP-P-I5` (vendor side; host `RegistryView` carved out, see below) |
| xchromo/osn-tracker#132 | `VP-P-I7` |

Closes xchromo/osn-tracker#128.
Closes xchromo/osn-tracker#129.
Closes xchromo/osn-tracker#131.
Closes xchromo/osn-tracker#132.

`#130` is deliberately **not** closed — one call site remains, see Out of scope.

**Opened**

None. Both review findings against this branch were fixed on it.

## Decisions

### The guard checks every family, not just that some font survived — `S-M1`

- **Issue** — the first version asserted that `dist/_astro/fonts/` was non-empty
  and that some `@font-face` existed anywhere under `dist`.
- **Why** — the security review showed that is not the failure mode. Astro drops
  a family whose metadata fetch failed and *continues* to the next one, emitting
  neither a real `@font-face` nor even the `optimizedFallbacks` rule for it.
  Every one of these packages declares two families, so a partial Google Fonts
  outage would leave the surviving family satisfying both checks while the
  wordmark and the couple's name fell back to a default serif — the same failure
  a reader sees, scoped to one family, shipping green.
- **Solution** — the guard reads the family names out of the package's own
  `astro.config.mjs` and asserts each appears in the built output.
- **Rationale** — reading the config rather than taking the names as arguments
  means the check cannot drift from what the package actually declares. Parsing
  the text rather than importing the config keeps Astro's whole toolchain out of
  a check that runs at the end of every build. **A config the parser cannot read
  fails rather than passes**: a guard that quietly stops guarding when its input
  changes shape is worse than no guard, and that is asserted by a test.

### The guard runs from the build script, not a workflow step — `#128`

- **Issue** — where to invoke it.
- **Why** — a check that only exists in CI does not protect a local build or a
  deploy path that does not run that job.
- **Solution** — `"build": "astro build && bun run ../../scripts/check-astro-fonts.ts dist"`
  in all three packages, the same shape in each.
- **Rationale** — turbo caches a `build` task only on a zero exit, so a failed
  guard can never be cached as a success; a later cache hit replays a build that
  passed the guard when it was made. Written in TypeScript rather than shell so
  its own tests run under the existing `bun test ./scripts/` CI step with no
  workflow edit — a `.test.sh` would have needed its own step.

### `hasAnyFile` counted directories — `S-L1`

- **Issue** — a bare recursive `readdir` returns subdirectories as well as files.
- **Why** — an empty nested directory read as "fonts present", defeating half
  the guard's contract. Latent, since all three packages write font files flat.
- **Solution** — `withFileTypes: true` and `entries.some(e => e.isFile())`.
- **Rationale** — makes the implementation match its own doc comment, and closes
  a false pass for nothing.

### A second textarea had the same bug — `P-W1`

- **Issue** — the performance review found `VendorEnquiryThread.tsx`'s reply box
  sits in the same `createAutoSize()` panel as the listing editor's description
  box and had the same `resize-y`.
- **Why** — `apply()`'s guard is `lastWidth !== width`, so a fixed-width height
  drag reads as a content swap and restarts a transition per observer delivery.
- **Solution** — `resize="none"`, same as the box that was fixed.
- **Rationale** — unlike `RegistryView.tsx`, nothing recorded this one as
  deliberate, so it was a miss rather than a scoped decision.

### The `resize` fix is a prop on the primitive, not a class at the call site

- **Issue** — `resize-y` is baked into `Field.tsx`'s `Textarea` in both packages.
- **Why** — passing `class="resize-none"` does not reliably win: `Field.tsx`
  appends `resize-y` *after* `own.class`, both land on the element, and Tailwind
  resolves conflicting utilities by stylesheet order, not attribute order.
- **Solution** — a `resize` prop defaulting to the current `"y"`, passed as
  `"none"` at the auto-sized call sites.
- **Rationale** — the default keeps every other caller unchanged, so
  `ui.test.tsx`'s assertion that a bare `<Textarea>` carries `resize-y` still
  holds and no textarea outside an auto-size frame loses a control it had.

### Font metadata caching, keyed on what can change its contents — `#128`, `P-I1`

- **Issue** — CI cached only `~/.bun/install/cache`, so every run re-fetched from
  `fonts.google.com` — exactly the fetch that can fail.
- **Why** — a build that never calls that endpoint cannot be broken by it. This
  is the half of #128 that makes the failure rarer rather than merely detected.
- **Solution** — cache `node_modules/.astro`, keyed on `bun.lock` plus the
  relevant `astro.config.mjs` files.
- **Rationale** — the config decides which families are fetched, so it belongs in
  the key. `bun.lock` was added after review: the cache's on-disk shape belongs
  to Astro and unifont, so an Astro upgrade would otherwise leave a stale-format
  entry alive under an unchanged key.

**Out of scope**

- `cire/host/src/components/RegistryView.tsx` still has the `#130` resize bug.
  It is held by the open PR stack `#760 → #831`; editing it here would conflict
  with work already in review. `#130` stays open for it.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37 tasks |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1431 files |
| `bun run test` | ✅ 1695 pass, 0 fail |
| `bun run build` (all three packages, `--force`) | ✅ guard runs and passes on each |
| `bun run test:scripts` | ✅ 80 pass |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run check:jest-dom-markers` | ✅ |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |

The guard was also driven by hand against synthetic `dist` directories, because
a guard that has only ever passed proves nothing. It fails on a fontless build,
fails when the fonts directory has files but no `@font-face` rule, fails when
one of two declared families is missing, fails on a config it cannot parse, and
passes on a complete build. Those cases are all in
`scripts/check-astro-fonts.test.ts`.

Not covered by any gate: nobody has watched a real Google Fonts outage, so the
guard is verified against a reconstruction of the failure rather than the failure
itself. The `_headers` change also needs one `curl -I` against the deployed
preview to confirm Pages is returning the new `Cache-Control` for `/_astro/*`.
