### PR TITLE
fix(cire): make the organiser stores' reactive readers actually reactive

### DIFF
--- a/.changeset/cire-store-reactive-readers.md
+++ b/.changeset/cire-store-reactive-readers.md
@@ -1,0 +1,36 @@
+---
+"@cire/host": patch
+---
+
+Fix the organiser stores' reactive readers so they actually are reactive.
+`vendorCount`, `openTaskCount` and `taskCounts` read `cache.get(weddingId)?.xxx()`,
+so from a cold cache the optional chain short-circuited before the signal's
+accessor was ever called, and a tracking computation built on any of them
+registered zero dependencies and never re-ran once the load resolved. The
+Overview's vendor-count widget and checklist card both stuck on their loading
+fallback for the life of the page whenever they raced ahead of the dashboard's
+own fetch. All three now mint the wedding's cache entry on read, exactly as
+`spentSoFar`/`upcomingPayments` already do, so they subscribe from a cold
+cache too. `peekCachedXxx` and `hasCachedXxx` are unchanged behaviourally, but
+now carry an accurate docblock instead of the false "non-reactive" or "without
+subscribing" claims some of them shipped with.
+
+`ensureXxxLoaded` now resolves `Promise<boolean>` instead of `Promise<void>`
+in all eight stores, so a caller can tell a generation-discarded load (which
+still fulfils, since nothing failed) apart from one that actually left the
+cache fresh. This is additive — no existing call site reads the resolved
+value yet.
+
+`upsertCachedEnquiry` is now a no-op against a `null` (not-loaded) cache
+instead of treating it as an empty list. The reachable path predates
+invalidation entirely: `EnquireDialog` (mounted from `DirectoryBrowseView` and
+`VendorsView`, neither of which ever loads the enquiries cache) upserts
+against a stone-cold cache, and writing `[next]` there used to collapse an
+organiser's whole inbox to the one just-sent enquiry and permanently suppress
+the refetch that would have restored the rest.
+
+Finally, every `invalidateXxx`'s comment now explains why dropping the
+in-flight slot is the right trade (one extra request, rather than joining a
+fetch whose result the generation guard is about to discard), and
+`invalidateRegistry`'s docblock drops its reference to the now-deleted
+`cire/wiki/todo/perf` page.

--- a/.changeset/cire-store-reactive-readers.md
+++ b/.changeset/cire-store-reactive-readers.md
@@ -7,9 +7,18 @@ Fix the organiser stores' reactive readers so they actually are reactive.
 so from a cold cache the optional chain short-circuited before the signal's
 accessor was ever called, and a tracking computation built on any of them
 registered zero dependencies and never re-ran once the load resolved. The
-Overview's vendor-count widget and checklist card both stuck on their loading
-fallback for the life of the page whenever they raced ahead of the dashboard's
-own fetch. All three now mint the wedding's cache entry on read, exactly as
+Overview's vendor-count widget stuck on `Loading your vendors…` for the life of
+the page: `Overview.tsx` memoises `vendorCount` at setup, before any fetch has
+resolved, so the memo captured `null` with no dependencies and nothing could
+make it recompute. The other two carried the identical defect without being
+reachable — `taskCounts` is only read inside a `<Show>` nested under the
+dashboard's own `!data.loading` gate, and `ensureTasksLoaded` is awaited in the
+same `Promise.all` that gate waits on, so the entry always exists by the time
+that read first happens; `openTaskCount` has no caller at all. They are fixed
+because a non-subscribing reader is one call site away from being the vendors
+bug again, not because they are currently broken on screen.
+
+All three now mint the wedding's cache entry on read, exactly as
 `spentSoFar`/`upcomingPayments` already do, so they subscribe from a cold
 cache too. `peekCachedXxx` and `hasCachedXxx` are unchanged behaviourally, but
 now carry an accurate docblock instead of the false "non-reactive" or "without

--- a/cire/host/src/lib/budget-store.ts
+++ b/cire/host/src/lib/budget-store.ts
@@ -63,6 +63,9 @@ export function budgetAccessor(weddingId: string): Accessor<BudgetSnapshot | nul
   return entryFor(weddingId).snapshot;
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedBudget(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.snapshot() != null;
 }
@@ -71,6 +74,9 @@ export function setCachedBudget(weddingId: string, snapshot: BudgetSnapshot): vo
   entryFor(weddingId).setSnapshot(snapshot);
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function peekCachedBudget(weddingId: string): BudgetSnapshot | null {
   return cache.get(weddingId)?.snapshot() ?? null;
 }
