### PR TITLE
fix(observability): check the annotation key against the redaction deny-list

### DIFF
--- a/.changeset/fix-annotation-key-redaction.md
+++ b/.changeset/fix-annotation-key-redaction.md
@@ -1,0 +1,21 @@
+---
+"@shared/observability": patch
+---
+
+Check the annotation key against the redaction deny-list, not just the value.
+
+`redact()` matches the deny-list against an object's keys. The redacting logger
+mapped over each annotation value and discarded the key `HashMap.map` supplies
+as its second argument, so a bare scalar arrived with no key attached and passed
+straight through. Nested values were still scrubbed; only top-level annotation
+keys escaped.
+
+No call site annotates a deny-listed key today, so nothing was leaking — but the
+control did not work, and the first `Effect.annotateLogs({ accessToken })` would
+have written the token in clear with nothing to catch it.
+
+Replaces the layer test that was named for this and did not test it: it built the
+layer into an unused variable, provided a raw capture logger with no redaction in
+the chain, and asserted the annotation came through unredacted. The new one runs
+the real layer, reads what reaches stdout, and is verified to fail against the
+old code.

--- a/shared/observability/src/logger/layer.ts
+++ b/shared/observability/src/logger/layer.ts
@@ -1,7 +1,7 @@
 import { HashMap, Layer, Logger, LogLevel } from "effect";
 
 import type { LogLevel as ConfigLogLevel, ObservabilityConfig } from "../config";
