### PR TITLE
chore(deps): move off the deprecated @testing-library/jest-dom 6.10.0

### DIFF
--- a/.changeset/brave-frogs-shout.md
+++ b/.changeset/brave-frogs-shout.md
@@ -1,0 +1,5 @@
+---
+"@pulse/web": patch
+---
+
+Take @testing-library/jest-dom 7.0.1. The pinned `^6.10.0` could only ever resolve 6.10.0, and npm marks that release **deprecated** — the maintainers shipped breaking changes (Node >= 22, a required `@testing-library/dom` peer) in a minor by mistake and their notice says to use 6.9.1 or move to 7.0.0. Since this repo already runs Node 24 and already has `@testing-library/dom` 10.4.1 in the tree via `@solidjs/testing-library`, 7.0.1 is the un-deprecated equivalent of what was already installed. No matcher changed; no test edit needed.

--- a/.changeset/warm-melons-guess.md
+++ b/.changeset/warm-melons-guess.md
@@ -1,0 +1,6 @@
+---
+"@cire/host": patch
+"@cire/vendor": patch
+---
+
+Take @testing-library/jest-dom 7.0.1, off the deprecated 6.10.0. See the accompanying changeset for why 6.10.0 is deprecated; the short version is that its breaking changes (Node >= 22, a required `@testing-library/dom` peer) were already in force here, so 7.0.1 is the supported equivalent of what was installed.

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
-        "@testing-library/jest-dom": "^6.10.0",
+        "@testing-library/jest-dom": "^7.0.1",
         "@vitest/browser": "4.1.11",
         "@vitest/browser-playwright": "4.1.11",
         "happy-dom": "^20.12.0",
@@ -178,7 +178,7 @@
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
-        "@testing-library/jest-dom": "^6.10.0",
+        "@testing-library/jest-dom": "^7.0.1",
         "happy-dom": "^20.12.0",
         "typescript": "^6.0.3",
         "vite": "^8.2.2",
@@ -425,7 +425,7 @@
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "@solidjs/testing-library": "^0.8.10",
-        "@testing-library/jest-dom": "^6.10.0",
+        "@testing-library/jest-dom": "^7.0.1",
         "@types/leaflet": "^1.9.22",
         "@vitest/coverage-istanbul": "^4.1.11",
         "happy-dom": "^20.12.0",
@@ -1556,7 +1556,7 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.10.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11" } }, "sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@7.0.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11", "vitest": ">= 0.32" }, "optionalPeers": ["vitest"] }, "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 

--- a/cire/host/package.json
+++ b/cire/host/package.json
@@ -37,7 +37,7 @@
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
-    "@testing-library/jest-dom": "^6.10.0",
+    "@testing-library/jest-dom": "^7.0.1",
     "@vitest/browser": "4.1.11",
     "@vitest/browser-playwright": "4.1.11",
     "happy-dom": "^20.12.0",

--- a/cire/vendor/package.json
+++ b/cire/vendor/package.json
@@ -32,7 +32,7 @@
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
-    "@testing-library/jest-dom": "^6.10.0",
+    "@testing-library/jest-dom": "^7.0.1",
     "happy-dom": "^20.12.0",
     "typescript": "^6.0.3",
     "vite": "^8.2.2",

--- a/pulse/web/package.json
+++ b/pulse/web/package.json
@@ -40,7 +40,7 @@
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
-    "@testing-library/jest-dom": "^6.10.0",
+    "@testing-library/jest-dom": "^7.0.1",
     "@types/leaflet": "^1.9.22",
     "@vitest/coverage-istanbul": "^4.1.11",
     "happy-dom": "^20.12.0",


### PR DESCRIPTION
## Summary

`@testing-library/jest-dom` 6.10.0 → **7.0.1**. This one is not a version chase — the installed release is deprecated on npm, and the deprecation notice is the upgrade instruction:

> Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.

`@cire/host`, `@cire/vendor` and `@pulse/web` all pin `^6.10.0`, and 6.10.0 is the last release of the 6.x line, so that range can resolve nothing else. The repo has been sitting on a deprecated release since it was published on 2026-07-20.

The important part: **the breaking changes that notice warns about are already in force here.** 6.10.0 itself declares the `@testing-library/dom >=10 <11` peer. Going *back* to 6.9.1 would be the real behaviour change; 7.0.1 is the supported equivalent of what is already installed.

## Workspaces affected

`@cire/host`, `@cire/vendor` (version-ignored) and `@pulse/web` (versioned). Two changesets, split so no file mixes the two kinds.

## Issues

**Closes**

None.

**Opened**

None.

## Decisions

### Go forward to 7.0.1 rather than back to 6.9.1 — `approach`

- **Issue** — The deprecation notice offers two exits: pin back to 6.9.1, or move to 7.0.0.
- **Why** — They are not equivalent. 6.9.1 predates the required `@testing-library/dom` peer and the Node >= 22 floor; 7.x keeps both.
- **Solution** — Take 7.0.1, the current `latest`.
- **Rationale** — Both preconditions already hold, so forward is the no-op and backward is the change. The repo runs Node 24.13.0, and `@testing-library/dom` 10.4.1 is already resolved in the tree through `@solidjs/testing-library` — it satisfies the `>=10 <11` peer without anything new being declared. Pinning back to 6.9.1 would also strand the repo on a line that gets no further fixes.

### Verified the peer is satisfied rather than declaring it — `approach`

- **Issue** — 7.x makes `@testing-library/dom` a **required** (non-optional) peer. Only `vitest` is marked optional.
- **Why** — An unsatisfied required peer is an install-time break, and none of the three packages declares `@testing-library/dom` directly.
- **Solution** — Confirmed `@testing-library/dom@10.4.1` is already in `bun.lock`, pulled by `@solidjs/testing-library@0.8.10` which depends on `^10.4.0`.
- **Rationale** — Adding a direct devDependency none of the three packages imports would misstate the graph. The peer is satisfied transitively and `bun install` is clean; if `@solidjs/testing-library` ever drops it, the install fails loudly rather than silently, which is the behaviour we want.

**Out of scope**

- Nothing.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37/37 tasks, 0 errors |
| `bun run build` | ✅ 13/13 tasks |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:browser` | ✅ 3/3 tasks, 46 tests in real Chromium |
| `bun run check:jest-dom-markers` | ✅ 14 Solid vitest configs, suppression intact |

No matcher signature changed and no test needed an edit. The repo-specific `check:jest-dom-markers` gate is the one worth naming: it asserts the jest-dom type suppression is still wired into all 14 Solid vitest configs, and a matcher-package major is exactly the change that could quietly break it.

Nothing here was left unverified — the change is three range edits and a lockfile, and every gate that touches the matchers ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
