### PR TITLE
fix(deps): clear two high browserslist advisories and take jose 6.2.10

### DIFF
--- a/.changeset/brown-pugs-repeat.md
+++ b/.changeset/brown-pugs-repeat.md
@@ -1,6 +1,14 @@
 ---
+"@osn/client": patch
+"@osn/landing": patch
 "@osn/social": patch
+"@osn/ui": patch
+"@pulse/landing": patch
 "@pulse/web": patch
+"@shared/rp-auth": patch
+"@shared/sortable": patch
+"@shared/toast": patch
+"@tools/lab": patch
 ---
 
-Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through @babel/core. Build output is unchanged.
+Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through the @babel/core that vite-plugin-solid and @astrojs/solid-js pull in. Every package listed here sits on that chain. Build output is byte-identical.

--- a/.changeset/brown-pugs-repeat.md
+++ b/.changeset/brown-pugs-repeat.md
@@ -1,0 +1,6 @@
+---
+"@osn/social": patch
+"@pulse/web": patch
+---
+
+Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through @babel/core. Build output is unchanged.

--- a/.changeset/lazy-hounds-clap.md
+++ b/.changeset/lazy-hounds-clap.md
@@ -1,0 +1,5 @@
+---
+"@cire/api": patch
+---
+
+Take jose 6.2.10 (from 6.2.4). Releases 6.2.5 through 6.2.10 are all JOSE and JWT input-validation hardening, covering the access JWTs the organiser routes verify. No API change; the tightening only narrows what parses.

--- a/.changeset/olive-moons-smoke.md
+++ b/.changeset/olive-moons-smoke.md
@@ -1,5 +1,8 @@
 ---
 "@cire/host": patch
+"@cire/invites": patch
+"@cire/landing": patch
+"@cire/vendor": patch
 ---
 
-Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through vite-plugin-solid's Babel chain. Build output is unchanged.
+Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through the @babel/core that vite-plugin-solid and @astrojs/solid-js pull in. Build output is byte-identical.

--- a/.changeset/olive-moons-smoke.md
+++ b/.changeset/olive-moons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@cire/host": patch
+---
+
+Pin browserslist to ^4.28.8 via a root override, clearing two high-severity advisories (GHSA-c83g-rgw3-j3cx unbounded query-cache growth, GHSA-73wf-gq98-2v4g crash and prototype write on untrusted browserslist-stats.json). Both affect <= 4.28.6, and the tree resolved 4.28.2 transitively through vite-plugin-solid's Babel chain. Build output is unchanged.

