### PR TITLE
chore(deps): take motion 13.1.1

### DIFF
--- a/.changeset/lucky-pears-tap.md
+++ b/.changeset/lucky-pears-tap.md
@@ -1,0 +1,8 @@
+---
+"@cire/invites": patch
+"@cire/landing": patch
+---
+
+Take motion 13.1.1 (from 12.43.0), and the bundled `framer-motion` alias with it.
+
+A motion major is the exact shape of the 2026-07-22 invite-reveal bug, where v10 → v12 drift left `UnlockReveal` stuck at `opacity: 0` and guests saw no events after claiming. That regression was invisible to the unit tests because they all stub the module. It is not invisible now: `tests/designs/InvitePage.browser.test.tsx` drives both `UnlockReveal` packs with the **real** library in real Chromium and asserts the post-animation end state, and it passes on 13.1.1. The SSR stub that keeps motion out of the Worker bundle still holds — the server output contains no `motion-dom` or `framer-motion`.

--- a/.changeset/silly-carrots-fold.md
+++ b/.changeset/silly-carrots-fold.md
@@ -1,0 +1,6 @@
+---
+"@osn/landing": patch
+"@pulse/landing": patch
+---
+
+Take motion 13.1.1 (from 12.43.0). The bundled `framer-motion` alias moves to 13.1.1 with it. The four landing and invite surfaces use only `animate`, `stagger` and `inView`, none of which changed signature. Verified through the real-Chromium browser tier rather than the mocked unit tests — see the accompanying `@cire/*` changeset for why that distinction matters here.

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
         "@shared/toast": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.9",
-        "motion": "^12.43.0",
+        "motion": "^13.1.1",
         "solid-js": "^1.9.15",
         "tailwindcss": "^4.3.3",
       },
@@ -136,7 +136,7 @@
         "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.9",
-        "motion": "^12.43.0",
+        "motion": "^13.1.1",
         "solid-js": "^1.9.15",
         "tailwindcss": "^4.3.3",
         "three": "^0.185.1",
@@ -261,7 +261,7 @@
         "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.9",
-        "motion": "^12.43.0",
+        "motion": "^13.1.1",
         "solid-js": "^1.9.15",
         "tailwindcss": "^4.3.3",
       },
@@ -385,7 +385,7 @@
         "@shared/legal": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.9",
-        "motion": "^12.43.0",
+        "motion": "^13.1.1",
         "solid-js": "^1.9.15",
         "tailwindcss": "^4.3.3",
       },
@@ -1930,7 +1930,7 @@
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
 
