### PR TITLE
docs: write down D1's real limits, and two prep-pr corrections

### DIFF
--- a/.claude/commands/prep-pr.md
+++ b/.claude/commands/prep-pr.md
@@ -123,6 +123,24 @@ Work is tracked in GitHub Issues, not in a markdown checklist. Two repos:
 
 `xchromo/osn` is public. A finding names an unpatched route, so filing one there publishes it. **Route by kind, not by severity** — an `S-`, `P-`, or `C-` ID always goes to the tracker, however minor it looks.
 
+### Auditing a defect class
+
+When a finding turns out to be an instance of a class — "this query does X, and
+X is wrong" — the audit that follows has to enumerate the **shapes** X can take,
+not just re-grep the form you happened to find first. Ask what other syntax has
+the same property, and check each: a helper call, a raw `sql` template, a
+different builder method, an implicit form.
+
+This is not theoretical. An audit for one D1 bind-cap bug grepped `inArray` and
+declared four siblings. It missed the two worst instances in the codebase —
+both multi-row `INSERT`s, which bind one parameter *per column per row* and so
+break an order of magnitude sooner than the id-list form that was searched for.
+One of them was a GDPR erasure path that could never complete. See
+`[[wiki/systems/d1-limits]]`.
+
+Report the shapes you enumerated and the verdict on each, so the next reader
+knows what was searched for and what was not.
+
 ### New findings from Step 6
 
 One issue per finding that this branch does **not** fix. Title leads with the finding ID; body keeps the same four fields the PR uses.
@@ -301,7 +319,14 @@ unverified — say so plainly rather than leaving it implied.>
 
 ### Section rules
 
-**Issues.** One row per issue. A same-repo issue closes on merge with plain `Closes #<n>` — put that line under the table, one per issue, since a table cell does not trigger GitHub's closing keyword. A tracker issue needs the full `Closes xchromo/osn-tracker#<n>`; that works cross-repo with write access to both, but verify it actually closed after the merge and close it by hand if not.
+**Issues.** One row per issue. **"Opened" means issues raised *against this
+branch* — findings from its own review, or work this branch deliberately split
+out.** An issue found while auditing something else, in another package, or in
+a file this branch never touches does not belong in the table however it was
+discovered: listing it implies a relationship the PR does not have, and a
+reviewer then has to work out which rows are actually theirs. Mention a
+cross-package audit in one line of prose under **Out of scope** and let the
+tracker hold the results. A same-repo issue closes on merge with plain `Closes #<n>` — put that line under the table, one per issue, since a table cell does not trigger GitHub's closing keyword. A tracker issue needs the full `Closes xchromo/osn-tracker#<n>`; that works cross-repo with write access to both, but verify it actually closed after the merge and close it by hand if not.
 
 **A PR on `xchromo/osn` is public.** Reference a tracker issue by number and finding ID only — never paste its title, its file:line, or a word of its body. `xchromo/osn-tracker#412 — S-M1` is the whole entry.
 

--- a/wiki/architecture/backend-patterns.md
+++ b/wiki/architecture/backend-patterns.md
@@ -11,6 +11,7 @@ tags:
   - effect
 status: current
 related:
+  - "[[d1-limits]]"
   - "[[schema-layers]]"
   - "[[testing-patterns]]"
   - "[[observability/overview]]"
@@ -20,7 +21,7 @@ packages:
   - "@osn/api"
   - "@zap/api"
   - "@cire/api"
-last-reviewed: 2026-08-24
+last-reviewed: 2026-08-31
 ---
 
 # Backend Code Patterns

--- a/wiki/architecture/schema-layers.md
+++ b/wiki/architecture/schema-layers.md
@@ -11,13 +11,14 @@ tags:
   - effect
 status: current
 related:
+  - "[[d1-limits]]"
   - "[[backend-patterns]]"
   - "[[testing-patterns]]"
 packages:
   - "@pulse/api"
   - "@osn/api"
   - "@osn/client"
