### PR TITLE
chore(deps): take @solidjs/router 1.0.0

### DIFF
--- a/.changeset/olive-jars-listen.md
+++ b/.changeset/olive-jars-listen.md
@@ -1,0 +1,6 @@
+---
+"@osn/social": patch
+"@pulse/web": patch
+---
+
+Take @solidjs/router 1.0.0 (from 0.16.3). The 1.0 release is the stability promise on an API that had already settled; the eight symbols this repo uses — `Router`, `Route`, `A`, `useNavigate`, `useLocation`, `useParams`, `useSearchParams` and the `RouteSectionProps` type — are unchanged. No source edit was needed.

--- a/bun.lock
+++ b/bun.lock
@@ -285,7 +285,7 @@
         "@shared/legal": "workspace:*",
         "@shared/toast": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",
-        "@solidjs/router": "^0.16.3",
+        "@solidjs/router": "^1.0.0",
         "@tailwindcss/vite": "^4.3.3",
         "solid-js": "^1.9.15",
         "tailwindcss": "^4.3.3",
@@ -413,7 +413,7 @@
         "@shared/rp-auth": "workspace:*",
         "@shared/toast": "workspace:*",
         "@solidjs/meta": "^0.29.4",
-        "@solidjs/router": "^0.16.3",
+        "@solidjs/router": "^1.0.0",
         "@solidjs/start": "^2.0.4",
         "@tailwindcss/vite": "^4.3.3",
         "leaflet": "^1.9.4",
@@ -1512,7 +1512,7 @@
 
     "@solidjs/meta": ["@solidjs/meta@0.29.4", "", { "peerDependencies": { "solid-js": ">=1.8.4" } }, "sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g=="],
 