-    "framer-motion": ["framer-motion@12.43.0", "", { "dependencies": { "motion-dom": "^12.43.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g=="],
+    "framer-motion": ["framer-motion@13.1.1", "", { "dependencies": { "motion-dom": "^13.1.1", "motion-utils": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -2144,11 +2144,11 @@
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
-    "motion": ["motion@12.43.0", "", { "dependencies": { "framer-motion": "^12.43.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ=="],
+    "motion": ["motion@13.1.1", "", { "dependencies": { "framer-motion": "^13.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q=="],
 
-    "motion-dom": ["motion-dom@12.43.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag=="],
+    "motion-dom": ["motion-dom@13.1.1", "", { "dependencies": { "motion-utils": "^13.0.0" } }, "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA=="],
 
-    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
+    "motion-utils": ["motion-utils@13.0.0", "", {}, "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 

--- a/cire/invites/package.json
+++ b/cire/invites/package.json
@@ -27,7 +27,7 @@
     "@shared/rp-auth": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.9",
-    "motion": "^12.43.0",
+    "motion": "^13.1.1",
     "solid-js": "^1.9.15",
     "tailwindcss": "^4.3.3"
   },

--- a/cire/landing/package.json
+++ b/cire/landing/package.json
@@ -20,7 +20,7 @@
     "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.9",
-    "motion": "^12.43.0",
+    "motion": "^13.1.1",
     "solid-js": "^1.9.15",
     "tailwindcss": "^4.3.3",
     "three": "^0.185.1"

--- a/osn/landing/package.json
+++ b/osn/landing/package.json
@@ -21,7 +21,7 @@
     "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.9",
-    "motion": "^12.43.0",
+    "motion": "^13.1.1",
     "solid-js": "^1.9.15",
     "tailwindcss": "^4.3.3"
   },

--- a/pulse/landing/package.json
+++ b/pulse/landing/package.json
@@ -21,7 +21,7 @@
     "@shared/legal": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.9",
-    "motion": "^12.43.0",
+    "motion": "^13.1.1",
     "solid-js": "^1.9.15",
     "tailwindcss": "^4.3.3"
   },


### PR DESCRIPTION
## Summary

`motion` 12.43.0 → **13.1.1**, across `@cire/invites`, `@cire/landing`, `@osn/landing` and `@pulse/landing`. The bundled `framer-motion` alias moves with it.

This is the bump in the stack with real history behind it. A `motion` major is the exact shape of the **2026-07-22 invite-reveal bug**: v10 → v12 drift left `UnlockReveal` stuck at `opacity: 0`, and guests saw no events after claiming their invite. That regression reached production because every unit test stubs the module, so a green suite proved nothing about the animation.

It would not reach production now, and that is the point of this PR's verification. `cire/invites` has a second Vitest project running real Chromium, and `tests/designs/InvitePage.browser.test.tsx` drives **both** `UnlockReveal` packs with the unmocked library and asserts the post-animation end state. It passes on 13.1.1.

## Workspaces affected

`@cire/invites`, `@cire/landing` (version-ignored) and `@osn/landing`, `@pulse/landing` (versioned). Two changesets, split by kind.

## Issues

**Closes**

None.

**Opened**

None.

## Decisions

### Verify through the browser tier, not the unit suite — `approach`

- **Issue** — All four surfaces' unit tests `vi.mock` the `motion` module, so `bun run test` going green says nothing about whether animations still work.
- **Why** — That is precisely how the 2026-07-22 reveal bug shipped. Repeating "the tests pass" for a `motion` major would be repeating the mistake.
- **Solution** — Treated `bun run test:browser` as the gate for this PR: 3 tasks, 46 tests, real Chromium, real library.
- **Rationale** — `InvitePage.browser.test.tsx` mocks only `PulseAccountLink` and `@shared/rp-auth/solid`; everything the reveal and the confirmation touch is the real thing. It is the only automated check in the repo that would have caught the original bug, so it is the only one whose result is worth quoting here.

### Confirm the SSR stub survived the major — `approach`

- **Issue** — `cire/invites/astro.config.mjs` stubs `motion` out of the **SSR** graph only (tracker #287), keeping ~187 KB of dead weight out of the Worker bundle. Its resolver matches on `/^motion(-dom|-utils)?(\/|$)/`.
- **Why** — A major is where a library can rename or re-split its internal packages. If 13.x moved code into a subpackage that regex does not match, the stub would silently stop working and the Worker bundle would grow.
- **Solution** — Built and grepped the server output: `dist/server` contains the stub chunk and **no** `motion-dom` and **no** `framer-motion`.
- **Rationale** — Checking the built artefact is the only honest test of a build-time resolver; the config file reading correctly proves nothing.

**Out of scope**

- Tracker #614 (`S-L`) — the SSR stub regex does not match `framer-motion`, which is `motion`'s own direct dependency. That finding predates this PR and this bump neither fixes nor worsens it: the server output is clean today because the source imports `motion`, not `framer-motion`. Left as filed.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37/37 tasks, 0 errors |
| `bun run build` | ✅ 13/13 tasks |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:browser` | ✅ 3/3 tasks, 46 tests in real Chromium |
| SSR stub intact | ✅ no `motion-dom` / `framer-motion` in `cire/invites/dist/server` (1.1 MB) |

What is **not** covered, stated plainly: the browser tier asserts the reveal's *end state*, not its visual quality mid-flight. Easing curve or duration changes in 13.x would pass every gate here and still look wrong. A reviewer should open an invite on the deploy preview and watch one reveal end to end — that is a ten-second check that no test in this repo replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