-last-reviewed: 2026-07-22
+last-reviewed: 2026-08-31
 ---
 
 # Schema Layers

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -62,6 +62,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[feature-flags]] — GrowthBook flags via `@shared/feature-flags`, key-optional and fail-safe
 - [[event-access]] — loadVisibleEvent, public/private visibility gate
 - [[venues]] — org-scoped venues, event lineups, venue detail page + Explore map layer
+- [[d1-limits]] — D1's 100 bound parameters and 5 compound-select terms, and why `bun:sqlite` never sees either
 - [[platform-limits]] — MAX_EVENT_GUESTS and other caps
 - [[redis]] — Redis-backed rate limiters + cluster-safe auth state stores
 - [[toast]] — `@shared/toast`, the `--toast-*` theming contract, and contrast on the surface a toast actually sits on

--- a/wiki/systems/d1-limits.md
+++ b/wiki/systems/d1-limits.md
@@ -1,0 +1,128 @@
+---
+title: D1 Limits
+aliases:
+  - D1 bound parameters
+  - too many SQL variables
+  - SQLITE_LIMIT_COMPOUND_SELECT
+  - json_each
+tags:
+  - systems
+  - infrastructure
+  - database
+status: current
+related:
+  - "[[platform-limits]]"
+  - "[[schema-layers]]"
+  - "[[backend-patterns]]"
+  - "[[social-graph]]"
+packages:
+  - "@shared/db-utils"
+  - "@osn/api"
+  - "@pulse/api"
+  - "@cire/api"
+  - "@zap/api"
+last-reviewed: 2026-08-31
+---
+
+# D1 Limits
+
+**D1 is not SQLite, and the difference is where our bugs come from.** Nine
+production defects were filed in one day because a limit was checked against
+SQLite's ceiling instead of D1's. Every one of them passed the whole test suite,
+because `bun:sqlite` — which every tier except the `d1-integration.test.ts`
+files runs on — enforces none of these.
+
+## The numbers that bite
+
+| What | SQLite | **D1 / workerd** | Source |
+|---|---|---|---|
+| Bound parameters per query | 999 | **100** | [D1 limits](https://developers.cloudflare.com/d1/platform/limits/) |
+| Terms in a compound SELECT (`UNION`, `UNION ALL`) | 500 | **5** | workerd source, `sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5)` |
+| Subrequests to CF services per invocation | — | 1,000 | [[free-tier-limits]] |
+
+**The compound-select limit is documented nowhere by Cloudflare.** It is
+compiled into workerd — raised from 3 to 5 in a workerd PR, still 5 at HEAD,
+asserted by workerd's own `sql-test.js`. Miniflare reproduces it exactly, so
+`bun run test:d1` can see it and nothing else can.
+
+## How the bind cap is reached, and why the second way is missed
+
+Two shapes, and the second is the one that keeps getting overlooked:
+
+- **A `SELECT` binding an id list** — `inArray(col, ids)` binds one parameter
+  per element. Cliff around 100 items, or **50** when the same list is bound
+  twice (once per branch of an `OR`, which is easy to do accidentally).
+- **A multi-row `INSERT`** — `db.insert(t).values(rows)` binds one parameter
+  **per column per row**, so it breaks an order of magnitude sooner. A
+  31-column table dies at **4 rows**. A 6-column one at 16.
+
+An audit that greps only for `inArray` finds the first and misses the second.
+That is exactly what happened: the two worst instances in `pulse/api` — every
+recurring series failing at four occurrences, and a GDPR erasure that could
+never complete for an account with more than a hundred hosted events — were
+both multi-row inserts, and both were missed by an `inArray`-only sweep.
+
+Also count the *whole* statement, not just the list. A literal in a `WHERE`, a
+join predicate and a `.limit()` each cost one parameter. `zap/api`'s export cap
+is set to exactly 100 ids and one of its two loaders binds **102**.
+
+## The fix: `json_each`
+
+`@shared/db-utils` provides `jsonEachIn` and `insertManyViaJsonEach`. Both bind
+the whole array as **one** JSON parameter and unpack it inside SQLite:
+
+```ts
+inArray(events.id, jsonEachIn(ids))              // 2 params for 1,000 ids
+db.run(insertManyViaJsonEach(events, rows))      // 1 param for 200 rows
+```
+
+SQLite flattens `col IN (SELECT value FROM json_each(?))` into a
+`LIST SUBQUERY` with a Bloom filter, so the outer query keeps its index seek —
+verified with `EXPLAIN QUERY PLAN` at every converted site. It also beat
+chunked `.values()` by 7–29× at the two insert sites measured.
+
+Three things it cannot carry, all of which **throw** rather than write wrong
+data:
+
+- rows whose key sets differ from the first row's — unlike `.values(rows)`,
+  which applies each column's schema default per row;
+- an integer outside ±2^53 — JSON numbers are IEEE-754 doubles, so
+  `9007199254740993` reads back as `9007199254740992`;
+- a blob column — its `Buffer` stringifies to an object `json_extract` cannot
+  return to a BLOB.
+
+`json_each` does **not** fit every shape. It cannot carry a per-group `LIMIT`,
+because this SQLite build has no implicit `LATERAL` — the organisation
+co-member fan-out in `osn/api` needed chunked `UNION ALL` batches instead. And
+a correlated `EXISTS` is not an equivalent substitute: on `osn/api` it turned an
+index seek into `SCAN c` and read twice the rows for an identical result.
+
+## Rules
+
+1. **A limit justified in a comment must name the engine and say where it was
+   measured.** `closeFriends.ts` carried "to stay within SQLite's variable
+   limit" — the wrong ceiling, written down as the reason, which is why the bug
+   survived every reading of that file.
+2. **Never bind per element.** A constant that happens to sit under the cap
+   today is not a fix; it is the next bug. Lowering a cap to make a query legal
+   usually swaps an error for silent truncation, which is worse.
+3. **Verify on `bun run test:d1`.** No other tier enforces any of this. A
+   regression test that seeds a realistic fixture is slow and imprecise —
+   assert the emitted bound-parameter count with `.toSQL()` instead, with the
+   expected figure **derived** from the column list rather than written by hand.
+4. **`EXPLAIN QUERY PLAN` works on D1**, but the authorizer blocks some
+   builtins: `SELECT sqlite_version()` throws `not authorized to use function`.
+
+## History
+
+| Finding | Where | Cliff |
+|---|---|---|
+| osn-tracker#589 | `osn/api` FOF fan-out, list bound twice | 51 connections |
+| osn-tracker#594 | `pulse/api` series materialisation, 31-col insert | 4 instances |
+| osn-tracker#595 | `pulse/api` GDPR erasure, atomic batch | 101 hosted events |
+| osn-tracker#590 | `pulse/api` guest invite, insert | ~17 guests |
+| osn-tracker#591 | `pulse/api` RSVP list, two queries | 101 attendees |
+| osn-tracker#592 | `pulse/api` friends-only discovery, bound twice | ~50 connections |
+| osn-tracker#593 | `osn/api` graph-internal batch route | 101 ids (schema says 200) |
+| osn-tracker#596 | `zap`/`pulse` export caps | 100 ids binds 102 |
+| P-C1 on PR #853 | `osn/api` co-member fan-out, `UNION ALL` arms | 6 organisations |

--- a/wiki/systems/platform-limits.md
+++ b/wiki/systems/platform-limits.md
@@ -10,12 +10,13 @@ tags:
   - pulse
 status: current
 related:
+  - "[[d1-limits]]"
   - "[[s2s-patterns]]"
   - "[[pulse-close-friends]]"
   - "[[pulse]]"
 packages:
   - "@pulse/api"
-last-reviewed: 2026-07-22
+last-reviewed: 2026-08-31
 ---
 
 # Platform Limits


### PR DESCRIPTION
## Summary

Nine defects were filed in one day because a limit had been checked against
SQLite's ceiling rather than D1's. Every one passed the entire test suite —
`bun:sqlite`, which every tier but the `d1-integration.test.ts` files runs on,
enforces none of them.

`wiki/systems/d1-limits.md` writes down the numbers that actually apply, and the
shape that keeps being missed.

Plus two corrections to `prep-pr`, both from getting them wrong on PRs in this
same run.

## Workspaces affected

None — `wiki/` and `.claude/` only. `scripts/changeset-required.sh` returns
`skip`, so no changeset is required and none is added.

## Issues

**Closes**

None. This is documentation of a class that has its own issues
(xchromo/osn-tracker#589, #590–#596), all tracked separately.

**Opened**

None.

## Decisions

### The compound-select limit is the one worth writing down

- **Issue** — where to record engine limits that differ between SQLite and D1.
- **Why** — the bind cap is at least documented by Cloudflare. **The
  compound-select limit is documented nowhere**: it is compiled into workerd as
  `sqlite3_limit(db, SQLITE_LIMIT_COMPOUND_SELECT, 5)`, raised from 3 to 5 in a
  workerd PR and still 5 at HEAD. SQLite's own default is 500. Nobody would find
  that number by reading Cloudflare's docs, and a `UNION ALL` of six arms is an
  ordinary thing to write.
- **Solution** — a `wiki/systems/` page with the numbers, their provenance, the
  two shapes that reach the bind cap, what `json_each` fixes and what it cannot,
  and a table of the nine findings with their cliffs.
- **Rationale** — linked from `platform-limits`, `schema-layers` and
  `backend-patterns`, which are the pages someone is reading when they are about
  to write one of these queries.

### The audit shape, not just the audit result

- **Issue** — `prep-pr`'s sibling-audit step said to look for other instances,
  without saying how.
- **Why** — an audit for the D1 bind cap grepped `inArray`, reported four
  siblings, and missed the two worst instances in the codebase. Both were
  multi-row `INSERT`s, which bind one parameter *per column per row* and so
  break an order of magnitude sooner than the id-list form being searched for.
  One was a GDPR erasure path that could never complete for the accounts with
  the most data.
- **Solution** — a new "Auditing a defect class" section: enumerate the shapes
  the defect can take, check each, and report which were searched for.
- **Rationale** — a grep finds the form you already know about. The class
  boundary is the thing you get wrong, and no gate can fail on a site nobody
  looked for.

### "Opened" means findings against this branch

- **Issue** — I filled a PR's "Opened" table with issues from an audit of a
  different package, in files that branch never touched.
- **Why** — it implies a relationship the PR does not have, and leaves a
  reviewer working out which rows are actually theirs.
- **Solution** — the section rule now says so, and points cross-package audit
  results at **Out of scope** prose instead.

**Out of scope**

- The equivalent shepherd-skill edits (worktree locking, the shared stash stack,
  reviews as a gate rather than a follow-up, and never skipping plan review for
  a defect-class batch) live in `~/.claude/skills/`, outside this repo.

## Test plan

| Gate | Result |
|---|---|
| `scripts/changeset-required.sh` | ✅ `skip` — wiki and `.claude` only |
| wikilink resolution | ✅ every `[[link]]` on the branch resolves |
| `last-reviewed` bumped on touched pages | ✅ 4 pages |

No code changed, so no build, test or lint gate is meaningful here — nothing
under a versioned package is touched, which is why the changeset gate skips.

Not verified: the numbers in the table are transcribed from measurements made
during the work that produced them (Miniflare-backed D1, and workerd's own
source for the compound-select limit). They have not been re-measured for this
PR.
