### PR TITLE
perf(cire-api): route each request's D1 queries through one D1 session

### DIFF
--- a/.changeset/cire-d1-sessions-api.md
+++ b/.changeset/cire-d1-sessions-api.md
@@ -1,0 +1,36 @@
+---
+"@cire/api": patch
+---
+
+Route every request's D1 queries through one D1 session, so read replicas can serve them.
+
+Without a session, each `prepare()` is an independent query and D1 sends all of
+them to the primary database. cire's primary is in Oceania, so a request served
+from a European or North American colo pays the full round trip to Sydney *per
+query* — measured at ~36 ms each from a Sydney client against the OC primary,
+and far worse from further away. With replication on, a session pins the first
+query to the primary and lets every later query be served by any replica caught
+up to the bookmark the first one returned: N × distance collapses to one round
+trip plus N-1 local reads.
+
+- New `db/d1-session.ts`. The Elysia app graph is built once per isolate with
+  the Drizzle handle baked in and ~50 route factories closing over it, so a
+  per-request handle cannot be threaded explicitly. Instead the handle is built
+  over a stable client shim whose `prepare`/`batch` delegate to whichever
+  session is current on an `AsyncLocalStorage`, established per request in
+  `fetch` (and once around the six `scheduled` sweeps). Outside a session the
+  shim falls through to the raw binding — exactly today's behaviour — so losing
+  the context costs latency, never correctness.
+- `createD1Db` now takes the two-method `D1QueryClient` rather than a full
+  `D1Database`: those two methods (`prepare`, `batch`) are all Drizzle's D1
+  driver ever calls, and are exactly what a `D1DatabaseSession` exposes.
+- The constraint is `first-primary`, never `first-unconstrained`, so a request
+  always observes every write committed before it started. `routes/invite.ts`
+  serves a `no-store`, edit-sensitive payload precisely so organiser edits show
+  up on the guest invite's revalidation; one constraint Worker-wide keeps that
+  from depending on which route was reached.
+
+Safe to ship before replication is enabled: with no replicas a session behaves
+exactly as today. Tests cover the routing (including two interleaved requests
+kept apart across Effect's fiber scheduler, which is what every service query
+runs on) and a real workerd-backed D1 via Miniflare.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ One label is orthogonal to all of that: **`needs:decision`**, on both repos. It 
 |---|---|
 | Understand monorepo layout | `[[wiki/architecture/monorepo-structure]]` |
 | Understand DB environments (local bun:sqlite vs dev/staging/prod D1) | `[[wiki/systems/database-environments]]` |
+| Cut D1 latency with read replicas (the Sessions API, `first-primary`, one session per invocation, turning replication on) | `[[wiki/systems/d1-read-replication]]` |
 | Write new Effect service or Elysia route | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]` |
 | Understand accounts, profiles, orgs | `[[wiki/systems/identity-model]]` |
 | Add or verify ARC S2S tokens | `[[wiki/systems/arc-tokens]]` |

--- a/cire/api/src/db/d1-session.test.ts
+++ b/cire/api/src/db/d1-session.test.ts
@@ -98,6 +98,32 @@ describe("session routing", () => {
     ]);
   });
 
+  it("opens every session with the first-primary constraint", () => {
+    // The constant is a correctness decision, not a tuning knob: `first-primary`
+    // is what makes a request observe every write committed before it started
+    // (see the module docs). Assert both the value and that `runInD1Session`
+    // actually hands it to `withSession` — a session opened unconstrained would
+    // look identical from the outside until a replica served a stale read.
+    const constraints: string[] = [];
+    const log: string[] = [];
+    const session = recordingClient("session", log);
+    const fake = {
+      withSession: (constraint: string) => {
+        constraints.push(constraint);
+        return session;
+      },
+    } as unknown as D1Database;
+
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+    runInD1Session(fake, () => {
+      client.prepare("select 1");
+    });
+
+    expect(D1_SESSION_CONSTRAINT).toBe("first-primary");
+    expect(constraints).toEqual(["first-primary"]);
+    expect(log).toEqual(["session:prepare:select 1"]);
+  });
+
   it("survives the Effect scheduler, which is what every service query runs on", async () => {
     // Services never call the driver directly — every read goes through
     // `dbQuery`, i.e. an `Effect.promise` thunk run by Effect's fiber scheduler,
@@ -201,6 +227,66 @@ describe("against a real D1", () => {
         );
         expect(rows).toEqual([{ id: "p2" }, { id: "p3" }]);
       });
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "advances the session's bookmark as the request queries",
+    async () => {
+      // The bookmark is the whole mechanism: it is what a replica has to have
+      // caught up to before it may serve the session's later reads. Holding the
+      // session (which is why `withD1Session` exists next to `runInD1Session`)
+      // lets the test watch it go from "nothing read yet" to a real position.
+      const session = d1.withSession(D1_SESSION_CONSTRAINT);
+      const db: Db = createD1Db(createSessionRoutedClient(d1));
+
+      expect(session.getBookmark()).toBeNull();
+
+      await withD1Session(session, async () => {
+        await db.all(sql`select label from probe limit 1`);
+      });
+
+      expect(session.getBookmark()).not.toBeNull();
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "needs nothing from its client but prepare and batch",
+    async () => {
+      // `D1QueryClient` is a *reading* of Drizzle's D1 driver — that it calls
+      // `prepare` and `batch` and nothing else — and the whole design collapses
+      // if that stops being true, because a `D1DatabaseSession` has no other
+      // method to offer. `drizzle-orm` is on a caret range, so a minor bump
+      // could add an `exec`/`dump` call path silently. This fails loudly if it
+      // ever does.
+      const touched = new Set<string>();
+      const guarded = new Proxy(d1 as object, {
+        get(target, prop, receiver) {
+          const key = String(prop);
+          touched.add(key);
+          if (key !== "prepare" && key !== "batch") {
+            throw new Error(
+              `Drizzle's D1 driver reached for \`${key}\`, which a D1DatabaseSession does not have`,
+            );
+          }
+          const value = Reflect.get(target, prop, receiver) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }) as unknown as D1QueryClient;
+
+      const db: Db = createD1Db(guarded);
+
+      await db.run(sql`insert into probe (id, label) values ('p5', 'guarded')`);
+      const rows = await db.all<{ label: string }>(sql`select label from probe where id = 'p5'`);
+      expect(rows).toEqual([{ label: "guarded" }]);
+
+      await (db as unknown as { batch: (s: unknown[]) => Promise<unknown[]> }).batch([
+        db.run(sql`insert into probe (id, label) values ('p6', 'guarded batch')`),
+      ]);
+
+      expect([...touched].toSorted()).toEqual(["batch", "prepare"]);
     },
     MF_TIMEOUT_MS,
   );

