### PR TITLE
fix(cire): make organiser store invalidation notify mounted views

### DIFF
--- a/.changeset/cire-store-notifying-invalidate.md
+++ b/.changeset/cire-store-notifying-invalidate.md
@@ -1,0 +1,21 @@
+---
+"@cire/host": patch
+---
+
+Fix `invalidateXxx` across seven organiser-portal caches (events, guests,
+households, enquiries, vendors, budget, tasks) so a mounted view actually
+notices. Each one used to `cache.delete(weddingId)`, which drops the map
+entry but leaves any signal a component already captured on mount pointing
+at a spot nothing writes to again — the view keeps showing stale rows
+forever, and the next `ensureXxxLoaded` call quietly builds a *new* signal
+that only a fresh mount would read. `invalidateXxx` now writes `null`
+through the existing signal instead, so every mounted consumer observes the
+transition, `hasCachedXxx` reports false, and a stale fetch that was still
+in flight at invalidate time can no longer land its result afterwards (each
+store already guarded this with a per-wedding generation counter; the four
+Group 1 stores — enquiries, vendors, budget, tasks — gain that same counter
+here, matching the three that already had it).
+
+Also corrects two stale doc claims: the sibling-store list in
+`registry-store.ts`'s file docblock, and `EnquiriesView.tsx`'s comment
+claiming invalidation could not refresh the inbox.

--- a/.changeset/cire-store-notifying-invalidate.md
+++ b/.changeset/cire-store-notifying-invalidate.md
@@ -2,20 +2,21 @@
 "@cire/host": patch
 ---
 
-Fix `invalidateXxx` across seven organiser-portal caches (events, guests,
-households, enquiries, vendors, budget, tasks) so a mounted view actually
-notices. Each one used to `cache.delete(weddingId)`, which drops the map
-entry but leaves any signal a component already captured on mount pointing
-at a spot nothing writes to again — the view keeps showing stale rows
-forever, and the next `ensureXxxLoaded` call quietly builds a *new* signal
-that only a fresh mount would read. `invalidateXxx` now writes `null`
-through the existing signal instead, so every mounted consumer observes the
-transition, `hasCachedXxx` reports false, and a stale fetch that was still
-in flight at invalidate time can no longer land its result afterwards (each
-store already guarded this with a per-wedding generation counter; the four
-Group 1 stores — enquiries, vendors, budget, tasks — gain that same counter
-here, matching the three that already had it).
+Fix `invalidateXxx` across eight organiser-portal caches (events, guests,
+households, enquiries, vendors, budget, tasks, registry) so a mounted view
+actually notices. Seven of them used to `cache.delete(weddingId)`, which drops
+the map entry but leaves any signal a component already captured on mount
+pointing at a spot nothing writes to again — the view keeps showing stale rows
+forever, and the next `ensureXxxLoaded` call quietly builds a *new* signal that
+only a fresh mount would read. `invalidateXxx` now writes `null` through the
+existing signal instead, so every mounted consumer observes the transition and
+`hasCachedXxx` reports false.
+
+A stale fetch that was still in flight at invalidate time can no longer land its
+result afterwards either: five stores (enquiries, vendors, budget, tasks and
+`registry-store.ts`, which already notified but had no such guard) gain the
+per-wedding generation counter the other three already carried.
 
 Also corrects two stale doc claims: the sibling-store list in
-`registry-store.ts`'s file docblock, and `EnquiriesView.tsx`'s comment
-claiming invalidation could not refresh the inbox.
+`registry-store.ts`'s file docblock, and `EnquiriesView.tsx`'s comment claiming
+invalidation could not refresh the inbox.

