### PR TITLE
fix(ci): install Chromium with the workspace playwright, not npm's latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,35 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
+      # Both installs run from `cire/host`, and the working directory is the
+      # whole point. `playwright` is a devDependency of `cire/host` and
+      # `cire/invites`, not of the root, so `bunx playwright` at the repo root
+      # finds nothing local and fetches the latest release from npm — which
+      # then installs the browser revision *that* version wants, not ours.
+      #
+      # That was harmless right up until it wasn't. The workspace pins
+      # playwright 1.62.1, and 1.62.1 was npm's latest from 2026-07-30 until
+      # 1.63.0 shipped on 2026-09-04 — so for five weeks the wrong lookup
+      # returned the right answer. From 1.63.0 on it installs chromium 1243
+      # while the tests look for chromium_headless_shell 1234, and
+      # `test:browser` fails with "Executable doesn't exist" on a run whose
+      # install step just reported success and downloaded 186.8 MiB.
+      #
+      # Existing branches did not fail, which is the misleading part: GitHub
+      # Actions scopes a cache to the branch that wrote it plus the default
+      # branch, so every branch with a Chromium cache from before 2026-09-04
+      # still restores revision 1234 and passes. Only a branch with no cache
+      # of its own falls through to a fresh install and sees this. Those
+      # caches expire, so without this fix the failure arrives on every
+      # branch in turn, main included.
       - name: Install Chromium's system libraries
         timeout-minutes: 10
+        working-directory: cire/host
         run: bunx playwright install-deps chromium
 
       - name: Install Chromium for browser tests
         timeout-minutes: 10
+        working-directory: cire/host
         run: bunx playwright install chromium
 
       - name: Browser tests


### PR DESCRIPTION
## Summary

The browser-test job installs Chromium for a playwright version this repo does not use, and since 2026-09-04 that has been the wrong browser.

`playwright` is a devDependency of `cire/host` and `cire/invites`, not of the root. `bunx playwright install chromium` run from the repo root therefore finds nothing local and fetches the latest release from npm, then installs the browser revision *that* version wants. The workspace pins playwright 1.62.1, whose `browsers.json` puts chromium and chromium-headless-shell at revision **1234**. npm's latest is now **1.63.0**, which installs **1243**.

The wrong lookup returned the right answer for five weeks — 1.62.1 was npm's latest from 2026-07-30 until 1.63.0 shipped on 2026-09-04 — which is why this has never been seen before and why it is not tied to any particular branch's changes.

Both install steps now run with `working-directory: cire/host`.

## Workspaces affected

None — the only changed file is `.github/workflows/ci.yml`. `scripts/changeset-required.sh` returns `skip`, so no changeset is needed: `.github/` is on the allowlist and no versioned package ships anything here.

## Issues

This branch closes no issue.

**Opened**

None.

## Decisions

### Fix the resolution, do not pin the version into CI — `approach`

- **Issue** — `bunx playwright install chromium` at the repo root resolves playwright from npm rather than from the workspace, so it installs whichever browser revision npm's current latest wants.
- **Why** — Since 1.63.0 shipped on 2026-09-04 that is revision 1243, while the tests look for `chromium_headless_shell` 1234. The install step reports success and downloads 186.8 MiB, then `test:browser` fails with `Executable doesn't exist at .../chromium_headless_shell-1234/...`. A green install step followed by a missing-binary failure is a confusing pair to debug from cold.
- **Solution** — `working-directory: cire/host` on both install steps, where bunx resolves the workspace's own playwright. Verified by version rather than by re-running and hoping: `bunx playwright --version` prints 1.63.0 at the repo root and 1.62.1 from `cire/host`, and `playwright-core@1.62.1`'s `browsers.json` lists chromium and chromium-headless-shell at 1234.
- **Rationale** — Pinning `playwright@1.62.1` into the CI command would also work and was rejected: it duplicates a version the lockfile already owns, so the next playwright bump reintroduces this failure with nothing pointing at the cause. Fixing *where* the resolution happens makes the lockfile the single source of the answer, which is what the Chromium cache's own key (`hashFiles('bun.lock')`) already assumes.

### Put this at the bottom of the dependency stack rather than in the PR that found it — `approach`

- **Issue** — This surfaced on `chore/deps-advisory-refresh` (#887), the top of an eleven-PR dependency stack, and was first committed there.
- **Why** — It is not that branch's bug and not a dependency change. More practically, leaving it at the top would have blocked the stack: #872 hit the identical failure while #887 was being fixed, and #872 is the base for six PRs above it. A fix at the top cannot unblock a PR below it.
- **Solution** — Moved to its own branch off `main`, with the whole stack rebased on top so every PR inherits it.
- **Rationale** — This is a repository-wide break, so it should merge on its own and fix `main` without waiting on eleven dependency PRs. It is also the only change here that touches `.github/`, which `CODEOWNERS` puts under a human owner — bundling it into a dependency PR would have pulled that review requirement onto work that does not need it.

**Out of scope**

- None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Version resolution at repo root | `bunx playwright --version` | `Version 1.63.0` — the bug |
| Version resolution from `cire/host` | `bunx playwright --version` | `Version 1.62.1` — matches the lockfile |
| Revision the workspace expects | `playwright-core@1.62.1/browsers.json` | `chromium 1234`, `chromium-headless-shell 1234` |
| Browser tier, locally | `bun run test:browser` | ✅ 2 files, 13 tests |
| Browser tier, on CI with this fix | `Build & Test` → Browser tests | ✅ `cire/host` 2 files / 13 tests, `cire/invites` 7 files / 33 tests, all real Chromium runs |

The CI row was observed on run [34010355469](https://github.com/xchromo/osn/actions/runs/34010355469), which carried this exact change while it was still committed on #887.

**Worth knowing when reviewing.** Most existing branches are still green, and that is not evidence against this. GitHub Actions scopes a cache to the branch that wrote it plus the default branch, so any branch holding a Chromium cache from before 2026-09-04 restores revision 1234 and passes its browser tests for real — I checked #869's log and the tests execute per file with timings, they are not skipped. Only a branch with no cache of its own falls through to a fresh install. Those caches expire after a week idle, so without this the failure arrives branch by branch, `main` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124xmomh3mBQfdDwECYzkeT