--- a/cire/api/src/db/d1-session.test.ts
+++ b/cire/api/src/db/d1-session.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { sql } from "drizzle-orm";
+import { Effect } from "effect";
+import { Miniflare } from "miniflare";
+
+import {
+  createSessionRoutedClient,
+  D1_SESSION_CONSTRAINT,
+  runInD1Session,
+  withD1Session,
+  type D1QueryClient,
+} from "./d1-session";
+import { createD1Db } from "./index";
+import type { Db } from "./index";
+
+// Two halves. The routing tests use recording stand-ins, because what matters
+// there is WHICH client each query reached, which a real D1 will not tell you.
+// The integration half then runs the same shim against a real workerd-backed D1
+// through Miniflare, which is the only way to prove a `D1DatabaseSession` really
+// satisfies everything Drizzle's D1 driver asks of a database.
+
+/** A client that records the queries it was handed and nothing else. */
+function recordingClient(name: string, log: string[]): D1QueryClient {
+  return {
+    prepare: (query: string) => {
+      log.push(`${name}:prepare:${query}`);
+      return { query } as unknown as D1PreparedStatement;
+    },
+    batch: async <T>(statements: D1PreparedStatement[]) => {
+      log.push(`${name}:batch:${statements.length}`);
+      return [] as unknown as D1Result<T>[];
+    },
+  };
+}
+
+describe("session routing", () => {
+  it("falls back to the raw binding when no session is in scope", () => {
+    const log: string[] = [];
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+
+    client.prepare("select 1");
+
+    expect(log).toEqual(["binding:prepare:select 1"]);
+  });
+
+  it("routes prepare and batch to the session in scope", async () => {
+    const log: string[] = [];
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+    const session = recordingClient("session", log);
+
+    await withD1Session(session, async () => {
+      client.prepare("select 1");
+      await client.batch([]);
+    });
+
+    expect(log).toEqual(["session:prepare:select 1", "session:batch:0"]);
+  });
+
+  it("restores the fallback once the session scope ends", async () => {
+    const log: string[] = [];
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+
+    await withD1Session(recordingClient("session", log), async () => {
+      client.prepare("inside");
+    });
+    client.prepare("after");
+
+    expect(log).toEqual(["session:prepare:inside", "binding:prepare:after"]);
+  });
+
+  it("keeps concurrent sessions apart", async () => {
+    // The property the whole design rests on: the app graph — and so the
+    // Drizzle handle — is shared by every request an isolate serves at once, so
+    // if two in-flight requests could see each other's session, one request's
+    // reads could be served from a replica pinned to the OTHER request's
+    // (older) bookmark, quietly losing read-your-writes. Interleaved on
+    // purpose, with a yield between the two queries of each "request".
+    const log: string[] = [];
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+
+    const request = (name: string) =>
+      withD1Session(recordingClient(name, log), async () => {
+        client.prepare("first");
+        await Promise.resolve();
+        client.prepare("second");
+      });
+
+    await Promise.all([request("a"), request("b")]);
+
+    expect(log.filter((entry) => entry.startsWith("a:"))).toEqual([
+      "a:prepare:first",
+      "a:prepare:second",
+    ]);
+    expect(log.filter((entry) => entry.startsWith("b:"))).toEqual([
+      "b:prepare:first",
+      "b:prepare:second",
+    ]);
+  });
+
+  it("survives the Effect scheduler, which is what every service query runs on", async () => {
+    // Services never call the driver directly — every read goes through
+    // `dbQuery`, i.e. an `Effect.promise` thunk run by Effect's fiber scheduler,
+    // which batches work from all live fibers into shared microtask flushes.
+    // That is precisely where an async-context mechanism can lose or cross its
+    // stores, so assert it here rather than trusting it.
+    const log: string[] = [];
+    const client = createSessionRoutedClient(recordingClient("binding", log));
+
+    const query = (label: string) =>
+      Effect.promise(async () => {
+        client.prepare(label);
+      });
+
+    const request = (name: string) =>
+      withD1Session(recordingClient(name, log), () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            yield* query("first");
+            yield* Effect.yieldNow();
+            yield* query("second");
+          }),
+        ),
+      );
+
+    await Promise.all([request("a"), request("b")]);
+
+    expect(log.filter((entry) => entry.startsWith("a:"))).toEqual([
+      "a:prepare:first",
+      "a:prepare:second",
+    ]);
+    expect(log.filter((entry) => entry.startsWith("b:"))).toEqual([
+      "b:prepare:first",
+      "b:prepare:second",
+    ]);
+  });
+});
+
+// Same cold-start reasoning as `d1-integration.test.ts`: booting workerd on a
+// fresh CI runner can take several seconds, well past bun's 5_000ms default.
+const MF_TIMEOUT_MS = 30_000;
+
+let mf: Miniflare;
+let d1: D1Database;
+
+describe("against a real D1", () => {
+  beforeAll(async () => {
+    mf = new Miniflare({
+      modules: true,
+      script: "export default { fetch() { return new Response('ok'); } };",
+      d1Databases: { DB: ":memory:" },
+    });
+    d1 = (await mf.getD1Database("DB")) as unknown as D1Database;
+    await d1.prepare("create table probe (id text primary key, label text not null)").run();
+  }, MF_TIMEOUT_MS);
+
+  afterAll(async () => {
+    // Disposing poisons every D1 stub this instance handed out, so only once
+    // the suite is done and nothing is in flight.
+    await mf?.dispose();
+  }, MF_TIMEOUT_MS);
+
+  it("exposes withSession, and a session answers prepare and batch", () => {
+    const session = d1.withSession(D1_SESSION_CONSTRAINT);
+
+    expect(typeof session.prepare).toBe("function");
+    expect(typeof session.batch).toBe("function");
+  });
+
+  it(
+    "reads back its own writes through a Drizzle handle built over the shim",
+    async () => {
+      // The end-to-end shape of production: one Drizzle handle over the shim,
+      // built once, with the session established per invocation around it.
+      const db: Db = createD1Db(createSessionRoutedClient(d1));
+
+      await runInD1Session(d1, async () => {
+        await db.run(sql`insert into probe (id, label) values ('p1', 'written in session')`);
+        const rows = await db.all<{ label: string }>(sql`select label from probe where id = 'p1'`);
+        expect(rows).toEqual([{ label: "written in session" }]);
+      });
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "routes a batch through the session too",
+    async () => {
+      const db: Db = createD1Db(createSessionRoutedClient(d1));
+
+      await runInD1Session(d1, async () => {
+        // `.batch()` is the D1-only driver path (bun:sqlite has none), and it is
+        // the second of the two methods the shim forwards, so it needs its own
+        // coverage against a real session.
+        await (db as unknown as { batch: (s: unknown[]) => Promise<unknown[]> }).batch([
+          db.run(sql`insert into probe (id, label) values ('p2', 'batched')`),
+          db.run(sql`insert into probe (id, label) values ('p3', 'batched')`),
+        ]);
+        const rows = await db.all<{ id: string }>(
+          sql`select id from probe where label = 'batched' order by id`,
+        );
+        expect(rows).toEqual([{ id: "p2" }, { id: "p3" }]);
+      });
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "still works with no session in scope",
+    async () => {
+      // The degraded path: if the async context is ever lost, every query goes
+      // straight to the binding — which is exactly the behaviour before this
+      // change, so losing the context costs latency, never correctness.
+      const db: Db = createD1Db(createSessionRoutedClient(d1));
+
+      await db.run(sql`insert into probe (id, label) values ('p4', 'no session')`);
+      const rows = await db.all<{ label: string }>(sql`select label from probe where id = 'p4'`);
+
+      expect(rows).toEqual([{ label: "no session" }]);
+    },
+    MF_TIMEOUT_MS,
+  );
+});

--- a/cire/api/src/db/d1-session.ts
+++ b/cire/api/src/db/d1-session.ts
@@ -45,6 +45,39 @@ import { AsyncLocalStorage } from "node:async_hooks";
  * bun:sqlite dev server, a handler that somehow escaped the async context) the
  * shim falls through to the raw binding, which is exactly today's behaviour —
  * so losing the context degrades to "always primary", never to a wrong answer.
+ *
+ * That degradation covers a *missing* session only. A binding that cannot open
+ * one at all is a different thing: {@link runInD1Session} calls `withSession`
+ * unguarded on purpose, so a D1 binding without it fails the request loudly
+ * rather than quietly serving every request off the primary forever.
+ *
+ * ## Why concurrent requests cannot see each other's session
+ *
+ * The whole design rests on two in-flight requests never sharing a store, and
+ * that property is not something this package owns — it comes from how Effect
+ * schedules fibers. Every service read runs through `dbQuery` →
+ * `Effect.promise`, so all queries execute inside fiber drains; if Effect
+ * drained several fibers in one shared microtask, that microtask would carry a
+ * single fiber's async context and every other fiber's queries would ride the
+ * wrong session. Since Effect 3.20 it does not: `SchedulerRunner.cached` keeps
+ * runners in a `WeakMap` keyed by fiber, so each fiber's drain microtask is
+ * created inside that fiber's own context. The shared fallback runner is used
+ * only when there is no fiber at all.
+ *
+ * Two consequences worth keeping in mind:
+ *
+ *  - The interleaved-requests test in `d1-session.test.ts` is the regression
+ *    guard for exactly this, and it fails under the old shared-runner
+ *    behaviour. It is load-bearing, not belt-and-braces — do not delete it as
+ *    redundant, and re-run it deliberately on an `effect` major bump.
+ *  - **Module-scope Effect primitives that suspend one request's fiber and
+ *    resume it from another's are incompatible with this design.** A shared
+ *    `Deferred`, `Semaphore`, `Queue`, `Effect.cached` value or forked daemon
+ *    fiber schedules its resume task from whichever fiber completed it, so the
+ *    woken fiber's next drain is created inside the *completing* request's
+ *    context and its queries would ride that request's session. `@cire/api`
+ *    uses none today. Anything of that shape needs the session captured and
+ *    re-established explicitly with {@link withD1Session}.
  */
 
 /**
@@ -96,6 +129,10 @@ export function withD1Session<T>(session: D1QueryClient, body: () => T): T {
  *
  * `withSession()` is local object construction — no network — so this costs
  * nothing per request beyond the allocation.
+ *
+ * Deliberately unguarded: a D1 binding is required to have `withSession`, and a
+ * binding that does not (a stub, a wrong binding type) is a misconfiguration
+ * worth a loud failure rather than a silent lifetime of primary-only reads.
  */
 export function runInD1Session<T>(d1: D1Database, body: () => T): T {
   return withD1Session(d1.withSession(D1_SESSION_CONSTRAINT), body);

--- a/cire/api/src/db/d1-session.ts
+++ b/cire/api/src/db/d1-session.ts
@@ -1,0 +1,102 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * D1 Sessions API wiring: route every query a request makes through one D1
+ * session, so read replicas can serve the second and later queries.
+ *
+ * ## Why
+ *
+ * Without a session, each `prepare()` is an independent query and D1 sends all
+ * of them to the primary database. cire's primary lives in Oceania, so a
+ * request served from a European or North American colo pays the full
+ * round-trip to Sydney *per query* — a request that reads three tables pays it
+ * three times. With read replication enabled, a session pins the first query to
+ * the primary and lets every later query in the same session be served by any
+ * replica that has caught up to the bookmark the first query returned. The
+ * round trips collapse from N × (distance to Sydney) to one, plus N-1 local
+ * reads.
+ *
+ * This is safe to deploy BEFORE replication is turned on: with no replicas, a
+ * session behaves exactly like today (every query goes to the primary), so the
+ * change is inert until the database has replicas to serve from.
+ *
+ * ## The constraint, and why it is `first-primary`
+ *
+ * {@link D1_SESSION_CONSTRAINT} is `"first-primary"`, never
+ * `"first-unconstrained"`. `first-primary` sends the first query of the session
+ * to the primary, so a request ALWAYS observes every write committed before it
+ * started — the ordinary read-your-writes expectation, including across
+ * requests (a guest who RSVPs and then reloads, an organiser who saves an edit
+ * and then re-reads it). `first-unconstrained` gives that up for one saved
+ * round trip on the first query, and cire has at least one route that
+ * explicitly cannot take it: `routes/invite.ts` serves a `no-store`,
+ * edit-sensitive payload precisely so organiser edits surface on the guest
+ * invite's revalidation. One constraint for the whole Worker keeps that
+ * property from depending on which route happened to be reached.
+ *
+ * ## How it threads through
+ *
+ * The Elysia app graph is built ONCE per isolate (see `index.ts`) with the
+ * Drizzle handle baked in, and ~50 route factories close over that handle — so
+ * a per-request Drizzle client is not something the app can be handed. Instead
+ * the handle is built over a *stable* client shim whose `prepare`/`batch`
+ * delegate to whichever session is current on the async context, established
+ * per request by {@link runInD1Session}. Outside a session (unit tests, the
+ * bun:sqlite dev server, a handler that somehow escaped the async context) the
+ * shim falls through to the raw binding, which is exactly today's behaviour —
+ * so losing the context degrades to "always primary", never to a wrong answer.
+ */
+
+/**
+ * The half of `D1Database` that Drizzle's D1 driver actually calls.
+ * `drizzle-orm@0.45.2`'s `d1/session.js` uses `client.prepare(sql)` and
+ * `client.batch(statements)` and nothing else — no `exec`, no `dump` — which is
+ * also exactly what a `D1DatabaseSession` exposes. Naming the narrow type here
+ * lets a session stand in for a database without pretending it is one.
+ */
+export type D1QueryClient = Pick<D1Database, "prepare" | "batch">;
+
+/**
+ * Sequential consistency for every request. See the module docs above for why
+ * this is not `"first-unconstrained"`.
+ */
+export const D1_SESSION_CONSTRAINT = "first-primary" as const;
+
+const currentSession = new AsyncLocalStorage<D1QueryClient>();
+
+/**
+ * A D1 client that sends each query to the session current on the async
+ * context, falling back to `fallback` (the raw binding) when there is none.
+ *
+ * Stable for the life of the isolate: build the Drizzle handle over this once,
+ * and every request routes itself.
+ */
+export function createSessionRoutedClient(fallback: D1QueryClient): D1QueryClient {
+  const active = (): D1QueryClient => currentSession.getStore() ?? fallback;
+  return {
+    prepare: (query) => active().prepare(query),
+    batch: <T>(statements: D1PreparedStatement[]) => active().batch<T>(statements),
+  };
+}
+
+/**
+ * Run `body` with `session` as the client every query routes to.
+ *
+ * Separate from {@link runInD1Session} so a caller that needs the session
+ * object itself — to read `getBookmark()`, or a test asserting the routing — can
+ * create it, hand it over, and still hold a reference.
+ */
+export function withD1Session<T>(session: D1QueryClient, body: () => T): T {
+  return currentSession.run(session, body);
+}
+
+/**
+ * Open a fresh D1 session on `d1` and run `body` inside it. Called once per
+ * Worker invocation (`fetch` and `scheduled`), wrapping the whole dispatch.
+ *
+ * `withSession()` is local object construction — no network — so this costs
+ * nothing per request beyond the allocation.
+ */
+export function runInD1Session<T>(d1: D1Database, body: () => T): T {
+  return withD1Session(d1.withSession(D1_SESSION_CONSTRAINT), body);
+}

--- a/cire/api/src/db/index.ts
+++ b/cire/api/src/db/index.ts
@@ -4,6 +4,8 @@ import { drizzle as drizzleD1 } from "drizzle-orm/d1";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 import { Context, Effect } from "effect";
 
+import type { D1QueryClient } from "./d1-session";
+
 /**
  * The Drizzle handle threaded through every service.
  *
@@ -22,12 +24,19 @@ export type Db = BaseSQLiteDatabase<"sync" | "async", unknown, typeof schema>;
 export class DbService extends Context.Tag("DbService")<DbService, Db>() {}
 
 /**
- * Construct a Drizzle client over a Cloudflare D1 binding. Called per request in
- * the Workers entry point (`index.ts`) — Workers have no long-lived process, so
- * the binding only exists on `env` inside `fetch`.
+ * Construct a Drizzle client over a Cloudflare D1 binding, or over anything that
+ * answers the two methods the D1 driver calls (see {@link D1QueryClient}) — in
+ * production that is the session-routing shim from `db/d1-session.ts`, so every
+ * query a request makes rides one D1 session and read replicas can serve it.
+ *
+ * Built once per isolate in the Workers entry point (`index.ts`), because the
+ * whole Elysia app graph is built with this handle baked in.
  */
-export function createD1Db(d1: D1Database): Db {
-  return drizzleD1(d1, { schema });
+export function createD1Db(client: D1QueryClient): Db {
+  // The driver only ever reaches for `prepare` and `batch`, which is exactly
+  // what `D1QueryClient` guarantees; the cast just satisfies the wider binding
+  // type Drizzle's signature asks for, and is confined to this one call.
+  return drizzleD1(client as D1Database, { schema });
 }
 
 /**

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -8,6 +8,7 @@ import { Effect, Layer } from "effect";
 
 import { type AppOptions, createApp } from "./app";
 import { createD1Db, DbService } from "./db";
+import { createSessionRoutedClient, runInD1Session } from "./db/d1-session";
 import { setExecutionCtx } from "./lib/execution-ctx";
 import { CIRE_OIDC_TX_HMAC_INFO } from "./lib/oidc";
 import { runCire } from "./observability";
@@ -238,7 +239,11 @@ const handler: ExportedHandler<Env> = {
     }
 
     if (!cached || cached.dbBinding !== env.DB) {
-      const db = createD1Db(env.DB);
+      // Built over the session-routing shim, not the binding itself: the handle
+      // is baked into the cached app graph, so it must be stable for the life of
+      // the isolate, while the D1 session it queries through has to be per
+      // request. The shim is the seam between the two — see db/d1-session.ts.
+      const db = createD1Db(createSessionRoutedClient(env.DB));
       // Any authenticated OSN user is a first-class organiser: they sign in,
       // see their own weddings (an empty list for a new account — never a 503),
       // and create new ones via POST /api/organiser/weddings. There is no
@@ -461,7 +466,13 @@ const handler: ExportedHandler<Env> = {
     // background after a transform. Keyed by this exact Request instance, which
     // Elysia passes straight through to the handler.
     setExecutionCtx(request, ctx);
-    return cached.app.fetch(request);
+    // One D1 session per request, so replicas can serve every query after the
+    // first (see db/d1-session.ts). Wraps the whole dispatch, which is what puts
+    // the session on the async context every handler inherits.
+    // Bound out of the mutable module-level cache before the closure, so the
+    // narrowing above survives into it.
+    const { app } = cached;
+    return runInD1Session(env.DB, () => app.fetch(request));
   },
 
   // Cron-triggered daily maintenance (C-M2/C-M15 + retention). Configured by the
@@ -488,96 +499,108 @@ const handler: ExportedHandler<Env> = {
   // the other and the isolate stays alive until each delete settles.
   async scheduled(_event, env, ctx) {
     if (!env.DB) return;
-    const db = createD1Db(env.DB);
+    // Same session routing as `fetch`, for the same reason. The sweeps are
+    // write-heavy, so this buys little today — but it keeps one path through
+    // the D1 client rather than two, and the reads each sweep does to find its
+    // work can be served by a replica once the first query has run.
+    const db = createD1Db(createSessionRoutedClient(env.DB));
     const dbLayer = Layer.succeed(DbService, db);
 
-    ctx.waitUntil(
-      Effect.runPromise(
-        sessionService.sweepExpired().pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled session sweep failed", { reason: err.reason }),
+    // All six sweeps share one session: `waitUntil` only registers the
+    // promises, and each is created inside this scope, so all six inherit it.
+    runInD1Session(env.DB, () => {
+      ctx.waitUntil(
+        Effect.runPromise(
+          sessionService.sweepExpired().pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled session sweep failed", { reason: err.reason }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
 
-    // Organiser sessions expire but do not delete themselves — `validate` only
-    // reports expiry. Same reasoning as the guest sweep above: without this the
-    // table grows for the life of the product, and every row holds a login-time
-    // snapshot of an OSN profile (email, handle, display name), so keeping dead
-    // ones is a data-retention problem as well as a size one.
-    ctx.waitUntil(
-      Effect.runPromise(
-        organiserSessionService.sweepExpired().pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled organiser session sweep failed", { reason: err.reason }),
+      // Organiser sessions expire but do not delete themselves — `validate` only
+      // reports expiry. Same reasoning as the guest sweep above: without this the
+      // table grows for the life of the product, and every row holds a login-time
+      // snapshot of an OSN profile (email, handle, display name), so keeping dead
+      // ones is a data-retention problem as well as a size one.
+      ctx.waitUntil(
+        Effect.runPromise(
+          organiserSessionService.sweepExpired().pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled organiser session sweep failed", { reason: err.reason }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
 
-    // Pass the SHEETS binding so the retention sweep also reclaims the
-    // personal-data objects it orphans (IB-S-L2 / C-H1): the uploaded guest/event
-    // spreadsheets in `cire-sheets` referenced by the `imports` rows it deletes.
-    // D1's ON DELETE cascade never reaches R2, so without this the CSVs (which
-    // carry guest PII) would outlive the deleted DB rows forever. The `cire-assets`
-    // invite images are NOT reaped here — those rows survive (the invite stays
-    // live); see retentionService.sweepExpiredGuestData.
-    ctx.waitUntil(
-      Effect.runPromise(
-        retentionService.sweepExpiredGuestData(new Date(), { sheets: env.SHEETS }).pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled guest-data retention sweep failed", { reason: err.reason }),
+      // Pass the SHEETS binding so the retention sweep also reclaims the
+      // personal-data objects it orphans (IB-S-L2 / C-H1): the uploaded guest/event
+      // spreadsheets in `cire-sheets` referenced by the `imports` rows it deletes.
+      // D1's ON DELETE cascade never reaches R2, so without this the CSVs (which
+      // carry guest PII) would outlive the deleted DB rows forever. The `cire-assets`
+      // invite images are NOT reaped here — those rows survive (the invite stays
+      // live); see retentionService.sweepExpiredGuestData.
+      ctx.waitUntil(
+        Effect.runPromise(
+          retentionService.sweepExpiredGuestData(new Date(), { sheets: env.SHEETS }).pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled guest-data retention sweep failed", {
+                reason: err.reason,
+              }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
 
-    // Expired vendor-claim tokens: 7-day TTL, nothing else ever deleted them.
-    ctx.waitUntil(
-      Effect.runPromise(
-        maintenanceSweeps.sweepExpiredVendorClaims().pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled vendor-claim sweep failed", { reason: err.reason }),
+      // Expired vendor-claim tokens: 7-day TTL, nothing else ever deleted them.
+      ctx.waitUntil(
+        Effect.runPromise(
+          maintenanceSweeps.sweepExpiredVendorClaims().pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled vendor-claim sweep failed", { reason: err.reason }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
 
-    // Abandoned `preview` change rows + their uploaded-sheet CSVs (guest PII
-    // in `cire-sheets`) — previously only reclaimed when the whole wedding
-    // aged out of retention, a year+ later.
-    ctx.waitUntil(
-      Effect.runPromise(
-        maintenanceSweeps.sweepStalePreviews(new Date(), { sheets: env.SHEETS }).pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled stale-preview sweep failed", { reason: err.reason }),
+      // Abandoned `preview` change rows + their uploaded-sheet CSVs (guest PII
+      // in `cire-sheets`) — previously only reclaimed when the whole wedding
+      // aged out of retention, a year+ later.
+      ctx.waitUntil(
+        Effect.runPromise(
+          maintenanceSweeps.sweepStalePreviews(new Date(), { sheets: env.SHEETS }).pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled stale-preview sweep failed", { reason: err.reason }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
 
-    // IB-S-L2: reconcile orphaned `cire-assets` invite images (re-upload/remove
-    // best-effort-delete failures leave objects no DB row references). Pass the
-    // ASSETS binding; absent ⇒ the reconcile is a no-op. The service refuses to
-    // delete anything unless it can positively confirm the live set (abort on a
-    // failed/empty referenced-key read) and only reaps objects past a 7-day
-    // grace window — so a freshly uploaded image whose row write lags is safe.
-    ctx.waitUntil(
-      Effect.runPromise(
-        assetReconcileService.reconcileOrphans(env.ASSETS).pipe(
-          Effect.catchAll((err) =>
-            Effect.logError("scheduled cire-assets reconciliation failed", { reason: err.reason }),
+      // IB-S-L2: reconcile orphaned `cire-assets` invite images (re-upload/remove
+      // best-effort-delete failures leave objects no DB row references). Pass the
+      // ASSETS binding; absent ⇒ the reconcile is a no-op. The service refuses to
+      // delete anything unless it can positively confirm the live set (abort on a
+      // failed/empty referenced-key read) and only reaps objects past a 7-day
+      // grace window — so a freshly uploaded image whose row write lags is safe.
+      ctx.waitUntil(
+        Effect.runPromise(
+          assetReconcileService.reconcileOrphans(env.ASSETS).pipe(
+            Effect.catchAll((err) =>
+              Effect.logError("scheduled cire-assets reconciliation failed", {
+                reason: err.reason,
+              }),
+            ),
+            Effect.provide(dbLayer),
           ),
-          Effect.provide(dbLayer),
         ),
-      ),
-    );
+      );
+    });
   },
 };
 

--- a/cire/api/src/index.ts
+++ b/cire/api/src/index.ts
@@ -476,23 +476,26 @@ const handler: ExportedHandler<Env> = {
   },
 
   // Cron-triggered daily maintenance (C-M2/C-M15 + retention). Configured by the
-  // single `[triggers] crons` entry in wrangler.toml — daily 04:00 UTC. Five
+  // single `[triggers] crons` entry in wrangler.toml — daily 04:00 UTC. Six
   // independent sweeps share the cron:
   //
   //  1. Expired-session sweep — guest logins leave session rows that are never
   //     deleted on the read path, so the table grows unbounded without this. The
   //     sweep deletes rows whose 30-day window has lapsed; `expiresAt` already
   //     encodes when a row becomes dead.
-  //  2. Guest-data retention sweep — enforces the published privacy promise
+  //  2. Expired organiser sessions — same growth problem, and each dead row
+  //     holds a login-time snapshot of an OSN profile, so it is a retention
+  //     question too.
+  //  3. Guest-data retention sweep — enforces the published privacy promise
   //     (cire/invites privacy.astro): guest PII (guests/families/rsvps incl. dietary
   //     + consent, plus imports bookkeeping) is deleted 1 year after a wedding's
   //     final event. Reaps the `cire-sheets` CSVs it orphans (env.SHEETS).
-  //  3. `cire-assets` orphan reconciliation (IB-S-L2) — best-effort deletes
+  //  4. `cire-assets` orphan reconciliation (IB-S-L2) — best-effort deletes
   //     invite-image objects under `assets/` referenced by NO live DB row and
   //     older than a 7-day grace window. Heavily guarded: aborts and deletes
   //     NOTHING if the referenced-key read fails or comes back empty against a
   //     non-empty bucket, and caps deletions per run. See asset-reconcile.ts.
-  //  4. Expired vendor-claim tokens + 5. abandoned `preview` change rows (with
+  //  5. Expired vendor-claim tokens + 6. abandoned `preview` change rows (with
   //     their uploaded-sheet CSVs) — see services/maintenance-sweeps.ts.
   //
   // Each is its own `waitUntil` + `catchAll`, so a failure in one never aborts
@@ -506,101 +509,114 @@ const handler: ExportedHandler<Env> = {
     const db = createD1Db(createSessionRoutedClient(env.DB));
     const dbLayer = Layer.succeed(DbService, db);
 
-    // All six sweeps share one session: `waitUntil` only registers the
-    // promises, and each is created inside this scope, so all six inherit it.
-    runInD1Session(env.DB, () => {
-      ctx.waitUntil(
-        Effect.runPromise(
-          sessionService.sweepExpired().pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled session sweep failed", { reason: err.reason }),
-            ),
-            Effect.provide(dbLayer),
-          ),
-        ),
-      );
+    // One session PER SWEEP, not one shared by all six. `waitUntil` only
+    // registers a promise — what decides which session a query rides is where
+    // the promise was created — so each sweep gets its own `runInD1Session`
+    // wrapping its own `Effect.runPromise`. Sharing one would couple six
+    // unrelated, delete-heavy sweeps to a single bookmark that each of them
+    // keeps advancing, so every read would be forwarded to the primary anyway.
+    //
+    // The sweep to keep in mind here is the `cire-assets` reconciliation at the
+    // bottom: it deletes R2 objects no DB row references, so unlike the others
+    // a stale read there would destroy live data rather than merely skip a row.
+    // What bounds that is RECONCILE_GRACE_MS (7 days, services/asset-reconcile.ts)
+    // plus its two abort guards — orders of magnitude more than any replica lag.
+    // Shortening that window is the change that would make this paragraph matter.
+    const d1 = env.DB;
+    const runSweep = <Result>(body: () => Promise<Result>) =>
+      ctx.waitUntil(runInD1Session(d1, body));
 
-      // Organiser sessions expire but do not delete themselves — `validate` only
-      // reports expiry. Same reasoning as the guest sweep above: without this the
-      // table grows for the life of the product, and every row holds a login-time
-      // snapshot of an OSN profile (email, handle, display name), so keeping dead
-      // ones is a data-retention problem as well as a size one.
-      ctx.waitUntil(
-        Effect.runPromise(
-          organiserSessionService.sweepExpired().pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled organiser session sweep failed", { reason: err.reason }),
-            ),
-            Effect.provide(dbLayer),
+    runSweep(() =>
+      Effect.runPromise(
+        sessionService.sweepExpired().pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled session sweep failed", { reason: err.reason }),
           ),
+          Effect.provide(dbLayer),
         ),
-      );
+      ),
+    );
 
-      // Pass the SHEETS binding so the retention sweep also reclaims the
-      // personal-data objects it orphans (IB-S-L2 / C-H1): the uploaded guest/event
-      // spreadsheets in `cire-sheets` referenced by the `imports` rows it deletes.
-      // D1's ON DELETE cascade never reaches R2, so without this the CSVs (which
-      // carry guest PII) would outlive the deleted DB rows forever. The `cire-assets`
-      // invite images are NOT reaped here — those rows survive (the invite stays
-      // live); see retentionService.sweepExpiredGuestData.
-      ctx.waitUntil(
-        Effect.runPromise(
-          retentionService.sweepExpiredGuestData(new Date(), { sheets: env.SHEETS }).pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled guest-data retention sweep failed", {
-                reason: err.reason,
-              }),
-            ),
-            Effect.provide(dbLayer),
+    // Organiser sessions expire but do not delete themselves — `validate` only
+    // reports expiry. Same reasoning as the guest sweep above: without this the
+    // table grows for the life of the product, and every row holds a login-time
+    // snapshot of an OSN profile (email, handle, display name), so keeping dead
+    // ones is a data-retention problem as well as a size one.
+    runSweep(() =>
+      Effect.runPromise(
+        organiserSessionService.sweepExpired().pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled organiser session sweep failed", { reason: err.reason }),
           ),
+          Effect.provide(dbLayer),
         ),
-      );
+      ),
+    );
 
-      // Expired vendor-claim tokens: 7-day TTL, nothing else ever deleted them.
-      ctx.waitUntil(
-        Effect.runPromise(
-          maintenanceSweeps.sweepExpiredVendorClaims().pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled vendor-claim sweep failed", { reason: err.reason }),
-            ),
-            Effect.provide(dbLayer),
+    // Pass the SHEETS binding so the retention sweep also reclaims the
+    // personal-data objects it orphans (IB-S-L2 / C-H1): the uploaded guest/event
+    // spreadsheets in `cire-sheets` referenced by the `imports` rows it deletes.
+    // D1's ON DELETE cascade never reaches R2, so without this the CSVs (which
+    // carry guest PII) would outlive the deleted DB rows forever. The `cire-assets`
+    // invite images are NOT reaped here — those rows survive (the invite stays
+    // live); see retentionService.sweepExpiredGuestData.
+    runSweep(() =>
+      Effect.runPromise(
+        retentionService.sweepExpiredGuestData(new Date(), { sheets: env.SHEETS }).pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled guest-data retention sweep failed", {
+              reason: err.reason,
+            }),
           ),
+          Effect.provide(dbLayer),
         ),
-      );
+      ),
+    );
 
-      // Abandoned `preview` change rows + their uploaded-sheet CSVs (guest PII
-      // in `cire-sheets`) — previously only reclaimed when the whole wedding
-      // aged out of retention, a year+ later.
-      ctx.waitUntil(
-        Effect.runPromise(
-          maintenanceSweeps.sweepStalePreviews(new Date(), { sheets: env.SHEETS }).pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled stale-preview sweep failed", { reason: err.reason }),
-            ),
-            Effect.provide(dbLayer),
+    // Expired vendor-claim tokens: 7-day TTL, nothing else ever deleted them.
+    runSweep(() =>
+      Effect.runPromise(
+        maintenanceSweeps.sweepExpiredVendorClaims().pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled vendor-claim sweep failed", { reason: err.reason }),
           ),
+          Effect.provide(dbLayer),
         ),
-      );
+      ),
+    );
 
-      // IB-S-L2: reconcile orphaned `cire-assets` invite images (re-upload/remove
-      // best-effort-delete failures leave objects no DB row references). Pass the
-      // ASSETS binding; absent ⇒ the reconcile is a no-op. The service refuses to
-      // delete anything unless it can positively confirm the live set (abort on a
-      // failed/empty referenced-key read) and only reaps objects past a 7-day
-      // grace window — so a freshly uploaded image whose row write lags is safe.
-      ctx.waitUntil(
-        Effect.runPromise(
-          assetReconcileService.reconcileOrphans(env.ASSETS).pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("scheduled cire-assets reconciliation failed", {
-                reason: err.reason,
-              }),
-            ),
-            Effect.provide(dbLayer),
+    // Abandoned `preview` change rows + their uploaded-sheet CSVs (guest PII
+    // in `cire-sheets`) — previously only reclaimed when the whole wedding
+    // aged out of retention, a year+ later.
+    runSweep(() =>
+      Effect.runPromise(
+        maintenanceSweeps.sweepStalePreviews(new Date(), { sheets: env.SHEETS }).pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled stale-preview sweep failed", { reason: err.reason }),
           ),
+          Effect.provide(dbLayer),
         ),
-      );
-    });
+      ),
+    );
+
+    // IB-S-L2: reconcile orphaned `cire-assets` invite images (re-upload/remove
+    // best-effort-delete failures leave objects no DB row references). Pass the
+    // ASSETS binding; absent ⇒ the reconcile is a no-op. The service refuses to
+    // delete anything unless it can positively confirm the live set (abort on a
+    // failed/empty referenced-key read) and only reaps objects past a 7-day
+    // grace window — so a freshly uploaded image whose row write lags is safe.
+    runSweep(() =>
+      Effect.runPromise(
+        assetReconcileService.reconcileOrphans(env.ASSETS).pipe(
+          Effect.catchAll((err) =>
+            Effect.logError("scheduled cire-assets reconciliation failed", {
+              reason: err.reason,
+            }),
+          ),
+          Effect.provide(dbLayer),
+        ),
+      ),
+    );
   },
 };
 

--- a/cire/api/tests/db/d1-integration.test.ts
+++ b/cire/api/tests/db/d1-integration.test.ts
@@ -14,6 +14,7 @@ import { asc, eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { Miniflare } from "miniflare";
 
+import { createSessionRoutedClient, runInD1Session } from "../../src/db/d1-session";
 import { createD1Db, DbService } from "../../src/db/index";
 import type { Db } from "../../src/db/index";
 import { DDL } from "../../src/db/setup";
@@ -40,6 +41,7 @@ const GUEST_1 = "g1";
 const GUEST_2 = "g2";
 
 let mf: Miniflare;
+let d1: D1Database;
 let db: Db;
 
 // Booting workerd (which backs Miniflare's D1) is a cold-start the first time a
@@ -141,7 +143,7 @@ beforeAll(async () => {
     script: "export default { fetch() { return new Response('ok'); } };",
     d1Databases: { DB: ":memory:" },
   });
-  const d1 = (await mf.getD1Database("DB")) as unknown as D1Database;
+  d1 = (await mf.getD1Database("DB")) as unknown as D1Database;
   // Apply the schema statement-by-statement — D1's `exec` splits on newlines,
   // which breaks multi-line CREATE TABLEs, so prepare/run each full statement.
   for (const stmt of DDL.split(";")
@@ -149,7 +151,12 @@ beforeAll(async () => {
     .filter(Boolean)) {
     await d1.prepare(stmt).run();
   }
-  db = createD1Db(d1);
+  // Over the session-routing shim, exactly as `index.ts` builds it, so every
+  // service test in this file exercises the production client path rather than
+  // a raw binding the deployed Worker never uses. With no session in scope the
+  // shim delegates straight to `d1`, which is the point: the shim has to be
+  // transparent to all of this.
+  db = createD1Db(createSessionRoutedClient(d1));
 }, MF_TIMEOUT_MS);
 
 afterAll(async () => {
@@ -175,6 +182,20 @@ describe("cire/api over real D1 (Miniflare)", () => {
       const res = await run(claimService.lookup(PUBLIC_ID));
       expect(res.familyId).toBe(FAMILY_ID);
       expect(res.publicId).toBe(PUBLIC_ID);
+      expect(res.members).toHaveLength(2);
+      expect(res.events.map((e) => e.name).toSorted()).toEqual(["Ceremony", "Reception"]);
+    },
+    MF_TIMEOUT_MS,
+  );
+
+  it(
+    "claim.lookup gives the same answer inside a D1 session",
+    async () => {
+      // The deployed shape: the whole dispatch runs inside one session, so a
+      // multi-read service call has its reads routed to the session rather than
+      // the binding. Nothing about the result may change.
+      const res = await runInD1Session(d1, () => run(claimService.lookup(PUBLIC_ID)));
+      expect(res.familyId).toBe(FAMILY_ID);
       expect(res.members).toHaveLength(2);
       expect(res.events.map((e) => e.name).toSorted()).toEqual(["Ceremony", "Reception"]);
     },

--- a/cire/api/tests/db/d1-session.test.ts
+++ b/cire/api/tests/db/d1-session.test.ts
@@ -10,9 +10,9 @@ import {
   runInD1Session,
   withD1Session,
   type D1QueryClient,
-} from "./d1-session";
-import { createD1Db } from "./index";
-import type { Db } from "./index";
+} from "../../src/db/d1-session";
+import { createD1Db } from "../../src/db/index";
+import type { Db } from "../../src/db/index";
 
 // Two halves. The routing tests use recording stand-ins, because what matters
 // there is WHICH client each query reached, which a real D1 will not tell you.

--- a/cire/api/tests/index.test.ts
+++ b/cire/api/tests/index.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
 import { Miniflare } from "miniflare";
 
+import { D1_SESSION_CONSTRAINT } from "../src/db/d1-session";
 import { DDL } from "../src/db/setup";
 import handler from "../src/index";
 import { jsonBody } from "./test-helpers";
@@ -223,5 +224,174 @@ describe("CLAIM_RATE_LIMITER fail-closed guard", () => {
     // Binding present ⇒ no guard 503; app boots and the route answers 401.
     expect(res.status).not.toBe(503);
     expect(res.status).toBe(401);
+  });
+});
+
+// D1 Sessions API wiring, asserted at the edge rather than in isolation. The
+// unit tests in `db/d1-session.test.ts` prove the shim routes to whatever
+// session is on the async context; these prove the Worker actually PUTS one
+// there, on both entry points, and that no query escapes to the raw binding.
+// That is the failure that would be invisible otherwise: everything keeps
+// working, replication is simply never used.
+describe("D1 session routing at the entry points", () => {
+  /**
+   * A D1 binding that records what it was asked for, delegating to the real
+   * Miniflare database so the request under test still gets real answers.
+   * Every probe is a fresh object, which also forces `index.ts` to rebuild its
+   * isolate-cached app (the cache is keyed on binding identity).
+   */
+  function probeD1() {
+    const constraints: string[] = [];
+    const sessionQueries: string[][] = [];
+    const bindingQueries: string[] = [];
+
+    const binding = {
+      // Reaching these two means a query bypassed the session entirely.
+      prepare: (query: string) => {
+        bindingQueries.push(query);
+        return DB.prepare(query);
+      },
+      batch: (statements: D1PreparedStatement[]) => {
+        bindingQueries.push(`batch:${statements.length}`);
+        return DB.batch(statements);
+      },
+      withSession: (constraint: string) => {
+        constraints.push(constraint);
+        const queries: string[] = [];
+        sessionQueries.push(queries);
+        const session = DB.withSession(constraint);
+        return {
+          prepare: (query: string) => {
+            queries.push(query);
+            // Drizzle parameterises every value, so the SQL text alone cannot
+            // say WHICH request a query belonged to. Record the bound
+            // parameters too — that is what the concurrency test reads.
+            const statement = session.prepare(query);
+            return new Proxy(statement as object, {
+              get(target, prop, receiver) {
+                if (prop === "bind") {
+                  return (...args: unknown[]) => {
+                    queries.push(`bind:${args.join(",")}`);
+                    return (target as D1PreparedStatement).bind(...args);
+                  };
+                }
+                const value = Reflect.get(target, prop, receiver) as unknown;
+                return typeof value === "function" ? value.bind(target) : value;
+              },
+            }) as D1PreparedStatement;
+          },
+          batch: (statements: D1PreparedStatement[]) => {
+            queries.push(`batch:${statements.length}`);
+            return session.batch(statements);
+          },
+          getBookmark: () => session.getBookmark(),
+        };
+      },
+    } as unknown as D1Database;
+
+    return { binding, constraints, sessionQueries, bindingQueries };
+  }
+
+  // Unauthenticated, and it reads D1 — an unknown slug still costs the lookup
+  // that answers 404, which is all this needs. The organiser routes the rest of
+  // this file uses would 401 before touching the database.
+  const inviteRequest = (slug = "no-such-slug"): Parameters<NonNullable<typeof handler.fetch>>[0] =>
+    new Request(`https://api.example.com/api/invite/${slug}`) as unknown as Parameters<
+      NonNullable<typeof handler.fetch>
+    >[0];
+
+  it("opens one first-primary session per request and routes every query to it", async () => {
+    const probe = probeD1();
+    const env = { ...BASE_ENV, DB: probe.binding } as unknown as Parameters<
+      NonNullable<typeof handler.fetch>
+    >[1];
+
+    const res = await handler.fetch!(inviteRequest(), env, ctx);
+
+    expect(res.status).toBe(404);
+    expect(probe.constraints).toEqual([D1_SESSION_CONSTRAINT]);
+    expect(probe.sessionQueries[0]?.length ?? 0).toBeGreaterThan(0);
+    // The one that matters: a Drizzle handle built over the raw binding would
+    // opt every query out of replication with nothing to notice.
+    expect(probe.bindingQueries).toEqual([]);
+  });
+
+  it("gives each request its own session", async () => {
+    // Two requests through the SAME isolate-cached app — the app graph and its
+    // Drizzle handle are shared, so the session is the only per-request thing.
+    const probe = probeD1();
+    const env = { ...BASE_ENV, DB: probe.binding } as unknown as Parameters<
+      NonNullable<typeof handler.fetch>
+    >[1];
+
+    await handler.fetch!(inviteRequest(), env, ctx);
+    await handler.fetch!(inviteRequest(), env, ctx);
+
+    expect(probe.constraints).toEqual([D1_SESSION_CONSTRAINT, D1_SESSION_CONSTRAINT]);
+    expect(probe.sessionQueries).toHaveLength(2);
+    expect(probe.sessionQueries[0]?.length ?? 0).toBeGreaterThan(0);
+    expect(probe.sessionQueries[1]?.length ?? 0).toBeGreaterThan(0);
+    expect(probe.bindingQueries).toEqual([]);
+  });
+
+  it("keeps two concurrent requests on their own sessions", async () => {
+    // The hazard the whole design turns on, asserted against the real thing:
+    // the shared `ManagedRuntime` behind `runCire`, the shared app graph, the
+    // shared Drizzle handle, two requests in flight at once. If the async
+    // context could cross, one request's read could be served by a replica
+    // pinned to the other's older bookmark — a stale answer, with nothing
+    // failing. Each session must see its own slug and only its own.
+    const probe = probeD1();
+    const env = { ...BASE_ENV, DB: probe.binding } as unknown as Parameters<
+      NonNullable<typeof handler.fetch>
+    >[1];
+
+    await Promise.all([
+      handler.fetch!(inviteRequest("slug-alpha"), env, ctx),
+      handler.fetch!(inviteRequest("slug-beta"), env, ctx),
+    ]);
+
+    expect(probe.constraints).toHaveLength(2);
+    const bound = probe.sessionQueries.map((queries) =>
+      queries.filter((entry) => entry.startsWith("bind:")).join("|"),
+    );
+    expect(bound.filter((entry) => entry.includes("slug-alpha"))).toHaveLength(1);
+    expect(bound.filter((entry) => entry.includes("slug-beta"))).toHaveLength(1);
+    expect(bound.some((entry) => entry.includes("slug-alpha") && entry.includes("slug-beta"))).toBe(
+      false,
+    );
+    expect(probe.bindingQueries).toEqual([]);
+  });
+
+  it("gives each scheduled sweep its own session", async () => {
+    // Six sweeps, six sessions — deliberately NOT one shared by all of them.
+    // Sharing would couple six unrelated delete-heavy sweeps to a single
+    // bookmark each of them keeps advancing, so every read would be forwarded
+    // to the primary regardless.
+    const probe = probeD1();
+    const env = { ...BASE_ENV, DB: probe.binding } as unknown as Parameters<
+      NonNullable<typeof handler.scheduled>
+    >[1];
+
+    const pending: Promise<unknown>[] = [];
+    const cronCtx = {
+      ...ctx,
+      waitUntil: (promise: Promise<unknown>) => {
+        pending.push(promise);
+      },
+    } as unknown as ExecutionContext;
+
+    await handler.scheduled!(
+      { cron: "0 4 * * *", scheduledTime: Date.now(), noRetry: () => {} } as ScheduledController,
+      env,
+      cronCtx,
+    );
+    // `allSettled`: a sweep failing on this bare schema is not what is under
+    // test — that its queries rode a session of its own is.
+    await Promise.allSettled(pending);
+
+    expect(pending).toHaveLength(6);
+    expect(probe.constraints).toEqual(Array.from({ length: 6 }, () => D1_SESSION_CONSTRAINT));
+    expect(probe.bindingQueries).toEqual([]);
   });
 });

--- a/wiki/apps/cire-development.md
+++ b/wiki/apps/cire-development.md
@@ -16,8 +16,9 @@ related:
   - "[[frontend-patterns]]"
   - "[[testing-patterns]]"
   - "[[browser-tests]]"
+  - "[[d1-read-replication]]"
   - "[[commands]]"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-09-01
 ---
 
 # Cire development guide
@@ -56,6 +57,9 @@ The platform shape is in [[backend-patterns]]. Cire's departures:
 - **Errors are tagged classes** extending `Data.TaggedError`. Nothing in the
   service layer throws.
 - **D1 access is Drizzle only** — no raw SQL string construction.
+- **The Drizzle handle is built over the session-routing shim**, never over
+  `env.DB` directly, and each Worker invocation opens exactly one D1 session at
+  the entry point — see [[d1-read-replication]].
 - **Effect is backend and DB only.** Never import it in `cire/invites`,
   `cire/host` or `cire/vendor`.
 - **Cloudflare bindings are typed from `wrangler types`** output

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -63,6 +63,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[event-access]] — loadVisibleEvent, public/private visibility gate
 - [[venues]] — org-scoped venues, event lineups, venue detail page + Explore map layer
 - [[d1-limits]] — D1's 100 bound parameters and 5 compound-select terms, and why `bun:sqlite` never sees either