--- a/cire/host/src/components/EnquiriesView.tsx
+++ b/cire/host/src/components/EnquiriesView.tsx
@@ -77,12 +77,11 @@ export default function EnquiriesView(props: EnquiriesViewProps) {
     const id = selectedId();
     if (!id) return;
     await replyEnquiry(authFetch, props.weddingId, id, message);
-    // Refresh the inbox row by writing through the LIVE signal.
-    // `invalidateEnquiries` + `ensureEnquiriesLoaded` can NOT do that job:
-    // invalidate DELETES the cache entry, so the reload mints a brand new
-    // signal and the inbox — which used to be unmounted here but now stays
-    // mounted beside the thread — would keep its subscription to the orphan.
-    // The round-trip would be paid and nothing on screen would change.
+    // Refresh the inbox row by writing through the LIVE signal, not by
+    // invalidate-then-reload. `invalidateEnquiries` now notifies the same
+    // signal the mounted inbox reads, so a reload WOULD reach it — but it
+    // would still cost a whole-list round-trip to learn one row's new
+    // timestamp, which is exactly the round-trip ENQ-P-I1 (below) paid down.
     //
     // ENQ-P-I1: refetching the WHOLE inbox to learn one row's new timestamp
     // was a list-sized round-trip per reply. The server's reply path sets only

--- a/cire/host/src/lib/budget-store.ts
+++ b/cire/host/src/lib/budget-store.ts
@@ -76,8 +76,19 @@ export function peekCachedBudget(weddingId: string): BudgetSnapshot | null {
 }
 
 export function invalidateBudget(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setSnapshot(null);
+  // A load already in flight was issued against PRE-mutation state, so its
+  // snapshot is stale the moment this runs. Clearing the signal alone is not
+  // enough — the fetch's own `.then` would still write it in AFTER this call —
+  // so the wedding's GENERATION is bumped too, and a resolving fetch from an
+  // older generation discards its result instead of caching it.
+  inflight.delete(weddingId);
+  generation.set(weddingId, generationOf(weddingId) + 1);
 }
+
+/** Monotonic per-wedding load generation, bumped by every invalidation. */
+const generation = new Map<string, number>();
+const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 
 /** Reactive spend-so-far for the Overview widget: `null` until first load. */
 export function spentSoFar(weddingId: string): number | null {
@@ -109,11 +120,21 @@ export function ensureBudgetLoaded(
   if (hasCachedBudget(weddingId)) return Promise.resolve();
   let pending = inflight.get(weddingId);
   if (!pending) {
-    pending = fetcher()
+    const startedAt = generationOf(weddingId);
+    const load = fetcher()
       .then((snap) => {
+        // A newer invalidation landed while this was in flight — its snapshot
+        // describes state that has since been mutated, so drop it rather than
+        // cache it.
+        if (generationOf(weddingId) !== startedAt) return;
         setCachedBudget(weddingId, snap);
       })
-      .finally(() => inflight.delete(weddingId));
+      .finally(() => {
+        // Only clear the slot if it is still OURS: an invalidation may already
+        // have replaced it with a newer load.
+        if (inflight.get(weddingId) === load) inflight.delete(weddingId);
+      });
+    pending = load;
     inflight.set(weddingId, pending);
   }
   return pending;
@@ -123,4 +144,5 @@ export function ensureBudgetLoaded(
 export function __resetBudgetCache(): void {
   cache.clear();
   inflight.clear();
+  generation.clear();
 }

--- a/cire/host/src/lib/enquiries-store.ts
+++ b/cire/host/src/lib/enquiries-store.ts
@@ -64,8 +64,19 @@ export function peekCachedEnquiries(weddingId: string): EnquiryListItem[] | null
 }
 
 export function invalidateEnquiries(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setEnquiries(null);
+  // A load already in flight was issued against PRE-mutation state, so its rows
+  // are stale the moment this runs. Clearing the signal alone is not enough —
+  // the fetch's own `.then` would still write them in AFTER this call — so the
+  // wedding's GENERATION is bumped too, and a resolving fetch from an older
+  // generation discards its result instead of caching it.
+  inflight.delete(weddingId);
+  generation.set(weddingId, generationOf(weddingId) + 1);
 }
+
+/** Monotonic per-wedding load generation, bumped by every invalidation. */
+const generation = new Map<string, number>();
+const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 
 export function upsertCachedEnquiry(weddingId: string, next: EnquiryListItem): void {
   const cur = peekCachedEnquiries(weddingId) ?? [];
@@ -85,12 +96,21 @@ export function ensureEnquiriesLoaded(
   if (hasCachedEnquiries(weddingId)) return Promise.resolve();
   let pending = inflight.get(weddingId);
   if (!pending) {
-    pending = fetcher()
+    const startedAt = generationOf(weddingId);
+    const load = fetcher()
       .then((items) => {
+        // A newer invalidation landed while this was in flight — its rows
+        // describe state that has since been mutated, so drop them rather than
+        // cache them.
+        if (generationOf(weddingId) !== startedAt) return;
         setCachedEnquiries(weddingId, items);
-        return undefined;
       })
-      .finally(() => inflight.delete(weddingId));
+      .finally(() => {
+        // Only clear the slot if it is still OURS: an invalidation may already
+        // have replaced it with a newer load.
+        if (inflight.get(weddingId) === load) inflight.delete(weddingId);
+      });
+    pending = load;
     inflight.set(weddingId, pending);
   }
   return pending;
@@ -100,4 +120,5 @@ export function ensureEnquiriesLoaded(
 export function __resetEnquiriesCache(): void {
   cache.clear();
   inflight.clear();
+  generation.clear();
 }

--- a/cire/host/src/lib/events-store.ts
+++ b/cire/host/src/lib/events-store.ts
@@ -102,7 +102,7 @@ export function patchCachedEvent(
 /** Drop a wedding's cached events so the next read refetches. Call after a
  *  mutation that can change the event list — e.g. an import apply. */
 export function invalidateEvents(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setEvents(null);
   // A load already in flight was issued against PRE-mutation state, so its rows
   // are stale the moment this runs. Dropping the entry alone is not enough — the
   // fetch's own `.then` would still write them into a fresh cache entry — so the

--- a/cire/host/src/lib/guests-store.ts
+++ b/cire/host/src/lib/guests-store.ts
@@ -79,7 +79,7 @@ export function peekCachedGuests(weddingId: string): OrganiserGuestRow[] | null 
 /** Drop a wedding's cached guest list so the next read refetches. Call after a
  *  mutation that can change the roster — e.g. an import apply. */
 export function invalidateGuests(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setGuests(null);
   // A load already in flight was issued against PRE-mutation state, so its rows
   // are stale the moment this runs. Dropping the entry alone is not enough — the
   // fetch's own `.then` would still write them into a fresh cache entry — so the

--- a/cire/host/src/lib/households-store.ts
+++ b/cire/host/src/lib/households-store.ts
@@ -56,7 +56,7 @@ export function hasCachedHouseholds(weddingId: string): boolean {
 /** Drop a wedding's cached households so the next read refetches. Call after a
  *  mutation that can change the roster — e.g. a change apply. */
 export function invalidateHouseholds(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setHouseholds(null);
   // A load already in flight was issued against PRE-mutation state, so its rows
   // are stale the moment this runs. Dropping the entry alone is not enough — the
   // fetch's own `.then` would still write them into a fresh cache entry — so the

--- a/cire/host/src/lib/registry-store.ts
+++ b/cire/host/src/lib/registry-store.ts
@@ -135,15 +135,27 @@ export function peekCachedRegistry(weddingId: string): RegistrySnapshot | null {
  *
  * Deleting the map entry would mint a fresh signal on the next `entryFor`, and
  * every view that captured the old accessor at mount would then read a signal
- * nothing writes to again — a dead view with stale content. The sibling stores
- * (`vendors-store`, `budget-store`, `events-store`, `enquiries-store`) still
- * delete; this is the repo-wide `P-W2` in `[[cire/wiki/todo/perf]]`, fixed here
- * because `RegistryView` is the first consumer to invalidate on several write
- * paths rather than only on unmount.
+ * nothing writes to again — a dead view with stale content. This was the
+ * repo-wide `P-W2` in `[[cire/wiki/todo/perf]]`; every sibling cache
+ * (`vendors-store`, `budget-store`, `tasks-store`, `enquiries-store`,
+ * `events-store`, `guests-store`, `households-store`) now notifies the same
+ * way.
+ *
+ * A load already in flight was issued against PRE-invalidation state, so its
+ * snapshot is stale the moment this runs. Clearing the signal alone is not
+ * enough — the fetch's own `.then` would still write it in AFTER this call —
+ * so the wedding's GENERATION is bumped too, and a resolving fetch from an
+ * older generation discards its result instead of caching it.
  */
 export function invalidateRegistry(weddingId: string): void {
   entryFor(weddingId).setSnapshot(null);
+  inflight.delete(weddingId);
+  generation.set(weddingId, generationOf(weddingId) + 1);
 }
+
+/** Monotonic per-wedding load generation, bumped by every invalidation. */
+const generation = new Map<string, number>();
+const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 
 /** How many of an item's wanted quantity are still unspoken for. Never negative
  *  — a race can land one claim past the wanted count, and a negative "still
@@ -161,12 +173,21 @@ export function ensureRegistryLoaded(
   if (hasCachedRegistry(weddingId)) return Promise.resolve();
   let pending = inflight.get(weddingId);
   if (!pending) {
-    pending = fetcher()
+    const startedAt = generationOf(weddingId);
+    const load = fetcher()
       .then((snap) => {
+        // A newer invalidation landed while this was in flight — its snapshot
+        // describes state that has since been mutated, so drop it rather than
+        // cache it.
+        if (generationOf(weddingId) !== startedAt) return;
         setCachedRegistry(weddingId, snap);
-        return undefined;
       })
-      .finally(() => inflight.delete(weddingId));
+      .finally(() => {
+        // Only clear the slot if it is still OURS: an invalidation may already
+        // have replaced it with a newer load.
+        if (inflight.get(weddingId) === load) inflight.delete(weddingId);
+      });
+    pending = load;
     inflight.set(weddingId, pending);
   }
   return pending;
@@ -176,4 +197,5 @@ export function ensureRegistryLoaded(
 export function __resetRegistryCache(): void {
   cache.clear();
   inflight.clear();
+  generation.clear();
 }

--- a/cire/host/src/lib/tasks-store.ts
+++ b/cire/host/src/lib/tasks-store.ts
@@ -52,8 +52,19 @@ export function peekCachedTasks(weddingId: string): TaskRow[] | null {
 }
 
 export function invalidateTasks(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setTasks(null);
+  // A load already in flight was issued against PRE-mutation state, so its rows
+  // are stale the moment this runs. Clearing the signal alone is not enough —
+  // the fetch's own `.then` would still write them in AFTER this call — so the
+  // wedding's GENERATION is bumped too, and a resolving fetch from an older
+  // generation discards its result instead of caching it.
+  inflight.delete(weddingId);
+  generation.set(weddingId, generationOf(weddingId) + 1);
 }
+
+/** Monotonic per-wedding load generation, bumped by every invalidation. */
+const generation = new Map<string, number>();
+const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 
 /** Reactive open-task count for the Overview widget: `null` until first load.
  *  Reads without allocating a dangling signal for a never-loaded weddingId. */
@@ -89,11 +100,21 @@ export function ensureTasksLoaded(
   if (hasCachedTasks(weddingId)) return Promise.resolve();
   let pending = inflight.get(weddingId);
   if (!pending) {
-    pending = fetcher()
+    const startedAt = generationOf(weddingId);
+    const load = fetcher()
       .then((rows) => {
+        // A newer invalidation landed while this was in flight — its rows
+        // describe state that has since been mutated, so drop them rather than
+        // cache them.
+        if (generationOf(weddingId) !== startedAt) return;
         setCachedTasks(weddingId, rows);
       })
-      .finally(() => inflight.delete(weddingId));
+      .finally(() => {
+        // Only clear the slot if it is still OURS: an invalidation may already
+        // have replaced it with a newer load.
+        if (inflight.get(weddingId) === load) inflight.delete(weddingId);
+      });
+    pending = load;
     inflight.set(weddingId, pending);
   }
   return pending;
@@ -103,4 +124,5 @@ export function ensureTasksLoaded(
 export function __resetTasksCache(): void {
   cache.clear();
   inflight.clear();
+  generation.clear();
 }

--- a/cire/host/src/lib/vendors-store.ts
+++ b/cire/host/src/lib/vendors-store.ts
@@ -58,8 +58,19 @@ export function peekCachedVendors(weddingId: string): VendorRow[] | null {
 }
 
 export function invalidateVendors(weddingId: string): void {
-  cache.delete(weddingId);
+  entryFor(weddingId).setVendors(null);
+  // A load already in flight was issued against PRE-mutation state, so its rows
+  // are stale the moment this runs. Clearing the signal alone is not enough —
+  // the fetch's own `.then` would still write them in AFTER this call — so the
+  // wedding's GENERATION is bumped too, and a resolving fetch from an older
+  // generation discards its result instead of caching it.
+  inflight.delete(weddingId);
+  generation.set(weddingId, generationOf(weddingId) + 1);
 }
+
+/** Monotonic per-wedding load generation, bumped by every invalidation. */
+const generation = new Map<string, number>();
+const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 
 /** Reactive vendor count for the Overview widget: `null` before first load. */
 export function vendorCount(weddingId: string): number | null {
@@ -77,12 +88,21 @@ export function ensureVendorsLoaded(
   if (hasCachedVendors(weddingId)) return Promise.resolve();
   let pending = inflight.get(weddingId);
   if (!pending) {
-    pending = fetcher()
+    const startedAt = generationOf(weddingId);
+    const load = fetcher()
       .then((rows) => {
+        // A newer invalidation landed while this was in flight — its rows
+        // describe state that has since been mutated, so drop them rather than
+        // cache them.
+        if (generationOf(weddingId) !== startedAt) return;
         setCachedVendors(weddingId, rows);
-        return undefined;
       })
-      .finally(() => inflight.delete(weddingId));
+      .finally(() => {
+        // Only clear the slot if it is still OURS: an invalidation may already
+        // have replaced it with a newer load.
+        if (inflight.get(weddingId) === load) inflight.delete(weddingId);
+      });
+    pending = load;
     inflight.set(weddingId, pending);
   }
   return pending;
@@ -92,4 +112,5 @@ export function ensureVendorsLoaded(
 export function __resetVendorsCache(): void {
   cache.clear();
   inflight.clear();
+  generation.clear();
 }

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -6,7 +6,10 @@ import {
   type BudgetSnapshot,
   budgetAccessor,
   ensureBudgetLoaded,
+  hasCachedBudget,
+  invalidateBudget,
   type PaymentRow,
+  peekCachedBudget,
   spentSoFar,
   upcomingPayments,
 } from "../../src/lib/budget-store";
@@ -84,5 +87,63 @@ describe("budget-store", () => {
       }),
     );
     expect(upcomingPayments("wed_1").map((p) => p.id)).toEqual(["p2", "p1"]);
+  });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted Budget view captures that accessor at mount. Deleting the
+   * map entry on invalidate would leave that accessor pointed at a signal
+   * nothing writes to again — a dead view showing stale figures forever. The
+   * fix writes THROUGH the signal, so an accessor captured before invalidate
+   * still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({})] }));
+    const mounted = budgetAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).not.toBeNull();
+    invalidateBudget("wed_1");
+    expect(mounted()).toBeNull();
+  });
+
+  it("hasCachedBudget is false after invalidate, so the next load refetches", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({}));
+    expect(hasCachedBudget("wed_1")).toBe(true);
+    invalidateBudget("wed_1");
+    expect(hasCachedBudget("wed_1")).toBe(false);
+    let calls = 0;
+    await ensureBudgetLoaded("wed_1", async () => {
+      calls += 1;
+      return snap({});
+    });
+    expect(calls).toBe(1);
+  });
+
+  /**
+   * A fetch already in flight when the invalidate runs was issued against
+   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
+   * writing that stale snapshot in afterwards — the generation bump does.
+   */
+  it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
+    let resolveStale!: (s: BudgetSnapshot) => void;
+    const stale = new Promise<BudgetSnapshot>((r) => {
+      resolveStale = r;
+    });
+    const pending = ensureBudgetLoaded("wed_1", () => stale);
+
+    invalidateBudget("wed_1");
+    resolveStale(snap({ items: [item({ id: "stale" })] }));
+    await pending;
+
+    const fresh = async () => snap({ items: [item({ id: "fresh" })] });
+    await ensureBudgetLoaded("wed_1", fresh);
+
+    expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh"]);
+  });
+
+  it("peekCachedBudget reflects fresh data after an invalidate/reload cycle", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "a" })] }));
+    invalidateBudget("wed_1");
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "b" })] }));
+    expect(peekCachedBudget("wed_1")?.items.map((i) => i.id)).toEqual(["b"]);
   });
 });

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -146,4 +146,77 @@ describe("budget-store", () => {
     await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "b" })] }));
     expect(peekCachedBudget("wed_1")?.items.map((i) => i.id)).toEqual(["b"]);
   });
