### PR TITLE
chore(deps): take ioredis 6

### DIFF
--- a/.changeset/proud-moths-race.md
+++ b/.changeset/proud-moths-race.md
@@ -1,0 +1,11 @@
+---
+"@shared/redis": patch
+"@osn/api": patch
+"@pulse/api": patch
+---
+
+Take ioredis 6.0.0 (from 5.11.1). This is not a dev-only bump: `osn/api/src/index.ts` and `pulse/api/src/index.ts` both statically import `./redis`, which statically imports `@shared/redis/ioredis`, so ioredis is compiled into both deployed Worker bundles and its module body runs at isolate startup. v6 drops the `redis-parser` package for an in-tree RESP decoder — confirmed, `redis-parser` is gone from the lockfile.
+
+Verified by booting the real built bundle on workerd (`wrangler dev --local`), not by a dry run: `osn-api` starts clean and serves 200 on `/health`, `/.well-known/jwks.json` and `/`, with no errors in the log. The Worker bundle grows 4594.90 KiB to 4716.41 KiB.
+
+One thing the bundle growth understates, found while reviewing this bump and filed separately: the ioredis in these Worker bundles can never execute. `osn/api/src/index.ts` reaches it only through `initRedisClientFromEnv`, which on workerd selects Upstash-over-HTTP or the in-memory store; the socket-opening `createClientFromUrl` is reached solely from `osn/api/src/local.ts`. Stubbing that one import out and rebuilding puts ioredis at 449.58 KiB raw / 72.50 KiB gzip in `osn-api`, about 8.8% of the compressed script, parsed on every cold isolate start. That is pre-existing — it was 337.98 / 61.75 KiB gzip on ioredis 5 — and this bump adds 111.60 / 10.75 to it. The fix is a module split in `@shared/redis`, not a change to this bump.

