### PR TITLE
chore(deps): take @cloudflare/workers-types 5

### DIFF
--- a/.changeset/eager-lions-march.md
+++ b/.changeset/eager-lions-march.md
@@ -1,0 +1,11 @@
+---
+"@osn/api": patch
+"@osn/db": patch
+"@pulse/api": patch
+"@pulse/db": patch
+"@shared/db-utils": patch
+"@zap/api": patch
+"@zap/db": patch
+---
+
+Take @cloudflare/workers-types 5.20260830.1 (from 4.20260702.1). This also fixes a peer range nobody had noticed: wrangler 4.127.1 declares an optional peer on `@cloudflare/workers-types` `^5.20260722.1`, which the old `^4.20260702.1` pin did not satisfy. Types only, no runtime change.

--- a/.changeset/proud-owls-camp.md
+++ b/.changeset/proud-owls-camp.md
@@ -1,0 +1,5 @@
+---
+"@cire/api": patch
+---
+
+Take @cloudflare/workers-types 5.20260830.1 (from 4.20260702.1), and update `tests/index.test.ts` to the tightened v5 shapes: `Span.setAttribute` now returns `this` with a required value, `Span` gained `setAttributes`, `Tracing` gained `startSpan`, and `ExecutionContext` gained the required members `exports` and `abort`. Test-only; no runtime change.

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "elysia": "^1.4.30",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
         "jose": "^6.2.10",
@@ -208,7 +208,7 @@
         "jose": "^6.2.10",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
@@ -243,7 +243,7 @@
         "effect": "^3.22.1",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/typescript-config": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
@@ -349,7 +349,7 @@
         "jose": "^6.2.10",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
@@ -367,7 +367,7 @@
         "effect": "^3.22.1",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/typescript-config": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
@@ -459,7 +459,7 @@
         "effect": "^3.22.1",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@shared/typescript-config": "workspace:*",
         "vitest": "^4.1.11",
       },
@@ -692,7 +692,7 @@
         "elysia": "^1.4.30",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/dev-urls": "workspace:*",
         "@shared/typescript-config": "workspace:*",
@@ -711,7 +711,7 @@
         "effect": "^3.22.1",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260830.1",
         "@effect/vitest": "^0.30.0",
         "@shared/typescript-config": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
@@ -934,7 +934,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260730.1", "", { "os": "win32", "cpu": "x64" }, "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260830.1", "", {}, "sha512-LBn0wg8kmCbdriUYmz6BSm4ukjFinU4iYGYuBTPaSG6malMhbIFk7Az1gcsFuvBYva2yHxUZFirCwjQY7yBN9A=="],
 
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
 

--- a/cire/api/package.json
+++ b/cire/api/package.json
@@ -35,7 +35,7 @@
     "elysia": "^1.4.30"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",
     "jose": "^6.2.10",

--- a/cire/api/tests/index.test.ts
+++ b/cire/api/tests/index.test.ts
@@ -54,7 +54,12 @@ class StubSpan {
   get isTraced(): boolean {
     return false;
   }
-  setAttribute(_key: string, _value?: boolean | number | string): void {}
+  setAttribute(_key: string, _value: boolean | number | string): this {
+    return this;
+  }
+  setAttributes(_attributes: Record<string, boolean | number | string | undefined>): this {
+    return this;
+  }
   end(): void {}
 }
 