+
+  /**
+   * The `.finally` that clears the in-flight slot is reached on a rejection
+   * too — a rejected fetcher never runs the `.then`, so this is the only path
+   * that exercises the guarded clear on a failed load. If the slot were left
+   * populated, every later `ensureBudgetLoaded` would await a dead promise
+   * forever instead of refetching.
+   */
+  it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("network down");
+    };
+    const [a, b] = await Promise.allSettled([
+      ensureBudgetLoaded("wed_1", failing),
+      ensureBudgetLoaded("wed_1", failing),
+    ]);
+    expect(a.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(calls).toBe(1); // deduped even in failure
+    expect(hasCachedBudget("wed_1")).toBe(false); // nothing poisoned the cache
+
+    // The in-flight slot was cleared — a later call re-invokes the fetcher.
+    let recoveringCalls = 0;
+    await ensureBudgetLoaded("wed_1", async () => {
+      recoveringCalls += 1;
+      return snap({ items: [item({})] });
+    });
+    expect(recoveringCalls).toBe(1);
+    expect(hasCachedBudget("wed_1")).toBe(true);
+  });
+
+  /**
+   * The ownership guard in `.finally` (`inflight.get(weddingId) === load`)
+   * only matters when a second load has already taken the slot by the time
+   * the first one settles: load A in flight, an invalidate, then load B takes
+   * the slot before A resolves. Unguarded, A's `.finally` would delete B's
+   * slot out from under it, and a caller arriving during B's flight would
+   * fire a redundant third fetch instead of joining B.
+   */
+  it("a settling stale load does not clear a newer load's in-flight slot", async () => {
+    let resolveA!: (s: BudgetSnapshot) => void;
+    const aPromise = new Promise<BudgetSnapshot>((r) => {
+      resolveA = r;
+    });
+    const loadA = ensureBudgetLoaded("wed_1", () => aPromise);
+
+    invalidateBudget("wed_1");
+
+    let resolveB!: (s: BudgetSnapshot) => void;
+    const bPromise = new Promise<BudgetSnapshot>((r) => {
+      resolveB = r;
+    });
+    const loadB = ensureBudgetLoaded("wed_1", () => bPromise);
+
+    resolveA(snap({ items: [item({ id: "stale" })] }));
+    await loadA;
+
+    // B is still in flight. If A's `.finally` deleted B's slot, this third
+    // caller would find no in-flight promise and fire its own fetch.
+    let thirdCalls = 0;
+    const thirdCaller = ensureBudgetLoaded("wed_1", async () => {
+      thirdCalls += 1;
+      return snap({ items: [item({ id: "third" })] });
+    });
+    expect(thirdCalls).toBe(0);
+
+    resolveB(snap({ items: [item({ id: "fresh-b" })] }));
+    await Promise.all([loadB, thirdCaller]);
+
+    expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh-b"]);
+  });
 });

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -4,6 +4,7 @@ import {
   __resetEnquiriesCache,
   enquiriesAccessor,
   ensureEnquiriesLoaded,
+  hasCachedEnquiries,
   peekCachedEnquiries,
   setCachedEnquiries,
   invalidateEnquiries,
@@ -69,5 +70,58 @@ describe("enquiries-store", () => {
       return [];
     });
     expect(calls).toBe(1);
+  });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted inbox captures that accessor at mount. Deleting the map
+   * entry on invalidate would leave that accessor pointed at a signal nothing
+   * writes to again — a dead view showing stale rows forever. The fix writes
+   * THROUGH the signal, so an accessor captured before invalidate still
+   * observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", () => {
+    setCachedEnquiries("wed_1", [item()]);
+    const mounted = enquiriesAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).toHaveLength(1);
+    invalidateEnquiries("wed_1");
+    expect(mounted()).toBeNull();
+  });
+
+  it("hasCachedEnquiries is false after invalidate", () => {
+    setCachedEnquiries("wed_1", [item()]);
+    expect(hasCachedEnquiries("wed_1")).toBe(true);
+    invalidateEnquiries("wed_1");
+    expect(hasCachedEnquiries("wed_1")).toBe(false);
+  });
+
+  /**
+   * A fetch already in flight when the invalidate runs was issued against
+   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
+   * writing those stale rows in afterwards — the generation bump does.
+   */
+  it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
+    let resolveStale!: (items: EnquiryListItem[]) => void;
+    const stale = new Promise<EnquiryListItem[]>((r) => {
+      resolveStale = r;
+    });
+    const pending = ensureEnquiriesLoaded("wed_1", () => stale);
+
+    invalidateEnquiries("wed_1");
+    resolveStale([item({ id: "stale" })]);
+    await pending;
+
+    const fresh = async () => [item({ id: "fresh" })];
+    await ensureEnquiriesLoaded("wed_1", fresh);
+
+    expect(peekCachedEnquiries("wed_1")?.map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("upsertCachedEnquiry and peekCachedEnquiries still work after an invalidate/reload cycle", async () => {
+    setCachedEnquiries("wed_1", [item({ id: "enq_1" })]);
+    invalidateEnquiries("wed_1");
+    await ensureEnquiriesLoaded("wed_1", async () => [item({ id: "enq_1" })]);
+    upsertCachedEnquiry("wed_1", item({ id: "enq_2" }));
+    expect(peekCachedEnquiries("wed_1")?.map((r) => r.id)).toContain("enq_2");
   });
 });

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -124,4 +124,36 @@ describe("enquiries-store", () => {
     upsertCachedEnquiry("wed_1", item({ id: "enq_2" }));
     expect(peekCachedEnquiries("wed_1")?.map((r) => r.id)).toContain("enq_2");
   });
+
+  /**
+   * The `.finally` that clears the in-flight slot is reached on a rejection
+   * too — a rejected fetcher never runs the `.then`, so this is the only path
+   * that exercises the guarded clear on a failed load. If the slot were left
+   * populated, every later `ensureEnquiriesLoaded` would await a dead promise
+   * forever instead of refetching.
+   */
+  it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls++;
+      throw new Error("network down");
+    };
+    const [a, b] = await Promise.allSettled([
+      ensureEnquiriesLoaded("wed_1", failing),
+      ensureEnquiriesLoaded("wed_1", failing),
+    ]);
+    expect(a.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(calls).toBe(1); // deduped even in failure
+    expect(hasCachedEnquiries("wed_1")).toBe(false); // nothing poisoned the cache
+
+    // The in-flight slot was cleared — a later call re-invokes the fetcher.
+    let recoveringCalls = 0;
+    await ensureEnquiriesLoaded("wed_1", async () => {
+      recoveringCalls++;
+      return [item()];
+    });
+    expect(recoveringCalls).toBe(1);
+    expect(hasCachedEnquiries("wed_1")).toBe(true);
+  });
 });

--- a/cire/host/tests/lib/events-store.test.ts
+++ b/cire/host/tests/lib/events-store.test.ts
@@ -87,4 +87,20 @@ describe("ensureEventsLoaded", () => {
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["fresh"]);
   });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted `EventTable` captures that accessor at mount. Deleting the
+   * map entry on invalidate would leave that accessor pointed at a signal
+   * nothing writes to again — a dead view showing stale rows forever. The fix
+   * writes THROUGH the signal, so an accessor captured before invalidate
+   * still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    await ensureEventsLoaded("wed_1", async () => [ROW]);
+    const mounted = eventsAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).toEqual([ROW]);
+    invalidateEvents("wed_1");
+    expect(mounted()).toBeNull();
+  });
 });

--- a/cire/host/tests/lib/guests-store.test.ts
+++ b/cire/host/tests/lib/guests-store.test.ts
@@ -96,4 +96,21 @@ describe("ensureGuestsLoaded", () => {
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["fresh"]);
   });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted `GuestTable` captures that accessor at mount. Deleting the
+   * map entry on invalidate would leave that accessor pointed at a signal
+   * nothing writes to again — a dead view showing stale rows forever. The fix
+   * writes THROUGH the signal, so an accessor captured before invalidate
+   * still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    const fetcher = vi.fn(async () => [ROW]);
+    await ensureGuestsLoaded("wed_1", fetcher);
+    const mounted = guestsAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).toEqual([ROW]);
+    invalidateGuests("wed_1");
+    expect(mounted()).toBeNull();
+  });
 });

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -109,4 +109,21 @@ describe("ensureHouseholdsLoaded", () => {
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["fam_fresh"]);
   });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted editor captures that accessor at mount. Deleting the map
+   * entry on invalidate would leave that accessor pointed at a signal nothing
+   * writes to again — a dead view showing stale rows forever. The fix writes
+   * THROUGH the signal, so an accessor captured before invalidate still
+   * observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    const fetcher = vi.fn(async () => [ROW]);
+    await ensureHouseholdsLoaded("wed_1", fetcher);
+    const mounted = householdsAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).toEqual([ROW]);
+    invalidateHouseholds("wed_1");
+    expect(mounted()).toBeNull();
+  });
 });

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -4,6 +4,7 @@ import {
   __resetRegistryCache,
   ensureRegistryLoaded,
   type GiftLogEntry,
+  hasCachedRegistry,
   invalidateRegistry,
   peekCachedRegistry,
   registryAccessor,
@@ -132,5 +133,63 @@ describe("registry-store", () => {
     // Claims race against each other, so one can land past the wanted count. A
     // negative "still wanted" would read as a fault.
     expect(stillWanted(item({ quantityWanted: 1, quantityClaimed: 2 }))).toBe(0);
+  });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted Registry view captures that accessor at mount. Deleting
+   * the map entry on invalidate would leave that accessor pointed at a
+   * signal nothing writes to again — a dead view showing a stale snapshot
+   * forever. The fix writes THROUGH the signal, so an accessor captured
+   * before invalidate still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot());
+    const mounted = registryAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).not.toBeNull();
+    invalidateRegistry("wed_1");
+    expect(mounted()).toBeNull();
+  });
+
+  it("hasCachedRegistry is false after invalidate, so the next load refetches", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot());
+    expect(hasCachedRegistry("wed_1")).toBe(true);
+    invalidateRegistry("wed_1");
+    expect(hasCachedRegistry("wed_1")).toBe(false);
+    let calls = 0;
+    await ensureRegistryLoaded("wed_1", async () => {
+      calls += 1;
+      return snapshot();
+    });
+    expect(calls).toBe(1);
+  });
+
+  /**
+   * A fetch already in flight when the invalidate runs was issued against
+   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
+   * writing that stale snapshot in afterwards — the generation bump does.
+   */
+  it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
+    let resolveStale!: (s: RegistrySnapshot) => void;
+    const stale = new Promise<RegistrySnapshot>((r) => {
+      resolveStale = r;
+    });
+    const pending = ensureRegistryLoaded("wed_1", () => stale);
+
+    invalidateRegistry("wed_1");
+    resolveStale(snapshot({ items: [item({ id: "stale" })] }));
+    await pending;
+
+    const fresh = async () => snapshot({ items: [item({ id: "fresh" })] });
+    await ensureRegistryLoaded("wed_1", fresh);
+
+    expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh"]);
+  });
+
+  it("peekCachedRegistry reflects fresh data after an invalidate/reload cycle", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "a" })] }));
+    invalidateRegistry("wed_1");
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "b" })] }));
+    expect(peekCachedRegistry("wed_1")?.items.map((i) => i.id)).toEqual(["b"]);
   });
 });

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -192,4 +192,36 @@ describe("registry-store", () => {
     await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "b" })] }));
     expect(peekCachedRegistry("wed_1")?.items.map((i) => i.id)).toEqual(["b"]);
   });
+
+  /**
+   * The `.finally` that clears the in-flight slot is reached on a rejection
+   * too — a rejected fetcher never runs the `.then`, so this is the only path
+   * that exercises the guarded clear on a failed load. If the slot were left
+   * populated, every later `ensureRegistryLoaded` would await a dead promise
+   * forever instead of refetching.
+   */
+  it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("network down");
+    };
+    const [a, b] = await Promise.allSettled([
+      ensureRegistryLoaded("wed_1", failing),
+      ensureRegistryLoaded("wed_1", failing),
+    ]);
+    expect(a.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(calls).toBe(1); // deduped even in failure
+    expect(hasCachedRegistry("wed_1")).toBe(false); // nothing poisoned the cache
+
+    // The in-flight slot was cleared — a later call re-invokes the fetcher.
+    let recoveringCalls = 0;
+    await ensureRegistryLoaded("wed_1", async () => {
+      recoveringCalls += 1;
+      return snapshot();
+    });
+    expect(recoveringCalls).toBe(1);
+    expect(hasCachedRegistry("wed_1")).toBe(true);
+  });
 });

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, beforeEach } from "vitest";
 import {
   __resetTasksCache,
   ensureTasksLoaded,
+  hasCachedTasks,
+  invalidateTasks,
   openTaskCount,
+  peekCachedTasks,
   taskCounts,
   type TaskRow,
   tasksAccessor,
@@ -56,5 +59,63 @@ describe("tasks-store", () => {
       row({ id: "c", status: "open" }),
     ]);
     expect(taskCounts("wed_1")).toEqual({ open: 2, done: 1, total: 3 });
+  });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted Checklist view captures that accessor at mount. Deleting
+   * the map entry on invalidate would leave that accessor pointed at a
+   * signal nothing writes to again — a dead view showing stale tasks
+   * forever. The fix writes THROUGH the signal, so an accessor captured
+   * before invalidate still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({})]);
+    const mounted = tasksAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).not.toBeNull();
+    invalidateTasks("wed_1");
+    expect(mounted()).toBeNull();
+  });
+
+  it("hasCachedTasks is false after invalidate, so the next load refetches", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({})]);
+    expect(hasCachedTasks("wed_1")).toBe(true);
+    invalidateTasks("wed_1");
+    expect(hasCachedTasks("wed_1")).toBe(false);
+    let calls = 0;
+    await ensureTasksLoaded("wed_1", async () => {
+      calls += 1;
+      return [row({})];
+    });
+    expect(calls).toBe(1);
+  });
+
+  /**
+   * A fetch already in flight when the invalidate runs was issued against
+   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
+   * writing those stale rows in afterwards — the generation bump does.
+   */
+  it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
+    let resolveStale!: (rows: TaskRow[]) => void;
+    const stale = new Promise<TaskRow[]>((r) => {
+      resolveStale = r;
+    });
+    const pending = ensureTasksLoaded("wed_1", () => stale);
+
+    invalidateTasks("wed_1");
+    resolveStale([row({ id: "stale" })]);
+    await pending;
+
+    const fresh = async () => [row({ id: "fresh" })];
+    await ensureTasksLoaded("wed_1", fresh);
+
+    expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["fresh"]);
+  });
+
+  it("peekCachedTasks reflects fresh rows after an invalidate/reload cycle", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "a" })]);
+    invalidateTasks("wed_1");
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "b" })]);
+    expect(peekCachedTasks("wed_1")?.map((t) => t.id)).toEqual(["b"]);
   });
 });

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -118,4 +118,36 @@ describe("tasks-store", () => {
     await ensureTasksLoaded("wed_1", async () => [row({ id: "b" })]);
     expect(peekCachedTasks("wed_1")?.map((t) => t.id)).toEqual(["b"]);
   });
+
+  /**
+   * The `.finally` that clears the in-flight slot is reached on a rejection
+   * too — a rejected fetcher never runs the `.then`, so this is the only path
+   * that exercises the guarded clear on a failed load. If the slot were left
+   * populated, every later `ensureTasksLoaded` would await a dead promise
+   * forever instead of refetching.
+   */
+  it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("network down");
+    };
+    const [a, b] = await Promise.allSettled([
+      ensureTasksLoaded("wed_1", failing),
+      ensureTasksLoaded("wed_1", failing),
+    ]);
+    expect(a.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(calls).toBe(1); // deduped even in failure
+    expect(hasCachedTasks("wed_1")).toBe(false); // nothing poisoned the cache
+
+    // The in-flight slot was cleared — a later call re-invokes the fetcher.
+    let recoveringCalls = 0;
+    await ensureTasksLoaded("wed_1", async () => {
+      recoveringCalls += 1;
+      return [row({})];
+    });
+    expect(recoveringCalls).toBe(1);
+    expect(hasCachedTasks("wed_1")).toBe(true);
+  });
 });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -72,4 +72,49 @@ describe("vendors-store", () => {
     await Promise.all([p1, p2]);
     expect(calls).toBe(1);
   });
+
+  /**
+   * The regression test for the actual bug: `entryFor` mints the signal once
+   * and a mounted Vendors view captures that accessor at mount. Deleting the
+   * map entry on invalidate would leave that accessor pointed at a signal
+   * nothing writes to again — a dead view showing stale rows forever. The fix
+   * writes THROUGH the signal, so an accessor captured before invalidate
+   * still observes the transition.
+   */
+  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({})]);
+    const mounted = vendorsAccessor("wed_1"); // captured once, as a real mount would
+    expect(mounted()).not.toBeNull();
+    invalidateVendors("wed_1");
+    expect(mounted()).toBeNull();
+  });
+
+  /**
+   * A fetch already in flight when the invalidate runs was issued against
+   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
+   * writing those stale rows in afterwards — the generation bump does.
+   */
+  it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
+    let resolveStale!: (rows: VendorRow[]) => void;
+    const stale = new Promise<VendorRow[]>((r) => {
+      resolveStale = r;
+    });
+    const pending = ensureVendorsLoaded("wed_1", () => stale);
+
+    invalidateVendors("wed_1");
+    resolveStale([vendor({ id: "stale" })]);
+    await pending;
+
+    const fresh = async () => [vendor({ id: "fresh" })];
+    await ensureVendorsLoaded("wed_1", fresh);
+
+    expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["fresh"]);
+  });
+
+  it("peekCachedVendors reflects fresh rows after an invalidate/reload cycle", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "a" })]);
+    invalidateVendors("wed_1");
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })]);
+    expect(peekCachedVendors("wed_1")?.map((v) => v.id)).toEqual(["b"]);
+  });
 });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -117,4 +117,36 @@ describe("vendors-store", () => {
     await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })]);
     expect(peekCachedVendors("wed_1")?.map((v) => v.id)).toEqual(["b"]);
   });
