### PR TITLE
perf(cire): keep the last-known rows on screen while an organiser cache revalidates

### DIFF
--- a/.changeset/cire-store-stale-while-revalidate.md
+++ b/.changeset/cire-store-stale-while-revalidate.md
@@ -1,0 +1,21 @@
+---
+"@cire/host": patch
+---
+
+The eight organiser caches (budget, enquiries, events, guests, households,
+registry, tasks, vendors) used to null their signal the instant a mutation
+invalidated them, so every edit flashed the panel empty for the length of the
+background refetch. Each store now marks the wedding `stale` instead and
+leaves the last-known rows on screen — a mounted view keeps rendering them
+across the invalidate, and `hasCachedXxx` still reports the miss so callers
+that check it behave the same as before.
+
+The refetch a stale wedding triggers is also the re-authorization check, so a
+failed or refused refetch blanks the signal and rethrows rather than leaving a
+demoted organiser looking at stale rows behind an error banner. Budget's
+`spentSoFar`/`upcomingPayments`, vendors' `vendorCount`, and every
+`peekCachedXxx` reader are unchanged — reserved for the separate reactivity
+fix tracked in #620. The four views that called their own reload helper
+(Budget, Checklist, Vendors, Registry) now route `reload()` through
+`ensureXxxLoaded` so they pick up the same generation-guarded success/failure
+handling instead of writing the cache directly.

