### PR TITLE
perf(cire-api): fold the entitlement probe into the role gate's own query

### DIFF
--- a/.changeset/cire-entitlement-reads.md
+++ b/.changeset/cire-entitlement-reads.md
@@ -1,0 +1,29 @@
+---
+"@cire/api": patch
+---
+
+Cut D1 round trips on cire's entitlement paths (osn-tracker#116, #117, #119, #120).
+
+- **Gated organiser routes** (`vendor-directory.ts`, `vendors.ts`, `registry.ts`):
+  `weddingMember(db, key)` / `weddingEditor(db, key)` now fold the entitlement
+  presence check into their own `authorize()` query (an `EXISTS` column, same
+  idiom as `directory.ts`'s `inWedding`) instead of `weddingEntitlement`
+  running a separate one after — a co-host drops from 3 selects to 2, an owner
+  from 2 to 1. Every route that mounts a role gate WITHOUT an entitlement gate
+  is unaffected: the key is optional and only the three gated route files pass
+  one.
+- **CSV/editor import** (`services/import.ts`): `diffAgainstDb`'s capacity
+  preview warning skips its entitlement query entirely once
+  `existingGuests + guestCreates` can't possibly clear the 100-guest floor, and
+  when it does run, `applyImport` reuses the derived cap (threaded through
+  `ImportPlan.derivedCap`) instead of re-deriving it from a second query in the
+  same request. Absent a cap on the plan, `applyImport` still enforces via its
+  own query — never a way to skip the check.
+- **Capacity queries narrowed**: `assertGuestCapacity` and the preview warning
+  above now read `WHERE entitlement IN ('capacity_500', 'capacity_1000')`
+  instead of every entitlement row on the wedding. `setsForWeddings` (feature
+  display + `organiser-weddings.ts`'s cap derivation) is untouched.
+
+No route contract changes; query-count claims proven by new tests
+(`wedding-entitlement-fold.test.ts`, `import-capacity-query-count.test.ts`)
+that count `db.select()` calls via a new `countingDb` test helper.

--- a/cire/api/src/middleware/upstream-context.ts
+++ b/cire/api/src/middleware/upstream-context.ts
@@ -31,3 +31,32 @@ export function hasWeddingGateError(ctx: unknown): boolean {
   if (typeof ctx !== "object" || ctx === null || !("weddingGateError" in ctx)) return false;
   return Boolean(ctx.weddingGateError);
 }
+
+/**
+ * The entitlement presence check a role gate (weddingMember/weddingEditor)
+ * already folded into its OWN authorize() query, when it was called with an
+ * `entitlementKey` (P-W1). `weddingEntitlement(db, key)` reads this instead of
+ * running its own query — but only trusts it when the fold's `key` matches
+ * ITS key; a mismatch (or absence, e.g. the role gate ran with no key, or this
+ * gate is mounted standalone in a test) returns `undefined` so the caller
+ * falls back to its own query rather than trust a wrong answer.
+ */
+export function readWeddingEntitlementFold(
+  ctx: unknown,
+): { key: string; entitled: boolean } | undefined {
+  if (typeof ctx !== "object" || ctx === null || !("weddingEntitlementFold" in ctx)) {
+    return undefined;
+  }
+  const fold = (ctx as { weddingEntitlementFold: unknown }).weddingEntitlementFold;
+  if (
+    typeof fold !== "object" ||
+    fold === null ||
+    !("key" in fold) ||
+    !("entitled" in fold) ||
+    typeof fold.key !== "string" ||
+    typeof fold.entitled !== "boolean"
+  ) {
+    return undefined;
+  }
+  return { key: fold.key, entitled: fold.entitled };
+}

--- a/cire/api/src/middleware/wedding-editor.ts
+++ b/cire/api/src/middleware/wedding-editor.ts
@@ -4,9 +4,10 @@ import { Elysia } from "elysia";
 import { DbService } from "../db";
 import type { Db } from "../db";
 import { runCire } from "../observability";
+import type { EntitlementKey } from "../services/entitlements";
 import { hostsService } from "../services/hosts";
 import { readOsnProfileId } from "./upstream-context";
-import type { WeddingRole } from "./wedding-member";
+import type { WeddingEntitlementFold, WeddingRole } from "./wedding-member";
 
 interface GateError {
   status: number;
@@ -18,10 +19,16 @@ const fail = (status: number, error: string) => ({
   weddingIsOwner: false,
   weddingRole: undefined as WeddingRole | undefined,
   weddingOwnerOsnProfileId: undefined as string | undefined,
+  weddingEntitlementFold: undefined as WeddingEntitlementFold | undefined,
   weddingGateError: { status, body: { error } } as GateError | undefined,
 });
 
-const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) => ({
+const pass = (
+  weddingId: string,
+  role: WeddingRole,
+  ownerOsnProfileId: string,
+  entitlementFold: WeddingEntitlementFold | undefined,
+) => ({
   weddingId: weddingId as string | undefined,
   weddingIsOwner: role === "owner",
   weddingRole: role as WeddingRole | undefined,
@@ -31,6 +38,7 @@ const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) =
   // owner as a host, and under `weddingOwner()` that check could lean on the
   // caller's own id. `authorize()` already reads the column, so it is free.
   weddingOwnerOsnProfileId: ownerOsnProfileId as string | undefined,
+  weddingEntitlementFold: entitlementFold,
   weddingGateError: undefined as GateError | undefined,
 });
 
@@ -50,8 +58,16 @@ const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) =
  * Mirrors `weddingMember()`'s lifecycle: the derive runs before osnAuth's
  * onBeforeHandle fires, so it tolerates an unauthenticated request (records the
  * gate failure; osnAuth's 401 wins).
+ *
+ * `entitlementKey`, when given, folds a presence check for that entitlement
+ * into this gate's own authorize() query (P-W1) and exposes the answer as
+ * `weddingEntitlementFold` for a downstream `weddingEntitlement(db, key)` to
+ * pick up — same total query count as today, not a new one. Routes that never
+ * mount an entitlement gate must NOT pass this: an unconditional fold here
+ * would add the entitlement check's cost to every route, gated or not, which
+ * is the regression this parameter exists to avoid, not introduce.
  */
-export function weddingEditor(db: Db) {
+export function weddingEditor(db: Db, entitlementKey?: EntitlementKey) {
   return new Elysia()
     .derive({ as: "scoped" }, async (ctx) => {
       const { params } = ctx;
@@ -62,13 +78,22 @@ export function weddingEditor(db: Db) {
       if (!osnProfileId) return fail(401, "unauthorised");
 
       const result = await runCire(
-        hostsService.authorize(weddingId, osnProfileId).pipe(Effect.provideService(DbService, db)),
+        hostsService
+          .authorize(weddingId, osnProfileId, entitlementKey)
+          .pipe(Effect.provideService(DbService, db)),
       );
 
       if (!result) return fail(404, "wedding_not_found");
       if (!result.role) return fail(403, "forbidden");
       if (result.role === "viewer") return fail(403, "read_only_role");
-      return pass(weddingId, result.role, result.ownerOsnProfileId);
+      return pass(
+        weddingId,
+        result.role,
+        result.ownerOsnProfileId,
+        entitlementKey && result.entitled !== undefined
+          ? { key: entitlementKey, entitled: result.entitled }
+          : undefined,
+      );
     })
     .onBeforeHandle({ as: "scoped" }, ({ weddingGateError, set }) => {
       if (weddingGateError) {

--- a/cire/api/src/middleware/wedding-entitlement-fold.test.ts
+++ b/cire/api/src/middleware/wedding-entitlement-fold.test.ts
@@ -93,6 +93,34 @@ function ungatedApp(db: Db, profileId: string) {
     .group("/w/:weddingId", (g) => g.use(weddingMember(db)).get("/thing", () => ({ ok: true })));
 }
 
+/**
+ * A route whose role gate folds ONE key while the entitlement gate asks for
+ * ANOTHER. Nothing in the tree does this today — every pairing in `routes/`
+ * matches — but the mismatch guard is what makes the fold safe to extend, so
+ * it is worth a test rather than a comment. If the guard ever stops working,
+ * the fold answers "registry" with the "vendors" row and the gate lets a
+ * caller past an entitlement they do not hold.
+ */
+function mismatchedApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId }))
+    .group("/w/:weddingId", (g) =>
+      g
+        .use(weddingMember(db, "vendors"))
+        .use(weddingEntitlement(db, "registry"))
+        .get("/thing", () => ({ ok: true })),
+    );
+}
+
+/** The entitlement gate with no role gate above it at all. */
+function standaloneApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId, weddingId: WEDDING_ID }))
+    .group("/w/:weddingId", (g) =>
+      g.use(weddingEntitlement(db, "vendors")).get("/thing", () => ({ ok: true })),
+    );
+}
+
 function ungatedEditorApp(db: Db, profileId: string) {
   return new Elysia({ aot: false })
     .derive(() => ({ osnProfileId: profileId }))
@@ -178,5 +206,28 @@ describe("P-W1: role-gate/entitlement-gate query fold", () => {
     );
     expect(resOwner.status).toBe(200);
     expect(countOwner()).toBe(1);
+  });
+
+  // The mismatch guard. A fold carries the key it answers; a gate asking a
+  // DIFFERENT key must ignore it and pay for its own query rather than trust
+  // an answer to a question it did not ask.
+  it("refuses a fold for a different key, and falls back to its own query", async () => {
+    // "vendors" granted, "registry" NOT — so trusting the mismatched fold
+    // would wrongly let the caller through.
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(mismatchedApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(402);
+    expect(await jsonBody(res)).toEqual({ error: "payment_required", entitlement: "registry" });
+    // 2 for the role gate, plus the fallback has() the mismatch forced.
+    expect(selectCount()).toBe(3);
+  });
+
+  it("answers correctly with no role gate above it, at the old cost", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(standaloneApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(200);
+    expect(selectCount()).toBe(1);
   });
 });