-    "@solidjs/router": ["@solidjs/router@0.16.3", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WWQkmSmSpl+15HgUktGPbeXkgWmonj4XwPOcZVHJz1EQV3dz5qWHIyQ/BKXFevor6u/0dKvC9FlUmKmDwE1QHw=="],
+    "@solidjs/router": ["@solidjs/router@1.0.0", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-cCSk1hvgCowiMa9bzzYWHiLu1U4E22+DfJe6/rOwAyECKrxc3jrd5QnoW3sDDJtW+e077cz/M67bPl3DqOBw1Q=="],
 
     "@solidjs/start": ["@solidjs/start@2.0.4", "", { "dependencies": { "@babel/core": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/trace-mapping": "^0.3.31", "@solidjs/meta": "^0.29.4", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.10", "cookie-es": "^3.1.1", "defu": "^6.1.7", "error-stack-parser-es": "^2.0.1", "fast-glob": "^3.3.3", "h3": "^2.0.1-rc.26", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "oxc-parser": "^0.141.0", "path-to-regexp": "^8.4.2", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.6.0", "seroval-plugins": "^1.6.0", "shiki": "^4.3.1", "solid-js": "^1.9.15", "srvx": "^0.12.4", "terracotta": "^1.2.4", "vite-plugin-solid": "^2.11.13" }, "peerDependencies": { "@solidjs/router": ">=0.16.0 <2.0.0-0", "vite": "^8 || ^9" }, "optionalPeers": ["@solidjs/router"] }, "sha512-RKIWYgdW+3XoaNa37QqH/Z1RRVglEOWDoCCe1nV+hVzbXa0wtW9uWntKk3DtM3IJlryKNSA6G3yfAe5LAcsSHw=="],
 
@@ -2664,8 +2664,6 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@effect/vitest/vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
-
     "@esbuild-kit/esm-loader/get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -2837,20 +2835,6 @@
     "@cloudflare/vite-plugin/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260828.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw=="],
 
     "@cloudflare/vite-plugin/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260828.1", "", { "os": "win32", "cpu": "x64" }, "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ=="],
-
-    "@effect/vitest/vitest/@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
-
-    "@effect/vitest/vitest/@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
-
-    "@effect/vitest/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
-
-    "@effect/vitest/vitest/@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
-
-    "@effect/vitest/vitest/@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
-
-    "@effect/vitest/vitest/@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
-
-    "@effect/vitest/vitest/@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 

--- a/osn/social/package.json
+++ b/osn/social/package.json
@@ -24,7 +24,7 @@
     "@shared/legal": "workspace:*",
     "@shared/toast": "workspace:*",
     "@simplewebauthn/browser": "^13.3.0",
-    "@solidjs/router": "^0.16.3",
+    "@solidjs/router": "^1.0.0",
     "@tailwindcss/vite": "^4.3.3",
     "solid-js": "^1.9.15",
     "tailwindcss": "^4.3.3"

--- a/pulse/web/package.json
+++ b/pulse/web/package.json
@@ -28,7 +28,7 @@
     "@shared/toast": "workspace:*",
     "@shared/rp-auth": "workspace:*",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.3",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^2.0.4",
     "@tailwindcss/vite": "^4.3.3",
     "leaflet": "^1.9.4",


### PR DESCRIPTION
## Summary

`@solidjs/router` 0.16.3 → **1.0.0**. The 1.0 release is a stability promise on an API that had already settled, not a redesign — the router had been feature-stable through the 0.16 line and 1.0 marks it as such.

This repo touches eight symbols across 23 call sites in `@osn/social` and `@pulse/web`: `Router`, `Route`, `A`, `useNavigate`, `useLocation`, `useParams`, `useSearchParams`, and the `RouteSectionProps` type. None changed shape. No source edit was needed.

This is the only major in the stack that survived adversarial review untouched — worth saying, because the others did not.

## Workspaces affected

`@osn/social`, `@pulse/web`. One changeset, `patch` on both.

## Issues

**Closes**

None.

**Opened**

None.

## Decisions

### Take 1.0.0 on its own rather than folding it into the in-range sweep — `approach`

- **Issue** — `@solidjs/router` had both an in-range hop (0.16.2 → 0.16.3) and a major (→ 1.0.0) available.
- **Why** — A major inside a 28-package sweep is unbisectable if a gate goes red.
- **Solution** — The PR below took 0.16.3; this one takes 1.0.0 on top.
- **Rationale** — The two-step also makes the diff honest: the sweep's `^0.16.2 → ^0.16.3` is genuinely routine, and this PR carries the whole major-version decision by itself.

### Accept the bump with no source change — `approach`

- **Issue** — A 1.0 release is where a project is entitled to drop deprecated surface, so "it compiles" is not sufficient evidence on its own.
- **Why** — A type-level break would surface in `bun run check`, but a *runtime* behaviour change in navigation or search-param handling would not.
- **Solution** — Enumerated the eight symbols actually imported and confirmed each against the release notes, then ran the component tests that mount a real `Router` — ten test files across the two apps import from `@solidjs/router`.
- **Rationale** — Coverage here is real rather than incidental: `Sidebar`, `MobileNav`, `MobileTopBar`, `GlobalSearch`, `SearchPage`, `DiscoverPage`, `AuthorizePage` and `turnstile-wiring` in `@osn/social`, plus `EventCard` and `OnboardingGate` in `@pulse/web`, all render inside the router.

**Out of scope**

- Nothing. This bump is self-contained.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37/37 tasks, 0 errors |
| `bun run build` | ✅ 13/13 tasks |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:browser` | ✅ 3/3 tasks, 46 tests in real Chromium |

The bump was independently attacked from three angles before it was written: one reviewer re-read every release note between 0.16.3 and 1.0.0 looking for a breaking change the first pass missed, one re-searched the codebase from scratch for call sites (including barrel re-exports, dynamic imports and type-only imports), and one checked peer ranges and transitive effects. All three came back with nothing.

Not verified by hand: in-browser navigation on the two apps. The router is exercised in tests but no test drives a real multi-page navigation, so a reviewer clicking through `@osn/social` once is worth the minute it costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