--- a/cire/host/src/components/BudgetView.tsx
+++ b/cire/host/src/components/BudgetView.tsx
@@ -67,7 +67,7 @@ export default function BudgetView(props: BudgetViewProps) {
   const reload = async () => {
     invalidateBudget(props.weddingId);
     try {
-      setCachedBudget(props.weddingId, await load());
+      await ensureBudgetLoaded(props.weddingId, load);
     } catch (err) {
       if (isAuthExpired(err)) return redirectToLogin();
       setError("Couldn't refresh your budget.");

--- a/cire/host/src/components/ChecklistView.tsx
+++ b/cire/host/src/components/ChecklistView.tsx
@@ -53,7 +53,7 @@ export default function ChecklistView(props: ChecklistViewProps) {
   const reload = async () => {
     invalidateTasks(props.weddingId);
     try {
-      setCachedTasks(props.weddingId, await load());
+      await ensureTasksLoaded(props.weddingId, load);
     } catch (err) {
       if (isAuthExpired(err)) return redirectToLogin();
       setError("Couldn't refresh your checklist.");

--- a/cire/host/src/components/RegistryView.tsx
+++ b/cire/host/src/components/RegistryView.tsx
@@ -125,7 +125,7 @@ export default function RegistryView(props: RegistryViewProps) {
   const reload = async () => {
     invalidateRegistry(props.weddingId);
     try {
-      setCachedRegistry(props.weddingId, await load());
+      await ensureRegistryLoaded(props.weddingId, load);
     } catch (err) {
       if (isAuthExpired(err)) return redirectToLogin();
       setError("Couldn't refresh your registry.");

--- a/cire/host/src/components/VendorsView.tsx
+++ b/cire/host/src/components/VendorsView.tsx
@@ -95,7 +95,7 @@ export default function VendorsView(props: VendorsViewProps) {
   const reload = async () => {
     invalidateVendors(props.weddingId);
     try {
-      setCachedVendors(props.weddingId, await load());
+      await ensureVendorsLoaded(props.weddingId, load);
     } catch (err) {
       if (isAuthExpired(err)) return redirectToLogin();
       setError("Couldn't refresh your vendors.");

--- a/cire/host/src/lib/budget-store.ts
+++ b/cire/host/src/lib/budget-store.ts
@@ -64,7 +64,7 @@ export function budgetAccessor(weddingId: string): Accessor<BudgetSnapshot | nul
 }
 
 export function hasCachedBudget(weddingId: string): boolean {
-  return cache.get(weddingId)?.snapshot() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.snapshot() != null;
 }
 
 export function setCachedBudget(weddingId: string, snapshot: BudgetSnapshot): void {
@@ -76,12 +76,17 @@ export function peekCachedBudget(weddingId: string): BudgetSnapshot | null {
 }
 
 export function invalidateBudget(weddingId: string): void {
-  entryFor(weddingId).setSnapshot(null);
+  // A mounted Budget view is still rendering the last-known snapshot, and
+  // pulling it out from under that view for one round trip is the flicker
+  // this cache exists to avoid — so the signal is left alone and the wedding
+  // is marked `stale` instead. `hasCachedBudget` treats a stale id as a miss,
+  // which is what makes the next `ensureBudgetLoaded` actually refetch rather
+  // than short-circuiting on the (still-present) cached value.
+  stale.add(weddingId);
   // A load already in flight was issued against PRE-mutation state, so its
-  // snapshot is stale the moment this runs. Clearing the signal alone is not
-  // enough — the fetch's own `.then` would still write it in AFTER this call —
-  // so the wedding's GENERATION is bumped too, and a resolving fetch from an
-  // older generation discards its result instead of caching it.
+  // snapshot describes state that has since been mutated: the wedding's
+  // GENERATION is bumped too, and a resolving fetch from an older generation
+  // discards its result instead of caching it.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -89,6 +94,10 @@ export function invalidateBudget(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** Reactive spend-so-far for the Overview widget: `null` until first load. */
 export function spentSoFar(weddingId: string): number | null {
@@ -122,13 +131,29 @@ export function ensureBudgetLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((snap) => {
-        // A newer invalidation landed while this was in flight — its snapshot
-        // describes state that has since been mutated, so drop it rather than
-        // cache it.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedBudget(weddingId, snap);
-      })
+      .then(
+        (snap) => {
+          // A newer invalidation landed while this was in flight — its snapshot
+          // describes state that has since been mutated, so drop it rather than
+          // cache it.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedBudget(weddingId, snap);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // budget figures behind an error banner. Same generation guard — if a
+          // newer invalidation has landed, a newer load owns the entry and this
+          // one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setSnapshot(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -145,4 +170,5 @@ export function __resetBudgetCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/enquiries-store.ts
+++ b/cire/host/src/lib/enquiries-store.ts
@@ -52,7 +52,7 @@ export function enquiriesAccessor(weddingId: string): Accessor<EnquiryListItem[]
 }
 
 export function hasCachedEnquiries(weddingId: string): boolean {
-  return cache.get(weddingId)?.enquiries() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.enquiries() != null;
 }
 
 export function setCachedEnquiries(weddingId: string, items: EnquiryListItem[]): void {
@@ -64,12 +64,17 @@ export function peekCachedEnquiries(weddingId: string): EnquiryListItem[] | null
 }
 
 export function invalidateEnquiries(weddingId: string): void {
-  entryFor(weddingId).setEnquiries(null);
-  // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Clearing the signal alone is not enough —
-  // the fetch's own `.then` would still write them in AFTER this call — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it.
+  // A mounted inbox is still rendering the last-known rows, and pulling them
+  // out from under it for one round trip is the flicker this cache exists to
+  // avoid — so the signal is left alone and the wedding is marked `stale`
+  // instead. `hasCachedEnquiries` treats a stale id as a miss, which is what
+  // makes the next `ensureEnquiriesLoaded` actually refetch rather than
+  // short-circuiting on the (still-present) cached value.
+  stale.add(weddingId);
+  // A load already in flight was issued against PRE-mutation state, so its
+  // rows describe state that has since been mutated: the wedding's GENERATION
+  // is bumped too, and a resolving fetch from an older generation discards its
+  // result instead of caching it.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -77,6 +82,10 @@ export function invalidateEnquiries(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 export function upsertCachedEnquiry(weddingId: string, next: EnquiryListItem): void {
   const cur = peekCachedEnquiries(weddingId) ?? [];
@@ -98,13 +107,29 @@ export function ensureEnquiriesLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((items) => {
-        // A newer invalidation landed while this was in flight — its rows
-        // describe state that has since been mutated, so drop them rather than
-        // cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedEnquiries(weddingId, items);
-      })
+      .then(
+        (items) => {
+          // A newer invalidation landed while this was in flight — its rows
+          // describe state that has since been mutated, so drop them rather than
+          // cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedEnquiries(weddingId, items);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // enquiry detail behind an error banner. Same generation guard — if a
+          // newer invalidation has landed, a newer load owns the entry and this
+          // one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setEnquiries(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -121,4 +146,5 @@ export function __resetEnquiriesCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/events-store.ts
+++ b/cire/host/src/lib/events-store.ts
@@ -77,7 +77,7 @@ export function eventsAccessor(weddingId: string): Accessor<EventRow[] | null> {
 /** Has this wedding's events already been fetched in this session? When true a
  *  remounting `EventTable` can skip the network round-trip entirely. */
 export function hasCachedEvents(weddingId: string): boolean {
-  return cache.get(weddingId)?.events() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.events() != null;
 }
 
 /** Replace the cached events for a wedding (used after a successful fetch). */
@@ -102,14 +102,19 @@ export function patchCachedEvent(
 /** Drop a wedding's cached events so the next read refetches. Call after a
  *  mutation that can change the event list — e.g. an import apply. */
 export function invalidateEvents(weddingId: string): void {
-  entryFor(weddingId).setEvents(null);
+  // A mounted EventTable is still rendering the last-known rows, and pulling
+  // them out from under it for one round trip is the flicker this cache exists
+  // to avoid — so the signal is left alone and the wedding is marked `stale`
+  // instead. `hasCachedEvents` treats a stale id as a miss, which is what makes
+  // the next `ensureEventsLoaded` actually refetch rather than short-circuiting
+  // on the (still-present) cached value.
+  stale.add(weddingId);
   // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Dropping the entry alone is not enough — the
-  // fetch's own `.then` would still write them into a fresh cache entry — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it. Without this, the
-  // editor's invalidate-then-reload after a successful save can re-cache exactly
-  // the rows the organiser just deleted.
+  // describe state that has since been mutated: the wedding's GENERATION is
+  // bumped too, and a resolving fetch from an older generation discards its
+  // result instead of caching it. Without this, the editor's invalidate-then-
+  // reload after a successful save can re-cache exactly the rows the organiser
+  // just deleted.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -117,6 +122,10 @@ export function invalidateEvents(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** In-flight loads, keyed by weddingId, so panels mounting in the same tick
  *  share ONE fetch instead of racing two identical requests at the empty
@@ -139,12 +148,28 @@ export function ensureEventsLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((rows) => {
-        // A newer invalidation landed while this was in flight — its rows describe
-        // state that has since been mutated, so drop them rather than cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedEvents(weddingId, rows);
-      })
+      .then(
+        (rows) => {
+          // A newer invalidation landed while this was in flight — its rows describe
+          // state that has since been mutated, so drop them rather than cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedEvents(weddingId, rows);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // event detail behind an error banner. Same generation guard — if a
+          // newer invalidation has landed, a newer load owns the entry and this
+          // one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setEvents(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -161,4 +186,5 @@ export function __resetEventsCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/guests-store.ts
+++ b/cire/host/src/lib/guests-store.ts
@@ -62,7 +62,7 @@ export function guestsAccessor(weddingId: string): Accessor<OrganiserGuestRow[] 
 /** Has this wedding's guest list already been fetched in this session? When true
  *  a remounting `GuestTable` can skip the network round-trip entirely. */
 export function hasCachedGuests(weddingId: string): boolean {
-  return cache.get(weddingId)?.guests() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.guests() != null;
 }
 
 /** Replace the cached guest rows for a wedding (used after a successful fetch or
@@ -79,14 +79,19 @@ export function peekCachedGuests(weddingId: string): OrganiserGuestRow[] | null 
 /** Drop a wedding's cached guest list so the next read refetches. Call after a
  *  mutation that can change the roster — e.g. an import apply. */
 export function invalidateGuests(weddingId: string): void {
-  entryFor(weddingId).setGuests(null);
+  // A mounted GuestTable is still rendering the last-known rows, and pulling
+  // them out from under it for one round trip is the flicker this cache exists
+  // to avoid — so the signal is left alone and the wedding is marked `stale`
+  // instead. `hasCachedGuests` treats a stale id as a miss, which is what makes
+  // the next `ensureGuestsLoaded` actually refetch rather than short-circuiting
+  // on the (still-present) cached value.
+  stale.add(weddingId);
   // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Dropping the entry alone is not enough — the
-  // fetch's own `.then` would still write them into a fresh cache entry — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it. Without this, the
-  // editor's invalidate-then-reload after a successful save can re-cache exactly
-  // the rows the organiser just deleted.
+  // describe state that has since been mutated: the wedding's GENERATION is
+  // bumped too, and a resolving fetch from an older generation discards its
+  // result instead of caching it. Without this, the editor's invalidate-then-
+  // reload after a successful save can re-cache exactly the rows the organiser
+  // just deleted.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -94,6 +99,10 @@ export function invalidateGuests(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** In-flight loads, keyed by weddingId, so two panels mounting in the same tick
  *  (e.g. GuestTable + Overview snapshot) share ONE fetch instead of racing two
@@ -115,12 +124,28 @@ export function ensureGuestsLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((rows) => {
-        // A newer invalidation landed while this was in flight — its rows describe
-        // state that has since been mutated, so drop them rather than cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedGuests(weddingId, rows);
-      })
+      .then(
+        (rows) => {
+          // A newer invalidation landed while this was in flight — its rows describe
+          // state that has since been mutated, so drop them rather than cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedGuests(weddingId, rows);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // guest detail behind an error banner. Same generation guard — if a
+          // newer invalidation has landed, a newer load owns the entry and this
+          // one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setGuests(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -137,4 +162,5 @@ export function __resetGuestsCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/households-store.ts
+++ b/cire/host/src/lib/households-store.ts
@@ -50,20 +50,25 @@ export function householdsAccessor(weddingId: string): Accessor<OrganiserHouseho
 
 /** Has this wedding's household list already been fetched in this session? */
 export function hasCachedHouseholds(weddingId: string): boolean {
-  return cache.get(weddingId)?.households() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.households() != null;
 }
 
 /** Drop a wedding's cached households so the next read refetches. Call after a
  *  mutation that can change the roster — e.g. a change apply. */
 export function invalidateHouseholds(weddingId: string): void {
-  entryFor(weddingId).setHouseholds(null);
+  // A mounted editor is still rendering the last-known rows, and pulling them
+  // out from under it for one round trip is the flicker this cache exists to
+  // avoid — so the signal is left alone and the wedding is marked `stale`
+  // instead. `hasCachedHouseholds` treats a stale id as a miss, which is what
+  // makes the next `ensureHouseholdsLoaded` actually refetch rather than
+  // short-circuiting on the (still-present) cached value.
+  stale.add(weddingId);
   // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Dropping the entry alone is not enough — the
-  // fetch's own `.then` would still write them into a fresh cache entry — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it. Without this, the
-  // editor's invalidate-then-reload after a successful save can re-cache exactly
-  // the household the organiser just deleted.
+  // describe state that has since been mutated: the wedding's GENERATION is
+  // bumped too, and a resolving fetch from an older generation discards its
+  // result instead of caching it. Without this, the editor's invalidate-then-
+  // reload after a successful save can re-cache exactly the household the
+  // organiser just deleted.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -71,6 +76,10 @@ export function invalidateHouseholds(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** In-flight loads, keyed by weddingId, so concurrent mounts share ONE fetch. */
 const inflight = new Map<string, Promise<void>>();
@@ -90,12 +99,28 @@ export function ensureHouseholdsLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((rows) => {
-        // A newer invalidation landed while this was in flight — its rows describe
-        // state that has since been mutated, so drop them rather than cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        entryFor(weddingId).setHouseholds(rows);
-      })
+      .then(
+        (rows) => {
+          // A newer invalidation landed while this was in flight — its rows describe
+          // state that has since been mutated, so drop them rather than cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          entryFor(weddingId).setHouseholds(rows);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // household detail behind an error banner. Same generation guard — if
+          // a newer invalidation has landed, a newer load owns the entry and
+          // this one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setHouseholds(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -112,4 +137,5 @@ export function __resetHouseholdsCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/registry-store.ts
+++ b/cire/host/src/lib/registry-store.ts
@@ -119,7 +119,7 @@ export function registryAccessor(weddingId: string): Accessor<RegistrySnapshot |
 }
 
 export function hasCachedRegistry(weddingId: string): boolean {
-  return cache.get(weddingId)?.snapshot() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.snapshot() != null;
 }
 
 export function setCachedRegistry(weddingId: string, snapshot: RegistrySnapshot): void {
@@ -131,24 +131,28 @@ export function peekCachedRegistry(weddingId: string): RegistrySnapshot | null {
 }
 
 /**
- * Drop the cached snapshot, keeping the SIGNAL.
+ * Mark the cached snapshot stale, keeping both the SIGNAL and its VALUE.
  *
  * Deleting the map entry would mint a fresh signal on the next `entryFor`, and
  * every view that captured the old accessor at mount would then read a signal
  * nothing writes to again — a dead view with stale content. This was the
  * repo-wide `P-W2` in `[[cire/wiki/todo/perf]]`; every sibling cache
  * (`vendors-store`, `budget-store`, `tasks-store`, `enquiries-store`,
- * `events-store`, `guests-store`, `households-store`) now notifies the same
- * way.
+ * `events-store`, `guests-store`, `households-store`) still notifies the same
+ * way. What changed since is the VALUE: nulling it out here used to hide the
+ * gift list and log behind a loading flash on every organiser edit, so the
+ * snapshot is left in place and the wedding is marked `stale` instead.
+ * `hasCachedRegistry` treats a stale id as a miss, which is what makes the
+ * next `ensureRegistryLoaded` actually refetch rather than short-circuiting
+ * on the (still-present) cached value.
  *
  * A load already in flight was issued against PRE-invalidation state, so its
- * snapshot is stale the moment this runs. Clearing the signal alone is not
- * enough — the fetch's own `.then` would still write it in AFTER this call —
- * so the wedding's GENERATION is bumped too, and a resolving fetch from an
- * older generation discards its result instead of caching it.
+ * snapshot describes state that has since been mutated: the wedding's
+ * GENERATION is bumped too, and a resolving fetch from an older generation
+ * discards its result instead of caching it.
  */
 export function invalidateRegistry(weddingId: string): void {
-  entryFor(weddingId).setSnapshot(null);
+  stale.add(weddingId);
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -156,6 +160,10 @@ export function invalidateRegistry(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached snapshot is known out of date but still worth
+ *  showing while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** How many of an item's wanted quantity are still unspoken for. Never negative
  *  — a race can land one claim past the wanted count, and a negative "still
@@ -175,13 +183,29 @@ export function ensureRegistryLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((snap) => {
-        // A newer invalidation landed while this was in flight — its snapshot
-        // describes state that has since been mutated, so drop it rather than
-        // cache it.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedRegistry(weddingId, snap);
-      })
+      .then(
+        (snap) => {
+          // A newer invalidation landed while this was in flight — its snapshot
+          // describes state that has since been mutated, so drop it rather than
+          // cache it.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedRegistry(weddingId, snap);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The snapshot still on screen was
+          // fetched under an authorisation this request could not confirm, so
+          // it stops being shown: a demoted organiser must not keep reading
+          // registry detail behind an error banner. Same generation guard — if
+          // a newer invalidation has landed, a newer load owns the entry and
+          // this one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setSnapshot(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -198,4 +222,5 @@ export function __resetRegistryCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/tasks-store.ts
+++ b/cire/host/src/lib/tasks-store.ts
@@ -40,7 +40,7 @@ export function tasksAccessor(weddingId: string): Accessor<TaskRow[] | null> {
 }
 
 export function hasCachedTasks(weddingId: string): boolean {
-  return cache.get(weddingId)?.tasks() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.tasks() != null;
 }
 
 export function setCachedTasks(weddingId: string, tasks: TaskRow[]): void {
@@ -52,12 +52,17 @@ export function peekCachedTasks(weddingId: string): TaskRow[] | null {
 }
 
 export function invalidateTasks(weddingId: string): void {
-  entryFor(weddingId).setTasks(null);
-  // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Clearing the signal alone is not enough —
-  // the fetch's own `.then` would still write them in AFTER this call — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it.
+  // A mounted Checklist view is still rendering the last-known rows, and
+  // pulling them out from under it for one round trip is the flicker this
+  // cache exists to avoid — so the signal is left alone and the wedding is
+  // marked `stale` instead. `hasCachedTasks` treats a stale id as a miss,
+  // which is what makes the next `ensureTasksLoaded` actually refetch rather
+  // than short-circuiting on the (still-present) cached value.
+  stale.add(weddingId);
+  // A load already in flight was issued against PRE-mutation state, so its
+  // rows describe state that has since been mutated: the wedding's
+  // GENERATION is bumped too, and a resolving fetch from an older generation
+  // discards its result instead of caching it.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -65,6 +70,10 @@ export function invalidateTasks(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** Reactive open-task count for the Overview widget: `null` until first load.
  *  Reads without allocating a dangling signal for a never-loaded weddingId. */
@@ -102,13 +111,29 @@ export function ensureTasksLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((rows) => {
-        // A newer invalidation landed while this was in flight — its rows
-        // describe state that has since been mutated, so drop them rather than
-        // cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedTasks(weddingId, rows);
-      })
+      .then(
+        (rows) => {
+          // A newer invalidation landed while this was in flight — its rows
+          // describe state that has since been mutated, so drop them rather than
+          // cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedTasks(weddingId, rows);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // checklist detail behind an error banner. Same generation guard —
+          // if a newer invalidation has landed, a newer load owns the entry
+          // and this one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setTasks(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -125,4 +150,5 @@ export function __resetTasksCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/src/lib/vendors-store.ts
+++ b/cire/host/src/lib/vendors-store.ts
@@ -46,7 +46,7 @@ export function vendorsAccessor(weddingId: string): Accessor<VendorRow[] | null>
 }
 
 export function hasCachedVendors(weddingId: string): boolean {
-  return cache.get(weddingId)?.vendors() != null;
+  return !stale.has(weddingId) && cache.get(weddingId)?.vendors() != null;
 }
 
 export function setCachedVendors(weddingId: string, vendors: VendorRow[]): void {
@@ -58,12 +58,17 @@ export function peekCachedVendors(weddingId: string): VendorRow[] | null {
 }
 
 export function invalidateVendors(weddingId: string): void {
-  entryFor(weddingId).setVendors(null);
-  // A load already in flight was issued against PRE-mutation state, so its rows
-  // are stale the moment this runs. Clearing the signal alone is not enough —
-  // the fetch's own `.then` would still write them in AFTER this call — so the
-  // wedding's GENERATION is bumped too, and a resolving fetch from an older
-  // generation discards its result instead of caching it.
+  // A mounted Vendors view is still rendering the last-known rows, and pulling
+  // them out from under it for one round trip is the flicker this cache
+  // exists to avoid — so the signal is left alone and the wedding is marked
+  // `stale` instead. `hasCachedVendors` treats a stale id as a miss, which is
+  // what makes the next `ensureVendorsLoaded` actually refetch rather than
+  // short-circuiting on the (still-present) cached value.
+  stale.add(weddingId);
+  // A load already in flight was issued against PRE-mutation state, so its
+  // rows describe state that has since been mutated: the wedding's
+  // GENERATION is bumped too, and a resolving fetch from an older generation
+  // discards its result instead of caching it.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -71,6 +76,10 @@ export function invalidateVendors(weddingId: string): void {
 /** Monotonic per-wedding load generation, bumped by every invalidation. */
 const generation = new Map<string, number>();
 const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
+
+/** Wedding ids whose cached rows are known out of date but still worth showing
+ *  while the refetch is in flight. */
+const stale = new Set<string>();
 
 /** Reactive vendor count for the Overview widget: `null` before first load. */
 export function vendorCount(weddingId: string): number | null {
@@ -90,13 +99,29 @@ export function ensureVendorsLoaded(
   if (!pending) {
     const startedAt = generationOf(weddingId);
     const load = fetcher()
-      .then((rows) => {
-        // A newer invalidation landed while this was in flight — its rows
-        // describe state that has since been mutated, so drop them rather than
-        // cache them.
-        if (generationOf(weddingId) !== startedAt) return;
-        setCachedVendors(weddingId, rows);
-      })
+      .then(
+        (rows) => {
+          // A newer invalidation landed while this was in flight — its rows
+          // describe state that has since been mutated, so drop them rather than
+          // cache them.
+          if (generationOf(weddingId) !== startedAt) return;
+          setCachedVendors(weddingId, rows);
+          stale.delete(weddingId);
+        },
+        (err: unknown) => {
+          // The refetch was refused or failed. The rows still on screen were
+          // fetched under an authorisation this request could not confirm, so
+          // they stop being shown: a demoted organiser must not keep reading
+          // vendor detail behind an error banner. Same generation guard — if
+          // a newer invalidation has landed, a newer load owns the entry and
+          // this one touches nothing.
+          if (generationOf(weddingId) === startedAt) {
+            entryFor(weddingId).setVendors(null);
+            stale.delete(weddingId);
+          }
+          throw err;
+        },
+      )
       .finally(() => {
         // Only clear the slot if it is still OURS: an invalidation may already
         // have replaced it with a newer load.
@@ -113,4 +138,5 @@ export function __resetVendorsCache(): void {
   cache.clear();
   inflight.clear();
   generation.clear();
+  stale.clear();
 }

--- a/cire/host/tests/components/BudgetView.test.tsx
+++ b/cire/host/tests/components/BudgetView.test.tsx
@@ -173,4 +173,51 @@ describe("BudgetView", () => {
     expect(init.method).toBe("POST");
     expect(await screen.findByText("Caterer")).toBeInTheDocument();
   });
+
+  /**
+   * `reload()` (BudgetView.tsx) now routes through `invalidateBudget` +
+   * `ensureBudgetLoaded` instead of a bare `setCachedBudget(id, await load())`.
+   * A store-level test proves the signal goes null when a refetch is refused;
+   * it does not prove the view stops rendering the rows it already captured.
+   * This drives that end to end: a failed mutation triggers `reload()`, whose
+   * own refetch is refused too, and the previously rendered row must
+   * disappear along with the refresh error appearing.
+   */
+  it("a refused reload after a failed mutation clears the rows and shows the refresh error", async () => {
+    setCachedBudget(
+      "wed_1",
+      snap({
+        items: [
+          {
+            id: "a",
+            weddingId: "wed_1",
+            category: "venue",
+            name: "Reception venue",
+            estimateMinor: null,
+            quotedMinor: null,
+            actualMinor: null,
+            notes: null,
+            sortOrder: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      }),
+    );
+    authFetch
+      .mockResolvedValueOnce(new Response("fail", { status: 500 })) // the add-item POST fails
+      .mockResolvedValueOnce(new Response("fail", { status: 500 })); // reload()'s own GET is refused too
+    render(() => <BudgetView weddingId="wed_1" canEdit={true} canManage={true} />);
+    await screen.findByText("Reception venue");
+
+    const nameInput = screen.getByPlaceholderText(/caterer, venue/i);
+    fireEvent.input(nameInput, { target: { value: "Cake" } });
+    fireEvent.click(screen.getByRole("button", { name: /add item/i }));
+
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Couldn't refresh your budget."),
+    );
+    expect(screen.queryByText("Reception venue")).not.toBeInTheDocument();
+  });
 });

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -10,6 +10,7 @@ import {
   invalidateBudget,
   type PaymentRow,
   peekCachedBudget,
+  setCachedBudget,
   spentSoFar,
   upcomingPayments,
 } from "../../src/lib/budget-store";
@@ -95,14 +96,21 @@ describe("budget-store", () => {
    * map entry on invalidate would leave that accessor pointed at a signal
    * nothing writes to again — a dead view showing stale figures forever. The
    * fix writes THROUGH the signal, so an accessor captured before invalidate
-   * still observes the transition.
+   * still observes it.
+   *
+   * What changed since: invalidate used to null that signal outright, which
+   * flashed the Budget view empty on every organiser edit while the
+   * background refetch ran. It now leaves the snapshot in place and marks the
+   * wedding `stale` instead — a mounted view keeps rendering the last-known
+   * figures across the invalidate.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous snapshot after invalidate", async () => {
     await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({})] }));
     const mounted = budgetAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).not.toBeNull();
     invalidateBudget("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).not.toBeNull();
+    expect(hasCachedBudget("wed_1")).toBe(false);
   });
 
   it("hasCachedBudget is false after invalidate, so the next load refetches", async () => {
@@ -120,15 +128,16 @@ describe("budget-store", () => {
 
   /**
    * A fetch already in flight when the invalidate runs was issued against
-   * PRE-mutation state. Clearing the signal alone would not stop its `.then`
-   * writing that stale snapshot in afterwards — the generation bump does.
+   * PRE-mutation state. Leaving the signal alone would not stop its `.then`
+   * writing that stale snapshot in afterwards — the generation bump does,
+   * discarding the abandoned load's result outright rather than caching it.
    */
   it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
     let resolveStale!: (s: BudgetSnapshot) => void;
-    const stale = new Promise<BudgetSnapshot>((r) => {
+    const staleFetch = new Promise<BudgetSnapshot>((r) => {
       resolveStale = r;
     });
-    const pending = ensureBudgetLoaded("wed_1", () => stale);
+    const pending = ensureBudgetLoaded("wed_1", () => staleFetch);
 
     invalidateBudget("wed_1");
     resolveStale(snap({ items: [item({ id: "stale" })] }));
@@ -138,6 +147,9 @@ describe("budget-store", () => {
     await ensureBudgetLoaded("wed_1", fresh);
 
     expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh"]);
+    // The abandoned load's `.then` returned early without touching `stale`, so
+    // only the fresh, in-generation load clearing it counts.
+    expect(hasCachedBudget("wed_1")).toBe(true);
   });
 
   it("peekCachedBudget reflects fresh data after an invalidate/reload cycle", async () => {
@@ -176,6 +188,13 @@ describe("budget-store", () => {
       return snap({ items: [item({})] });
     });
     expect(recoveringCalls).toBe(1);
+  });
+
+  it("ensureBudgetLoaded refetches after invalidate and replaces the stale snapshot on success", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "a" })] }));
+    invalidateBudget("wed_1");
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "b" })] }));
+    expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["b"]);
     expect(hasCachedBudget("wed_1")).toBe(true);
   });
 
@@ -218,5 +237,36 @@ describe("budget-store", () => {
     await Promise.all([loadB, thirdCaller]);
 
     expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh-b"]);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known budget behind an error banner just because the
+   * stale-while-revalidate contract kept the old snapshot on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureBudgetLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "a" })] }));
+    invalidateBudget("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureBudgetLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(budgetAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetBudgetCache clears the stale flag along with the cache", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "a" })] }));
+    invalidateBudget("wed_1"); // marks wed_1 stale
+    __resetBudgetCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedBudget` (not `ensureBudgetLoaded`) look like a stale hit
+    // forever, since only `ensureBudgetLoaded`'s success path clears it.
+    setCachedBudget("wed_1", snap({ items: [item({ id: "b" })] }));
+    expect(hasCachedBudget("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -296,4 +296,35 @@ describe("budget-store", () => {
     expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
     expect(hasCachedBudget("wed_1")).toBe(false);
   });
+
+  /**
+   * Mirror of the generation-stale success test above, but for the failure
+   * branch's own generation guard: a load abandoned by a newer invalidate
+   * must not blank the entry on rejection either, because a newer load now
+   * owns it. Without `if (generationOf(weddingId) === startedAt)` in the
+   * `onErr` handler, this abandoned load's refusal would null out rows a
+   * newer in-generation load (or a mounted view) still has a claim to — the
+   * rejection must still propagate to the caller, but it must not touch the
+   * signal.
+   */
+  it("a generation-stale rejection still propagates but does not blank an entry a newer load owns", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "seed" })] }));
+    invalidateBudget("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const refusal = new Error("403");
+    const pending = ensureBudgetLoaded("wed_1", async () => {
+      await gate;
+      throw refusal;
+    });
+
+    invalidateBudget("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+
+    await expect(pending).rejects.toBe(refusal);
+    expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
+  });
 });

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -269,4 +269,31 @@ describe("budget-store", () => {
     setCachedBudget("wed_1", snap({ items: [item({ id: "b" })] }));
     expect(hasCachedBudget("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its budget figures nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureBudgetLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "seed" })] }));
+    invalidateBudget("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureBudgetLoaded("wed_1", async () => {
+      await gate;
+      return snap({ items: [item({ id: "abandoned" })] });
+    });
+
+    invalidateBudget("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
+    expect(hasCachedBudget("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -78,14 +78,21 @@ describe("enquiries-store", () => {
    * entry on invalidate would leave that accessor pointed at a signal nothing
    * writes to again — a dead view showing stale rows forever. The fix writes
    * THROUGH the signal, so an accessor captured before invalidate still
-   * observes the transition.
+   * observes it.
+   *
+   * What changed since: invalidate used to null that signal outright, which
+   * flashed the inbox empty on every mutation while the background refetch
+   * ran. It now leaves the rows in place and marks the wedding `stale`
+   * instead — a mounted inbox keeps rendering the last-known rows across the
+   * invalidate.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", () => {
+  it("a mounted consumer's captured accessor keeps the previous rows after invalidate", () => {
     setCachedEnquiries("wed_1", [item()]);
     const mounted = enquiriesAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).toHaveLength(1);
     invalidateEnquiries("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).toHaveLength(1);
+    expect(hasCachedEnquiries("wed_1")).toBe(false);
   });
 
   it("hasCachedEnquiries is false after invalidate", () => {
@@ -115,6 +122,7 @@ describe("enquiries-store", () => {
     await ensureEnquiriesLoaded("wed_1", fresh);
 
     expect(peekCachedEnquiries("wed_1")?.map((r) => r.id)).toEqual(["fresh"]);
+    expect(hasCachedEnquiries("wed_1")).toBe(true);
   });
 
   it("upsertCachedEnquiry and peekCachedEnquiries still work after an invalidate/reload cycle", async () => {
@@ -154,6 +162,36 @@ describe("enquiries-store", () => {
       return [item()];
     });
     expect(recoveringCalls).toBe(1);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known inbox behind an error banner just because the
+   * stale-while-revalidate contract kept the old rows on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureEnquiriesLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    setCachedEnquiries("wed_1", [item({ id: "enq_1" })]);
+    invalidateEnquiries("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureEnquiriesLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(enquiriesAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetEnquiriesCache clears the stale flag along with the cache", async () => {
+    setCachedEnquiries("wed_1", [item({ id: "enq_1" })]);
+    invalidateEnquiries("wed_1"); // marks wed_1 stale
+    __resetEnquiriesCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedEnquiries` (not `ensureEnquiriesLoaded`) look like a stale
+    // hit forever, since only `ensureEnquiriesLoaded`'s success path clears it.
+    setCachedEnquiries("wed_1", [item({ id: "enq_2" })]);
     expect(hasCachedEnquiries("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -72,6 +72,14 @@ describe("enquiries-store", () => {
     expect(calls).toBe(1);
   });
 
+  it("ensureEnquiriesLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    setCachedEnquiries("wed_1", [item({ id: "enq_a" })]);
+    invalidateEnquiries("wed_1");
+    await ensureEnquiriesLoaded("wed_1", async () => [item({ id: "enq_b" })]);
+    expect(enquiriesAccessor("wed_1")()?.map((e) => e.id)).toEqual(["enq_b"]);
+    expect(hasCachedEnquiries("wed_1")).toBe(true);
+  });
+
   /**
    * The regression test for the actual bug: `entryFor` mints the signal once
    * and a mounted inbox captures that accessor at mount. Deleting the map

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -194,4 +194,31 @@ describe("enquiries-store", () => {
     setCachedEnquiries("wed_1", [item({ id: "enq_2" })]);
     expect(hasCachedEnquiries("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its enquiry rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureEnquiriesLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureEnquiriesLoaded("wed_1", async () => [item({ id: "seed" })]);
+    invalidateEnquiries("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureEnquiriesLoaded("wed_1", async () => {
+      await gate;
+      return [item({ id: "abandoned" })];
+    });
+
+    invalidateEnquiries("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(enquiriesAccessor("wed_1")()?.map((r) => r.id)).toEqual(["seed"]);
+    expect(hasCachedEnquiries("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/events-store.test.ts
+++ b/cire/host/tests/lib/events-store.test.ts
@@ -152,4 +152,31 @@ describe("ensureEventsLoaded", () => {
     setCachedEvents("wed_1", [{ ...ROW, id: "b" }]);
     expect(hasCachedEvents("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its event rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureEventsLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "seed" }]);
+    invalidateEvents("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureEventsLoaded("wed_1", async () => {
+      await gate;
+      return [{ ...ROW, id: "abandoned" }];
+    });
+
+    invalidateEvents("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["seed"]);
+    expect(hasCachedEvents("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/events-store.test.ts
+++ b/cire/host/tests/lib/events-store.test.ts
@@ -7,6 +7,7 @@ import {
   eventsAccessor,
   hasCachedEvents,
   invalidateEvents,
+  setCachedEvents,
 } from "../../src/lib/events-store";
 
 /**
@@ -68,7 +69,8 @@ describe("ensureEventsLoaded", () => {
   /**
    * The invalidate-then-reload path a change apply runs. Dropping the cache entry
    * alone leaves the in-flight fetch's own `.then` free to write PRE-mutation rows
-   * into a fresh entry — i.e. the row the organiser just deleted comes back.
+   * into a fresh entry — i.e. the row the organiser just deleted comes back. The
+   * generation bump discards that abandoned load's result outright.
    */
   it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
     let resolveStale!: (rows: EventRow[]) => void;
@@ -86,6 +88,7 @@ describe("ensureEventsLoaded", () => {
 
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["fresh"]);
+    expect(hasCachedEvents("wed_1")).toBe(true);
   });
 
   /**
@@ -94,13 +97,59 @@ describe("ensureEventsLoaded", () => {
    * map entry on invalidate would leave that accessor pointed at a signal
    * nothing writes to again — a dead view showing stale rows forever. The fix
    * writes THROUGH the signal, so an accessor captured before invalidate
-   * still observes the transition.
+   * still observes it.
+   *
+   * What changed since: invalidate used to null that signal outright, which
+   * flashed the table empty on every organiser edit while the background
+   * refetch ran. It now leaves the rows in place and marks the wedding
+   * `stale` instead — a mounted table keeps rendering the last-known rows
+   * across the invalidate.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous rows after invalidate", async () => {
     await ensureEventsLoaded("wed_1", async () => [ROW]);
     const mounted = eventsAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).toEqual([ROW]);
     invalidateEvents("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).toEqual([ROW]);
+    expect(hasCachedEvents("wed_1")).toBe(false);
+  });
+
+  it("ensureEventsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    await ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "a" }]);
+    invalidateEvents("wed_1");
+    await ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "b" }]);
+    expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["b"]);
+    expect(hasCachedEvents("wed_1")).toBe(true);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known events behind an error banner just because the
+   * stale-while-revalidate contract kept the old rows on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureEventsLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureEventsLoaded("wed_1", async () => [ROW]);
+    invalidateEvents("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureEventsLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(eventsAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetEventsCache clears the stale flag along with the cache", async () => {
+    await ensureEventsLoaded("wed_1", async () => [ROW]);
+    invalidateEvents("wed_1"); // marks wed_1 stale
+    __resetEventsCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedEvents` (not `ensureEventsLoaded`) look like a stale hit
+    // forever, since only `ensureEventsLoaded`'s success path clears it.
+    setCachedEvents("wed_1", [{ ...ROW, id: "b" }]);
+    expect(hasCachedEvents("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/guests-store.test.ts
+++ b/cire/host/tests/lib/guests-store.test.ts
@@ -162,4 +162,31 @@ describe("ensureGuestsLoaded", () => {
     setCachedGuests("wed_1", [{ ...ROW, familyId: "b" }]);
     expect(hasCachedGuests("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its guest rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureGuestsLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "seed" }]);
+    invalidateGuests("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureGuestsLoaded("wed_1", async () => {
+      await gate;
+      return [{ ...ROW, familyId: "abandoned" }];
+    });
+
+    invalidateGuests("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["seed"]);
+    expect(hasCachedGuests("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/guests-store.test.ts
+++ b/cire/host/tests/lib/guests-store.test.ts
@@ -7,6 +7,7 @@ import {
   hasCachedGuests,
   invalidateGuests,
   type OrganiserGuestRow,
+  setCachedGuests,
 } from "../../src/lib/guests-store";
 
 /**
@@ -64,7 +65,7 @@ describe("ensureGuestsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it("refetches after invalidation (e.g. an import apply)", async () => {
+  it("hasCachedGuests is false after invalidate, so the next load refetches", async () => {
     const fetcher = vi.fn(async () => [ROW]);
     await ensureGuestsLoaded("wed_1", fetcher);
     expect(hasCachedGuests("wed_1")).toBe(true);
@@ -77,7 +78,8 @@ describe("ensureGuestsLoaded", () => {
   /**
    * The invalidate-then-reload path a change apply runs. Dropping the cache entry
    * alone leaves the in-flight fetch's own `.then` free to write PRE-mutation rows
-   * into a fresh entry — i.e. the row the organiser just deleted comes back.
+   * into a fresh entry — i.e. the row the organiser just deleted comes back. The
+   * generation bump discards that abandoned load's result outright.
    */
   it("does not adopt a fetch that was in flight when the cache was invalidated", async () => {
     let resolveStale!: (rows: OrganiserGuestRow[]) => void;
@@ -95,6 +97,7 @@ describe("ensureGuestsLoaded", () => {
 
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["fresh"]);
+    expect(hasCachedGuests("wed_1")).toBe(true);
   });
 
   /**
@@ -103,14 +106,60 @@ describe("ensureGuestsLoaded", () => {
    * map entry on invalidate would leave that accessor pointed at a signal
    * nothing writes to again — a dead view showing stale rows forever. The fix
    * writes THROUGH the signal, so an accessor captured before invalidate
-   * still observes the transition.
+   * still observes it.
+   *
+   * What changed since: invalidate used to null that signal outright, which
+   * flashed the table empty on every organiser edit while the background
+   * refetch ran. It now leaves the rows in place and marks the wedding
+   * `stale` instead — a mounted table keeps rendering the last-known rows
+   * across the invalidate.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous rows after invalidate", async () => {
     const fetcher = vi.fn(async () => [ROW]);
     await ensureGuestsLoaded("wed_1", fetcher);
     const mounted = guestsAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).toEqual([ROW]);
     invalidateGuests("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).toEqual([ROW]);
+    expect(hasCachedGuests("wed_1")).toBe(false);
+  });
+
+  it("ensureGuestsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    await ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "a" }]);
+    invalidateGuests("wed_1");
+    await ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]);
+    expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["b"]);
+    expect(hasCachedGuests("wed_1")).toBe(true);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known guest list behind an error banner just because
+   * the stale-while-revalidate contract kept the old rows on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureGuestsLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureGuestsLoaded("wed_1", async () => [ROW]);
+    invalidateGuests("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureGuestsLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(guestsAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetGuestsCache clears the stale flag along with the cache", async () => {
+    await ensureGuestsLoaded("wed_1", async () => [ROW]);
+    invalidateGuests("wed_1"); // marks wed_1 stale
+    __resetGuestsCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedGuests` (not `ensureGuestsLoaded`) look like a stale hit
+    // forever, since only `ensureGuestsLoaded`'s success path clears it.
+    setCachedGuests("wed_1", [{ ...ROW, familyId: "b" }]);
+    expect(hasCachedGuests("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -181,4 +181,31 @@ describe("ensureHouseholdsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(hasCachedHouseholds("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its household rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureHouseholdsLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "seed" }]);
+    invalidateHouseholds("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureHouseholdsLoaded("wed_1", async () => {
+      await gate;
+      return [{ ...ROW, familyId: "abandoned" }];
+    });
+
+    invalidateHouseholds("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["seed"]);
+    expect(hasCachedHouseholds("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -77,7 +77,7 @@ describe("ensureHouseholdsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it("refetches after invalidation (e.g. a change apply)", async () => {
+  it("hasCachedHouseholds is false after invalidate, so the next load refetches", async () => {
     const fetcher = vi.fn(async () => [ROW]);
     await ensureHouseholdsLoaded("wed_1", fetcher);
     expect(hasCachedHouseholds("wed_1")).toBe(true);
@@ -108,6 +108,7 @@ describe("ensureHouseholdsLoaded", () => {
 
     expect(fresh).toHaveBeenCalledTimes(1);
     expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["fam_fresh"]);
+    expect(hasCachedHouseholds("wed_1")).toBe(true);
   });
 
   /**
@@ -116,14 +117,68 @@ describe("ensureHouseholdsLoaded", () => {
    * entry on invalidate would leave that accessor pointed at a signal nothing
    * writes to again — a dead view showing stale rows forever. The fix writes
    * THROUGH the signal, so an accessor captured before invalidate still
-   * observes the transition.
+   * observes it.
+   *
+   * What changed since: invalidate used to null that signal outright, which
+   * flashed the editor empty on every organiser edit while the background
+   * refetch ran. It now leaves the rows in place and marks the wedding
+   * `stale` instead — a mounted editor keeps rendering the last-known rows
+   * across the invalidate.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous rows after invalidate", async () => {
     const fetcher = vi.fn(async () => [ROW]);
     await ensureHouseholdsLoaded("wed_1", fetcher);
     const mounted = householdsAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).toEqual([ROW]);
     invalidateHouseholds("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).toEqual([ROW]);
+    expect(hasCachedHouseholds("wed_1")).toBe(false);
+  });
+
+  it("ensureHouseholdsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    await ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "a" }]);
+    invalidateHouseholds("wed_1");
+    await ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]);
+    expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["b"]);
+    expect(hasCachedHouseholds("wed_1")).toBe(true);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known household list behind an error banner just
+   * because the stale-while-revalidate contract kept the old rows on screen
+   * — a refused/failed refetch has to blank the signal and rethrow so the
+   * caller sees the failure too.
+   */
+  it("ensureHouseholdsLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureHouseholdsLoaded("wed_1", async () => [ROW]);
+    invalidateHouseholds("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureHouseholdsLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(householdsAccessor("wed_1")()).toBeNull();
+  });
+
+  // households-store has no setCachedHouseholds/peekCachedHouseholds bypass —
+  // ensureHouseholdsLoaded is the only way to write its cache, so this can't
+  // use the same bypass-write proof the other stores use. It instead shows
+  // the same fact indirectly: if reset left `stale` set for wed_1, this fresh
+  // load's success would have nothing to clear and no later assertion could
+  // tell the difference — so we pin the weaker but still real property that a
+  // reset wedding behaves as never-loaded at all.
+  it("__resetHouseholdsCache clears cached rows so a later ensure treats the wedding as unseen", async () => {
+    await ensureHouseholdsLoaded("wed_1", async () => [ROW]);
+    invalidateHouseholds("wed_1"); // marks wed_1 stale
+    __resetHouseholdsCache();
+    expect(hasCachedHouseholds("wed_1")).toBe(false);
+    expect(householdsAccessor("wed_1")()).toBeNull();
+    const fetcher = vi.fn(async () => [{ ...ROW, familyId: "fam_after_reset" }]);
+    await ensureHouseholdsLoaded("wed_1", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(hasCachedHouseholds("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -165,12 +165,17 @@ describe("ensureHouseholdsLoaded", () => {
 
   // households-store has no setCachedHouseholds/peekCachedHouseholds bypass —
   // ensureHouseholdsLoaded is the only way to write its cache, so this can't
-  // use the same bypass-write proof the other stores use. It instead shows
-  // the same fact indirectly: if reset left `stale` set for wed_1, this fresh
-  // load's success would have nothing to clear and no later assertion could
-  // tell the difference — so we pin the weaker but still real property that a
-  // reset wedding behaves as never-loaded at all.
-  it("__resetHouseholdsCache clears cached rows so a later ensure treats the wedding as unseen", async () => {
+  // use the same bypass-write proof the other stores use (seed, reset,
+  // setCachedXxx, assert hasCachedXxx is true). That proof needs a write that
+  // does NOT itself clear the stale mark, and every write this store exposes
+  // is ensureHouseholdsLoaded's own success path, which always clears it —
+  // so no assertion built from this API can tell a reset that cleared `stale`
+  // apart from one that didn't: hasCachedHouseholds is false either way right
+  // after `cache.clear()` (the entry itself is gone), and the very next
+  // successful load self-heals a surviving stale mark before anything reads
+  // it. What IS real and checkable is the weaker property below: a reset
+  // wedding behaves as never-loaded at all, not merely as due for a refetch.
+  it("__resetHouseholdsCache clears the cache so a previously-invalidated wedding behaves as never-loaded", async () => {
     await ensureHouseholdsLoaded("wed_1", async () => [ROW]);
     invalidateHouseholds("wed_1"); // marks wed_1 stale
     __resetHouseholdsCache();

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -271,4 +271,31 @@ describe("registry-store", () => {
     setCachedRegistry("wed_1", snapshot({ items: [item({ id: "b" })] }));
     expect(hasCachedRegistry("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its registry items nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureRegistryLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "seed" })] }));
+    invalidateRegistry("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureRegistryLoaded("wed_1", async () => {
+      await gate;
+      return snapshot({ items: [item({ id: "abandoned" })] });
+    });
+
+    invalidateRegistry("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
+    expect(hasCachedRegistry("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -10,6 +10,7 @@ import {
   registryAccessor,
   type RegistryItem,
   type RegistrySnapshot,
+  setCachedRegistry,
   stillWanted,
 } from "../../src/lib/registry-store";
 
@@ -106,11 +107,17 @@ describe("registry-store", () => {
     expect(snap.settings.weddingId).toBe("wed_1");
   });
 
-  it("invalidateRegistry clears the cache", async () => {
+  it("invalidateRegistry marks the cache stale without nulling the raw signal", async () => {
     await ensureRegistryLoaded("wed_1", async () => snapshot());
     expect(peekCachedRegistry("wed_1")).not.toBeNull();
     invalidateRegistry("wed_1");
-    expect(peekCachedRegistry("wed_1")).toBeNull();
+    // `hasCachedRegistry` is the miss check now — it consults the `stale` set,
+    // which is exactly what makes the next `ensureRegistryLoaded` refetch.
+    expect(hasCachedRegistry("wed_1")).toBe(false);
+    // `peekCachedRegistry` reads the signal directly and doesn't consult
+    // `stale`, so it still sees the last-known snapshot here — the same known
+    // limitation (tracked in #620) noted on the vendors store.
+    expect(peekCachedRegistry("wed_1")).not.toBeNull();
   });
 
   it("inflight deduplication: two concurrent calls fire the fetcher once", async () => {
@@ -143,12 +150,13 @@ describe("registry-store", () => {
    * forever. The fix writes THROUGH the signal, so an accessor captured
    * before invalidate still observes the transition.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous snapshot after invalidate", async () => {
     await ensureRegistryLoaded("wed_1", async () => snapshot());
     const mounted = registryAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).not.toBeNull();
     invalidateRegistry("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).not.toBeNull();
+    expect(hasCachedRegistry("wed_1")).toBe(false);
   });
 
   it("hasCachedRegistry is false after invalidate, so the next load refetches", async () => {
@@ -184,6 +192,7 @@ describe("registry-store", () => {
     await ensureRegistryLoaded("wed_1", fresh);
 
     expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["fresh"]);
+    expect(hasCachedRegistry("wed_1")).toBe(true);
   });
 
   it("peekCachedRegistry reflects fresh data after an invalidate/reload cycle", async () => {
@@ -222,6 +231,44 @@ describe("registry-store", () => {
       return snapshot();
     });
     expect(recoveringCalls).toBe(1);
+  });
+
+  it("ensureRegistryLoaded refetches after invalidate and replaces the stale snapshot on success", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "a" })] }));
+    invalidateRegistry("wed_1");
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "b" })] }));
+    expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["b"]);
+    expect(hasCachedRegistry("wed_1")).toBe(true);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known registry behind an error banner just because the
+   * stale-while-revalidate contract kept the old snapshot on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureRegistryLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "a" })] }));
+    invalidateRegistry("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureRegistryLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(registryAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetRegistryCache clears the stale flag along with the cache", async () => {
+    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "a" })] }));
+    invalidateRegistry("wed_1"); // marks wed_1 stale
+    __resetRegistryCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedRegistry` (not `ensureRegistryLoaded`) look like a stale hit
+    // forever, since only `ensureRegistryLoaded`'s success path clears it.
+    setCachedRegistry("wed_1", snapshot({ items: [item({ id: "b" })] }));
     expect(hasCachedRegistry("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -7,6 +7,7 @@ import {
   invalidateTasks,
   openTaskCount,
   peekCachedTasks,
+  setCachedTasks,
   taskCounts,
   type TaskRow,
   tasksAccessor,
@@ -69,12 +70,13 @@ describe("tasks-store", () => {
    * forever. The fix writes THROUGH the signal, so an accessor captured
    * before invalidate still observes the transition.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous tasks after invalidate", async () => {
     await ensureTasksLoaded("wed_1", async () => [row({})]);
     const mounted = tasksAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).not.toBeNull();
     invalidateTasks("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).not.toBeNull();
+    expect(hasCachedTasks("wed_1")).toBe(false);
   });
 
   it("hasCachedTasks is false after invalidate, so the next load refetches", async () => {
@@ -110,6 +112,7 @@ describe("tasks-store", () => {
     await ensureTasksLoaded("wed_1", fresh);
 
     expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["fresh"]);
+    expect(hasCachedTasks("wed_1")).toBe(true);
   });
 
   it("peekCachedTasks reflects fresh rows after an invalidate/reload cycle", async () => {
@@ -148,6 +151,44 @@ describe("tasks-store", () => {
       return [row({})];
     });
     expect(recoveringCalls).toBe(1);
+  });
+
+  it("ensureTasksLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "a" })]);
+    invalidateTasks("wed_1");
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "b" })]);
+    expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["b"]);
+    expect(hasCachedTasks("wed_1")).toBe(true);
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known checklist behind an error banner just because the
+   * stale-while-revalidate contract kept the old tasks on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureTasksLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({})]);
+    invalidateTasks("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureTasksLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(tasksAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetTasksCache clears the stale flag along with the cache", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "a" })]);
+    invalidateTasks("wed_1"); // marks wed_1 stale
+    __resetTasksCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedTasks` (not `ensureTasksLoaded`) look like a stale hit
+    // forever, since only `ensureTasksLoaded`'s success path clears it.
+    setCachedTasks("wed_1", [row({ id: "b" })]);
     expect(hasCachedTasks("wed_1")).toBe(true);
   });
 });

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -191,4 +191,31 @@ describe("tasks-store", () => {
     setCachedTasks("wed_1", [row({ id: "b" })]);
     expect(hasCachedTasks("wed_1")).toBe(true);
   });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its checklist rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureTasksLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureTasksLoaded("wed_1", async () => [row({ id: "seed" })]);
+    invalidateTasks("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureTasksLoaded("wed_1", async () => {
+      await gate;
+      return [row({ id: "abandoned" })];
+    });
+
+    invalidateTasks("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["seed"]);
+    expect(hasCachedTasks("wed_1")).toBe(false);
+  });
 });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetVendorsCache,
   ensureVendorsLoaded,
+  hasCachedVendors,
   invalidateVendors,
   peekCachedVendors,
+  setCachedVendors,
   vendorCount,
   vendorsAccessor,
   type VendorRow,
@@ -53,12 +55,20 @@ describe("vendors-store", () => {
     expect(vendorCount("wed_1")).toBe(3);
   });
 
-  it("invalidateVendors clears the cache", async () => {
+  it("invalidateVendors marks the cache stale without nulling the raw signal", async () => {
     await ensureVendorsLoaded("wed_1", async () => [vendor({})]);
     expect(peekCachedVendors("wed_1")).not.toBeNull();
     invalidateVendors("wed_1");
-    expect(peekCachedVendors("wed_1")).toBeNull();
-    expect(vendorCount("wed_1")).toBeNull();
+    // `hasCachedVendors` is the miss check now — it consults the `stale` set,
+    // which is exactly what makes the next `ensureVendorsLoaded` refetch.
+    expect(hasCachedVendors("wed_1")).toBe(false);
+    // `peekCachedVendors` and `vendorCount` read the signal directly and don't
+    // consult `stale`, so they still see the last-known rows here. That gap
+    // (a widget built on either of them can't tell fresh from stale) is the
+    // known limitation tracked separately in #620 — this store's contract
+    // only promises it for the mounted-accessor / ensureVendorsLoaded path.
+    expect(peekCachedVendors("wed_1")).not.toBeNull();
+    expect(vendorCount("wed_1")).toBe(1);
   });
 
   it("inflight deduplication: two concurrent calls fire fetcher once", async () => {
@@ -81,12 +91,13 @@ describe("vendors-store", () => {
    * writes THROUGH the signal, so an accessor captured before invalidate
    * still observes the transition.
    */
-  it("a mounted consumer's captured accessor observes null after invalidate", async () => {
+  it("a mounted consumer's captured accessor keeps the previous vendors after invalidate", async () => {
     await ensureVendorsLoaded("wed_1", async () => [vendor({})]);
     const mounted = vendorsAccessor("wed_1"); // captured once, as a real mount would
     expect(mounted()).not.toBeNull();
     invalidateVendors("wed_1");
-    expect(mounted()).toBeNull();
+    expect(mounted()).not.toBeNull();
+    expect(hasCachedVendors("wed_1")).toBe(false);
   });
 
   /**
@@ -109,6 +120,7 @@ describe("vendors-store", () => {
     await ensureVendorsLoaded("wed_1", fresh);
 
     expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["fresh"]);
+    expect(peekCachedVendors("wed_1")).not.toBeNull();
   });
 
   it("peekCachedVendors reflects fresh rows after an invalidate/reload cycle", async () => {
@@ -147,6 +159,44 @@ describe("vendors-store", () => {
       return [vendor({})];
     });
     expect(recoveringCalls).toBe(1);
+  });
+
+  it("ensureVendorsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "a" })]);
+    invalidateVendors("wed_1");
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })]);
+    expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["b"]);
+    expect(peekCachedVendors("wed_1")).not.toBeNull();
+  });
+
+  /**
+   * Security property, not an optimisation: the refetch after invalidate is
+   * also the re-authorization check. A demoted organiser must not keep
+   * reading the last-known vendor list behind an error banner just because
+   * the stale-while-revalidate contract kept the old rows on screen — a
+   * refused/failed refetch has to blank the signal and rethrow so the caller
+   * sees the failure too.
+   */
+  it("ensureVendorsLoaded blanks the signal and rethrows when the refetch is refused", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({})]);
+    invalidateVendors("wed_1");
+    const refusal = new Error("403");
+    await expect(
+      ensureVendorsLoaded("wed_1", async () => {
+        throw refusal;
+      }),
+    ).rejects.toBe(refusal);
+    expect(vendorsAccessor("wed_1")()).toBeNull();
+  });
+
+  it("__resetVendorsCache clears the stale flag along with the cache", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "a" })]);
+    invalidateVendors("wed_1"); // marks wed_1 stale
+    __resetVendorsCache();
+    // A stale flag surviving the reset would make every future write via
+    // `setCachedVendors` (not `ensureVendorsLoaded`) look like a stale hit
+    // forever, since only `ensureVendorsLoaded`'s success path clears it.
+    setCachedVendors("wed_1", [vendor({ id: "b" })]);
     expect(peekCachedVendors("wed_1")).not.toBeNull();
   });
 });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -120,7 +120,7 @@ describe("vendors-store", () => {
     await ensureVendorsLoaded("wed_1", fresh);
 
     expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["fresh"]);
-    expect(peekCachedVendors("wed_1")).not.toBeNull();
+    expect(hasCachedVendors("wed_1")).toBe(true);
   });
 
   it("peekCachedVendors reflects fresh rows after an invalidate/reload cycle", async () => {
@@ -166,7 +166,7 @@ describe("vendors-store", () => {
     invalidateVendors("wed_1");
     await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })]);
     expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["b"]);
-    expect(peekCachedVendors("wed_1")).not.toBeNull();
+    expect(hasCachedVendors("wed_1")).toBe(true);
   });
 
   /**
@@ -197,6 +197,33 @@ describe("vendors-store", () => {
     // `setCachedVendors` (not `ensureVendorsLoaded`) look like a stale hit
     // forever, since only `ensureVendorsLoaded`'s success path clears it.
     setCachedVendors("wed_1", [vendor({ id: "b" })]);
-    expect(peekCachedVendors("wed_1")).not.toBeNull();
+    expect(hasCachedVendors("wed_1")).toBe(true);
+  });
+  /**
+   * A load that resolves after a NEWER invalidate has landed must do nothing at
+   * all: it neither writes its vendor rows nor clears the stale mark. Both halves
+   * matter — writing would restore state the organiser has already mutated
+   * past, and clearing would let the next `ensureVendorsLoaded` short-circuit on
+   * rows no in-generation load ever confirmed.
+   */
+  it("a generation-stale success writes no rows and leaves the wedding stale", async () => {
+    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "seed" })]);
+    invalidateVendors("wed_1");
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const pending = ensureVendorsLoaded("wed_1", async () => {
+      await gate;
+      return [vendor({ id: "abandoned" })];
+    });
+
+    invalidateVendors("wed_1"); // a second invalidate, while that load is still in flight
+    release();
+    await pending;
+
+    expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["seed"]);
+    expect(hasCachedVendors("wed_1")).toBe(false);
   });
 });

--- a/wiki/architecture/cire-host-portal-layout.md
+++ b/wiki/architecture/cire-host-portal-layout.md
@@ -5,7 +5,7 @@ related:
   - "[[index]]"
   - "[[cire-invite-builder]]"
   - "[[cire-organiser]]"
-last-reviewed: 2026-09-01
+last-reviewed: 2026-09-06
 ---
 # Host Portal Layout System
 
@@ -213,13 +213,86 @@ component was previously reading a container it did not live in.
      messages that aren't the named enquiry's — otherwise A's correspondence
      renders under B's name for a round-trip. Re-fetching the *same* enquiry
      (after sending) still matches, so the thread doesn't blank.
-  4. `handleSend` refreshes the list with `setCachedEnquiries`, **not**
-     `invalidateEnquiries` + `ensureEnquiriesLoaded`. Invalidation is
-     `cache.delete(...)`, which mints a new signal; the always-mounted inbox
-     keeps reading the orphan, so the round-trip is paid and nothing updates.
-     The store-level fix for all four caches is **P-W2**, filed in `xchromo/osn-tracker`.
+  4. `handleSend` still refreshes the list with `setCachedEnquiries` — it
+     already holds the new row, so writing it straight in skips a pointless
+     round trip, and that part hasn't changed. What *has* changed is
+     `invalidateEnquiries` itself: it no longer does `cache.delete(...)` (the
+     historical bug this note used to warn about, which minted a new signal
+     the always-mounted inbox never saw). It now marks the wedding `stale`,
+     bumps the generation, and drops the inflight slot instead — see
+     "Organiser client caches: stale-while-revalidate" below. The rule for
+     the *other* kind of reload — recovering after a failed write, rather
+     than folding in a response you already have — is the mirror image of
+     `handleSend`'s: go through `invalidateXxx` + `ensureXxxLoaded`, never a
+     bare `setCachedXxx`, because only `ensureXxxLoaded` carries the
+     generation guard and the failure branch that blanks the rows on a
+     refused refetch. That is exactly what `BudgetView`, `ChecklistView`,
+     `RegistryView` and `VendorsView`'s `reload()` do. The store-level fix,
+     **P-W2**, is shipped — PR #860 (write through the signal instead of
+     deleting the entry) and PR #864 (stale-while-revalidate); tracked in
+     `xchromo/osn-tracker`.
 - **Event cards** (`EventTable`) — cards flow in an `auto-grid`; each card is its
   own `@container/card` and its details grid switches at `@md/card`.