+
+  /**
+   * The `.finally` that clears the in-flight slot is reached on a rejection
+   * too — a rejected fetcher never runs the `.then`, so this is the only path
+   * that exercises the guarded clear on a failed load. If the slot were left
+   * populated, every later `ensureVendorsLoaded` would await a dead promise
+   * forever instead of refetching.
+   */
+  it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("network down");
+    };
+    const [a, b] = await Promise.allSettled([
+      ensureVendorsLoaded("wed_1", failing),
+      ensureVendorsLoaded("wed_1", failing),
+    ]);
+    expect(a.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(calls).toBe(1); // deduped even in failure
+    expect(peekCachedVendors("wed_1")).toBeNull(); // nothing poisoned the cache
+
+    // The in-flight slot was cleared — a later call re-invokes the fetcher.
+    let recoveringCalls = 0;
+    await ensureVendorsLoaded("wed_1", async () => {
+      recoveringCalls += 1;
+      return [vendor({})];
+    });
+    expect(recoveringCalls).toBe(1);
+    expect(peekCachedVendors("wed_1")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

`invalidateXxx(weddingId)` in every organiser-portal signal cache was
`cache.delete(weddingId)`. That drops the map entry, but a view that captured the
accessor at mount keeps reading the old signal — which nothing ever writes to again.
The view shows stale rows forever, while the next `ensureXxxLoaded` quietly builds a
fresh signal only a new mount would see.

Invalidation now writes `null` **through** the existing signal, so a mounted consumer
observes the transition and `hasCachedXxx` reports false. All eight caches were on
this shape: events, guests, households, enquiries, vendors, budget, tasks, registry.

- The four that had no staleness guard (enquiries, vendors, budget, tasks) gained the
  per-wedding monotonic generation counter the others already had, so a fetch in
  flight when the invalidate ran can no longer land its pre-mutation rows afterwards.
  `registry-store.ts` gained the same guard and a corrected sibling list in its
  docblock.
- `EnquiriesView.tsx`'s comment claiming invalidation could not refresh the inbox is
  now false, and gone.
- `BudgetView.reload` and `VendorsView.reload` already invalidated while mounted, so
  the latent bug was one always-mounted consumer away in three more places.

## Workspaces affected

`@cire/host`. One changeset naming `"@cire/host": patch` and nothing else — `@cire/*`
packages are version-ignored, so they never share a changeset with a versioned
package.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#82 | `P-W2` |

Closes xchromo/osn-tracker#82

**Opened**

None.

## Decisions

### Write through the signal rather than re-mint the entry — `P-W2`

- **Issue** — `cache.delete(weddingId)` orphaned the signal a mounted view had already
  captured.
- **Why** — the accessor is captured once, at mount. Deleting the map entry does not
  reach it, so the view goes on reading a signal nobody writes to — a dead view
  showing stale rows for as long as it stays mounted.
- **Solution** — `invalidateXxx` writes `null` through the existing entry.
- **Rationale** — the alternative, making every consumer re-read the accessor on each
  render, pushes the correctness burden onto every call site and would have to be
  re-decided every time one is added.

### Give the remaining five caches the generation counter — `approach`

- **Issue** — three of the eight discarded a fetch that resolved after an invalidate;
  five did not.
- **Why** — a fetch issued before a mutation lands after it, and re-caches exactly the
  rows the organiser just deleted.
- **Solution** — the same per-wedding monotonic counter, captured as `startedAt` and
  re-checked in the `.then`.
- **Rationale** — these eight files are deliberately identical, and a reader who has
  understood one has understood all of them. Half-migrating destroys that, and the
  next bug is in whichever half was skipped.

### Timing — `approach`

- **Issue** — a notifying invalidate makes every mounted consumer re-render on each
  invalidate, which would previously have traded a stale-UI bug for a jank one.
- **Why** — the sequencing condition set by two enquiries findings — the per-row
  re-render and the per-row `Intl.NumberFormat` — had to be paid down first.
- **Solution** — both landed on 2026-07-30, so this is now safe to ship.
- **Rationale** — noted here because the ordering is not visible in the diff and would
  otherwise look like an oversight.

### Test the rewritten `.finally`, not just the fix — `T-E1` / `T-E2`

- **Issue** — the review pass found the five stores that gained the rewritten
  `.finally` had no test where the fetcher rejects, and that the
  `inflight.get(...) === load` ownership guard could be reverted to an unconditional
  delete with all 1157 tests still green.
- **Why** — the eight "captured accessor observes null" tests pin the fix itself, but
  everything around it was unpinned. An in-flight slot left holding a dead rejected
  promise makes every later caller inherit that rejection.
- **Solution** — the rejecting-fetcher case is now in all five suites, and one
  interleaving test makes the ownership guard load-bearing: a stale load settles while
  a newer one is still in flight, and a third caller must join the newer load rather
  than fire its own fetch.
- **Rationale** — both were verified by reverting the code and watching the new test
  fail, then restoring. A test nobody has watched fail is not coverage.

**Out of scope** — `cire/host/src/lib/registry-store.ts:139` keeps a wikilink to a
page deleted in the 2026-08 vault migration; it is removed two PRs up this stack, so
fixing it here would only conflict. `wiki/architecture/cire-host-portal-layout.md` is
updated on the PR directly above this one, for the same reason. Three test suggestions
from the review pass were deliberately deferred.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass |
| Type check | `bun run check` | pass, 37/37 |
| Tests | `bun run test` | pass, 38/38 tasks; `@cire/host` 1163 |
| Format | `bun run fmt:check` | pass |
| Changesets | `bash scripts/validate-changesets.sh` | pass |
| Browser tier | `bun run test:browser` | not run — nothing in the diff reads CSS, layout or geometry |

Per store: an accessor captured before the invalidate observes `null` (the actual
bug); a fetch in flight at invalidate time is not adopted; a peek after an
invalidate/reload cycle returns the fresh rows; and, added by this pass, a rejecting
fetcher rejects every waiter and leaves the slot clear for the next call.

By hand: nothing. The bug is only visible with a view mounted across a mutation, which
is what the captured-accessor tests reproduce without a browser.