@@ -86,7 +92,13 @@ export function invalidateBudget(weddingId: string): void {
   // A load already in flight was issued against PRE-mutation state, so its
   // snapshot describes state that has since been mutated: the wedding's
   // GENERATION is bumped too, and a resolving fetch from an older generation
-  // discards its result instead of caching it.
+  // discards its result instead of caching it. Dropping the in-flight slot
+  // here (not just bumping the generation) means the next
+  // `ensureBudgetLoaded` does not join that doomed fetch — it starts a new
+  // one, at the cost of one extra request. That is the right trade: joining
+  // would await a promise whose result the generation guard is about to
+  // discard, leaving the caller with `false` and the view unrefreshed until
+  // whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -120,13 +132,13 @@ export function upcomingPayments(weddingId: string): PaymentRow[] {
     });
 }
 
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 export function ensureBudgetLoaded(
   weddingId: string,
   fetcher: () => Promise<BudgetSnapshot>,
-): Promise<void> {
-  if (hasCachedBudget(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedBudget(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -136,9 +148,10 @@ export function ensureBudgetLoaded(
           // A newer invalidation landed while this was in flight — its snapshot
           // describes state that has since been mutated, so drop it rather than
           // cache it.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedBudget(weddingId, snap);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/enquiries-store.ts
+++ b/cire/host/src/lib/enquiries-store.ts
@@ -51,6 +51,9 @@ export function enquiriesAccessor(weddingId: string): Accessor<EnquiryListItem[]
   return entryFor(weddingId).enquiries;
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedEnquiries(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.enquiries() != null;
 }
@@ -59,6 +62,9 @@ export function setCachedEnquiries(weddingId: string, items: EnquiryListItem[]):
   entryFor(weddingId).setEnquiries(items);
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function peekCachedEnquiries(weddingId: string): EnquiryListItem[] | null {
   return cache.get(weddingId)?.enquiries() ?? null;
 }
@@ -74,7 +80,12 @@ export function invalidateEnquiries(weddingId: string): void {
   // A load already in flight was issued against PRE-mutation state, so its
   // rows describe state that has since been mutated: the wedding's GENERATION
   // is bumped too, and a resolving fetch from an older generation discards its
-  // result instead of caching it.
+  // result instead of caching it. Dropping the in-flight slot here (not just
+  // bumping the generation) means the next `ensureEnquiriesLoaded` does not
+  // join that doomed fetch — it starts a new one, at the cost of one extra
+  // request. That is the right trade: joining would await a promise whose
+  // result the generation guard is about to discard, leaving the caller with
+  // `false` and the view unrefreshed until whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -88,7 +99,11 @@ const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 const stale = new Set<string>();
 
 export function upsertCachedEnquiry(weddingId: string, next: EnquiryListItem): void {
-  const cur = peekCachedEnquiries(weddingId) ?? [];
+  const cur = peekCachedEnquiries(weddingId);
+  // `null` is "not loaded", not "no rows". Writing a one-row list here would both
+  // hide the rest and flip `hasCachedEnquiries` to true, suppressing the refetch
+  // that would have restored them.
+  if (cur == null) return;
   const without = cur.filter((e) => e.id !== next.id);
   setCachedEnquiries(
     weddingId,
@@ -96,13 +111,13 @@ export function upsertCachedEnquiry(weddingId: string, next: EnquiryListItem): v
   );
 }
 
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 export function ensureEnquiriesLoaded(
   weddingId: string,
   fetcher: () => Promise<EnquiryListItem[]>,
-): Promise<void> {
-  if (hasCachedEnquiries(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedEnquiries(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -112,9 +127,10 @@ export function ensureEnquiriesLoaded(
           // A newer invalidation landed while this was in flight — its rows
           // describe state that has since been mutated, so drop them rather than
           // cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedEnquiries(weddingId, items);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/events-store.ts
+++ b/cire/host/src/lib/events-store.ts
@@ -75,7 +75,10 @@ export function eventsAccessor(weddingId: string): Accessor<EventRow[] | null> {
 }
 
 /** Has this wedding's events already been fetched in this session? When true a
- *  remounting `EventTable` can skip the network round-trip entirely. */
+ *  remounting `EventTable` can skip the network round-trip entirely.
+ *  Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedEvents(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.events() != null;
 }
@@ -114,7 +117,12 @@ export function invalidateEvents(weddingId: string): void {
   // bumped too, and a resolving fetch from an older generation discards its
   // result instead of caching it. Without this, the editor's invalidate-then-
   // reload after a successful save can re-cache exactly the rows the organiser
-  // just deleted.
+  // just deleted. Dropping the in-flight slot here (not just bumping the
+  // generation) means the next `ensureEventsLoaded` does not join that doomed
+  // fetch — it starts a new one, at the cost of one extra request. That is
+  // the right trade: joining would await a promise whose result the
+  // generation guard is about to discard, leaving the caller with `false`
+  // and the view unrefreshed until whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -130,7 +138,7 @@ const stale = new Set<string>();
 /** In-flight loads, keyed by weddingId, so panels mounting in the same tick
  *  share ONE fetch instead of racing two identical requests at the empty
  *  cache. */
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 /**
  * Load a wedding's events into the cache exactly once. A cache hit returns
@@ -142,8 +150,8 @@ const inflight = new Map<string, Promise<void>>();
 export function ensureEventsLoaded(
   weddingId: string,
   fetcher: () => Promise<EventRow[]>,
-): Promise<void> {
-  if (hasCachedEvents(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedEvents(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -152,9 +160,10 @@ export function ensureEventsLoaded(
         (rows) => {
           // A newer invalidation landed while this was in flight — its rows describe
           // state that has since been mutated, so drop them rather than cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedEvents(weddingId, rows);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/guests-store.ts
+++ b/cire/host/src/lib/guests-store.ts
@@ -60,7 +60,10 @@ export function guestsAccessor(weddingId: string): Accessor<OrganiserGuestRow[] 
 }
 
 /** Has this wedding's guest list already been fetched in this session? When true
- *  a remounting `GuestTable` can skip the network round-trip entirely. */
+ *  a remounting `GuestTable` can skip the network round-trip entirely.
+ *  Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedGuests(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.guests() != null;
 }
@@ -71,7 +74,10 @@ export function setCachedGuests(weddingId: string, guests: OrganiserGuestRow[]):
   entryFor(weddingId).setGuests(guests);
 }
 
-/** Read the current cached rows without subscribing (for an in-place patch). */
+/** Read the current cached rows for an in-place patch. Subscribes only when
+ *  the entry already exists — a read from a cold cache registers no
+ *  dependency. Never use it for a value a view must track; use the accessor
+ *  for that. */
 export function peekCachedGuests(weddingId: string): OrganiserGuestRow[] | null {
   return cache.get(weddingId)?.guests() ?? null;
 }
@@ -91,7 +97,12 @@ export function invalidateGuests(weddingId: string): void {
   // bumped too, and a resolving fetch from an older generation discards its
   // result instead of caching it. Without this, the editor's invalidate-then-
   // reload after a successful save can re-cache exactly the rows the organiser
-  // just deleted.
+  // just deleted. Dropping the in-flight slot here (not just bumping the
+  // generation) means the next `ensureGuestsLoaded` does not join that doomed
+  // fetch — it starts a new one, at the cost of one extra request. That is
+  // the right trade: joining would await a promise whose result the
+  // generation guard is about to discard, leaving the caller with `false`
+  // and the view unrefreshed until whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -107,7 +118,7 @@ const stale = new Set<string>();
 /** In-flight loads, keyed by weddingId, so two panels mounting in the same tick
  *  (e.g. GuestTable + Overview snapshot) share ONE fetch instead of racing two
  *  identical requests at the empty cache. */
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 /**
  * Load a wedding's guest rows into the cache exactly once. A cache hit returns
@@ -118,8 +129,8 @@ const inflight = new Map<string, Promise<void>>();
 export function ensureGuestsLoaded(
   weddingId: string,
   fetcher: () => Promise<OrganiserGuestRow[]>,
-): Promise<void> {
-  if (hasCachedGuests(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedGuests(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -128,9 +139,10 @@ export function ensureGuestsLoaded(
         (rows) => {
           // A newer invalidation landed while this was in flight — its rows describe
           // state that has since been mutated, so drop them rather than cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedGuests(weddingId, rows);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/households-store.ts
+++ b/cire/host/src/lib/households-store.ts
@@ -48,7 +48,10 @@ export function householdsAccessor(weddingId: string): Accessor<OrganiserHouseho
   return entryFor(weddingId).households;
 }
 
-/** Has this wedding's household list already been fetched in this session? */
+/** Has this wedding's household list already been fetched in this session?
+ *  Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedHouseholds(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.households() != null;
 }
@@ -68,7 +71,12 @@ export function invalidateHouseholds(weddingId: string): void {
   // bumped too, and a resolving fetch from an older generation discards its
   // result instead of caching it. Without this, the editor's invalidate-then-
   // reload after a successful save can re-cache exactly the household the
-  // organiser just deleted.
+  // organiser just deleted. Dropping the in-flight slot here (not just
+  // bumping the generation) means the next `ensureHouseholdsLoaded` does not
+  // join that doomed fetch — it starts a new one, at the cost of one extra
+  // request. That is the right trade: joining would await a promise whose
+  // result the generation guard is about to discard, leaving the caller with
+  // `false` and the view unrefreshed until whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -82,7 +90,7 @@ const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 const stale = new Set<string>();
 
 /** In-flight loads, keyed by weddingId, so concurrent mounts share ONE fetch. */
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 /**
  * Load a wedding's households into the cache exactly once. A cache hit returns
@@ -93,8 +101,8 @@ const inflight = new Map<string, Promise<void>>();
 export function ensureHouseholdsLoaded(
   weddingId: string,
   fetcher: () => Promise<OrganiserHouseholdRow[]>,
-): Promise<void> {
-  if (hasCachedHouseholds(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedHouseholds(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -103,9 +111,10 @@ export function ensureHouseholdsLoaded(
         (rows) => {
           // A newer invalidation landed while this was in flight — its rows describe
           // state that has since been mutated, so drop them rather than cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           entryFor(weddingId).setHouseholds(rows);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/registry-store.ts
+++ b/cire/host/src/lib/registry-store.ts
@@ -118,6 +118,9 @@ export function registryAccessor(weddingId: string): Accessor<RegistrySnapshot |
   return entryFor(weddingId).snapshot;
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedRegistry(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.snapshot() != null;
 }
@@ -126,6 +129,9 @@ export function setCachedRegistry(weddingId: string, snapshot: RegistrySnapshot)
   entryFor(weddingId).setSnapshot(snapshot);
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function peekCachedRegistry(weddingId: string): RegistrySnapshot | null {
   return cache.get(weddingId)?.snapshot() ?? null;
 }
@@ -136,20 +142,25 @@ export function peekCachedRegistry(weddingId: string): RegistrySnapshot | null {
  * Deleting the map entry would mint a fresh signal on the next `entryFor`, and
  * every view that captured the old accessor at mount would then read a signal
  * nothing writes to again — a dead view with stale content. This was the
- * repo-wide `P-W2` in `[[cire/wiki/todo/perf]]`; every sibling cache
- * (`vendors-store`, `budget-store`, `tasks-store`, `enquiries-store`,
- * `events-store`, `guests-store`, `households-store`) still notifies the same
- * way. What changed since is the VALUE: nulling it out here used to hide the
- * gift list and log behind a loading flash on every organiser edit, so the
- * snapshot is left in place and the wedding is marked `stale` instead.
- * `hasCachedRegistry` treats a stale id as a miss, which is what makes the
- * next `ensureRegistryLoaded` actually refetch rather than short-circuiting
- * on the (still-present) cached value.
+ * repo-wide `P-W2` finding; every sibling cache (`vendors-store`,
+ * `budget-store`, `tasks-store`, `enquiries-store`, `events-store`,
+ * `guests-store`, `households-store`) still notifies the same way. What
+ * changed since is the VALUE: nulling it out here used to hide the gift list
+ * and log behind a loading flash on every organiser edit, so the snapshot is
+ * left in place and the wedding is marked `stale` instead. `hasCachedRegistry`
+ * treats a stale id as a miss, which is what makes the next
+ * `ensureRegistryLoaded` actually refetch rather than short-circuiting on the
+ * (still-present) cached value.
  *
  * A load already in flight was issued against PRE-invalidation state, so its
  * snapshot describes state that has since been mutated: the wedding's
  * GENERATION is bumped too, and a resolving fetch from an older generation
- * discards its result instead of caching it.
+ * discards its result instead of caching it. Dropping the in-flight slot here
+ * (not just bumping the generation) means the next `ensureRegistryLoaded`
+ * does not join that doomed fetch — it starts a new one, at the cost of one
+ * extra request. That is the right trade: joining would await a promise
+ * whose result the generation guard is about to discard, leaving the caller
+ * with `false` and the view unrefreshed until whatever call comes next.
  */
 export function invalidateRegistry(weddingId: string): void {
   stale.add(weddingId);
@@ -172,13 +183,13 @@ export function stillWanted(item: RegistryItem): number {
   return Math.max(0, item.quantityWanted - item.quantityClaimed);
 }
 
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 export function ensureRegistryLoaded(
   weddingId: string,
   fetcher: () => Promise<RegistrySnapshot>,
-): Promise<void> {
-  if (hasCachedRegistry(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedRegistry(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -188,9 +199,10 @@ export function ensureRegistryLoaded(
           // A newer invalidation landed while this was in flight — its snapshot
           // describes state that has since been mutated, so drop it rather than
           // cache it.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedRegistry(weddingId, snap);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The snapshot still on screen was

--- a/cire/host/src/lib/tasks-store.ts
+++ b/cire/host/src/lib/tasks-store.ts
@@ -39,6 +39,9 @@ export function tasksAccessor(weddingId: string): Accessor<TaskRow[] | null> {
   return entryFor(weddingId).tasks;
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedTasks(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.tasks() != null;
 }
@@ -47,6 +50,9 @@ export function setCachedTasks(weddingId: string, tasks: TaskRow[]): void {
   entryFor(weddingId).setTasks(tasks);
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function peekCachedTasks(weddingId: string): TaskRow[] | null {
   return cache.get(weddingId)?.tasks() ?? null;
 }
@@ -62,7 +68,13 @@ export function invalidateTasks(weddingId: string): void {
   // A load already in flight was issued against PRE-mutation state, so its
   // rows describe state that has since been mutated: the wedding's
   // GENERATION is bumped too, and a resolving fetch from an older generation
-  // discards its result instead of caching it.
+  // discards its result instead of caching it. Dropping the in-flight slot
+  // here (not just bumping the generation) means the next
+  // `ensureTasksLoaded` does not join that doomed fetch — it starts a new
+  // one, at the cost of one extra request. That is the right trade: joining
+  // would await a promise whose result the generation guard is about to
+  // discard, leaving the caller with `false` and the view unrefreshed until
+  // whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -76,20 +88,24 @@ const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
 const stale = new Set<string>();
 
 /** Reactive open-task count for the Overview widget: `null` until first load.
- *  Reads without allocating a dangling signal for a never-loaded weddingId. */
+ *  Mints the wedding's cache entry so the read subscribes even from a cold
+ *  cache — the entry is per-wedding and bounded by the same key space
+ *  `cache`, `generation` and `stale` already occupy. */
 export function openTaskCount(weddingId: string): number | null {
-  const rows = cache.get(weddingId)?.tasks() ?? null;
+  const rows = entryFor(weddingId).tasks();
   if (rows == null) return null;
   return rows.filter((t) => t.status === "open").length;
 }
 
-/** Reactive open/done/total counts for the Overview completion bar: `null` until
- *  first load. Reads without allocating a dangling signal for a never-loaded
- *  weddingId (mirrors {@link openTaskCount}). */
+/** Reactive open/done/total counts for the Overview completion bar: `null`
+ *  until first load. Mints the wedding's cache entry so the read subscribes
+ *  even from a cold cache (mirrors {@link openTaskCount}) — the entry is
+ *  per-wedding and bounded by the same key space `cache`, `generation` and
+ *  `stale` already occupy. */
 export function taskCounts(
   weddingId: string,
 ): { open: number; done: number; total: number } | null {
-  const rows = cache.get(weddingId)?.tasks() ?? null;
+  const rows = entryFor(weddingId).tasks();
   if (rows == null) return null;
   let open = 0;
   let done = 0;
@@ -100,13 +116,13 @@ export function taskCounts(
   return { open, done, total: rows.length };
 }
 
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 export function ensureTasksLoaded(
   weddingId: string,
   fetcher: () => Promise<TaskRow[]>,
-): Promise<void> {
-  if (hasCachedTasks(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedTasks(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -116,9 +132,10 @@ export function ensureTasksLoaded(
           // A newer invalidation landed while this was in flight — its rows
           // describe state that has since been mutated, so drop them rather than
           // cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedTasks(weddingId, rows);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/src/lib/vendors-store.ts
+++ b/cire/host/src/lib/vendors-store.ts
@@ -45,6 +45,9 @@ export function vendorsAccessor(weddingId: string): Accessor<VendorRow[] | null>
   return entryFor(weddingId).vendors;
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function hasCachedVendors(weddingId: string): boolean {
   return !stale.has(weddingId) && cache.get(weddingId)?.vendors() != null;
 }
@@ -53,6 +56,9 @@ export function setCachedVendors(weddingId: string, vendors: VendorRow[]): void 
   entryFor(weddingId).setVendors(vendors);
 }
 
+/** Subscribes only when the entry already exists — a read from a cold cache
+ *  registers no dependency. Never use it for a value a view must track; use
+ *  the accessor for that. */
 export function peekCachedVendors(weddingId: string): VendorRow[] | null {
   return cache.get(weddingId)?.vendors() ?? null;
 }
@@ -68,7 +74,13 @@ export function invalidateVendors(weddingId: string): void {
   // A load already in flight was issued against PRE-mutation state, so its
   // rows describe state that has since been mutated: the wedding's
   // GENERATION is bumped too, and a resolving fetch from an older generation
-  // discards its result instead of caching it.
+  // discards its result instead of caching it. Dropping the in-flight slot
+  // here (not just bumping the generation) means the next
+  // `ensureVendorsLoaded` does not join that doomed fetch — it starts a new
+  // one, at the cost of one extra request. That is the right trade: joining
+  // would await a promise whose result the generation guard is about to
+  // discard, leaving the caller with `false` and the view unrefreshed until
+  // whatever call comes next.
   inflight.delete(weddingId);
   generation.set(weddingId, generationOf(weddingId) + 1);
 }
@@ -81,20 +93,23 @@ const generationOf = (weddingId: string) => generation.get(weddingId) ?? 0;
  *  while the refetch is in flight. */
 const stale = new Set<string>();
 
-/** Reactive vendor count for the Overview widget: `null` before first load. */
+/** Reactive vendor count for the Overview widget: `null` before first load.
+ *  Mints the wedding's cache entry so the read subscribes even from a cold
+ *  cache — the entry is per-wedding and bounded by the same key space
+ *  `cache`, `generation` and `stale` already occupy. */
 export function vendorCount(weddingId: string): number | null {
-  const rows = cache.get(weddingId)?.vendors() ?? null;
+  const rows = entryFor(weddingId).vendors();
   if (rows == null) return null;
   return rows.length;
 }
 
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<boolean>>();
 
 export function ensureVendorsLoaded(
   weddingId: string,
   fetcher: () => Promise<VendorRow[]>,
-): Promise<void> {
-  if (hasCachedVendors(weddingId)) return Promise.resolve();
+): Promise<boolean> {
+  if (hasCachedVendors(weddingId)) return Promise.resolve(true);
   let pending = inflight.get(weddingId);
   if (!pending) {
     const startedAt = generationOf(weddingId);
@@ -104,9 +119,10 @@ export function ensureVendorsLoaded(
           // A newer invalidation landed while this was in flight — its rows
           // describe state that has since been mutated, so drop them rather than
           // cache them.
-          if (generationOf(weddingId) !== startedAt) return;
+          if (generationOf(weddingId) !== startedAt) return false;
           setCachedVendors(weddingId, rows);
           stale.delete(weddingId);
+          return true;
         },
         (err: unknown) => {
           // The refetch was refused or failed. The rows still on screen were

--- a/cire/host/tests/components/Overview.checklist.test.tsx
+++ b/cire/host/tests/components/Overview.checklist.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
-import { render, screen } from "@solidjs/testing-library";
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
 import "@testing-library/jest-dom/vitest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import Overview from "../../src/components/Overview";
 import { __resetBudgetCache } from "../../src/lib/budget-store";
@@ -62,6 +62,10 @@ beforeEach(() => {
   setCachedGuests("wed_1", [{ familyId: "fam_a", firstName: "Al" } as never]);
 });
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("Overview checklist widget", () => {
   it("shows the N-of-M completion line", async () => {
     setCachedTasks("wed_1", [row({ id: "a", status: "open" }), row({ id: "b", status: "done" })]);
@@ -79,5 +83,39 @@ describe("Overview checklist widget", () => {
     // The containing <p> text should read "1 open task".
     const p = countSpan.closest("p");
     expect(p?.textContent?.replace(/\s+/g, " ").trim()).toMatch(/1 open task/i);
+  });
+
+  /**
+   * Regression test for #620, the twin of the two cases above. Both of those
+   * call `setCachedTasks` BEFORE `render`, which mints the wedding's cache
+   * entry ahead of time — the one state the pre-branch
+   * `cache.get(id)?.tasks() ?? null` reader handled correctly. Starting cold
+   * here (no seed) is what makes this case fail against the old reader:
+   * `taskCounts` was read for the first time while the cache was still
+   * empty, registered no dependency, and the Checklist card stayed on
+   * "Loading your tasks…" forever even after the fetch resolved.
+   */
+  it("cold: resolves off 'Loading your tasks…' once the tasks fetch completes", async () => {
+    authFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith("/settings"))
+        return json({ wedding: { weddingDate: null, currency: "AUD", budgetTotalMinor: null } });
+      if (url.endsWith("/rsvps")) return json({ events: [] });
+      if (url.endsWith("/tasks"))
+        return json({
+          tasks: [row({ id: "a", status: "open" }), row({ id: "b", status: "done" })],
+        });
+      if (url.endsWith("/events")) return json([]);
+      if (url.endsWith("/guests")) return json([]);
+      if (url.endsWith("/budget"))
+        return json({ items: [], payments: [], budgetTotalMinor: null, currency: "AUD" });
+      return json({}, 404);
+    });
+    render(() => <Overview weddingId="wed_1" onNavigate={() => {}} />);
+
+    const checklistCard = (await screen.findByText("Checklist")).closest("button")!;
+    await waitFor(() =>
+      expect(checklistCard.textContent!.replace(/\s+/g, " ").trim()).toMatch(/1 of 2 done/i),
+    );
+    expect(checklistCard.textContent).not.toMatch(/Loading your tasks…/i);
   });
 });

--- a/cire/host/tests/components/Overview.test.tsx
+++ b/cire/host/tests/components/Overview.test.tsx
@@ -33,6 +33,7 @@ import { __resetBudgetCache } from "../../src/lib/budget-store";
 import { __resetEventsCache } from "../../src/lib/events-store";
 import { __resetGuestsCache, setCachedGuests } from "../../src/lib/guests-store";
 import { __resetTasksCache } from "../../src/lib/tasks-store";
+import { __resetVendorsCache } from "../../src/lib/vendors-store";
 import { authFetchMock, resetOrganiserMocks } from "../test-support/mocks";
 
 function json(body: unknown, status = 200) {
@@ -42,14 +43,15 @@ function json(body: unknown, status = 200) {
   });
 }
 
-/** Route the five Overview fetches (settings, rsvps, events, guests, tasks) by URL so
- *  the order the component fires them in doesn't matter. */
+/** Route the six Overview fetches (settings, rsvps, events, guests, tasks, vendors) by
+ *  URL so the order the component fires them in doesn't matter. */
 function routeFetch(opts: {
   settings?: unknown;
   rsvps?: unknown;
   events?: unknown;
   guests?: unknown;
   tasks?: unknown;
+  vendors?: unknown;
 }) {
   authFetchMock.mockImplementation((url: string) => {
     if (url.endsWith("/settings")) return Promise.resolve(json({ wedding: opts.settings ?? {} }));
@@ -57,6 +59,7 @@ function routeFetch(opts: {
     if (url.endsWith("/events")) return Promise.resolve(json(opts.events ?? []));
     if (url.endsWith("/guests")) return Promise.resolve(json(opts.guests ?? []));
     if (url.endsWith("/tasks")) return Promise.resolve(json({ tasks: opts.tasks ?? [] }));
+    if (url.endsWith("/vendors")) return Promise.resolve(json({ vendors: opts.vendors ?? [] }));
     return Promise.resolve(json({}, 404));
   });
 }
@@ -128,6 +131,7 @@ describe("Overview", () => {
     __resetEventsCache();
     __resetGuestsCache();
     __resetTasksCache();
+    __resetVendorsCache();
   });
 
   it("shows the getting-started empty-state for a brand-new wedding", async () => {
@@ -211,6 +215,44 @@ describe("Overview", () => {
     expect(screen.queryByText(/Coming soon/i)).toBeNull();
     // Checklist shows the live empty state (tasks loaded, none open).
     await waitFor(() => expect(screen.getByText(/No tasks yet/i)).toBeTruthy());
+  });
+
+  /**
+   * Regression test for #620: `vendorCount` used to read
+   * `cache.get(weddingId)?.vendors() ?? null`, so from a COLD cache the
+   * optional chain short-circuited before the accessor ran, `vendorCountValue`
+   * registered zero dependencies, and the Vendors card never left "Loading
+   * your vendors…" even once the fetch resolved. This starts the cache cold
+   * (no `setCachedVendors` before render, unlike the pre-seeded tests
+   * elsewhere in this file) so the widget can only pass if the memo actually
+   * subscribes to the load.
+   */
+  it("shows the live vendor count once the cold vendors cache resolves", async () => {
+    routeFetch({
+      settings: { weddingDate: null, currency: "AUD", budgetTotalMinor: null },
+      rsvps: RSVPS,
+      events: EVENTS,
+      guests: GUESTS,
+      tasks: [],
+      vendors: [
+        { id: "v1", weddingId: "wed_1", name: "Florist", category: "florals", status: "booked" },
+        { id: "v2", weddingId: "wed_1", name: "Caterer", category: "catering", status: "quoted" },
+        { id: "v3", weddingId: "wed_1", name: "DJ", category: "music", status: "researching" },
+      ],
+    });
+    render(() => <Overview weddingId="wed_1" onNavigate={vi.fn()} />);
+    // The vendors cache starts cold (nothing seeded before render), so this
+    // can only pass if `vendorCountValue` actually subscribes to the load —
+    // the #620 bug left it permanently stuck on the "Loading your vendors…"
+    // fallback because the memo captured its (dependency-free) `null` value
+    // before the fetch ever resolved. The count ("3") sits in its own <span>
+    // inside the card's <p>, so match on the card's normalised text instead
+    // of a single text node.
+    const vendorsCard = (await screen.findByText("Vendors")).closest("button")!;
+    await waitFor(() =>
+      expect(vendorsCard.textContent!.replace(/\s+/g, " ").trim()).toMatch(/3 vendors tracked/i),
+    );
+    expect(vendorsCard.textContent).not.toMatch(/Loading your vendors…/i);
   });
 
   it("renders the RSVP progress bar and per-event attending breakdown", async () => {

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -204,7 +204,9 @@ describe("budget-store", () => {
   it("ensureBudgetLoaded refetches after invalidate and replaces the stale snapshot on success", async () => {
     await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "a" })] }));
     invalidateBudget("wed_1");
-    await ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "b" })] }));
+    await expect(
+      ensureBudgetLoaded("wed_1", async () => snap({ items: [item({ id: "b" })] })),
+    ).resolves.toBe(true);
     expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["b"]);
     expect(hasCachedBudget("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/budget-store.test.ts
+++ b/cire/host/tests/lib/budget-store.test.ts
@@ -113,6 +113,17 @@ describe("budget-store", () => {
     expect(hasCachedBudget("wed_1")).toBe(false);
   });
 
+  it("ensureBudgetLoaded resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return snap({ items: [item({})] });
+    };
+    await expect(ensureBudgetLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureBudgetLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(calls).toBe(1);
+  });
+
   it("hasCachedBudget is false after invalidate, so the next load refetches", async () => {
     await ensureBudgetLoaded("wed_1", async () => snap({}));
     expect(hasCachedBudget("wed_1")).toBe(true);
@@ -291,7 +302,7 @@ describe("budget-store", () => {
 
     invalidateBudget("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(budgetAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
     expect(hasCachedBudget("wed_1")).toBe(false);

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -111,7 +111,9 @@ describe("enquiries-store", () => {
   it("ensureEnquiriesLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     setCachedEnquiries("wed_1", [item({ id: "enq_a" })]);
     invalidateEnquiries("wed_1");
-    await ensureEnquiriesLoaded("wed_1", async () => [item({ id: "enq_b" })]);
+    await expect(ensureEnquiriesLoaded("wed_1", async () => [item({ id: "enq_b" })])).resolves.toBe(
+      true,
+    );
     expect(enquiriesAccessor("wed_1")()?.map((e) => e.id)).toEqual(["enq_b"]);
     expect(hasCachedEnquiries("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/enquiries-store.test.ts
+++ b/cire/host/tests/lib/enquiries-store.test.ts
@@ -61,6 +61,42 @@ describe("enquiries-store", () => {
     expect(rows.map((r) => r.id)).toContain("enq_2");
   });
 
+  /**
+   * #606: `null` means "not loaded", not "no rows". The simplest reachable
+   * path has nothing to do with invalidation — `EnquireDialog` calls
+   * `upsertCachedEnquiry` from `DirectoryBrowseView`/`VendorsView`, neither of
+   * which ever loads the enquiries cache, so this hits a stone-cold cache. A
+   * `peek ?? []` here used to collapse the (unfetched) inbox to a single row
+   * and flip `hasCachedEnquiries` to true, permanently suppressing the
+   * refetch that would have restored the rest.
+   */
+  it("upsertCachedEnquiry is a no-op against a cold cache (the EnquireDialog path)", () => {
+    upsertCachedEnquiry("wed_1", item({ id: "enq_1" }));
+    expect(hasCachedEnquiries("wed_1")).toBe(false);
+    expect(enquiriesAccessor("wed_1")()).toBeNull();
+  });
+
+  /**
+   * The second reachable path, introduced by PR #864: invalidate no longer
+   * nulls the signal, but the FAILURE branch of `ensureEnquiriesLoaded` still
+   * does — so a refused refetch followed by an upsert reaches the same
+   * "null cache" state as the cold-start path above.
+   */
+  it("upsertCachedEnquiry is a no-op after a refused refetch has nulled the signal", async () => {
+    setCachedEnquiries("wed_1", [item({ id: "enq_1" })]);
+    invalidateEnquiries("wed_1");
+    await expect(
+      ensureEnquiriesLoaded("wed_1", async () => {
+        throw new Error("403");
+      }),
+    ).rejects.toThrow("403");
+    expect(enquiriesAccessor("wed_1")()).toBeNull();
+
+    upsertCachedEnquiry("wed_1", item({ id: "enq_2" }));
+    expect(hasCachedEnquiries("wed_1")).toBe(false);
+    expect(enquiriesAccessor("wed_1")()).toBeNull();
+  });
+
   it("invalidateEnquiries clears the cache so a reload refetches", async () => {
     setCachedEnquiries("wed_1", [item()]);
     invalidateEnquiries("wed_1");
@@ -101,6 +137,17 @@ describe("enquiries-store", () => {
     invalidateEnquiries("wed_1");
     expect(mounted()).toHaveLength(1);
     expect(hasCachedEnquiries("wed_1")).toBe(false);
+  });
+
+  it("ensureEnquiriesLoaded resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return [item()];
+    };
+    await expect(ensureEnquiriesLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureEnquiriesLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(calls).toBe(1);
   });
 
   it("hasCachedEnquiries is false after invalidate", () => {
@@ -224,7 +271,7 @@ describe("enquiries-store", () => {
 
     invalidateEnquiries("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(enquiriesAccessor("wed_1")()?.map((r) => r.id)).toEqual(["seed"]);
     expect(hasCachedEnquiries("wed_1")).toBe(false);

--- a/cire/host/tests/lib/events-store.test.ts
+++ b/cire/host/tests/lib/events-store.test.ts
@@ -39,6 +39,13 @@ describe("ensureEventsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    const fetcher = vi.fn(async () => [ROW]);
+    await expect(ensureEventsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureEventsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
     const failing = vi.fn(async () => {
       throw new Error("network down");
@@ -174,7 +181,7 @@ describe("ensureEventsLoaded", () => {
 
     invalidateEvents("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["seed"]);
     expect(hasCachedEvents("wed_1")).toBe(false);

--- a/cire/host/tests/lib/events-store.test.ts
+++ b/cire/host/tests/lib/events-store.test.ts
@@ -124,7 +124,9 @@ describe("ensureEventsLoaded", () => {
   it("ensureEventsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     await ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "a" }]);
     invalidateEvents("wed_1");
-    await ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "b" }]);
+    await expect(ensureEventsLoaded("wed_1", async () => [{ ...ROW, id: "b" }])).resolves.toBe(
+      true,
+    );
     expect(eventsAccessor("wed_1")()?.map((r) => r.id)).toEqual(["b"]);
     expect(hasCachedEvents("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/guests-store.test.ts
+++ b/cire/host/tests/lib/guests-store.test.ts
@@ -39,6 +39,13 @@ describe("ensureGuestsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    const fetcher = vi.fn(async () => [ROW]);
+    await expect(ensureGuestsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureGuestsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
     const failing = vi.fn(async () => {
       throw new Error("network down");
@@ -184,7 +191,7 @@ describe("ensureGuestsLoaded", () => {
 
     invalidateGuests("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["seed"]);
     expect(hasCachedGuests("wed_1")).toBe(false);

--- a/cire/host/tests/lib/guests-store.test.ts
+++ b/cire/host/tests/lib/guests-store.test.ts
@@ -134,7 +134,9 @@ describe("ensureGuestsLoaded", () => {
   it("ensureGuestsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     await ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "a" }]);
     invalidateGuests("wed_1");
-    await ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]);
+    await expect(
+      ensureGuestsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]),
+    ).resolves.toBe(true);
     expect(guestsAccessor("wed_1")()?.map((r) => r.familyId)).toEqual(["b"]);
     expect(hasCachedGuests("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -51,6 +51,13 @@ describe("ensureHouseholdsLoaded", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    const fetcher = vi.fn(async () => [ROW]);
+    await expect(ensureHouseholdsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureHouseholdsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects every waiter on failure, caches nothing, and retries next call", async () => {
     const failing = vi.fn(async () => {
       throw new Error("network down");
@@ -208,7 +215,7 @@ describe("ensureHouseholdsLoaded", () => {
 
     invalidateHouseholds("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["seed"]);
     expect(hasCachedHouseholds("wed_1")).toBe(false);

--- a/cire/host/tests/lib/households-store.test.ts
+++ b/cire/host/tests/lib/households-store.test.ts
@@ -145,7 +145,9 @@ describe("ensureHouseholdsLoaded", () => {
   it("ensureHouseholdsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     await ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "a" }]);
     invalidateHouseholds("wed_1");
-    await ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]);
+    await expect(
+      ensureHouseholdsLoaded("wed_1", async () => [{ ...ROW, familyId: "b" }]),
+    ).resolves.toBe(true);
     expect(householdsAccessor("wed_1")()?.map((h) => h.familyId)).toEqual(["b"]);
     expect(hasCachedHouseholds("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -247,7 +247,9 @@ describe("registry-store", () => {
   it("ensureRegistryLoaded refetches after invalidate and replaces the stale snapshot on success", async () => {
     await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "a" })] }));
     invalidateRegistry("wed_1");
-    await ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "b" })] }));
+    await expect(
+      ensureRegistryLoaded("wed_1", async () => snapshot({ items: [item({ id: "b" })] })),
+    ).resolves.toBe(true);
     expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["b"]);
     expect(hasCachedRegistry("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/registry-store.test.ts
+++ b/cire/host/tests/lib/registry-store.test.ts
@@ -159,6 +159,17 @@ describe("registry-store", () => {
     expect(hasCachedRegistry("wed_1")).toBe(false);
   });
 
+  it("ensureRegistryLoaded resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return snapshot();
+    };
+    await expect(ensureRegistryLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureRegistryLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(calls).toBe(1);
+  });
+
   it("hasCachedRegistry is false after invalidate, so the next load refetches", async () => {
     await ensureRegistryLoaded("wed_1", async () => snapshot());
     expect(hasCachedRegistry("wed_1")).toBe(true);
@@ -293,7 +304,7 @@ describe("registry-store", () => {
 
     invalidateRegistry("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(registryAccessor("wed_1")()?.items.map((i) => i.id)).toEqual(["seed"]);
     expect(hasCachedRegistry("wed_1")).toBe(false);

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -1,3 +1,4 @@
+import { createEffect, createRoot } from "solid-js";
 import { describe, expect, it, beforeEach } from "vitest";
 
 import {
@@ -63,6 +64,61 @@ describe("tasks-store", () => {
   });
 
   /**
+   * The regression test for the actual bug (#620): `openTaskCount` used to
+   * read `cache.get(weddingId)?.tasks()`, so from a COLD cache the optional
+   * chain short-circuited before the accessor was ever called — a tracking
+   * computation that only reads `openTaskCount` registered zero dependencies
+   * and never re-ran once the load resolved. `expect(openTaskCount(...)).toBe(2)`
+   * after an await (the test above) can't see that: it re-reads the map
+   * directly on every call, so it passes against the broken code too. Only a
+   * live tracking computation, asserted on the values it actually observed,
+   * proves the subscription fired.
+   */
+  it("a tracking computation reading only openTaskCount re-runs once the cold load resolves", async () => {
+    const seen: (number | null)[] = [];
+    const dispose = createRoot((d) => {
+      createEffect(() => {
+        seen.push(openTaskCount("wed_1"));
+      });
+      return d;
+    });
+    await ensureTasksLoaded("wed_1", async () => [
+      row({ id: "a", status: "open" }),
+      row({ id: "b", status: "done" }),
+      row({ id: "c", status: "open" }),
+    ]);
+    // Let any effect queued by the cache write flush before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    dispose();
+    expect(seen).toEqual([null, 2]);
+  });
+
+  /**
+   * Same regression, for `taskCounts`. It returns a fresh object on every
+   * run, so the observed values are asserted structurally, never by identity.
+   */
+  it("a tracking computation reading only taskCounts re-runs once the cold load resolves", async () => {
+    const seen: ({ open: number; done: number; total: number } | null)[] = [];
+    const dispose = createRoot((d) => {
+      createEffect(() => {
+        seen.push(taskCounts("wed_1"));
+      });
+      return d;
+    });
+    await ensureTasksLoaded("wed_1", async () => [
+      row({ id: "a", status: "open" }),
+      row({ id: "b", status: "done" }),
+      row({ id: "c", status: "open" }),
+    ]);
+    // Let any effect queued by the cache write flush before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    dispose();
+    expect(seen).toEqual([null, { open: 2, done: 1, total: 3 }]);
+  });
+
+  /**
    * The regression test for the actual bug: `entryFor` mints the signal once
    * and a mounted Checklist view captures that accessor at mount. Deleting
    * the map entry on invalidate would leave that accessor pointed at a
@@ -77,6 +133,17 @@ describe("tasks-store", () => {
     invalidateTasks("wed_1");
     expect(mounted()).not.toBeNull();
     expect(hasCachedTasks("wed_1")).toBe(false);
+  });
+
+  it("ensureTasksLoaded resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return [row({})];
+    };
+    await expect(ensureTasksLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureTasksLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(calls).toBe(1);
   });
 
   it("hasCachedTasks is false after invalidate, so the next load refetches", async () => {
@@ -213,7 +280,7 @@ describe("tasks-store", () => {
 
     invalidateTasks("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["seed"]);
     expect(hasCachedTasks("wed_1")).toBe(false);

--- a/cire/host/tests/lib/tasks-store.test.ts
+++ b/cire/host/tests/lib/tasks-store.test.ts
@@ -223,7 +223,7 @@ describe("tasks-store", () => {
   it("ensureTasksLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     await ensureTasksLoaded("wed_1", async () => [row({ id: "a" })]);
     invalidateTasks("wed_1");
-    await ensureTasksLoaded("wed_1", async () => [row({ id: "b" })]);
+    await expect(ensureTasksLoaded("wed_1", async () => [row({ id: "b" })])).resolves.toBe(true);
     expect(tasksAccessor("wed_1")()?.map((t) => t.id)).toEqual(["b"]);
     expect(hasCachedTasks("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -207,7 +207,9 @@ describe("vendors-store", () => {
   it("ensureVendorsLoaded refetches after invalidate and replaces the stale rows on success", async () => {
     await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "a" })]);
     invalidateVendors("wed_1");
-    await ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })]);
+    await expect(ensureVendorsLoaded("wed_1", async () => [vendor({ id: "b" })])).resolves.toBe(
+      true,
+    );
     expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["b"]);
     expect(hasCachedVendors("wed_1")).toBe(true);
   });

--- a/cire/host/tests/lib/vendors-store.test.ts
+++ b/cire/host/tests/lib/vendors-store.test.ts
@@ -1,3 +1,4 @@
+import { createEffect, createRoot } from "solid-js";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -55,6 +56,37 @@ describe("vendors-store", () => {
     expect(vendorCount("wed_1")).toBe(3);
   });
 
+  /**
+   * The regression test for the actual bug (#620): `vendorCount` used to read
+   * `cache.get(weddingId)?.vendors()`, so from a COLD cache the optional
+   * chain short-circuited before the accessor was ever called — a tracking
+   * computation that only reads `vendorCount` registered zero dependencies
+   * and never re-ran once the load resolved. `expect(vendorCount(...)).toBe(3)`
+   * after an await (the test above) can't see that: it re-reads the map
+   * directly on every call, so it passes against the broken code too. Only a
+   * live tracking computation, asserted on the values it actually observed,
+   * proves the subscription fired.
+   */
+  it("a tracking computation reading only vendorCount re-runs once the cold load resolves", async () => {
+    const seen: (number | null)[] = [];
+    const dispose = createRoot((d) => {
+      createEffect(() => {
+        seen.push(vendorCount("wed_1"));
+      });
+      return d;
+    });
+    await ensureVendorsLoaded("wed_1", async () => [
+      vendor({ id: "a" }),
+      vendor({ id: "b" }),
+      vendor({ id: "c" }),
+    ]);
+    // Let any effect queued by the cache write flush before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    dispose();
+    expect(seen).toEqual([null, 3]);
+  });
+
   it("invalidateVendors marks the cache stale without nulling the raw signal", async () => {
     await ensureVendorsLoaded("wed_1", async () => [vendor({})]);
     expect(peekCachedVendors("wed_1")).not.toBeNull();
@@ -69,6 +101,17 @@ describe("vendors-store", () => {
     // only promises it for the mounted-accessor / ensureVendorsLoaded path.
     expect(peekCachedVendors("wed_1")).not.toBeNull();
     expect(vendorCount("wed_1")).toBe(1);
+  });
+
+  it("ensureVendorsLoaded resolves true after a normal load, and true again on a cache hit without refetching", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return [vendor({})];
+    };
+    await expect(ensureVendorsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    await expect(ensureVendorsLoaded("wed_1", fetcher)).resolves.toBe(true);
+    expect(calls).toBe(1);
   });
 
   it("inflight deduplication: two concurrent calls fire fetcher once", async () => {
@@ -221,7 +264,7 @@ describe("vendors-store", () => {
 
     invalidateVendors("wed_1"); // a second invalidate, while that load is still in flight
     release();
-    await pending;
+    await expect(pending).resolves.toBe(false);
 
     expect(vendorsAccessor("wed_1")()?.map((v) => v.id)).toEqual(["seed"]);
     expect(hasCachedVendors("wed_1")).toBe(false);

--- a/wiki/architecture/cire-host-portal-layout.md
+++ b/wiki/architecture/cire-host-portal-layout.md
@@ -283,11 +283,21 @@ Shared export surface, and what each does under a stale mark:
 | `ensureXxxLoaded(id, fetcher)` | No-op if already fresh; otherwise dedupes and fetches. Success writes the rows and clears the stale mark; failure blanks the signal and rethrows. Both branches generation-guarded |
 
 **Known gap, tracked in #620:** `peekCachedXxx` and the readers built
-directly on it — `spentSoFar`/`upcomingPayments` (`budget-store.ts`) and
-`vendorCount` (`vendors-store.ts`) — don't consult the stale mark, so they
-keep returning pre-invalidate figures for the length of the refetch. A
-deliberate trade for now, and not yet even inconsistency-checked across the
-other six stores' own derived readers.
+directly on it — `spentSoFar`/`upcomingPayments` (`budget-store.ts`) — don't
+consult the stale mark, so they keep returning pre-invalidate figures for the
+length of the refetch. A deliberate trade for now, and not yet even
+inconsistency-checked across the other six stores' own derived readers.
+`vendorCount` (`vendors-store.ts`), `openTaskCount` and `taskCounts`
+(`tasks-store.ts`) no longer belong in that first group: they used to read
+`cache.get(id)?.xxx()`, so from a cold cache the optional chain short-circuited
+before the accessor ever ran and a tracking computation reading them
+registered no dependency at all — not a stale-mark gap but a missing
+subscription. They now mint the wedding's cache entry and subscribe, the
+same as `spentSoFar`/`upcomingPayments` already did, so they re-render once a
+load resolves. They still don't consult the stale mark, so the same
+pre-invalidate-figures trade this section describes applies to them too —
+what changed is that they update at all, not that they update the moment a
+refetch starts.
 
 Shipped across all eight caches by PR #860 (write through the signal instead
 of deleting the cache entry on invalidate) and PR #864 (this

--- a/wiki/systems/cire-checklist-tasks.md
+++ b/wiki/systems/cire-checklist-tasks.md
@@ -103,7 +103,7 @@ Public API:
 | `tasksAccessor(weddingId)` | Reactive `Accessor<TaskRow[] \| null>` |
 | `hasCachedTasks(weddingId)` | Boolean: are the cached tasks fresh? `false` both before the first load and while the wedding is marked stale (see [[cire-host-portal-layout#Organiser client caches: stale-while-revalidate]]) — it is the refetch trigger, not a render gate |
 | `setCachedTasks(weddingId, tasks)` | Populate/replace cache from a fetch. Does not clear the stale mark |
-| `peekCachedTasks(weddingId)` | Non-reactive snapshot |
+| `peekCachedTasks(weddingId)` | Snapshot read; subscribes only once the entry exists — never track it, use `tasksAccessor` |
 | `invalidateTasks(weddingId)` | Mark stale after a write. The rows stay on screen and the signal is untouched — the next `ensureTasksLoaded` is what refetches |
 | `ensureTasksLoaded(weddingId, fetcher)` | Fetch if not fresh; dedupes concurrent callers. On success, writes the rows and clears the stale mark; on a refused/failed refetch, blanks the signal and rethrows |
 | `openTaskCount(weddingId)` | `number \| null` — open-task count for the Overview widget |


### PR DESCRIPTION
## Summary

Three exported readers in the organiser stores were documented as "Reactive" and were
not. They read `cache.get(weddingId)?.xxx() ?? null`, and when the map entry is absent
— the cold start, because nothing mints it until `ensureXxxLoaded`'s success branch
writes — the optional chain short-circuits **before the accessor is called**. No signal
is read, so a tracked computation built on the result registers zero dependencies, and
a computation with no dependencies never re-runs.

One of the three is a live user-visible bug: `Overview.tsx:334` memoises `vendorCount`
at component setup, before any fetch has resolved, so on the Overview-first path the
memo captures `null` with no dependencies and `Overview.tsx:662` renders
`Loading your vendors…` for the life of the page.

- The other two carry the identical defect without being reachable. `taskCounts` is
  read only inside a `<Show>` nested under the dashboard's own `!data.loading` gate,
  and `ensureTasksLoaded` is awaited in the same `Promise.all` that gate waits on, so
  the entry always exists by the time that read first happens. `openTaskCount` has no
  caller at all. Both are fixed because a non-subscribing reader is one call site away
  from being the vendors bug again — not because they are broken on screen today.
- All three now read `entryFor(weddingId).xxx()`, which mints the entry and subscribes,
  exactly as `budget-store.ts`'s `spentSoFar` and `upcomingPayments` already did. That
  allocates no id the load path did not already allocate.
- The docblocks were the bug written down as a feature — `tasks-store.ts` promised
  "Reads without allocating a dangling signal for a never-loaded weddingId". The six
  `peekCachedXxx` and eight `hasCachedXxx` now say what is true: they subscribe **only
  when the entry already exists**, so a cold read registers no dependency. Not
  "non-reactive" — they do subscribe once it is there, and `Overview.tsx` relies on it.

## Workspaces affected

`@cire/host`. One changeset naming `"@cire/host": patch` and nothing else. Two more
`@cire/host` changesets arrive from the PRs beneath it; changesets are additive per
package, so three on one branch is expected and valid.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#620 | `P-W3` |
| xchromo/osn-tracker#605 | `S-I1` |
| xchromo/osn-tracker#606 | `S-I3` |
| xchromo/osn-tracker#600 | `P-L1` |

Closes xchromo/osn-tracker#620
Closes xchromo/osn-tracker#605
Closes xchromo/osn-tracker#606
Closes xchromo/osn-tracker#600

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#621 | `P-I` |
| xchromo/osn-tracker#622 | `S-L` |

## Decisions

### Fix the readers per store rather than add a shared helper — `P-W3`

- **Issue** — #620 proposed a shared cross-store read helper so a call site shows
  whether it subscribes.
- **Why** — the trap is that `entryFor(id).xxx()` and `cache.get(id)?.xxx()` look
  alike and behave differently.
- **Solution** — the three readers use `entryFor`, and every `peekCachedXxx` /
  `hasCachedXxx` gains an accurate docblock.
- **Rationale** — the eight stores are independent duplicates by design, and a shared
  import would be the first thing coupling them. The honest counter-argument is on the
  record: docblocks are what failed here the first time, so the durable version of this
  guard is mechanical — filed as xchromo/osn-tracker#621, and deliberately not bundled
  into this PR.

### `ensureXxxLoaded` resolves a boolean — `S-I1`

- **Issue** — when the generation guard fires, `ensureXxxLoaded` returns early and the
  promise **fulfils**, though nothing was cached.
- **Why** — a caller that reads resolution as "data is loaded" renders an empty state
  with no error and no retry, and `onMount` has already run.
- **Solution** — `Promise<boolean>` in all eight stores: `true` when the call left the
  cache fresh, `false` when the guard discarded the result. A failure still **rejects**.
- **Rationale** — additive; all 24 call sites ignore the value and keep compiling. No
  retry is added: a wedding invalidated repeatedly would spin, and the honest answer
  for the organiser is "this did not load".

### `upsertCachedEnquiry` stops reading `null` as `[]` — `S-I3`

- **Issue** — it did `peekCachedEnquiries(id) ?? []` and wrote the result back, so
  against a `null` cache it replaced the whole list with the one upserted row **and**
  flipped `hasCachedEnquiries` to true, suppressing the refetch that would have
  restored the rest.
- **Why** — filed as unreachable, and it is not. `EnquireDialog.tsx:46` calls it, and
  that dialog is mounted from `DirectoryBrowseView` and `VendorsView`, neither of which
  ever loads the enquiries cache — so an organiser who already has enquiries, opens the
  directory and sends one more watches their inbox collapse to that row. A second path
  arrived with the PR below: the failure branch nulls the signal, so a refused refetch
  followed by an upsert lands in the same place, and the old behaviour re-armed the
  cache after an authorisation recheck had deliberately blanked it.
- **Solution** — return early when the cache holds `null`.
- **Rationale** — `?? []` conflates "no rows" with "not loaded", and those must stay
  distinct wherever a `has*` predicate gates refetching.

### #600 is comment-only — `P-L1`

- **Issue** — every `invalidateXxx` drops the in-flight slot and none said why.
- **Why** — joining that fetch would await a promise the generation guard is about to
  discard, so the next `ensureXxxLoaded` starts a fresh one at the cost of exactly one
  extra request per invalidate-during-flight. The behaviour is right; the next reader's
  instinct is to "fix" the duplicate request by keeping the slot.
- **Solution** — all eight comments now name the trade.
- **Rationale** — nothing to change but the explanation.

### Correct the changeset's claim about which card was broken — `approach`

- **Issue** — the changeset said the vendor-count widget and the checklist card both
  stuck on their loading fallback.
- **Why** — changeset prose ships verbatim into a `CHANGELOG.md`, and only one card
  ever stuck.
- **Solution** — corrected, with the reason the checklist card cannot observe it.
- **Rationale** — found by reverting both readers and running the Overview suites: one
  test fails, and every checklist test stays green. The tracker issue carried the same
  wrong claim in a comment of mine and has been corrected there too.

**Out of scope** — xchromo/osn-tracker#621 and xchromo/osn-tracker#622. Two test
suggestions from the review pass were deferred, and three module wiki pages were left
for a separate sweep.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass |
| Type check | `bun run check` | pass |
| Tests | `bun run test` | pass, 38/38 tasks; `@cire/host` 1212 |
| Format | `bun run fmt:check` | pass |
| Changesets | `bash scripts/validate-changesets.sh` | pass |
| Browser tier | `bun run test:browser` | not run — nothing in the diff reads CSS, layout or geometry |

The regression test is the awkward one, so it is worth naming what does **not** work:
`expect(vendorCount(id)).toBe(3)` after an `await` passes against the broken code,
because it re-reads the map on every call. Only a live tracking computation, asserted
on the values it observed, proves the subscription fired — so all three readers have a
`createRoot`/`createEffect` test asserting `seen` is `[null, 3]` rather than `[null]`,
and Overview has a component test that renders against a cold vendors cache and
asserts the card leaves its fallback.

Per store: `ensureXxxLoaded` resolves `true` after a normal load, `true` on a cache hit
without refetching, `true` on the post-invalidate revalidate, and `false` when the
generation guard discards. Pinned with `toBe`, never `toBeTruthy` — the old code
resolved `undefined`, so a truthiness assertion would pass either way.

By hand: land on the Overview of a wedding with vendors, from a cold page load rather
than by navigating back from the Vendors module. That is the path the memo breaks on.