--- a/cire/api/src/middleware/wedding-entitlement-fold.test.ts
+++ b/cire/api/src/middleware/wedding-entitlement-fold.test.ts
@@ -25,7 +25,9 @@ const WEDDING_ID = "wed_fold";
 const OWNER = "usr_owner";
 const COHOST = "usr_cohost";
 
-function buildDb(opts: { grantVendors: boolean }): Db {
+// No explicit `Db` return type: these tests reach for `$client.exec` to break
+// one table on purpose, and `Db` does not surface the underlying client.
+function buildDb(opts: { grantVendors: boolean }) {
   const db = createDb(":memory:");
   const now = new Date();
   db.insert(weddings)
@@ -229,5 +231,31 @@ describe("P-W1: role-gate/entitlement-gate query fold", () => {
     const res = await appRequest(standaloneApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
     expect(res.status).toBe(200);
     expect(selectCount()).toBe(1);
+  });
+
+  // S-L1 (found reviewing this branch): folding the entitlement probe into the
+  // role query folded their failure modes together too. A defect confined to
+  // `wedding_entitlements` used to deny only the entitlement half — a scoped
+  // 402 — while the role check, a separate query, still answered. In one
+  // SELECT it would take the whole route down with a generic 500. The fold now
+  // catches its own defect and falls back to the plain role query, which
+  // restores the old contract.
+  it("degrades to a scoped 402, not a 500, when the entitlement table is broken", async () => {
+    const db = buildDb({ grantVendors: true });
+    // Break ONLY the entitlement side. The role tables are untouched, so the
+    // plain fallback can still answer who the caller is.
+    db.$client.exec("DROP TABLE wedding_entitlements");
+    const res = await appRequest(gatedApp(db, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(402);
+    expect(await jsonBody(res)).toEqual({ error: "payment_required", entitlement: "vendors" });
+  });
+
+  it("still answers the owner's role through the fallback when the fold breaks", async () => {
+    const db = buildDb({ grantVendors: true });
+    db.$client.exec("DROP TABLE wedding_entitlements");
+    const res = await appRequest(ungatedApp(db, OWNER), `/w/${WEDDING_ID}/thing`);
+    // No entitlement gate on this route at all, so a broken entitlement table
+    // must not touch it — the role gate passes no key and never folds.
+    expect(res.status).toBe(200);
   });
 });

--- a/cire/api/src/middleware/wedding-entitlement-fold.test.ts
+++ b/cire/api/src/middleware/wedding-entitlement-fold.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "bun:test";
+
+import { weddingEntitlements, weddingHosts, weddings } from "@cire/db";
+import { Elysia } from "elysia";
+
+import type { Db } from "../db";
+import { createDb } from "../db/setup";
+import { countingDb, appRequest, jsonBody } from "../test-helpers";
+import { weddingEditor } from "./wedding-editor";
+import { weddingEntitlement } from "./wedding-entitlement";
+import { weddingMember } from "./wedding-member";
+
+/**
+ * Proves P-W1 (osn-tracker#116): folding the entitlement check into the role
+ * gate's own authorize() query must (a) drop a GATED route's query count —
+ * previously the role gate's own 1-2 queries PLUS a separate
+ * `entitlementService.has()` query — and (b) leave every route that mounts
+ * ONLY a role gate, no entitlement gate, at EXACTLY the query count it always
+ * had. (b) is the one a naive "always fetch the set in the role gate" fix
+ * would silently break, which is why it gets its own assertions here rather
+ * than trusting (a) to cover it.
+ */
+
+const WEDDING_ID = "wed_fold";
+const OWNER = "usr_owner";
+const COHOST = "usr_cohost";
+
+function buildDb(opts: { grantVendors: boolean }): Db {
+  const db = createDb(":memory:");
+  const now = new Date();
+  db.insert(weddings)
+    .values({
+      id: WEDDING_ID,
+      slug: "fold-wedding",
+      displayName: "Fold Wedding",
+      ownerOsnProfileId: OWNER,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(weddingHosts)
+    .values({
+      id: "whost_cohost",
+      weddingId: WEDDING_ID,
+      osnProfileId: COHOST,
+      addedByOsnProfileId: OWNER,
+      role: "editor",
+      createdAt: now,
+    })
+    .run();
+  if (opts.grantVendors) {
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+  }
+  return db;
+}
+
+function gatedApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId }))
+    .group("/w/:weddingId", (g) =>
+      g
+        .use(weddingMember(db, "vendors"))
+        .use(weddingEntitlement(db, "vendors"))
+        .get("/thing", () => ({ ok: true })),
+    );
+}
+
+function gatedEditorApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId }))
+    .group("/w/:weddingId", (g) =>
+      g
+        .use(weddingEditor(db, "vendors"))
+        .use(weddingEntitlement(db, "vendors"))
+        .post("/thing", () => ({ ok: true })),
+    );
+}
+
+/** Mirrors a route file that mounts ONLY the role gate — tasks.ts, budget.ts,
+ *  invite.ts, organiser-hosts.ts, and the rest of the ~dozen route files
+ *  weddingEntitlement never touches. */
+function ungatedApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId }))
+    .group("/w/:weddingId", (g) => g.use(weddingMember(db)).get("/thing", () => ({ ok: true })));
+}
+
+function ungatedEditorApp(db: Db, profileId: string) {
+  return new Elysia({ aot: false })
+    .derive(() => ({ osnProfileId: profileId }))
+    .group("/w/:weddingId", (g) => g.use(weddingEditor(db)).post("/thing", () => ({ ok: true })));
+}
+
+describe("P-W1: role-gate/entitlement-gate query fold", () => {
+  it("a co-host on a GATED route costs 2 selects, not 3", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(gatedApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(200);
+    expect(await jsonBody(res)).toEqual({ ok: true });
+    expect(selectCount()).toBe(2);
+  });
+
+  it("an owner on a GATED route costs 1 select, not 2", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(gatedApp(counted, OWNER), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(200);
+    expect(selectCount()).toBe(1);
+  });
+
+  it("the fold still answers correctly when the entitlement is ABSENT (402), at the same reduced cost", async () => {
+    const db = buildDb({ grantVendors: false });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(gatedApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(402);
+    expect(await jsonBody(res)).toEqual({ error: "payment_required", entitlement: "vendors" });
+    expect(selectCount()).toBe(2);
+  });
+
+  it("weddingEditor's fold matches weddingMember's — 2 selects for a co-host, granted", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(gatedEditorApp(counted, COHOST), `/w/${WEDDING_ID}/thing`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(selectCount()).toBe(2);
+  });
+
+  it("a co-host on a route with ONLY the role gate (no entitlement gate) still costs 2 selects — UNCHANGED", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(ungatedApp(counted, COHOST), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(200);
+    // Same 2 selects authorize() has always cost a co-host (owner-row lookup +
+    // host-row lookup). A regression here means the role gate started paying
+    // for the entitlement fold even though nothing downstream asked for it —
+    // exactly the repo-wide regression this task exists to avoid.
+    expect(selectCount()).toBe(2);
+  });
+
+  it("an owner on a route with ONLY the role gate still costs 1 select — UNCHANGED", async () => {
+    const db = buildDb({ grantVendors: true });
+    const { db: counted, selectCount } = countingDb(db);
+    const res = await appRequest(ungatedApp(counted, OWNER), `/w/${WEDDING_ID}/thing`);
+    expect(res.status).toBe(200);
+    expect(selectCount()).toBe(1);
+  });
+
+  it("weddingEditor with no entitlement key: co-host still 2 selects, owner still 1 — UNCHANGED", async () => {
+    const dbCohost = buildDb({ grantVendors: true });
+    const { db: countedCohost, selectCount: countCohost } = countingDb(dbCohost);
+    const resCohost = await appRequest(
+      ungatedEditorApp(countedCohost, COHOST),
+      `/w/${WEDDING_ID}/thing`,
+      { method: "POST" },
+    );
+    expect(resCohost.status).toBe(200);
+    expect(countCohost()).toBe(2);
+
+    const dbOwner = buildDb({ grantVendors: true });
+    const { db: countedOwner, selectCount: countOwner } = countingDb(dbOwner);
+    const resOwner = await appRequest(
+      ungatedEditorApp(countedOwner, OWNER),
+      `/w/${WEDDING_ID}/thing`,
+      {
+        method: "POST",
+      },
+    );
+    expect(resOwner.status).toBe(200);
+    expect(countOwner()).toBe(1);
+  });
+});

--- a/cire/api/src/middleware/wedding-entitlement.ts
+++ b/cire/api/src/middleware/wedding-entitlement.ts
@@ -6,7 +6,7 @@ import type { Db } from "../db";
 import { runCire } from "../observability";
 import { entitlementService } from "../services/entitlements";
 import type { EntitlementKey } from "../services/entitlements";
-import { hasWeddingGateError } from "./upstream-context";
+import { hasWeddingGateError, readWeddingEntitlementFold } from "./upstream-context";
 
 interface EntitlementGateError {
   status: number;
@@ -31,6 +31,16 @@ interface EntitlementGateError {
  * Skipping it keeps the status ordering the routes are tested against (401, then
  * 403 `read_only_role`, then 402 `payment_required`) and denies an anonymous
  * caller a free D1 read on every request.
+ *
+ * P-W1: every mount site sits directly behind `weddingMember()`/`weddingEditor()`
+ * (see those files), which — called with this SAME `key` — already folded the
+ * entitlement presence check into its own authorize() query, no extra round
+ * trip. This derive picks that answer up via `readWeddingEntitlementFold`
+ * rather than running `entitlementService.has()` itself, so a gated route no
+ * longer pays for a THIRD query on top of the role gate's own. The `has()` call
+ * survives as a fallback for the (currently only-in-tests) case of this gate
+ * mounted standalone with no preceding role gate, or one that ran without a
+ * key — it must still answer correctly there, just at the old cost.
  */
 export function weddingEntitlement(db: Db, key: EntitlementKey) {
   return new Elysia()
@@ -48,17 +58,21 @@ export function weddingEntitlement(db: Db, key: EntitlementKey) {
           } as EntitlementGateError | undefined,
         };
       }
-      const entitled = await runCire(
-        entitlementService.has(weddingId, key).pipe(
-          Effect.provideService(DbService, db),
-          Effect.catchAllDefect(() =>
-            Effect.logWarning("cire.entitlement.gate check failed — failing closed").pipe(
-              Effect.annotateLogs({ weddingId, entitlement: key }),
-              Effect.as(false),
-            ),
-          ),
-        ),
-      );
+      const fold = readWeddingEntitlementFold(ctx);
+      const entitled =
+        fold && fold.key === key
+          ? fold.entitled
+          : await runCire(
+              entitlementService.has(weddingId, key).pipe(
+                Effect.provideService(DbService, db),
+                Effect.catchAllDefect(() =>
+                  Effect.logWarning("cire.entitlement.gate check failed — failing closed").pipe(
+                    Effect.annotateLogs({ weddingId, entitlement: key }),
+                    Effect.as(false),
+                  ),
+                ),
+              ),
+            );
       return {
         entitlementGateError: entitled
           ? (undefined as EntitlementGateError | undefined)

--- a/cire/api/src/middleware/wedding-member.ts
+++ b/cire/api/src/middleware/wedding-member.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 import { DbService } from "../db";
 import type { Db } from "../db";
 import { runCire } from "../observability";
+import type { EntitlementKey } from "../services/entitlements";
 import { hostsService } from "../services/hosts";
 import type { HostRole } from "../services/hosts";
 import { readOsnProfileId } from "./upstream-context";
@@ -16,15 +17,30 @@ interface GateError {
 /** The caller's effective role on the wedding, derived by the member gate. */
 export type WeddingRole = "owner" | HostRole;
 
+/**
+ * The result of folding an entitlement presence check into THIS gate's own
+ * authorize() query (P-W1) — carries the key it answers so a downstream
+ * `weddingEntitlement(db, key)` can tell a fold for its OWN key apart from a
+ * fold for a different one and fall back to its own query rather than trust a
+ * mismatched answer.
+ */
+export type WeddingEntitlementFold = { key: EntitlementKey; entitled: boolean };
+
 const fail = (status: number, error: string) => ({
   weddingId: undefined as string | undefined,
   weddingIsOwner: false,
   weddingRole: undefined as WeddingRole | undefined,
   weddingOwnerOsnProfileId: undefined as string | undefined,
+  weddingEntitlementFold: undefined as WeddingEntitlementFold | undefined,
   weddingGateError: { status, body: { error } } as GateError | undefined,
 });
 
-const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) => ({
+const pass = (
+  weddingId: string,
+  role: WeddingRole,
+  ownerOsnProfileId: string,
+  entitlementFold: WeddingEntitlementFold | undefined,
+) => ({
   weddingId: weddingId as string | undefined,
   weddingIsOwner: role === "owner",
   weddingRole: role as WeddingRole | undefined,
@@ -32,6 +48,7 @@ const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) =
   // the write gates) is the one place the co-host list has to name the owner
   // to show them alongside the hosts they don't stand among.
   weddingOwnerOsnProfileId: ownerOsnProfileId as string | undefined,
+  weddingEntitlementFold: entitlementFold,
   weddingGateError: undefined as GateError | undefined,
 });
 
@@ -48,8 +65,16 @@ const pass = (weddingId: string, role: WeddingRole, ownerOsnProfileId: string) =
  * Mirrors `weddingOwner()`'s lifecycle: the derive runs before osnAuth's
  * onBeforeHandle fires, so it tolerates an unauthenticated request (records the
  * gate failure; osnAuth's 401 wins).
+ *
+ * `entitlementKey`, when given, folds a presence check for that entitlement
+ * into this gate's own authorize() query (P-W1) and exposes the answer as
+ * `weddingEntitlementFold` for a downstream `weddingEntitlement(db, key)` to
+ * pick up — same total query count as today, not a new one. Routes that never
+ * mount an entitlement gate must NOT pass this: an unconditional fold here
+ * would add the entitlement check's cost to every route, gated or not, which
+ * is the regression this parameter exists to avoid, not introduce.
  */
-export function weddingMember(db: Db) {
+export function weddingMember(db: Db, entitlementKey?: EntitlementKey) {
   return new Elysia()
     .derive({ as: "scoped" }, async (ctx) => {
       const { params } = ctx;
@@ -60,12 +85,21 @@ export function weddingMember(db: Db) {
       if (!osnProfileId) return fail(401, "unauthorised");
 
       const result = await runCire(
-        hostsService.authorize(weddingId, osnProfileId).pipe(Effect.provideService(DbService, db)),
+        hostsService
+          .authorize(weddingId, osnProfileId, entitlementKey)
+          .pipe(Effect.provideService(DbService, db)),
       );
 
       if (!result) return fail(404, "wedding_not_found");
       if (!result.role) return fail(403, "forbidden");
-      return pass(weddingId, result.role, result.ownerOsnProfileId);
+      return pass(
+        weddingId,
+        result.role,
+        result.ownerOsnProfileId,
+        entitlementKey && result.entitled !== undefined
+          ? { key: entitlementKey, entitled: result.entitled }
+          : undefined,
+      );
     })
     .onBeforeHandle({ as: "scoped" }, ({ weddingGateError, set }) => {
       if (weddingGateError) {

--- a/cire/api/src/routes/registry.ts
+++ b/cire/api/src/routes/registry.ts
@@ -158,7 +158,7 @@ export const createRegistryReadRoutes = (db: Db, osnAuthOptions: OsnAuthOptions)
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingMember(db))
+        .use(weddingMember(db, "registry"))
         .use(weddingEntitlement(db, "registry"))
         .get("/registry", async ({ weddingId, query, set }) => {
           if (!weddingId) return internalSync(set);
@@ -216,7 +216,7 @@ export const createRegistryWriteRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingEditor(db))
+        .use(weddingEditor(db, "registry"))
         .use(weddingEntitlement(db, "registry"))
         .put(
           "/registry/settings",
@@ -430,7 +430,7 @@ export const createRegistryLinkPreviewRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingEditor(db))
+        .use(weddingEditor(db, "registry"))
         .use(weddingEntitlement(db, "registry"))
         .use(rateLimitMiddlewareByUser(deps.limiter))
         .post(
@@ -549,7 +549,7 @@ export const createRegistryImageRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingEditor(db))
+        .use(weddingEditor(db, "registry"))
         .use(weddingEntitlement(db, "registry"))
         .use(rateLimitMiddlewareByUser(deps.limiter))
         .post(
@@ -691,7 +691,7 @@ export const createRegistryImageServeRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingMember(db))
+        .use(weddingMember(db, "registry"))
         .use(weddingEntitlement(db, "registry"))
         .get("/registry/image/:name", ({ weddingId, params, query, request, set }) => {
           if (!weddingId) return internalSync(set);

--- a/cire/api/src/routes/vendor-directory.ts
+++ b/cire/api/src/routes/vendor-directory.ts
@@ -69,7 +69,7 @@ export const createVendorDirectoryReadRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingMember(db))
+        .use(weddingMember(db, "vendors"))
         .use(weddingEntitlement(db, "vendors"))
         .use(rateLimitMiddlewareByUser(limiter))
         .get("/directory", async ({ weddingId, query, set }) => {
@@ -106,7 +106,7 @@ export const createVendorDirectoryWriteRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingEditor(db))
+        .use(weddingEditor(db, "vendors"))
         .use(weddingEntitlement(db, "vendors"))
         .use(rateLimitMiddlewareByUser(limiter))
         .post(

--- a/cire/api/src/routes/vendors.ts
+++ b/cire/api/src/routes/vendors.ts
@@ -65,7 +65,7 @@ export const createVendorReadRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingMember(db))
+        .use(weddingMember(db, "vendors"))
         .use(weddingEntitlement(db, "vendors"))
         .get("/vendors", async ({ weddingId, set }) => {
           if (!weddingId) return internalSync(set);
@@ -109,7 +109,7 @@ export const createVendorWriteRoutes = (
     .use(osnAuth(osnAuthOptions))
     .group("/weddings/:weddingId", (group) =>
       group
-        .use(weddingEditor(db))
+        .use(weddingEditor(db, "vendors"))
         .use(weddingEntitlement(db, "vendors"))
         .post(
           "/vendors",

--- a/cire/api/src/schemas/import.ts
+++ b/cire/api/src/schemas/import.ts
@@ -207,6 +207,16 @@ export const ImportPlan = Schema.Struct({
   eventLinkCreates: Schema.Array(EventLink),
   eventLinkRemoves: Schema.Array(EventLink),
   warnings: Schema.Array(Schema.String),
+  /**
+   * The wedding's guest-capacity ceiling, when `diffAgainstDb`'s preview
+   * warning already derived it from the entitlement set (P-W2) — lets
+   * `applyImport` enforce the cap without re-scanning the same rows in the
+   * SAME request. Absent whenever the preview never needed the real cap
+   * (P-I2's pre-check proved the import couldn't breach it, or `guestCreates`
+   * was empty); `applyImport` MUST keep enforcing the cap itself in that case,
+   * never treat absence as "no cap".
+   */
+  derivedCap: Schema.optional(Schema.Number),
 });
 export type ImportPlan = Schema.Schema.Type<typeof ImportPlan>;
 

--- a/cire/api/src/services/entitlements.test.ts
+++ b/cire/api/src/services/entitlements.test.ts
@@ -101,4 +101,69 @@ describe("assertGuestCapacity", () => {
     );
     expect(Exit.isSuccess(exit)).toBe(true);
   });
+
+  // P-I3: the fallback query only reads capacity_500/capacity_1000. A wedding
+  // holding every OTHER entitlement must still land on the 100 floor.
+  it("non-capacity entitlements (vendors, ai, registry, premium_templates) never raise the cap", async () => {
+    const db = createDb();
+    const w = seedWedding(db);
+    await run(db, entitlementService.grant(w, "vendors", { source: "comp", grantedBy: "x" }));
+    await run(db, entitlementService.grant(w, "ai", { source: "comp", grantedBy: "x" }));
+    await run(db, entitlementService.grant(w, "registry", { source: "comp", grantedBy: "x" }));
+    await run(
+      db,
+      entitlementService.grant(w, "premium_templates", { source: "comp", grantedBy: "x" }),
+    );
+    const exit = await Effect.runPromiseExit(
+      entitlementService.assertGuestCapacity(w, 101).pipe(Effect.provideService(DbService, db)),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  // P-W2: precomputedCap, when given, is trusted outright — no query runs, no
+  // re-derivation from the entitlement table happens. Proven here at the
+  // service boundary; import.ts's own test proves the actual query-count
+  // saving end to end.
+  describe("precomputedCap", () => {
+    it("enforces against the given cap, ignoring what the entitlement table would derive", async () => {
+      const db = createDb();
+      const w = seedWedding(db);
+      // Wedding actually holds capacity_1000 (real cap 1000), but a caller
+      // hands assertGuestCapacity a stale/smaller precomputedCap of 50 — the
+      // function must trust it, not re-derive and override it.
+      await run(
+        db,
+        entitlementService.grant(w, "capacity_1000", { source: "comp", grantedBy: "x" }),
+      );
+      const err = await run(
+        db,
+        entitlementService.assertGuestCapacity(w, 51, 50).pipe(Effect.flip),
+      );
+      expect(err).toBeInstanceOf(CapacityExceeded);
+      expect(err.limit).toBe(50);
+    });
+
+    it("a generous precomputedCap admits guests the wedding's real entitlements would have refused", async () => {
+      const db = createDb();
+      const w = seedWedding(db);
+      // No capacity entitlement (real cap 100), but precomputedCap says 500.
+      const exit = await Effect.runPromiseExit(
+        entitlementService
+          .assertGuestCapacity(w, 400, 500)
+          .pipe(Effect.provideService(DbService, db)),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+
+    it("undefined precomputedCap falls back to the entitlement query — unchanged behaviour", async () => {
+      const db = createDb();
+      const w = seedWedding(db);
+      const exit = await Effect.runPromiseExit(
+        entitlementService
+          .assertGuestCapacity(w, 101, undefined)
+          .pipe(Effect.provideService(DbService, db)),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
 });

--- a/cire/api/src/services/entitlements.ts
+++ b/cire/api/src/services/entitlements.ts
@@ -18,17 +18,36 @@ export const ENTITLEMENT_KEYS = [
 ] as const;
 export type EntitlementKey = (typeof ENTITLEMENT_KEYS)[number];
 
+/**
+ * The only two rows that can ever raise `deriveCap`'s result above the floor.
+ * Narrows the capacity-check queries (`assertGuestCapacity`, and
+ * `diffAgainstDb`'s preview warning) to `WHERE entitlement IN (...)` instead
+ * of fetching every entitlement row on the wedding — P-I3. NOT used by
+ * `setsForWeddings`, which feeds feature display and `deriveCap` in
+ * `organiser-weddings.ts` and must keep returning the full set.
+ */
+export const CAPACITY_ENTITLEMENT_KEYS = ["capacity_500", "capacity_1000"] as const;
+
 /** Raised when a guest-adding write would breach the wedding's derived cap. */
 export class CapacityExceeded extends Data.TaggedError("CapacityExceeded")<{
   limit: number;
   current: number;
 }> {}
 
+/**
+ * Guest ceiling for a wedding holding neither capacity entitlement — the
+ * floor every wedding starts at. Named (not inlined) so `diffAgainstDb`'s
+ * pre-check (P-I2: skip the capacity query when the post-import guest count
+ * can't possibly exceed this floor) can never drift from what `deriveCap`
+ * actually falls back to.
+ */
+export const BASE_GUEST_CAP = 100;
+
 /** Effective guest ceiling from the entitlement set. Pure. */
 function deriveCap(keys: readonly string[]): number {
   if (keys.includes("capacity_1000")) return 1000;
   if (keys.includes("capacity_500")) return 500;
-  return 100;
+  return BASE_GUEST_CAP;
 }
 
 /** Count real guests on a wedding, EXCLUDING the synthetic host-preview family. */
@@ -115,20 +134,40 @@ export const entitlementService = {
     }).pipe(Effect.withSpan("cire.entitlements.grant"));
   },
 
+  /**
+   * `precomputedCap`, when given, skips this function's own entitlement query
+   * entirely and enforces against that cap instead (P-W2) — the caller
+   * (`applyImport`) already has it from `diffAgainstDb`'s preview, which ran
+   * in the SAME request, so re-fetching the same rows here would just be a
+   * second scan of data already in hand. Omitted (the common case for any
+   * caller besides `applyImport`, and `applyImport` itself whenever the plan
+   * carries no cap — see `import.ts:713-716`'s "hard atomic block" comment),
+   * this runs its own query and enforces exactly as it always has. A given
+   * cap is NEVER a way to skip the check, only to skip re-deriving it.
+   */
   assertGuestCapacity(
     weddingId: string,
     incomingNewGuests: number,
+    precomputedCap?: number,
   ): Effect.Effect<void, CapacityExceeded, DbService> {
     return Effect.gen(function* () {
       const db = yield* DbService;
-      const rows = yield* dbQuery(() =>
-        db
-          .select({ e: weddingEntitlements.entitlement })
-          .from(weddingEntitlements)
-          .where(eq(weddingEntitlements.weddingId, weddingId))
-          .all(),
-      );
-      const cap = deriveCap((rows as { e: string }[]).map((r) => r.e));
+      let cap = precomputedCap;
+      if (cap === undefined) {
+        const rows = yield* dbQuery(() =>
+          db
+            .select({ e: weddingEntitlements.entitlement })
+            .from(weddingEntitlements)
+            .where(
+              and(
+                eq(weddingEntitlements.weddingId, weddingId),
+                inArray(weddingEntitlements.entitlement, CAPACITY_ENTITLEMENT_KEYS),
+              ),
+            )
+            .all(),
+        );
+        cap = deriveCap((rows as { e: string }[]).map((r) => r.e));
+      }
       const current = yield* countGuests(db, weddingId);
       if (current + incomingNewGuests > cap) {
         return yield* Effect.fail(new CapacityExceeded({ limit: cap, current }));

--- a/cire/api/src/services/hosts.test.ts
+++ b/cire/api/src/services/hosts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import { weddingHosts, weddings } from "@cire/db";
+import { weddingEntitlements, weddingHosts, weddings } from "@cire/db";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 
@@ -479,5 +479,142 @@ describe("hostsService.authorize", () => {
   it("returns null for an unknown wedding", async () => {
     const db = buildDb();
     expect(await run(db, hostsService.authorize("wed_nope", OWNER))).toBeNull();
+  });
+
+  it("omits `entitled` entirely when no entitlementKey is given", async () => {
+    const db = buildDb();
+    const now = new Date();
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, OWNER));
+    expect(result?.entitled).toBeUndefined();
+  });
+});
+
+describe("hostsService.authorize — entitlement fold (P-W1)", () => {
+  it("owner branch: entitled:true when the wedding holds the key, folded into the same query", async () => {
+    const db = buildDb();
+    const now = new Date();
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, OWNER, "vendors"));
+    expect(result).toEqual({
+      ownerOsnProfileId: OWNER,
+      isOwner: true,
+      isHost: false,
+      role: "owner",
+      entitled: true,
+    });
+  });
+
+  it("owner branch: entitled:false when the wedding lacks the key", async () => {
+    const db = buildDb();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, OWNER, "vendors"));
+    expect(result?.entitled).toBe(false);
+  });
+
+  it("owner branch: entitled reflects the SPECIFIC key asked for, not just any grant", async () => {
+    const db = buildDb();
+    const now = new Date();
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "ai",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, OWNER, "vendors"));
+    expect(result?.entitled).toBe(false);
+  });
+
+  it("co-host branch: entitled:true when the wedding holds the key", async () => {
+    const db = buildDb();
+    const now = new Date();
+    await run(
+      db,
+      hostsService.add({
+        weddingId: WEDDING_ID,
+        osnProfileId: ALICE,
+        addedByOsnProfileId: OWNER,
+        ownerOsnProfileId: OWNER,
+        role: "editor",
+      }),
+    );
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "registry",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, ALICE, "registry"));
+    expect(result).toEqual({
+      ownerOsnProfileId: OWNER,
+      isOwner: false,
+      isHost: true,
+      role: "editor",
+      entitled: true,
+    });
+  });
+
+  it("co-host branch: entitled:false when the wedding lacks the key", async () => {
+    const db = buildDb();
+    await run(
+      db,
+      hostsService.add({
+        weddingId: WEDDING_ID,
+        osnProfileId: ALICE,
+        addedByOsnProfileId: OWNER,
+        ownerOsnProfileId: OWNER,
+        role: "editor",
+      }),
+    );
+    const result = await run(db, hostsService.authorize(WEDDING_ID, ALICE, "registry"));
+    expect(result?.entitled).toBe(false);
+  });
+
+  it("stranger branch: role:null and entitled:false — no query answer is meaningful without a role", async () => {
+    const db = buildDb();
+    const now = new Date();
+    db.insert(weddingEntitlements)
+      .values({
+        weddingId: WEDDING_ID,
+        entitlement: "vendors",
+        source: "comp",
+        grantedAt: now,
+        grantedBy: OWNER,
+      })
+      .run();
+    const result = await run(db, hostsService.authorize(WEDDING_ID, "usr_stranger", "vendors"));
+    expect(result).toEqual({
+      ownerOsnProfileId: OWNER,
+      isOwner: false,
+      isHost: false,
+      role: null,
+      entitled: false,
+    });
+  });
+
+  it("unknown wedding: still null, entitlementKey doesn't change that", async () => {
+    const db = buildDb();
+    expect(await run(db, hostsService.authorize("wed_nope", OWNER, "vendors"))).toBeNull();
   });
 });

--- a/cire/api/src/services/hosts.ts
+++ b/cire/api/src/services/hosts.ts
@@ -1,8 +1,9 @@
-import { weddingHosts, weddings } from "@cire/db";
-import { and, asc, count, eq } from "drizzle-orm";
+import { weddingEntitlements, weddingHosts, weddings } from "@cire/db";
+import { and, asc, count, eq, sql } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
 import { DbService, dbQuery } from "../db";
+import type { EntitlementKey } from "./entitlements";
 
 /**
  * A co-host's role. `editor` gets full module writes (guests, schedule,
@@ -96,6 +97,78 @@ export function hostConflictReason(message: string): HostConflict["reason"] | nu
   if (!message.includes("UNIQUE constraint failed")) return null;
   if (message.includes("wedding_hosts")) return "already_host";
   return null;
+}
+
+/**
+ * The `entitlementKey`-carrying half of `authorize()` — kept as a separate
+ * function rather than an inline branch so the plain path above stays exactly
+ * the query it always was, byte for byte, for every caller that never asks
+ * for an entitlement fold. Each SELECT gains one boolean `entitled` column
+ * (an `EXISTS` subquery against `wedding_entitlements`) instead of the caller
+ * issuing a THIRD, separate `entitlementService.has()` round trip afterward —
+ * same total query count as the plain path (one query on the owner branch,
+ * two on the co-host branch), now carrying the entitlement answer too.
+ */
+function authorizeWithEntitlement(
+  weddingId: string,
+  osnProfileId: string,
+  entitlementKey: EntitlementKey,
+): Effect.Effect<
+  {
+    ownerOsnProfileId: string;
+    isOwner: boolean;
+    isHost: boolean;
+    role: "owner" | HostRole | null;
+    entitled: boolean;
+  } | null,
+  never,
+  DbService
+> {
+  const entitledExists = sql<number>`EXISTS (SELECT 1 FROM ${weddingEntitlements} WHERE ${weddingEntitlements.weddingId} = ${weddingId} AND ${weddingEntitlements.entitlement} = ${entitlementKey})`;
+
+  return Effect.gen(function* () {
+    const db = yield* DbService;
+    const [owner] = yield* dbQuery(() =>
+      db
+        .select({ owner: weddings.ownerOsnProfileId, entitled: entitledExists })
+        .from(weddings)
+        .where(eq(weddings.id, weddingId))
+        .all(),
+    );
+    if (!owner) return null;
+
+    const isOwner = owner.owner === osnProfileId;
+    if (isOwner) {
+      return {
+        ownerOsnProfileId: owner.owner,
+        isOwner: true,
+        isHost: false,
+        role: "owner" as const,
+        entitled: Boolean(owner.entitled),
+      };
+    }
+
+    const [host] = yield* dbQuery(() =>
+      db
+        .select({ id: weddingHosts.id, role: weddingHosts.role, entitled: entitledExists })
+        .from(weddingHosts)
+        .where(
+          and(eq(weddingHosts.weddingId, weddingId), eq(weddingHosts.osnProfileId, osnProfileId)),
+        )
+        .limit(1)
+        .all(),
+    );
+    return {
+      ownerOsnProfileId: owner.owner,
+      isOwner: false,
+      isHost: Boolean(host),
+      role: host ? normaliseHostRole(host.role) : null,
+      // No host row means neither the owner nor a co-host branch matched — the
+      // caller is a stranger, and `entitled` is meaningless (the role gate
+      // 403s before anything reads it), so `false` rather than a bogus query.
+      entitled: host ? Boolean(host.entitled) : false,
+    };
+  }).pipe(Effect.withSpan("cire.host.authorize"));
 }
 
 export const hostsService = {
@@ -337,20 +410,33 @@ export const hostsService = {
    * owner from co-host — and, via `role`, editor from viewer — in a single
    * round-trip. `null` result means the wedding doesn't exist (caller maps to
    * 404); `role` is `null` when the caller is neither owner nor host.
+   *
+   * `entitlementKey`, when given, folds a presence check for that entitlement
+   * into the SAME query as the owner/host lookup (an `EXISTS` column, same
+   * idiom as `directory.ts`'s `inWedding`) rather than a separate round trip —
+   * see P-W1 / `weddingEntitlement`. Omitted, this runs exactly the query
+   * shape it always has; every caller that never passes a key (every route
+   * gate but the three that also mount `weddingEntitlement`) is unaffected.
    */
   authorize(
     weddingId: string,
     osnProfileId: string,
+    entitlementKey?: EntitlementKey,
   ): Effect.Effect<
     {
       ownerOsnProfileId: string;
       isOwner: boolean;
       isHost: boolean;
       role: "owner" | HostRole | null;
+      /** Only present when `entitlementKey` was passed. */
+      entitled?: boolean;
     } | null,
     never,
     DbService
   > {
+    if (entitlementKey) {
+      return authorizeWithEntitlement(weddingId, osnProfileId, entitlementKey);
+    }
     return Effect.gen(function* () {
       const db = yield* DbService;
       const [owner] = yield* dbQuery(() =>

--- a/cire/api/src/services/hosts.ts
+++ b/cire/api/src/services/hosts.ts
@@ -99,6 +99,62 @@ export function hostConflictReason(message: string): HostConflict["reason"] | nu
   return null;
 }
 
+type AuthorizeResult = {
+  ownerOsnProfileId: string;
+  isOwner: boolean;
+  isHost: boolean;
+  role: "owner" | HostRole | null;
+};
+
+/**
+ * The entitlement-free `authorize()` — the query shape this service has always
+ * run, extracted so both the plain caller and
+ * {@link authorizeWithEntitlement}'s defect fallback can reach it.
+ */
+function authorizePlain(
+  weddingId: string,
+  osnProfileId: string,
+): Effect.Effect<AuthorizeResult | null, never, DbService> {
+  return Effect.gen(function* () {
+    const db = yield* DbService;
+    const [owner] = yield* dbQuery(() =>
+      db
+        .select({ owner: weddings.ownerOsnProfileId })
+        .from(weddings)
+        .where(eq(weddings.id, weddingId))
+        .all(),
+    );
+    if (!owner) return null;
+
+    const isOwner = owner.owner === osnProfileId;
+    if (isOwner) {
+      return {
+        ownerOsnProfileId: owner.owner,
+        isOwner: true,
+        isHost: false,
+        role: "owner" as const,
+      };
+    }
+
+    const [host] = yield* dbQuery(() =>
+      db
+        .select({ id: weddingHosts.id, role: weddingHosts.role })
+        .from(weddingHosts)
+        .where(
+          and(eq(weddingHosts.weddingId, weddingId), eq(weddingHosts.osnProfileId, osnProfileId)),
+        )
+        .limit(1)
+        .all(),
+    );
+    return {
+      ownerOsnProfileId: owner.owner,
+      isOwner: false,
+      isHost: Boolean(host),
+      role: host ? normaliseHostRole(host.role) : null,
+    };
+  }).pipe(Effect.withSpan("cire.host.authorize"));
+}
+
 /**
  * The `entitlementKey`-carrying half of `authorize()` — kept as a separate
  * function rather than an inline branch so the plain path above stays exactly
@@ -113,17 +169,7 @@ function authorizeWithEntitlement(
   weddingId: string,
   osnProfileId: string,
   entitlementKey: EntitlementKey,
-): Effect.Effect<
-  {
-    ownerOsnProfileId: string;
-    isOwner: boolean;
-    isHost: boolean;
-    role: "owner" | HostRole | null;
-    entitled: boolean;
-  } | null,
-  never,
-  DbService
-> {
+): Effect.Effect<(AuthorizeResult & { entitled?: boolean }) | null, never, DbService> {
   const entitledExists = sql<number>`EXISTS (SELECT 1 FROM ${weddingEntitlements} WHERE ${weddingEntitlements.weddingId} = ${weddingId} AND ${weddingEntitlements.entitlement} = ${entitlementKey})`;
 
   return Effect.gen(function* () {
@@ -168,7 +214,34 @@ function authorizeWithEntitlement(
       // 403s before anything reads it), so `false` rather than a bogus query.
       entitled: host ? Boolean(host.entitled) : false,
     };
-  }).pipe(Effect.withSpan("cire.host.authorize"));
+  }).pipe(
+    Effect.withSpan("cire.host.authorize"),
+    // S-L1 (found reviewing this branch): folding the entitlement probe into
+    // the role query also folded their FAILURE modes together. Before the
+    // fold, a defect confined to `wedding_entitlements` — a bad row, a lock,
+    // an index problem — denied only the entitlement half (a scoped 402, with
+    // a log line naming the wedding and the key) while the role check, a
+    // separate query, still answered. In one SELECT, that same defect throws
+    // out of the gate's derive and the whole route 500s, on all nine gated
+    // mount sites, with a generic log nobody can triage from.
+    //
+    // Fall back to the query shape this service always ran. It answers the
+    // role on its own, and returns no `entitled` — so no fold reaches the
+    // context, and `weddingEntitlement` runs its own `has()`, still wrapped in
+    // its own defect-to-false-with-log. That is exactly the old contract: the
+    // two checks fail independently, each with its own scoped outcome. If the
+    // role half is what defected, `authorizePlain` defects too and the request
+    // 500s as it always would have.
+    Effect.catchAllDefect((defect) =>
+      Effect.logWarning(
+        "cire.host.authorize entitlement fold failed — falling back to the plain role query",
+      ).pipe(
+        Effect.annotateLogs({ weddingId, entitlement: entitlementKey }),
+        Effect.zipRight(Effect.logDebug(String(defect))),
+        Effect.zipRight(authorizePlain(weddingId, osnProfileId)),
+      ),
+    ),
+  );
 }
 
 export const hostsService = {
@@ -437,43 +510,6 @@ export const hostsService = {
     if (entitlementKey) {
       return authorizeWithEntitlement(weddingId, osnProfileId, entitlementKey);
     }
-    return Effect.gen(function* () {
-      const db = yield* DbService;
-      const [owner] = yield* dbQuery(() =>
-        db
-          .select({ owner: weddings.ownerOsnProfileId })
-          .from(weddings)
-          .where(eq(weddings.id, weddingId))
-          .all(),
-      );
-      if (!owner) return null;
-
-      const isOwner = owner.owner === osnProfileId;
-      if (isOwner) {
-        return {
-          ownerOsnProfileId: owner.owner,
-          isOwner: true,
-          isHost: false,
-          role: "owner" as const,
-        };
-      }
-
-      const [host] = yield* dbQuery(() =>
-        db
-          .select({ id: weddingHosts.id, role: weddingHosts.role })
-          .from(weddingHosts)
-          .where(
-            and(eq(weddingHosts.weddingId, weddingId), eq(weddingHosts.osnProfileId, osnProfileId)),
-          )
-          .limit(1)
-          .all(),
-      );
-      return {
-        ownerOsnProfileId: owner.owner,
-        isOwner: false,
-        isHost: Boolean(host),
-        role: host ? normaliseHostRole(host.role) : null,
-      };
-    }).pipe(Effect.withSpan("cire.host.authorize"));
+    return authorizePlain(weddingId, osnProfileId);
   },
 };

--- a/cire/api/src/services/import-capacity-query-count.test.ts
+++ b/cire/api/src/services/import-capacity-query-count.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "bun:test";
+
+import { BOOTSTRAP_WEDDING_ID, families } from "@cire/db";
+import { Effect, Exit } from "effect";
+
+import { DbService } from "../db";
+import { createDb, seedBootstrapWedding } from "../db/setup";
+import type { ImportPlan, ParsedFamily } from "../schemas/import";
+import { countingDb } from "../test-helpers";
+import { entitlementService } from "./entitlements";
+import { applyImport, diffAgainstDb } from "./import";
+
+/**
+ * Proves osn-tracker#119 (P-I2) and osn-tracker#117 (P-W2): `diffAgainstDb`
+ * skips the entitlement query entirely when the import can't possibly breach
+ * the floor cap, and `applyImport` skips its OWN entitlement query when the
+ * plan already carries a `derivedCap` from the SAME request's preview.
+ *
+ * `countingDb` counts `.select()` calls, the entry point of every read this
+ * codebase issues — there is no query-log to assert on directly, so this is
+ * the mechanism, matching the one added for P-W1 (see
+ * `wedding-entitlement-fold.test.ts`).
+ */
+
+function planCreatingNGuests(n: number): ParsedFamily[] {
+  return [
+    {
+      familyName: "QueryCountFamily",
+      guests: Array.from({ length: n }, (_, i) => ({
+        firstName: `Guest${i}`,
+        lastName: "Count",
+        nickname: null,
+        eventNames: [],
+      })),
+    },
+  ];
+}
+
+describe("P-I2: diffAgainstDb's capacity pre-check", () => {
+  it("skips the entitlement query when existing+new guests can't exceed the floor (100)", async () => {
+    const raw = createDb(":memory:");
+    seedBootstrapWedding(raw);
+    const { db: counted, selectCount } = countingDb(raw);
+
+    // 0 existing + 5 new = 5, nowhere near the 100 floor.
+    const before = selectCount();
+    const plan = await Effect.runPromise(
+      diffAgainstDb([], planCreatingNGuests(5), BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, counted),
+      ),
+    );
+    const afterSmall = selectCount() - before;
+
+    // Same shape, but enough new guests to cross the floor (0 + 101 > 100) —
+    // this run MUST issue the entitlement query, so the two counts differ by
+    // exactly one query: the one the pre-check skipped above.
+    const raw2 = createDb(":memory:");
+    seedBootstrapWedding(raw2);
+    const { db: counted2, selectCount: selectCount2 } = countingDb(raw2);
+    const before2 = selectCount2();
+    await Effect.runPromise(
+      diffAgainstDb([], planCreatingNGuests(101), BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, counted2),
+      ),
+    );
+    const afterLarge = selectCount2() - before2;
+
+    expect(afterLarge - afterSmall).toBe(1);
+    expect(plan.derivedCap).toBeUndefined();
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it("still runs the query — and still warns — right at the threshold boundary (101 > 100)", async () => {
+    const raw = createDb(":memory:");
+    seedBootstrapWedding(raw);
+    const plan = await Effect.runPromise(
+      diffAgainstDb([], planCreatingNGuests(101), BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, raw),
+      ),
+    );
+    expect(plan.derivedCap).toBe(100);
+    expect(plan.warnings.some((w) => /capped at 100/i.test(w))).toBe(true);
+  });
+
+  it("skipping the query never skips the warning check — exactly 100 (not over) stays silent, no query needed", async () => {
+    const raw = createDb(":memory:");
+    seedBootstrapWedding(raw);
+    const { db: counted, selectCount } = countingDb(raw);
+    const before = selectCount();
+    const plan = await Effect.runPromise(
+      diffAgainstDb([], planCreatingNGuests(100), BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, counted),
+      ),
+    );
+    // 0 + 100 = 100, not > 100 (BASE_GUEST_CAP) — the pre-check's own
+    // boundary, so this must NOT have queried the entitlement table.
+    expect(plan.warnings).toEqual([]);
+    expect(plan.derivedCap).toBeUndefined();
+    // Only the queries diffAgainstDb always issues for a plain family/guest
+    // diff ran — none of them touch wedding_entitlements at this size.
+    expect(selectCount() - before).toBeGreaterThan(0);
+  });
+});
+
+describe("P-W2: applyImport reuses diffAgainstDb's derivedCap", () => {
+  it("does not re-query entitlements when the plan already carries derivedCap", async () => {
+    const raw = createDb(":memory:");
+    seedBootstrapWedding(raw);
+    // Grant capacity_500 so the preview's own query is forced to run and
+    // resolves to a real, non-default cap — proves applyImport actually USES
+    // the threaded value rather than coincidentally landing on the same
+    // number via its own fallback query.
+    await Effect.runPromise(
+      entitlementService
+        .grant(BOOTSTRAP_WEDDING_ID, "capacity_500", { source: "comp", grantedBy: "usr_admin" })
+        .pipe(Effect.provideService(DbService, raw)),
+    );
+
+    const plan = await Effect.runPromise(
+      diffAgainstDb([], planCreatingNGuests(101), BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, raw),
+      ),
+    );
+    expect(plan.derivedCap).toBe(500);
+
+    const { db: counted, selectCount } = countingDb(raw);
+    const before = selectCount();
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_derived_cap", plan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, counted),
+      ),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+
+    // Build the SAME plan by hand, minus derivedCap, and apply it against an
+    // identically-seeded+granted DB to measure the query applyImport issues
+    // WITHOUT a threaded cap — the difference is the query the fold saved.
+    const rawBaseline = createDb(":memory:");
+    seedBootstrapWedding(rawBaseline);
+    await Effect.runPromise(
+      entitlementService
+        .grant(BOOTSTRAP_WEDDING_ID, "capacity_500", { source: "comp", grantedBy: "usr_admin" })
+        .pipe(Effect.provideService(DbService, rawBaseline)),
+    );
+    const { derivedCap: _derivedCap, ...planWithoutCap } = plan;
+    void _derivedCap;
+    const { db: countedBaseline, selectCount: selectCountBaseline } = countingDb(rawBaseline);
+    const beforeBaseline = selectCountBaseline();
+    const exitBaseline = await Effect.runPromiseExit(
+      applyImport("imp_no_derived_cap", planWithoutCap as ImportPlan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, countedBaseline),
+      ),
+    );
+    expect(Exit.isSuccess(exitBaseline)).toBe(true);
+
+    expect(selectCountBaseline() - beforeBaseline - (selectCount() - before)).toBe(1);
+  });
+
+  it("keeps enforcing the cap when derivedCap is ABSENT from the plan — never a way to skip the check", async () => {
+    const raw = createDb(":memory:");
+    seedBootstrapWedding(raw);
+    const now = new Date();
+    const familyId = crypto.randomUUID();
+    raw
+      .insert(families)
+      .values({
+        id: familyId,
+        weddingId: BOOTSTRAP_WEDDING_ID,
+        publicId: "NO-CAP-FAM",
+        familyName: "NoCapFamily",
+        kind: "guest",
+        source: "import",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // A hand-built plan (never touched diffAgainstDb) with NO derivedCap,
+    // creating 101 guests on a wedding with no capacity entitlement — must
+    // still fail, proving assertGuestCapacity's own fallback query enforces
+    // exactly as it always has when the fold has nothing to give it.
+    const plan: ImportPlan = {
+      eventCreates: [],
+      eventUpdates: [],
+      eventRemoves: [],
+      familyCreates: [],
+      familyUpdates: [],
+      familyRemoves: [],
+      guestCreates: Array.from({ length: 101 }, (_, i) => ({
+        id: crypto.randomUUID(),
+        familyId,
+        firstName: `NoCapGuest${i}`,
+        lastName: "Absent",
+        nickname: null,
+        sortOrder: i,
+      })),
+      guestUpdates: [],
+      guestRemoves: [],
+      eventLinkCreates: [],
+      eventLinkRemoves: [],
+      warnings: [],
+      // derivedCap intentionally omitted.
+    };
+    expect(plan.derivedCap).toBeUndefined();
+
+    const exit = await Effect.runPromiseExit(
+      applyImport("imp_absent_cap", plan, BOOTSTRAP_WEDDING_ID).pipe(
+        Effect.provideService(DbService, raw),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    const n = (raw.$client.query("SELECT COUNT(*) AS n FROM guests").get() as { n: number }).n;
+    expect(n).toBe(0);
+  });
+});

--- a/cire/api/src/services/import.ts
+++ b/cire/api/src/services/import.ts
@@ -31,7 +31,12 @@ import type {
   ParsedEvent,
   ParsedFamily,
 } from "../schemas/import";
-import { entitlementService, CapacityExceeded } from "./entitlements";
+import {
+  entitlementService,
+  CapacityExceeded,
+  BASE_GUEST_CAP,
+  CAPACITY_ENTITLEMENT_KEYS,
+} from "./entitlements";
 import { generateFamilyCode } from "./family-code";
 import type { CodeStyle } from "./family-code";
 import { resolvePinUrl } from "./pinterest-resolve";
@@ -714,24 +719,48 @@ export function diffAgainstDb(
     // block lives in applyImport — this warning lets the preview UI surface the
     // issue before the organiser commits. Host-preview families are excluded from
     // the current-guest count (same join + ne(kind,'host') as entitlementService).
+    //
+    // `derivedCap` rides on the returned plan so `applyImport` doesn't re-scan
+    // the SAME entitlement rows a second time in the SAME request (P-W2) — see
+    // `applyImport`'s call to `assertGuestCapacity`. It's set ONLY when this
+    // block actually ran the entitlement query below; the pre-check branch
+    // (P-I2) proves the cap can't matter without ever learning its real value,
+    // so it leaves `derivedCap` unset and `applyImport` falls back to its own
+    // (still cheap, still narrowed) query — correct either way, per
+    // `assertGuestCapacity`'s "never a way to skip the check" contract.
+    let derivedCap: number | undefined;
     if (guestCreates.length > 0) {
-      const entRows = yield* dbQuery(() =>
-        db
-          .select({ e: weddingEntitlements.entitlement })
-          .from(weddingEntitlements)
-          .where(eq(weddingEntitlements.weddingId, weddingId))
-          .all(),
-      );
-      const cap = entitlementService.deriveCap((entRows as { e: string }[]).map((r) => r.e));
       // `existingGuests` was already fetched above with ne(families.kind, 'host'),
       // so it already excludes host-preview guests. The resulting headcount after
       // this plan: current real guests minus removals plus new creates.
       const currentRealGuests = existingGuests.length;
       const resulting = currentRealGuests - guestRemoves.length + guestCreates.length;
-      if (resulting > cap) {
-        warnings.push(
-          `This import brings you to ${resulting} guests; your plan is capped at ${cap}. Upgrade to add more.`,
+      // P-I2: `resulting` can only rise as far as `currentRealGuests +
+      // guestCreates.length` (removes only ever bring it DOWN), and the cap can
+      // never fall below `BASE_GUEST_CAP` — so once that upper bound sits at or
+      // under the floor, no entitlement row on earth could make this breach.
+      // Skip the query entirely rather than fetch rows whose answer is moot.
+      if (currentRealGuests + guestCreates.length > BASE_GUEST_CAP) {
+        // P-I3: only the two capacity keys can raise the cap above the floor —
+        // narrow the scan instead of pulling every entitlement row.
+        const entRows = yield* dbQuery(() =>
+          db
+            .select({ e: weddingEntitlements.entitlement })
+            .from(weddingEntitlements)
+            .where(
+              and(
+                eq(weddingEntitlements.weddingId, weddingId),
+                inArray(weddingEntitlements.entitlement, CAPACITY_ENTITLEMENT_KEYS),
+              ),
+            )
+            .all(),
         );
+        derivedCap = entitlementService.deriveCap((entRows as { e: string }[]).map((r) => r.e));
+        if (resulting > derivedCap) {
+          warnings.push(
+            `This import brings you to ${resulting} guests; your plan is capped at ${derivedCap}. Upgrade to add more.`,
+          );
+        }
       }
     }
 
@@ -748,6 +777,7 @@ export function diffAgainstDb(
       eventLinkCreates,
       eventLinkRemoves,
       warnings,
+      derivedCap,
     };
   }).pipe(Effect.withSpan("cire.import.diff"));
 }
@@ -1057,7 +1087,15 @@ export function applyImport(
     // and a negative or zero incoming can never exceed.
     const netGuestDelta = plan.guestCreates.length - plan.guestRemoves.length;
     if (netGuestDelta > 0) {
-      yield* entitlementService.assertGuestCapacity(weddingId, netGuestDelta);
+      // `plan.derivedCap` — set by `diffAgainstDb` in the SAME request when its
+      // own preview warning already ran the entitlement query (P-W2) — lets
+      // this skip a second scan of the same rows. Absent (a plan built before
+      // this field existed, the P-I2 pre-check branch that proved the cap
+      // couldn't matter without learning it, or any other caller of
+      // `applyImport`), `assertGuestCapacity` runs its own query and enforces
+      // exactly as it always has — a missing cap is never a reason to skip
+      // the check.
+      yield* entitlementService.assertGuestCapacity(weddingId, netGuestDelta, plan.derivedCap);
     }
 
     statements.push(...finalize);

--- a/cire/api/src/test-helpers.ts
+++ b/cire/api/src/test-helpers.ts
@@ -1,5 +1,7 @@
 import { Effect, Layer } from "effect";
 
+import type { Db } from "./db";
+
 /** Default `cf-connecting-ip` injected for tests — simulates the Cloudflare edge
  *  so the fail-closed rate limiter (C4) resolves a real IP instead of denying. */
 export const TEST_CF_IP = "203.0.113.7";
@@ -80,4 +82,28 @@ export function effWith<R>(layer: Layer.Layer<R>) {
   return <A>(effect: Effect.Effect<A, unknown, R>): (() => Promise<A>) =>
     () =>
       Effect.runPromise(effect.pipe(Effect.provide(layer)));
+}
+
+/**
+ * Wraps a real `Db` so every call to `.select()` is counted — the entry
+ * point of every read query this codebase issues (`dbQuery(() =>
+ * db.select()...all())`). Nothing in the test suite mocks the driver (real
+ * bun:sqlite backs every test `Db`), so this is the mechanism for proving a
+ * "this many D1 round trips" claim: count `.select()` invocations rather than
+ * assert on a call log no service exposes. Built via prototype delegation
+ * (`Object.create(db)` plus one overridden own property) rather than a
+ * `Proxy` + `Reflect.get`, so every other method (`.insert`/`.update`/
+ * `.delete`/`.$client`/…) keeps its real, typed behaviour untouched.
+ */
+export function countingDb(db: Db) {
+  let n = 0;
+  const counted: Db = Object.create(db);
+  Object.defineProperty(counted, "select", {
+    enumerable: true,
+    value: (fields?: Parameters<typeof db.select>[0]) => {
+      n++;
+      return fields === undefined ? db.select() : db.select(fields);
+    },
+  });
+  return { db: counted, selectCount: () => n };
 }

--- a/wiki/systems/cire-entitlements.md
+++ b/wiki/systems/cire-entitlements.md
@@ -5,7 +5,7 @@ related:
   - "[[cire-vendors]]"
   - "[[cire-registry]]"
   - "[[cire-auth]]"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-08-31
 ---
 # Entitlements — per-wedding capability gates
 
@@ -71,7 +71,7 @@ All methods are Effect programs returning `Effect.Effect<A, E, DbService>`. Impl
 | `setsForWeddings` | `(weddingIds[]) → Effect<Map<weddingId, EntitlementKey[]>, never, DbService>` | Batch-fetches all entitlement rows for a list of wedding IDs; used to annotate wedding-list responses |
 | `deriveCap` | `(keys: string[]) → number` | Pure — derives the effective guest ceiling from an entitlement key array |
 | `grant` | `(weddingId, key, { source, grantedBy, providerRef? }) → Effect<void, never, DbService>` | Inserts a row; idempotent on conflict |
-| `assertGuestCapacity` | `(weddingId, incomingNewGuests) → Effect<void, CapacityExceeded, DbService>` | Fetches the wedding's entitlement set, derives the cap, counts current (non-host) guests, fails with `CapacityExceeded { limit, current }` if the import would breach the ceiling |
+| `assertGuestCapacity` | `(weddingId, incomingNewGuests, precomputedCap?) → Effect<void, CapacityExceeded, DbService>` | Derives the cap (from `precomputedCap` if given, else its own — now narrowed, see below — entitlement query), counts current (non-host) guests, fails with `CapacityExceeded { limit, current }` if the import would breach the ceiling. `precomputedCap` only ever skips the RE-DERIVATION, never the check itself |
 
 `CapacityExceeded` is a tagged error (`Data.TaggedError`); handlers map it to a **402** response with body `{ error: "payment_required", entitlement: "capacity", limit, current }`.
 
@@ -104,13 +104,21 @@ A missing `weddingId` in `params` (should not occur after the role gate validate
 
 **It does no D1 read when the role gate has already refused.** Both role gates park their refusal on the context as `weddingGateError`; the entitlement `derive` returns immediately when it finds one. Elysia runs every `derive` before any `onBeforeHandle`, so without that check a stranger's request still paid for an entitlement query whose answer could never change the response — a free, unauthenticated read on every request to every gated route. Skipping it leaves the status ordering untouched (401, then 403 `read_only_role`, then 402 `payment_required`), which route tests pin.
 
+**It shares a query with the role gate instead of running its own (P-W1, fixed).** `weddingMember(db, key)` / `weddingEditor(db, key)` take the SAME entitlement key this middleware is mounted with as an optional second argument. When given, `hostsService.authorize()` folds an `EXISTS` check against `wedding_entitlements` into the SAME `SELECT` it already runs for the owner/host row (one extra column, not a second query — the `directory.ts` `inWedding` idiom) and exposes the answer as `weddingEntitlementFold` on context. `weddingEntitlement`'s derive picks that up (`readWeddingEntitlementFold` in `upstream-context.ts`) instead of calling `entitlementService.has()` itself, provided the fold's key matches its own — a mismatch or absence (the gate mounted standalone, or a role gate called with no key) falls back to the old separate query, so correctness never depends on the two call sites staying in sync, only the round-trip saving does. Net effect on a gated route: an owner drops from 2 queries to 1, a co-host from 3 to 2. **Every route that mounts a role gate WITHOUT `weddingEntitlement` must never pass a key** — an unconditional fold would add the entitlement query's cost to every organiser route, gated or not; only the three route files that also `.use(weddingEntitlement(db, key))` pass one (`vendor-directory.ts`, `vendors.ts`, `registry.ts`). Proven by `cire/api/src/middleware/wedding-entitlement-fold.test.ts`, which counts `db.select()` calls on both a gated and an ungated route.
+
 ---
 
 ## Capacity enforcement in `applyImport`
 
-`applyImport` (in `cire/api/src/services/import.ts`) calls `entitlementService.assertGuestCapacity(weddingId, netGuestDelta)` — where `netGuestDelta = guestCreates.length - guestRemoves.length` — **before** writing any rows. `applyImport` skips the check when the net delta is zero or negative (a churn import that removes K and adds K at cap succeeds). The check and the D1 batch write that follows are sequenced atomically: if the capacity check fails, no guests are written. There are no partial writes.
+`applyImport` (in `cire/api/src/services/import.ts`) calls `entitlementService.assertGuestCapacity(weddingId, netGuestDelta, plan.derivedCap)` — where `netGuestDelta = guestCreates.length - guestRemoves.length` — **before** writing any rows. `applyImport` skips the check when the net delta is zero or negative (a churn import that removes K and adds K at cap succeeds). The check and the D1 batch write that follows are sequenced atomically: if the capacity check fails, no guests are written. There are no partial writes.
 
 The check counts real guests only — a `ne(families.kind, 'host')` filter excludes the synthetic `host`-kind family row used for invite previews.
+
+**The capacity query only ever reads the two rows that can matter (P-I3, fixed).** `assertGuestCapacity`'s own fallback query, and `diffAgainstDb`'s preview-warning query below, both filter `WHERE entitlement IN ('capacity_500', 'capacity_1000')` (the `CAPACITY_ENTITLEMENT_KEYS` constant in `entitlements.ts`) instead of fetching every entitlement row on the wedding — `deriveCap` only ever inspects those two keys, so the wider fetch was pure waste. **`setsForWeddings` is NOT narrowed** — it feeds `deriveCap` in `organiser-weddings.ts` and also drives feature display (`premium_templates`/`vendors`/`ai`/`registry`), so it keeps returning the full set.
+
+**`diffAgainstDb`'s preview warning skips its own query below a floor threshold (P-I2, fixed).** The resulting guest count after any plan is `existing − removes + creates`, which can never exceed `existing + creates` (removes only ever help). Since the cap can never fall below `BASE_GUEST_CAP` (100, exported from `entitlements.ts`, the same fallback `deriveCap` returns), `diffAgainstDb` skips the entitlement query — and the warning check — entirely once `existingGuests.length + guestCreates.length <= BASE_GUEST_CAP`: no entitlement row on any wedding could make that import breach the cap. Above the threshold it runs the (now narrowed) query as before.
+
+**`applyImport` reuses `diffAgainstDb`'s already-derived cap instead of re-scanning (P-W2, fixed).** `ImportPlan` carries an optional `derivedCap: number`, set by `diffAgainstDb` ONLY when its own preview-warning block actually ran the entitlement query (i.e. above the P-I2 threshold, with `guestCreates.length > 0`). `applyImport` passes it straight to `assertGuestCapacity`'s `precomputedCap` parameter, which then skips its own query. `derivedCap` is absent whenever the preview never needed the real cap (below the P-I2 threshold, or no guests were being created) — `assertGuestCapacity` MUST keep enforcing in that case by running its own (narrowed) query; a missing cap is never treated as "no cap". This composes with P-I2 cleanly: a small import pays one query total (`applyImport`'s own, since the preview skipped its), a large one also pays one query total (the preview's, reused by `applyImport`) — never the two separate scans of the same rows either fix alone would still leave on the table. Both call sites that feed `applyImport` a plan (`organiser-changes.ts` and `revert.ts`) run `diffAgainstDb` then `applyImport` in the SAME request — plan objects never cross the client boundary, so there is no TOCTOU window between the two.
 
 ---
 


### PR DESCRIPTION
## Summary

A gated cire route cost three D1 reads where two would do: the role gate
round-tripped to the wedding, and the entitlement gate sitting directly behind
it then made its own point lookup. The entitlement probe now folds into the role
gate's own query as an `EXISTS` column.

The interesting part is what it must not do. `weddingMember` and `weddingEditor`
are mounted by roughly a dozen route files, and **most of them have no
entitlement gate at all**. An unconditional fetch in the role gate would have
added a query to every one of them — a repo-wide regression dressed as an
optimisation. So the key is an optional parameter, and a route that does not ask
for one runs exactly the query it always ran.

The import path also scanned entitlements twice per apply, fetched them when the
guest count could not possibly breach the cap, and read every entitlement row to
derive a ceiling only two of them can raise.

## Workspaces affected

`cire/api`. `.changeset/cire-entitlement-reads.md` names `@cire/api` as `patch`.
No schema change and no migration — the open PR stack `#760 → #831` already
claims migrations 0058–0060.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#116 | `ENT-P-W1` |
| xchromo/osn-tracker#117 | `ENT-P-W2` |
| xchromo/osn-tracker#119 | `ENT-P-I2` |
| xchromo/osn-tracker#120 | `ENT-P-I3` |

Closes xchromo/osn-tracker#116.
Closes xchromo/osn-tracker#117.
Closes xchromo/osn-tracker#119.
Closes xchromo/osn-tracker#120.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#586 | `S-L2` |

## Decisions

### The entitlement key is optional, and that is the whole design — `ENT-P-W1`

- **Issue** — folding an entitlement check into the role gate makes gated routes
  cheaper and every other route more expensive.
- **Why** — only `registry.ts`, `vendor-directory.ts` and `vendors.ts` mount an
  entitlement gate. `tasks.ts`, `budget.ts`, `invite.ts`, `organiser-hosts.ts`,
  `organiser-settings.ts`, `organiser-rsvp.ts`, `organiser-changes.ts`,
  `organiser-enquiries.ts` and `organiser-weddings.ts` do not, and an
  unconditional fold would have charged all of them for a check they never make.
- **Solution** — `weddingMember(db, key?)` / `weddingEditor(db, key?)`. Without a
  key the query is unchanged; with one, an `EXISTS` column rides along and the
  answer is exposed as `weddingEntitlementFold`.
- **Rationale** — the fold carries the key it answers, and `weddingEntitlement`
  trusts it **only** on an exact key match, falling back to its own query
  otherwise. So a mismatched pairing is safe rather than wrong, and the
  optimisation is opt-in per route rather than imposed on the whole tree.
  `entitlementService.setsForWeddings` was deliberately left alone — it feeds
  `deriveCap` on the dashboard and drives feature display, so it must keep
  returning full sets.

### The fold fails on its own again — `S-L1`

- **Issue** — folding the two probes into one SELECT folded their failure modes
  together with them.
- **Why** — before, a defect confined to `wedding_entitlements` denied only the
  entitlement half: a scoped 402 with a log line naming the wedding and the key,
  while the role check, a separate query, still answered. In one SELECT that
  defect threw out of the gate's derive and took the whole route down as a
  generic 500, across all nine gated mount sites, with nothing worth triaging in
  the log. Never a bypass — a defect could not resolve to a truthy role — but a
  worse contract for no reason.
- **Solution** — the fold catches its own defect, warns with the wedding and key,
  and falls back to the query shape this service always ran.
- **Rationale** — the fallback answers the role and returns no `entitled`, so no
  fold reaches the context and `weddingEntitlement` runs its own `has()`, still
  wrapped in its own defect-to-false. The two checks fail independently again.
  If the role half is what defected, the fallback defects too and the request
  500s exactly as it always would have.

### A supplied cap skips deriving, never enforcing — `ENT-P-W2`

- **Issue** — `assertGuestCapacity` re-fetched entitlement rows that
  `diffAgainstDb` had already fetched in the same request.
- **Why** — the import-apply path ran the entitlement scan twice.
- **Solution** — `diffAgainstDb` puts the derived cap on the `ImportPlan`, and
  `applyImport` passes it to `assertGuestCapacity` as `precomputedCap`.
- **Rationale** — `precomputedCap` skips only the derivation. `countGuests` and
  the comparison run regardless, and a plan with no cap makes
  `assertGuestCapacity` derive its own — absence is never a reason to skip the
  check, which is what `import.ts`'s "hard atomic block" comment promises. The
  guest count is deliberately **not** threaded through: it must be read fresh at
  apply time, or a concurrent write could slip past the cap. The cap never
  crosses a trust boundary — both `applyImport` call sites receive a plan built
  by `diffAgainstDb` in the same request, and nothing in the tree decodes an
  `ImportPlan` from input.

### The cap query is skipped when it cannot matter — `ENT-P-I2`, `ENT-P-I3`

- **Issue** — the entitlement rows were fetched whenever an import created any
  guest, and every row was read to derive the ceiling.
- **Why** — removals only ever bring the resulting count down, and the cap can
  never fall below the floor, so once `existing + creates` sits at or under it,
  no entitlement row could make the import breach.
- **Solution** — a pre-check against `BASE_GUEST_CAP` before the query, and
  `WHERE entitlement IN ('capacity_500','capacity_1000')` on the two capacity
  call sites.
- **Rationale** — `BASE_GUEST_CAP` is named rather than inlined so the pre-check
  cannot drift from what `deriveCap` actually falls back to.

**Out of scope**

- Nothing enforces that a `weddingEntitlement` mount is paired with a same-key
  role gate. A mismatch is safe (it falls back), but silently loses the win —
  xchromo/osn-tracker#586.
- If xchromo/osn-tracker#107 lands and persists the parsed plan, `derivedCap`
  becomes a stored value that can go stale between preview and apply. Noted on
  that issue.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37 tasks |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1433 files |
| `bun run test` | ✅ 1723 pass, 0 fail |
| `bun run test:d1` | ✅ all 5 tasks green, forced past the turbo cache |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run test:scripts` | ✅ |
| `bun run check:jest-dom-markers` | ✅ |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |

`wedding-entitlement-fold.test.ts` counts D1 selects directly rather than
asserting the shape of the code: gated co-host 2 (was 3), gated owner 1 (was 2),
and **ungated unchanged at 2 and 1** — that last pair is the regression this
design exists to avoid, so it gets its own assertions rather than being trusted
to fall out of the others. Also covered: a mismatched key still 402s and pays
for its own third query, the gate standalone with no role gate above it still
answers at the old cost, and a broken `wedding_entitlements` table degrades to a
scoped 402 rather than a 500 while a route with no entitlement gate is untouched
by it.

`bun run test:d1` matters here — these are query-shape changes on the
asynchronous D1 driver, and `bun run test` never reaches those files.

Not covered by any gate: nobody has measured the round-trip saving against real
D1 latency. The counts are proven; the wall-clock win is inferred from them.
