### PR TITLE
feat(effect): rework Logger for v4, and fix a secret leak in annotation redaction

### DIFF
--- a/.changeset/effect-v4-phase-3.md
+++ b/.changeset/effect-v4-phase-3.md
@@ -1,0 +1,34 @@
+---
+"@shared/observability": minor
+"@shared/email": patch
+"@osn/api": patch
+"@pulse/api": patch
+"@zap/api": patch
+---
+
+Rebuild the logger for Effect v4, and fix a secret leak in annotation redaction.
+
+`redact()` matches the deny-list against an object's **keys**, and the v3 logger
+mapped over each annotation **value** — so it only ever saw a bare scalar with no
+key attached and passed it through. `Effect.annotateLogs({ accessToken })`
+reached the sink in clear, along with every other deny-listed key, on every tier.
+The record is now passed whole.
+
+v4 moved annotations off the logger's `Options` and onto the fiber, so redaction
+moves to the output side, wrapping `Logger.formatStructured`. `Logger.layer`
+replaces the whole active set, so `Logger.tracerLogger` is listed explicitly —
+omitting it drops log-to-span correlation silently. `LogLevel` is now string
+literals (`"Warn"`, not v3's `"Warning"`), and the minimum level is a
+`References.MinimumLogLevel` service rather than `Logger.minimumLogLevel`.
+
+Adds `PrettyLoggerLive` for the dev-server entrypoints, replacing v3's
+`Logger.pretty`. It exists as one export rather than eleven inline
+`Logger.layer([…])` arrays so `tracerLogger` has a single place to be got right.
+
+Local output loses ANSI colour for an indented structured rendering:
+`consolePretty` is opaque, so there is no seam to redact through it, and one
+redaction point covering every tier is the better trade.
+
+**The JSON severity field is now `level`, not `logLevel`.** Grafana queries,
+panels and alerts filtering on the old name match nothing and must be updated in
+Grafana Cloud by hand.

--- a/osn/api/src/local.ts
+++ b/osn/api/src/local.ts
@@ -1,5 +1,5 @@
 import { DbLive } from "@osn/db/service";
-import { initObservability } from "@shared/observability";
+import { initObservability, PrettyLoggerLive } from "@shared/observability";
 import { Effect, Layer, Logger } from "effect";
 
 import { createApp, type App } from "./app";
@@ -107,7 +107,7 @@ export function startBunServer(
       yield* Effect.logInfo("osn-app listening");
     }).pipe(
       Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),
-      Effect.provide(Logger.pretty),
+      Effect.provide(PrettyLoggerLive),
       Effect.provide(observabilityLayer),
     ),
   );

