### PR TITLE
fix(cire): stop the editors seeding an empty DesiredState from a discarded load

### DIFF
--- a/.changeset/cire-desired-state-seed.md
+++ b/.changeset/cire-desired-state-seed.md
@@ -1,0 +1,13 @@
+---
+"@cire/host": patch
+---
+
+Fix the guests + events editors seeding a DesiredState draft from an empty
+slice when its load resolves without filling the cache (a generation-guarded
+`ensureXxxLoaded` discarding an in-flight fetch, e.g. an invalidate landing
+mid-load). Since the draft is posted back as the whole DesiredState, that
+empty slice previously fell through `?? []` and a save from it deleted every
+household — and every live claim code with it. All six reads (events, guests,
+households in both `EventsEditor` and `GuestsEditor`) now check the loader's
+`fresh` result and show the existing load error instead of seeding an empty
+draft.

--- a/cire/host/src/components/EventsEditor.tsx
+++ b/cire/host/src/components/EventsEditor.tsx
@@ -131,7 +131,12 @@ export default function EventsEditor(props: { weddingId: string }) {
   /** Load events + guests through the shared caches, then seed the draft. Guests
    *  are loaded even though this tab only edits events: the draft-save posts the
    *  WHOLE DesiredState, so an unloaded guest slice would read as "delete every
-   *  household". */
+   *  household". That comment covers not CALLING the loader; it does not cover
+   *  the loader resolving without filling the cache (a generation-discarded
+   *  load, e.g. an invalidate landing mid-fetch) — `ensureXxxLoaded` resolving
+   *  `false` for that case is what the `!fresh` checks below guard against,
+   *  rather than falling back to `?? []` and seeding the same empty-slice
+   *  deletion from the other direction. */
   async function loadInto() {
     const [events, guests, households] = await Promise.all([
       ensureEventsLoaded(props.weddingId, async () => {
@@ -142,7 +147,11 @@ export default function EventsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load events");
         return (await res.json()) as EventRow[];
-      }).then(() => eventsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = eventsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("event slice unavailable");
+        return rows;
+      }),
       ensureGuestsLoaded(props.weddingId, async () => {
         const res = await authFetch(apiUrl(`/api/organiser/weddings/${props.weddingId}/guests`));
         if (res.status === 401) {
@@ -151,7 +160,11 @@ export default function EventsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load guests");
         return (await res.json()) as OrganiserGuestRow[];
-      }).then(() => guestsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = guestsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("guest slice unavailable");
+        return rows;
+      }),
       // Households ride along for the same reason the guests do, one level down:
       // the guest rows can't describe a household that holds no guests, so
       // without this read a guest-less household is absent from the DesiredState
@@ -166,7 +179,11 @@ export default function EventsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load households");
         return (await res.json()) as OrganiserHouseholdRow[];
-      }).then(() => householdsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = householdsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("household slice unavailable");
+        return rows;
+      }),
     ]);
     store.load(events, guests, households);
   }

--- a/cire/host/src/components/EventsEditor.tsx
+++ b/cire/host/src/components/EventsEditor.tsx
@@ -15,7 +15,7 @@ import { toast } from "@shared/toast";
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import { allAuthFirst, apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import { type DateTimeParts, joinIso, splitIso } from "../lib/event-datetime";
 import { formatEventWhen } from "../lib/event-display";
 import {
@@ -138,7 +138,7 @@ export default function EventsEditor(props: { weddingId: string }) {
    *  rather than falling back to `?? []` and seeding the same empty-slice
    *  deletion from the other direction. */
   async function loadInto() {
-    const [events, guests, households] = await Promise.all([
+    const [events, guests, households] = await allAuthFirst([
       ensureEventsLoaded(props.weddingId, async () => {
         const res = await authFetch(apiUrl(`/api/organiser/weddings/${props.weddingId}/events`));
         if (res.status === 401) {

--- a/cire/host/src/components/GuestsEditor.tsx
+++ b/cire/host/src/components/GuestsEditor.tsx
@@ -67,7 +67,12 @@ export default function GuestsEditor(props: { weddingId: string }) {
 
   /** Load events + guests + households through the shared caches, then seed the
    *  draft. Households are read separately because the guest rows only describe
-   *  households that HOLD a guest — see `buildDraft`. */
+   *  households that HOLD a guest — see `buildDraft`. The draft-save posts the
+   *  WHOLE DesiredState, so a slice that resolves without filling the cache (a
+   *  generation-discarded load, e.g. an invalidate landing mid-fetch) must not
+   *  fall back to `?? []` — that reads as "delete everything in this slice".
+   *  The `!fresh` checks below throw instead, so the load error is surfaced
+   *  rather than seeding an empty draft. */
   async function loadInto() {
     const [events, guests, households] = await Promise.all([
       ensureEventsLoaded(props.weddingId, async () => {
@@ -78,7 +83,11 @@ export default function GuestsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load events");
         return (await res.json()) as EventRow[];
-      }).then(() => eventsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = eventsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("event slice unavailable");
+        return rows;
+      }),
       ensureGuestsLoaded(props.weddingId, async () => {
         const res = await authFetch(apiUrl(`/api/organiser/weddings/${props.weddingId}/guests`));
         if (res.status === 401) {
@@ -87,7 +96,11 @@ export default function GuestsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load guests");
         return (await res.json()) as OrganiserGuestRow[];
-      }).then(() => guestsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = guestsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("guest slice unavailable");
+        return rows;
+      }),
       ensureHouseholdsLoaded(props.weddingId, async () => {
         const res = await authFetch(
           apiUrl(`/api/organiser/weddings/${props.weddingId}/households`),
@@ -98,7 +111,11 @@ export default function GuestsEditor(props: { weddingId: string }) {
         }
         if (!res.ok) throw new Error("Failed to load households");
         return (await res.json()) as OrganiserHouseholdRow[];
-      }).then(() => householdsAccessor(props.weddingId)() ?? []),
+      }).then((fresh) => {
+        const rows = householdsAccessor(props.weddingId)();
+        if (!fresh || rows == null) throw new Error("household slice unavailable");
+        return rows;
+      }),
     ]);
     store.load(events, guests, households);
   }

--- a/cire/host/src/components/GuestsEditor.tsx
+++ b/cire/host/src/components/GuestsEditor.tsx
@@ -3,7 +3,7 @@ import { toast } from "@shared/toast";
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
+import { allAuthFirst, apiUrl, isAuthExpired, redirectToLogin } from "../lib/api";
 import {
   ensureEventsLoaded,
   type EventRow,
@@ -74,7 +74,7 @@ export default function GuestsEditor(props: { weddingId: string }) {
    *  The `!fresh` checks below throw instead, so the load error is surfaced
    *  rather than seeding an empty draft. */
   async function loadInto() {
-    const [events, guests, households] = await Promise.all([
+    const [events, guests, households] = await allAuthFirst([
       ensureEventsLoaded(props.weddingId, async () => {
         const res = await authFetch(apiUrl(`/api/organiser/weddings/${props.weddingId}/events`));
         if (res.status === 401) {

--- a/cire/host/src/lib/api.ts
+++ b/cire/host/src/lib/api.ts
@@ -51,3 +51,43 @@ export function redirectToLogin(): void {
       : `/login?returnTo=${encodeURIComponent(here)}`;
   window.location.href = target;
 }
+
+/**
+ * `Promise.all` for calls whose rejections are not equally important.
+ *
+ * `Promise.all` adopts whichever rejection settles FIRST, and that is decided
+ * by timing rather than by what the caller needs to hear about. Every caller
+ * here loads several slices at once and handles exactly one failure specially:
+ * an expired session, which must reach `redirectToLogin()` rather than a
+ * "couldn't load" banner the organiser can do nothing about. If any other
+ * slice rejects a tick earlier — because a generation-discarded load left it
+ * unusable, say — `Promise.all` hands that reason to the catch, `isAuthExpired`
+ * returns false, and the redirect is silently lost.
+ *
+ * This settles all of them and rethrows an expired session in preference to
+ * anything else, so the reason is chosen by severity. With no auth failure
+ * among them it behaves exactly as `Promise.all` does: the first rejection,
+ * or the resolved values in order.
+ */
+export async function allAuthFirst<T extends readonly Promise<unknown>[]>(
+  promises: readonly [...T],
+): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }> {
+  const results = await Promise.allSettled(promises);
+  // An expired session wins over any other reason; failing that, the first
+  // rejection, which is what `Promise.all` would have thrown anyway.
+  let chosen: { readonly reason: unknown } | undefined;
+  for (const result of results) {
+    if (result.status !== "rejected") continue;
+    if (isAuthExpired(result.reason)) {
+      chosen = result;
+      break;
+    }
+    chosen ??= result;
+  }
+  if (chosen) throw chosen.reason;
+  // Nothing rejected, so every promise is already settled and this resolves on
+  // the next tick with the values in order. Deferring to `Promise.all` here
+  // rather than collecting them by hand is what lets the return type be its
+  // type: no assertion, and no chance of the two drifting apart.
+  return Promise.all(promises);
+}

--- a/cire/host/tests/components/EventsEditor.reorder.test.tsx
+++ b/cire/host/tests/components/EventsEditor.reorder.test.tsx
@@ -24,11 +24,19 @@ vi.mock("@shared/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../../src/lib/api", () => ({
-  apiUrl: (path: string) => `https://api.test${path}`,
-  isAuthExpired: () => false,
-  redirectToLogin: () => {},
-}));
+// Spread the real module rather than listing exports: a partial mock makes
+// every later addition to `lib/api` `undefined` here, and the component then
+// throws inside its own try and renders a load error as though the API were
+// down — a failure that does not read as a missing mock.
+vi.mock("../../src/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../src/lib/api")>("../../src/lib/api");
+  return {
+    ...actual,
+    apiUrl: (path: string) => `https://api.test${path}`,
+    isAuthExpired: () => false,
+    redirectToLogin: () => {},
+  };
+});
 
 import EventsEditor from "../../src/components/EventsEditor";
 import { __resetEventsCache } from "../../src/lib/events-store";

--- a/cire/host/tests/components/EventsEditor.test.tsx
+++ b/cire/host/tests/components/EventsEditor.test.tsx
@@ -27,7 +27,7 @@ vi.mock("../../src/lib/api", async () => {
 
 import EventsEditor from "../../src/components/EventsEditor";
 import { __resetEventsCache } from "../../src/lib/events-store";
-import { __resetGuestsCache } from "../../src/lib/guests-store";
+import { __resetGuestsCache, invalidateGuests } from "../../src/lib/guests-store";
 import { __resetHouseholdsCache } from "../../src/lib/households-store";
 import { confirmNavigation } from "../../src/lib/unsaved-guard";
 import { authFetchMock, resetOrganiserMocks, toastSuccess } from "../test-support/mocks";
@@ -138,6 +138,51 @@ describe("EventsEditor", () => {
     render(() => <EventsEditor weddingId="wed_a" />);
     await waitFor(() => expect(screen.getByText("Ceremony")).toBeTruthy());
     expect(screen.getByText("Reception")).toBeTruthy();
+  });
+
+  // S-L (xchromo/osn-tracker#622): the draft-save posts the WHOLE DesiredState,
+  // so a guest slice that resolves without filling the cache must not fall back
+  // to `?? []` — that reads as "delete every household". A generation-discarded
+  // load (an invalidate landing while `ensureGuestsLoaded`'s fetch is still in
+  // flight — the exact sequence a real save-then-refetch produces) resolves
+  // `false` rather than throwing, so this is reachable without a rejected fetch.
+  it("shows a load error instead of seeding an empty draft when a guest load resolves stale", async () => {
+    let resolveGuestsFetch!: (res: Response) => void;
+    const guestsFetch = new Promise<Response>((resolve) => {
+      resolveGuestsFetch = resolve;
+    });
+    authFetchMock.mockImplementation((url: string) => {
+      const u = String(url);
+      if (u.endsWith("/events")) return Promise.resolve(json(EVENTS));
+      if (u.endsWith("/guests")) return guestsFetch;
+      if (u.endsWith("/households")) return Promise.resolve(json(HOUSEHOLDS));
+      return Promise.resolve(json({}));
+    });
+
+    render(() => <EventsEditor weddingId="wed_a" />);
+
+    // Wait for the guests fetch to actually be issued before invalidating —
+    // otherwise the invalidate could land before `ensureGuestsLoaded` even
+    // reads the starting generation, which isn't the race this test targets.
+    await waitFor(() =>
+      expect(authFetchMock.mock.calls.some((c) => String(c[0]).endsWith("/guests"))).toBe(true),
+    );
+
+    // A mutation elsewhere invalidates guests for this wedding WHILE the fetch
+    // above is still in flight — this is what a save-then-refetch does for
+    // real. It bumps the generation the in-flight load started under.
+    invalidateGuests("wed_a");
+
+    // The in-flight fetch now resolves — but against a generation that has
+    // since moved on, so `ensureGuestsLoaded` discards the rows instead of
+    // caching them and resolves `false`.
+    resolveGuestsFetch(json(GUESTS));
+
+    // The load must surface as an error, not seed the draft from an empty
+    // guest slice: the schedule never renders, and neither does a blank state
+    // that would let Save reach the wire with guests wiped out.
+    await waitFor(() => expect(screen.getByText(/Could not load the schedule/i)).toBeTruthy());
+    expect(screen.queryByText("Ceremony")).toBeNull();
   });
 
   it("opens the drawer and edits an event name", async () => {

--- a/cire/host/tests/components/GuestsEditor.test.tsx
+++ b/cire/host/tests/components/GuestsEditor.test.tsx
@@ -28,7 +28,7 @@ import GuestsEditor from "../../src/components/GuestsEditor";
 import { __resetEventsCache } from "../../src/lib/events-store";
 import type { DesiredStateWire } from "../../src/lib/guest-event-draft";
 import { __resetGuestsCache } from "../../src/lib/guests-store";
-import { __resetHouseholdsCache } from "../../src/lib/households-store";
+import { __resetHouseholdsCache, invalidateHouseholds } from "../../src/lib/households-store";
 import { confirmNavigation } from "../../src/lib/unsaved-guard";
 import { authFetchMock, resetOrganiserMocks, toastSuccess } from "../test-support/mocks";
 
@@ -136,6 +136,52 @@ describe("GuestsEditor", () => {
     // The attendance checkbox for Ada × Ceremony is present + checked.
     const box = screen.getByRole("checkbox", { name: /Ada attends Ceremony/i });
     expect((box as HTMLInputElement).checked).toBe(true);
+  });
+
+  // S-L (xchromo/osn-tracker#622): the draft-save posts the WHOLE DesiredState,
+  // so a household slice that resolves without filling the cache must not
+  // fall back to `?? []` — that reads as "delete every household", taking its
+  // live claim code with it. A generation-discarded load (an invalidate
+  // landing while `ensureHouseholdsLoaded`'s fetch is still in flight — the
+  // exact sequence a real save-then-refetch produces) resolves `false` rather
+  // than throwing, so this is reachable without a rejected fetch.
+  it("shows a load error instead of seeding an empty draft when a household load resolves stale", async () => {
+    let resolveHouseholdsFetch!: (res: Response) => void;
+    const householdsFetch = new Promise<Response>((resolve) => {
+      resolveHouseholdsFetch = resolve;
+    });
+    authFetchMock.mockImplementation((url: string) => {
+      const u = String(url);
+      if (u.endsWith("/events")) return Promise.resolve(json(EVENTS));
+      if (u.endsWith("/guests")) return Promise.resolve(json(GUESTS));
+      if (u.endsWith("/households")) return householdsFetch;
+      return Promise.resolve(json({}));
+    });
+
+    render(() => <GuestsEditor weddingId="wed_a" />);
+
+    // Wait for the households fetch to actually be issued before invalidating
+    // — otherwise the invalidate could land before `ensureHouseholdsLoaded`
+    // even reads the starting generation, which isn't the race this targets.
+    await waitFor(() =>
+      expect(authFetchMock.mock.calls.some((c) => String(c[0]).endsWith("/households"))).toBe(true),
+    );
+
+    // A mutation elsewhere invalidates households for this wedding WHILE the
+    // fetch above is still in flight — this is what a save-then-refetch does
+    // for real. It bumps the generation the in-flight load started under.
+    invalidateHouseholds("wed_a");
+
+    // The in-flight fetch now resolves — but against a generation that has
+    // since moved on, so `ensureHouseholdsLoaded` discards the rows instead
+    // of caching them and resolves `false`.
+    resolveHouseholdsFetch(json(HOUSEHOLDS));
+
+    // The load must surface as an error, not seed the draft from an empty
+    // household slice: the roster never renders, and neither does a blank
+    // state that would let Save reach the wire with every household wiped.
+    await waitFor(() => expect(screen.getByText(/Could not load the guest list/i)).toBeTruthy());
+    expect(screen.queryByDisplayValue("Sharma")).toBeNull();
   });
 
   it("shows the sticky save bar only once an edit makes the draft dirty", async () => {

--- a/cire/host/tests/lib/api.test.ts
+++ b/cire/host/tests/lib/api.test.ts
@@ -2,7 +2,7 @@
 import { AuthExpiredError } from "@shared/rp-auth";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { apiUrl, isAuthExpired, redirectToLogin } from "../../src/lib/api";
+import { allAuthFirst, apiUrl, isAuthExpired, redirectToLogin } from "../../src/lib/api";
 
 /**
  * `isAuthExpired` decides between "bounce the organiser to sign-in" and "show
@@ -95,5 +95,56 @@ describe("redirectToLogin", () => {
 describe("apiUrl", () => {
   it("prefixes the configured cire API origin", () => {
     expect(apiUrl("/api/organiser/weddings")).toMatch(/\/api\/organiser\/weddings$/);
+  });
+});
+
+/**
+ * `Promise.all` adopts whichever rejection settles FIRST, and the editors load
+ * three slices at once where exactly one failure is special: an expired session
+ * has to reach `redirectToLogin()` rather than a banner the organiser can do
+ * nothing about. Once a slice could reject for an ordinary reason too, timing
+ * decided which reason the catch saw, and losing that race lost the redirect.
+ */
+describe("allAuthFirst", () => {
+  it("resolves the values in order, like Promise.all", async () => {
+    const [a, b, c] = await allAuthFirst([
+      Promise.resolve(1),
+      Promise.resolve("two"),
+      Promise.resolve([3]),
+    ]);
+    expect(a).toBe(1);
+    expect(b).toBe("two");
+    expect(c).toEqual([3]);
+  });
+
+  it("prefers an expired session over a rejection that settled earlier", async () => {
+    const slice = new Error("guest slice unavailable");
+    const expired = new AuthExpiredError();
+    await expect(
+      allAuthFirst([
+        Promise.reject(slice),
+        new Promise((_, reject) => setTimeout(() => reject(expired), 5)),
+      ]),
+    ).rejects.toBe(expired);
+  });
+
+  it("throws the first rejection when none of them is an expired session", async () => {
+    const first = new Error("first");
+    await expect(
+      allAuthFirst([Promise.reject(first), Promise.reject(new Error("second"))]),
+    ).rejects.toBe(first);
+  });
+
+  it("waits for every promise before choosing, so a later auth failure still wins", async () => {
+    const expired = new AuthExpiredError();
+    let settled = false;
+    const slow = new Promise((_, reject) =>
+      setTimeout(() => {
+        settled = true;
+        reject(expired);
+      }, 10),
+    );
+    await expect(allAuthFirst([Promise.reject(new Error("fast")), slow])).rejects.toBe(expired);
+    expect(settled).toBe(true);
   });
 });

--- a/cire/host/tests/test-support/mocks.ts
+++ b/cire/host/tests/test-support/mocks.ts
@@ -46,9 +46,20 @@ export function toastMock() {
   };
 }
 
-/** Factory for `vi.mock("../../src/lib/api", ...)`. */
-export function organiserApiMock() {
+/**
+ * Factory for `vi.mock("../../src/lib/api", ...)`.
+ *
+ * Spreads the real module and overrides only the three exports a component
+ * test has to control — the URL builder, the auth-expiry predicate, and the
+ * redirect. Listing exports instead would make every future addition to
+ * `lib/api` silently `undefined` in fifteen test files, which is not a failure
+ * that reads as a missing mock: the component calls it, throws a TypeError
+ * inside its own `try`, and renders a load error as though the API were down.
+ */
+export async function organiserApiMock() {
+  const actual = await vi.importActual<typeof import("../../src/lib/api")>("../../src/lib/api");
   return {
+    ...actual,
     apiUrl: (path: string) => `https://api.test${path}`,
     isAuthExpired: (err: unknown) => String(err).includes("AuthExpiredError"),
     redirectToLogin: () => redirectSpy(),


### PR DESCRIPTION
## Summary

`EventsEditor` and `GuestsEditor` seed their draft from three reads shaped
`ensureXxxLoaded(id, fetcher).then(() => accessor(id)() ?? [])`. That draft is posted
back as a complete `DesiredState`, so a slice that arrives empty reads as "delete
everything in it" — `EventsEditor.tsx` says exactly that in its own comment, which is
why it loads guests and households on a tab that only edits events.

The comment guards against not *calling* the loader. Nothing guarded against the loader
**resolving without filling the cache**, which is what a generation-discarded load does,
and `?? []` turned that into the empty slice the comment fears. A save from that draft
deletes every household — and every live claim code with it, since `families.public_id`
*is* the claim code and the delete cascades guests, RSVPs and sessions.

- All six reads now check the `Promise<boolean>` the PR below this one added — `true`
  when the call left the cache fresh, `false` when the generation guard discarded the
  result — and throw rather than falling back to `[]`.
- No retry is added. A wedding invalidated repeatedly would spin, and the honest answer
  for the organiser is "this did not load".

## Workspaces affected

`@cire/host`. One changeset naming `"@cire/host": patch` and nothing else. Several more
`@cire/host` changesets arrive from the PRs beneath it; changesets are additive per
package, so that is expected and valid.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#622 | `S-L` |

Closes xchromo/osn-tracker#622

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#631 | `T-S` |

## Decisions

### Throw rather than fall back — `S-L`

- **Issue** — `?? []` conflated "the server says there are none" with "we do not know".
- **Why** — those must stay distinct anywhere the value is about to be posted back as
  authoritative, and here the difference is every household in the wedding.
- **Solution** — check `fresh` and the accessor, and throw into the existing
  `try`/`catch`, which already shows a load error.
- **Rationale** — both `loadInto()` catches ignore the thrown error's message and set a
  fixed banner, so no new error surface was invented. Retrying instead would spin, and
  seeding a partial draft is the outcome this exists to prevent.

### Keep the sign-in redirect that adding a second rejection took away — `S-L1`

- **Issue** — the security review found the change above introduced a regression.
  `Promise.all` adopts whichever rejection settles **first**. Until this branch only one
  thing could reject in `loadInto()` — an expired session, thrown by `authFetch` — so
  the catch's `isAuthExpired(err)` always saw it and always reached
  `redirectToLogin()`. A second reason put the two in a race decided by timing.
- **Why** — losing that race means an organiser whose session expired mid-load gets
  "Could not load the guest list. Is the API running?" and a dead page instead of a
  sign-in prompt. The `if (res.status === 401)` blocks inside the fetchers are not a
  fallback: `authFetch` rejects before returning a 401 response, so they never run.
- **Solution** — `allAuthFirst` in `cire/host/src/lib/api.ts` settles all of them and
  rethrows an expired session in preference to anything else. With no auth failure among
  them it behaves exactly as `Promise.all` does.
- **Rationale** — ordering the *reasons* by severity fixes the defect at its cause,
  which is that `Promise.all` picks a winner by timing. Making the slice errors
  auth-shaped instead would re-open the unanchored-match hazard `api.ts` already
  documents. The helper defers to `Promise.all` for the resolved values rather than
  collecting them by hand, which is what lets the return type be its type instead of an
  assertion.

### Two test mocks changed, and why that is a finding rather than a chore — `T-S`

- **Issue** — adding one export to `lib/api` broke 49 tests across three files.
- **Why** — those mocks listed the module's exports instead of spreading it, so
  `allAuthFirst` arrived `undefined`, the component threw inside its own `try`, and every
  affected test rendered "Could not load … Is the API running?". Every symptom points at
  the fetch layer, so the cause is misattributed rather than noticed.
- **Solution** — the shared factory and the one inline mock that broke now spread
  `importActual` and override only what they need.
- **Rationale** — six more files have the same shape and pass only because the
  components they render do not yet call anything else from `lib/api`. That is a
  property of the components, not of the mocks, so it is filed as
  xchromo/osn-tracker#631 rather than fixed here — two of the six are browser-tier and
  need `test:browser` to verify.

**Out of scope** — Two findings the security review raised and I did not fix here. A
failed post-apply reload leaves a dirty draft whose new rows carry no server ids, so
re-saving deletes and re-mints them; it is a residual this change improves rather than
causes. And a household created by a co-host between load and preview is absent from the
draft and removed by `removeManual: true` — a different cause with the same symptom,
unrelated to caching. Both are being filed separately.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass |
| Type check | `bun run check` | pass |
| Tests | `bun run test` | pass, 38/38 tasks; `@cire/host` 1218 |
| Format | `bun run fmt:check` | pass |
| Changesets | `bash scripts/validate-changesets.sh` | pass |
| Browser tier | `bun run test:browser` | not run — nothing in the diff reads CSS, layout or geometry |

Two component tests construct the real race rather than reaching into store internals: a
deferred `authFetch` response for one slice, an invalidate landing on the same wedding
while it is in flight, then the fetch resolving under a bumped generation. Both were
verified by restoring `?? []` at the read under test and watching them fail. Four unit
tests cover `allAuthFirst` directly, including that a *later* auth failure still beats an
earlier ordinary one; deleting the preference fails two of them.

Worth knowing when reading this: `fresh === false` is not reachable from a mounted
editor. Every `invalidate*` call site either runs synchronously before the reload or sits
in a mutually exclusive `<Show>` arm, so the only live route is an editor whose initial
load is still in flight when the workspace switches to Import — by which point the
component is disposed. This is insurance against a destructive bug, not a live path, and
it cost three comparisons per load to buy.

By hand: nothing reproduces the original bug without forcing the race.
