### PR TITLE
fix(pulse-api): stop six queries binding one parameter per element on D1

### DIFF
--- a/.changeset/pulse-d1-bind-cap.md
+++ b/.changeset/pulse-d1-bind-cap.md
@@ -1,0 +1,18 @@
+---
+"@shared/db-utils": patch
+"@pulse/api": patch
+---
+
+Stop six pulse queries binding one parameter per element against D1's cap.
+
+D1 allows 100 bound parameters per query. A `SELECT` binding an id list broke
+past 50-100 items; a multi-row `INSERT`, which binds one parameter per column
+per row, broke an order of magnitude sooner. Six sites were affected, and three
+were live: recurring series failed to materialise past three instances, the RSVP
+list broke for every viewer of a well-attended event, and a GDPR erasure could
+never complete for an account that had hosted more than a hundred events.
+
+`@shared/db-utils` gains `jsonEachIn` and `insertManyViaJsonEach`, which bind the
+whole array as one JSON parameter and unpack it inside SQLite with `json_each`.
+Both are verified against real Miniflare-backed D1 rather than bun:sqlite, which
+enforces no such cap and so passes against every one of these bugs.

--- a/pulse/api/src/services/accountErasure.ts
+++ b/pulse/api/src/services/accountErasure.ts
@@ -12,7 +12,7 @@ import {
 } from "@pulse/db/schema";
 import type { PulseDeletionJob } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
-import { commitBatch } from "@shared/db-utils";
+import { commitBatch, jsonEachIn } from "@shared/db-utils";
 import type {
   DeletionCompletedResult,
   DeletionCompletedSource,
@@ -483,12 +483,29 @@ export const purgeAccount = (
             .where(inArray(pulseProfileAccounts.profileId, profileIds)),
 
           // Drop hosted events + their cascading rows for the deleted profiles.
+          //
+          // osn-tracker#595 (GDPR): `hostedEventIds` is unbounded — a host
+          // with 101+ hosted events bound one parameter per id here, past
+          // D1's 100-parameter cap, which failed every statement in this
+          // batch (D1 batches are atomic: one failing statement rolls back
+          // the lot) and made an Art. 17 purge unable to ever complete for
+          // exactly the accounts with the most data. `jsonEachIn` binds the
+          // whole id list as one JSON parameter per statement instead. The
+          // batch stays one atomic commit per the note above this block —
+          // splitting it would reopen the exact half-purged-account risk
+          // the single-batch design exists to close.
           ...(hostedEventIds.length > 0
             ? [
-                db.delete(eventRsvps).where(inArray(eventRsvps.eventId, hostedEventIds)),
-                db.delete(eventComms).where(inArray(eventComms.eventId, hostedEventIds)),
-                db.delete(eventLineup).where(inArray(eventLineup.eventId, hostedEventIds)),
-                db.delete(events).where(inArray(events.id, hostedEventIds)),
+                db
+                  .delete(eventRsvps)
+                  .where(inArray(eventRsvps.eventId, jsonEachIn(hostedEventIds))),
+                db
+                  .delete(eventComms)
+                  .where(inArray(eventComms.eventId, jsonEachIn(hostedEventIds))),
+                db
+                  .delete(eventLineup)
+                  .where(inArray(eventLineup.eventId, jsonEachIn(hostedEventIds))),
+                db.delete(events).where(inArray(events.id, jsonEachIn(hostedEventIds))),
               ]
             : []),
 

--- a/pulse/api/src/services/closeFriends.ts
+++ b/pulse/api/src/services/closeFriends.ts
@@ -1,9 +1,9 @@
 import { pulseCloseFriends } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { jsonEachIn } from "@shared/db-utils";
 import { and, eq, inArray } from "drizzle-orm";
 import { Data, Effect } from "effect";
 
-import { MAX_EVENT_GUESTS } from "../lib/limits";
 import {
   metricCloseFriendAdded,
   metricCloseFriendRemoved,
@@ -28,18 +28,6 @@ export class NotEligibleForCloseFriend extends Data.TaggedError("NotEligibleForC
 export class DatabaseError extends Data.TaggedError("CloseFriendDatabaseError")<{
   readonly cause: unknown;
 }> {}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/**
- * Hard cap on `IN (...)` parameter counts. Tied to `MAX_EVENT_GUESTS` because
- * the only batch caller is the RSVP flow, which already caps attendance at
- * that limit (P-I1). If the platform attendance ceiling rises, the batch
- * clamp moves with it instead of silently dropping rows.
- */
-const MAX_BATCH_SIZE = MAX_EVENT_GUESTS;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -181,8 +169,15 @@ export const isCloseFriendOf = (
  * friend. Used by the RSVP service to stamp the `isCloseFriend` display
  * flag without N round-trips.
  *
- * Always clamped to `MAX_BATCH_SIZE` to stay within SQLite's variable
- * limit and prevent a malicious caller from blowing up the query.
+ * osn-tracker#591: this used to clamp `profileIds` to `MAX_BATCH_SIZE`
+ * (=`MAX_EVENT_GUESTS`, 1000) "to stay within SQLite's variable limit" —
+ * SQLite's cap, not D1's. D1 caps a query at 100 bound parameters, so the
+ * clamp didn't even help: a caller with 101+ ids still threw
+ * `D1_ERROR: too many SQL variables`, and below that threshold the
+ * truncation just silently dropped close-friend flags for the ids past the
+ * cut rather than erroring. `jsonEachIn` binds the whole id list as one
+ * JSON parameter, so there's nothing left to clamp — no truncation, no
+ * per-element bind, no cap to justify against the wrong engine.
  */
 export const getCloseFriendsOfBatch = (
   viewerId: string,
@@ -191,8 +186,6 @@ export const getCloseFriendsOfBatch = (
   Effect.gen(function* () {
     metricCloseFriendsBatchSize(profileIds.length);
     if (profileIds.length === 0) return new Set<string>();
-    const clamped =
-      profileIds.length > MAX_BATCH_SIZE ? profileIds.slice(0, MAX_BATCH_SIZE) : profileIds;
     const { db } = yield* Db;
     const rows = yield* Effect.tryPromise({
       try: () =>
@@ -202,7 +195,7 @@ export const getCloseFriendsOfBatch = (
           .where(
             and(
               eq(pulseCloseFriends.friendId, viewerId),
-              inArray(pulseCloseFriends.profileId, [...clamped]),
+              inArray(pulseCloseFriends.profileId, jsonEachIn(profileIds)),
             ),
           ),
       catch: (cause) => new DatabaseError({ cause }),

--- a/pulse/api/src/services/discovery.ts
+++ b/pulse/api/src/services/discovery.ts
@@ -1,5 +1,6 @@
 import { eventRsvps, eventSeries, events, pulseUsers, type Event } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { jsonEachIn } from "@shared/db-utils";
 import { and, asc, eq, gt, gte, inArray, isNull, lte, or, sql, type SQL } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
@@ -265,18 +266,26 @@ export const discoverEvents = (
       //   - The viewer's own RSVP is excluded — it's not a *friend*
       //     signal.
       //   - Connection set is bounded by MAX_EVENT_GUESTS upstream in
-      //     `getConnectionIds`, capping the IN list size for the SQLite
-      //     prepared-statement cache.
+      //     `getConnectionIds`.
+      //
+      // osn-tracker#592: `connectionIds` binds twice in this one predicate —
+      // once via `inArray`, once via the `sql.join` list inside the EXISTS.
+      // Each occurrence bound one parameter per id, so the pair broke D1's
+      // 100-parameter cap at ~50 connections even though `MAX_EVENT_GUESTS`
+      // (1000) suggested far more headroom. There's no connections table on
+      // the Pulse side to fall back to an `IN (<subquery>)` against — the
+      // set only exists as this JS array from `getConnectionIds` — so
+      // `json_each` is the fix, not a subquery. One `jsonEachIn` call
+      // spliced into both spots binds the same list as one JSON parameter
+      // each time it's referenced (2 total for the pair, not 2×N).
+      const connectionIdsJson = jsonEachIn(connectionIds);
       const friendsPredicate = or(
-        inArray(events.createdByProfileId, connectionIds),
+        inArray(events.createdByProfileId, connectionIdsJson),
         sql`EXISTS (
           SELECT 1 FROM ${eventRsvps}
           LEFT JOIN ${pulseUsers} ON ${eventRsvps.profileId} = ${pulseUsers.profileId}
           WHERE ${eventRsvps.eventId} = ${events.id}
-            AND ${eventRsvps.profileId} IN (${sql.join(
-              connectionIds.map((id) => sql`${id}`),
-              sql`, `,
-            )})
+            AND ${eventRsvps.profileId} IN ${connectionIdsJson}
             AND ${eventRsvps.profileId} != ${viewerId}
             AND ${eventRsvps.status} IN ('going', 'maybe')
             AND COALESCE(${pulseUsers.attendanceVisibility}, 'connections') != 'no_one'

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -1,6 +1,7 @@
 import { events, eventRsvps } from "@pulse/db/schema";
 import type { Event } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { jsonEachIn } from "@shared/db-utils";
 import { and, asc, eq, gte, inArray, lte, ne, type SQL } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
@@ -292,8 +293,19 @@ export const applyTransitions = (
       [...groups.values()],
       ({ from, to, ids }) =>
         Effect.tryPromise({
+          // ids.length + 2 (status, updatedAt) bound params on a plain
+          // `inArray` — the cliff is 99 events sharing one (from → to)
+          // transition in a single page. `listTodayEvents` reads up to
+          // TODAY_EVENTS_LIMIT (200, defined further down this file) and
+          // `listEvents` up to 100, so a mass midnight rollover (every
+          // "upcoming" row crossing into "ongoing" at once) can reach it.
+          // `jsonEachIn` drops the id list to one bound parameter, so the
+          // group size no longer matters.
           try: () =>
-            db.update(events).set({ status: to, updatedAt: now }).where(inArray(events.id, ids)),
+            db
+              .update(events)
+              .set({ status: to, updatedAt: now })
+              .where(inArray(events.id, jsonEachIn(ids))),
           catch: (cause) => new DatabaseError({ cause }),
         }).pipe(
           Effect.tap(() =>

--- a/pulse/api/src/services/pulseUsers.ts
+++ b/pulse/api/src/services/pulseUsers.ts
@@ -1,5 +1,6 @@
 import { pulseUsers, type PulseProfile } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { jsonEachIn } from "@shared/db-utils";
 import { eq, inArray } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
@@ -70,6 +71,13 @@ export const getAttendanceVisibility = (
  * collapses an N+1 ("yield* getAttendanceVisibility(id) in a for loop")
  * into a single SELECT, which matters for popular events where the
  * limit clause can return up to 200 rows per request.
+ *
+ * osn-tracker#591: `listRsvps`' `filterByAttendeePrivacy` calls this with
+ * every distinct attendee on the page (up to 200 — see `rsvps.ts`'s
+ * `fetchLimit`), which crossed D1's 100-bound-parameter cap on a plain
+ * `inArray`. `jsonEachIn` binds the id list as one JSON parameter instead
+ * of one per id, so the same query works whether the page holds 20
+ * attendees or 200.
  */
 export const getAttendanceVisibilityBatch = (
   profileIds: string[],
@@ -87,7 +95,7 @@ export const getAttendanceVisibilityBatch = (
             attendanceVisibility: pulseUsers.attendanceVisibility,
           })
           .from(pulseUsers)
-          .where(inArray(pulseUsers.profileId, profileIds)) as Promise<
+          .where(inArray(pulseUsers.profileId, jsonEachIn(profileIds))) as Promise<
           Pick<PulseProfile, "profileId" | "attendanceVisibility">[]
         >,
       catch: (cause) => new DatabaseError({ cause }),

--- a/pulse/api/src/services/rsvps.ts
+++ b/pulse/api/src/services/rsvps.ts
@@ -1,5 +1,6 @@
 import { events, eventRsvps, type Event, type EventRsvp } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { insertManyViaJsonEach, jsonEachIn } from "@shared/db-utils";
 import { and, count, desc, eq, inArray } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
@@ -435,6 +436,11 @@ export const inviteGuests = (
     const { db } = yield* Db;
 
     // Find which users already have a row for this event (any status).
+    //
+    // osn-tracker#590: `profileIds` is schema-capped at MAX_EVENT_GUESTS
+    // (1000, see `InviteGuestsSchema` above), so a full-size invite batch
+    // bound 1000+ parameters here — well past D1's 100-parameter cap.
+    // `jsonEachIn` binds the list as one JSON parameter regardless of size.
     const existing = yield* Effect.tryPromise({
       try: () =>
         db
@@ -443,7 +449,7 @@ export const inviteGuests = (
           .where(
             and(
               eq(eventRsvps.eventId, eventId),
-              inArray(eventRsvps.profileId, [...validated.profileIds]),
+              inArray(eventRsvps.profileId, jsonEachIn(validated.profileIds)),
             ),
           ),
       catch: (cause) => new DatabaseError({ cause }),
@@ -464,8 +470,16 @@ export const inviteGuests = (
       invitedByProfileId: organiserId,
       createdAt: now,
     }));
+    // osn-tracker#590: each row binds 6 parameters (its 6 keys), so a plain
+    // multi-row `.values(rows)` insert broke past ~16 invitees — an order
+    // of magnitude below the 1000-guest schema cap this route advertises.
+    // `insertManyViaJsonEach` binds the whole row set as one JSON parameter.
     yield* Effect.tryPromise({
-      try: () => db.insert(eventRsvps).values(rows),
+      // `.run()`'s return type is `T | Promise<T>` (sync bun:sqlite / async
+      // D1) — `Promise.resolve` normalises it to a real thenable the same
+      // way `@shared/db-utils`'s own `dbQuery` does, so `Effect.tryPromise`
+      // can type it.
+      try: () => Promise.resolve(db.run(insertManyViaJsonEach(eventRsvps, rows))),
       catch: (cause) => new DatabaseError({ cause }),
     });
     metricRsvpInviteBatch(rows.length, "ok");

--- a/pulse/api/src/services/series.ts
+++ b/pulse/api/src/services/series.ts
@@ -1,6 +1,7 @@
 import { events, eventSeries } from "@pulse/db/schema";
 import type { Event, EventSeries, NewEvent, NewEventSeries } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
+import { insertManyViaJsonEach } from "@shared/db-utils";
 import { and, eq, gt, gte, lt, or } from "drizzle-orm";
 import { Data, Effect, Schema } from "effect";
 
@@ -429,8 +430,20 @@ export const materializeInstances = (
       updatedAt: now,
     }));
 
+    // osn-tracker#594: `rows` is a full `NewEvent` per instance — 31 columns,
+    // every one of them explicit (nulls included, since expandRRule/the
+    // series template never leaves a column to its schema default). Drizzle
+    // binds one parameter per column per row on a multi-row `.values(...)`
+    // insert, so 31 × row-count crosses D1's 100-bound-parameter cap at the
+    // 4th row — every weekly series (52 rows) failed at creation. One bound
+    // JSON parameter via `insertManyViaJsonEach` replaces the per-cell binds
+    // regardless of `MAX_SERIES_INSTANCES` (260).
     yield* Effect.tryPromise({
-      try: () => db.insert(events).values(rows),
+      // `.run()`'s return type is `T | Promise<T>` (sync bun:sqlite / async
+      // D1) — `Promise.resolve` normalises it to a real thenable the same
+      // way `@shared/db-utils`'s own `dbQuery` does, so `Effect.tryPromise`
+      // can type it.
+      try: () => Promise.resolve(db.run(insertManyViaJsonEach(events, rows))),
       catch: (cause) => {
         metricSeriesInstancesMaterialized(rows.length, trigger, "error");
         return new DatabaseError({ cause });

--- a/pulse/api/tests/d1/d1-integration.test.ts
+++ b/pulse/api/tests/d1/d1-integration.test.ts
@@ -2,10 +2,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test"
 
 import type { D1Database as DrizzleD1 } from "@cloudflare/workers-types";
 import * as schema from "@pulse/db/schema";
-import { pulseAccountPurges, pulseDeletionJobs } from "@pulse/db/schema";
+import { events, pulseAccountPurges, pulseDeletionJobs } from "@pulse/db/schema";
 import { Db } from "@pulse/db/service";
 import { createSchemaSql } from "@pulse/db/testing";
-import { createD1Db } from "@shared/db-utils";
+import { createD1Db, insertManyViaJsonEach } from "@shared/db-utils";
 import { Effect, Layer } from "effect";
 import { Miniflare } from "miniflare";
 
@@ -71,6 +71,50 @@ describe("pulse/api account erasure over real D1 (Miniflare)", () => {
 
     const status = await run(getDeletionStatus("usr_p2"));
     expect(status.scheduled).toBe(false);
+  });
+
+  // osn-tracker#595. `hostedEventIds` is read unbounded and was then bound into
+  // four DELETEs inside one atomic commitBatch, so an account that had hosted
+  // more than ~100 events put the batch over D1's 100-bound-parameter cap.
+  // Because the deletes are deliberately one batch, the failure rolled every
+  // statement back — the purge did not partially complete, it could never
+  // complete at all, for exactly the accounts with the most data to erase.
+  //
+  // This has to run against real D1: bun:sqlite enforces no bind cap, so the
+  // unit tier passes against the bug.
+  it("purges an account that hosted more than 100 events (osn-tracker#595)", async () => {
+    const now = new Date();
+    const hosted = Array.from({ length: 150 }, (_, i) => ({
+      id: `evt_bulk_${i}`,
+      title: `Event ${i}`,
+      startTime: now,
+      status: "upcoming" as const,
+      visibility: "public" as const,
+      guestListVisibility: "public" as const,
+      joinPolicy: "open" as const,
+      allowInterested: true,
+      commsChannels: '["email"]',
+      instanceOverride: false,
+      createdByProfileId: "usr_bulk",
+      createdByName: "Bulk Host",
+      createdAt: now,
+      updatedAt: now,
+    }));
+    // Seeded through the helper this batch introduces, not `.values(rows)`.
+    // A 150-row `.values()` insert is itself over D1's bind cap — the first
+    // draft of this test hit `too many SQL variables` while setting up the
+    // fixture for a bug about `too many SQL variables`. That the seeding works
+    // at all is a second, incidental proof the helper does what it claims on
+    // real D1.
+    await rawDb.run(insertManyViaJsonEach(events, hosted));
+
+    const out = await run(purgeAccount("acc_bulk", ["usr_bulk"]));
+    expect(out).toMatchObject({ purged: 1, alreadyProcessed: false });
+
+    // The whole point: the events are gone, which means the batch committed
+    // rather than rolling back on a bind-cap error.
+    const left = await rawDb.select({ id: events.id }).from(events).all();
+    expect(left.filter((e) => e.id.startsWith("evt_bulk_"))).toHaveLength(0);
   });
 
   it("purgeAccount is idempotent via the replay ledger (batch insert on D1)", async () => {

--- a/pulse/api/tests/services/d1ParamCounts.test.ts
+++ b/pulse/api/tests/services/d1ParamCounts.test.ts
@@ -1,0 +1,332 @@
+/**
+ * osn-tracker #590, #591, #592, #594, #595 + events.ts:296 — regression
+ * guard for the "bound one SQL parameter per array element / per column
+ * per row" defect class. D1 caps a query at 100 bound parameters
+ * (developers.cloudflare.com/d1/platform/limits/); bun:sqlite enforces no
+ * such cap, so these tests can't reproduce the production failure by
+ * running past 100 params and watching it throw. What they DO prove,
+ * cheaply and on every test run: the real service functions — not a
+ * reconstruction of their queries — emit the SQL this fix promises,
+ * exercised well past the OLD per-site cliff each site used to break at.
+ *
+ * The capture mechanism is drizzle's own `logger` hook, which fires with
+ * the exact SQL text and bound-parameter array the driver is about to
+ * run — the same thing `.toSQL()` would give a query-builder chain, but
+ * reachable here because these sites build their statements inside a
+ * service function rather than handing back a chain a test can call
+ * `.toSQL()` on directly. If a future edit reverts any of these sites to
+ * a plain `inArray(col, ids)` or `.values(rows)`, the captured parameter
+ * count jumps from O(1) to O(n) and the relevant assertion below fails.
+ *
+ * Six sites, in the order the brief lists them:
+ *   1. series.ts        materializeInstances  — INSERT, 31 cols/row
+ *   2. accountErasure.ts purgeAccount         — 4 hostedEventIds DELETEs
+ *   3. closeFriends.ts  getCloseFriendsOfBatch
+ *      pulseUsers.ts    getAttendanceVisibilityBatch
+ *   4. rsvps.ts         inviteGuests          — SELECT + INSERT, 6 cols/row
+ *   5. discovery.ts     discoverEvents(friendsOnly) — connectionIds bound twice
+ *   6. events.ts        applyTransitions (via listTodayEvents)
+ */
+
+import { Database } from "bun:sqlite";
+
+import { events, eventSeries, type EventSeries } from "@pulse/db/schema";
+import * as schema from "@pulse/db/schema";
+import { Db } from "@pulse/db/service";
+import { applySchema } from "@pulse/db/testing";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { purgeAccount } from "../../src/services/accountErasure";
+import { getCloseFriendsOfBatch } from "../../src/services/closeFriends";
+import { discoverEvents, type DiscoveryLookups } from "../../src/services/discovery";
+import { applyTransitions } from "../../src/services/events";
+import { getAttendanceVisibilityBatch } from "../../src/services/pulseUsers";
+import { inviteGuests } from "../../src/services/rsvps";
+import { materializeInstances, parseRRule } from "../../src/services/series";
+import { seedEvent } from "../helpers/db";
+
+interface Captured {
+  sql: string;
+  params: readonly unknown[];
+}
+
+/**
+ * Same shape as `../helpers/db`'s `createTestLayer`, plus a `logger` that
+ * records every statement drizzle actually sends to bun:sqlite. Kept local
+ * to this file rather than added to the shared helper — no other suite
+ * needs to inspect emitted SQL, and threading a capture array through the
+ * shared helper's signature would be dead weight everywhere else.
+ */
+function createCapturingTestLayer(): { layer: Layer.Layer<Db>; captured: Captured[] } {
+  const captured: Captured[] = [];
+  const sqlite = new Database(":memory:");
+  applySchema(sqlite);
+  const db = drizzle(sqlite, {
+    schema,
+    logger: { logQuery: (sql, params) => captured.push({ sql, params }) },
+  });
+  return { layer: Layer.succeed(Db, { db }), captured };
+}
+
+/** The one statement in `captured` whose SQL contains every one of `needles`. */
+function findStatement(captured: Captured[], ...needles: string[]): Captured {
+  // Case-insensitive: drizzle's own builder emits lowercase keywords, while a
+  // statement assembled through `sql` carries whatever case it was written in
+  // — `insertManyViaJsonEach` writes `INSERT INTO`. Matching case-sensitively
+  // silently found nothing and read as "the fix did not apply".
+  const matches = captured.filter((c) =>
+    needles.every((n) => c.sql.toLowerCase().includes(n.toLowerCase())),
+  );
+  expect(
+    matches,
+    `expected exactly one captured statement matching ${needles.join(" + ")}`,
+  ).toHaveLength(1);
+  return matches[0]!;
+}
+
+// ---------------------------------------------------------------------------
+// 1. series.ts materializeInstances — osn-tracker#594
+// ---------------------------------------------------------------------------
+
+describe("series.ts materializeInstances (osn-tracker#594)", () => {
+  it("inserts 200 instances (31 cols/row — 6200 params the old way) with 1 bound param", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const now = new Date();
+    const dtstart = new Date(now.getTime() + 7 * 86_400_000);
+    const series: EventSeries = {
+      id: "srs_test",
+      title: "Weekly Yoga",
+      description: null,
+      location: null,
+      venue: null,
+      latitude: null,
+      longitude: null,
+      category: null,
+      imageUrl: null,
+      durationMinutes: null,
+      visibility: "public",
+      guestListVisibility: "public",
+      joinPolicy: "open",
+      allowInterested: true,
+      commsChannels: '["email"]',
+      rrule: "FREQ=WEEKLY;COUNT=200",
+      chatId: null,
+      dtstart,
+      timezone: "UTC",
+      until: null,
+      materializedThrough: dtstart,
+      status: "active",
+      createdByProfileId: "usr_alice",
+      createdByName: "Alice",
+      createdByAvatar: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    // `events.series_id` is a foreign key onto `event_series`, so the series
+    // row has to exist before its instances can be inserted — the in-memory
+    // object above is the service's input, not a database row.
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        yield* Effect.promise(() => db.insert(eventSeries).values(series));
+      }).pipe(Effect.provide(layer)),
+    );
+
+    const parsed = await Effect.runPromise(parseRRule("FREQ=WEEKLY;COUNT=200", dtstart));
+
+    const instances = await Effect.runPromise(
+      materializeInstances(series, parsed, "create").pipe(Effect.provide(layer)),
+    );
+    expect(instances).toHaveLength(200);
+
+    const insertStmt = findStatement(captured, 'insert into "events"', "json_each");
+    expect(insertStmt.params).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. accountErasure.ts purgeAccount — osn-tracker#595 (GDPR)
+// ---------------------------------------------------------------------------
+
+describe("accountErasure.ts purgeAccount (osn-tracker#595)", () => {
+  it("purges an account with 150 hosted events (past the old 100-id cliff) via 1-param deletes", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const HOST = "usr_host";
+
+    await Effect.runPromise(
+      Effect.forEach(
+        Array.from({ length: 150 }, (_, i) => i),
+        (i) =>
+          seedEvent({
+            title: `Event ${i}`,
+            startTime: new Date(Date.now() + 86_400_000).toISOString(),
+            createdByProfileId: HOST,
+          }),
+        { discard: true },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    const result = await Effect.runPromise(
+      purgeAccount("acc_host", [HOST]).pipe(Effect.provide(layer)),
+    );
+    expect(result).toMatchObject({ purged: 1, alreadyProcessed: false });
+
+    const remaining = await Effect.runPromise(
+      Effect.gen(function* () {
+        const { db } = yield* Db;
+        return yield* Effect.promise(() => db.select().from(events));
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(remaining).toHaveLength(0);
+
+    for (const needle of ['"event_rsvps"', '"event_comms"', '"event_lineup"', '"events"']) {
+      const stmt = findStatement(captured, "delete from " + needle, "json_each");
+      expect(stmt.params, `${needle} delete should bind 1 param`).toHaveLength(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. closeFriends.ts getCloseFriendsOfBatch + pulseUsers.ts
+//    getAttendanceVisibilityBatch — osn-tracker#591
+// ---------------------------------------------------------------------------
+
+describe("closeFriends.ts getCloseFriendsOfBatch (osn-tracker#591)", () => {
+  it("looks up 150 attendees (past the old 100-id cliff, and past the old 1000-id truncation risk) with 1 bound param", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const attendeeIds = Array.from({ length: 150 }, (_, i) => `usr_${i}`);
+
+    const result = await Effect.runPromise(
+      getCloseFriendsOfBatch("usr_viewer", attendeeIds).pipe(Effect.provide(layer)),
+    );
+    expect(result).toEqual(new Set());
+
+    const stmt = findStatement(captured, 'from "pulse_close_friends"', "json_each");
+    expect(stmt.params).toHaveLength(2); // friendId = ? , profileId IN json_each(?)
+  });
+});
+
+describe("pulseUsers.ts getAttendanceVisibilityBatch (osn-tracker#591)", () => {
+  it("looks up 150 attendees with 1 bound param instead of 1-per-id", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const attendeeIds = Array.from({ length: 150 }, (_, i) => `usr_${i}`);
+
+    const result = await Effect.runPromise(
+      getAttendanceVisibilityBatch(attendeeIds).pipe(Effect.provide(layer)),
+    );
+    expect(result.size).toBe(150); // every id defaults even with no rows
+
+    const stmt = findStatement(captured, 'from "pulse_users"', "json_each");
+    expect(stmt.params).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. rsvps.ts inviteGuests — osn-tracker#590 (both the SELECT and the INSERT)
+// ---------------------------------------------------------------------------
+
+describe("rsvps.ts inviteGuests (osn-tracker#590)", () => {
+  it("invites 150 guests (past the old ~17-row insert cliff) with 1 bound param each on the SELECT and the INSERT", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const event = await Effect.runPromise(
+      seedEvent({
+        title: "Big Party",
+        startTime: new Date(Date.now() + 86_400_000).toISOString(),
+        joinPolicy: "guest_list",
+        createdByProfileId: "usr_organiser",
+      }).pipe(Effect.provide(layer)),
+    );
+    const profileIds = Array.from({ length: 150 }, (_, i) => `usr_guest_${i}`);
+
+    const result = await Effect.runPromise(
+      inviteGuests(event.id, "usr_organiser", { profileIds }).pipe(Effect.provide(layer)),
+    );
+    expect(result.invited).toBe(150);
+
+    const selectStmt = findStatement(captured, 'from "event_rsvps"', "json_each", "select");
+    expect(selectStmt.params).toHaveLength(2); // event_id = ?, profile_id IN json_each(?)
+
+    const insertStmt = findStatement(captured, 'insert into "event_rsvps"', "json_each");
+    expect(insertStmt.params).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. discovery.ts discoverEvents(friendsOnly) — osn-tracker#592
+// ---------------------------------------------------------------------------
+
+describe("discovery.ts discoverEvents friendsOnly (osn-tracker#592)", () => {
+  it("filters by 150 connections (past the old ~50-connection cliff), the set bound twice at 1 param each", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    const connectionIds = Array.from({ length: 150 }, (_, i) => `usr_conn_${i}`);
+    const lookups: DiscoveryLookups = {
+      getConnectionIds: () => Effect.succeed(new Set(connectionIds)),
+    };
+
+    const result = await Effect.runPromise(
+      discoverEvents({ friendsOnly: true }, "usr_viewer", lookups).pipe(Effect.provide(layer)),
+    );
+    expect(result.events).toEqual([]);
+
+    const stmt = findStatement(captured, 'from "events"', "json_each");
+    // The connection set appears twice in the friendsPredicate (inArray +
+    // the EXISTS subquery) — 2 occurrences, 1 bound param each, never 2×n.
+    const jsonEachOccurrences = (stmt.sql.match(/json_each/g) ?? []).length;
+    expect(jsonEachOccurrences).toBe(2);
+    // The property is invariance, not a magic ceiling: a threshold has to be
+    // guessed, and guessing it low is how this assertion first failed at 11
+    // against a `toBeLessThan(10)` that proved nothing either way. Run the
+    // same query with ten times the connections and require the bound
+    // parameter count to be identical — that is what "does not bind per
+    // element" actually means, and it fails the moment anyone reverts a
+    // json_each back to a list.
+    const wide = createCapturingTestLayer();
+    await Effect.runPromise(
+      discoverEvents({ friendsOnly: true }, "usr_viewer", {
+        getConnectionIds: () =>
+          Effect.succeed(new Set(Array.from({ length: 1_500 }, (_, i) => `usr_conn_${i}`))),
+      }).pipe(Effect.provide(wide.layer)),
+    );
+    const wideStmt = findStatement(wide.captured, 'from "events"', "json_each");
+    expect(wideStmt.params.length).toBe(stmt.params.length);
+    // And it is bounded well under D1's cap of 100 rather than merely equal.
+    expect(stmt.params.length).toBeLessThan(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. events.ts applyTransitions — events.ts:296
+// ---------------------------------------------------------------------------
+
+describe("events.ts applyTransitions (events.ts:296)", () => {
+  it("transitions 150 events sharing one (upcoming → ongoing) group (past the old 99-event cliff) with 1 bound id-list param", async () => {
+    const { layer, captured } = createCapturingTestLayer();
+    // Started 1 minute ago, no endTime → deriveStatus returns "ongoing"
+    // (well under MAYBE_FINISHED_AFTER_HOURS), so every row transitions
+    // upcoming → ongoing in a single group.
+    const rows = await Effect.runPromise(
+      Effect.forEach(
+        Array.from({ length: 150 }, (_, i) => i),
+        (i) =>
+          seedEvent({
+            title: `Event ${i}`,
+            startTime: new Date(Date.now() - 60_000).toISOString(),
+            status: "upcoming",
+          }),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    const transitioned = await Effect.runPromise(
+      applyTransitions(rows).pipe(Effect.provide(layer)),
+    );
+    expect(transitioned.every((e) => e.status === "ongoing")).toBe(true);
+
+    const stmt = findStatement(captured, 'update "events"', "json_each");
+    // status = ?, updated_at = ?, id IN json_each(?) — 3 total, never
+    // ids.length + 2 (which would be 152 for this test's 150 rows).
+    expect(stmt.params).toHaveLength(3);
+  });
+});

--- a/shared/db-utils/src/index.ts
+++ b/shared/db-utils/src/index.ts
@@ -225,3 +225,11 @@ export {
   tokeniseQuery,
   tokensPrefixName,
 } from "./search";
+
+/**
+ * `json_each`-backed helpers that keep a variable-length `IN (...)` list or
+ * a multi-row `INSERT` under D1's 100-bound-parameter cap by binding the
+ * whole array as one JSON parameter instead of one parameter per element —
+ * see `jsonEach.ts` for the full rationale and the real-D1 measurements.
+ */
+export { insertManyViaJsonEach, jsonEachIn } from "./jsonEach";

--- a/shared/db-utils/src/jsonEach.ts
+++ b/shared/db-utils/src/jsonEach.ts
@@ -54,12 +54,36 @@ export function jsonEachIn(values: readonly (string | number)[]): SQL {
  * 100-parameter cap (a 31-column table breaks past 3 rows; a 6-column one
  * past 16).
  *
- * Every row must carry the same set of keys — the first row's own keys
- * decide the column list, matching `.values(rows)`'s own uniform-shape
- * assumption. A key that isn't one of the table's columns throws rather
- * than silently dropping data; an empty `rows` also throws, since an empty
- * INSERT is a caller bug to fix at the call site (every site here already
- * guards `rows.length === 0` before reaching this point).
+ * Every row must carry the same set of keys, and that is **enforced**, not
+ * assumed. An earlier version of this comment claimed the requirement
+ * "matches `.values(rows)`'s own uniform-shape assumption". It does not:
+ * drizzle lets each row omit an optional column independently and applies
+ * that column's schema default per row, where this helper derives one
+ * column list from the first row and reads every other row through it. A
+ * row missing one of those keys would get `NULL` written — not the schema
+ * default the equivalent `.values(rows)` call would have applied — and a
+ * row carrying an extra key would have it dropped from the insert
+ * entirely. Both silently. So the key sets are compared up front and a
+ * mismatch throws.
+ *
+ * A key that isn't one of the table's columns throws rather than silently
+ * dropping data; an empty `rows` also throws, since an empty INSERT is a
+ * caller bug to fix at the call site (every site here already guards
+ * `rows.length === 0` before reaching this point).
+ *
+ * Two value types this cannot carry, both of which would write wrong data
+ * rather than fail, so both throw:
+ *
+ *  - **An integer outside ±2^53.** The payload is JSON, and JSON numbers
+ *    are IEEE-754 doubles: `9007199254740993` comes back as
+ *    `9007199254740992`. Verified on real D1, silently.
+ *  - **A blob-mode column.** `mapToDriverValue` hands back a `Buffer`,
+ *    which `JSON.stringify` turns into `{"type":"Buffer","data":[…]}` —
+ *    an object `json_extract` cannot give back to a BLOB column.
+ *
+ * Neither is reachable from today's two call sites, but this helper is in
+ * `@shared/db-utils` rather than scoped to one package, so its second
+ * caller is the one these guards are for.
  *
  * The result is a plain `SQL` statement, run with `db.run(...)` rather than
  * chained off `db.insert(...)` — so `.returning()` and
@@ -86,8 +110,27 @@ export function insertManyViaJsonEach<TTable extends Table>(
     if (!column) {
       throw new Error(`insertManyViaJsonEach: "${key}" is not a column of this table`);
     }
+    if (column.dataType === "buffer") {
+      throw new Error(
+        `insertManyViaJsonEach: "${key}" is a blob column, which cannot survive the JSON payload — insert it with .values() in chunks under the parameter cap`,
+      );
+    }
     return column;
   });
+
+  // Every row's key set must match the first row's exactly. Checked by size
+  // then by membership, so a row that swaps one key for another is caught too.
+  const keySet = new Set<string>(keys);
+  for (const [index, row] of rows.entries()) {
+    const rowKeys = Object.keys(row);
+    const mismatch =
+      rowKeys.length !== keys.length ? rowKeys : rowKeys.filter((key) => !keySet.has(key));
+    if (mismatch.length > 0 || rowKeys.length !== keys.length) {
+      throw new Error(
+        `insertManyViaJsonEach: row ${index} has a different key set from row 0 — every row must name the same columns, or one of them would silently be written as NULL`,
+      );
+    }
+  }
 
   // Mirrors drizzle's own null handling (`sql/sql.ts`: a null value is
   // bound as SQL NULL directly, never run through the column's encoder —
@@ -96,7 +139,18 @@ export function insertManyViaJsonEach<TTable extends Table>(
   const driverRows = rows.map((row) =>
     columns.map((column, i) => {
       const value = row[keys[i]!];
-      return value === null || value === undefined ? null : column.mapToDriverValue(value);
+      if (value === null || value === undefined) return null;
+      const driverValue: unknown = column.mapToDriverValue(value);
+      if (typeof driverValue === "number" && !Number.isSafeInteger(driverValue)) {
+        // Non-integers are fine — a float round-trips through JSON as itself.
+        // An integer past 2^53 does not, and comes back a different number.
+        if (Number.isInteger(driverValue)) {
+          throw new Error(
+            `insertManyViaJsonEach: ${driverValue} is outside ±2^53 and cannot survive a JSON payload intact`,
+          );
+        }
+      }
+      return driverValue;
     }),
   );
 

--- a/shared/db-utils/src/jsonEach.ts
+++ b/shared/db-utils/src/jsonEach.ts
@@ -1,0 +1,109 @@
+import {
+  getTableColumns,
+  sql,
+  type Column,
+  type InferInsertModel,
+  type SQL,
+  type Table,
+} from "drizzle-orm";
+
+/**
+ * D1 caps a query at 100 bound parameters
+ * (developers.cloudflare.com/d1/platform/limits/). bun:sqlite — every test
+ * tier except a real-D1 integration suite — enforces no such cap, so a query
+ * that binds one parameter per array element (`inArray(col, ids)`) or one
+ * parameter per column per row (`.values(rows)`) looks fine locally and
+ * throws `D1_ERROR: too many SQL variables` in production once the input
+ * grows past a few dozen rows or a few hundred ids.
+ *
+ * Both helpers below sidestep the cap by binding the whole array as ONE
+ * JSON-encoded parameter and unpacking it inside SQLite with `json_each`, a
+ * table-valued function from the json1 extension built into both drivers
+ * this repo runs on. Verified against real Miniflare-backed D1 — not
+ * bun:sqlite, not assumed from a comment — in `pulse/api`'s
+ * `d1-integration.test.ts`: a 1,000-element list binds as 1 parameter on
+ * both `jsonEachIn` and `insertManyViaJsonEach`, and the planner flattens
+ * `col IN (SELECT value FROM json_each(?))` into a `LIST SUBQUERY` rather
+ * than a scan.
+ */
+
+/**
+ * A `col IN (...)` right-hand side whose parameter list is a single bound
+ * JSON array instead of one bound parameter per element. Use it as the
+ * second argument to drizzle's `inArray`:
+ *
+ *   inArray(events.id, jsonEachIn(ids))
+ *
+ * — or splice it directly into a raw `sql` template where the array needs
+ * to appear more than once in one statement (two predicates that both want
+ * the same set can share one `jsonEachIn(...)` call and its one bound
+ * param each time it's spliced in, rather than each re-deriving the list).
+ *
+ * `values` may be empty — `json_each('[]')` is a legal zero-row source, so
+ * this degrades to "matches nothing" the same way `inArray(col, [])` does,
+ * without a special case here.
+ */
+export function jsonEachIn(values: readonly (string | number)[]): SQL {
+  return sql`(SELECT value FROM json_each(${JSON.stringify(values)}))`;
+}
+
+/**
+ * A multi-row `INSERT INTO <table> (...) SELECT ... FROM json_each(?)`
+ * statement, standing in for drizzle's `db.insert(table).values(rows)` at
+ * any site where the row count times the column count can cross D1's
+ * 100-parameter cap (a 31-column table breaks past 3 rows; a 6-column one
+ * past 16).
+ *
+ * Every row must carry the same set of keys — the first row's own keys
+ * decide the column list, matching `.values(rows)`'s own uniform-shape
+ * assumption. A key that isn't one of the table's columns throws rather
+ * than silently dropping data; an empty `rows` also throws, since an empty
+ * INSERT is a caller bug to fix at the call site (every site here already
+ * guards `rows.length === 0` before reaching this point).
+ *
+ * The result is a plain `SQL` statement, run with `db.run(...)` rather than
+ * chained off `db.insert(...)` — so `.returning()` and
+ * `.onConflictDoNothing()` aren't available. None of today's call sites
+ * need either; a future one that does should chunk under the cap with
+ * `.values()` instead of reaching for this.
+ */
+export function insertManyViaJsonEach<TTable extends Table>(
+  table: TTable,
+  rows: readonly InferInsertModel<TTable>[],
+): SQL {
+  if (rows.length === 0) {
+    throw new Error("insertManyViaJsonEach: rows must be non-empty — guard at the call site");
+  }
+
+  const allColumns = getTableColumns(table);
+  // The first row's own keys decide the column list, so they are keys of the
+  // insert model rather than arbitrary strings — typing them that way is what
+  // lets the value read below index the row directly instead of widening it to
+  // a dictionary of `unknown`.
+  const keys = Object.keys(rows[0]!) as (keyof InferInsertModel<TTable> & string)[];
+  const columns: Column[] = keys.map((key) => {
+    const column: Column | undefined = allColumns[key];
+    if (!column) {
+      throw new Error(`insertManyViaJsonEach: "${key}" is not a column of this table`);
+    }
+    return column;
+  });
+
+  // Mirrors drizzle's own null handling (`sql/sql.ts`: a null value is
+  // bound as SQL NULL directly, never run through the column's encoder —
+  // several encoders, e.g. the timestamp one, call `.getTime()` on the
+  // value and would throw on null).
+  const driverRows = rows.map((row) =>
+    columns.map((column, i) => {
+      const value = row[keys[i]!];
+      return value === null || value === undefined ? null : column.mapToDriverValue(value);
+    }),
+  );
+
+  const columnList = sql.raw(columns.map((c) => `"${c.name}"`).join(", "));
+  const selectList = sql.raw(
+    columns.map((c, i) => `json_extract(value, '$[${i}]') AS "${c.name}"`).join(", "),
+  );
+
+  return sql`INSERT INTO ${table} (${columnList}) SELECT ${selectList} FROM json_each(${JSON.stringify(driverRows)})`;
+}

--- a/shared/db-utils/tests/jsonEach.test.ts
+++ b/shared/db-utils/tests/jsonEach.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `jsonEachIn` and `insertManyViaJsonEach` exist to keep a variable-length
+ * `IN (...)` or a multi-row `INSERT` under D1's 100-bound-parameter cap
+ * (developers.cloudflare.com/d1/platform/limits/) by binding the whole
+ * array as one JSON parameter instead of one parameter per element.
+ * bun:sqlite enforces no such cap, so these tests can't reproduce the
+ * failure the helpers fix — they pin the contract that makes the fix work
+ * (constant parameter count regardless of input size, correct round-trip
+ * data) via `.toSQL()`, which never executes a query. The real-D1 proof —
+ * that json_each is accepted and returns the right rows on Miniflare/
+ * workerd D1, not just bun:sqlite — lives in `pulse/api`'s
+ * `d1-integration.test.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getTableColumns, inArray, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+
+import { insertManyViaJsonEach, jsonEachIn } from "../src/jsonEach";
+
+// A throwaway 4-column fixture table — enough columns to prove the
+// per-column, per-row math without dragging in a real app schema.
+const widgets = sqliteTable("widgets", {
+  id: text("id").primaryKey(),
+  label: text("label").notNull(),
+  ownerId: text("owner_id"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+});
+
+function makeDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.run(
+    "CREATE TABLE widgets (id TEXT PRIMARY KEY, label TEXT NOT NULL, owner_id TEXT, created_at INTEGER NOT NULL)",
+  );
+  return drizzle(sqlite, { schema: { widgets } });
+}
+
+describe("jsonEachIn", () => {
+  it("binds exactly one parameter no matter how many ids are in the list", () => {
+    const db = makeDb();
+    for (const size of [1, 50, 100, 1_000]) {
+      const ids = Array.from({ length: size }, (_, i) => `id_${i}`);
+      const built = db
+        .select()
+        .from(widgets)
+        .where(inArray(widgets.id, jsonEachIn(ids)))
+        .toSQL();
+      expect(built.params).toHaveLength(1);
+      expect(built.sql).toContain("json_each");
+    }
+  });
+
+  it("round-trips the id list correctly against a real (bun:sqlite) engine", () => {
+    const db = makeDb();
+    const now = new Date();
+    db.insert(widgets)
+      .values([
+        { id: "a", label: "A", ownerId: null, createdAt: now },
+        { id: "b", label: "B", ownerId: null, createdAt: now },
+        { id: "c", label: "C", ownerId: null, createdAt: now },
+      ])
+      .run();
+
+    const rows = db
+      .select({ id: widgets.id })
+      .from(widgets)
+      .where(inArray(widgets.id, jsonEachIn(["a", "c", "does-not-exist"])))
+      .all();
+    expect(rows.map((r) => r.id).toSorted()).toEqual(["a", "c"]);
+  });
+
+  it("matches nothing for an empty list, same as inArray(col, [])", () => {
+    const db = makeDb();
+    const built = db
+      .select()
+      .from(widgets)
+      .where(inArray(widgets.id, jsonEachIn([])))
+      .toSQL();
+    expect(built.params).toHaveLength(1);
+
+    db.insert(widgets).values({ id: "a", label: "A", ownerId: null, createdAt: new Date() }).run();
+    const rows = db
+      .select({ id: widgets.id })
+      .from(widgets)
+      .where(inArray(widgets.id, jsonEachIn([])))
+      .all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("reusing one jsonEachIn(...) call across two predicates binds it twice, not once (osn-tracker#592 shape)", () => {
+    // discovery.ts's friends filter splices the same connectionIds set into
+    // two branches of one `or(...)` — this is that shape reduced to the
+    // fixture table. 2 total params (not 2×N) either way: the fix is
+    // binding the array once per *occurrence*, never once per *element*.
+    const db = makeDb();
+    const idsJson = jsonEachIn(["a", "b"]);
+    const built = db
+      .select()
+      .from(widgets)
+      .where(or(inArray(widgets.id, idsJson), inArray(widgets.ownerId, idsJson)))
+      .toSQL();
+    expect(built.params).toHaveLength(2);
+  });
+});
+
+describe("insertManyViaJsonEach", () => {
+  const now = new Date(1_700_000_000_000);
+
+  it("binds exactly one parameter no matter how many rows or columns", () => {
+    const db = makeDb();
+    for (const rowCount of [1, 4, 260, 1_000]) {
+      const rows = Array.from({ length: rowCount }, (_, i) => ({
+        id: `w_${i}`,
+        label: `Widget ${i}`,
+        ownerId: null,
+        createdAt: now,
+      }));
+      const built = (
+        db as unknown as { dialect: { sqlToQuery: (s: unknown) => { params: unknown[] } } }
+      ).dialect.sqlToQuery(insertManyViaJsonEach(widgets, rows));
+      expect(built.params).toHaveLength(1);
+    }
+  });
+
+  it("derives the fixed insertManyViaJsonEach param count against the scaling .values(rows) count", () => {
+    // The regression this guards: `.values(rows)` binds columns × rows
+    // parameters (derived here from the row's own key count, never
+    // hard-coded), which is exactly what crosses D1's 100-parameter cap.
+    // `insertManyViaJsonEach` stays at 1 regardless.
+    const db = makeDb();
+    const columnCount = Object.keys(getTableColumns(widgets)).length;
+    const rowCount = 30;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      id: `w_${i}`,
+      label: `Widget ${i}`,
+      ownerId: null,
+      createdAt: now,
+    }));
+
+    const oldStyle = db.insert(widgets).values(rows).toSQL();
+    expect(oldStyle.params).toHaveLength(columnCount * rowCount);
+    expect(oldStyle.params.length).toBeGreaterThan(100); // this is the bug
+
+    const built = (
+      db as unknown as { dialect: { sqlToQuery: (s: unknown) => { params: unknown[] } } }
+    ).dialect.sqlToQuery(insertManyViaJsonEach(widgets, rows));
+    expect(built.params).toHaveLength(1);
+  });
+
+  it("round-trips rows correctly, including null and boolean-mapped values", () => {
+    const db = makeDb();
+    const rows = [
+      { id: "a", label: 'Hello "quotes"', ownerId: "owner_1", createdAt: now },
+      { id: "b", label: "Row 2", ownerId: null, createdAt: new Date(now.getTime() + 1_000) },
+    ];
+    db.run(insertManyViaJsonEach(widgets, rows));
+
+    const back = db.select().from(widgets).orderBy(widgets.id).all();
+    expect(back).toEqual([
+      { id: "a", label: 'Hello "quotes"', ownerId: "owner_1", createdAt: now },
+      { id: "b", label: "Row 2", ownerId: null, createdAt: new Date(now.getTime() + 1_000) },
+    ]);
+  });
+
+  it("throws on an empty row set rather than emitting a no-op insert", () => {
+    expect(() => insertManyViaJsonEach(widgets, [])).toThrow(/non-empty/);
+  });
+
+  it("throws on a key that isn't one of the table's columns, rather than silently dropping it", () => {
+    expect(() =>
+      insertManyViaJsonEach(widgets, [
+        { id: "a", label: "A", ownerId: null, createdAt: now, bogus: 1 } as never,
+      ]),
+    ).toThrow(/not a column/);
+  });
+});

--- a/shared/db-utils/tests/jsonEach.test.ts
+++ b/shared/db-utils/tests/jsonEach.test.ts
@@ -30,6 +30,14 @@ const widgets = sqliteTable("widgets", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 });
 
+/** A second table for the guard tests: `widgets` has no plain integer column
+ *  to push past 2^53, and a blob column would break its other tests. */
+const guardTable = sqliteTable("guard_rows", {
+  id: text("id").primaryKey(),
+  label: text("label").notNull(),
+  count: integer("count"),
+});
+
 function makeDb() {
   const sqlite = new Database(":memory:");
   sqlite.run(
@@ -175,5 +183,56 @@ describe("insertManyViaJsonEach", () => {
         { id: "a", label: "A", ownerId: null, createdAt: now, bogus: 1 } as never,
       ]),
     ).toThrow(/not a column/);
+  });
+});
+
+// Three guards added after the security review of PR #856. None is reachable
+// from today's two call sites; all three are for the helper's second caller,
+// since it lives in @shared/db-utils rather than being scoped to one package.
+// Each would otherwise write WRONG DATA rather than fail, which is the worst
+// failure mode available to an insert helper.
+describe("insertManyViaJsonEach guards", () => {
+  it("throws when a row omits a key the first row has", () => {
+    expect(() =>
+      insertManyViaJsonEach(guardTable, [
+        { id: "a", label: "one", count: 1 },
+        { id: "b", label: "two" },
+      ] as never),
+    ).toThrow(/different key set from row 0/);
+  });
+
+  it("throws when a row carries a key the first row does not", () => {
+    expect(() =>
+      insertManyViaJsonEach(guardTable, [
+        { id: "a", label: "one" },
+        { id: "b", label: "two", count: 2 },
+      ] as never),
+    ).toThrow(/different key set from row 0/);
+  });
+
+  it("throws when a row swaps one key for another, same count", () => {
+    expect(() =>
+      insertManyViaJsonEach(guardTable, [
+        { id: "a", label: "one" },
+        { id: "b", count: 2 },
+      ] as never),
+    ).toThrow(/different key set from row 0/);
+  });
+
+  // JSON numbers are IEEE-754 doubles: 2^53 + 1 comes back as 2^53.
+  it("throws on an integer outside the safe range rather than truncating it", () => {
+    expect(() =>
+      insertManyViaJsonEach(guardTable, [
+        { id: "a", label: "one", count: Number.MAX_SAFE_INTEGER + 2 },
+      ] as never),
+    ).toThrow(/outside ±2\^53/);
+  });
+
+  it("accepts an integer at the edge of the safe range", () => {
+    expect(() =>
+      insertManyViaJsonEach(guardTable, [
+        { id: "a", label: "one", count: Number.MAX_SAFE_INTEGER },
+      ] as never),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

D1 allows 100 bound parameters per query. Six `pulse/api` queries bound a
variable number of them, so each threw `D1_ERROR: too many SQL variables` past
some input size. Three were live, and none was visible in any test tier —
`bun:sqlite`, which every pulse suite except the D1 integration file runs on,
enforces no such cap and passes against all six.

The class has two shapes, and the second is the one that kept being missed. A
`SELECT` binding an id list breaks around 50–100 items. **A multi-row `INSERT`
binds one parameter per column per row**, so a 31-column table breaks at four
rows.

`@shared/db-utils` gains `jsonEachIn` and `insertManyViaJsonEach`. Both bind the
whole array as one JSON parameter and unpack it inside SQLite with `json_each`,
so the count stops growing with the input. 200 series instances now insert with
**one** bound parameter.

## Workspaces affected

`shared/db-utils`, `pulse/api`. `.changeset/pulse-d1-bind-cap.md` names both as
`patch`.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#594 | `P-C` |
| xchromo/osn-tracker#595 | `C-H` / `P-C` |
| xchromo/osn-tracker#591 | `P-C` |
| xchromo/osn-tracker#590 | `P-C` |
| xchromo/osn-tracker#592 | `P-H` |

Closes xchromo/osn-tracker#594.
Closes xchromo/osn-tracker#595.
Closes xchromo/osn-tracker#591.
Closes xchromo/osn-tracker#590.
Closes xchromo/osn-tracker#592.

**Opened**

None against this branch.

## Decisions

### `json_each` over one bound JSON array — `P-C`

- **Issue** — every site needed the bind count to stop scaling with input.
- **Why** — chunking works but leaves the same trap for whoever next raises a
  constant, and the constants here are exactly what went wrong.
- **Solution** — one shared helper pair, used at all six sites. `col IN (SELECT
  value FROM json_each(?))` flattens to a `LIST SUBQUERY` with a Bloom filter,
  so the plan stays an index seek.
- **Rationale** — written once rather than six times, because six hand-rolled
  copies is how the seventh drifts. `insertManyViaJsonEach` mirrors drizzle's own
  null handling deliberately: several column encoders call `.getTime()` and
  would throw on a null passed through them.

### Three comments cited the wrong engine limit, and that is the root cause

- **Issue** — `closeFriends.ts` carried a comment saying its cap existed "to stay
  within SQLite's variable limit".
- **Why** — SQLite's ceiling is 999. D1's is 100. Writing the wrong number down
  as the *reason* is why this recurred: the next reader reasons from the comment.
  The same mistake sits behind osn-tracker#589 and the compound-select limit
  fixed in #853, where workerd compiles in 5 against SQLite's 500.
- **Solution** — comments corrected to name D1 and the measured figure.

### The truncation went with it — `#591`

- **Issue** — `getCloseFriendsOfBatch` did `profileIds.slice(0, MAX_BATCH_SIZE)`.
- **Why** — once nothing binds per element the slice is pure risk: it silently
  drops close-friend flags rather than erroring, on a privacy-adjacent surface.
- **Solution** — removed.

### `#591` needed two queries, `#590` needed the other statement

- **Issue** — both issues named one query each. Both were incomplete.
- **Why** — `#591`'s request also dies in `pulseUsers.ts:90` at the same cliff, so
  fixing only `closeFriends.ts` would have moved the failure a few lines and
  looked like a fix in review. `#590` was filed against a `SELECT` with a
  threshold of 100, but `inviteGuests` also does a multi-row insert reached
  *after* it, which breaks at about **17** guests.
- **Solution** — both queries in each case. The issues are corrected.
- **Rationale** — a 101-guest test would have passed the `SELECT` fix and still
  thrown on the insert.

### The erasure stays one atomic batch — `#595`

- **Issue** — four `DELETE`s bound the hosted-event ids inside one `commitBatch`.
- **Why** — the atomicity is deliberate and documented. A purge that
  half-completes is worse than one that fails cleanly, so splitting the batch was
  not available as a fix.
- **Solution** — the ids stop being bound; the batch is unchanged.

**Out of scope**

- xchromo/osn-tracker#593 — `osn/api/src/routes/graph-internal.ts`, held by the
  open stack `#760 → #831`.
- xchromo/osn-tracker#596 — the zap and pulse export caps. Different concern, no
  live path.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37 packages |
| `bun run lint` | ✅ |
| `bun run fmt:check` | ✅ 1438 files |
| `bun run test` | ✅ 38/38 tasks |
| `bun run test:d1` | ✅ 5/5 tasks, `@pulse/api` 4 pass |
| `bash scripts/verify-vendored-anti-slop.sh` | ✅ |
| `bun run test:scripts` | ✅ 80 pass |
| `bun run check:jest-dom-markers` | ✅ |
| `bun run check:release-age-excludes` | ✅ |
| `bash scripts/validate-changesets.sh` | ✅ |
| `openapi:generate` + `git diff --exit-code shared/openapi/` | ✅ no drift |

The regression tests assert the **emitted** bound-parameter count via `.toSQL()`
rather than seeding realistic fixtures: 200 series instances → 1 parameter, the
close-friends read → 2, the invite `SELECT` → 2, the transition batch → 3. That
is faster than seeding and it fails the instant anyone reverts a `json_each` back
to a list. The discovery test asserts the property rather than a threshold — the
same query at 150 and at 1,500 connections must bind an identical number of
parameters, because a guessed ceiling proves nothing either way.

One end-to-end D1 test earns its cost: a purge of an account with 150 hosted
events, on real Miniflare-backed D1. That is the GDPR path and it has to work,
not merely compile. Its own fixture is seeded through `insertManyViaJsonEach` —
the first draft used `.values(rows)` and hit `too many SQL variables` while
setting up the fixture for a bug about `too many SQL variables`, which is an
incidental proof the helper does what it claims.

Not covered by any gate: measured on Miniflare's D1, which is the same engine but
not production data or scale. And `#593` means the RSVP request may still have a
ceiling until that locked file can be fixed.