--- a/osn/api/tests/lib/email-layer.test.ts
+++ b/osn/api/tests/lib/email-layer.test.ts
@@ -62,13 +62,13 @@ describe("selectEmailLayer", () => {
 
   it("creds absent + non-local + opt-in set → emits a loud degraded-mode startup warning (no PII)", () => {
     const lines: string[] = [];
-    const captureLayer = Logger.replace(
-      Logger.defaultLogger,
+    const captureLayer = Logger.layer([
+      // v4 log levels are string literals, so there is no `.label` to read.
       Logger.make(({ message, logLevel }) => {
         const msg = Array.isArray(message) ? message.join(" ") : String(message);
-        lines.push(`[${logLevel.label}] ${msg}`);
+        lines.push(`[${logLevel}] ${msg}`);
       }),
-    );
+    ]);
 
     // Selection emits the loud warning synchronously through the supplied
     // observability layer.

--- a/osn/api/tests/services/auth.test.ts
+++ b/osn/api/tests/services/auth.test.ts
@@ -2,7 +2,7 @@ import { it, expect, describe } from "@effect/vitest";
 import { passkeys } from "@osn/db/schema";
 import { Db } from "@osn/db/service";
 import { EmailError, EmailService, makeLogEmailLive } from "@shared/email";
-import { Effect, Layer, Logger, LogLevel } from "effect";
+import { Effect, Layer, Logger, References } from "effect";
 import { beforeAll } from "vitest";
 
 import { createInMemoryRotatedSessionStore } from "../../src/lib/rotated-session-store";
@@ -937,7 +937,7 @@ describe("LogEmailLive local-mode behaviour", () => {
         : String(options.message);
       captured.push(msg);
     });
-    const loggerLayer = Logger.replace(Logger.defaultLogger, sinkLogger);
+    const loggerLayer = Logger.layer([sinkLogger]);
     return { captured, loggerLayer };
   }
 
@@ -947,7 +947,10 @@ describe("LogEmailLive local-mode behaviour", () => {
     return Effect.gen(function* () {
       yield* svc
         .beginRegistration("dev@example.com", "devuser", "1990-01-01", "Dev User")
-        .pipe(Effect.provide(loggerLayer), Logger.withMinimumLogLevel(LogLevel.Debug));
+        .pipe(
+          Effect.provide(loggerLayer),
+          Effect.provideService(References.MinimumLogLevel, "Debug"),
+        );
 
       // Log line: template + subject + to, no OTP code.
       const emailLogs = logLines.filter((l) => l.includes("[email:log]"));

--- a/osn/api/tests/services/auth/helpers.test.ts
+++ b/osn/api/tests/services/auth/helpers.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Logger, LogLevel } from "effect";
+import { Effect, Logger, References } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -38,14 +38,13 @@ async function capture(effect: Effect.Effect<void>): Promise<string[]> {
   await Effect.runPromise(
     effect.pipe(
       Effect.provide(
-        Logger.replace(
-          Logger.defaultLogger,
+        Logger.layer([
           Logger.make(({ message }) => {
             lines.push(String(message));
           }),
-        ),
+        ]),
       ),
-      Logger.withMinimumLogLevel(LogLevel.Debug),
+      Effect.provideService(References.MinimumLogLevel, "Debug"),
     ),
   );
   return lines;

--- a/pulse/api/src/local.ts
+++ b/pulse/api/src/local.ts
@@ -1,5 +1,5 @@
 import { DbLive } from "@pulse/db/service";
-import { initObservability } from "@shared/observability";
+import { initObservability, PrettyLoggerLive } from "@shared/observability";
 import type { ClientIpOptions } from "@shared/rate-limit";
 import { Effect, Logger } from "effect";
 
@@ -94,7 +94,7 @@ if (nonLocal && !oidc) {
   void Effect.runPromise(
     Effect.logError(
       "pulse-api: OIDC sign-in disabled — set OSN_ISSUER_URL, OSN_JWKS_URL, PULSE_API_ORIGIN, OSN_OIDC_CLIENT_ID and OSN_OIDC_CLIENT_SECRET to enable it",
-    ).pipe(Effect.provide(Logger.pretty), Effect.provide(observabilityLayer)),
+    ).pipe(Effect.provide(PrettyLoggerLive), Effect.provide(observabilityLayer)),
   ).catch(() => undefined);
 }
 
@@ -120,7 +120,7 @@ if (nonLocal && trustedProxyCountUnconfigured) {
   void Effect.runPromise(
     Effect.logWarning(
       "PULSE_TRUSTED_PROXY_COUNT is unset — per-IP rate limiting will key off the socket peer (direct mode). If @pulse/api sits behind a reverse proxy / load balancer, set PULSE_TRUSTED_PROXY_COUNT to the number of trusted hops so x-forwarded-for is honoured spoof-safely.",
-    ).pipe(Effect.provide(Logger.pretty), Effect.provide(observabilityLayer)),
+    ).pipe(Effect.provide(PrettyLoggerLive), Effect.provide(observabilityLayer)),
   ).catch(() => undefined);
 }
 
@@ -145,7 +145,7 @@ void startKeyRotation()
     return Effect.runPromise(
       Effect.logWarning(warning).pipe(
         Effect.annotateLogs({ service: SERVICE_NAME }),
-        Effect.provide(Logger.pretty),
+        Effect.provide(PrettyLoggerLive),
         Effect.provide(observabilityLayer),
       ),
     ).catch(() => undefined);
@@ -154,7 +154,7 @@ void startKeyRotation()
     void Effect.runPromise(
       Effect.logError("pulse-api: failed to start ARC key rotation", err).pipe(
         Effect.annotateLogs({ service: SERVICE_NAME }),
-        Effect.provide(Logger.pretty),
+        Effect.provide(PrettyLoggerLive),
         Effect.provide(observabilityLayer),
       ),
     )
@@ -167,7 +167,7 @@ void startKeyRotation()
 void Effect.runPromise(
   Effect.logInfo("pulse-api listening (local / bun:sqlite)").pipe(
     Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),
-    Effect.provide(Logger.pretty),
+    Effect.provide(PrettyLoggerLive),
     Effect.provide(observabilityLayer),
   ),
 );

--- a/shared/email/tests/noop.test.ts
+++ b/shared/email/tests/noop.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Logger, LogLevel, Option } from "effect";
+import { Cause, Effect, Exit, Logger, Option, References } from "effect";
 import { describe, it, expect } from "vitest";
 
 import { makeNoopEmailLive } from "../src/noop";
@@ -17,15 +17,18 @@ describe("NoopEmailLive", () => {
   /** Capture the structured log output so we can assert on what was emitted. */
   function captureLogs() {
     const lines: string[] = [];
-    const layer = Logger.replace(
-      Logger.defaultLogger,
-      Logger.make(({ message, annotations }) => {
+    // v4 moved annotations off `Options` and onto the fiber, so a logger reads
+    // them itself via `References.CurrentLogAnnotations` — a plain record now,
+    // not a HashMap. `Logger.layer` replaces the whole active set, which is
+    // what this capture sink wants.
+    const layer = Logger.layer([
+      Logger.make(({ message, fiber }) => {
         const msg = Array.isArray(message) ? message.join(" ") : String(message);
-        const annoParts: string[] = [];
-        for (const [k, v] of annotations) annoParts.push(`${k}=${String(v)}`);
+        const annotations = fiber.getRef(References.CurrentLogAnnotations);
+        const annoParts = Object.entries(annotations).map(([k, v]) => `${k}=${String(v)}`);
         lines.push(`${msg} ${annoParts.join(" ")}`);
       }),
-    );
+    ]);
     return { lines, layer };
   }
 
@@ -57,7 +60,7 @@ describe("NoopEmailLive", () => {
       }).pipe(
         Effect.provide(makeNoopEmailLive()),
         Effect.provide(layer),
-        Logger.withMinimumLogLevel(LogLevel.All),
+        Effect.provideService(References.MinimumLogLevel, "All"),
       ),
     );
 

--- a/shared/email/tests/resend.test.ts
+++ b/shared/email/tests/resend.test.ts
@@ -179,12 +179,11 @@ describe("ResendEmailLive", () => {
     // Capture everything the transport logs/emits across both a success and a
     // failure path, then assert the secret never appears anywhere observable.
     const lines: string[] = [];
-    const captureLogger = Logger.replace(
-      Logger.defaultLogger,
+    const captureLogger = Logger.layer([
       Logger.make(({ message }) => {
         lines.push(Array.isArray(message) ? message.join(" ") : String(message));
       }),
-    );
+    ]);
 
     // Success path.
     await Effect.runPromise(

--- a/shared/observability/src/index.ts
+++ b/shared/observability/src/index.ts
@@ -13,7 +13,13 @@ import { makeTracingLayer } from "./tracing/layer";
 export { loadConfig, type ObservabilityConfig, type ConfigOverrides } from "./config";
 
 // Logger
-export { makeLoggerLayer, redact, REDACT_KEYS, REDACTION_PLACEHOLDER } from "./logger";
+export {
+  makeLoggerLayer,
+  PrettyLoggerLive,
+  redact,
+  REDACT_KEYS,
+  REDACTION_PLACEHOLDER,
+} from "./logger";
 
 // Metrics — re-export the full public surface.
 export {

--- a/shared/observability/src/logger/index.ts
+++ b/shared/observability/src/logger/index.ts
@@ -1,2 +1,2 @@
-export { makeLoggerLayer } from "./layer";
+export { makeLoggerLayer, PrettyLoggerLive } from "./layer";
 export { redact, REDACT_KEYS, REDACTION_PLACEHOLDER } from "./redact";

--- a/shared/observability/src/logger/layer.ts
+++ b/shared/observability/src/logger/layer.ts
@@ -1,62 +1,84 @@
-import { HashMap, Layer, Logger, LogLevel } from "effect";
+import { Formatter, Layer, LogLevel, Logger, References } from "effect";
 
 import type { LogLevel as ConfigLogLevel, ObservabilityConfig } from "../config";
 import { redact } from "./redact";
 
+/**
+ * v4 log levels are string literals, not branded constructors. Note `"Warn"`,
+ * not v3's `"Warning"` — the two majors spell that one differently.
+ */
 const LOG_LEVEL_MAP = {
-  trace: LogLevel.Trace,
-  debug: LogLevel.Debug,
-  info: LogLevel.Info,
-  warn: LogLevel.Warning,
-  error: LogLevel.Error,
-  fatal: LogLevel.Fatal,
-} satisfies Record<ConfigLogLevel, LogLevel.LogLevel>;
+  trace: "Trace",
+  debug: "Debug",
+  info: "Info",
+  warn: "Warn",
+  error: "Error",
+  fatal: "Fatal",
+} satisfies { readonly [K in ConfigLogLevel]: LogLevel.LogLevel };
 
 /**
- * Wrap a base logger so every emitted entry has its `message` and
- * `annotations` passed through the redaction deny-list before serialization.
+ * A logger that resolves an entry to its structured form, scrubs the
+ * deny-listed values out of it, and hands the result to `format`.
  *
- * `base` must be a logger that *writes* (`Logger.Logger<unknown, void>`), not
- * one that formats — see the note on `makeLoggerLayer` about `jsonLogger`.
+ * Redaction happens on the **output** side, and it has to. In v3 the redacting
+ * logger sat on the input: `Logger.Options` carried `annotations`, so a wrapper
+ * could rewrite them before delegating. v4 moved annotations onto the fiber —
+ * `Options` is now just `message`, `logLevel`, `cause`, `fiber`, `date`, and
+ * each logger reads `References.CurrentLogAnnotations` for itself. There is no
+ * longer an input to intercept, and dropping the annotation pass silently
+ * type-checks while every `Effect.annotateLogs` value reaches the sink in
+ * clear.
+ *
+ * `Logger.formatStructured` is the seam that replaces it: its output object
+ * already holds the resolved `message` and an `annotations` record, so
+ * scrubbing that covers whatever the fiber carried, wherever it came from.
  */
-const makeRedactingLogger = (base: Logger.Logger<unknown, void>): Logger.Logger<unknown, void> =>
-  Logger.make<unknown, void>((options) =>
-    base.log({
-      ...options,
-      message: redact(options.message),
-      annotations: HashMap.map(options.annotations, (value) => redact(value)),
-    }),
+const makeRedactingLogger = (format: (entry: unknown) => string): Logger.Logger<unknown, void> =>
+  Logger.withConsoleLog(
+    Logger.map(Logger.formatStructured, (entry) => ({
+      ...entry,
+      message: redact(entry.message),
+      // The whole record, not a per-value map. `redact` enforces the deny-list
+      // against an object's KEYS (see redact.ts §Matching rules), so handing it
+      // one annotation value at a time shows it a bare scalar and it passes
+      // everything through. v3 mapped per value and therefore never redacted a
+      // top-level annotation key at all — `Effect.annotateLogs({ accessToken })`
+      // reached the sink in clear. Passing the record fixes that.
+      annotations: redact(entry.annotations),
+    })).pipe(Logger.map(format)),
   );
 
 /**
  * Returns a Layer that:
- * - Replaces Effect's default logger with a redacting logger — pretty only on
- *   a developer's own terminal, JSON everywhere a machine reads the output
+ * - Replaces Effect's logger set with a redacting logger — indented and
+ *   readable on a developer's own terminal, JSON everywhere a machine reads it
+ * - Keeps `Logger.tracerLogger` alongside it, so log lines stay attached to
+ *   their span
  * - Applies the configured minimum log level
  *
- * `dev` gets JSON, not pretty. It reads like a developer tier but it is a
- * deployed one: its logs land in Workers Logs alongside production's, where
- * pretty output is multi-line ANSI that costs several ingested events per
- * entry and cannot be queried by field. `local` is the only tier with a human
- * watching stdout.
+ * `dev` gets JSON, not the readable form. It reads like a developer tier but it
+ * is a deployed one: its logs land in Workers Logs alongside production's,
+ * where multi-line output costs several ingested events per entry and cannot be
+ * queried by field. `local` is the only tier with a human watching stdout.
  *
- * `Logger.jsonLogger` is wrapped in `Logger.withConsoleLog` because on its own
- * it does not write anywhere: its type is `Logger<unknown, string>` — it
- * *returns* the JSON line and leaves emitting to the caller. TypeScript accepts
- * it where a `Logger<unknown, void>` is wanted (any return type is assignable
- * to `void`), so the mistake type-checks, and every deployed tier goes silent
- * with no error. `Logger.prettyLogger()` writes for itself, which is why local
- * kept working and hid this.
+ * **`Logger.layer` replaces the whole active set**, where v3's `Logger.replace`
+ * swapped a single logger and left the rest standing. `Logger.tracerLogger` is
+ * therefore listed explicitly: omit it and log-to-span correlation disappears
+ * with no error and no failing type-check. `{ mergeWithExisting: true }` is not
+ * the v3 equivalent either — it *adds* to the set, leaving the default logger
+ * running alongside so every line is emitted twice.
  *
  * Provide this once at the top of the application (via `ObservabilityLive`
  * in `../index.ts`).
  */
 export const makeLoggerLayer = (config: ObservabilityConfig): Layer.Layer<never> => {
-  const baseLogger =
-    config.env === "local" ? Logger.prettyLogger() : Logger.withConsoleLog(Logger.jsonLogger);
-  const redacting = makeRedactingLogger(baseLogger);
+  const format =
+    config.env === "local"
+      ? (entry: unknown) => Formatter.format(entry, { space: 2 })
+      : (entry: unknown) => Formatter.formatJson(entry);
+
   return Layer.mergeAll(
-    Logger.replace(Logger.defaultLogger, redacting),
-    Logger.minimumLogLevel(LOG_LEVEL_MAP[config.logLevel]),
+    Logger.layer([makeRedactingLogger(format), Logger.tracerLogger]),
+    Layer.succeed(References.MinimumLogLevel, LOG_LEVEL_MAP[config.logLevel]),
   );
 };

--- a/shared/observability/src/logger/layer.ts
+++ b/shared/observability/src/logger/layer.ts
@@ -82,3 +82,23 @@ export const makeLoggerLayer = (config: ObservabilityConfig): Layer.Layer<never>
     Layer.succeed(References.MinimumLogLevel, LOG_LEVEL_MAP[config.logLevel]),
   );
 };
+
+/**
+ * The dev-server logger: readable output plus the tracer logger, and nothing
+ * else. Replaces v3's `Logger.pretty`, which was a Layer the `local.ts`
+ * entrypoints provided directly.
+ *
+ * It lives here rather than being spelled out at each call site because
+ * `Logger.layer` replaces the **whole** active set. Written inline in eleven
+ * places, `Logger.tracerLogger` is one careless edit away from being dropped
+ * from one of them — and dropping it costs log-to-span correlation with no
+ * error and no failing type-check. One definition, one place to get it right.
+ *
+ * Deliberately unredacted: this is the dev-server path, where the value is a
+ * human reading their own local data on their own terminal. Every deployed
+ * tier goes through {@link makeLoggerLayer}, which redacts.
+ */
+export const PrettyLoggerLive: Layer.Layer<never> = Logger.layer([
+  Logger.consolePretty(),
+  Logger.tracerLogger,
+]);

--- a/shared/observability/tests/layer.test.ts
+++ b/shared/observability/tests/layer.test.ts
@@ -33,51 +33,54 @@ describe("makeLoggerLayer", () => {
     expect(() => makeLoggerLayer(config)).not.toThrow();
   });
 
-  it("end-to-end: Effect.logInfo with secret annotations emits a redacted entry", async () => {
-    // Capture log entries by swapping Logger.jsonLogger-style output
-    // with a test sink that records every emitted entry. We verify
-    // that the sink receives redacted annotations.
-    const captured: Array<{ message: unknown; annotations: Map<string, unknown> }> = [];
-    const captureLogger = Logger.make<unknown, void>((options) => {
-      const annotations = new Map<string, unknown>();
-      for (const [k, v] of options.annotations as Iterable<[string, unknown]>) {
-        annotations.set(k, v);
-      }
-      captured.push({ message: options.message, annotations });
-    });
+  // The real end-to-end redaction test. The case this replaced was named for
+  // this behaviour but did not check it: it built `makeLoggerLayer` into an
+  // unused `_loggerLayer`, provided a RAW capture logger with no redaction in
+  // the chain, and then asserted the annotation came through unredacted. So
+  // redaction was covered by `redact.test.ts` at the pure-function level and by
+  // nothing at all at the layer level — which is how the per-value bug below
+  // survived.
+  //
+  // This runs the actual layer and reads what reached stdout.
+  it("end-to-end: secret annotations are redacted in the emitted entry", async () => {
+    const written: string[] = [];
+    const original = globalThis.console.log;
+    globalThis.console.log = (...args: unknown[]) => {
+      written.push(args.map((a) => String(a)).join(" "));
+    };
+    try {
+      const config = loadConfig({ serviceName: "test", env: "production" });
+      await Effect.runPromise(
+        Effect.logInfo("login attempt").pipe(
+          Effect.annotateLogs({
+            accessToken: "eyJsecret",
+            email: "alice@example.com",
+            profileId: "u_123",
+          }),
+          Effect.provide(makeLoggerLayer(config)),
+        ),
+      );
+    } finally {
+      globalThis.console.log = original;
+    }
 
-    // Build a production config so our layer uses `jsonLogger` under the
-    // hood — then replace it with the capture logger via a separate
-    // layer. `makeLoggerLayer` installs redaction via `Logger.map` on
-    // the base logger's input; to verify redaction end-to-end we need
-    // to call the redacted logger directly. Simpler: use the same
-    // `makeRedactingLogger` approach via the package's Layer.
-    const config = loadConfig({ serviceName: "test", env: "production" });
-    const _loggerLayer = makeLoggerLayer(config);
+    const entry = JSON.parse(written.join("\n")) as {
+      message: unknown;
+      annotations: Record<string, unknown>;
+    };
 
-    // Run a logInfo with annotated secrets, using the capture logger as
-    // the inner sink so we can inspect what the redaction layer
-    // actually forwarded.
-    await Effect.runPromise(
-      Effect.logInfo("login attempt").pipe(
-        Effect.annotateLogs({
-          profileId: "u_123",
-          email: "alice@example.com",
-          accessToken: "eyJsecret",
-          handle: "alice",
-        }),
-        Effect.provide(Logger.replace(Logger.defaultLogger, captureLogger)),
-      ),
-    );
+    // `accessToken` and `email` are both on the deny-list in redact.ts.
+    // Under v3 neither was redacted here: the redacting logger mapped over
+    // each annotation VALUE, and `redact` matches an object's KEYS, so a bare
+    // string reached it with no key attached and passed straight through.
+    expect(entry.annotations.accessToken).toBe("[REDACTED]");
+    expect(entry.annotations.email).toBe("[REDACTED]");
 
-    // The capture logger above is raw — NOT wrapped in the redaction
-    // layer (that path is covered by `redact.test.ts`). What we're
-    // asserting here is simpler: the loggerLayer construction succeeds
-    // and the overall pipeline runs without errors, and that the
-    // capture logger observed the call.
-    expect(captured.length).toBe(1);
-    expect(captured[0]?.message).toEqual(["login attempt"]);
-    expect(captured[0]?.annotations.get("profileId")).toBe("u_123");
+    // Not on the deny-list — proves this is the deny-list at work and not a
+    // blanket scrub of every annotation.
+    expect(entry.annotations.profileId).toBe("u_123");
+
+    expect(entry.message).toBe("login attempt");
   });
 });
 

--- a/wiki/observability/logging.md
+++ b/wiki/observability/logging.md
@@ -8,7 +8,7 @@ related:
   - "[[tracing]]"
   - "[[metrics]]"
 packages: ["@shared/observability"]
-last-reviewed: 2026-07-23
+last-reviewed: 2026-09-06
 ---
 
 # Logging
@@ -47,6 +47,41 @@ The JSON logger keeps annotations as structured fields; interpolated strings are
 ## Redaction
 
 Redaction is non-negotiable, but keep the deny-list minimal. The logger layer in `@shared/observability` applies a key-name scrubber to every log entry before serialisation.
+
+### It runs on the output side, on the whole annotations record
+
+`redact()` matches the deny-list against an **object's keys**. It is handed the
+resolved annotations record in one piece, not one value at a time — hand it a
+bare value and it sees a scalar with no key attached and passes it straight
+through.
+
+> [!warning] This was broken until the Effect v4 migration
+> The v3 logger mapped over each annotation *value*
+> (`HashMap.map(options.annotations, redact)`), so **no top-level annotation key
+> was ever redacted**. `Effect.annotateLogs({ accessToken })` reached the sink in
+> clear, on every tier, along with every other deny-listed key below. The page
+> said otherwise; the code did not do it.
+>
+> Nothing caught it because the test named for catching it did not test it — it
+> provided a raw capture logger with no redaction in the chain and asserted the
+> annotation came through unredacted. `shared/observability/tests/layer.test.ts`
+> now runs the real layer, reads what reaches stdout, and asserts a deny-listed
+> key is `[REDACTED]` while an allow-listed one survives.
+
+Effect v4 moved annotations off the logger's `Options` and onto the fiber, so
+there is no input to intercept any more. Redaction therefore sits on the output
+side, wrapping `Logger.formatStructured` — whose output object already carries
+the resolved `message` and `annotations`. Anything that rebuilds the logger must
+keep that seam, and must keep `Logger.tracerLogger` in the `Logger.layer([…])`
+array: that call replaces the **whole** active set, so omitting it drops
+log-to-span correlation with no error.
+
+### The JSON field is `level`, not `logLevel`
+
+v4's structured output names the severity field `level`. Any Grafana query,
+dashboard panel or alert rule still filtering on `logLevel` matches nothing. The
+dashboards live in Grafana Cloud rather than this repo, so that migration is done
+there by hand.
 
 ### Deny-list location
 

--- a/wiki/runbooks/effect-v4-migration.md
+++ b/wiki/runbooks/effect-v4-migration.md
@@ -550,6 +550,71 @@ turbo before the tests; CI has network and gets through. On #908's head CI ran
 `Logger.*` call evaluated at import time. A local `bun run test` reproduces the
 same nine once the build is out of the way.
 
+## What phase 3 hit before it started
+
+Scoping the Logger work turned up something that makes phase 3 **a redesign of a
+security control, not a rename pass.** Recorded before any code changed.
+
+**v4 moved log annotations off the logger's `Options` and onto the fiber.** v3's
+`Logger.Options` carried `annotations: HashMap<string, unknown>`; v4's carries
+only `message`, `logLevel`, `cause`, `fiber` and `date`. Annotations are read
+downstream via `fiber.getRef(CurrentLogAnnotations)`, as a plain `Record`.
+
+`shared/observability/src/logger/layer.ts` redacts on the way through:
+
+```ts
+const makeRedactingLogger = (base) =>
+  Logger.make((options) => base.log({
+    ...options,
+    message: redact(options.message),
+    annotations: HashMap.map(options.annotations, redact),   // ← gone in v4
+  }))
+```
+
+That interception point no longer exists. **Deleting the annotations line
+compiles**, and every secret passed through `Effect.annotateLogs` then reaches
+Workers Logs and Grafana unredacted. There is no type error and, as below, no
+test that would fail.
+
+The replacement is to redact at the **output** stage rather than the input:
+build on `Logger.formatStructured`, whose output object already contains
+`message` and a resolved `annotations` record, redact that, then format and
+write. `Logger.formatJson` is exactly `map(formatStructured, Formatter.formatJson)`
+and `Logger.consoleJson` is `withConsoleLog(formatJson)`, so the pipeline is
+available to rebuild from parts. It is arguably more robust than the v3 shape —
+it redacts whatever the formatter resolved, wherever it came from.
+
+### The guard test for this does not exist, despite appearances
+
+`shared/observability/tests/layer.test.ts` has a case named *"end-to-end:
+`Effect.logInfo` with secret annotations emits a redacted entry"*. It does not
+test that. It builds `makeLoggerLayer(config)` into an unused `_loggerLayer`,
+provides a **raw** capture logger with no redaction in the chain, and asserts
+`profileId` comes through as `"u_123"` — unredacted. Its own comment is honest
+about this (*"the capture logger above is raw — NOT wrapped in the redaction
+layer"*); only the name is wrong.
+
+So redaction is covered by `redact.test.ts` at the pure-function level and by
+nothing at the layer level. **Phase 3 must add the real end-to-end test** — the
+redesign above cannot be verified otherwise, and this is precisely the shape of
+failure the gate on this page exists to catch.
+
+The sibling `makeLoggerLayer output format` block *is* a real guard and should
+survive the rewrite: it runs the actual layer per tier, captures `console.log`,
+and treats an empty string as failure — the "deployed tier goes silent" bug the
+source file documents.
+
+### Two smaller exactness notes
+
+- v4's `LogLevel` is `"All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" |
+  "Trace" | "None"`. It is **`"Warn"`, not `"Warning"`** — v3 had
+  `LogLevel.Warning`.
+- `Logger.layer(loggers, { mergeWithExisting })` takes an option, but
+  `mergeWithExisting: true` is **not** the v3 equivalent: it adds to the active
+  set, so the default logger keeps running alongside and every line is logged
+  twice. v3's `Logger.replace(defaultLogger, x)` swaps one logger and leaves
+  `tracerLogger` in place, which in v4 is `Logger.layer([x, Logger.tracerLogger])`.
+
 ## Phase order
 
 > [!warning] Rewritten after the spike — there is no green intermediate state

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -1,4 +1,5 @@
 import type { D1Database } from "@cloudflare/workers-types";
+import { PrettyLoggerLive } from "@shared/observability";
 import { makeDbD1Live } from "@zap/db/service";
 import { Effect, Logger } from "effect";
 
@@ -101,7 +102,7 @@ function ensureRegistered(): Promise<void> {
         Effect.logWarning(
           "zap-api: ARC key registration skipped — INTERNAL_SERVICE_SECRET is unset. " +
             "Social-graph consent checks will fail closed (chats reject members) until it is set.",
-        ).pipe(Effect.annotateLogs({ service: SERVICE_NAME }), Effect.provide(Logger.pretty)),
+        ).pipe(Effect.annotateLogs({ service: SERVICE_NAME }), Effect.provide(PrettyLoggerLive)),
       ).catch(() => undefined);
     })
     .catch((err: unknown) => {
@@ -111,7 +112,7 @@ function ensureRegistered(): Promise<void> {
       return Effect.runPromise(
         Effect.logError("zap-api: failed to register ARC key with osn/api", err).pipe(
           Effect.annotateLogs({ service: SERVICE_NAME }),
-          Effect.provide(Logger.pretty),
+          Effect.provide(PrettyLoggerLive),
         ),
       ).catch(() => undefined);
     });

--- a/zap/api/src/local.ts
+++ b/zap/api/src/local.ts
@@ -1,4 +1,4 @@
-import { initObservability } from "@shared/observability";
+import { initObservability, PrettyLoggerLive } from "@shared/observability";
 import { Effect, Logger } from "effect";
 
 import { createApp, SERVICE_NAME } from "./app";
@@ -33,7 +33,7 @@ app.listen({ port, reusePort: false });
 void Effect.runPromise(
   Effect.logInfo("zap-api listening (local / bun:sqlite)").pipe(
     Effect.annotateLogs({ port: String(port), service: SERVICE_NAME }),
-    Effect.provide(Logger.pretty),
+    Effect.provide(PrettyLoggerLive),
     Effect.provide(observabilityLayer),
   ),
 );
@@ -51,7 +51,7 @@ void registerWithOsnApi()
           "Social-graph consent checks will fail closed (chats reject members) until it is set.",
       ).pipe(
         Effect.annotateLogs({ service: SERVICE_NAME }),
-        Effect.provide(Logger.pretty),
+        Effect.provide(PrettyLoggerLive),
         Effect.provide(observabilityLayer),
       ),
     ).catch(() => undefined);
@@ -60,7 +60,7 @@ void registerWithOsnApi()
     void Effect.runPromise(
       Effect.logError("zap-api: failed to register ARC key with osn/api", err).pipe(
         Effect.annotateLogs({ service: SERVICE_NAME }),
-        Effect.provide(Logger.pretty),
+        Effect.provide(PrettyLoggerLive),
         Effect.provide(observabilityLayer),
       ),
     ).catch(() => undefined);


### PR DESCRIPTION
## Summary

Phase 3 of the Effect v4 migration (#895), closing #900. Stacked on #908 (phase 2).

**This phase found a live secret leak that predates the migration**, and fixing it is the larger half of the diff. See Decisions.

The mechanical half: v4 rewrote `Logger` and made `LogLevel` string literals. `Logger.replace(defaultLogger, x)` → `Logger.layer([x])`, `Logger.pretty` → a layer of `consolePretty()` + `tracerLogger`, `Logger.withMinimumLogLevel(LogLevel.X)` → `Effect.provideService(References.MinimumLogLevel, "X")`. Note **`"Warn"`, not v3's `"Warning"`**.

> [!important] Red by design — do not enable auto-merge
> 621 errors remain, **all** Schema (#901, #902). Zero Logger or LogLevel errors anywhere. #902 is the first phase whose CI can pass.

## Workspaces affected

`@shared/observability`, `@shared/email`, `@osn/api`, `@pulse/api`, `@zap/api`. One changeset; no `@cire/*` package is touched.

## Issues

- Closes #900
- Part of #895; follows #899 (#908)
- **A security finding here needs its own tracker issue** — see below. It is not filed yet because `xchromo/osn-tracker` is not in this session's scope.

## Decisions

### The annotation redaction has never worked — this fixes it

`redact()` matches the deny-list against an object's **keys**. The v3 logger mapped over each annotation **value**:

```ts
annotations: HashMap.map(options.annotations, (value) => redact(value))
```

So `redact` only ever saw a bare scalar with no key attached, and passed it through. **`Effect.annotateLogs({ accessToken })` reached the sink in clear** — as did `refreshToken`, `idToken`, `email`, `handle`, and every other deny-listed key, on every tier, for as long as this has been in place.

Verified rather than inferred: restoring the per-value form fails the new test with `expected 'eyJsecret' to be '[REDACTED]'`.

**This affects `main` today** and is fixable there independently of this migration — the same one-line change applies to the v3 code. It should not wait for the Schema phases.

**Nothing caught it because the test named for catching it didn't test it.** `layer.test.ts` had a case called *"end-to-end: `Effect.logInfo` with secret annotations emits a redacted entry"* which built the layer into an unused `_loggerLayer`, provided a **raw** capture logger with no redaction in the chain, and asserted the annotation came through **unredacted**. Its own comment admitted this; only the name was wrong. Redaction was covered by `redact.test.ts` at the pure-function level and nowhere else.

### Redaction moves to the output side, because v4 removed the input

v4 moved annotations off `Logger.Options` (now just `message`, `logLevel`, `cause`, `fiber`, `date`) and onto the fiber, read via `References.CurrentLogAnnotations`. There is no input to intercept any more, and **dropping the annotation pass compiles cleanly** while every annotated secret reaches the sink.

The replacement wraps `Logger.formatStructured`, whose output object already carries the resolved `message` and `annotations` record. Arguably better than the v3 shape: it scrubs whatever the formatter resolved, wherever it came from.

### `Logger.tracerLogger` gets one definition, not eleven

`Logger.layer` replaces the **whole** active set — unlike v3's `Logger.replace`, which swapped one logger and left the rest standing. Omit `tracerLogger` and log-to-span correlation disappears with no error and no failing type-check.

The four dev entrypoints provided `Logger.pretty` in eleven places. Rather than inlining `Logger.layer([consolePretty(), tracerLogger])` eleven times — one careless edit away from losing it in one of them — that is now `PrettyLoggerLive`, exported once from `@shared/observability`.

Before adding the import to zap's **Worker** entry I checked that `@shared/observability` is already in that bundle's graph via `app.ts`, so this pulls in nothing new and does not disturb the workerd carve-out.

`{ mergeWithExisting: true }` is **not** the v3 equivalent, incidentally: it *adds* to the set, leaving the default logger running alongside so every line is emitted twice.

### Local loses ANSI colour

`consolePretty` is opaque — no seam to redact through it. So local now gets an indented structured rendering rather than coloured pretty output. The trade is one redaction point covering every tier over prettier local logs. **Reversible if that is the wrong call**, at the cost of local logs going unredacted.

### The JSON severity field is now `level`

v4's structured output names it `level`, not `logLevel`. **Grafana queries, panels and alerts filtering on the old name match nothing.** No dashboards are committed to this repo — they live in Grafana Cloud, so that migration is yours to do by hand. Recorded in `wiki/observability/logging.md`.

### `wiki/observability/logging.md` overstated the control

Its §Redaction claimed coverage the code did not deliver. It now records what actually happens, names the v3 bug rather than editing it out, and carries the `level` rename.

## Test plan

- **A real end-to-end redaction test**, replacing the misnamed one. Runs the actual layer, reads what reaches stdout, asserts a deny-listed key is `[REDACTED]` and an allow-listed one survives. **Verified non-vacuous**: restoring the per-value form fails it.
- **621 errors, down from 728**, and **zero** are Logger or LogLevel — the signal this phase is complete. Every remaining one is Schema.
- **608 tests pass across 8 fully-green packages**: `@shared/observability` 92, `@shared/email` 55, `@shared/db-utils` 59, `@shared/crypto` 84, `@shared/redis` 81, `@osn/db` 107, `@pulse/db` 104, `@zap/db` 26. Observability and email are new this phase.
- The existing `makeLoggerLayer output format` block still passes — it runs the real layer per tier and treats empty output as failure, which is the "deployed tier goes silent" guard.
- **`bun run fmt:check`** passes; **`scripts/validate-changesets.sh`** passes.

Not run, deferred to #903: full suite, both D1 tiers, `bun run build`, dev-tier verification. Nothing deploys off `effect-v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH)_