+- [[d1-read-replication]] — the Sessions API, why every request opens one `first-primary` session, and how to turn replicas on
 - [[platform-limits]] — MAX_EVENT_GUESTS and other caps
 - [[redis]] — Redis-backed rate limiters + cluster-safe auth state stores
 - [[toast]] — `@shared/toast`, the `--toast-*` theming contract, and contrast on the surface a toast actually sits on

--- a/wiki/systems/d1-limits.md
+++ b/wiki/systems/d1-limits.md
@@ -15,13 +15,14 @@ related:
   - "[[schema-layers]]"
   - "[[backend-patterns]]"
   - "[[social-graph]]"
+  - "[[d1-read-replication]]"
 packages:
   - "@shared/db-utils"
   - "@osn/api"
   - "@pulse/api"
   - "@cire/api"
   - "@zap/api"
-last-reviewed: 2026-08-31
+last-reviewed: 2026-09-01
 ---
 
 # D1 Limits
@@ -112,6 +113,12 @@ index seek into `SCAN c` and read twice the rows for an identical result.
    expected figure **derived** from the column list rather than written by hand.
 4. **`EXPLAIN QUERY PLAN` works on D1**, but the authorizer blocks some
    builtins: `SELECT sqlite_version()` throws `not authorized to use function`.
+
+## Not a limit, but the same "D1 is not SQLite" trap
+
+Every query also pays the round trip to the single primary in Oceania — 35.7 ms
+measured from Sydney, more from anywhere else — which `bun:sqlite` likewise never
+shows you. Cutting the count is one half; [[d1-read-replication]] is the other.
 
 ## History
 

--- a/wiki/systems/d1-read-replication.md
+++ b/wiki/systems/d1-read-replication.md
@@ -1,0 +1,168 @@
+---
+title: D1 Read Replication and the Sessions API
+aliases:
+  - D1 sessions
+  - withSession
+  - first-primary
+  - read replicas
+tags:
+  - systems
+  - infrastructure
+  - database
+  - performance
+status: current
+related:
+  - "[[database-environments]]"
+  - "[[d1-limits]]"
+  - "[[backend-patterns]]"
+  - "[[cire-development]]"
+  - "[[free-tier-limits]]"
+packages:
+  - "@cire/api"
+last-reviewed: 2026-09-01
+---
+
+# D1 Read Replication and the Sessions API
+
+A D1 database has one **primary**, in one region, and every query goes to it
+unless the request opts into a **session**. cire's primary is in Oceania, so a
+guest opening an invite from London pays a round trip to Sydney *for each query
+the request makes*. Read replication puts read-only copies in other regions;
+the [Sessions API](https://developers.cloudflare.com/d1/best-practices/read-replication/)
+is how a Worker actually uses them without giving up read-your-writes.
+
+## The cost being paid
+
+Measured 2026-08-31 from a Sydney client against the OC-primary `cire-db`, by
+diffing a route that runs one extra `SELECT` against a route that runs none:
+
+| Measure | Value |
+|---|---|
+| Control (no D1 query) | 15.0 ms |
+| One extra `SELECT` | 50.7 ms |
+| **Cost of one query** | **35.7 ms** (p10 33.0, p90 39.3, n=25) |
+
+That is the *near* case. The same query from Europe or North America pays the
+transoceanic round trip on top, and a request that reads four tables pays it
+four times. Folding queries together — the work in #849, #852 — cuts N. Sessions
+cut the distance instead: the first query goes to the primary, and every later
+query in the same session can be served by any replica caught up to the
+bookmark the first one returned.
+
+```mermaid
+graph LR
+  subgraph "Without a session"
+    E1[Worker in London] -->|query 1| P1[(Primary, Sydney)]
+    E1 -->|query 2| P1
+    E1 -->|query 3| P1
+  end
+  subgraph "With a session"
+    E2[Worker in London] -->|query 1| P2[(Primary, Sydney)]
+    E2 -->|query 2| R2[(Replica, London)]
+    E2 -->|query 3| R2
+  end
+```
+
+## How a session is threaded through the Worker
+
+`D1Database.withSession(constraint)` returns a `D1DatabaseSession` exposing
+`prepare`, `batch` and `getBookmark()` — and `prepare` + `batch` are *exactly*
+the two methods Drizzle's D1 driver ever calls, so a session can stand in for a
+database.
+
+The problem is where to put it. `@cire/api` builds its whole Elysia app graph
+**once per isolate** (`aot: false`, ~50 route factories closing over one Drizzle
+handle), so a per-request handle cannot be threaded explicitly through the
+routes. The seam is `cire/api/src/db/d1-session.ts`:
+
+| Piece | Lifetime | Job |
+|---|---|---|
+| `createSessionRoutedClient(binding)` | One per isolate | A stable `{ prepare, batch }` the Drizzle handle is built over. Each call delegates to whichever session is current. |
+| `withD1Session(session, body)` | One per request | Puts a session on an `AsyncLocalStorage` for the duration of `body`. |
+| `runInD1Session(d1, body)` | One per request | Opens a fresh session and does the above. Called in `fetch`, wrapping the entire dispatch, and once around each of the six `scheduled` sweeps. |
+
+`node:async_hooks` is available because the Worker sets `nodejs_compat`.
+
+> [!important] Losing the context is safe; crossing it would not be
+> With no session on the context the shim falls through to the raw binding —
+> every query goes to the primary, which is exactly the behaviour before this
+> existed. So a handler that somehow escapes the async context costs latency,
+> never correctness.
+>
+> The dangerous case is the opposite one: two concurrent requests seeing each
+> other's session, so request A's read is served by a replica pinned to B's
+> older bookmark. Every service query runs through `dbQuery` →
+> `Effect.promise` → Effect's fiber scheduler, which batches work from all live
+> fibers into shared microtask flushes — precisely where an async-context
+> mechanism could cross stores. `d1-session.test.ts` asserts it does not, with
+> two interleaved requests run through the real scheduler.
+
+## The constraint: always `first-primary`
+
+`withSession()` takes `"first-primary"` or `"first-unconstrained"`.
+
+| Constraint | First query | What you get |
+|---|---|---|
+| `first-primary` | Primary | The request observes every write committed before it started. |
+| `first-unconstrained` | Anywhere | One more round trip saved; the request may not see a write that has already committed. |
+
+cire uses `first-primary` Worker-wide. `routes/invite.ts` deliberately serves a
+`no-store`, edit-sensitive payload so an organiser's edit shows up when a guest
+revalidates the invite — `first-unconstrained` would reintroduce exactly the
+staleness that header exists to prevent. One constraint for the whole Worker
+keeps that property from depending on which route a request happened to reach.
+
+## Turning replication on
+
+Adopting the Sessions API is **inert until the database has replicas**: with
+none, a session behaves exactly as before. So the code ships first and the
+switch is flipped afterwards, separately and reversibly.
+
+There is no `wrangler` subcommand as of wrangler 4.x — it is the dashboard
+(D1 → database → Settings → Read replication) or the REST API:
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/d1/database/$DB_ID" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"read_replication":{"mode":"auto"}}'
+```
+
+`mode: "auto"` lets Cloudflare place and manage replicas; `"disabled"` turns it
+back off. Replicas are read-only and asynchronous — a write always goes to the
+primary, and replication lag is what the bookmark protects a session from.
+
+> [!note] Cost
+> Cloudflare's docs are explicit that you "incur the exact same D1 usage billing
+> with or without replicas, based on `rows_read` and `rows_written`" — so
+> replication changes latency, not the row-count ceilings in
+> [[free-tier-limits]]. What those docs do *not* state either way is whether the
+> feature is available on the free plan; confirm that in the dashboard before
+> counting on it.
+
+## Rules
+
+- **Never `first-unconstrained`.** See above. If a route ever genuinely wants
+  it, it needs its own session and its own argument in writing, not a change to
+  the Worker-wide constant.
+- **One session per unit of work, established at the entry point.** One per
+  request in `fetch`, one per sweep in `scheduled`. Not per route, not per
+  service — a session opened deeper down starts its own bookmark chain and
+  re-pays the first-query trip to the primary.
+- **Anything that queries after the response is sent must be created inside the
+  session scope.** `ctx.waitUntil(p)` only registers `p`; what matters is where
+  `p` was created. Each `scheduled` sweep is wrapped for this reason — one
+  session per sweep, not one shared by all six, so six unrelated delete-heavy
+  sweeps do not keep advancing a single bookmark that then forwards every read
+  to the primary anyway.
+- **Build the Drizzle handle over the shim, never over `env.DB` directly** —
+  a handle over the raw binding silently opts every query it serves out of
+  replication, with no error to notice.
+
+## History
+
+| Date | Change |
+|---|---|
+| 2026-08-31 | Measured the per-query cost from Sydney: 35.7 ms against the OC primary. |
+| 2026-09-01 | `@cire/api` adopts the Sessions API — `db/d1-session.ts`, one session per `fetch` and per `scheduled` sweep, `first-primary`. Ships inert. |

--- a/wiki/systems/d1-read-replication.md
+++ b/wiki/systems/d1-read-replication.md
@@ -137,9 +137,25 @@ primary, and replication lag is what the bookmark protects a session from.
 > Cloudflare's docs are explicit that you "incur the exact same D1 usage billing
 > with or without replicas, based on `rows_read` and `rows_written`" — so
 > replication changes latency, not the row-count ceilings in
-> [[free-tier-limits]]. What those docs do *not* state either way is whether the
-> feature is available on the free plan; confirm that in the dashboard before
-> counting on it.
+> [[free-tier-limits]]. The docs do not state whether the feature needs a paid
+> plan; it does not — the `PUT` above was accepted on this account's free plan
+> and `wrangler d1 info cire-db` reports `read_replication.mode  auto`.
+
+### It really is inert without sessions
+
+`cire-db` was switched to `auto` on 2026-08-31, while the deployed Worker still
+had no session code. Re-running the probe from §The cost being paid gave a
+per-query cost of **36.7 ms** (p10 34.0, p90 40.3, n=29) — the same 35.7 ms as
+before, inside the noise. That is the expected result and worth keeping: a query
+made outside a session goes to the primary whatever the database is configured
+to do, so enabling replication on its own buys nothing and costs nothing. The
+saving only appears once a Worker that opens sessions is deployed.
+
+A second thing that measurement cannot show from here: the client and the
+primary are both in Oceania, so even with sessions live, a Sydney reader has
+almost no distance to save. The win this page is about is for readers in Europe
+and North America, and confirming it needs a probe run from one of those
+regions.
 
 ## Rules
 
@@ -165,4 +181,5 @@ primary, and replication lag is what the bookmark protects a session from.
 | Date | Change |
 |---|---|
 | 2026-08-31 | Measured the per-query cost from Sydney: 35.7 ms against the OC primary. |
+| 2026-08-31 | Read replication switched to `auto` on `cire-db` (free plan). Measured no change, as expected — nothing opened a session yet. |
 | 2026-09-01 | `@cire/api` adopts the Sessions API — `db/d1-session.ts`, one session per `fetch` and per `scheduled` sweep, `first-primary`. Ships inert. |

--- a/wiki/systems/database-environments.md
+++ b/wiki/systems/database-environments.md
@@ -15,6 +15,7 @@ related:
   - "[[schema-layers]]"
   - "[[monorepo-structure]]"
   - "[[dev-environment]]"
+  - "[[d1-read-replication]]"
 last-reviewed: 2026-09-01
 ---
 
@@ -131,7 +132,10 @@ CI deploys it. See [[musubi-identity-migration]] and [[dev-environment]].
 
 **Databases and region.** All D1 databases are in **`oc` (Oceania / Sydney)** and
 both Upstash Redis databases are in **`ap-southeast-2` (Sydney)** — co-located for
-low AU latency (the project is AU-centric).
+low AU latency (the project is AU-centric). One region means one **primary**: a
+request served from a colo outside Oceania pays a round trip to Sydney for every
+query it makes, which is what read replication and the D1 Sessions API address —
+see [[d1-read-replication]].
 
 | Database | Environment | Id |
 |---|---|---|


### PR DESCRIPTION
## Summary

Routes every D1 query a request makes through a single D1 session, so that once
read replication is enabled on `cire-db` the second and later queries of a
request can be served by a replica near the reader instead of by the primary in
Oceania.

Today each `prepare()` is an independent query and D1 sends all of them to the
primary. A request that reads three tables pays the Sydney round trip three
times. With a session, the first query pins the bookmark and every later query in
that session can be served by any replica caught up to it — N round trips become
one, plus N-1 local reads.

Measured, from a Sydney client against the Oceania primary: **35.7 ms per
query** (control 15.0 ms, one-select 50.7 ms; p10 33.0, p90 39.3, n=25). From
Europe or North America that figure is several times larger, and it is paid per
query.

**This ships inert.** With no replicas, a session behaves exactly as today —
every query goes to the primary. Enabling replication on the database is a
separate, reversible dashboard change, made after this merges.

### How it threads through

The Elysia app graph is built once per isolate with the Drizzle handle baked in,
and ~50 route factories close over that handle, so a per-request Drizzle client
is not something the app can be handed. Instead the handle is built over a
*stable* client shim (`createSessionRoutedClient`) whose `prepare`/`batch`
delegate to whichever session is current on an `AsyncLocalStorage`, established
per request in `index.ts` by `runInD1Session`. `node:async_hooks` is available
because the Worker already sets `nodejs_compat`.

Outside a session — unit tests, the bun:sqlite dev server, a handler that
somehow escaped the context — the shim falls through to the raw binding, which is
exactly today's behaviour. Losing the context costs latency, never correctness.

Two decisions worth stating:

- **The constraint is `first-primary`, never `first-unconstrained`.**
  `first-primary` sends the first query of a session to the primary, so a request
  always observes every write committed before it started — ordinary
  read-your-writes, including across requests. `first-unconstrained` trades that
  for one saved round trip, and `routes/invite.ts` explicitly cannot take the
  trade: it serves a `no-store`, edit-sensitive payload precisely so organiser
  edits surface on the guest invite's revalidation. One constraint for the whole
  Worker keeps that property from depending on which route was reached.
- **One session per sweep in `scheduled`, not one shared by all six.**
  `ctx.waitUntil` only registers a promise; what decides which session a query
  rides is where the promise was created. Sharing one session would couple six
  unrelated, delete-heavy sweeps to a single bookmark each of them keeps
  advancing, so every read would be forwarded to the primary anyway.

### Why concurrent requests cannot cross sessions

The whole design rests on two in-flight requests never sharing a store, and that
property is not owned by this code — it comes from how Effect schedules fibers.
Every service read runs through `dbQuery` → `Effect.promise`, so all queries
execute inside fiber drains. Since Effect 3.20, `SchedulerRunner.cached` keeps
runners in a `WeakMap` keyed by fiber, so each fiber's drain microtask is created
inside that fiber's own context. There are tests for exactly this, and they fail
under the older shared-runner behaviour — they are load-bearing, not
belt-and-braces.

The consequence to keep in mind when writing new code: a module-scope Effect
primitive that suspends one request's fiber and resumes it from another's (a
shared `Deferred`, `Semaphore`, `Queue`, `Effect.cached` value, or a forked
daemon fiber) is incompatible with this design. `@cire/api` uses none today, and
the wiki page says so.

## Workspaces affected

- `@cire/api` — new `src/db/d1-session.ts`; `createD1Db` widened to accept the
  narrow `D1QueryClient`; `src/index.ts` wraps `fetch` and each `scheduled` sweep.
- `wiki/` + `CLAUDE.md` — new `wiki/systems/d1-read-replication.md`, linked from
  the navigation table, `wiki/index.md`, `wiki/apps/cire-development.md`,
  `wiki/systems/d1-limits.md` and `wiki/systems/database-environments.md`.

## Issues

Two follow-ups filed from the review, both informational: `xchromo/osn-tracker`
#597 (P-I1) and #598 (P-I3).

## Decisions

- **`first-primary` Worker-wide**, rather than per-route constraints. Reasoning
  above; a route that ever genuinely wants `first-unconstrained` needs its own
  session and its own argument in writing, not a change to the shared constant.
- **A shim on the async context**, rather than threading a per-request Drizzle
  handle through the app. The app graph is isolate-cached by design (`aot: false`
  plus ~50 route factories closing over the handle); rebuilding it per request
  would cost far more than the round trips this saves.
- **`runInD1Session` calls `withSession` unguarded on purpose.** A D1 binding is
  required to have it, and a binding that does not — a stub, a wrong binding type
  — is a misconfiguration worth a loud failure rather than a silent lifetime of
  primary-only reads. That is deliberately different from the *missing session*
  fallback, which is silent because it is safe.
- **Ship before enabling replication**, so the mechanical change and the
  consistency-affecting change are separately revertible.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Type check | `bunx --bun tsc --noEmit -p cire/api` | clean |
| Unit + route tests | `bun run --cwd cire/api test` | 1740 pass, 0 fail, 5413 expect() |
| Lint | `bunx --bun oxlint cire/api/src` | clean (pre-existing unused-var warnings in unrelated test files) |
| Format | `bunx --bun oxfmt --check cire/api/src` | clean |
| Changesets | `./scripts/validate-changesets.sh` | pass |
| Worker build | `bunx --bun wrangler deploy --dry-run` | builds |

New coverage, in three places:

- `src/db/d1-session.test.ts` — routing, fallback when no session is in scope,
  restoration after the scope ends, concurrent sessions kept apart, the same
  through the Effect fiber scheduler, and the constraint constant actually being
  what `withSession` receives. Then, against a real workerd-backed D1 through
  Miniflare: a Drizzle handle over the shim reads back its own writes, `.batch()`
  routes through the session too, the bookmark advances from null to a real
  position as the request queries, and — the premise of the whole substitution —
  Drizzle's D1 driver touches nothing but `prepare` and `batch`. `drizzle-orm` is
  on a caret range, so that last one fails loudly if a minor bump adds a call
  path a `D1DatabaseSession` cannot answer.
- `src/index.test.ts` — the entry points, through a recording D1 binding: one
  `first-primary` session per request; a distinct session per request through the
  shared isolate-cached app; two concurrent requests never seeing each other's
  session (read off the bound parameters, since Drizzle parameterises every value
  and the SQL text alone cannot say which request a query belonged to); six
  `waitUntil`ed sweeps to six sessions; and, on every one of those, that no query
  ever reaches the raw binding. That last assertion is the silent failure this
  change is most exposed to: a handle built over the raw binding would work
  perfectly and simply never use replication.
- `src/db/d1-integration.test.ts` — the suite's Drizzle handle now runs over the
  shim, so the existing integration tests exercise the production shape, plus one
  test that `claim.lookup` gives the same answer inside a session as outside.

Not covered by tests, and verified by reading: the behaviour once replicas exist.
There is no local way to run one.

## After merge

Enable read replication on `cire-db` (D1 → database → Settings → Read
replication, or the REST `PUT` documented on the wiki page) and re-measure
against the 35.7 ms/query baseline above. Billing is unchanged either way —
Cloudflare bills `rows_read`/`rows_written` with or without replicas.