--- a/.changeset/quiet-falcons-shave.md
+++ b/.changeset/quiet-falcons-shave.md
@@ -1,0 +1,9 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+"@shared/crypto": patch
+"@shared/osn-auth-client": patch
+"@zap/api": patch
+---
+
+Take jose 6.2.10 (from 6.2.4). Releases 6.2.5 through 6.2.10 are all JOSE and JWT input-validation hardening: reject characters outside the Base64URL alphabet, reject invalid UTF-8 in JOSE headers and JWT claims sets, reject truncated ASN.1 key data, reject duplicate `crit` values, reject an unencoded payload in the JWS Compact Serialization, compare claim values correctly for falsy validation options, and enforce verification key metadata from a JWKS. jose sits under both the ARC service-to-service tokens and the five-minute osn-access JWTs, so this is parser hardening on the two token types where it matters most. No API change; the tightening only narrows what parses.

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,7 @@
     },
     "osn/api": {
       "name": "@osn/api",
-      "version": "3.20.12",
+      "version": "3.20.30",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/openapi": "1.4.15",
@@ -219,7 +219,7 @@
     },
     "osn/client": {
       "name": "@osn/client",
-      "version": "2.13.2",
+      "version": "2.13.6",
       "dependencies": {
         "effect": "^3.22.0",
       },
@@ -236,7 +236,7 @@
     },
     "osn/db": {
       "name": "@osn/db",
-      "version": "0.20.7",
+      "version": "0.20.11",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -255,7 +255,7 @@
     },
     "osn/landing": {
       "name": "@osn/landing",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
         "@shared/legal": "workspace:*",
@@ -278,7 +278,7 @@
     },
     "osn/social": {
       "name": "@osn/social",
-      "version": "0.12.11",
+      "version": "0.12.20",
       "dependencies": {
         "@osn/client": "workspace:*",
         "@osn/ui": "workspace:*",
@@ -304,7 +304,7 @@
     },
     "osn/ui": {
       "name": "@osn/ui",
-      "version": "1.8.4",
+      "version": "1.10.3",
       "dependencies": {
         "@kobalte/core": "^0.13.12",
         "@osn/client": "workspace:*",
@@ -329,7 +329,7 @@
     },
     "pulse/api": {
       "name": "@pulse/api",
-      "version": "0.26.11",
+      "version": "0.26.24",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -360,7 +360,7 @@
     },
     "pulse/db": {
       "name": "@pulse/db",
-      "version": "0.19.2",
+      "version": "0.19.4",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -379,7 +379,7 @@
     },
     "pulse/landing": {
       "name": "@pulse/landing",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
         "@astrojs/solid-js": "^7.0.1",
         "@shared/legal": "workspace:*",
@@ -402,7 +402,7 @@
     },
     "pulse/web": {
       "name": "@pulse/web",
-      "version": "0.22.17",
+      "version": "0.22.36",
       "dependencies": {
         "@fontsource/geist-mono": "^5.3.0",
         "@fontsource/geist-sans": "^5.3.0",
@@ -437,7 +437,7 @@
     },
     "shared/crypto": {
       "name": "@shared/crypto",
-      "version": "0.10.7",
+      "version": "0.10.14",
       "dependencies": {
         "@osn/db": "workspace:*",
         "@shared/observability": "workspace:*",
@@ -453,7 +453,7 @@
     },
     "shared/db-utils": {
       "name": "@shared/db-utils",
-      "version": "0.6.2",
+      "version": "0.6.4",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "effect": "^3.22.0",
@@ -466,7 +466,7 @@
     },
     "shared/dev-urls": {
       "name": "@shared/dev-urls",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "dev-env": "./src/cli.ts",
       },
@@ -477,7 +477,7 @@
     },
     "shared/email": {
       "name": "@shared/email",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "@shared/observability": "workspace:*",
         "effect": "^3.22.0",
@@ -490,7 +490,7 @@
     },
     "shared/feature-flags": {
       "name": "@shared/feature-flags",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@growthbook/growthbook": "^1.6.5",
         "@shared/observability": "workspace:*",
@@ -510,7 +510,7 @@
     },
     "shared/observability": {
       "name": "@shared/observability",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "dependencies": {
         "@effect/opentelemetry": "^0.64.0",
         "@effect/platform": "^0.97.0",
@@ -543,7 +543,7 @@
     },
     "shared/osn-auth-client": {
       "name": "@shared/osn-auth-client",
-      "version": "0.4.7",
+      "version": "0.4.15",
       "dependencies": {
         "@shared/crypto": "workspace:*",
         "jose": "^6.2.4",
@@ -567,7 +567,7 @@
     },
     "shared/redis": {
       "name": "@shared/redis",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@upstash/redis": "^1.38.0",
         "effect": "^3.22.0",
@@ -581,7 +581,7 @@
     },
     "shared/rp-auth": {
       "name": "@shared/rp-auth",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
@@ -600,7 +600,7 @@
     },
     "shared/sortable": {
       "name": "@shared/sortable",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
@@ -616,7 +616,7 @@
     },
     "shared/toast": {
       "name": "@shared/toast",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
@@ -632,7 +632,7 @@
     },
     "shared/turnstile": {
       "name": "@shared/turnstile",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@shared/observability": "workspace:*",
       },
@@ -647,7 +647,7 @@
     },
     "tools/lab": {
       "name": "@tools/lab",
-      "version": "0.1.0",
+      "version": "0.1.7",
       "dependencies": {
         "@osn/ui": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
@@ -677,7 +677,7 @@
     },
     "zap/api": {
       "name": "@zap/api",
-      "version": "0.8.22",
+      "version": "0.8.33",
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@elysiajs/eden": "^1.4.9",
@@ -704,7 +704,7 @@
     },
     "zap/db": {
       "name": "@zap/db",
-      "version": "0.5.8",
+      "version": "0.5.12",
       "dependencies": {
         "@shared/db-utils": "workspace:*",
         "drizzle-orm": "^0.45.2",
@@ -725,6 +725,7 @@
   "overrides": {
     "@babel/core": "^7.29.7",
     "@opentelemetry/core": "^2.10.0",
+    "browserslist": "^4.28.8",
     "devalue": "^5.8.1",
     "esbuild": "^0.28.1",
     "fast-uri": "^3.1.5",
@@ -1709,7 +1710,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.15", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
@@ -1727,7 +1728,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -1737,7 +1738,7 @@
 
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001785", "", {}, "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -1847,7 +1848,7 @@
 
     "effect": ["effect@3.22.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.416", "", {}, "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA=="],
 
     "elysia": ["elysia@1.4.29", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
 
@@ -2191,7 +2192,7 @@
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
-    "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+    "node-releases": ["node-releases@2.0.54", "", {}, "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -2527,7 +2528,7 @@
 
     "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+    "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "@cloudflare/workers-types": "^4.20260702.1",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
         "miniflare": "^4.20260722.0",
         "wrangler": "^4.114.0",
       },
@@ -205,7 +205,7 @@
         "drizzle-orm": "^0.45.2",
         "effect": "^3.22.0",
         "elysia": "^1.4.29",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
@@ -346,7 +346,7 @@
         "drizzle-orm": "^0.45.2",
         "effect": "^3.22.0",
         "elysia": "^1.4.29",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
@@ -443,7 +443,7 @@
         "@shared/observability": "workspace:*",
         "drizzle-orm": "^0.45.2",
         "effect": "^3.22.0",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
       },
       "devDependencies": {
         "@effect/vitest": "^0.30.0",
@@ -546,7 +546,7 @@
       "version": "0.4.15",
       "dependencies": {
         "@shared/crypto": "workspace:*",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
       },
       "devDependencies": {
         "@shared/typescript-config": "workspace:*",
@@ -696,7 +696,7 @@
         "@effect/vitest": "^0.30.0",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
-        "jose": "^6.2.4",
+        "jose": "^6.2.10",
         "miniflare": "^4.20260722.0",
         "vitest": "^4.1.10",
         "wrangler": "^4.114.0",
@@ -2036,7 +2036,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@6.2.4", "", {}, "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA=="],
+    "jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/cire/api/package.json
+++ b/cire/api/package.json
@@ -38,7 +38,7 @@
     "@cloudflare/workers-types": "^4.20260702.1",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
-    "jose": "^6.2.4",
+    "jose": "^6.2.10",
     "miniflare": "^4.20260722.0",
     "wrangler": "^4.114.0"
   }

--- a/osn/api/package.json
+++ b/osn/api/package.json
@@ -37,7 +37,7 @@
     "drizzle-orm": "^0.45.2",
     "effect": "^3.22.0",
     "elysia": "^1.4.29",
-    "jose": "^6.2.4"
+    "jose": "^6.2.10"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "overrides": {
     "@babel/core": "^7.29.7",
     "@opentelemetry/core": "^2.10.0",
+    "browserslist": "^4.28.8",
     "devalue": "^5.8.1",
     "esbuild": "^0.28.1",
     "fast-uri": "^3.1.5",

--- a/pulse/api/package.json
+++ b/pulse/api/package.json
@@ -42,7 +42,7 @@
     "drizzle-orm": "^0.45.2",
     "effect": "^3.22.0",
     "elysia": "^1.4.29",
-    "jose": "^6.2.4"
+    "jose": "^6.2.10"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",

--- a/shared/crypto/package.json
+++ b/shared/crypto/package.json
@@ -20,7 +20,7 @@
     "@shared/observability": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "effect": "^3.22.0",
-    "jose": "^6.2.4"
+    "jose": "^6.2.10"
   },
   "devDependencies": {
     "@effect/vitest": "^0.30.0",

--- a/shared/osn-auth-client/package.json
+++ b/shared/osn-auth-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@shared/crypto": "workspace:*",
-    "jose": "^6.2.4"
+    "jose": "^6.2.10"
   },
   "peerDependencies": {
     "elysia": "^1.4.29"

--- a/zap/api/package.json
+++ b/zap/api/package.json
@@ -43,7 +43,7 @@
     "@effect/vitest": "^0.30.0",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
-    "jose": "^6.2.4",
+    "jose": "^6.2.10",
     "miniflare": "^4.20260722.0",
     "vitest": "^4.1.10",
     "wrangler": "^4.114.0"


### PR DESCRIPTION
## Summary

`bun audit` was reporting two high-severity advisories against `browserslist` 4.28.2, which nothing declares directly — it arrived transitively through the `@babel/core` that `vite-plugin-solid`, `@astrojs/solid-js`, `@solidjs/start` and `@vitest/coverage-istanbul` all pull in. A root override at `^4.28.8` clears both. `bun audit` now reports no vulnerabilities across 907 packages.

The dependency sweep that found it also turned up tracker #229, an open finding asking for `jose` 6.2.5 "on the next dependency sweep". This is that sweep, so it takes `jose` to 6.2.10 as well — six releases of JOSE and JWT input-validation hardening sitting directly under the ARC service-to-service tokens and the five-minute `osn-access` JWTs.

- The two advisories are **GHSA-c83g-rgw3-j3cx** (the query cache never evicts, so distinct queries grow it without limit until the process runs out of memory) and **GHSA-73wf-gq98-2v4g** (`normalizeStats` crashes, and can write to the prototype, on an untrusted `browserslist-stats.json`). Both affect `<= 4.28.6`.
- No version drift anywhere in the monorepo. All 79 third-party packages declare identical ranges across every workspace; the only variance is the deliberately loose `solid-js` peer range (`>=1.9`) in the four library packages.
- 4.28.8 published 2026-08-08 and `jose` 6.2.10 on 2026-08-21, so both clear the three-day soak in `bunfig.toml` on their own. No `minimumReleaseAgeExcludes` entry was added, and `bunfig.toml` is untouched.

## Workspaces affected

No source file changed. The override and the `jose` range bump reach `@osn/api`, `@osn/client`, `@osn/landing`, `@osn/social`, `@osn/ui`, `@pulse/api`, `@pulse/landing`, `@pulse/web`, `@shared/crypto`, `@shared/osn-auth-client`, `@shared/rp-auth`, `@shared/sortable`, `@shared/toast`, `@tools/lab`, `@zap/api`, and the version-ignored `@cire/api`, `@cire/host`, `@cire/invites`, `@cire/landing`, `@cire/vendor`.

Four changesets, all `patch`, split so no file mixes versioned and version-ignored packages: `brown-pugs-repeat` (versioned, browserslist), `olive-moons-smoke` (`@cire/*`, browserslist), `quiet-falcons-shave` (versioned, jose), `lazy-hounds-clap` (`@cire/api`, jose). `scripts/changeset-required.sh` says `required` for this diff and `scripts/validate-changesets.sh` passes.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#229 | `S-L` |

Closes xchromo/osn-tracker#229

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#623 | `P-I1` |

## Decisions

### Fix the advisories with a root override rather than a direct dependency — `approach`

- **Issue** — `browserslist` is a build-time transitive dependency of `@babel/core`. No workspace declares it, so there is no range to bump.
- **Why** — Both advisories are reachable in every frontend build. Leaving them means `bun audit` stays red, and a future CVE-scanning CI step (tracker #370) would fail on day one.
- **Solution** — One line in the root `overrides` block, `"browserslist": "^4.28.8"`, alongside the seventeen overrides already there.
- **Rationale** — Adding `browserslist` as a real dependency of packages that never import it would misstate the dependency graph and give changesets a package to version that ships nothing. An override says exactly what is true: the tree may resolve this however it likes, above this floor. The caret form matches all seventeen siblings.

### Take jose to 6.2.10 in the same PR — `S-L`

- **Issue** — tracker #229 records that the 2026-07-30 sweep stopped at `jose` 6.2.4, which was a docs update plus an inert `exportJWK` refactor. The hardening starts at 6.2.5, and the issue asks for it "on the next sweep".
- **Why** — Across 6.2.5 to 6.2.10 `jose` learned to reject characters outside the Base64URL alphabet, reject invalid UTF-8 in JOSE headers and JWT claims sets, reject truncated ASN.1 key data, reject duplicate `crit` values, reject an unencoded payload in the JWS Compact Serialization, compare claim values correctly for falsy validation options, and enforce verification key metadata coming from a JWKS. `jose` is the parser under both the ARC tokens and the `osn-access` JWTs.
- **Solution** — `^6.2.4` to `^6.2.10` in the six packages that declare it; the lockfile resolves a single `jose@6.2.10`.
- **Rationale** — This is a dependency sweep, and #229 explicitly scheduled the bump for one. There is no API change, so the only risk is a token that previously parsed now being rejected — which is the point of the release, and which the full suite plus the D1/workerd tier exercise across both token types without a failure. Splitting it into its own PR would mean a second lockfile round-trip for a change of the same kind and the same blast radius.

### Widen the browserslist changesets past the three packages `bun audit` named — `P-I`

- **Issue** — The first draft named only `@osn/social`, `@pulse/web` and `@cire/host`, which are the three entry points `bun audit` prints.
- **Why** — `bun audit` deduplicates paths; it reports representative chains, not the full affected set. Ten versioned packages sit on the `vite-plugin-solid` / `@astrojs/solid-js` chain, so the release notes would have under-reported what the pin covers.
- **Solution** — Enumerated the chain from the manifests and listed every package on it.
- **Rationale** — A changelog entry that names three of ten packages is worse than none, because it reads as a deliberate scope statement. Versioned and version-ignored packages stay in separate files, as `validate-changesets.sh` requires.

**Out of scope**

- `P-I1` — the repo pins the browserslist *version* but not a browserslist *query*, so a future `@babel/preset-env`, `autoprefixer` or `@vitejs/plugin-legacy` would silently inherit whatever `caniuse-lite` shipped that week. The default query already moved from 38 browsers to 32 across this bump, dropping Safari 18.5-18.7. Inert today because nothing reads it. Tracked in xchromo/osn-tracker#623.
- Roughly thirty other packages are behind their latest in-range version (`effect` 3.22.0→3.22.1, `elysia` 1.4.29→1.4.30, `astro` 7.1.3→7.2.9, `wrangler` 4.114.0→4.127.1, `vitest` 4.1.10→4.1.11, `solid-js` 1.9.14→1.9.15 and so on), plus nine major-version gaps (`typescript` 6→7, `ioredis` 5→6, `jsdom` 29→30, `better-sqlite3` 12→13, `@changesets/cli` 2→3, `@testing-library/jest-dom` 6→7, `@cloudflare/workers-types` 4→5, `@solidjs/router` 0.16→1.0, `motion` 12→13). None carries an advisory, so none belongs in a security fix. Left for a separate sweep.
- Tracker #370 (`C-M7`, dependency CVE scanning in CI) stays open. This PR fixes the findings by hand; it does not add the automation that would have caught them.

## Test plan

| Gate | Result |
|---|---|
| `bun audit` | ✅ no vulnerabilities, 907 packages (was 2 high) |
| `bun install --frozen-lockfile` | ✅ 870 installs across 1027 packages, no changes |
| `bun run check` | ✅ 37/37 tasks |
| `bun run build` | ✅ 13/13 tasks |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:d1` | ✅ 5/5 tasks, 23 pass, 0 fail |
| `bun run check:release-age-excludes` | ✅ |
| `scripts/validate-changesets.sh` | ✅ |

Two things a reviewer should know rather than infer.

**The build output is byte-identical, and that was measured, not assumed.** The performance review built each toolchain twice — once normally, once under `BROWSERSLIST="ie 11, chrome 40, safari 9"`, a target set far more extreme than any `caniuse-lite` refresh could produce — and compared hashes. `@osn/social` and `@cire/host`: 71 JS/CSS files, identical sha1 across both builds. `@pulse/web`: 52 of 53 identical, the one difference being `.output/server/index.mjs`, which differs between two consecutive *unmodified* builds because nitro stamps a build id. Output that does not move under a forced extreme query cannot move on a data refresh.

**The advisory that was fixed was never live here.** GHSA-c83g-rgw3-j3cx needs a caller feeding many distinct queries into one long-lived process. This repo issues no browserslist queries during a build at all, so the bump is correct hygiene and clears the audit but buys no measurable build-time or memory improvement. Worth saying plainly so nobody looks for one.

Not run: `bun run test:browser`, which needs a Playwright browser this environment does not have. It covers CSS and layout assertions in `@cire/host` and `@cire/invites`, and no CSS is generated through browserslist, so the gap is real but not load-bearing for this diff. CI will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
