### PR TITLE
fix(cire): __Host- the consent cookie, and tear down embeds a guest revokes

### DIFF
--- a/.changeset/cire-consent-cookie-prefix-and-reload.md
+++ b/.changeset/cire-consent-cookie-prefix-and-reload.md
@@ -1,0 +1,23 @@
+---
+"@cire/invites": patch
+---
+
+Two consent-cookie fixes.
+
+S-L1 (osn-tracker#163): the `cire_consent` cookie now writes as
+`__Host-cire_consent` whenever the document is on a secure origin, so a
+script on a sibling `*.cireweddings.com` origin can no longer plant a
+`Domain`-scoped cookie of the same name and silently override a guest's
+stored refusal back to "allowed". Reads accept both names and prefer the
+prefixed one, so an existing guest's choice survives the change and a
+planted domain cookie can never outrank it. Falls back to the bare name on
+http dev, where `__Host-` cookies are rejected outright.
+
+CON-S-M1 (osn-tracker#162): withdrawing consent for a category with a
+`"gated"` vendor (currently `embeds` — Pinterest, Google Maps) now reloads
+the page, so a third party's already-executed globals, listeners and
+storage are actually torn down rather than merely stopped from loading
+further. The reload only fires on a granted → revoked transition, and only
+once a read-back of `document.cookie` confirms the refusal was actually
+persisted — a reload on a failed write would have thrown the refusal away
+on the very reload meant to enforce it.

--- a/cire/invites/src/components/consent/ConsentGate.tsx
+++ b/cire/invites/src/components/consent/ConsentGate.tsx
@@ -5,6 +5,7 @@ import {
   grantCategory,
   hydrateConsent,
   isCategoryGranted,
+  noteGatedContentLoaded,
   openConsentPreferences,
 } from "../../lib/consent/store";
 import { vendorById } from "../../lib/consent/vendors";
@@ -56,6 +57,19 @@ export function ConsentGate(props: ConsentGateProps) {
   // so a stored refusal is never briefly overridden by the opt-out default.
   onMount(hydrateConsent);
 
+  // Whether this gate ever actually ran third-party code decides whether a
+  // later refusal has anything to tear down — see `noteGatedContentLoaded`.
+  // Read inside the `Show`'s children so it runs when children render, not on
+  // the placeholder branch, and only for a `"gated"` vendor: an `"always"`
+  // vendor was never blocked by this switch, so revoking the category changes
+  // nothing it is doing and a reload would clear nothing.
+  const noteLoaded = () => {
+    if (vendorById(props.vendor)?.enforcement === "gated") {
+      noteGatedContentLoaded(props.category);
+    }
+    return props.children;
+  };
+
   return (
     <Show
       when={isCategoryGranted(props.category)}
@@ -63,7 +77,7 @@ export function ConsentGate(props: ConsentGateProps) {
         props.fallback ?? <ConsentPlaceholder category={props.category} vendor={props.vendor} />
       }
     >
-      {props.children}
+      {noteLoaded()}
     </Show>
   );
 }

--- a/cire/invites/src/components/consent/ConsentPreferences.tsx
+++ b/cire/invites/src/components/consent/ConsentPreferences.tsx
@@ -141,15 +141,18 @@ export function ConsentPreferences() {
           Choose what this invite is allowed to load. You can change this at any time from the link
           in the footer of any page.
         </p>
-        {/* CON-S-M1: turning off a category that governs third-party content
-            (currently "embeds") reloads the page — see `saveConsent` in
-            `lib/consent/store.ts` — so code from that company which already
-            ran during this visit is cleared, not just stopped from running
-            again. Stated here rather than left implicit, because a silent
-            reload the guest didn't expect is its own kind of surprising. */}
+        {/* CON-S-M1: turning off a category whose content already ran this
+            visit reloads the page — see `saveConsent` in
+            `lib/consent/store.ts` — so that company's code is cleared, not
+            just stopped from running again. Stated here rather than left
+            implicit, because a silent reload the guest didn't expect is its
+            own kind of surprising. Hedged on "if", because the reload only
+            happens when there is something to clear (P-W1): a guest who never
+            opened an event's details sheet loaded no embed, and reloading them
+            would cost a full page load to clear nothing. */}
         <p class="font-body text-text-muted/80 mt-1.5 text-[0.76rem] leading-relaxed">
-          Switching off a category that loads content from another company reloads the page, so
-          anything already loaded from them during this visit is cleared too.
+          Switching something off takes effect straight away. If content from that company already
+          loaded during this visit, the page reloads to clear it.
         </p>
 
         <div class="mt-5 flex flex-col gap-4">

--- a/cire/invites/src/components/consent/ConsentPreferences.tsx
+++ b/cire/invites/src/components/consent/ConsentPreferences.tsx
@@ -141,14 +141,15 @@ export function ConsentPreferences() {
           Choose what this invite is allowed to load. You can change this at any time from the link
           in the footer of any page.
         </p>
-        {/* S-M1 residual, stated rather than glossed over: switching a category
-            off stops anything further loading, but code from that company which
-            already ran during this visit stays in the page until it is
-            reloaded. Claiming a clean revocation without a reload would
-            overstate what the toggle does. */}
+        {/* CON-S-M1: turning off a category that governs third-party content
+            (currently "embeds") reloads the page — see `saveConsent` in
+            `lib/consent/store.ts` — so code from that company which already
+            ran during this visit is cleared, not just stopped from running
+            again. Stated here rather than left implicit, because a silent
+            reload the guest didn't expect is its own kind of surprising. */}
         <p class="font-body text-text-muted/80 mt-1.5 text-[0.76rem] leading-relaxed">
-          Switching something off takes effect straight away for anything not yet loaded. To also
-          clear content already loaded during this visit, reload the page afterwards.
+          Switching off a category that loads content from another company reloads the page, so
+          anything already loaded from them during this visit is cleared too.
         </p>
 
         <div class="mt-5 flex flex-col gap-4">

--- a/cire/invites/src/lib/consent/cookie.test.ts
+++ b/cire/invites/src/lib/consent/cookie.test.ts
@@ -1,17 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CONSENT_COOKIE_MAX_AGE_SECONDS,
   CONSENT_COOKIE_NAME,
+  PREFIXED_CONSENT_COOKIE_NAME,
   readConsentCookieValue,
+  readConsentFromDocument,
   readConsentRecord,
   serialiseConsentCookie,
+  writeConsentToDocumentAndVerify,
 } from "./cookie";
 import { allGrants, defaultGrants, encodeConsentRecord, makeConsentRecord } from "./record";
 
 const NOW = new Date("2026-07-29T10:00:00.000Z");
 const record = makeConsentRecord({ ...defaultGrants(), embeds: true }, NOW);
 const encoded = encodeConsentRecord(record);
+
+const OTHER_NOW = new Date("2026-07-30T10:00:00.000Z");
+const otherRecord = makeConsentRecord({ ...defaultGrants(), embeds: false }, OTHER_NOW);
+const otherEncoded = encodeConsentRecord(otherRecord);
+
+function clearBothCookies(): void {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0`;
+  document.cookie = `${PREFIXED_CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0; Secure`;
+}
 
 describe("readConsentCookieValue", () => {
   it("finds the value among other cookies", () => {
@@ -41,6 +53,32 @@ describe("readConsentCookieValue", () => {
   it("tolerates malformed segments without throwing", () => {
     expect(readConsentCookieValue(`novalue; ; ${CONSENT_COOKIE_NAME}=${encoded}`)).toBe(encoded);
   });
+
+  // osn-tracker#163: precedence between the `__Host-` and bare names. The
+  // prefixed name must win whenever it's present — that is what stops a
+  // domain cookie planted by a sibling origin under the bare name from
+  // overriding a refusal this site actually recorded under the prefixed one.
+  describe("prefix precedence (osn-tracker#163)", () => {
+    it("reads the bare name when it is the only one present", () => {
+      const header = `${CONSENT_COOKIE_NAME}=${encoded}`;
+      expect(readConsentCookieValue(header)).toBe(encoded);
+    });
+
+    it("reads the prefixed name when it is the only one present", () => {
+      const header = `${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`;
+      expect(readConsentCookieValue(header)).toBe(encoded);
+    });
+
+    it("prefers the prefixed value when both names are present", () => {
+      const header = `${CONSENT_COOKIE_NAME}=${otherEncoded}; ${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`;
+      expect(readConsentCookieValue(header)).toBe(encoded);
+    });
+
+    it("returns null when neither name is present", () => {
+      const header = "cire_session=abc123; other=1";
+      expect(readConsentCookieValue(header)).toBeNull();
+    });
+  });
 });
 
 describe("readConsentRecord", () => {
@@ -56,7 +94,7 @@ describe("readConsentRecord", () => {
 
 describe("serialiseConsentCookie", () => {
   it("scopes the cookie to the whole site with a six-month lifetime", () => {
-    const serialised = serialiseConsentCookie(record, true);
+    const serialised = serialiseConsentCookie(record, false);
     expect(serialised.startsWith(`${CONSENT_COOKIE_NAME}=${encoded}`)).toBe(true);
     expect(serialised).toContain("Path=/");
     expect(serialised).toContain(`Max-Age=${CONSENT_COOKIE_MAX_AGE_SECONDS}`);
@@ -80,5 +118,56 @@ describe("serialiseConsentCookie", () => {
     const serialised = serialiseConsentCookie(makeConsentRecord(allGrants(), NOW), false);
     const header = serialised.split(";")[0]!;
     expect(readConsentRecord(header)?.grants).toEqual(allGrants());
+  });
+
+  // osn-tracker#163
+  describe("cookie name (osn-tracker#163)", () => {
+    it("writes the __Host- prefixed name when secure", () => {
+      const serialised = serialiseConsentCookie(record, true);
+      expect(serialised.startsWith(`${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`)).toBe(true);
+    });
+
+    it("writes the bare name when not secure", () => {
+      // __Host- cookies are rejected outright without Secure; falling back to
+      // the bare name is what keeps consent persisting on http://localhost.
+      const serialised = serialiseConsentCookie(record, false);
+      expect(serialised.startsWith(`${CONSENT_COOKIE_NAME}=${encoded}`)).toBe(true);
+      expect(serialised.startsWith(PREFIXED_CONSENT_COOKIE_NAME)).toBe(false);
+    });
+  });
+});
+
+describe("writeConsentToDocumentAndVerify (osn-tracker#162 read-back)", () => {
+  afterEach(clearBothCookies);
+
+  it("returns true and leaves the record readable when the write actually lands", () => {
+    clearBothCookies();
+    expect(writeConsentToDocumentAndVerify(record)).toBe(true);
+    expect(readConsentFromDocument()?.grants).toEqual(record.grants);
+  });
+
+  it("returns false when the read-back does not show the new value", () => {
+    // Simulate a blocked/overridden write: something else holds the bare name
+    // to a DIFFERENT value than the one we're about to try to write, and
+    // `document.cookie` here (jsdom, http) never accepts the prefixed name
+    // because it isn't secure — so the write can't land on the plain
+    // assignment path and the read-back has to catch it.
+    clearBothCookies();
+    const originalCookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "cookie");
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => `${CONSENT_COOKIE_NAME}=${otherEncoded}`,
+      set: () => {
+        // Swallow the write entirely — nothing lands, exactly like a browser
+        // configured to block cookies outright.
+      },
+    });
+    try {
+      expect(writeConsentToDocumentAndVerify(record)).toBe(false);
+    } finally {
+      if (originalCookieDescriptor) {
+        Object.defineProperty(document, "cookie", originalCookieDescriptor);
+      }
+    }
   });
 });

--- a/cire/invites/src/lib/consent/cookie.test.ts
+++ b/cire/invites/src/lib/consent/cookie.test.ts
@@ -4,6 +4,7 @@ import {
   CONSENT_COOKIE_MAX_AGE_SECONDS,
   CONSENT_COOKIE_NAME,
   PREFIXED_CONSENT_COOKIE_NAME,
+  migrateBareConsentCookie,
   readConsentCookieValue,
   readConsentFromDocument,
   readConsentRecord,
@@ -19,6 +20,16 @@ const encoded = encodeConsentRecord(record);
 const OTHER_NOW = new Date("2026-07-30T10:00:00.000Z");
 const otherRecord = makeConsentRecord({ ...defaultGrants(), embeds: false }, OTHER_NOW);
 const otherEncoded = encodeConsentRecord(otherRecord);
+
+function readNamed(cookieString: string, name: string): string | null {
+  for (const part of cookieString.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return null;
+}
 
 function clearBothCookies(): void {
   document.cookie = `${CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0`;
@@ -169,5 +180,118 @@ describe("writeConsentToDocumentAndVerify (osn-tracker#162 read-back)", () => {
         Object.defineProperty(document, "cookie", originalCookieDescriptor);
       }
     }
+  });
+});
+
+/**
+ * Drive the module's `isSecureContext()` — it reads `location.protocol`, and
+ * jsdom serves the suite over http, so the `__Host-` half of every path below
+ * is unreachable without this. Also swaps in a cookie jar we control, because
+ * jsdom on http refuses a `Secure` cookie outright and the migration's whole
+ * point is what it writes on https.
+ */
+function onSecureOriginWithJar(initial: string, body: (jar: () => string) => void): void {
+  const originalLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+  const originalCookie = Object.getOwnPropertyDescriptor(Document.prototype, "cookie");
+  const jar = new Map<string, string>();
+  for (const part of initial.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    jar.set(part.slice(0, separator).trim(), part.slice(separator + 1).trim());
+  }
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    get: () => ({ protocol: "https:" }),
+  });
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => [...jar.entries()].map(([name, value]) => `${name}=${value}`).join("; "),
+    set: (assignment: string) => {
+      const [pair, ...attributes] = assignment.split(";");
+      const separator = pair!.indexOf("=");
+      const name = pair!.slice(0, separator).trim();
+      const value = pair!.slice(separator + 1).trim();
+      // A browser deletes on Max-Age=0 rather than storing an empty value.
+      if (attributes.some((a) => a.trim().toLowerCase() === "max-age=0")) jar.delete(name);
+      else jar.set(name, value);
+    },
+  });
+  try {
+    body(() => document.cookie);
+  } finally {
+    if (originalLocation) Object.defineProperty(globalThis, "location", originalLocation);
+    if (originalCookie) Object.defineProperty(document, "cookie", originalCookie);
+  }
+}
+
+/**
+ * S-M1 (found reviewing this branch): preferring the prefixed name on read only
+ * helps once this origin has WRITTEN the prefixed name — and for an
+ * already-decided guest that write never happens, because their choice reads
+ * back fine, the banner stays away, and `saveConsent` is never called again.
+ * Without a read-path migration their refusal stays shadowable for the cookie's
+ * whole 182 days.
+ */
+describe("migrateBareConsentCookie (S-M1)", () => {
+  it("moves an already-decided guest onto the prefixed name, and drops the bare one", () => {
+    onSecureOriginWithJar(`${CONSENT_COOKIE_NAME}=${encoded}`, (jar) => {
+      migrateBareConsentCookie();
+      expect(jar()).toContain(`${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`);
+      expect(readConsentCookieValue(jar())).toBe(encoded);
+      // The shadowable name is gone, not merely out-ranked.
+      expect(readNamed(jar(), CONSENT_COOKIE_NAME)).toBeNull();
+    });
+  });
+
+  it("preserves the decision itself, not just the name", () => {
+    onSecureOriginWithJar(`${CONSENT_COOKIE_NAME}=${encoded}`, (jar) => {
+      migrateBareConsentCookie();
+      expect(readConsentRecord(jar())?.grants).toEqual(record.grants);
+    });
+  });
+
+  it("leaves a guest already on the prefixed name alone", () => {
+    onSecureOriginWithJar(`${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`, (jar) => {
+      migrateBareConsentCookie();
+      expect(jar()).toBe(`${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}`);
+    });
+  });
+
+  it("prefers the prefixed value and still clears the bare one when both exist", () => {
+    // The planted-cookie case: a sibling origin's bare cookie sitting beside
+    // ours. The prefixed one already exists, so nothing is rewritten — the read
+    // precedence is what defends here, and it does.
+    onSecureOriginWithJar(
+      `${PREFIXED_CONSENT_COOKIE_NAME}=${encoded}; ${CONSENT_COOKIE_NAME}=${otherEncoded}`,
+      (jar) => {
+        migrateBareConsentCookie();
+        expect(readConsentCookieValue(jar())).toBe(encoded);
+      },
+    );
+  });
+
+  it("does nothing when there is no decision to move", () => {
+    onSecureOriginWithJar("", (jar) => {
+      migrateBareConsentCookie();
+      expect(jar()).toBe("");
+    });
+  });
+
+  it("does nothing when the bare cookie holds something unparseable", () => {
+    onSecureOriginWithJar(`${CONSENT_COOKIE_NAME}=not-a-record`, (jar) => {
+      migrateBareConsentCookie();
+      // Left exactly as found rather than replaced with a fabricated record.
+      expect(jar()).toBe(`${CONSENT_COOKIE_NAME}=not-a-record`);
+    });
+  });
+});
+
+describe("a secure write expires the bare name (S-M1)", () => {
+  it("clears a stale bare cookie as a side effect of saving", () => {
+    onSecureOriginWithJar(`${CONSENT_COOKIE_NAME}=${otherEncoded}`, (jar) => {
+      expect(writeConsentToDocumentAndVerify(record)).toBe(true);
+      expect(readNamed(jar(), CONSENT_COOKIE_NAME)).toBeNull();
+      expect(readNamed(jar(), PREFIXED_CONSENT_COOKIE_NAME)).toBe(encoded);
+    });
   });
 });

--- a/cire/invites/src/lib/consent/cookie.ts
+++ b/cire/invites/src/lib/consent/cookie.ts
@@ -29,6 +29,25 @@ import { type ConsentRecord, decodeConsentRecord, encodeConsentRecord } from "./
 export const CONSENT_COOKIE_NAME = "cire_consent";
 
 /**
+ * The `__Host-` form, written whenever the document is on a secure origin.
+ *
+ * `__Host-` is a browser-enforced promise, not just a naming convention: a
+ * cookie carrying it is rejected outright unless it also has `Secure`,
+ * `Path=/`, and no `Domain` attribute — which stops a script on a sibling
+ * `*.cireweddings.com` origin from setting a same-named `Domain=.cireweddings.com`
+ * cookie that could shadow or outrace this one. Without the prefix, a planted
+ * domain cookie and our host-only cookie are both valid matches for the plain
+ * name, and which one a browser returns first for `document.cookie` is
+ * unspecified — so a guest's stored REFUSAL could be silently overridden back
+ * to "allowed" by a cookie this site never set. This is osn-tracker#163.
+ *
+ * `serialiseConsentCookie` already writes `Path=/`, no `Domain`, and `Secure`
+ * whenever `secure` is true, so the prefixed form is compatible with the
+ * cookie as written today — no attribute needs to change to add it.
+ */
+export const PREFIXED_CONSENT_COOKIE_NAME = `__Host-${CONSENT_COOKIE_NAME}`;
+
+/**
  * Six months. Long enough that a guest checking the invite across a year-long
  * engagement isn't nagged every visit, short enough to match the ~6-month
  * re-ask interval European regulators treat as the reasonable ceiling for
@@ -43,18 +62,37 @@ export const CONSENT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 182;
  * Accepts either side's format — they are identical: a request's `Cookie`
  * header and the browser's `document.cookie` are both `a=1; b=2`. One parser
  * therefore serves both the (future) server-side read and the client store.
+ *
+ * Reads BOTH the prefixed and bare names and prefers the prefixed one when
+ * both are present. Two things this buys:
+ *
+ *  - An existing guest's choice, stored under the bare name before this
+ *    change shipped, still reads back correctly on http and survives the
+ *    upgrade to `__Host-` on https — there is no migration step, just a
+ *    fallback.
+ *  - A cookie planted under the bare name by a sibling origin (the attack
+ *    `PREFIXED_CONSENT_COOKIE_NAME` exists to stop) can never win once this
+ *    site has itself written the prefixed one: the prefixed value always
+ *    takes precedence, so the planted cookie is inert as soon as this origin
+ *    has made its own secure write.
  */
 export function readConsentCookieValue(cookieString: string | null | undefined): string | null {
   if (!cookieString) return null;
+
+  let bareValue: string | null = null;
+  let prefixedValue: string | null = null;
 
   for (const part of cookieString.split(";")) {
     const separator = part.indexOf("=");
     if (separator === -1) continue;
     const name = part.slice(0, separator).trim();
-    if (name !== CONSENT_COOKIE_NAME) continue;
-    return part.slice(separator + 1).trim();
+    if (name === PREFIXED_CONSENT_COOKIE_NAME) {
+      prefixedValue = part.slice(separator + 1).trim();
+    } else if (name === CONSENT_COOKIE_NAME) {
+      bareValue = part.slice(separator + 1).trim();
+    }
   }
-  return null;
+  return prefixedValue ?? bareValue;
 }
 
 /** Parse a cookie string straight into a record (or `null` if absent/untrusted). */
@@ -70,10 +108,17 @@ export function readConsentRecord(cookieString: string | null | undefined): Cons
  * cookie is silently DROPPED on `http://localhost` — which would make consent
  * appear not to persist in local dev while working fine in production, the most
  * annoying class of bug to chase.
+ *
+ * Writes {@link PREFIXED_CONSENT_COOKIE_NAME} when `secure` is true and the
+ * bare {@link CONSENT_COOKIE_NAME} otherwise. `__Host-` cookies are rejected by
+ * the browser without `Secure`, so on http dev the prefixed name would simply
+ * fail to set — falling back to the bare name there is what keeps consent
+ * persisting in local dev at all, matching the `Secure`-dropping trade above.
  */
 export function serialiseConsentCookie(record: ConsentRecord, secure: boolean): string {
+  const name = secure ? PREFIXED_CONSENT_COOKIE_NAME : CONSENT_COOKIE_NAME;
   const attributes = [
-    `${CONSENT_COOKIE_NAME}=${encodeConsentRecord(record)}`,
+    `${name}=${encodeConsentRecord(record)}`,
     "Path=/",
     `Max-Age=${CONSENT_COOKIE_MAX_AGE_SECONDS}`,
     "SameSite=Lax",
@@ -107,4 +152,26 @@ export function writeConsentToDocument(record: ConsentRecord): void {
   } catch {
     // Storage disabled — consent applies for this visit only.
   }
+}
+
+/**
+ * Write a record and confirm it actually landed, by reading `document.cookie`
+ * straight back.
+ *
+ * `writeConsentToDocument` returns `void` and swallows a blocked write by
+ * design (see its doc), so a caller that needs to know whether the write
+ * really took — the reload-on-revoke path in `store.ts` (osn-tracker#162) —
+ * cannot use "the call returned" as its success signal. A browser that blocks
+ * cookies outright, or a Set-Cookie the browser itself rejects (an oversized
+ * value, say), leaves `document.cookie` unchanged, and the read-back is the
+ * only way to see that from here.
+ *
+ * Compares the round-tripped record against `record` by RE-encoding both
+ * rather than string-matching the raw cookie value, so it does not care which
+ * of the two cookie names was actually written.
+ */
+export function writeConsentToDocumentAndVerify(record: ConsentRecord): boolean {
+  writeConsentToDocument(record);
+  const readBack = readConsentFromDocument();
+  return readBack !== null && encodeConsentRecord(readBack) === encodeConsentRecord(record);
 }

--- a/cire/invites/src/lib/consent/cookie.ts
+++ b/cire/invites/src/lib/consent/cookie.ts
@@ -76,6 +76,20 @@ export const CONSENT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 182;
  *    takes precedence, so the planted cookie is inert as soon as this origin
  *    has made its own secure write.
  */
+export function readNamedCookie(
+  cookieString: string | null | undefined,
+  name: string,
+): string | null {
+  if (!cookieString) return null;
+  for (const part of cookieString.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return null;
+}
+
 export function readConsentCookieValue(cookieString: string | null | undefined): string | null {
   if (!cookieString) return null;
 
@@ -147,10 +161,73 @@ export function readConsentFromDocument(): ConsentRecord | null {
  */
 export function writeConsentToDocument(record: ConsentRecord): void {
   if (typeof document === "undefined") return;
+  const secure = isSecureContext();
   try {
-    document.cookie = serialiseConsentCookie(record, isSecureContext());
+    document.cookie = serialiseConsentCookie(record, secure);
+    if (secure) expireBareConsentCookie();
   } catch {
     // Storage disabled — consent applies for this visit only.
+  }
+}
+
+/**
+ * Expire the bare-named cookie, leaving the `__Host-` one as the only match.
+ *
+ * Writing the prefixed name does NOT remove a bare `cire_consent` sitting
+ * beside it, and while both exist the ambiguity S-L1 (osn-tracker#163) is
+ * about is still there — `readConsentCookieValue` prefers the prefixed one, so
+ * this origin is safe, but the shadowing cookie is still in the jar and any
+ * reader that does not know the precedence rule can still pick the wrong one.
+ * Removing the name outright is the only thing that ends the condition rather
+ * than out-running it.
+ *
+ * Host-only, `Path=/`, no `Domain` — deliberately the same scope this origin
+ * writes with, so it clears OUR old cookie and not a sibling's. A page cannot
+ * delete a `Domain=.cireweddings.com` cookie set by another origin, and should
+ * not try: the read precedence is what defends against that one.
+ */
+function expireBareConsentCookie(): void {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
+}
+
+/**
+ * Move an already-decided guest onto the prefixed cookie without asking them
+ * anything.
+ *
+ * The fix for osn-tracker#163 only bites once this origin has written the
+ * prefixed name — and for the guests who most need it, that write was never
+ * going to happen. `saveConsent` runs only when someone touches the consent UI,
+ * and a guest who already decided is precisely the one the banner never shows
+ * again: their choice reads back fine through the bare-name fallback, so
+ * `needsConsentDecision()` stays false and nothing writes for up to the
+ * cookie's full 182 days. Their stored refusal would sit shadowable for six
+ * months, which is most of the exposure the finding was filed about.
+ *
+ * So the migration runs on READ instead. On a secure origin, when the bare name
+ * is present and the prefixed one is not, re-write the record under the
+ * prefixed name and expire the bare one. The guest is migrated on their next
+ * visit and sees nothing. On http dev there is nothing to do — `__Host-` needs
+ * `Secure`, so the bare name is the correct and only form there.
+ *
+ * Best-effort, like every write in this module: a browser that blocks the write
+ * leaves the guest exactly where they were, which is the status quo, not a
+ * regression.
+ */
+export function migrateBareConsentCookie(): void {
+  if (typeof document === "undefined" || !isSecureContext()) return;
+  const cookies = document.cookie;
+  if (!cookies.includes(`${CONSENT_COOKIE_NAME}=`)) return;
+  // Already on the prefixed name — nothing to move. Checked by parsing rather
+  // than substring, because `cire_consent=` is itself a substring of
+  // `__Host-cire_consent=`.
+  if (readNamedCookie(cookies, PREFIXED_CONSENT_COOKIE_NAME) !== null) return;
+  const record = readConsentRecord(cookies);
+  if (!record) return;
+  try {
+    document.cookie = serialiseConsentCookie(record, true);
+    expireBareConsentCookie();
+  } catch {
+    // Blocked — the guest stays on the bare cookie, same as before.
   }
 }
 

--- a/cire/invites/src/lib/consent/store.test.ts
+++ b/cire/invites/src/lib/consent/store.test.ts
@@ -5,6 +5,7 @@ import { allGrants, defaultGrants } from "./record";
 import {
   acceptAllConsent,
   hydrateConsent,
+  noteGatedContentLoaded,
   rejectAllConsent,
   saveConsent,
   setReloadPageForTest,
@@ -36,9 +37,10 @@ describe("saveConsent — reload on granted → revoked (osn-tracker#162)", () =
     resetConsentForTest();
   });
 
-  it("reloads when a gated category (embeds) goes from granted to revoked", () => {
+  it("reloads when a gated category (embeds) goes from granted to revoked, after its content ran", () => {
     seedConsentForTest({ embeds: true });
     hydrateConsent();
+    noteGatedContentLoaded("embeds");
     setReloadPageForTest(reload);
 
     saveConsent({ ...defaultGrants(), embeds: false });
@@ -46,17 +48,45 @@ describe("saveConsent — reload on granted → revoked (osn-tracker#162)", () =
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("reloads on the FIRST-EVER decision, when 'Reject all' revokes the opt-out default", () => {
-    // The common path per the module doc: the banner appears after the
-    // opt-out-granted embeds have already loaded, so a guest's very first
-    // decision is very often exactly this transition.
+  it("reloads on the FIRST-EVER decision, when the embeds already ran", () => {
+    // A guest who opened an event's details sheet — mounting the moodboard or
+    // the map under the opt-out default — and only then pressed "Reject all".
+    // Third-party code really did run, so there really is something to clear.
+    resetConsentForTest();
+    hydrateConsent();
+    noteGatedContentLoaded("embeds");
+    setReloadPageForTest(reload);
+
+    rejectAllConsent();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  // P-W1 (found reviewing this branch): the reload exists to tear down code
+  // that already ran, and on the COMMON path none has. Both gated vendors
+  // mount only inside a click-opened details sheet, while the banner appears
+  // immediately — so a guest who lands and presses "Reject all" has almost
+  // never opened one, and reloading them would spend a whole document load,
+  // every island's hydration and a re-fetch of the invite to clear nothing.
+  it("does NOT reload when no gated content ever rendered this visit", () => {
     resetConsentForTest();
     hydrateConsent();
     setReloadPageForTest(reload);
 
     rejectAllConsent();
 
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload when the category that ran is not the one revoked", () => {
+    seedConsentForTest({ embeds: true, analytics: true });
+    hydrateConsent();
+    noteGatedContentLoaded("embeds");
+    setReloadPageForTest(reload);
+
+    saveConsent({ ...defaultGrants(), embeds: true });
+
+    expect(reload).not.toHaveBeenCalled();
   });
 
   it("does NOT reload on revoked → granted", () => {

--- a/cire/invites/src/lib/consent/store.test.ts
+++ b/cire/invites/src/lib/consent/store.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CONSENT_COOKIE_NAME } from "./cookie";
+import { allGrants, defaultGrants } from "./record";
+import {
+  acceptAllConsent,
+  hydrateConsent,
+  rejectAllConsent,
+  saveConsent,
+  setReloadPageForTest,
+} from "./store";
+import { resetConsentForTest, seedConsentForTest } from "./testing";
+
+/**
+ * CON-S-M1 (osn-tracker#162): `saveConsent` reloads the page on a
+ * granted → revoked transition for a category that governs at least one
+ * `"gated"` vendor — the only way to tear down a third party's already-run
+ * side effects, not just stop it loading further. These tests pin the two
+ * conditions that gate the reload (see `saveConsent`'s doc in `store.ts`):
+ * the transition direction, and a successful cookie write.
+ *
+ * `location.reload()` itself is not callable in jsdom, so `reloadPage` is
+ * substituted with a spy via `setReloadPageForTest` rather than stubbing
+ * `window.location` — the module-level indirection `store.ts` defines for
+ * exactly this.
+ */
+describe("saveConsent — reload on granted → revoked (osn-tracker#162)", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    resetConsentForTest();
+    reload.mockClear();
+  });
+
+  afterEach(() => {
+    resetConsentForTest();
+  });
+
+  it("reloads when a gated category (embeds) goes from granted to revoked", () => {
+    seedConsentForTest({ embeds: true });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    saveConsent({ ...defaultGrants(), embeds: false });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads on the FIRST-EVER decision, when 'Reject all' revokes the opt-out default", () => {
+    // The common path per the module doc: the banner appears after the
+    // opt-out-granted embeds have already loaded, so a guest's very first
+    // decision is very often exactly this transition.
+    resetConsentForTest();
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    rejectAllConsent();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reload on revoked → granted", () => {
+    seedConsentForTest({ embeds: false });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    saveConsent({ ...defaultGrants(), embeds: true });
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload on a no-op save", () => {
+    seedConsentForTest({ embeds: true });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    saveConsent({ ...defaultGrants(), embeds: true });
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload on a first-time grant (off → on, nothing was ever running)", () => {
+    resetConsentForTest();
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    // Accept-all only turns `analytics` on for real (the other opt-out
+    // categories are already granted pre-decision) — an off → on move, not a
+    // revoke.
+    acceptAllConsent();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload for a revoked category with no gated vendors (functional)", () => {
+    seedConsentForTest({ functional: true });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    saveConsent({ ...defaultGrants(), functional: false });
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload when the cookie write's read-back fails, even on a real revoke", () => {
+    seedConsentForTest({ embeds: true });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    // Simulate a blocked write: `document.cookie` accepts nothing, so the
+    // read-back inside `writeConsentToDocumentAndVerify` can never show the
+    // new value.
+    const originalCookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "cookie");
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => `${CONSENT_COOKIE_NAME}=stale`,
+      set: () => {
+        // Nothing lands.
+      },
+    });
+
+    try {
+      saveConsent({ ...defaultGrants(), embeds: false });
+    } finally {
+      if (originalCookieDescriptor) {
+        Object.defineProperty(document, "cookie", originalCookieDescriptor);
+      }
+    }
+
+    // The reload — which would have discarded the very refusal it was meant
+    // to enforce, landing the guest back on the opt-out defaults with no
+    // record of having tried — must not fire.
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("round-trips through allGrants() without reloading (accept-all is never a revoke)", () => {
+    seedConsentForTest({ embeds: false });
+    hydrateConsent();
+    setReloadPageForTest(reload);
+
+    saveConsent(allGrants());
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/cire/invites/src/lib/consent/store.ts
+++ b/cire/invites/src/lib/consent/store.ts
@@ -1,7 +1,11 @@
 import { createSignal } from "solid-js";
 
 import { CONSENT_CATEGORIES, type ConsentCategory } from "./categories";
-import { readConsentFromDocument, writeConsentToDocumentAndVerify } from "./cookie";
+import {
+  migrateBareConsentCookie,
+  readConsentFromDocument,
+  writeConsentToDocumentAndVerify,
+} from "./cookie";
 import {
   allGrants,
   type ConsentGrants,
@@ -76,6 +80,12 @@ function clearLegacyPinterestConsent(): void {
 export function hydrateConsent(): void {
   if (hydrated()) return;
   clearLegacyPinterestConsent();
+  // Move an already-decided guest onto the `__Host-` name before reading. It
+  // has to happen here, on the read path, because the write path never runs
+  // again for them: their stored choice reads back fine, so the banner stays
+  // away and nothing would ever perform the secure write the fix for
+  // osn-tracker#163 depends on. See `migrateBareConsentCookie`.
+  migrateBareConsentCookie();
   setRecord(readConsentFromDocument());
   setHydrated(true);
 }

--- a/cire/invites/src/lib/consent/store.ts
+++ b/cire/invites/src/lib/consent/store.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 
-import type { ConsentCategory } from "./categories";
-import { readConsentFromDocument, writeConsentToDocument } from "./cookie";
+import { CONSENT_CATEGORIES, type ConsentCategory } from "./categories";
+import { readConsentFromDocument, writeConsentToDocumentAndVerify } from "./cookie";
 import {
   allGrants,
   type ConsentGrants,
@@ -12,6 +12,7 @@ import {
   normaliseGrants,
   preDecisionGrants,
 } from "./record";
+import { gatedVendorsInCategory } from "./vendors";
 
 /**
  * The shared, page-wide consent state.
@@ -121,12 +122,82 @@ export function closeConsentPreferences(): void {
   setPreferencesOpen(false);
 }
 
-/** Persist `grants` as the guest's decision and close the dialog. */
+/**
+ * The reload triggered by a granted → revoked transition (see
+ * {@link saveConsent}). A module-level reference rather than a direct
+ * `location.reload()` call, so a test can substitute a spy in place of it. The
+ * alternative — stubbing out the global `location` object — breaks every other
+ * jsdom test in the same file that happens to touch `location` or navigation,
+ * because jsdom exposes exactly one `window.location` per test document; a
+ * narrow, purpose-built seam avoids that.
+ */
+function defaultReloadPage(): void {
+  location.reload();
+}
+
+/** See `resetConsentStoreForTest`'s doc for why the test default is this, not {@link defaultReloadPage}. */
+function noopReloadPageForTest(): void {
+  // Intentionally does nothing.
+}
+
+let reloadPage: () => void = defaultReloadPage;
+
+/** Test-only: substitute {@link reloadPage}. Reset by `resetConsentStoreForTest`. */
+export function setReloadPageForTest(fn: () => void): void {
+  reloadPage = fn;
+}
+
+/**
+ * Does moving from `previous` to `next` revoke a category that governs at
+ * least one `"gated"` vendor?
+ *
+ * Category-level, not vendor-level, because a category is the unit the toggle
+ * actually grants or revokes. Only `"gated"` vendors count: an `"always"`
+ * vendor was never blocked by this category's switch, so revoking the category
+ * changes nothing that vendor is doing.
+ */
+function revokesGatedCategory(previous: ConsentGrants, next: ConsentGrants): boolean {
+  return CONSENT_CATEGORIES.some(
+    (category) =>
+      previous[category] && !next[category] && gatedVendorsInCategory(category).length > 0,
+  );
+}
+
+/**
+ * Persist `grants` as the guest's decision and close the dialog.
+ *
+ * CON-S-M1: switching a gated category off unmounts its embeds (see
+ * `ConsentGate`), but that only stops FURTHER requests — a vendor's script
+ * that already ran (globals it set, listeners it attached, its own storage) is
+ * still live in the page for the rest of the visit. Under the opt-out defaults
+ * this is the common case, not an edge one: the banner appears after the
+ * gated embeds have already loaded, so "Reject all" is nearly always clicked
+ * with a third-party context already running.
+ *
+ * The only clean teardown is a reload, and it is gated on two conditions, both
+ * load-bearing:
+ *
+ *  1. Granted → revoked ONLY. Not revoked → granted (nothing to tear down),
+ *     not a no-op save (nothing changed), not a first-time grant (nothing was
+ *     ever running to begin with).
+ *  2. The cookie write must have actually SUCCEEDED, checked by reading it
+ *     back ({@link writeConsentToDocumentAndVerify}) rather than trusting that
+ *     the write call merely returned — it swallows failures by design. A
+ *     reload on an unpersisted refusal would throw the choice away on the very
+ *     reload meant to enforce it, which is worse than the bug being fixed:
+ *     the guest would watch the page reload believing they had just refused,
+ *     and land back on the opt-out defaults with no record of having tried.
+ */
 export function saveConsent(grants: ConsentGrants): void {
+  const previous = currentGrants();
   const next = makeConsentRecord(normaliseGrants(grants), new Date());
-  writeConsentToDocument(next);
+  const written = writeConsentToDocumentAndVerify(next);
   setRecord(next);
   setPreferencesOpen(false);
+
+  if (written && revokesGatedCategory(previous, next.grants)) {
+    reloadPage();
+  }
 }
 
 /** "Accept all" — every category on. */
@@ -220,10 +291,20 @@ export function claimConsentDialogHost(): ConsentDialogHostClaim {
  * Test-only: return the store to its pre-hydration state. Lets a test simulate
  * a fresh page load after seeding or clearing `document.cookie`, without a real
  * reload (the module is evaluated once per test file).
+ *
+ * Also returns {@link reloadPage} to a no-op, NOT {@link defaultReloadPage}.
+ * `location.reload()` is unimplemented in jsdom and logs a "Not implemented:
+ * navigation" warning on every call, so a gate/banner test that happens to
+ * drive a real granted → revoked save (most of them do, incidentally, when
+ * asserting teardown) would otherwise spam that warning for a reload it never
+ * asked about. A test that means to assert the reload itself calls
+ * {@link setReloadPageForTest} with its own spy after this runs, same as any
+ * other test-only default here.
  */
 export function resetConsentStoreForTest(): void {
   setRecord(null);
   setHydrated(false);
   setPreferencesOpen(false);
   setDialogHostId(null);
+  reloadPage = noopReloadPageForTest;
 }

--- a/cire/invites/src/lib/consent/store.ts
+++ b/cire/invites/src/lib/consent/store.ts
@@ -169,8 +169,39 @@ export function setReloadPageForTest(fn: () => void): void {
 function revokesGatedCategory(previous: ConsentGrants, next: ConsentGrants): boolean {
   return CONSENT_CATEGORIES.some(
     (category) =>
-      previous[category] && !next[category] && gatedVendorsInCategory(category).length > 0,
+      previous[category] &&
+      !next[category] &&
+      gatedVendorsInCategory(category).length > 0 &&
+      loadedGatedCategories.has(category),
   );
+}
+
+/**
+ * Categories whose gated content actually rendered during this visit.
+ *
+ * The reload exists to tear down third-party code that already ran. If none
+ * ever ran, there is nothing to tear down and the reload is pure cost — and
+ * that is the COMMON path, not the rare one: both gated vendors (the Pinterest
+ * board and the Google Maps preview) mount only inside a click-opened event
+ * details sheet, while the banner appears immediately, so a guest who lands and
+ * presses "Reject all" has almost never opened one. Reloading them would spend
+ * a full document load, every island's hydration and a re-fetch of the invite
+ * to clear nothing at all.
+ *
+ * A plain module-level `Set`, not a signal: nothing renders from it, it only
+ * has to be readable at save time, and a signal would invalidate the store's
+ * subscribers on every gate mount for no benefit. It resets on reload, which is
+ * exactly right — a reload is what clears the thing it tracks.
+ */
+const loadedGatedCategories = new Set<ConsentCategory>();
+
+/**
+ * Record that a gated vendor's content rendered. Called by `ConsentGate` when
+ * it actually renders children for a `"gated"` vendor — not when it renders the
+ * placeholder, which runs no third-party code.
+ */
+export function noteGatedContentLoaded(category: ConsentCategory): void {
+  loadedGatedCategories.add(category);
 }
 
 /**
@@ -317,4 +348,5 @@ export function resetConsentStoreForTest(): void {
   setPreferencesOpen(false);
   setDialogHostId(null);
   reloadPage = noopReloadPageForTest;
+  loadedGatedCategories.clear();
 }

--- a/cire/invites/src/lib/consent/testing.ts
+++ b/cire/invites/src/lib/consent/testing.ts
@@ -1,5 +1,5 @@
 import type { ConsentCategory } from "./categories";
-import { CONSENT_COOKIE_NAME } from "./cookie";
+import { CONSENT_COOKIE_NAME, PREFIXED_CONSENT_COOKIE_NAME } from "./cookie";
 import {
   type ConsentGrants,
   defaultGrants,
@@ -21,10 +21,15 @@ import { resetConsentStoreForTest } from "./store";
  * hand-rolled approximation of one that might no longer parse.
  */
 
-/** Delete the consent cookie and return the store to its pre-hydration state. */
+/**
+ * Delete the consent cookie — both names, since a browser-tier test running
+ * on https may have left the `__Host-` form set by a real `saveConsent` call —
+ * and return the store to its pre-hydration state.
+ */
 export function resetConsentForTest(): void {
   if (typeof document !== "undefined") {
     document.cookie = `${CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    document.cookie = `${PREFIXED_CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0; Secure`;
   }
   resetConsentStoreForTest();
 }

--- a/wiki/architecture/cire-consent.md
+++ b/wiki/architecture/cire-consent.md
@@ -162,11 +162,31 @@ prefix, a script on a sibling `*.cireweddings.com` origin could set its own
 same-named cookies a browser returns first is unspecified — so a guest's
 stored REFUSAL could be silently overridden back to "allowed". `__Host-` is a
 browser-enforced promise (rejected without `Secure`, `Path=/`, and no
-`Domain`), which the cookie's existing attributes already satisfy. Preferring
-the prefixed name on read is what makes a planted bare-name cookie inert the
-moment this origin has made its own secure write, and reading the bare name at
-all is what lets an existing guest's pre-upgrade choice keep working with no
-migration step.
+`Domain`), which the cookie's existing attributes already satisfy.
+
+**The bare name is removed, not merely out-ranked.** Preferring the prefixed
+name on read only defends this origin, and only once the prefixed cookie
+actually exists — so two writes end the ambiguity rather than out-running it:
+
+- a secure write also expires the bare name, so saving clears the old cookie;
+- `hydrateConsent` calls `migrateBareConsentCookie` on the way in, which on a
+  secure origin moves a bare-name record onto the prefixed name and expires the
+  bare one.
+
+The second is the one that matters, and it is not belt-and-braces. `saveConsent`
+runs only when a guest touches the consent UI, and a guest who has already
+decided is exactly the one the banner never shows again — their stored choice
+reads back fine through the bare-name fallback, so `needsConsentDecision()`
+stays false and nothing would ever perform the secure write. Without a migration
+on the READ path, their refusal would stay shadowable for the cookie's full 182
+days. Migrating on read moves them silently on their next visit. On http dev
+there is nothing to migrate: `__Host-` needs `Secure`, so the bare name is the
+correct and only form there.
+
+A page cannot delete a `Domain=.cireweddings.com` cookie another origin set, and
+does not try — the read precedence is what defends against that one. The expiry
+is host-only, `Path=/`, no `Domain`, so it clears our own old cookie and nothing
+else.
 
 **Why a cookie and not `localStorage`** (which the old Pinterest gate used): a
 cookie is the only store the server can read. Both currently-gated embeds mount

--- a/wiki/architecture/cire-consent.md
+++ b/wiki/architecture/cire-consent.md
@@ -4,7 +4,7 @@ tags: [architecture, privacy, compliance, web, cire]
 related:
   - "[[index]]"
   - "[[cire-invite-builder]]"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-08-31
 ---
 # Site-wide consent framework
 
@@ -100,7 +100,7 @@ Two traps this separation exists to avoid:
 | `lib/consent/categories.ts` | The category enum + display metadata. `necessary` is the only required one. |
 | `lib/consent/vendors.ts` | **The vendor registry** — one source of truth (see below). |
 | `lib/consent/record.ts` | The persisted record: versions, grant normalisation, encode/decode. |
-| `lib/consent/cookie.ts` | Cookie transport (`cire_consent`). |
+| `lib/consent/cookie.ts` | Cookie transport (`__Host-cire_consent` / `cire_consent`). |
 | `lib/consent/store.ts` | Module-level Solid signals shared by every island. |
 | `lib/consent/testing.ts` | `seedConsentForTest` / `resetConsentForTest`. |
 | `components/consent/ConsentGate.tsx` | The wrapper + the default blocked-content placeholder. |
@@ -149,8 +149,24 @@ voice.
 
 ## Storage
 
-A cookie, `cire_consent`, `Path=/`, `Max-Age` 182 days, `SameSite=Lax`, `Secure`
-on https only. Not `HttpOnly` — client code rewrites it.
+A cookie, `Path=/`, `Max-Age` 182 days, `SameSite=Lax`. Not `HttpOnly` — client
+code rewrites it.
+
+**Two names, chosen by `secure`.** On https the cookie is written as
+`__Host-cire_consent`; on http (local dev) it falls back to the bare
+`cire_consent`, because `__Host-` cookies are rejected outright without
+`Secure`, which http can never set. A read accepts BOTH names and prefers the
+prefixed one when both are present. This is osn-tracker#163 (S-L1): without the
+prefix, a script on a sibling `*.cireweddings.com` origin could set its own
+`Domain=.cireweddings.com` cookie of the same bare name, and which of the two
+same-named cookies a browser returns first is unspecified — so a guest's
+stored REFUSAL could be silently overridden back to "allowed". `__Host-` is a
+browser-enforced promise (rejected without `Secure`, `Path=/`, and no
+`Domain`), which the cookie's existing attributes already satisfy. Preferring
+the prefixed name on read is what makes a planted bare-name cookie inert the
+moment this origin has made its own secure write, and reading the bare name at
+all is what lets an existing guest's pre-upgrade choice keep working with no
+migration step.
 
 **Why a cookie and not `localStorage`** (which the old Pinterest gate used): a
 cookie is the only store the server can read. Both currently-gated embeds mount
@@ -163,6 +179,35 @@ late: the request has gone before any script reads it.
 `SameSite=Lax` not `Strict`, because a guest arriving from the couple's emailed
 link is a cross-site top-level navigation and `Strict` would withhold the cookie
 on exactly that first hop — re-prompting someone who already decided.
+
+### Withdrawal tears down what already ran (osn-tracker#162 / CON-S-M1)
+
+Switching a category off unmounts its gated embeds immediately — `ConsentGate`
+doesn't render children, it disposes them, so no further request escapes. But a
+vendor's script that already ran before the switch flipped has already set its
+own globals, attached its own listeners and written its own storage, and none
+of that unwinds just because the DOM node is gone. Under the opt-out defaults
+this is the common case, not an edge one: the banner appears only after the
+gated embeds have already loaded, so "Reject all" is nearly always clicked with
+a third-party context already live.
+
+`saveConsent` (`store.ts`) reloads the page — `location.reload()`, via an
+injectable module-level `reloadPage` reference so tests can substitute a spy —
+whenever a category holding at least one `enforcement: "gated"` vendor moves
+from granted to revoked in that save. Two conditions gate it, both load-bearing:
+
+1. **Granted → revoked only.** Not revoked → granted, not a no-op save, not a
+   first-time grant — none of those leave anything to tear down.
+2. **The cookie write must have actually succeeded**, checked with a read-back
+   of `document.cookie` (`writeConsentToDocumentAndVerify` in `cookie.ts`)
+   rather than trusting that the write call merely returned — it swallows
+   failures by design (see "Storage" above). Reloading on an unpersisted
+   refusal would discard the very refusal the reload exists to enforce: the
+   guest would watch the page reload believing they'd just refused, and land
+   back on the opt-out defaults with no record of having tried.
+
+The preferences dialog states this plainly rather than leaving it implicit — a
+silent reload the guest didn't expect is its own kind of surprising.
 
 ### Two versions, two jobs
 

--- a/wiki/architecture/cire-consent.md
+++ b/wiki/architecture/cire-consent.md
@@ -207,18 +207,27 @@ doesn't render children, it disposes them, so no further request escapes. But a
 vendor's script that already ran before the switch flipped has already set its
 own globals, attached its own listeners and written its own storage, and none
 of that unwinds just because the DOM node is gone. Under the opt-out defaults
-this is the common case, not an edge one: the banner appears only after the
-gated embeds have already loaded, so "Reject all" is nearly always clicked with
-a third-party context already live.
+this is not an edge case: where a gated embed HAS loaded, the banner appeared
+after it, so "Reject all" is clicked with a third-party context already live.
 
 `saveConsent` (`store.ts`) reloads the page — `location.reload()`, via an
-injectable module-level `reloadPage` reference so tests can substitute a spy —
-whenever a category holding at least one `enforcement: "gated"` vendor moves
-from granted to revoked in that save. Two conditions gate it, both load-bearing:
+injectable module-level `reloadPage` reference so tests can substitute a spy.
+Three conditions gate it, all load-bearing:
 
 1. **Granted → revoked only.** Not revoked → granted, not a no-op save, not a
    first-time grant — none of those leave anything to tear down.
-2. **The cookie write must have actually succeeded**, checked with a read-back
+2. **The category's gated content must actually have rendered this visit**,
+   tracked by `noteGatedContentLoaded`, which `ConsentGate` calls when it
+   renders children for a `"gated"` vendor — never for the placeholder, which
+   runs no third-party code. Both gated vendors (the Pinterest board, the
+   Google Maps preview) mount only inside a click-opened event details sheet,
+   while the banner appears immediately, so a guest who lands and presses
+   "Reject all" has usually opened neither. Reloading them would spend a full
+   document load, every island's hydration and a re-fetch of the invite to
+   clear nothing at all. The tracking is a plain module-level `Set`, not a
+   signal — nothing renders from it, and it resets on reload, which is exactly
+   right, since a reload is what clears the thing it tracks.
+3. **The cookie write must have actually succeeded**, checked with a read-back
    of `document.cookie` (`writeConsentToDocumentAndVerify` in `cookie.ts`)
    rather than trusting that the write call merely returned — it swallows
    failures by design (see "Storage" above). Reloading on an unpersisted
@@ -227,7 +236,8 @@ from granted to revoked in that save. Two conditions gate it, both load-bearing:
    back on the opt-out defaults with no record of having tried.
 
 The preferences dialog states this plainly rather than leaving it implicit — a
-silent reload the guest didn't expect is its own kind of surprising.
+silent reload the guest didn't expect is its own kind of surprising — and
+hedges it on "if", because condition 2 means it does not always happen.
 
 ### Two versions, two jobs
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -7,7 +7,7 @@ related:
   - "[[deferred-decisions]]"
   - "[[monorepo-structure]]"
   - "[[compliance/index]]"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-08-31
 ---
 
 # OSN Wiki
@@ -32,7 +32,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[cire-platform-plan]] — cire's build plan from digital invite to wedding-management platform
 - [[cire-invite-builder]] — organiser-editable invite images + copy (slots, storage, API, guest rendering)
 - [[cire-guest-event-editor]] — the interactive events + guests editor alongside the CSV schema
-- [[cire-consent]] — cire's site-wide cookie/third-party consent: categories, vendor registry, the `cire_consent` record
+- [[cire-consent]] — cire's site-wide cookie/third-party consent: categories, vendor registry, the `__Host-cire_consent` record
 - [[cire-host-portal-layout]] — how the organiser portal decides widths: `page-frame`, `auto-grid`, named container queries
 
 ## Systems


### PR DESCRIPTION
## Summary

Two consent findings, and both turned out to be bigger than they read.

`cire_consent` had no `__Host-` prefix, so a script on a sibling
`*.cireweddings.com` origin could set a `Domain=.cireweddings.com` cookie of the
same name; which of two same-named cookies a browser returns first is
unspecified, so a guest's stored **refusal** could be silently flipped back to
allowed. The cookie now takes the prefix on https, falls back to the bare name
on http dev, and — after review — actively migrates guests off the bare name
instead of merely out-ranking it.

Withdrawing consent unmounted the embed but left third-party code that had
already run alive for the rest of the visit. A revoke now reloads the page, but
only when there is genuinely something to tear down.

## Workspaces affected

`cire/invites`. `.changeset/cire-consent-cookie-prefix-and-reload.md` names
`@cire/invites` as `patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#163 | `CON-S-L1` |
| xchromo/osn-tracker#162 | `CON-S-M1` |

Closes xchromo/osn-tracker#163.
Closes xchromo/osn-tracker#162.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#587 | `P-I1` |

## Decisions

### The bare cookie is removed, not out-ranked — `S-M1`

- **Issue** — the first version wrote `__Host-cire_consent` on https, read both
  names and preferred the prefixed one. The security review showed that does not
  reach the guests who need it.
- **Why** — preferring the prefixed name only defends once the prefixed cookie
  exists, and for an already-decided guest it never would. `saveConsent` runs
  only when someone touches the consent UI, and a decided guest is exactly the
  one the banner never shows again: their choice reads back fine through the
  bare-name fallback, so `needsConsentDecision()` stays false and nothing writes.
  Their refusal would have sat shadowable for the cookie's full 182 days — most
  of the exposure the finding was about. It was never a short migration window;
  it was bounded by guest behaviour, not by time since deploy.
- **Solution** — two writes. A secure write expires the bare name as a side
  effect of saving, and `hydrateConsent` calls `migrateBareConsentCookie` on the
  way in: on a secure origin a bare-name record is rewritten under the prefixed
  name and the bare one expired. The guest moves on their next visit and sees
  nothing.
- **Rationale** — the migration has to run on the **read** path, because the
  write path is the one that never runs again for these guests. Neither write
  touches a `Domain` cookie set by another origin: a page cannot delete one, and
  should not try — the read precedence is what defends there. On http dev there
  is nothing to migrate, since `__Host-` needs `Secure`.

### The reload only fires when gated content actually ran — `P-W1`

- **Issue** — the first version decided from the vendor registry alone: does
  this category hold a gated vendor. It never asked whether one had mounted.
- **Why** — on the common path none has. Both gated vendors mount only inside a
  click-opened event details sheet, while the banner appears immediately, so a
  guest who lands and presses "Reject all" has usually opened neither. That
  spent a full document load, every island's hydration and a re-fetch of the
  invite to clear nothing at all — on the most common interaction on the invite.
- **Solution** — `ConsentGate` records the category when it renders children for
  a gated vendor, never for the placeholder, which runs nothing. The save
  reloads only if that category actually loaded.
- **Rationale** — a plain module-level `Set`, not a signal: nothing renders from
  it, and a signal would invalidate the store's subscribers on every gate mount
  for no benefit. It resets on reload, which is right, because a reload is what
  clears the thing it tracks.

### "The write succeeded" means a read-back, not a returned call — `CON-S-M1`

- **Issue** — the reload must not fire on a refusal that did not persist.
- **Why** — the guest would watch the page reload believing they had refused,
  and land back on the opt-out defaults with no record of having tried. That is
  worse than the bug being fixed.
- **Solution** — `writeConsentToDocumentAndVerify` writes, reads
  `document.cookie` back, and compares by re-encoding both sides.
- **Rationale** — `writeConsentToDocument` returns `void` and swallows a blocked
  write by design, so "the call returned" is not a success signal. Re-encoding
  rather than string-matching the raw value means the comparison does not care
  which of the two cookie names landed.

**Out of scope**

- The reload is decided per category, but only Pinterest leaves a main-realm
  footprint — the Maps `<iframe>` is fully torn down by the unmount
  `ConsentGate` already does. Narrowing it per vendor needs a new flag on the
  vendor registry — xchromo/osn-tracker#587.
- `clearLegacyPinterestConsent` still runs on every page load. It has a real
  time trigger rather than being accepted, so its issue stays open.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37 tasks |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1432 files |
| `bun run test` | ✅ 1695 pass repo-wide; `@cire/invites` 999 pass, 0 fail |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run test:scripts` | ✅ |
| `bun run check:jest-dom-markers` | ✅ |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |

The migration is tested against a controlled cookie jar on a stubbed https
origin, because jsdom serves the suite over http and refuses a `Secure` cookie
outright — without that, the `__Host-` half of every path is unreachable in a
test. Covered: a bare-name guest is moved and the bare name is gone, the decision
itself survives, a guest already on the prefixed name is left alone, a planted
bare cookie beside a prefixed one does not win, an unparseable bare value is left
as found, and a secure save clears a stale bare cookie.

Not covered by any gate, and worth one pass on the preview before merge: the
reload is exercised through an injected seam rather than a real
`location.reload()`, so nobody has watched the actual sequence — open an event's
details sheet so an embed mounts, reject, and confirm the page reloads once,
the refusal survives it, and the embed does not come back.