@@ -62,11 +67,20 @@ const ctx: ExecutionContext = {
   waitUntil: () => {},
   passThroughOnException: () => {},
   props: undefined,
+  // `exports` and `abort` became required members of `ExecutionContext` in
+  // @cloudflare/workers-types 5. Neither is reachable from a boot test: the
+  // handler never looks up a sibling entrypoint, and nothing aborts the
+  // invocation.
+  exports: {},
+  abort: () => {},
   tracing: {
     enterSpan: () => {
       throw new Error("tracing not available in this test context");
     },
     startActiveSpan: () => {
+      throw new Error("tracing not available in this test context");
+    },
+    startSpan: () => {
       throw new Error("tracing not available in this test context");
     },
     Span: StubSpan,

--- a/osn/api/package.json
+++ b/osn/api/package.json
@@ -40,7 +40,7 @@
     "jose": "^6.2.10"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",

--- a/osn/db/package.json
+++ b/osn/db/package.json
@@ -30,7 +30,7 @@
     "effect": "^3.22.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/typescript-config": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",

--- a/pulse/api/package.json
+++ b/pulse/api/package.json
@@ -45,7 +45,7 @@
     "jose": "^6.2.10"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",

--- a/pulse/db/package.json
+++ b/pulse/db/package.json
@@ -30,7 +30,7 @@
     "effect": "^3.22.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/typescript-config": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",

--- a/shared/db-utils/package.json
+++ b/shared/db-utils/package.json
@@ -17,7 +17,7 @@
     "effect": "^3.22.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@shared/typescript-config": "workspace:*",
     "vitest": "^4.1.11"
   }

--- a/zap/api/package.json
+++ b/zap/api/package.json
@@ -39,7 +39,7 @@
     "elysia": "^1.4.30"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/dev-urls": "workspace:*",
     "@shared/typescript-config": "workspace:*",

--- a/zap/db/package.json
+++ b/zap/db/package.json
@@ -30,7 +30,7 @@
     "effect": "^3.22.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260830.1",
     "@effect/vitest": "^0.30.0",
     "@shared/typescript-config": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
## Summary

`@cloudflare/workers-types` 4.20260702.1 → **5.20260830.1** across the eight packages that declare it.

This one is not only a version chase. The old `^4.20260702.1` pin had quietly stopped satisfying a peer: `wrangler` 4.127.1 declares an optional peer on `@cloudflare/workers-types` `^5.20260722.1`. Every Worker package here depends on that wrangler, so the tree was carrying an unsatisfied peer — this is the fix for it as much as an upgrade.

v5 tightens four ambient shapes, and every one of them lands in a single file — `cire/api/tests/index.test.ts`, which hand-implements `ExecutionContext` and `Span` to boot the Worker handler.

## Workspaces affected

`@cire/api` (version-ignored) and `@osn/api`, `@osn/db`, `@pulse/api`, `@pulse/db`, `@shared/db-utils`, `@zap/api`, `@zap/db` (versioned). Two changesets, split by kind.

One source file changed: `cire/api/tests/index.test.ts`. Types only — no runtime code moved.

## Issues

**Closes**

None.

**Opened**

None.

## Decisions

### Update the hand-written stubs rather than casting past the new members — `S-approach`

- **Issue** — v5 changed four ambient shapes the boot test implements by hand: `Span.setAttribute` now returns `this` instead of `void` and its `value` parameter is required rather than optional; `Span` gained `setAttributes`; `Tracing` gained `startSpan`; and `ExecutionContext` gained two required members, `exports` and `abort`.
- **Why** — The quick escape is `as unknown as ExecutionContext`, which compiles immediately and is what a hurried bump would reach for.
- **Solution** — Implemented the new members honestly. `setAttribute`/`setAttributes` return `this`, `startSpan` throws like its two siblings already do, `exports` is `{}` and `abort` is a no-op.
- **Rationale** — A cast would silence *future* additions too, so the next time Cloudflare adds a required member the test would keep compiling against a shape it no longer satisfies. These are three lines; the cast is a permanent hole. None of the new members is reachable from a boot test anyway — the handler never creates a span, never looks up a sibling entrypoint via `exports`, and nothing aborts the invocation — so the stubs stay stubs and only their signatures move.

### Verified the soak window rather than assuming it — `approach`

- **Issue** — 5.20260830.1 published on 2026-08-30T01:20Z, and `bunfig.toml` enforces a 3-day `minimumReleaseAge`.
- **Why** — This was the one bump in the stack close enough to the window to be refused.
- **Solution** — Checked the publish timestamp against the gate; it cleared at 2026-09-02T01:20Z and `bun install` accepted it.
- **Rationale** — `bun install` enforces the gate itself, so a clean install *is* the proof. Worth stating because a reader checking the dates would otherwise have to redo the arithmetic.

**Out of scope**

- The `wrangler types` migration. Cloudflare now recommends generating env types from `wrangler.toml` rather than importing the ambient package. That is a real change to how seven packages get their types and does not belong in a version bump.

## Test plan

| Gate | Result |
|---|---|
| `bun run check` | ✅ 37/37 tasks, 0 errors |
| `bun run build` | ✅ 13/13 tasks |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:d1` | ✅ 5/5 tasks, 23 pass, 0 fail |
| `bun run lint` | ✅ exit 0 |
| `bun run fmt:check` | ✅ 1435 files |

The D1 tier is the gate that matters here: it boots real workerd through Miniflare, so it exercises the `ExecutionContext` the stub is standing in for.

Worth a reviewer's attention: `bun run check` catches every consumer of these types by construction, since the package is types-only and has no runtime surface at all. There is nothing here that could fail at runtime but pass the typechecker — which is the opposite of the situation in the `ioredis` bump that was dropped from this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