-import { redact } from "./redact";
+import { redact, REDACT_KEYS, REDACTION_PLACEHOLDER } from "./redact";
 
 const LOG_LEVEL_MAP = {
   trace: LogLevel.Trace,
@@ -18,13 +18,25 @@ const LOG_LEVEL_MAP = {
  *
  * `base` must be a logger that *writes* (`Logger.Logger<unknown, void>`), not
  * one that formats — see the note on `makeLoggerLayer` about `jsonLogger`.
+ *
+ * **The annotation key has to be checked, not just the value.** `redact()`
+ * matches the deny-list against an object's KEYS; handed a bare value it sees a
+ * scalar with no key attached and returns it untouched. This used to read
+ * `HashMap.map(options.annotations, (value) => redact(value))` — discarding the
+ * key `HashMap.map` supplies as its second argument — so no top-level
+ * annotation was ever redacted and `Effect.annotateLogs({ accessToken })`
+ * reached the sink in clear. `redact(value)` still runs on the values that
+ * survive the key check, so a secret nested inside a non-deny-listed annotation
+ * is scrubbed as before.
  */
 const makeRedactingLogger = (base: Logger.Logger<unknown, void>): Logger.Logger<unknown, void> =>
   Logger.make<unknown, void>((options) =>
     base.log({
       ...options,
       message: redact(options.message),
-      annotations: HashMap.map(options.annotations, (value) => redact(value)),
+      annotations: HashMap.map(options.annotations, (value, key) =>
+        REDACT_KEYS.has(String(key).toLowerCase()) ? REDACTION_PLACEHOLDER : redact(value),
+      ),
     }),
   );
 

--- a/shared/observability/tests/layer.test.ts
+++ b/shared/observability/tests/layer.test.ts
@@ -33,51 +33,53 @@ describe("makeLoggerLayer", () => {
     expect(() => makeLoggerLayer(config)).not.toThrow();
   });
 
-  it("end-to-end: Effect.logInfo with secret annotations emits a redacted entry", async () => {
-    // Capture log entries by swapping Logger.jsonLogger-style output
-    // with a test sink that records every emitted entry. We verify
-    // that the sink receives redacted annotations.
-    const captured: Array<{ message: unknown; annotations: Map<string, unknown> }> = [];
-    const captureLogger = Logger.make<unknown, void>((options) => {
-      const annotations = new Map<string, unknown>();
-      for (const [k, v] of options.annotations as Iterable<[string, unknown]>) {
-        annotations.set(k, v);
-      }
-      captured.push({ message: options.message, annotations });
-    });
+  // The real end-to-end redaction test. The case this replaced was named for
+  // this behaviour but did not check it: it built `makeLoggerLayer` into an
+  // unused `_loggerLayer`, provided a RAW capture logger with no redaction in
+  // the chain, and then asserted the annotation came through unredacted. So
+  // redaction was covered by `redact.test.ts` at the pure-function level and by
+  // nothing at the layer level — which is how the key-vs-value bug survived.
+  //
+  // This runs the actual layer and reads what reached stdout.
+  it("end-to-end: secret annotations are redacted in the emitted entry", async () => {
+    const written: string[] = [];
+    const original = globalThis.console.log;
+    globalThis.console.log = (...args: unknown[]) => {
+      written.push(args.map((a) => String(a)).join(" "));
+    };
+    try {
+      const config = loadConfig({ serviceName: "test", env: "production" });
+      await Effect.runPromise(
+        Effect.logInfo("login attempt").pipe(
+          Effect.annotateLogs({
+            accessToken: "eyJsecret",
+            email: "alice@example.com",
+            profileId: "u_123",
+          }),
+          Effect.provide(makeLoggerLayer(config)),
+        ),
+      );
+    } finally {
+      globalThis.console.log = original;
+    }
 
-    // Build a production config so our layer uses `jsonLogger` under the
-    // hood — then replace it with the capture logger via a separate
-    // layer. `makeLoggerLayer` installs redaction via `Logger.map` on
-    // the base logger's input; to verify redaction end-to-end we need
-    // to call the redacted logger directly. Simpler: use the same
-    // `makeRedactingLogger` approach via the package's Layer.
-    const config = loadConfig({ serviceName: "test", env: "production" });
-    const _loggerLayer = makeLoggerLayer(config);
+    const entry = JSON.parse(written.join("\n")) as {
+      message: unknown;
+      annotations: Record<string, unknown>;
+    };
 
-    // Run a logInfo with annotated secrets, using the capture logger as
-    // the inner sink so we can inspect what the redaction layer
-    // actually forwarded.
-    await Effect.runPromise(
-      Effect.logInfo("login attempt").pipe(
-        Effect.annotateLogs({
-          profileId: "u_123",
-          email: "alice@example.com",
-          accessToken: "eyJsecret",
-          handle: "alice",
-        }),
-        Effect.provide(Logger.replace(Logger.defaultLogger, captureLogger)),
-      ),
-    );
+    // Both are on the deny-list in redact.ts. Neither was redacted before the
+    // key check went in: the logger mapped over each annotation VALUE, and
+    // `redact` matches an object's KEYS, so a bare string arrived with no key
+    // attached and passed straight through.
+    expect(entry.annotations.accessToken).toBe("[REDACTED]");
+    expect(entry.annotations.email).toBe("[REDACTED]");
 
-    // The capture logger above is raw — NOT wrapped in the redaction
-    // layer (that path is covered by `redact.test.ts`). What we're
-    // asserting here is simpler: the loggerLayer construction succeeds
-    // and the overall pipeline runs without errors, and that the
-    // capture logger observed the call.
-    expect(captured.length).toBe(1);
-    expect(captured[0]?.message).toEqual(["login attempt"]);
-    expect(captured[0]?.annotations.get("profileId")).toBe("u_123");
+    // Not on the deny-list — proves this is the deny-list at work and not a
+    // blanket scrub of every annotation.
+    expect(entry.annotations.profileId).toBe("u_123");
+
+    expect(entry.message).toBe("login attempt");
   });
 });
 

--- a/shared/observability/tests/layer.test.ts
+++ b/shared/observability/tests/layer.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Logger } from "effect";
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 import type { DeploymentEnvironment } from "../src/config";


### PR DESCRIPTION
## Summary

`redact()` matches the deny-list against an object's **keys**. The redacting logger mapped over each annotation **value** and threw away the key `HashMap.map` supplies as its second argument:

```ts
annotations: HashMap.map(options.annotations, (value) => redact(value))
```

So `redact` only ever saw a bare scalar with no key attached, and returned it untouched.

**Scope, stated precisely — this is a latent control failure, not an active leak.** Two things bound it:

- **Only top-level annotation keys escaped.** `redact(value)` still ran on each value, so a secret nested inside an annotation was scrubbed exactly as before.
- **No call site annotates a deny-listed key today.** The keys actually in use across the repo are `service`, `reason`, `error`, `port`, `entitlement`, `enquiryId`, `template`, `tag`, `limit`, `directoryVendorId`, `declared`, `contentType` — none on the list.

So nothing has been leaking. What was broken is the control: the first `Effect.annotateLogs({ accessToken })` anyone writes would have put the token in the logs in clear, on every tier, with nothing to catch it.

Found while rebuilding this logger for Effect v4 (#900, in #909), where v4 moves annotations onto the fiber and forces the redaction seam to move anyway. **This lands on `main` separately because the bug predates that work and the v4 stack is four PRs from merging.**

## Workspaces affected

`@shared/observability` only. One changeset, patch.

## Issues

Filed as a finding in `xchromo/osn-tracker` (private, per the routing rule — `xchromo/osn` is public and a finding names an unpatched surface).

## Decisions

### Check the key, keep the value pass

`HashMap.map`'s callback takes `(value, key)`; the old code just ignored the second argument. The fix uses it:

```ts
annotations: HashMap.map(options.annotations, (value, key) =>
  REDACT_KEYS.has(String(key).toLowerCase()) ? REDACTION_PLACEHOLDER : redact(value),
),
```

Keeping `redact(value)` on the surviving values matters — that is what scrubs secrets nested inside a non-deny-listed annotation, which was never broken and should stay working.

### The guard test was fake, and is replaced

`layer.test.ts` had a case named *"end-to-end: `Effect.logInfo` with secret annotations emits a redacted entry"*. It built `makeLoggerLayer` into an unused `_loggerLayer`, provided a **raw** capture logger with no redaction in the chain, and asserted the annotation came through **unredacted**. Its own comment admitted this; only the name was wrong.

That is why the bug survived: redaction was covered by `redact.test.ts` at the pure-function level and by nothing at the layer level.

The replacement runs the real layer, captures `console.log`, and asserts a deny-listed key is `[REDACTED]` while an allow-listed one survives.

### I overstated this before finding the bound

Earlier notes on #909 described it as an active leak. That was wrong: I had not yet checked which keys are actually annotated. Correcting the record here rather than leaving the stronger claim standing.

## Test plan

- **The new test is verified non-vacuous.** Restoring the per-value form fails it with `expected 'eyJsecret' to be '[REDACTED]'`; the fix passes it.
- **`bun run --cwd shared/observability test:run`** — 92 passed.
- **`bun run check`** — 37/37 workspaces.
- **`bun run test`** — 38/38 tasks, whole monorepo.
- **`bun run lint`** — exit 0, no warnings. **`bun run fmt:check`** — passes.
- **`scripts/validate-changesets.sh`** — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH)_