--- a/bun.lock
+++ b/bun.lock
@@ -571,7 +571,7 @@
       "dependencies": {
         "@upstash/redis": "^1.38.3",
         "effect": "^3.22.1",
-        "ioredis": "^5.11.1",
+        "ioredis": "^6.0.0",
       },
       "devDependencies": {
         "@effect/vitest": "^0.30.0",
@@ -1136,7 +1136,7 @@
 
     "@internationalized/number": ["@internationalized/number@3.6.5", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g=="],
 
-    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
+    "@ioredis/commands": ["@ioredis/commands@2.0.0", "", {}, "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg=="],
 
     "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
 
@@ -1938,7 +1938,7 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
-    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
+    "ioredis": ["ioredis@6.0.0", "", { "dependencies": { "@ioredis/commands": "2.0.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "standard-as-callback": "2.1.0" } }, "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -2195,8 +2195,6 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
-
-    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 

--- a/shared/redis/package.json
+++ b/shared/redis/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@upstash/redis": "^1.38.3",
     "effect": "^3.22.1",
-    "ioredis": "^5.11.1"
+    "ioredis": "^6.0.0"
   },
   "devDependencies": {
     "@effect/vitest": "^0.30.0",


### PR DESCRIPTION
## Summary

`ioredis` 5.11.1 → **6.0.0**, declared in `shared/redis/package.json`.

This is not a dev-only bump, and that is the whole reason it needs care. Both deployed Workers reach ioredis statically:

```
osn/api/src/index.ts:12        -> ./redis
osn/api/src/redis.ts:25        -> @shared/redis/ioredis
shared/redis/src/ioredis.ts:15 -> ioredis
```

`pulse/api` has the identical chain through its own `index.ts` and `redis.ts`. `src/redis.ts` holds the Bun root **and** the Workers selector in one module, so importing `initRedisClientFromEnv` pulls all of ioredis into the Worker graph. esbuild does not tree-shake it out and the import is eager, so the module body runs at isolate startup on workerd. The built bundle proves it: **107 ioredis references** in `osn/api/dist/index.js`.

v6 replaces the `redis-parser` package with an in-tree RESP decoder — confirmed, `redis-parser` is gone from `bun.lock`. The osn-api bundle grows 4594.90 → 4716.41 KiB.

## Workspaces affected

`@shared/redis` (the declaration), `@osn/api` and `@pulse/api` (the two Workers that bundle it). One changeset, `patch` on all three.

No source file changes.

## Issues

**Closes**

| Issue | What |
|---|---|
| #878 | ioredis 6 needs a real dev-tier deploy to verify |

Closes #878

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#883 | `wrangler dev --local` is broken for `pulse/api` at module eval, pre-existing |
| xchromo/osn-tracker#628 | P-W1 |

## Decisions

### Verify by booting the real bundle on workerd, not by a dry run — `approach`

- **Issue** — `CLAUDE.md` §Cloudflare Workers debugging is explicit that `wrangler deploy --dry-run` does **not** catch the module-eval crash class. Since v6's module body runs at isolate startup in these bundles, that is exactly the risk, so a green `bun run build` is not evidence on its own.
- **Why** — Every ioredis-touching unit test either `vi.mock`s the module or hand-rolls a mock, and the D1 tier never loads `src/index.ts` — it imports `../../src/services/…`. So the entire existing test suite is blind to this.
- **Solution** — Booted the real built bundle on workerd via `wrangler dev --local`. `osn-api` starts clean and serves 200 on `/health`, `/.well-known/jwks.json` and `/`, with zero errors in the log.
- **Rationale** — That is the module-eval proof, one tier below a deploy and available without one. It exercises the same workerd runtime, the same bundle, and the same isolate-startup path that a dev-tier deploy would.

### Correct the risk framing from the original assessment — `approach`

- **Issue** — The first assessment of this bump weighted `RedisLive` (`shared/redis/src/ioredis.ts:157`) as the production risk, citing v6's RESP3 default, the `keepAlive` 0 → 30000 change and the new `retryStrategy`.
- **Why** — That is backwards. `RedisLive` is **dead code**: no consumers repo-wide, and not re-exported from the package index. The only constructor that opens a socket is at line 115, reached solely from the Bun dev server (`osn/api/src/local.ts:34`, `pulse/api/src/local.ts:46`).
- **Solution** — Recorded the real exposure instead: the bundle, which is what got verified above.
- **Rationale** — RESP3, keepAlive and retryStrategy touch **local dev only**. Production for both APIs is workerd via `initRedisClientFromEnv`, which selects Upstash-over-HTTP or the in-memory store. Getting this the wrong way round would have meant testing the wrong thing carefully.

### Record that the bundled ioredis can never execute — `P-W1`

- **Issue** — The changeset noted that the `osn-api` Worker bundle grows 4594.90 → 4716.41 KiB. A performance review of this branch established what that number is actually buying: nothing. The ioredis compiled into these Worker bundles is unreachable at runtime.
- **Why** — On workerd `initRedisClientFromEnv` only ever selects the Upstash-over-HTTP backend or the in-memory store; the socket-opening `createClientFromUrl` is reached solely from `osn/api/src/local.ts`, the Bun dev server. Measured by stubbing that one import and rebuilding: ioredis is 449.58 KiB raw / 72.50 KiB gzip in `osn-api`, about 8.8% of the compressed script, parsed and evaluated on every cold isolate start. The module docstring in `@shared/redis` asserts the opposite — that the Workers bundle "never pulls it in" — which is why it went unnoticed.
- **Solution** — Recorded in the changeset and filed as xchromo/osn-tracker#628. Not fixed here: the fix is a module split in `@shared/redis` separating the Workers selector from the Bun-only TCP transport, which is a source change with its own review surface.
- **Rationale** — This is pre-existing — ioredis 5 was already 337.98 KiB raw / 61.75 KiB gzip in the bundle, and this bump adds 111.60 / 10.75 on top. Turning a dependency bump into a bundle refactor would hide the refactor inside a PR nobody would review as one. The honest move is to state the real cost of the bump and file the underlying problem, which the review's measurement now makes actionable.

**Out of scope**

- The pre-existing `pulse/api` local-dev breakage described below.

## Test plan

| Gate | Result |
|---|---|
| **`wrangler dev --local`, osn-api on real workerd** | ✅ boots, 200 on 3 routes, 0 errors in log |
| `bun run build` (wrangler bundle, all 4 Workers) | ✅ 13/13 tasks |
| `bun run check` | ✅ 37/37 tasks, 0 errors |
| `bun run test` | ✅ 38/38 tasks, 0 fail |
| `bun run test:d1` | ✅ 5/5 tasks, 23 pass, 0 fail |
| `redis-parser` removed from lockfile | ✅ confirmed absent |

**What could not be verified locally, precisely.** `pulse-api` could not be booted the same way: `wrangler dev --local` crashes it at module eval on `fileURLToPath` returning undefined, with or without `--env dev`. **It does the same on ioredis 5.11.1** — I checked out the parent branch, reinstalled to 5.11.1, rebuilt and reproduced it — so the breakage is pre-existing and unrelated to this bump. Filed separately. pulse-api's coverage here is its `bun run build` wrangler bundle, which passes, plus the dev tier on merge.

Merging to `main` auto-deploys the dev tier, and production waits on the `production` environment approval. Watch the dev tier's Redis-backed paths — rate limiting and session stores — before approving production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT

