### PR TITLE
perf(cire-invites): cut the guest-site Worker from 285 KB to 163 KB gzip

### DIFF
--- a/.changeset/cire-invites-ssr-bundle-minify.md
+++ b/.changeset/cire-invites-ssr-bundle-minify.md
@@ -21,10 +21,15 @@ small inline Astro integration hooks `astro:build:setup`, which runs after that
 config is built and whose `updateConfig` wins, to force `minify: true` for the
 server and prerender builds only — the client build is unaffected (#616).
 Because minified output loses source line numbers on a production exception,
-this ships with `build.sourcemap: true` and `upload_source_maps: true` in
-`wrangler.jsonc`, so Cloudflare can symbolicate a crash back to a real source
-line. `.map` files are excluded from the size guard — they're uploaded for
-symbolication, not part of what the Worker runs.
+this ships with `sourcemap: true` set through that same hook and
+`upload_source_maps: true` in `wrangler.jsonc`, so Cloudflare can symbolicate a
+crash back to a real source line. Setting `sourcemap` through the hook rather
+than as a plain Vite config value is deliberate: the plain form also reaches the
+client build, which would emit `.map` files into `dist/client` — the directory
+Cloudflare serves as public Static Assets — and publish the guest site's
+unminified source. `.map` files are excluded from the size guard (they're
+uploaded for symbolication, not part of what the Worker runs), and the guard now
+fails outright if any `.map` file appears under `dist/client`.
 
 `zod` was traced (#617): it comes from Astro's own actions request handler
 (`actions/handler.js` → `actions/runtime/server.js`, which imports
@@ -34,5 +39,11 @@ config to skip that code path, so `zod` stays — it's a real Astro core
 dependency, not dead weight, and it is not stubbed the way `motion` was.
 
 `cire/invites/scripts/guard-ssr-size.sh`'s threshold moves from 310000 to
-211103 (the new measured total plus the same motion-class headroom used
-before), and its `find` now also excludes `*.map` files from the measurement.
+175000: the new measured total plus about 11.7 KB of ordinary-growth headroom.
+The headroom is now deliberately smaller than the mistake the guard is for —
+`motion` costs 21261 bytes gzip in the minified build, so a library of that
+class overshoots and fails, where the old "measured plus one motion" arithmetic
+would have let it through. The guard also excludes `*.map` from the
+measurement, fails if any `.map` file appears under the publicly served
+`dist/client`, and now runs from the package's own `build` script rather than
+only from CI, so the by-hand deploy path is covered too.

--- a/.changeset/cire-invites-ssr-bundle-minify.md
+++ b/.changeset/cire-invites-ssr-bundle-minify.md
@@ -1,0 +1,38 @@
+---
+"@cire/invites": patch
+---
+
+Cut the guest site's server bundle further, from 285 KB to 163 KB gzip, and re-baseline the size guard.
+
+Trackers #618, #616, #617: three follow-ups from the original SSR bundle-size
+audit (tracker #287).
+
+Astro sessions are unused (`Astro.session` is never read or written), so
+`astro.config.mjs` now sets `session: false` instead of pinning an in-memory
+driver. Astro's session config accepts `false` as a literal, and the
+Cloudflare adapter's KV-binding auto-provisioning is gated on that same
+literal, so this drops the session runtime and `unstorage` from `dist/server`
+without introducing a `SESSION` KV binding (#618).
+
+The SSR build was unminified — Astro's Vite build config hard-sets
+`minify: false` for the server build after spreading the user's own `vite.build`,
+so the usual `vite: { build: { minify: true } }` config is a no-op there. A
+small inline Astro integration hooks `astro:build:setup`, which runs after that
+config is built and whose `updateConfig` wins, to force `minify: true` for the
+server and prerender builds only — the client build is unaffected (#616).
+Because minified output loses source line numbers on a production exception,
+this ships with `build.sourcemap: true` and `upload_source_maps: true` in
+`wrangler.jsonc`, so Cloudflare can symbolicate a crash back to a real source
+line. `.map` files are excluded from the size guard — they're uploaded for
+symbolication, not part of what the Worker runs.
+
+`zod` was traced (#617): it comes from Astro's own actions request handler
+(`actions/handler.js` → `actions/runtime/server.js`, which imports
+`zod/v4/core`), invoked on every non-prerendered request regardless of whether
+the app defines any actions. This app doesn't, but there's no app-level
+config to skip that code path, so `zod` stays — it's a real Astro core
+dependency, not dead weight, and it is not stubbed the way `motion` was.
+
+`cire/invites/scripts/guard-ssr-size.sh`'s threshold moves from 310000 to
+211103 (the new measured total plus the same motion-class headroom used
+before), and its `find` now also excludes `*.map` files from the measurement.

--- a/cire/invites/astro.config.mjs
+++ b/cire/invites/astro.config.mjs
@@ -29,13 +29,30 @@ import { defineConfig } from "astro/config";
  *
  * The minifier under this Astro/Vite (7.2.10 → Vite 8 / rolldown-vite) is OXC,
  * not esbuild — `minify: true` selects it; do not pass `"esbuild"`.
+ *
+ * `sourcemap` goes through the SAME hook, and it has to. Minified server output
+ * means a production Worker exception no longer names a real source line, so
+ * the maps are what make `wrangler.jsonc`'s `upload_source_maps` worth setting.
+ * But `sourcemap` is NOT overridden the way `minify` is: written as a plain
+ * `vite: { build: { sourcemap: true } }` it rides the `...viteConfig.build`
+ * spread at `:36` into the top level AND is read by the client environment at
+ * `:135` (`userClient?.build?.sourcemap ?? viteConfig.build?.sourcemap ?? false`)
+ * — so it emits `dist/client/_astro/*.js.map` too. `dist/client` is this
+ * Worker's Static Assets directory (the adapter writes
+ * `"assets": { "directory": "../client" }` into the generated wrangler config),
+ * and Cloudflare serves any file there verbatim, so those maps would publish
+ * the guest site's unminified source at `/_astro/<chunk>.js.map` to anyone
+ * asking. Setting it here instead lands it on the top-level `build` AFTER `:135`
+ * has already baked the client's own `sourcemap: false`, so only the server and
+ * prerender builds emit maps. If you ever move this back to plain `vite.build`,
+ * check `dist/client` for `.map` files before you deploy.
  */
 function minifySsrBuild() {
   return {
     name: "cire-invites:minify-ssr-build",
     hooks: {
       "astro:build:setup"({ updateConfig }) {
-        updateConfig({ build: { minify: true } });
+        updateConfig({ build: { minify: true, sourcemap: true } });
       },
     },
   };
@@ -168,15 +185,5 @@ export default defineConfig({
   integrations: [solidJs(), minifySsrBuild()],
   vite: {
     plugins: [tailwindcss(), stubMotionForSsr()],
-    // Minifying the SSR build (above) renames identifiers and collapses lines,
-    // so a production Worker exception no longer names a real source line.
-    // Unlike `minify`, `build.sourcemap` rides the `...viteConfig.build` spread
-    // at `vite-build-config.js:36` untouched — nothing after it overrides
-    // `sourcemap` the way line 100 overrides `minify` — so this plain config
-    // form is enough; no `astro:build:setup` hook needed. Maps are uploaded to
-    // Cloudflare for symbolication (`wrangler.jsonc`'s `upload_source_maps`)
-    // and excluded from the size guard (`scripts/guard-ssr-size.sh`) — they
-    // are not part of the script the Worker runs.
-    build: { sourcemap: true },
   },
 });

--- a/cire/invites/astro.config.mjs
+++ b/cire/invites/astro.config.mjs
@@ -2,8 +2,76 @@ import cloudflare from "@astrojs/cloudflare";
 import solidJs from "@astrojs/solid-js";
 import { devPort } from "@shared/dev-urls";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig, sessionDrivers } from "astro/config";
+import { defineConfig } from "astro/config";
 
+/**
+ * Minify the SSR build (tracker #616). The plain config form —
+ * `vite: { build: { minify: true } }` — is a no-op: `createViteBuildConfig`
+ * (`astro/dist/core/build/vite-build-config.js:36`) spreads the user's
+ * `vite.build` into its own object, but line 100 hard-sets `minify: false`
+ * afterward ("improve build performance"), overriding it again. The `ssr`
+ * environment's build config (`:164-174`) replaces the whole `build` key with
+ * just `{ outDir, rolldownOptions }`, so a `vite.environments.ssr.build.minify`
+ * would be dropped too — there is no config field left for the SSR build to
+ * read `minify` from.
+ *
+ * The only place that still takes a user value is `astro:build:setup`
+ * (`astro/dist/integrations/hooks.js:400` `runHookBuildSetup`), which Astro
+ * runs once with `target: "server"` (`astro/dist/core/build/static-build.js:188`)
+ * AFTER `createViteBuildConfig` has already produced the config above, and
+ * whose `updateConfig` merges on top via `mergeViteConfig` — winning over the
+ * `minify: false` set earlier. The merged value lands on the top-level
+ * `build.minify`, which the `prerender` and `ssr` environments inherit (neither
+ * sets its own `build.minify`); the `client` environment does not inherit it,
+ * because its value is baked in separately
+ * (`vite-build-config.js:136`, `userClient?.build?.minify ?? viteConfig.build?.minify ?? true`)
+ * — so the client bundle stays exactly as minified as before this change.
+ *
+ * The minifier under this Astro/Vite (7.2.10 → Vite 8 / rolldown-vite) is OXC,
+ * not esbuild — `minify: true` selects it; do not pass `"esbuild"`.
+ */
+function minifySsrBuild() {
+  return {
+    name: "cire-invites:minify-ssr-build",
+    hooks: {
+      "astro:build:setup"({ updateConfig }) {
+        updateConfig({ build: { minify: true } });
+      },
+    },
+  };
+}
+
+/**
+ * `zod` (tracker #617) is NOT stubbed like `motion` below, and stays in
+ * `dist/server` on purpose — this bundle traced it, unlike `motion`, to a
+ * module that genuinely runs on every request.
+ *
+ * `src/actions` doesn't exist in this app, but Astro's own request pipeline
+ * doesn't gate on that: `core/routing/handler.js`'s `actionsAndPages()` calls
+ * `handleAction(ctx, state)` (from `actions/handler.js`) on every
+ * non-prerendered request unless `state.skipMiddleware` is set, which nothing
+ * here sets. `actions/handler.js` imports `getActionContext` from
+ * `actions/runtime/server.js:6`, and that file's first line is
+ * `import * as z from "zod/v4/core"` — a static, top-level import, so it loads
+ * whether or not the request actually names an action. `getActionContext`
+ * itself just returns early when there's no action to run, but by then the
+ * module (and `zod/v4/core`) is already part of the SSR chunk graph. There is
+ * no `actions: false`-style config to opt out of this path — grepped
+ * `astro/dist/core/config` for an actions schema key and found none.
+ *
+ * Turning off sessions (tracker #618, `session: false` below) does NOT touch
+ * this: the zod import that session config used to pull in
+ * (`astro/dist/core/session/config.js:1`, `zod/v4`) is a separate module from
+ * the actions one, and the fingerprint grep below still finds
+ * `ZodError`/`Invalid input` strings in `dist/server` after the sessions
+ * change, source-mapping back to `actions/runtime/server.js`, not to any
+ * session file:
+ *
+ *   grep -rlE 'ZodError|\$ZodError|z\.core|Invalid input' dist/server
+ *
+ * So #617 stays open on its own: astro's actions runtime is the entry, it
+ * runs at request time, and there's no app-level lever to remove it.
+ */
 /**
  * `motion` (plus its `motion-dom`/`motion-utils` deps) is ~187 KB raw of dead
  * weight in the SSR Worker build (tracker #287). The three `.motion.ts`
@@ -87,14 +155,28 @@ export default defineConfig({
     // doesn't require a Cloudflare Images binding on THIS Worker.
     imageService: "passthrough",
   }),
-  // We don't use Astro sessions at all (no `Astro.session` reads/writes). Left to
-  // its default the Cloudflare adapter auto-provisions a KV session driver and a
-  // `SESSION` KV binding the deploy would then require. Pin an in-memory driver
-  // so the adapter injects NO KV binding — keeping the Worker deploy binding-free
-  // (no manual KV namespace to create). The store is never exercised.
-  session: { driver: sessionDrivers.memory() },
-  integrations: [solidJs()],
+  // We don't use Astro sessions at all (no `Astro.session` reads/writes). Astro's
+  // own schema accepts `session: false` (`astro/dist/core/session/config.js:29`,
+  // `SessionSchema = z.union([z.literal(false), SessionObjectSchema])`), and the
+  // Cloudflare adapter's auto-provision check is gated on that same literal
+  // (`@astrojs/cloudflare/dist/index.js:107`, `if (session !== false && ...)`) —
+  // so `false` skips the KV-binding provisioning block entirely, same as it did
+  // for the in-memory driver, but also drops the session runtime and `unstorage`
+  // from the SSR module graph (tracker #618), since there is no longer a driver
+  // to load at all.
+  session: false,
+  integrations: [solidJs(), minifySsrBuild()],
   vite: {
     plugins: [tailwindcss(), stubMotionForSsr()],
+    // Minifying the SSR build (above) renames identifiers and collapses lines,
+    // so a production Worker exception no longer names a real source line.
+    // Unlike `minify`, `build.sourcemap` rides the `...viteConfig.build` spread
+    // at `vite-build-config.js:36` untouched — nothing after it overrides
+    // `sourcemap` the way line 100 overrides `minify` — so this plain config
+    // form is enough; no `astro:build:setup` hook needed. Maps are uploaded to
+    // Cloudflare for symbolication (`wrangler.jsonc`'s `upload_source_maps`)
+    // and excluded from the size guard (`scripts/guard-ssr-size.sh`) — they
+    // are not part of the script the Worker runs.
+    build: { sourcemap: true },
   },
 });

--- a/cire/invites/package.json
+++ b/cire/invites/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "portless",
     "dev:app": "dev-env astro dev",
-    "build": "astro build",
+    "build": "astro build && ./scripts/guard-ssr-size.sh",
     "preview": "astro preview",
     "check": "bunx --bun astro check",
     "test": "vitest run --project unit",

--- a/cire/invites/scripts/guard-ssr-size.sh
+++ b/cire/invites/scripts/guard-ssr-size.sh
@@ -24,7 +24,10 @@ cd "$pkg_dir"
 # the gzip of the directory as a whole. Everything except `wrangler.json` is
 # uploaded, so measure exactly that set: matching on `*.mjs` would coincide with
 # it today and stop matching the moment the adapter emitted a `.js` chunk, which
-# its own generated `rules` already declare as an ES module.
+# its own generated `rules` already declare as an ES module. `.map` files are
+# excluded too: they're uploaded to Cloudflare for symbolication
+# (`upload_source_maps` in `wrangler.jsonc`), not part of the script the
+# Worker runs, and roughly double the reading if left in.
 if [ ! -d dist/server ]; then
   echo "::error::cire/invites dist/server is missing — run \`astro build\` before this guard."
   exit 1
@@ -39,7 +42,7 @@ while IFS= read -r -d '' f; do
   size=$(gzip -nc "$f" | wc -c)
   total=$((total + size))
   count=$((count + 1))
-done < <(find dist/server -type f ! -name 'wrangler.json' -print0)
+done < <(find dist/server -type f ! -name 'wrangler.json' ! -name '*.map' -print0)
 
 if [ "$count" -eq 0 ]; then
   echo "::error::cire/invites dist/server holds no deployable files — the guard measured nothing, which is a broken build, not a pass."
@@ -48,16 +51,22 @@ fi
 
 echo "cire/invites dist/server gzip total: ${total} bytes across ${count} files"
 
-# Threshold = the measured total after both #287 fixes, plus room for ordinary
-# dependency growth. What it catches is a library-scale mistake: motion cost
-# 47657 bytes gzip in THIS bundle (470489 before the stub, 422832 after), so a
-# single new library of that class entering the SSR graph trips this with room
-# to spare. Measure against the SSR figure, not against the same library's size
-# in `dist/client` — the client build is minified and the server build is not,
-# so a library costs roughly twice as much here as it does there. It does NOT
-# catch a few KB of ordinary bump, and it is nowhere near the Workers Free-tier
-# 3 MB cap — this watches the trajectory, it is not a check against the cap.
-threshold=310000
+# Threshold = the measured total after #287, #618, #616 and #617, plus room
+# for ordinary dependency growth. What it catches is a library-scale mistake:
+# motion cost 47657 bytes gzip in the (then-unminified) SSR bundle, so a
+# single new library of that class entering the SSR graph still trips this
+# with room to spare. 163446 (measured total, this bundle, after sessions off
+# + SSR minify + source maps) + 47657 (motion-class headroom) = 211103.
+#
+# The SSR build is now minified (tracker #616 — an inline `astro:build:setup`
+# integration in `astro.config.mjs`, since the plain `vite.build.minify` config
+# form is a no-op for the SSR environment), so this no longer needs the old
+# "server build isn't minified, client is" caveat: both builds are minified
+# now, and a library costs roughly what it costs in `dist/client`, gzip for
+# gzip. It does NOT catch a few KB of ordinary bump, and it is nowhere near
+# the Workers Free-tier 3 MB cap — this watches the trajectory, it is not a
+# check against the cap.
+threshold=211103
 if [ "$total" -gt "$threshold" ]; then
   echo "::error::cire/invites dist/server gzip total ${total} bytes exceeds the ${threshold} byte guard (tracker #287). Something is likely pulling a new dependency into the SSR module graph that never runs server-side — check what is newly reachable from a server-side import() or import, the way motion was."
   exit 1

--- a/cire/invites/scripts/guard-ssr-size.sh
+++ b/cire/invites/scripts/guard-ssr-size.sh
@@ -33,6 +33,24 @@ if [ ! -d dist/server ]; then
   exit 1
 fi
 
+# Source maps belong in `dist/server` and NOWHERE ELSE. `dist/client` is this
+# Worker's Static Assets directory (the adapter writes
+# `"assets": { "directory": "../client" }` into the generated wrangler config)
+# and Cloudflare serves every file there verbatim, so a `.map` that lands in it
+# publishes the guest site's unminified source at `/_astro/<chunk>.js.map` to
+# anyone who asks. That is exactly what a plain `vite: { build: { sourcemap:
+# true } }` does, because the client environment reads the top-level value at
+# `astro/dist/core/build/vite-build-config.js:135` — which is why
+# `astro.config.mjs` sets `sourcemap` inside the `astro:build:setup` hook
+# instead. This check is the tripwire for that mistake coming back.
+if [ -d dist/client ]; then
+  client_maps=$(find dist/client -type f -name '*.map' | wc -l | tr -d ' ')
+  if [ "$client_maps" -ne 0 ]; then
+    echo "::error::cire/invites dist/client holds ${client_maps} source map(s). dist/client is served publicly as Static Assets, so these would publish the guest site's unminified source. Scope \`sourcemap\` to the server build (see the minifySsrBuild() comment in astro.config.mjs)."
+    exit 1
+  fi
+fi
+
 total=0
 count=0
 while IFS= read -r -d '' f; do
@@ -51,22 +69,28 @@ fi
 
 echo "cire/invites dist/server gzip total: ${total} bytes across ${count} files"
 
-# Threshold = the measured total after #287, #618, #616 and #617, plus room
-# for ordinary dependency growth. What it catches is a library-scale mistake:
-# motion cost 47657 bytes gzip in the (then-unminified) SSR bundle, so a
-# single new library of that class entering the SSR graph still trips this
-# with room to spare. 163446 (measured total, this bundle, after sessions off
-# + SSR minify + source maps) + 47657 (motion-class headroom) = 211103.
+# Threshold = the measured total plus headroom for ordinary dependency growth.
+# 163317 (measured total, this bundle, after sessions off + SSR minify +
+# server-only source maps) + 11683 = 175000.
 #
-# The SSR build is now minified (tracker #616 — an inline `astro:build:setup`
-# integration in `astro.config.mjs`, since the plain `vite.build.minify` config
-# form is a no-op for the SSR environment), so this no longer needs the old
-# "server build isn't minified, client is" caveat: both builds are minified
-# now, and a library costs roughly what it costs in `dist/client`, gzip for
-# gzip. It does NOT catch a few KB of ordinary bump, and it is nowhere near
-# the Workers Free-tier 3 MB cap — this watches the trajectory, it is not a
-# check against the cap.
-threshold=211103
+# The headroom is deliberately SMALLER than the mistake this guard exists to
+# catch, which is the half the pre-minification threshold got wrong. `motion`
+# costs 21261 bytes gzip in the MINIFIED build — measured, not assumed: that is
+# the size of its own already-minified client vendor chunk
+# (`dist/client/_astro/animate.*.js`), and rebuilding with `stubMotionForSsr()`
+# removed moves the server total by the same ~21.4 KB. The old threshold budgeted
+# 47657 bytes, motion's cost back when this build was UNMINIFIED, so a fresh
+# library of exactly that class would have landed under the line and shipped
+# silently. At 11683 bytes of headroom a motion-class mistake overshoots by
+# roughly 9.6 KB and fails the build, while ordinary dependency bumps have real
+# room to move.
+#
+# Re-baselining after an intentional change: take the new reading, add the same
+# ~11.7 KB, and re-check that the gap to a current library of motion's class is
+# still comfortably positive. It does NOT catch a few hundred bytes of ordinary
+# bump, and it is nowhere near the Workers Free-tier 3 MB cap — this watches the
+# trajectory, it is not a check against the cap.
+threshold=175000
 if [ "$total" -gt "$threshold" ]; then
   echo "::error::cire/invites dist/server gzip total ${total} bytes exceeds the ${threshold} byte guard (tracker #287). Something is likely pulling a new dependency into the SSR module graph that never runs server-side — check what is newly reachable from a server-side import() or import, the way motion was."
   exit 1

--- a/cire/invites/wrangler.jsonc
+++ b/cire/invites/wrangler.jsonc
@@ -13,6 +13,12 @@
   // 7-day Workers Logs retention, 100% sampling (low guest-site volume). Mirrors
   // cire-api's observability block.
   "observability": { "enabled": true },
+  // The SSR build is minified (astro.config.mjs); upload source maps so a
+  // production exception still symbolicates to a real source line. The
+  // adapter never sets this itself (grepped `@astrojs/cloudflare/dist` for
+  // `upload_source_maps`: no hits) — it must come from this file, which the
+  // adapter's generated `dist/server/wrangler.json` extends.
+  "upload_source_maps": true,
   // Custom-domain route: serves the guest site on `invite.cireweddings.com`.
   // (Domain reshuffle 2026-07-16: the apex `cireweddings.com` now serves the
   // marketing landing site; guest invites moved to the `invite.` subdomain,

--- a/wiki/apps/cire-development.md
+++ b/wiki/apps/cire-development.md
@@ -162,7 +162,9 @@ fails if any `.map` file turns up under `dist/client`, which is served publicly
 as Static Assets — see the source-map warning below.
 
 It runs from the package's own `build` script, so it fires wherever the build
-does: every pull request, both deploy jobs, and the by-hand deploy above. To
+actually executes: the by-hand deploy above, and any local build. `ci.yml` and
+both `deploy.yml` jobs also invoke it as their own step, which is what covers the
+case where Turborepo replays a cached `build` and the script never runs. To
 re-baseline after an intentional bundle change, build, read the printed total,
 and set `threshold` to that total plus **about 11.7 KB** of ordinary-growth
 headroom.

--- a/wiki/apps/cire-development.md
+++ b/wiki/apps/cire-development.md
@@ -157,15 +157,26 @@ cd cire/invites && bunx wrangler deploy --config dist/server/wrangler.json
 deployable file under `cire/invites/dist/server` (excluding the adapter's
 generated `wrangler.json` and, since tracker #616's source-map follow-up,
 `.map` files — `no_bundle: true` ships each chunk as its own module, so the
-sum of each file's own gzip size is what actually crosses the wire). It runs
-on every pull request and on both deploy jobs, and fails the build if the
-total passes its `threshold`. To re-baseline after an intentional bundle
-change: `bun run --cwd cire/invites build` then
-`cd cire/invites && ./scripts/guard-ssr-size.sh` to get the new measured
-total, then set `threshold` in the script to that total plus headroom for one
-library of `motion`'s class (47657 bytes gzip in this bundle) — the arithmetic
-is spelled out in the comment above `threshold=` so the next reader can check
-it without rebuilding.
+sum of each file's own gzip size is what actually crosses the wire). It also
+fails if any `.map` file turns up under `dist/client`, which is served publicly
+as Static Assets — see the source-map warning below.
+
+It runs from the package's own `build` script, so it fires wherever the build
+does: every pull request, both deploy jobs, and the by-hand deploy above. To
+re-baseline after an intentional bundle change, build, read the printed total,
+and set `threshold` to that total plus **about 11.7 KB** of ordinary-growth
+headroom.
+
+The headroom is deliberately smaller than the mistake the guard exists to
+catch, and that is the part worth getting right. `motion` costs **21261 bytes
+gzip in the minified build** — the size of its own already-minified client
+vendor chunk, `dist/client/_astro/animate.*.js`, and the same figure you get by
+rebuilding with `stubMotionForSsr()` removed. A threshold set to "measured plus
+one motion" would put a fresh library of exactly that class *under* the line,
+which is how the first version of this number went wrong: it carried 47657
+bytes, motion's cost back when the build was unminified. The arithmetic is
+spelled out in the comment above `threshold=` so the next reader can check it
+without rebuilding.
 
 Three tracker follow-ups (#618, #616, #617) to the original size audit
 (#287) cut the bundle from 285 KB to 163 KB gzip:
@@ -191,15 +202,28 @@ Three tracker follow-ups (#618, #616, #617) to the original size audit
   `client` environment doesn't, because its own `minify` is set independently,
   so the client bundle is unaffected. The minifier under this Astro (Vite 8 /
   rolldown-vite) is OXC — pass `minify: true`, not `"esbuild"`.
-- **Source maps.** Minifying the server build means a production Worker
-  exception no longer names a real source line, so this ships with
-  `build.sourcemap: true` (a plain Vite config value, unaffected by the
-  override above) and `upload_source_maps: true` in `cire/invites/wrangler.jsonc`
-  — the adapter never sets that key itself, so it has to come from the
-  checked-in config the generated `dist/server/wrangler.json` extends. Both
-  CI rewrite steps that touch that generated file (`deploy.yml`, dev and
-  prod) only delete `legacy_env` and set `name`/`routes`, so the key survives
-  into the deployed config untouched.
+- **Source maps, server-side only.** Minifying the server build means a
+  production Worker exception no longer names a real source line, so this ships
+  with `sourcemap: true` set **through the same `astro:build:setup` hook** as
+  `minify`, plus `upload_source_maps: true` in `cire/invites/wrangler.jsonc` —
+  the adapter never sets that key itself, so it has to come from the checked-in
+  config the generated `dist/server/wrangler.json` extends. Both CI rewrite
+  steps that touch that generated file (`deploy.yml`, dev and prod) only delete
+  `legacy_env` and set `name`/`routes`, so the key survives into the deployed
+  config untouched.
+
+  > [!warning] Never set `sourcemap` as a plain `vite.build` value here.
+  > Unlike `minify`, it is not overridden — it reaches the top level *and* the
+  > client environment reads it
+  > (`astro/dist/core/build/vite-build-config.js:135`), so the client build
+  > emits `dist/client/_astro/*.js.map` too. `dist/client` is this Worker's
+  > Static Assets directory (the adapter writes
+  > `"assets": { "directory": "../client" }` into the generated wrangler
+  > config) and Cloudflare serves everything in it verbatim, so those maps
+  > publish the guest site's unminified source at `/_astro/<chunk>.js.map` to
+  > anyone who asks. The plain form was written that way first and caught in
+  > review; `guard-ssr-size.sh` now fails the build if any `.map` file appears
+  > under `dist/client`.
 - **`zod` stays (#617).** Traced to Astro's own actions request handler
   (`actions/handler.js` → `actions/runtime/server.js`, top-level
   `import * as z from "zod/v4/core"`), which `core/routing/handler.js` calls

--- a/wiki/apps/cire-development.md
+++ b/wiki/apps/cire-development.md
@@ -18,7 +18,7 @@ related:
   - "[[browser-tests]]"
   - "[[d1-read-replication]]"
   - "[[commands]]"
-last-reviewed: 2026-09-01
+last-reviewed: 2026-09-06
 ---
 
 # Cire development guide
@@ -150,6 +150,64 @@ The **guest site is a Worker, not Pages.** The adapter emits `dist/server` +
 bun run --cwd cire/invites build
 cd cire/invites && bunx wrangler deploy --config dist/server/wrangler.json
 ```
+
+## Guest-site SSR bundle size
+
+`cire/invites/scripts/guard-ssr-size.sh` measures the gzip size of every
+deployable file under `cire/invites/dist/server` (excluding the adapter's
+generated `wrangler.json` and, since tracker #616's source-map follow-up,
+`.map` files — `no_bundle: true` ships each chunk as its own module, so the
+sum of each file's own gzip size is what actually crosses the wire). It runs
+on every pull request and on both deploy jobs, and fails the build if the
+total passes its `threshold`. To re-baseline after an intentional bundle
+change: `bun run --cwd cire/invites build` then
+`cd cire/invites && ./scripts/guard-ssr-size.sh` to get the new measured
+total, then set `threshold` in the script to that total plus headroom for one
+library of `motion`'s class (47657 bytes gzip in this bundle) — the arithmetic
+is spelled out in the comment above `threshold=` so the next reader can check
+it without rebuilding.
+
+Three tracker follow-ups (#618, #616, #617) to the original size audit
+(#287) cut the bundle from 285 KB to 163 KB gzip:
+
+- **Sessions off (#618).** Astro's session config accepts `session: false`
+  (`astro/dist/core/session/config.js`), and `@astrojs/cloudflare`'s
+  KV-binding auto-provisioning is gated on that same literal
+  (`@astrojs/cloudflare/dist/index.js`, `if (session !== false && ...)`), so
+  turning sessions off entirely — rather than pinning the in-memory driver —
+  drops the session runtime and `unstorage` from `dist/server` with no KV
+  binding required. Safe here because the guest site never reads or writes
+  `Astro.session`.
+- **SSR minification (#616).** `vite: { build: { minify: true } }` in
+  `astro.config.mjs` does nothing for the server build: Astro's
+  `createViteBuildConfig` (`astro/dist/core/build/vite-build-config.js`)
+  spreads the user's `vite.build` and then hard-sets `minify: false`
+  afterward for build-performance reasons, and separately replaces the `ssr`
+  environment's whole `build` key, dropping any environment-scoped
+  `minify` too. The fix is a small inline Astro integration hooking
+  `astro:build:setup`, which Astro runs once (`target: "server"`) after that
+  config exists, and whose `updateConfig` merges on top of it — the `prerender`
+  and `ssr` environments inherit the resulting top-level `minify: true`; the
+  `client` environment doesn't, because its own `minify` is set independently,
+  so the client bundle is unaffected. The minifier under this Astro (Vite 8 /
+  rolldown-vite) is OXC — pass `minify: true`, not `"esbuild"`.
+- **Source maps.** Minifying the server build means a production Worker
+  exception no longer names a real source line, so this ships with
+  `build.sourcemap: true` (a plain Vite config value, unaffected by the
+  override above) and `upload_source_maps: true` in `cire/invites/wrangler.jsonc`
+  — the adapter never sets that key itself, so it has to come from the
+  checked-in config the generated `dist/server/wrangler.json` extends. Both
+  CI rewrite steps that touch that generated file (`deploy.yml`, dev and
+  prod) only delete `legacy_env` and set `name`/`routes`, so the key survives
+  into the deployed config untouched.
+- **`zod` stays (#617).** Traced to Astro's own actions request handler
+  (`actions/handler.js` → `actions/runtime/server.js`, top-level
+  `import * as z from "zod/v4/core"`), which `core/routing/handler.js` calls
+  on every non-prerendered request whether or not the app defines any
+  actions (`src/actions` doesn't exist here). There's no app-level config to
+  skip that code path, so unlike `motion` (see the SSR-stub comment in
+  `astro.config.mjs`) this is not stubbed — it's a real, reachable Astro core
+  dependency, not dead weight from an unreachable path.
 
 ## Related
 


### PR DESCRIPTION
## Summary

This branch closes three follow-ups to the guest-site bundle audit (tracker #287)
and cuts `cire/invites`'s deployed Worker from **284981 to 163317 bytes gzip** —
a 42.6% reduction, measured with the repo's own guard before and after. Astro
sessions are turned off outright rather than pinned to an inert driver, and the
SSR build is minified for the first time, with source maps uploaded so a
production exception still symbolicates.

The third finding turned out to be an answer rather than a fix, and is reported
as one: `zod` stays in the bundle because Astro's own request pipeline imports it
unconditionally.

- Minifying the SSR build is not a config flag. Astro hard-sets `minify: false`
  for the server build after spreading the user's `vite.build`
  (`astro/dist/core/build/vite-build-config.js:100`) and replaces the `ssr`
  environment's whole `build` key, so both obvious forms are silently no-ops. It
  takes an inline integration on the `astro:build:setup` hook.
- The size guard's threshold moves 310000 → 175000, and its headroom is now
  smaller than the mistake it exists to catch rather than twice as large.
- The guard now runs from the package's `build` script, so the by-hand deploy
  path documented in the wiki is covered, not just CI.

## Workspaces affected

`@cire/invites`. One changeset, `patch`, naming `"@cire/invites"` alone —
`@cire/*` packages are version-less, so they never share a changeset with a
versioned package. `scripts/changeset-required.sh` says `required` for this diff
and `scripts/validate-changesets.sh` passes.

## Issues

**Closes**

| Issue | What |
|---|---|
| xchromo/osn-tracker#618 | `P-I3` |
| xchromo/osn-tracker#616 | `P-I1` |
| xchromo/osn-tracker#617 | `P-I2` — closed by the trace it asked for, not by a code change; see Decisions |

Closes xchromo/osn-tracker#618
Closes xchromo/osn-tracker#616
Closes xchromo/osn-tracker#617

**Opened**

| Issue | What |
|---|---|
| xchromo/osn-tracker#634 | `S-L1` |
| xchromo/osn-tracker#635 | `T-M1` |

## Decisions

### Turn Astro sessions off rather than pinning an inert driver — `P-I3`

- **Issue** — `astro.config.mjs` pinned `session: { driver: sessionDrivers.memory() }`
  purely to stop the Cloudflare adapter auto-provisioning a `SESSION` KV binding.
  The session runtime and `unstorage` shipped anyway, for a feature the config's
  own comment described as never exercised.
- **Why** — bytes parsed on every cold start of a guest site that never reads or
  writes `Astro.session`.
- **Solution** — `session: false`. Astro's schema accepts the literal
  (`astro/dist/core/session/config.js:29`) and the adapter's auto-provision check
  keys on the same literal (`@astrojs/cloudflare/dist/index.js:107`,
  `if (session !== false && ...)`), so it keeps the Worker binding-free *and*
  drops the runtime. Worth 6976 bytes gzip.
- **Rationale** — the old comment's reasoning was sound for `session` being left
  *undefined*; it simply did not apply to `false`. Verified nothing reads
  `Astro.session` anywhere in `cire/invites/src`.

### Minify the SSR build through a build hook, not a config flag — `P-I1`

- **Issue** — the SSR bundle shipped unminified: roughly 40% of the Worker was
  whitespace and comments.
- **Why** — it is the largest single lever left on the number the size guard
  watches, and bundle size feeds cold-start parse time as well as upload size.
- **Solution** — an inline integration whose `astro:build:setup` hook calls
  `updateConfig({ build: { minify: true, sourcemap: true } })`. The hook runs
  after `createViteBuildConfig` and its merge wins, which is the only remaining
  path: `vite.build.minify` is discarded at `vite-build-config.js:100` and
  `vite.environments.ssr.build.minify` at `:164-174`. The client build is
  untouched because its own `minify` is baked in separately at `:136`.
- **Rationale** — both obvious config forms are no-ops that produce a clean diff
  and change nothing, so the mechanism and the two dead ends are written into the
  config comment. The minifier here is OXC (Vite 8 / rolldown-vite): `true`, never
  `"esbuild"`.

### Ship source maps, and keep them off the public asset path — `S-H1`

- **Issue** — minified server output means a production Worker exception no longer
  names a source line. The first attempt set `vite: { build: { sourcemap: true } }`
  as a plain config value, and this branch's own security review caught that the
  client environment reads that value back (`vite-build-config.js:135`), so the
  client build emitted 29 `.js.map` files into `dist/client`.
- **Why** — `dist/client` is this Worker's Static Assets directory
  (`"assets": { "directory": "../client" }` in the generated wrangler config) and
  Cloudflare serves it verbatim, so the guest site's unminified source — comments
  and all, including the claim and RSVP paths — would have been fetchable at
  `/_astro/<chunk>.js.map` by anyone.
- **Solution** — `sourcemap` moved into the same `astro:build:setup` hook, which
  lands it after the client environment has baked its own `sourcemap: false`;
  `upload_source_maps: true` in `wrangler.jsonc` (the adapter never writes it) so
  Cloudflare can symbolicate; and `guard-ssr-size.sh` now fails the build if any
  `.map` file turns up under `dist/client`.
- **Rationale** — the maps are what make minified server output debuggable, so
  dropping them was the wrong trade. Verified after the fix: `dist/client` holds
  0 maps, `dist/server` holds 28, and a request for
  `/_astro/animate.DTOCmSk7.js.map` against the running Worker returns 404.
  Nothing was ever exposed in production — the plain form existed only on this
  branch and was caught by its own review before the PR opened.

### Re-baseline the guard on the measured minified cost — `P-W1`

- **Issue** — the re-baselined threshold was 163446 + 47657, and 47657 is what
  `motion` cost gzip back when this build was *unminified*.
- **Why** — a guard whose headroom is larger than the mistake it watches for
  cannot catch that mistake. Minified, `motion` costs **21261 bytes gzip** — its
  own already-minified client vendor chunk, `dist/client/_astro/animate.*.js`, and
  the same figure you get by rebuilding with the SSR stub removed. A fresh library
  of exactly that class would have landed ~26 KB under the line.
- **Solution** — `threshold=175000`: measured 163317 plus 11683 bytes of
  ordinary-growth headroom, deliberately smaller than a motion-class library, which
  now overshoots by roughly 9.6 KB.
- **Rationale** — the number is now derived from a measurement of the current
  build rather than carried forward from the previous one, and the comment shows
  the arithmetic so the next re-baseline can be checked without rebuilding.

### Run the guard from `build`, not only from CI — `P-I1` (performance review)

- **Issue** — the guard was invoked only from `ci.yml` and the two `deploy.yml`
  jobs. `cire/invites`'s own `build` script did not call it.
- **Why** — the by-hand deploy path documented in `wiki/apps/cire-development.md`
  builds and deploys without ever running the guard, so it gives no signal at the
  moment it would be most useful.
- **Solution** — `"build": "astro build && ./scripts/guard-ssr-size.sh"`.
- **Rationale** — the guard costs ~0.15s and reads a `dist/server` the build just
  made. The existing CI and deploy steps are left in place; tracker #619 rewires
  them when the script moves to `scripts/`.

### `zod` stays, and that is the answer #617 asked for — `P-I2`

- **Issue** — `zod` is the third-largest package in `dist/server` and no file under
  `cire/invites/src` imports it.
- **Why** — the issue asked for a trace before any fix, explicitly warning against
  stubbing it the way `motion` was stubbed.
- **Solution** — traced, not stubbed. `core/routing/handler.js:25` calls
  `handleAction` on every non-prerendered request regardless of whether the app
  defines any actions; `actions/handler.js` imports
  `actions/runtime/server.js`, whose line 2 is a static top-level
  `import * as z from "zod/v4/core"`. There is no `actions: false` config lever.
  The trace is recorded in the `astro.config.mjs` comment block beside the motion
  stub, which is where the next size audit will already be reading.
- **Rationale** — this is a real, request-time Astro core dependency, not dead
  weight from an unreachable path, so the `motion` treatment would be wrong here.
  Turning sessions off removed the *other* zod import
  (`core/session/config.js:1`); this one is separate and remains.

**Out of scope** — xchromo/osn-tracker#634 — `S-L1`; xchromo/osn-tracker#635 — `T-M1`.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass (pre-existing warnings only, none in touched files) |
| Format | `bun run fmt:check` | pass — 1444 files |
| Type check | `bun run check` | pass — 37/37 tasks |
| Unit tests | `bun run --cwd cire/invites test` | pass — 999 tests, 62 files |
| Browser tests | `bun run --cwd cire/invites test:browser` | pass — 33 tests, 7 files |
| Changesets | `./scripts/validate-changesets.sh` | pass |
| Changeset needed? | `git diff --name-only main...HEAD \| ./scripts/changeset-required.sh` | `required` — one is present |
| Size guard | `cd cire/invites && ./scripts/guard-ssr-size.sh` | pass — 163317 bytes across 33 files, threshold 175000 |

Run by hand, because no suite exercises the built artefact — the vitest projects
test `src/`, and this is the first time the repo minifies a Worker built by
rolldown-vite:

| Check | Result |
|---|---|
| `bunx wrangler dev --config dist/server/wrangler.json`, `GET /` | 302 (bare-domain redirect, expected) |
| same, `GET /<slug>` | 200 |
| same, `GET /privacy` | 307 (trailing-slash redirect to the prerendered page) |
| same, `GET /_astro/animate.DTOCmSk7.js.map` | 404 — the S-H1 exposure, confirmed closed |
| `.map` files in `dist/client` | 0 (was 29 before the S-H1 fix) |
| `.map` files in `dist/server` | 28 |
| `upload_source_maps` in the generated `dist/server/wrangler.json` | present |

Measure the guard from a clean build in a quiet worktree. Two builds running at
once in one checkout interleave their chunks in `dist/server` and the guard then
reads roughly 170 KB across 51 files instead of 163317 across 33 — that is the
mixed tree, not a regression. It happened twice while preparing this branch.

Not verified here: that Cloudflare actually symbolicates a production stack trace
from the uploaded maps. That needs a real deploy and a real exception, so it is
worth a look on the dev tier after this merges.