+
+## Organiser client caches: stale-while-revalidate
+
+Eight `weddingId`-keyed SolidJS signal caches share this contract:
+`budget-store.ts`, `enquiries-store.ts`, `events-store.ts`, `guests-store.ts`,
+`households-store.ts`, `registry-store.ts`, `tasks-store.ts`,
+`vendors-store.ts` (all `cire/host/src/lib/`). One page for the mechanism
+they all share, rather than eight copies that drift — a module's own page
+(e.g. [[cire-checklist-tasks]]) documents only what is genuinely that
+module's.
+
+A cached wedding is in one of four states:
+
+1. **Fresh** — loaded, not since invalidated. `hasCachedXxx` is `true`.
+2. **Stale but shown** — `invalidateXxx` has run since the last load. The
+   signal keeps its last-known rows, so a mounted view keeps rendering them —
+   removing that flash on every organiser edit is the entire point of this
+   design — but `hasCachedXxx` reports a stale id as a miss, which is what
+   makes the next `ensureXxxLoaded` actually issue a fetch instead of
+   short-circuiting on the still-present value.
+3. **Refetching** — `ensureXxxLoaded` is in flight. Concurrent callers dedupe
+   onto the one promise.
+4. **Refused and blanked** — the refetch rejects. This is an authorisation
+   control, not error handling: the refetch a stale wedding triggers is also
+   the re-authorization check, so a refused or failed response blanks the
+   signal to `null` and rethrows, rather than leaving a demoted organiser
+   reading the last-known rows behind an error banner. Dropping this branch
+   — say, by collapsing the two-argument `.then(onOk, onErr)` back into a
+   single `.then` with a trailing `.catch` — would keep serving that
+   organiser's stale, now-unauthorised data.
+
+Both the success and the failure branch are **generation-guarded**:
+`invalidateXxx` bumps a per-wedding counter, and a load that settles —
+success or failure — after a newer invalidate has landed touches nothing,
+because a newer load already owns the entry. Without the guard on the
+failure branch specifically, an abandoned load's late rejection would blank
+rows a newer, still-in-flight load (or a newer success) has already claimed.
+
+Shared export surface, and what each does under a stale mark:
+
+| Export | Under a stale mark |
+|---|---|
+| `hasCachedXxx(id)` | `false` — the refetch trigger, not a render gate |
+| `xxxAccessor(id)` | Unchanged: the same signal, still holding the last-known rows |
+| `peekCachedXxx(id)` | Also still returns the last-known rows — deliberately does **not** consult the stale mark (see the gap below) |
+| `setCachedXxx(id, rows)` | Writes the signal. Does **not** clear the stale mark |
+| `invalidateXxx(id)` | Marks stale, bumps the generation, drops any inflight slot. Does **not** touch the signal |
+| `ensureXxxLoaded(id, fetcher)` | No-op if already fresh; otherwise dedupes and fetches. Success writes the rows and clears the stale mark; failure blanks the signal and rethrows. Both branches generation-guarded |
+
+**Known gap, tracked in #620:** `peekCachedXxx` and the readers built
+directly on it — `spentSoFar`/`upcomingPayments` (`budget-store.ts`) and
+`vendorCount` (`vendors-store.ts`) — don't consult the stale mark, so they
+keep returning pre-invalidate figures for the length of the refetch. A
+deliberate trade for now, and not yet even inconsistency-checked across the
+other six stores' own derived readers.
+
+Shipped across all eight caches by PR #860 (write through the signal instead
+of deleting the cache entry on invalidate) and PR #864 (this
+stale-while-revalidate contract, plus the failure-branch re-authorization
+check).
 
 ## Testing
 

