### PR TITLE
perf(osn-api): give every organisation a share of the co-member budget

### DIFF
--- a/.changeset/osn-recommender-fanout.md
+++ b/.changeset/osn-recommender-fanout.md
@@ -1,0 +1,19 @@
+---
+"@osn/api": patch
+"@osn/client": patch
+---
+
+Connection recommendations (`GET /recommendations/connections`):
+
+- **Fixed** (osn-tracker#574): the organisation co-member fan-out was one query
+  bounded by a single global row cap, ordered by organisation id — so whichever
+  organisation the caller happened to belong to sorted first absorbed the whole
+  budget, and every other organisation contributed nothing, permanently (50
+  organisations of 250 members each, only ~8 ever won). The fan-out is now one
+  statement, a `UNION ALL` of a per-organisation subselect each bounded by its
+  own share of the budget, so every organisation the caller belongs to
+  contributes candidates.
+- Added `generatedAt` (ISO 8601) to the response, alongside `suggestions`, so a
+  client can tell how fresh a list is (osn-tracker#311, timestamp half only —
+  the cache half is a separate, undecided change). `@osn/client`'s
+  `suggestConnections` return type carries the new field.

--- a/.changeset/osn-recommender-fanout.md
+++ b/.changeset/osn-recommender-fanout.md
@@ -9,10 +9,18 @@ Connection recommendations (`GET /recommendations/connections`):
   bounded by a single global row cap, ordered by organisation id — so whichever
   organisation the caller happened to belong to sorted first absorbed the whole
   budget, and every other organisation contributed nothing, permanently (50
-  organisations of 250 members each, only ~8 ever won). The fan-out is now one
-  statement, a `UNION ALL` of a per-organisation subselect each bounded by its
-  own share of the budget, so every organisation the caller belongs to
-  contributes candidates.
+  organisations of 250 members each, only ~8 ever won). The fan-out is now a
+  `UNION ALL` of a per-organisation subselect each bounded by its own share of
+  the budget, so every organisation the caller belongs to contributes
+  candidates.
+- **Fixed** (osn-tracker#589, P-C1 — the fix above's own regression): that
+  `UNION ALL` was one statement for up to 50 organisations, which throws on
+  real D1 for any caller in 6 or more — D1 runs on workerd's embedded SQLite,
+  capped at 5 terms in a compound `SELECT`, not the 500-term default
+  `bun:sqlite` (and the original comment) assumed. The fan-out now runs in
+  batches of at most 5 organisations per statement, executed concurrently and
+  merged in application code, so a caller in any number of organisations up to
+  the 50-organisation cap gets a result instead of a 500.
 - Added `generatedAt` (ISO 8601) to the response, alongside `suggestions`, so a
   client can tell how fresh a list is (osn-tracker#311, timestamp half only —
   the cache half is a separate, undecided change). `@osn/client`'s

--- a/osn/api/src/d1-integration.test.ts
+++ b/osn/api/src/d1-integration.test.ts
@@ -238,10 +238,21 @@ describe("UNIQUE_CONSTRAINT_ERROR over real D1 (Miniflare)", () => {
 describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", () => {
   it("stays within the MAX_ORG_COMEMBER_ROWS budget even when one organisation has far more members than its share", async () => {
     // osn-tracker#574. MAX_ORG_COMEMBER_ROWS (services/recommendations.ts) is
-    // 2 000. This seeds one organisation with 2 500 members — 500 more than
-    // the whole budget — and confirms the fan-out reads no more than the
-    // budget from `organisation_members`, using D1's own `rows_read` figure
-    // rather than assuming the query's LIMIT clauses did their job.
+    // 2 000, split evenly across the caller's organisations. Seeding a single
+    // organisation the caller belongs to gives that organisation the *whole*
+    // budget as its share, so proving the cap requires seeding upwards of
+    // 2 000 members regardless of fixture size — that was the original form
+    // of this test, and it cost ~4.8s, nearly all of it seeding 2 500 rows
+    // through three FK-linked tables (osn-tracker#589 / P-W1).
+    //
+    // Putting the caller in ORG_COUNT organisations instead shrinks each
+    // one's share to `MAX_ORG_COMEMBER_ROWS / ORG_COUNT`, so the same "far
+    // more members than its share" property needs far fewer seeded rows:
+    // with 10 organisations the share is 200, and 500 members in the one
+    // oversized organisation is already 2.5x its share — a clear violation
+    // for the fan-out to cap, at a fifth of the previous row count. The other
+    // nine organisations need no extra members; the caller's own membership
+    // row is enough to exercise their arm of the fan-out.
     const callerId = "usr_boundtest_caller";
     const callerAccountId = "acc_boundtest_caller";
     const ts = new Date();
@@ -259,21 +270,29 @@ describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", (
       createdAt: ts,
       updatedAt: ts,
     });
-    await rawDb.insert(organisations).values({
-      id: "org_boundtest",
-      handle: "boundtest",
-      name: "Bound Test Org",
-      ownerId: callerId,
-      createdAt: ts,
-      updatedAt: ts,
-    });
-    await rawDb.insert(organisationMembers).values({
-      id: "orgm_boundtest_caller",
-      organisationId: "org_boundtest",
-      profileId: callerId,
-      role: "admin",
-      createdAt: ts,
-    });
+
+    const ORG_COUNT = 10;
+    const OVERSIZED_ORG_ID = "org_boundtest_0";
+    for (let i = 0; i < ORG_COUNT; i++) {
+      const organisationId = `org_boundtest_${i}`;
+      // eslint-disable-next-line no-await-in-loop -- sequential, FK-ordered seeding
+      await rawDb.insert(organisations).values({
+        id: organisationId,
+        handle: `boundtest${i}`,
+        name: `Bound Test Org ${i}`,
+        ownerId: callerId,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(organisationMembers).values({
+        id: `orgm_boundtest_caller_${i}`,
+        organisationId,
+        profileId: callerId,
+        role: "admin",
+        createdAt: ts,
+      });
+    }
 
     // D1 caps bound parameters at 100 PER STATEMENT (see the FOF test below),
     // so a multi-row `INSERT ... VALUES (...), (...), …` — one statement,
@@ -282,7 +301,7 @@ describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", (
     // single-row statements as one D1 `batch()` round trip instead: each
     // statement stays far under the per-statement cap, and the batch itself
     // is still one network hop.
-    const MEMBER_COUNT = 2_500;
+    const MEMBER_COUNT = 500;
     const BATCH = 100;
     for (let i = 0; i < MEMBER_COUNT; i += BATCH) {
       const indices = Array.from({ length: Math.min(BATCH, MEMBER_COUNT - i) }, (_, j) => i + j);
@@ -319,7 +338,7 @@ describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", (
         indices.map((n) =>
           rawDb.insert(organisationMembers).values({
             id: `orgm_boundtest_m${n}`,
-            organisationId: "org_boundtest",
+            organisationId: OVERSIZED_ORG_ID,
             profileId: `usr_boundtest_m${n}`,
             role: "member" as const,
             createdAt: ts,
@@ -338,11 +357,103 @@ describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", (
 
     const rowsRead = await total();
     expect(suggestions.length).toBeGreaterThan(0);
-    // 2 500 members exist; the read must never approach that. The small
-    // margin above the exact 2 000 budget covers the caller's own membership
-    // row (a separate, tiny query against the same table) and planner
-    // overhead — not a second organisation's worth of reads.
-    expect(rowsRead).toBeLessThanOrEqual(2_010);
+    // 500 members exist in the oversized organisation alone, against a
+    // 200-row share; the read must never approach 500. The other nine
+    // organisations contribute at most one row each (the caller's own
+    // membership), and the caller's own organisation list is a separate,
+    // tiny query against the same table — so 300 comfortably covers the
+    // 200-row share plus that overhead, while still sitting far under both
+    // the oversized organisation's real membership count and the 2 000
+    // global budget.
+    expect(rowsRead).toBeLessThanOrEqual(300);
+  });
+
+  it("does not throw for a caller in 6 organisations — the exact arm count the removed comment claimed was safe", async () => {
+    // osn-tracker#589 (P-C1). The co-member fan-out used to be one `UNION
+    // ALL` of one arm per organisation the caller belongs to, and a removed
+    // comment claimed that was safe because `MAX_MY_ORGANISATIONS` (50) sits
+    // "well under SQLite's 500-term compound-select limit". That figure is
+    // right for `bun:sqlite` and wrong for the engine this actually runs
+    // on: D1 runs on workerd's embedded SQLite, which caps a compound
+    // `SELECT` at 5 terms (`MAX_ORG_COMEMBER_ARMS_PER_QUERY`, see its
+    // comment in services/recommendations.ts) — so the single-statement
+    // form threw `D1_ERROR: too many terms in compound SELECT` for any
+    // caller in 6 or more organisations. This seeds exactly that caller —
+    // 6 organisations, one arm each — and asserts `suggestConnections`
+    // succeeds. Revert the batching in `services/recommendations.ts` and
+    // this test is the one that goes red.
+    const callerId = "usr_sixorg_caller";
+    const callerAccountId = "acc_sixorg_caller";
+    const ts = new Date();
+    await rawDb.insert(accounts).values({
+      id: callerAccountId,
+      email: "sixorg-caller@example.com",
+      passkeyUserId: crypto.randomUUID(),
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await rawDb.insert(users).values({
+      id: callerId,
+      accountId: callerAccountId,
+      handle: "sixorg_caller",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const ORG_COUNT = 6;
+    for (let i = 0; i < ORG_COUNT; i++) {
+      const organisationId = `org_sixorg_${i}`;
+      const memberAccountId = `acc_sixorg_m${i}`;
+      const memberId = `usr_sixorg_m${i}`;
+      // eslint-disable-next-line no-await-in-loop -- sequential, FK-ordered seeding
+      await rawDb.insert(organisations).values({
+        id: organisationId,
+        handle: `sixorg${i}`,
+        name: `Six Org ${i}`,
+        ownerId: callerId,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(organisationMembers).values({
+        id: `orgm_sixorg_caller_${i}`,
+        organisationId,
+        profileId: callerId,
+        role: "admin",
+        createdAt: ts,
+      });
+      // A co-member per organisation, so the fan-out has a real candidate to
+      // surface — not merely a query that returns nothing without throwing.
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(accounts).values({
+        id: memberAccountId,
+        email: `sixorg-m${i}@example.com`,
+        passkeyUserId: crypto.randomUUID(),
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(users).values({
+        id: memberId,
+        accountId: memberAccountId,
+        handle: `sixorgm${i}`,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(organisationMembers).values({
+        id: `orgm_sixorg_m${i}`,
+        organisationId,
+        profileId: memberId,
+        role: "member" as const,
+        createdAt: ts,
+      });
+    }
+
+    const recs = createRecommendationService();
+    const suggestions = await run(recs.suggestConnections(callerId, 50));
+
+    expect(suggestions.length).toBe(ORG_COUNT);
   });
 });
 

--- a/osn/api/src/d1-integration.test.ts
+++ b/osn/api/src/d1-integration.test.ts
@@ -4,7 +4,10 @@ import type { D1Database as DrizzleD1 } from "@cloudflare/workers-types";
 import {
   accounts,
   appEnrollments,
+  connections,
   deletionJobs,
+  organisationMembers,
+  organisations,
   passkeys,
   recoveryCodes,
   securityEvents,
@@ -16,11 +19,12 @@ import { Db } from "@osn/db/service";
 import { createSchemaSql } from "@osn/db/testing";
 import { commitBatch, createD1Db } from "@shared/db-utils";
 import { eq } from "drizzle-orm";
-import { Effect, Layer } from "effect";
+import { Cause, Effect, Layer, Option, Runtime } from "effect";
 import { Miniflare } from "miniflare";
 
 import { UNIQUE_CONSTRAINT_ERROR } from "./lib/unique-constraint";
 import { cancelErasure, getDeletionStatus, requestErasure } from "./services/account-erasure";
+import { createRecommendationService } from "./services/recommendations";
 
 // Integration tests against a REAL (workerd-backed) D1 database via Miniflare.
 // The rest of the OSN suite runs on synchronous bun:sqlite; these exercise the
@@ -38,11 +42,75 @@ import { cancelErasure, getDeletionStatus, requestErasure } from "./services/acc
 const ACCOUNT_ID = "acc_d1test";
 
 let mf: Miniflare;
+let d1: DrizzleD1;
 let layer: Layer.Layer<Db>;
 let rawDb: ReturnType<typeof createD1Db<typeof schema>>;
 
 const run = <A, E>(eff: Effect.Effect<A, E, Db>): Promise<A> =>
   Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+/**
+ * Wraps a D1 binding so every `SELECT` whose SQL text contains `tableHint`
+ * has its `meta.rows_read` (D1's own read-accounting figure — see
+ * developers.cloudflare.com/d1/platform/limits/) added to a running total,
+ * readable once every in-flight measurement has resolved.
+ *
+ * This is the only way this repo can *observe* whether a fan-out's read is
+ * actually bounded rather than merely assumed to be: bun:sqlite (every other
+ * test in the suite) reports no such figure, and D1 is the driver production
+ * runs on.
+ *
+ * It cannot read `.meta` off the call drizzle itself makes: for a `select({
+ * ... })` with an explicit field list, drizzle's D1 driver calls
+ * `.raw()`, not `.all()`/`.run()` — `.raw()` returns bare row tuples with no
+ * `.meta` at all (`D1PreparedStatement.raw()` in `@cloudflare/workers-types`).
+ * So on every matching `bind()`, this fires a second, identically-bound
+ * `.all()` purely to read its `meta.rows_read` — safe because every query
+ * this test runs through it is a pure `SELECT` — and leaves the statement
+ * drizzle actually executes untouched, `.raw()` and all, so the real result
+ * path behaves exactly as production does.
+ */
+function trackRowsRead(
+  base: DrizzleD1,
+  tableHint: string,
+): { d1: DrizzleD1; total: () => Promise<number> } {
+  let total = 0;
+  const pending: Promise<void>[] = [];
+  const tracked = new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop !== "prepare") return Reflect.get(target, prop, receiver);
+      return (query: string) => {
+        const stmt = target.prepare(query);
+        if (!query.includes(tableHint)) return stmt;
+        return new Proxy(stmt, {
+          get(stmtTarget, stmtProp, stmtReceiver) {
+            if (stmtProp !== "bind") return Reflect.get(stmtTarget, stmtProp, stmtReceiver);
+            return (...values: unknown[]) => {
+              pending.push(
+                target
+                  .prepare(query)
+                  .bind(...values)
+                  .all()
+                  .then((res) => {
+                    total += res.meta.rows_read ?? 0;
+                    return undefined;
+                  }),
+              );
+              return stmtTarget.bind(...values);
+            };
+          },
+        });
+      };
+    },
+  });
+  return {
+    d1: tracked,
+    total: async () => {
+      await Promise.all(pending);
+      return total;
+    },
+  };
+}
 
 const seedAccount = async (): Promise<void> => {
   const ts = new Date();
@@ -61,7 +129,7 @@ beforeAll(async () => {
     script: "export default { fetch() { return new Response('ok'); } };",
     d1Databases: { DB: ":memory:" },
   });
-  const d1 = (await mf.getD1Database("DB")) as unknown as DrizzleD1;
+  d1 = (await mf.getD1Database("DB")) as unknown as DrizzleD1;
   for (const stmt of createSchemaSql()) {
     await d1.prepare(stmt).run();
   }
@@ -75,7 +143,8 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // FK-safe truncation (D1 enforces foreign keys): every table that erasure
-  // writes and references `accounts` must be cleared before the account row.
+  // OR the recommendations tests below write, and that references `accounts`
+  // or `users`, must be cleared before those parent rows.
   for (const table of [
     deletionJobs,
     securityEvents,
@@ -83,6 +152,9 @@ beforeEach(async () => {
     passkeys,
     recoveryCodes,
     appEnrollments,
+    connections,
+    organisationMembers,
+    organisations,
     users,
     accounts,
   ]) {
@@ -156,5 +228,217 @@ describe("UNIQUE_CONSTRAINT_ERROR over real D1 (Miniflare)", () => {
       expect(UNIQUE_CONSTRAINT_ERROR.test(msg)).toBe(false);
     }
     expect(threw).toBe(true);
+  });
+});
+
+// The two describes below are the first D1 coverage of
+// `services/recommendations.ts` — everything else exercising it runs on
+// synchronous bun:sqlite, which cannot see either the read-accounting D1
+// reports or the bound-parameter cap D1 enforces.
+describe("osn/api recommendations co-member fan-out over real D1 (Miniflare)", () => {
+  it("stays within the MAX_ORG_COMEMBER_ROWS budget even when one organisation has far more members than its share", async () => {
+    // osn-tracker#574. MAX_ORG_COMEMBER_ROWS (services/recommendations.ts) is
+    // 2 000. This seeds one organisation with 2 500 members — 500 more than
+    // the whole budget — and confirms the fan-out reads no more than the
+    // budget from `organisation_members`, using D1's own `rows_read` figure
+    // rather than assuming the query's LIMIT clauses did their job.
+    const callerId = "usr_boundtest_caller";
+    const callerAccountId = "acc_boundtest_caller";
+    const ts = new Date();
+    await rawDb.insert(accounts).values({
+      id: callerAccountId,
+      email: "boundtest-caller@example.com",
+      passkeyUserId: crypto.randomUUID(),
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await rawDb.insert(users).values({
+      id: callerId,
+      accountId: callerAccountId,
+      handle: "boundtest_caller",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await rawDb.insert(organisations).values({
+      id: "org_boundtest",
+      handle: "boundtest",
+      name: "Bound Test Org",
+      ownerId: callerId,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await rawDb.insert(organisationMembers).values({
+      id: "orgm_boundtest_caller",
+      organisationId: "org_boundtest",
+      profileId: callerId,
+      role: "admin",
+      createdAt: ts,
+    });
+
+    // D1 caps bound parameters at 100 PER STATEMENT (see the FOF test below),
+    // so a multi-row `INSERT ... VALUES (...), (...), …` — one statement,
+    // many binds — hits that cap almost immediately at these row widths.
+    // `commitBatch` (already used above, `@shared/db-utils`) sends many
+    // single-row statements as one D1 `batch()` round trip instead: each
+    // statement stays far under the per-statement cap, and the batch itself
+    // is still one network hop.
+    const MEMBER_COUNT = 2_500;
+    const BATCH = 100;
+    for (let i = 0; i < MEMBER_COUNT; i += BATCH) {
+      const indices = Array.from({ length: Math.min(BATCH, MEMBER_COUNT - i) }, (_, j) => i + j);
+      // eslint-disable-next-line no-await-in-loop -- sequential batches; each
+      // depends on nothing but must land before the assertions below run.
+      await commitBatch(
+        rawDb,
+        indices.map((n) =>
+          rawDb.insert(accounts).values({
+            id: `acc_boundtest_m${n}`,
+            email: `boundtest-m${n}@example.com`,
+            passkeyUserId: crypto.randomUUID(),
+            createdAt: ts,
+            updatedAt: ts,
+          }),
+        ),
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await commitBatch(
+        rawDb,
+        indices.map((n) =>
+          rawDb.insert(users).values({
+            id: `usr_boundtest_m${n}`,
+            accountId: `acc_boundtest_m${n}`,
+            handle: `boundtestm${n}`,
+            createdAt: ts,
+            updatedAt: ts,
+          }),
+        ),
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await commitBatch(
+        rawDb,
+        indices.map((n) =>
+          rawDb.insert(organisationMembers).values({
+            id: `orgm_boundtest_m${n}`,
+            organisationId: "org_boundtest",
+            profileId: `usr_boundtest_m${n}`,
+            role: "member" as const,
+            createdAt: ts,
+          }),
+        ),
+      );
+    }
+
+    const { d1: trackedD1, total } = trackRowsRead(d1, "organisation_members");
+    const trackedLayer = Layer.succeed(Db, { db: createD1Db(trackedD1, schema) });
+    const recs = createRecommendationService();
+
+    const suggestions = await Effect.runPromise(
+      recs.suggestConnections(callerId, 50).pipe(Effect.provide(trackedLayer)),
+    );
+
+    const rowsRead = await total();
+    expect(suggestions.length).toBeGreaterThan(0);
+    // 2 500 members exist; the read must never approach that. The small
+    // margin above the exact 2 000 budget covers the caller's own membership
+    // row (a separate, tiny query against the same table) and planner
+    // overhead — not a second organisation's worth of reads.
+    expect(rowsRead).toBeLessThanOrEqual(2_010);
+  });
+});
+
+describe("osn/api recommendations FOF fan-out over real D1 (Miniflare)", () => {
+  it("suggestConnections throws once the caller's accepted-connection count pushes the FOF query past D1's 100-bound-parameter cap", async () => {
+    // The FOF fan-out (services/recommendations.ts) binds `myConnectionIds`
+    // TWICE — once per edge direction, in
+    // `inArray(requesterId, ids) OR inArray(addresseeId, ids)`.
+    // MAX_MY_CONNECTIONS_FOR_FOF allows up to 500 ids (1 000 binds), but D1's
+    // documented cap is 100 bound parameters per query
+    // (developers.cloudflare.com/d1/platform/limits/: "Maximum bound
+    // parameters per query | 100", applying per statement including within a
+    // batch). 51 accepted connections already produces 102 binds — over the
+    // cap — so `GET /recommendations/connections` already fails in
+    // production for any caller with more than 50 accepted connections.
+    //
+    // Confirmed empirically against THIS Miniflare version before writing
+    // this test: it enforces the same 100-parameter cap D1 documents (100
+    // bound params succeeds, 101 throws "too many SQL variables"), so this
+    // is real coverage of the failure, not a false negative that only
+    // production would catch.
+    const callerId = "usr_bindtest_caller";
+    const callerAccountId = "acc_bindtest_caller";
+    const ts = new Date();
+    await rawDb.insert(accounts).values({
+      id: callerAccountId,
+      email: "bindtest-caller@example.com",
+      passkeyUserId: crypto.randomUUID(),
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await rawDb.insert(users).values({
+      id: callerId,
+      accountId: callerAccountId,
+      handle: "bindtest_caller",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const FRIEND_COUNT = 60; // 2 x 60 = 120 binds, over D1's 100-bind cap
+    for (let i = 0; i < FRIEND_COUNT; i++) {
+      const friendAccountId = `acc_bindtest_f${i}`;
+      const friendId = `usr_bindtest_f${i}`;
+      // eslint-disable-next-line no-await-in-loop -- sequential, FK-ordered seeding
+      await rawDb.insert(accounts).values({
+        id: friendAccountId,
+        email: `bindtest-f${i}@example.com`,
+        passkeyUserId: crypto.randomUUID(),
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(users).values({
+        id: friendId,
+        accountId: friendAccountId,
+        handle: `bindtestf${i}`,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await rawDb.insert(connections).values({
+        id: `conn_bindtest_${i}`,
+        requesterId: callerId,
+        addresseeId: friendId,
+        status: "accepted",
+        createdAt: ts,
+        updatedAt: ts,
+      });
+    }
+
+    const recs = createRecommendationService();
+    let threw = false;
+    let message = "";
+    try {
+      await run(recs.suggestConnections(callerId));
+    } catch (e) {
+      threw = true;
+      // The Effect error channel wraps three deep here: the service's own
+      // `DatabaseError`, wrapping drizzle's `DrizzleQueryError`, wrapping the
+      // real `D1_ERROR: too many SQL variables …` — walk `.cause` down to the
+      // bottom rather than asserting on the generic outer message.
+      // `Effect.runPromise` rejects with a `FiberFailure` wrapping the typed
+      // failure, never the tagged error itself — same unwrap `safe-error.ts`
+      // does for route handlers (Runtime.isFiberFailure → Cause.failureOption).
+      const failure = Runtime.isFiberFailure(e)
+        ? Option.getOrNull(Cause.failureOption(e[Runtime.FiberFailureCauseId]))
+        : e;
+      let cause: unknown = failure;
+      for (let depth = 0; depth < 5; depth++) {
+        const next = (cause as { cause?: unknown } | undefined)?.cause;
+        if (next === undefined || next === null) break;
+        cause = next;
+      }
+      message = cause instanceof Error ? cause.message : String(cause);
+    }
+    expect(threw).toBe(true);
+    expect(message).toContain("too many SQL variables");
   });
 });

--- a/osn/api/src/routes/recommendations.ts
+++ b/osn/api/src/routes/recommendations.ts
@@ -147,7 +147,12 @@ export function createRecommendationRoutes(
             const suggestions = await run(
               recommendations.suggestConnections(caller.profileId, limit),
             );
-            return { suggestions };
+            // The list itself is never cached or stored (see the header
+            // above), but the caller has no other way to tell how fresh it
+            // is — this is that timestamp, set at request time, not read
+            // from anywhere stored (osn-tracker#311; the cache half of that
+            // issue, #588, is a separate change pending a staleness call).
+            return { suggestions, generatedAt: new Date().toISOString() };
           } catch {
             set.status = 500;
             return { error: "Request failed" };
@@ -162,7 +167,11 @@ export function createRecommendationRoutes(
           response: {
             // An empty list is the normal answer for a new account with no
             // connections and no organisation — not a 404.
-            200: t.Object({ suggestions: t.Array(suggestionSummary) }),
+            200: t.Object({
+              suggestions: t.Array(suggestionSummary),
+              /** When this list was generated — set at request time, never cached. */
+              generatedAt: t.String({ format: "date-time" }),
+            }),
             401: errorResponse,
             429: errorResponse,
             // The fan-out is several queries deep; anything it throws is

--- a/osn/api/src/services/recommendations.ts
+++ b/osn/api/src/services/recommendations.ts
@@ -83,6 +83,31 @@ const MAX_FOF_FANOUT_ROWS = 10_000;
 const MAX_ORG_COMEMBER_ROWS = 2_000;
 
 /**
+ * Arms per `UNION ALL` batch in the co-member fan-out query, below
+ * (osn-tracker#589, P-C1).
+ *
+ * D1 does not run on `bun:sqlite`, which is what this repo's local/test
+ * engine uses and where a compound `SELECT` may carry up to SQLite's own
+ * default of 500 terms. D1 runs on workerd's embedded SQLite, and workerd
+ * calls `sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5)` when it opens a
+ * connection (cloudflare/workerd#795, landed in #796) — a deliberate,
+ * compiled-in ceiling, not a measured-under-load estimate. Confirmed three
+ * ways rather than taken on any one of them: bisected against this repo's
+ * pinned Miniflare version (a 5-arm `UNION ALL` succeeds, 6 throws
+ * `D1_ERROR: too many terms in compound SELECT`); read directly out of
+ * workerd's own `src/workerd/api/tests/sql-test.js` at HEAD, which asserts
+ * that exact 5/6 boundary; and read out of the PR that set the limit.
+ * Cloudflare's D1 limits page documents no compound-select limit at all, so
+ * there is no published figure to reconcile this against — the workerd
+ * source is the ground truth, and Miniflare reproduces it exactly.
+ *
+ * No margin taken below 5: unlike a heuristic threshold, this number cannot
+ * drift request to request, so shaving it further would only shrink the
+ * common single-query case for no safety gained.
+ */
+const MAX_ORG_COMEMBER_ARMS_PER_QUERY = 5;
+
+/**
  * The organisation label on a suggestion card, or `null`.
  *
  * `null` for a candidate with no shared organisation, and also for one whose
@@ -519,7 +544,7 @@ export function createRecommendationService() {
               }),
           myOrgIds.length === 0
             ? Effect.succeed([] as { profileId: string; organisationId: string }[])
-            : Effect.tryPromise({
+            : Effect.gen(function* () {
                 // Ids only. This reads at most MAX_ORG_COMEMBER_ROWS rows and at
                 // most `safeLimit` candidates survive ranking, so joining
                 // `organisations` here re-serialised a handle and a name for
@@ -527,48 +552,65 @@ export function createRecommendationService() {
                 // them. The surviving organisations are hydrated in step 5,
                 // alongside the profiles, from a set that is already small.
                 //
-                // One statement, `UNION ALL` of a per-organisation subselect
-                // for each of the caller's organisations (osn-tracker#574).
-                // The single query this replaced gave the whole budget to one
+                // Batched `UNION ALL`: one statement per group of up to
+                // MAX_ORG_COMEMBER_ARMS_PER_QUERY (5) of the caller's
+                // organisations, the batches run concurrently and merged here
+                // in application code (osn-tracker#574, reopened as
+                // osn-tracker#589 / P-C1 — see that constant's comment for why
+                // 5, not the 50 this originally unioned in one statement). The
+                // query both versions replaced gave the whole budget to one
                 // global `ORDER BY (organisation_id, profile_id) LIMIT
                 // MAX_ORG_COMEMBER_ROWS` — see the note on that constant for
                 // why that starved every organisation but the lowest-id one.
                 // Splitting the budget per organisation, with its own `ORDER
                 // BY profile_id LIMIT <share>`, is what fixes it: every
                 // organisation the caller belongs to contributes candidates,
-                // not just whichever one sorts first.
+                // not just whichever one sorts first — batching changes how
+                // many round trips that takes, not which organisations
+                // contribute.
                 //
-                // The issue that reported this proposed a window function
-                // (`ROW_NUMBER() OVER (PARTITION BY organisation_id ORDER BY
-                // profile_id)`, filtered to `rn <= share`) instead. That is
-                // the wrong fix: a window function's `PARTITION BY` filters
-                // *after* the window scan, so it still reads every membership
-                // row of every organisation the caller belongs to — exactly
-                // the unbounded read MAX_ORG_COMEMBER_ROWS exists to prevent.
+                // The issue that reported the starvation proposed a window
+                // function (`ROW_NUMBER() OVER (PARTITION BY organisation_id
+                // ORDER BY profile_id)`, filtered to `rn <= share`) instead.
+                // That is still the wrong fix: a window function's `PARTITION
+                // BY` filters *after* the window scan, so it still reads
+                // every membership row of every organisation the caller
+                // belongs to — exactly the unbounded read
+                // MAX_ORG_COMEMBER_ROWS exists to prevent. `json_each()` was
+                // also considered, for a single statement carrying the whole
+                // organisation list as one bound JSON array — D1 does expose
+                // that function, confirmed against Miniflare, but it does
+                // not fit this shape: giving each organisation its own
+                // `ORDER BY … LIMIT <share>` needs a per-row-correlated
+                // subquery in the `FROM` clause, and this SQLite build has no
+                // implicit `LATERAL` (`no such column: je.value` — confirmed
+                // against Miniflare rather than assumed). It stays useful
+                // elsewhere for a flat `IN`-style list past the
+                // 100-bound-parameter cap; it does not replace a per-group
+                // `LIMIT`.
+                //
                 // Measured on real (Miniflare/workerd) D1, three organisations
-                // of 600/300/100 members, cap 150, share 50: the current
-                // global query reads 151 rows for 150 results; the window
-                // function reads 2,860 for the same 150; this `UNION ALL`
-                // shape reads exactly 150. A single organisation with 50,000
-                // members would cost the window function 50,000+ rows read on
-                // every request, forever — the same failure this constant was
-                // added to stop.
-                //
-                // `MAX_MY_ORGANISATIONS` (50) caps the arm count, well under
-                // SQLite's 500-term compound-select limit, so this is always
-                // one statement rather than one query per organisation.
+                // of 600/300/100 members, cap 150, share 50: the pre-#574
+                // global query read 151 rows for 150 results, and the window
+                // function read 2,860 for the same 150. Both the single-
+                // statement `UNION ALL` this batching replaces and the
+                // batched form read exactly 150 — batching changes round-trip
+                // count, not rows read. A single organisation with 50,000
+                // members would still cost the window function 50,000+ rows
+                // read on every request, forever — the same failure this
+                // constant was added to stop.
                 //
                 // The share is MAX_ORG_COMEMBER_ROWS divided evenly by the
-                // caller's actual organisation count, not by the 50-org cap —
-                // a caller in one organisation gets the whole budget (same as
-                // the query this replaces did), a caller in three splits it
-                // three ways, and a caller at the 50-organisation cap gets the
-                // same 40-per-organisation worst case a fixed division would
-                // have given throughout. Integer division: the remainder —
-                // at most `myOrgIds.length - 1` rows of budget — goes to no
-                // organisation. Handing it to whichever organisation sorts
-                // first would reintroduce, in miniature, the exact bias this
-                // change exists to remove.
+                // caller's actual organisation count, not by the 50-org cap or
+                // the batch size — a caller in one organisation gets the whole
+                // budget (same as the query this replaces did), a caller in
+                // three splits it three ways, and a caller at the
+                // 50-organisation cap gets the same 40-per-organisation worst
+                // case a fixed division would have given throughout. Integer
+                // division: the remainder — at most `myOrgIds.length - 1` rows
+                // of budget — goes to no organisation. Handing it to whichever
+                // organisation sorts first would reintroduce, in miniature,
+                // the exact bias this change exists to remove.
                 //
                 // Each arm is wrapped as a subquery (`.as(...)` then an outer
                 // `.select().from(...)`) because SQLite's compound-select
@@ -579,38 +621,61 @@ export function createRecommendationService() {
                 // ("ORDER BY clause should come after UNION ALL not before"),
                 // not merely unidiomatic.
                 //
-                // `myOrgIds` is sorted before the arms are built so the
-                // union's row order reproduces the old query's `(organisation_
-                // id, profile_id)` order — arm N's rows are fully emitted
-                // before arm N+1's, and each arm is itself ordered by
-                // `profile_id`. That keeps "first organisation wins the
-                // label" in step 3 deterministic across requests, same as the
-                // comment there has always promised.
-                try: () => {
-                  const orgComemberShare = Math.floor(MAX_ORG_COMEMBER_ROWS / myOrgIds.length);
-                  const arms = [...myOrgIds].toSorted().map((organisationId, index) => {
-                    const capped = db
-                      .select({
-                        profileId: organisationMembers.profileId,
-                        organisationId: organisationMembers.organisationId,
-                      })
-                      .from(organisationMembers)
-                      .where(eq(organisationMembers.organisationId, organisationId))
-                      .orderBy(asc(organisationMembers.profileId))
-                      .limit(orgComemberShare)
-                      .as(`org_share_${index}`);
-                    return db
-                      .select({
-                        profileId: capped.profileId,
-                        organisationId: capped.organisationId,
-                      })
-                      .from(capped);
-                  });
-                  return arms.length === 1
-                    ? arms[0]!
-                    : unionAll(arms[0]!, arms[1]!, ...arms.slice(2));
-                },
-                catch: (cause) => new DatabaseError({ cause }),
+                // `myOrgIds` is sorted once, up front, and cut into batches in
+                // that order, so the merged result reproduces the old query's
+                // `(organisation_id, profile_id)` order: batch 0's rows are
+                // fully emitted before batch 1's, arm N's rows before arm
+                // N+1's within a batch, and each arm is itself ordered by
+                // `profile_id`. `Effect.all` returns results in input order
+                // regardless of which batch's query resolves first, so that
+                // order survives the concurrency below. That keeps "first
+                // organisation wins the label" in step 3 deterministic across
+                // requests, same as the comment there has always promised.
+                const orgComemberShare = Math.floor(MAX_ORG_COMEMBER_ROWS / myOrgIds.length);
+                const sortedOrgIds = [...myOrgIds].toSorted();
+                const batches: string[][] = [];
+                for (let i = 0; i < sortedOrgIds.length; i += MAX_ORG_COMEMBER_ARMS_PER_QUERY) {
+                  batches.push(sortedOrgIds.slice(i, i + MAX_ORG_COMEMBER_ARMS_PER_QUERY));
+                }
+
+                const batchResults = yield* Effect.all(
+                  batches.map((batchOrgIds) =>
+                    Effect.tryPromise({
+                      try: () => {
+                        const arms = batchOrgIds.map((organisationId, index) => {
+                          const capped = db
+                            .select({
+                              profileId: organisationMembers.profileId,
+                              organisationId: organisationMembers.organisationId,
+                            })
+                            .from(organisationMembers)
+                            .where(eq(organisationMembers.organisationId, organisationId))
+                            .orderBy(asc(organisationMembers.profileId))
+                            .limit(orgComemberShare)
+                            .as(`org_share_${index}`);
+                          return db
+                            .select({
+                              profileId: capped.profileId,
+                              organisationId: capped.organisationId,
+                            })
+                            .from(capped);
+                        });
+                        return arms.length === 1
+                          ? arms[0]!
+                          : unionAll(arms[0]!, arms[1]!, ...arms.slice(2));
+                      },
+                      catch: (cause) => new DatabaseError({ cause }),
+                    }),
+                  ),
+                  // Bounded, not "unbounded": at the 50-organisation cap this
+                  // is 10 batches, and the same care that caps one query's
+                  // arms at 5 caps how many of those queries run at once,
+                  // rather than opening 10 concurrent D1 round trips for a
+                  // single request.
+                  { concurrency: MAX_ORG_COMEMBER_ARMS_PER_QUERY },
+                );
+
+                return batchResults.flat();
               }),
         ],
         { concurrency: "unbounded" },

--- a/osn/api/src/services/recommendations.ts
+++ b/osn/api/src/services/recommendations.ts
@@ -18,7 +18,7 @@ import {
   tokensPrefixName,
 } from "@shared/db-utils/search";
 import { and, asc, eq, gte, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
-import { alias, type SQLiteColumn } from "drizzle-orm/sqlite-core";
+import { alias, unionAll, type SQLiteColumn } from "drizzle-orm/sqlite-core";
 import { Data, Effect } from "effect";
 
 // ---------------------------------------------------------------------------
@@ -69,12 +69,16 @@ const MAX_FOF_FANOUT_ROWS = 10_000;
  * defence as MAX_FOF_FANOUT_ROWS: membership of one very large organisation
  * must not turn a suggestion request into an unbounded read.
  *
- * It is a budget for the whole fan-out, not per organisation, and the rows
- * arrive ordered by `(organisation_id, profile_id)` — so a caller in one large
- * organisation fills the budget from that organisation alone and never sees a
- * co-member from any other. Organisation ids are random, so which one wins is
- * a fixed draw per caller. Tracked as its own finding; the fix is a
- * per-organisation budget rather than a bigger global one.
+ * This used to be a budget for the whole fan-out, filled by one query ordered
+ * `(organisation_id, profile_id)` — so a caller in one large organisation
+ * filled the budget from that organisation alone and never saw a co-member
+ * from any other, and a caller in fifty organisations of 250 members each saw
+ * co-members from about eight of them, every time, because organisation ids
+ * are random and the draw is fixed per caller (osn-tracker#574). It is now
+ * split evenly across the caller's organisations — see the query that reads
+ * it, below — so this constant is the *total* budget and each organisation's
+ * actual share is `MAX_ORG_COMEMBER_ROWS / (number of the caller's
+ * organisations)`.
  */
 const MAX_ORG_COMEMBER_ROWS = 2_000;
 
@@ -516,37 +520,96 @@ export function createRecommendationService() {
           myOrgIds.length === 0
             ? Effect.succeed([] as { profileId: string; organisationId: string }[])
             : Effect.tryPromise({
-                // Ids only. This reads up to MAX_ORG_COMEMBER_ROWS rows and at
+                // Ids only. This reads at most MAX_ORG_COMEMBER_ROWS rows and at
                 // most `safeLimit` candidates survive ranking, so joining
                 // `organisations` here re-serialised a handle and a name for
                 // every row to throw away roughly forty out of forty-one of
                 // them. The surviving organisations are hydrated in step 5,
                 // alongside the profiles, from a set that is already small.
                 //
-                // The ORDER BY pins what was left to the planner. Without
-                // one the row order under the LIMIT is unspecified — in
-                // practice SQLite already walked `org_members_pair_idx` in
-                // this order, so `EXPLAIN QUERY PLAN` is identical either way
-                // and no behaviour changes today. What it buys is that the
-                // slice stays the same slice if the planner ever chooses
-                // differently, which matters because org-only candidates all
-                // tie at `mutualCount: 0` and are separated only by the id
-                // tiebreak in step 4. It costs nothing: the index is UNIQUE
-                // on exactly (organisation_id, profile_id), so this is its own
-                // order and adds no sort.
+                // One statement, `UNION ALL` of a per-organisation subselect
+                // for each of the caller's organisations (osn-tracker#574).
+                // The single query this replaced gave the whole budget to one
+                // global `ORDER BY (organisation_id, profile_id) LIMIT
+                // MAX_ORG_COMEMBER_ROWS` — see the note on that constant for
+                // why that starved every organisation but the lowest-id one.
+                // Splitting the budget per organisation, with its own `ORDER
+                // BY profile_id LIMIT <share>`, is what fixes it: every
+                // organisation the caller belongs to contributes candidates,
+                // not just whichever one sorts first.
                 //
-                // What the ordering does NOT fix is which organisations the
-                // cap reaches — see the note on MAX_ORG_COMEMBER_ROWS.
-                try: () =>
-                  db
-                    .select({
-                      profileId: organisationMembers.profileId,
-                      organisationId: organisationMembers.organisationId,
-                    })
-                    .from(organisationMembers)
-                    .where(inArray(organisationMembers.organisationId, myOrgIds))
-                    .orderBy(organisationMembers.organisationId, organisationMembers.profileId)
-                    .limit(MAX_ORG_COMEMBER_ROWS),
+                // The issue that reported this proposed a window function
+                // (`ROW_NUMBER() OVER (PARTITION BY organisation_id ORDER BY
+                // profile_id)`, filtered to `rn <= share`) instead. That is
+                // the wrong fix: a window function's `PARTITION BY` filters
+                // *after* the window scan, so it still reads every membership
+                // row of every organisation the caller belongs to — exactly
+                // the unbounded read MAX_ORG_COMEMBER_ROWS exists to prevent.
+                // Measured on real (Miniflare/workerd) D1, three organisations
+                // of 600/300/100 members, cap 150, share 50: the current
+                // global query reads 151 rows for 150 results; the window
+                // function reads 2,860 for the same 150; this `UNION ALL`
+                // shape reads exactly 150. A single organisation with 50,000
+                // members would cost the window function 50,000+ rows read on
+                // every request, forever — the same failure this constant was
+                // added to stop.
+                //
+                // `MAX_MY_ORGANISATIONS` (50) caps the arm count, well under
+                // SQLite's 500-term compound-select limit, so this is always
+                // one statement rather than one query per organisation.
+                //
+                // The share is MAX_ORG_COMEMBER_ROWS divided evenly by the
+                // caller's actual organisation count, not by the 50-org cap —
+                // a caller in one organisation gets the whole budget (same as
+                // the query this replaces did), a caller in three splits it
+                // three ways, and a caller at the 50-organisation cap gets the
+                // same 40-per-organisation worst case a fixed division would
+                // have given throughout. Integer division: the remainder —
+                // at most `myOrgIds.length - 1` rows of budget — goes to no
+                // organisation. Handing it to whichever organisation sorts
+                // first would reintroduce, in miniature, the exact bias this
+                // change exists to remove.
+                //
+                // Each arm is wrapped as a subquery (`.as(...)` then an outer
+                // `.select().from(...)`) because SQLite's compound-select
+                // grammar does not give a non-final arm of a UNION its own
+                // ORDER BY/LIMIT — only a derived-table subquery gets one.
+                // Confirmed against a real SQLite engine: the unwrapped form
+                // (`... LIMIT ? UNION ALL SELECT ...`) is a syntax error
+                // ("ORDER BY clause should come after UNION ALL not before"),
+                // not merely unidiomatic.
+                //
+                // `myOrgIds` is sorted before the arms are built so the
+                // union's row order reproduces the old query's `(organisation_
+                // id, profile_id)` order — arm N's rows are fully emitted
+                // before arm N+1's, and each arm is itself ordered by
+                // `profile_id`. That keeps "first organisation wins the
+                // label" in step 3 deterministic across requests, same as the
+                // comment there has always promised.
+                try: () => {
+                  const orgComemberShare = Math.floor(MAX_ORG_COMEMBER_ROWS / myOrgIds.length);
+                  const arms = [...myOrgIds].toSorted().map((organisationId, index) => {
+                    const capped = db
+                      .select({
+                        profileId: organisationMembers.profileId,
+                        organisationId: organisationMembers.organisationId,
+                      })
+                      .from(organisationMembers)
+                      .where(eq(organisationMembers.organisationId, organisationId))
+                      .orderBy(asc(organisationMembers.profileId))
+                      .limit(orgComemberShare)
+                      .as(`org_share_${index}`);
+                    return db
+                      .select({
+                        profileId: capped.profileId,
+                        organisationId: capped.organisationId,
+                      })
+                      .from(capped);
+                  });
+                  return arms.length === 1
+                    ? arms[0]!
+                    : unionAll(arms[0]!, arms[1]!, ...arms.slice(2));
+                },
                 catch: (cause) => new DatabaseError({ cause }),
               }),
         ],

--- a/osn/api/tests/routes/recommendations.test.ts
+++ b/osn/api/tests/routes/recommendations.test.ts
@@ -109,6 +109,24 @@ describe("recommendations routes", () => {
     expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 
+  // osn-tracker#311 (timestamp half): a list this endpoint never caches or
+  // stores otherwise gives the client no way to say how fresh it is.
+  it("GET /recommendations/connections returns a generatedAt timestamp", async () => {
+    const alice = await registerAndGetToken("a@e.com", "alice");
+    const before = new Date();
+    const res = await recsApp.handle(
+      new Request("http://localhost/recommendations/connections", {
+        headers: { Authorization: `Bearer ${alice.token}` },
+      }),
+    );
+    const after = new Date();
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { generatedAt: string };
+    const generatedAt = new Date(json.generatedAt);
+    expect(generatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(generatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
   it("returns FOF suggestions with mutual counts", async () => {
     const alice = await registerAndGetToken("a@e.com", "alice");
     const bob = await registerAndGetToken("b@e.com", "bob");

--- a/osn/api/tests/services/recommendations.test.ts
+++ b/osn/api/tests/services/recommendations.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, describe } from "@effect/vitest";
-import { accounts, organisations } from "@osn/db/schema";
+import { accounts, organisationMembers, organisations, users } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 import { eq, sql } from "drizzle-orm";
 import { Effect } from "effect";
@@ -448,6 +448,151 @@ describe("suggestConnections", () => {
       const result = yield* recs.suggestConnections(alice.id);
       expect(result).toEqual([]);
     }).pipe(Effect.provide(createTestLayer())),
+  );
+
+  // osn-tracker#574: the co-member fan-out used to be one query bounded by
+  // MAX_ORG_COMEMBER_ROWS across ALL the caller's organisations, ordered
+  // `(organisation_id, profile_id)`. Whichever organisation the caller
+  // belonged to happened to sort first absorbed the whole budget, and every
+  // other organisation contributed nothing — a fixed draw per caller, since
+  // organisation ids don't change. This seeds exactly that shape: one
+  // organisation alone big enough to have exhausted the old global budget,
+  // and two small ones that used to be starved by it.
+  it.effect(
+    "every organisation the caller belongs to contributes candidates, not just the biggest one",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* auth.registerProfile("a@e.com", "alice");
+        const smallOneMember = yield* auth.registerProfile("s1@e.com", "smallone");
+        const smallTwoMember = yield* auth.registerProfile("s2@e.com", "smalltwo");
+
+        const { db } = yield* Db;
+        const now = new Date();
+
+        // The three organisations and alice's (+ the two real members')
+        // memberships are inserted directly, bypassing the org service, so
+        // their ids are controlled rather than random. `org_0_big` sorts
+        // before the other two — the exact shape that used to matter: under
+        // the old single global `ORDER BY organisation_id LIMIT
+        // MAX_ORG_COMEMBER_ROWS`, whichever organisation sorted first
+        // absorbed the budget before the query ever reached the others. With
+        // 2 001 members, `org_0_big` alone exceeds the entire 2 000-row
+        // budget, so the old query would return zero rows for `org_1_small`
+        // and `org_2_small` regardless of how few members they have.
+        yield* Effect.promise(async () => {
+          await db.insert(organisations).values([
+            {
+              id: "org_0_big",
+              handle: "big",
+              name: "Big Org",
+              ownerId: alice.id,
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              id: "org_1_small",
+              handle: "small1",
+              name: "Small One",
+              ownerId: alice.id,
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              id: "org_2_small",
+              handle: "small2",
+              name: "Small Two",
+              ownerId: alice.id,
+              createdAt: now,
+              updatedAt: now,
+            },
+          ]);
+          await db.insert(organisationMembers).values([
+            {
+              id: "orgm_alice_big",
+              organisationId: "org_0_big",
+              profileId: alice.id,
+              role: "admin",
+              createdAt: now,
+            },
+            {
+              id: "orgm_alice_s1",
+              organisationId: "org_1_small",
+              profileId: alice.id,
+              role: "admin",
+              createdAt: now,
+            },
+            {
+              id: "orgm_alice_s2",
+              organisationId: "org_2_small",
+              profileId: alice.id,
+              role: "admin",
+              createdAt: now,
+            },
+            {
+              id: "orgm_s1_member",
+              organisationId: "org_1_small",
+              profileId: smallOneMember.id,
+              role: "member",
+              createdAt: now,
+            },
+            {
+              id: "orgm_s2_member",
+              organisationId: "org_2_small",
+              profileId: smallTwoMember.id,
+              role: "member",
+              createdAt: now,
+            },
+          ]);
+        });
+
+        // Bulk-inserted directly too: 2 001 rows is MAX_ORG_COMEMBER_ROWS
+        // (2 000) + 1, more than the entire old global budget on its own.
+        // Ids are chosen to sort AFTER any handle the auth service generates
+        // (`usr_` + lowercase hex) so they never crowd the two real members
+        // above out of the final ranking's id tiebreak — this test is about
+        // the fan-out reading from every organisation, not about which
+        // candidate wins ties.
+        const FILLER_COUNT = 2_001;
+        const fillerAccounts = Array.from({ length: FILLER_COUNT }, (_, i) => ({
+          id: `acc_zzz_filler_${String(i).padStart(5, "0")}`,
+          email: `filler${i}@example.com`,
+          passkeyUserId: crypto.randomUUID(),
+          createdAt: now,
+          updatedAt: now,
+        }));
+        const fillerUsers = fillerAccounts.map((a, i) => ({
+          id: `usr_zzz_filler_${String(i).padStart(5, "0")}`,
+          accountId: a.id,
+          handle: `zzzfiller${i}`,
+          createdAt: now,
+          updatedAt: now,
+        }));
+        const fillerMemberships = fillerUsers.map((u, i) => ({
+          id: `orgm_zzz_filler_${String(i).padStart(5, "0")}`,
+          organisationId: "org_0_big",
+          profileId: u.id,
+          role: "member" as const,
+          createdAt: now,
+        }));
+        const CHUNK = 200;
+        yield* Effect.promise(async () => {
+          for (let i = 0; i < FILLER_COUNT; i += CHUNK) {
+            // eslint-disable-next-line no-await-in-loop -- sequential bulk
+            // seeding chunks; each chunk depends on nothing but must land
+            // before the assertions below run.
+            await db.insert(accounts).values(fillerAccounts.slice(i, i + CHUNK));
+            // eslint-disable-next-line no-await-in-loop
+            await db.insert(users).values(fillerUsers.slice(i, i + CHUNK));
+            // eslint-disable-next-line no-await-in-loop
+            await db.insert(organisationMembers).values(fillerMemberships.slice(i, i + CHUNK));
+          }
+        });
+
+        const result = yield* recs.suggestConnections(alice.id, 50);
+        const handles = new Set(result.map((s) => s.handle));
+        expect(handles.has("smallone")).toBe(true);
+        expect(handles.has("smalltwo")).toBe(true);
+      }).pipe(Effect.provide(createTestLayer())),
   );
 });
 

--- a/osn/client/src/recommendations.ts
+++ b/osn/client/src/recommendations.ts
@@ -58,7 +58,7 @@ export interface RecommendationClient {
   suggestConnections(
     token: string,
     options?: { limit?: number },
-  ): Promise<{ suggestions: Suggestion[] }>;
+  ): Promise<{ suggestions: Suggestion[]; generatedAt: string }>;
   /**
    * Search people and organisations for autocomplete. A query with no word
    * characters left after trimming and stripping a leading `@` comes back as
@@ -93,7 +93,10 @@ export function createRecommendationClient(
     suggestConnections: async (token, options) => {
       const limit = options?.limit;
       const qs = limit !== undefined ? `?limit=${encodeURIComponent(String(limit))}` : "";
-      return authGet<{ suggestions: Suggestion[] }>(`${base}/connections${qs}`, token);
+      return authGet<{ suggestions: Suggestion[]; generatedAt: string }>(
+        `${base}/connections${qs}`,
+        token,
+      );
     },
 
     search: async (token, query, options) => {

--- a/shared/openapi/osn.json
+++ b/shared/openapi/osn.json
@@ -9447,6 +9447,10 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "generatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
                     "suggestions": {
                       "items": {
                         "properties": {
@@ -9508,7 +9512,8 @@
                     }
                   },
                   "required": [
-                    "suggestions"
+                    "suggestions",
+                    "generatedAt"
                   ],
                   "type": "object"
                 }

--- a/wiki/compliance/dsa.md
+++ b/wiki/compliance/dsa.md
@@ -6,7 +6,8 @@ related:
   - "[[scope-matrix]]"
   - "[[event-access]]"
   - "[[social-graph]]"
-last-reviewed: 2026-08-02
+  - "[[connection-recommender]]"
+last-reviewed: 2026-08-31
 ---
 
 # Digital Services Act
@@ -46,7 +47,7 @@ language is narrower than most summaries suggest.
 | Art. 24 | Transparency reporting (online platforms specifically) | **SME-exempt per Art. 19** (Section 3 carve-out) | Skip until threshold; data collected anyway via C-L10. |
 | Art. 25 | No "dark patterns" in interface design that distort autonomous choice | **Continuous** | Cover in design review checklist. |
 | Art. 26 | Online advertising transparency — show "ad", who paid, parameters used | **N/A today** | Activate when "promoted events" lands. |
-| Art. 27 | Recommender system transparency — main parameters disclosed in ToS | **Gap** | Three recommenders in scope — Pulse discovery, OSN contact suggestions, OSN search ranking; Zap has no recommender. Parameters inventoried under C-L8 below; document in ToS. |
+| Art. 27 | Recommender system transparency — main parameters disclosed in ToS | **Partial** | Three recommenders in scope — Pulse discovery, OSN contact suggestions, OSN search ranking; Zap has no recommender. The OSN contact-suggestions recommender is now documented — [[connection-recommender]] — but not yet published in a ToS; the other two remain inventoried only under C-L8 below. |
 | Art. 28 | Online protection of minors — proportionate measures; no targeted ads to known minors | We hard-gate <13. Add: no "promoted events" to known 13–17 if/when ads land. | — |
 | Art. 30 | Trader traceability — collect + verify identity of traders dealing with consumers via the platform | **Gap** | Verified-organisation flow in Zap M3 must capture: name, address, phone, email, registration ID, self-declaration of compliance. Block trader from interacting until verified. |
 | Art. 31 | Compliance by design when the platform allows traders to conclude distance contracts | **N/A today** | Activate with paid Pulse ticketing. |
@@ -63,7 +64,7 @@ Tracked with `C-` IDs:
 5. **Trader-traceability flow** in Zap M3 verification. ID: **C-M12** (built as part of Zap M3 spec).
 6. **Recommender-transparency disclosure** in ToS — documented in plain language, covering all three recommenders. ID: **C-L8**. Current parameters, kept current so the ToS text is drafted from a live inventory rather than a stale one:
    - **Pulse discovery** — friends, location, recency.
-   - **OSN contact suggestions** — mutual connections (stronger), then shared organisations. Discloses `mutualCount` per suggestion.
+   - **OSN contact suggestions** — mutual connections (stronger), then shared organisations. Discloses `mutualCount` per suggestion. Full write-up, verified against source: [[connection-recommender]]. Publishing this in an actual ToS is a separate step — `xchromo/osn-tracker#373`, `needs:decision`.
    - **OSN people/organisation search ranking** (updated 2026-08-02) — a five-tier text-match score (exact handle, handle prefix, name-token prefix, handle infix, name infix) **summed with** a social-proximity score (existing connection, pending request either way, shared organisation the caller belongs to). Proximity is applied before the page is sliced, so it changes *which* results appear, not only their order. Explicitly **not** a parameter: mutual connections / friends-of-friends, excluded because ordering by them would disclose graph facts the caller cannot otherwise read. See [[social-graph]] §Search.
 7. **Strike system + misuse safeguards** — counter on accounts; auto-suspend at threshold; auto-rate-limit unfounded reporters. ID: **C-L9**.
 8. **Annual transparency report scaffold** — collect the data even while SME-exempt; ready to publish if threshold crossed. ID: **C-L10**.

--- a/wiki/compliance/legal-drafts/connection-recommender.md
+++ b/wiki/compliance/legal-drafts/connection-recommender.md
@@ -43,15 +43,22 @@ Source: `recommendations.ts:672-676` —
 
 ## 2. Where candidates come from
 
-Two sources, both capped:
+Two sources, both bounded:
 
 - **Connections of your connections** ("friends of friends") —
-  `recommendations.ts:505-520`, capped at `MAX_FOF_FANOUT_ROWS`
-  (`recommendations.ts:65`, currently 10,000 rows read per request).
+  `recommendations.ts:505-520`.
 - **Co-members of organisations you belong to** —
-  `recommendations.ts:522-620`, capped at `MAX_ORG_COMEMBER_ROWS`
-  (`recommendations.ts:83`, currently 2,000 rows read per request, split
-  evenly across the organisations you belong to).
+  `recommendations.ts:522-620`. Every organisation you belong to
+  contributes; no single one absorbs the whole search.
+
+Both are bounded, so that no one very large organisation and no one
+unusually well-connected person can force an unbounded search. Where a
+source is larger than its bound, the system reads part of it rather than
+all of it — so for a very large organisation, or for someone with an
+unusual number of connections, the candidate set is a sample rather than
+an exhaustive list.
+
+The exact bounds are deliberately not repeated here. See **Scope**.
 
 Nobody outside those two sources — not "people nearby," not "people who
 viewed your profile," not any directory search — is ever a candidate.
@@ -74,14 +81,15 @@ end of this section.
   NULL` (`recommendations.ts:710-712`), so an account mid-deletion under
   Art. 17 never surfaces.
 
-**Caveat.** The exclusion set (blocks, connections, pending requests) is
-built from at most `MAX_MY_EDGE_ROWS` edge rows — 1,000
-(`recommendations.ts:55`, `.limit()` at `:444`). For the overwhelming
-majority of accounts this is every edge they have. For an account with
-more than 1,000 edges, the exclusion set is built from the first 1,000
-read, not a guaranteed-complete list — so "already-connected accounts are
-excluded" is what the system does with the edges it reads, not an absolute
-promise for every caller regardless of how many connections they have.
+**Caveat.** The exclusion set is built from a bounded read of your own
+edges (`recommendations.ts:55`, `.limit()` at `:444`). For the
+overwhelming majority of accounts that is every edge they have. For an
+account with an unusually large number of edges it is a partial read — so
+"already-connected accounts are excluded" describes what the system does
+with the edges it reads, rather than an absolute promise for every account
+regardless of size.
+
+The threshold itself is deliberately not repeated here. See **Scope**.
 
 ## 4. No commercial input
 
@@ -108,6 +116,41 @@ language, where it lives, how it is kept current — is
 `xchromo/osn-tracker#373`, which carries `needs:decision` and is not
 resolved by this page. A ToS author can draw the four points above
 directly into ToS prose; this page is written so they can.
+
+### Why the thresholds are not written out here
+
+An earlier draft gave the literal row bounds and the arithmetic dividing
+the co-member budget between organisations. They came out, because that
+half of the description is more use to someone gaming the recommender
+than to someone trying to understand it:
+
+- The point at which the exclusion read stops being complete is a recipe
+  for getting a blocked or already-requested account to surface as a
+  suggestion to a high-degree recipient. That is a bypass condition, not
+  a ranking parameter.
+- The per-organisation division tells an organisation admin, or a set of
+  coordinated accounts, how many profiles are needed to crowd an
+  organisation's real members out of a given recipient's suggestions.
+
+**This is not a secrecy measure and should not be mistaken for one.**
+`xchromo/osn` is a public repository: every constant named above is
+readable in `recommendations.ts` by anyone who looks. What is being
+decided here is narrower — what a document intended as ToS source
+*commits to publishing as a parameter*, which is a different thing from
+what a reader can derive from the source.
+
+Art. 27 asks for the main parameters in plain and intelligible language,
+and for any options a recipient has to change them. It does not ask for
+threshold values. The qualitative statements above — what ranks, where
+candidates come from, what is suppressed, that nothing commercial is an
+input — are the parameters; the constants are implementation.
+
+That reading is a judgment, not a rule, and it belongs to whoever owns
+`xchromo/osn-tracker#373`. A regulator may read a qualitative range as
+evasive and want figures, which is defensible. Decide it there
+deliberately, rather than inheriting it from a page that happened to be
+written with `file:line` precision because it was verified against the
+source.
 
 See [[dsa]] §Project changes required, item 6 (`C-L8`) for the
 tracker-level entry this page fulfils, and the same item for the other two

--- a/wiki/compliance/legal-drafts/connection-recommender.md
+++ b/wiki/compliance/legal-drafts/connection-recommender.md
@@ -1,0 +1,115 @@
+---
+title: Connection Recommender — Main Parameters
+aliases: [suggested connections, people you may know, recommender transparency]
+tags: [compliance, dsa, recommenders]
+related:
+  - "[[dsa]]"
+  - "[[social-graph]]"
+  - "[[index]]"
+last-reviewed: 2026-08-31
+---
+
+# Connection Recommender — Main Parameters
+
+DSA Art. 27 requires the main parameters of a recommender system to be set
+out for recipients "in plain and intelligible language." This page is that
+disclosure, for the one recommender in scope here: `suggestConnections()`,
+which powers the "Suggested for you" surface on the `@osn/social` Discover
+page. It is source material for a future ToS — see **Scope** below — not a
+ToS itself.
+
+Everything on this page is verified against
+`osn/api/src/services/recommendations.ts` as of 2026-08-31 (the
+`perf/osn-recommender-fanout` change, osn-tracker#574). **If that function
+changes, this page is stale until someone checks it again** — a disclosure
+describing an old ranker is worse than no disclosure, because it is
+actively misleading. Re-verify it against the source alongside
+[[social-graph]] §Recommendations whenever `suggestConnections()` changes.
+
+## 1. How a suggestion is ranked
+
+Ranked by number of mutual connections (people you and the suggested
+profile both know), then by number of organisations you both belong to, in
+that order. Ties break on the profile's internal ID, which has no meaning
+to a recipient beyond making the order the same on repeat requests.
+
+No other signal affects rank. There is no engagement score, no recency
+weighting, no personalisation beyond your own connections and
+organisations, and no experiment or A/B variant that changes the order for
+some users and not others.
+
+Source: `recommendations.ts:672-676` —
+`.toSorted(([idA, a], [idB, b]) => b.mutualCount - a.mutualCount || b.organisationCount - a.organisationCount || (idA < idB ? -1 : idA > idB ? 1 : 0))`.
+
+## 2. Where candidates come from
+
+Two sources, both capped:
+
+- **Connections of your connections** ("friends of friends") —
+  `recommendations.ts:505-520`, capped at `MAX_FOF_FANOUT_ROWS`
+  (`recommendations.ts:65`, currently 10,000 rows read per request).
+- **Co-members of organisations you belong to** —
+  `recommendations.ts:522-620`, capped at `MAX_ORG_COMEMBER_ROWS`
+  (`recommendations.ts:83`, currently 2,000 rows read per request, split
+  evenly across the organisations you belong to).
+
+Nobody outside those two sources — not "people nearby," not "people who
+viewed your profile," not any directory search — is ever a candidate.
+
+## 3. What gets suppressed
+
+Before ranking, the candidate pool is narrowed. This is a description of
+what the system *does*, not an absolute guarantee — see the caveat at the
+end of this section.
+
+- **Accounts you have blocked, or that have blocked you** — checked both
+  directions (`recommendations.ts:445-452`, `:486-490`).
+- **Existing connections and pending requests, in either direction** —
+  every edge you have, whatever its status, not only accepted ones
+  (`recommendations.ts:428-444`, excluded at `:486-490`). This is why a
+  connection request already sent or received never reappears as a
+  suggestion.
+- **Accounts pending erasure** — a candidate is only hydrated into a
+  suggestion through an inner join that requires `accounts.deleted_at IS
+  NULL` (`recommendations.ts:710-712`), so an account mid-deletion under
+  Art. 17 never surfaces.
+
+**Caveat.** The exclusion set (blocks, connections, pending requests) is
+built from at most `MAX_MY_EDGE_ROWS` edge rows — 1,000
+(`recommendations.ts:55`, `.limit()` at `:444`). For the overwhelming
+majority of accounts this is every edge they have. For an account with
+more than 1,000 edges, the exclusion set is built from the first 1,000
+read, not a guaranteed-complete list — so "already-connected accounts are
+excluded" is what the system does with the edges it reads, not an absolute
+promise for every caller regardless of how many connections they have.
+
+## 4. No commercial input
+
+No advertising, no payment, and no paid placement is an input to this
+recommender. Nobody can pay to appear, rank higher, or be excluded from
+appearing to someone else. If that ever changes, Art. 26 (advertising
+transparency) applies in addition to this page, and this page needs a
+rewrite before it ships.
+
+## What this recommender discloses about you
+
+Each suggestion the endpoint returns carries a `mutualCount` — the exact
+number of mutual connections. This is itself a disclosure with a privacy
+cost tracked separately: see `S-L4` in `xchromo/osn-tracker` and
+[[social-graph]] §Recommendations. It is noted here because "how many
+mutual connections you have with someone" is a fact about you the ranking
+parameters (§1) make visible, which Art. 27 disclosure should not omit.
+
+## Scope
+
+This page describes the recommender. **It is not a Terms of Service.**
+Publishing the actual DSA Art. 27 disclosure to end users — the ToS
+language, where it lives, how it is kept current — is
+`xchromo/osn-tracker#373`, which carries `needs:decision` and is not
+resolved by this page. A ToS author can draw the four points above
+directly into ToS prose; this page is written so they can.
+
+See [[dsa]] §Project changes required, item 6 (`C-L8`) for the
+tracker-level entry this page fulfils, and the same item for the other two
+recommenders in scope (Pulse discovery, OSN people/organisation search) —
+neither is described by this page.

--- a/wiki/systems/social-graph.md
+++ b/wiki/systems/social-graph.md
@@ -17,7 +17,7 @@ related:
 packages:
   - "@osn/api"
   - "@osn/db"
-last-reviewed: 2026-08-17
+last-reviewed: 2026-08-31
 ---
 
 # Social Graph
@@ -128,17 +128,19 @@ The `:handle` route parameter uses TypeBox `HandleParam` with regex + length bou
 2. Build the exclusion set: self, every counterpart on an existing edge, and everyone blocked either way. Pending edges count, so a request already in flight never resurfaces as a suggestion whose Connect button would fail with "Connection already exists".
 3. Fan out twice, each branch skipped when its seed set is empty:
    - **Friends-of-friends** — accepted connections of the caller's first 500 accepted connections, capped at **10 000 rows**.
-   - **Organisation co-members** — members of the caller's organisations, capped at **2 000 rows**.
+   - **Organisation co-members** — members of the caller's organisations, capped at **2 000 rows total**, split evenly across the caller's organisations (`MAX_ORG_COMEMBER_ROWS` divided by how many organisations the caller belongs to) so one organisation can no longer absorb the whole budget and starve the rest (osn-tracker#574).
 4. Tally `mutualCount` and shared organisations per candidate in JS with an O(1) `Set` on the caller's direct connections.
 5. Rank by mutual count desc, then shared-organisation count desc, then profile ID (stable ties). Slice to `limit` (bounded `[1, 50]` at the HTTP boundary).
 6. Hydrate the top N via `users ⋈ accounts WHERE deleted_at IS NULL`, so a tombstoned account is never suggested.
 
 Each suggestion carries a `reason` (`mutual_connections` | `shared_organisation`) naming the strongest signal, plus `sharedOrganisation` as card context when there is one. `reason` is what the Discover card turns into "3 mutual connections" or "Also in Acme Inc".
 
+`GET /recommendations/connections` also returns `generatedAt` (ISO 8601, set at request time) alongside `suggestions`, so a client can tell how fresh a list is (osn-tracker#311). The list itself is still never cached or stored server-side — a short-lived cache is the separate, not-yet-decided osn-tracker#588.
+
 Current shape prioritises correctness + bounded cost over peak throughput. Next steps are open issues in `xchromo/osn`:
 
 - **P-W6** — short-lived per-caller cache (5-15 min) so a Discover-page visit doesn't re-run the pipeline.
-- **P-W7** — push aggregation to SQL (`GROUP BY … ORDER BY … LIMIT`) and add compound indexes `connections(status, requester_id)` / `connections(status, addressee_id)`.
+- **P-W7** — push aggregation to SQL (`GROUP BY … ORDER BY … LIMIT`) is still open. This line used to also propose two compound indexes, `connections(status, requester_id)` / `connections(status, addressee_id)` — **don't add them.** Measured on real D1: the existing `connections_requester_idx` / `connections_addressee_idx` already give a MULTI-INDEX OR, and the proposed indexes cut rows_read only 120 → 112 (about 7%) — and on a fresh un-`ANALYZE`d database the planner instead picked `(status, addressee_id)` and scanned every accepted edge, a strict regression. `status` has two values; it is the worst possible leading column. The measurements are recorded on osn-tracker#312 and #278. If a real need is ever proven, the right shape is `(requester_id, status, addressee_id)` — the selective column first, not `status`.
 
 Privacy: the endpoint returns `mutualCount` alongside each suggestion. This leaks graph-inference signal — see `S-L4` in `xchromo/osn-tracker` for the bucketing follow-up.
 


### PR DESCRIPTION
## Summary

The connection recommender's organisation fan-out had a global row budget, so
the lowest-id organisation absorbed it and the rest contributed nothing. It is
now split per organisation. The endpoint also gained a `generatedAt` stamp, and
the ranker finally has a written description — DSA Art. 27 requires one and
there was none.

**Read the Decisions section before the diff.** Two of the four things this
batch was scoped to do turned out to be wrong, and one of them would have made
the endpoint dramatically worse. Both were settled by measurement on real
Miniflare/workerd D1, not by argument.

> **This branch surfaced a live production bug, fixed in #854 on top of it.**
> `GET /recommendations/connections` threw for any caller with more than 50
> accepted connections — xchromo/osn-tracker#589. The characterisation test
> added here **asserts the broken behaviour**; #854 inverts it. Merge this
> first, then #854.

## Workspaces affected

`osn/api`, `osn/client`. `.changeset/osn-recommender-fanout.md` names
`@osn/api` and `@osn/client`, both `patch`. No `@osn/db` — there is no schema
change, see Decisions.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#574 | `P-W` |
| xchromo/osn-tracker#576 | `C-M` |
| xchromo/osn-tracker#311 | `P-W6`, timestamp half |

Closes xchromo/osn-tracker#574.
Closes xchromo/osn-tracker#576.
Closes xchromo/osn-tracker#311.

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#588 | `P-W6b` |
| xchromo/osn-tracker#589 | `P-C1` / `S-H` |

## Decisions

### The first `UNION ALL` broke at 6 organisations — `P-C1`

- **Issue** — the review of this branch found the fan-out rewrite threw on real
  D1 for any caller in 6 or more organisations. 1, 3 and 5 succeeded; 6, 10 and
  50 all returned a 500.
- **Why** — the comment justified the arm count against "SQLite's 500-term
  compound-select limit". That is true of `bun:sqlite` and false of the engine
  this runs on: **workerd compiles in `SQLITE_LIMIT_COMPOUND_SELECT = 5`**,
  traced to its own source and confirmed at HEAD, and Cloudflare's D1 limits
  page documents no compound-select limit at all. This is the same class of
  mistake as #589 — a bound checked against SQLite's ceiling rather than D1's —
  made inside the change that fixes it.
- **Solution** — the arms are chunked into batches of 5, run with bounded
  `Effect.all` and merged in application code. A caller in 1–5 organisations
  still costs exactly one query; 50 costs ten. `rows_read` at the 50-org cap is
  2,050, against a 2,000-row budget.
- **Rationale** — `json_each()` was investigated as a single-statement
  alternative and rejected on evidence: D1 exposes it, but this SQLite build has
  no implicit `LATERAL`, so it cannot carry the per-organisation `LIMIT` this
  query needs. Tested against Miniflare, not assumed. The new test seeds a
  caller in exactly 6 organisations — the case the old comment called safe — and
  was proved to go red when the fix is reverted.

### The recommended window function was the wrong fix — `P-W`

- **Issue** — `#574` proposed `ROW_NUMBER() OVER (PARTITION BY organisation_id
  ORDER BY profile_id)` filtered to a per-organisation share.
- **Why** — it does work, and drizzle emits it cleanly. But `rn <= share`
  filters *after* the window scan, so the query reads every membership row of
  every organisation the caller belongs to. That is precisely the unbounded
  read `MAX_ORG_COMEMBER_ROWS` exists to prevent — the comment on that constant
  says so in as many words. One 50,000-member organisation would cost 50,000+
  rows read per request, forever.
- **Solution** — one statement, `UNION ALL` of per-organisation subselects,
  each with its own `ORDER BY profile_id LIMIT <share>`. Measured on real D1,
  three organisations of 600/300/100 members, cap 150:

  | shape | results | rows_read |
  |---|---|---|
  | old global `ORDER BY` + `LIMIT` | 150 | 151 |
  | window function, `rn <= 50` | 150 | **3,009** |
  | this `UNION ALL` shape | 150 | **150** |

- **Rationale** — the issue rejected "one query per organisation" as up to 50
  round trips, which is true but a false dilemma: a per-organisation `LIMIT`
  does not need per-organisation queries. `MAX_MY_ORGANISATIONS` (50) caps the
  arm count well under SQLite's 500-term compound limit, so this is always one
  statement. Each arm is wrapped as a derived table because SQLite's grammar
  gives a non-final `UNION` arm no `ORDER BY`/`LIMIT` of its own — the
  unwrapped form is a syntax error, not merely unidiomatic.

### The share is divided by the caller's real organisation count — `P-W`

- **Issue** — how to split a 2,000-row budget.
- **Why** — dividing by the 50-organisation cap would give a caller in one
  organisation 40 rows where they used to get 2,000, a large regression for the
  most common shape.
- **Solution** — `MAX_ORG_COMEMBER_ROWS / myOrgIds.length`. One organisation
  gets the whole budget, as before; fifty get 40 each, the same worst case a
  fixed division would have given throughout.
- **Rationale** — the integer-division remainder goes to no organisation.
  Handing it to whichever sorts first would reintroduce, in miniature, exactly
  the bias being removed. `myOrgIds` is sorted before the arms are built so the
  union reproduces the old `(organisation_id, profile_id)` row order, which is
  what keeps "first organisation wins the label" deterministic across requests.

### The two compound indexes were dropped, and the wiki that recommended them corrected

- **Issue** — `#312` asks for `connections(status, requester_id)` and
  `connections(status, addressee_id)`, and `wiki/systems/social-graph.md` said
  so too.
- **Why** — measured on real D1 with a 2,000-user fixture after `ANALYZE`: the
  existing single-column indexes already produce a `MULTI-INDEX OR`, and the
  new pair moves rows_read 120 → 112. About 7%, for a fifth and sixth index
  maintained on every connection insert, accept and delete. On a **fresh,
  un-`ANALYZE`d** database — a new D1 region, or a restored copy — the planner
  instead chose `(status, addressee_id)` and scanned every accepted edge, a
  strict regression from today.
- **Solution** — no indexes, therefore no migration, therefore no `@osn/db`
  changeset. `social-graph.md` now says not to add them and why.
- **Rationale** — `status` has two values; it is the worst available leading
  column. If a need is ever measured the shape is `(requester_id, status,
  addressee_id)`, selective column first. The measurements are on
  xchromo/osn-tracker#312 and #278, the latter because it cited the same
  indexes as its own cheap win.

### `#311` ships the timestamp and not the cache — `P-W6`

- **Issue** — the issue asks for a short-lived per-caller cache "and/or" a
  timestamp.
- **Why** — the store was never the open question (`shared/redis` is the repo's
  answer, and osn-api already keeps request-path state there). What is open is
  invalidation — a 15-minute list re-suggests someone you just connected with,
  and acting on it 409s — plus fail-open behaviour against this route's
  deliberately fail-closed rate limiters, and the Upstash command budget. Three
  decisions, none of them mine.
- **Solution** — `generatedAt` here; the cache as xchromo/osn-tracker#588,
  which names Upstash Redis as the store so only the real decisions remain.
- **Rationale** — `generatedAt` rather than `generated_at`: every response field
  in this API is camelCase. ISO 8601 rather than `/recovery/status`'s unix
  seconds, matching `connectedAt` / `requestedAt` / `joinedAt` in the same
  response-schema file. `osn/client` hand-mirrors these types, so the field is
  added there too — a timestamp no client can read would not have closed
  anything. The cache must land *after* this, or it caches the old pipeline.

### The disclosure says what the system does, not what it guarantees — `C-M`

- **Issue** — DSA Art. 27 wants the recommender's main parameters in plain
  language. Nothing described the ranker anywhere.
- **Why** — the ranking was being tuned against a disclosure nobody had
  written, and writing it later from drifted code is harder and likelier wrong.
- **Solution** — `wiki/compliance/legal-drafts/connection-recommender.md`,
  linked from `wiki/compliance/dsa.md`, verified line by line against the
  service.
- **Rationale** — one bullet needed care. The exclusion set is built from at
  most `MAX_MY_EDGE_ROWS` (1,000) edge rows, so "already-connected accounts are
  excluded" is not absolute for a caller with more edges than that. The page
  says what the system does with the edges it reads rather than making a
  promise it cannot keep. Writing the disclosure is in scope; publishing a ToS
  is not — that is xchromo/osn-tracker#373, which carries `needs:decision`.

**Out of scope**

- **xchromo/osn-tracker#589** — the live bind-cap bug this branch surfaced. Fixed
  in #854, stacked directly on this one.
- `#312`'s SQL-aggregation half stays open. A SQL `LIMIT` would apply before
  today's JS exclusion filtering and could empty a page, and the exclusion set
  cannot move as bound parameters against the same cap as #589. Notes on the
  issue.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37 packages |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ |
| `bun run test` | ✅ 38/38 tasks |
| `bun run test:d1` | ✅ `@osn/api` 7 pass, incl. the 6-organisation regression |
| `bun run --cwd osn/db test:run` | ✅ 107 pass, `ddl-lockstep` included |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run test:scripts` | ✅ |
| `bun run check:jest-dom-markers` | ✅ |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |
| `openapi:generate` + `git diff --exit-code shared/openapi/` | ✅ no drift |

`bun run --cwd osn/db test:run` is in the list because `ddl-lockstep.test.ts` is
what catches a schema edit with no matching migration. This branch makes no
schema change, so its staying green is the assertion.

Both the `#574` test and the new 6-organisation test were proved discriminating
rather than merely green: reverting `recommendations.ts` turns each red, and
restoring turns them green. The rows_read bound is asserted in the D1 lane, not
the bun:sqlite one — bun:sqlite has no rows_read facility, so asserting a read
bound there would have been theatre. The budget test's fixture was cut from
2,500 rows to 500, taking it from 4.8s to 1.0s without losing the property it
proves.

Not covered by any gate: the `UNION ALL` shape is measured on Miniflare's D1,
which is the same engine but not the same data. Nobody has watched a real
50-organisation account on production D1. And `generatedAt` is returned and
typed through the SDK but no UI renders it yet.