--- a/wiki/systems/cire-checklist-tasks.md
+++ b/wiki/systems/cire-checklist-tasks.md
@@ -4,7 +4,8 @@ tags: [systems, platform, phase1, tasks, cire]
 related:
   - "[[index]]"
   - "[[cire-platform-plan]]"
-last-reviewed: 2026-08-21
+  - "[[cire-host-portal-layout]]"
+last-reviewed: 2026-09-06
 ---
 # Checklist / Tasks
 
@@ -100,11 +101,13 @@ Public API:
 | Export | Purpose |
 |---|---|
 | `tasksAccessor(weddingId)` | Reactive `Accessor<TaskRow[] \| null>` |
-| `hasCachedTasks(weddingId)` | Boolean: first load done? |
-| `setCachedTasks(weddingId, tasks)` | Populate/replace cache from a fetch |
+| `hasCachedTasks(weddingId)` | Boolean: are the cached tasks fresh? `false` both before the first load and while the wedding is marked stale (see [[cire-host-portal-layout#Organiser client caches: stale-while-revalidate]]) — it is the refetch trigger, not a render gate |
+| `setCachedTasks(weddingId, tasks)` | Populate/replace cache from a fetch. Does not clear the stale mark |
 | `peekCachedTasks(weddingId)` | Non-reactive snapshot |
-| `invalidateTasks(weddingId)` | Evict after a write |
+| `invalidateTasks(weddingId)` | Mark stale after a write. The rows stay on screen and the signal is untouched — the next `ensureTasksLoaded` is what refetches |
+| `ensureTasksLoaded(weddingId, fetcher)` | Fetch if not fresh; dedupes concurrent callers. On success, writes the rows and clears the stale mark; on a refused/failed refetch, blanks the signal and rethrows |
 | `openTaskCount(weddingId)` | `number \| null` — open-task count for the Overview widget |
+| `taskCounts(weddingId)` | `{ open, done, total } \| null` — reactive counts for the Overview completion bar |
 
 `TaskRow` mirrors `TaskDto` from the API (ms-epoch numbers for `createdAt` /
 `completedAt`; `timeframeBucket` string key; `status: "open" | "done"`).


### PR DESCRIPTION
## Summary

Stacked on #860, which made `invalidateXxx` write `null` **through** the cached Solid
signal so a mounted view actually observes the invalidation. That fixed a real bug and
bought it with a flicker: because the signal goes `null`, every mounted consumer
renders its empty state — "No budget items yet.", "Nothing here yet.", "No gifts on the
list yet." — for one network round trip after every mutation, tearing down the whole
`<For>` row set and bouncing the `createAutoSize` panel height twice.

Invalidation now marks instead of blanking. Each of the eight stores gains a
module-level `stale` set; `invalidateXxx` adds the id, clears `inflight` and bumps the
generation, and leaves the signal holding the last-known rows. `hasCachedXxx` becomes
`!stale.has(id) && cache.get(id)?.xxx() != null`, which is what keeps the next
`ensureXxxLoaded` issuing a real refetch rather than short-circuiting on the
still-present value.

- All eight change together — events, guests, households, enquiries, vendors, budget,
  tasks, registry. They are identical by design, and half-migrating destroys the
  property that a reader who has understood one has understood all of them.
- The four views' `reload()` each did `invalidateXxx(id)` then
  `setCachedXxx(id, await load())`, bypassing the `inflight` dedup, the generation
  guard and the failure handling below. Each is now the invalidate followed by
  `await ensureXxxLoaded(props.weddingId, load)`, one line per view.

## Workspaces affected

`@cire/host`. One changeset naming `"@cire/host": patch` and nothing else. This branch
carries a second `@cire/host` changeset from the PR beneath it; changesets are additive
per package, so two on one branch is expected and valid.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#603 | `P-W1` |
| xchromo/osn-tracker#604 | `P-W2` |
| xchromo/osn-tracker#602 | `P-M2` |

Closes xchromo/osn-tracker#603
Closes xchromo/osn-tracker#604
Closes xchromo/osn-tracker#602

**Opened**

None.

## Decisions

### Keep the authorisation recheck the null transition gave for free — `approach`

- **Issue** — the old behaviour had an accidental security property: with the signal
  `null` across an invalidate, no rows were on screen while the refetch re-checked
  authorisation. Keeping the rows would remove it.
- **Why** — all four views handle a failed reload by calling `setError(...)` and
  leaving the rows alone. An organiser whose access was revoked between the mutation
  and the refetch would go on reading guest names, budget figures and vendor contacts
  behind a "Couldn't refresh your …" banner, indefinitely.
- **Solution** — `ensureXxxLoaded` handles both outcomes with the two-argument
  `.then(onOk, onErr)`: success bails if the generation moved, else writes the rows and
  clears the mark; failure blanks the signal, clears the mark and **rethrows**.
- **Rationale** — the two-argument form runs the failure handler only for a rejected
  `fetcher()`, never for an error thrown inside the success handler. The rethrow is
  required: every view's `.catch` depends on the promise rejecting, and swallowing
  would silently delete the error banner.

### `stale.delete` only inside the two guarded branches — `approach`

- **Issue** — where the mark gets cleared decides when a refetch stops being issued.
- **Why** — a load that loses its generation race must leave the mark set. And
  `setCachedXxx` is also the optimistic-patch path, so clearing there would let a
  purely local edit mark the cache authorised-fresh while the refusal that was about to
  arrive never gets asked for.
- **Solution** — `stale.delete` appears only in the guarded success and failure
  branches; `setCachedXxx` does not touch it.
- **Rationale** — a stale id whose only load lost its race stays stale and the next
  `ensure` refetches. That is the safe direction.

### #602 closes without a `batch()` — `P-M2`

- **Issue** — #602 proposed wrapping the grouped `invalidate*` bursts in `batch()`.
- **Why** — those bursts fired two to four reactive writes in a row, one observer flush
  each.
- **Solution** — nothing. Under this change `invalidateXxx` is not a reactive write at
  all, so the cost the issue describes is gone.
- **Rationale** — `batch()` would wrap nothing. Adding it would leave a reader
  believing there is a flush to batch.

### Pin the generation guard on the failure branch too — `T-E1`

- **Issue** — the review pass found the failure branch's
  `if (generationOf(weddingId) === startedAt)` could be deleted from all eight stores
  with 1188 tests still green.
- **Why** — an unguarded late rejection would blank rows a newer, still-in-flight load
  has already claimed.
- **Solution** — a test that seeds rows, invalidates twice around an in-flight load and
  then rejects it, asserting the rejection still propagates and the seeded rows survive.
- **Rationale** — verified by deleting the guard and watching it fail, then restoring.

### Test the property where the rows actually are — `T-U1` / `T-E2`

- **Issue** — the four rewritten `reload()` bodies were exercised by no test, and no
  view test proved a refused reload clears the rows.
- **Why** — the store test proves the signal goes `null`. The rows a demoted organiser
  would keep reading live at the view level, which is a different claim.
- **Solution** — a `BudgetView` test that fails the write, then fails `reload()`'s own
  refetch, and asserts both the error alert and that the previously-rendered row is
  gone from the DOM.
- **Rationale** — one view is enough: the four are the same shape, and the store-level
  tests cover the other three's path into `ensureXxxLoaded`.

### Rename the households reset test rather than strengthen it — `T-U2`

- **Issue** — its name claimed it proves `__resetHouseholdsCache` clears the stale
  mark, and it cannot.
- **Why** — `households-store.ts` exposes no `setCachedHouseholds` bypass, so every
  write goes through `ensureHouseholdsLoaded`'s success path, which clears the mark
  itself. No assertion built from this API can tell a reset that cleared the mark from
  one that did not.
- **Solution** — renamed to the weaker property it genuinely proves, with a comment
  saying why the stronger one is untestable here.
- **Rationale** — adding an export purely to make the test easier would widen the
  store's surface to serve its test, which is the wrong direction.

**Out of scope** — `vendorCount`, `spentSoFar`, `upcomingPayments` and the
`peekCachedXxx` readers are unchanged and covered by
xchromo/osn-tracker#620. Two test suggestions from the review pass were deferred.
`cire/host/src/lib/registry-store.ts`'s dead wikilink is removed on the PR above this
one.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass |
| Type check | `bun run check` | pass |
| Tests | `bun run test` | pass, 38/38 tasks; `@cire/host` 1197 |
| Format | `bun run fmt:check` | pass |
| Changesets | `bash scripts/validate-changesets.sh` | pass |
| Browser tier | `bun run test:browser` | not run — nothing in the diff reads CSS, layout or geometry |

Six cases in each of the eight store suites, not a representative sample: the accessor
still returns the previous rows after an invalidate; `hasCachedXxx` is false; `ensure`
refetches and restores freshness; the **security case**, named as such in its title —
the fetcher rejects, the promise rejects, the accessor is back to `null`; a
generation-stale success writes no rows and leaves the wedding stale; and
`__resetXxxCache()` clears the mark.

Two of those did not bite as first written and were rebuilt: the vendors reset case
asserted on `peekCachedVendors`, which never consults the stale set, so it passed
against a build with `stale.clear()` deleted; and the generation-stale case was folded
into a test starting from an empty cache, where `hasCachedXxx` reads false either way.

By hand: the flicker itself. Save a budget item, a checklist task, a registry gift or a
vendor and watch the panel — before this change the list blanks to its empty state for
one round trip and the panel height bounces twice.
