### PR TITLE
feat(effect): migrate the Schema surface of osn-api, pulse-api, zap-api and the client

### DIFF
--- a/.changeset/effect-v4-phase-4.md
+++ b/.changeset/effect-v4-phase-4.md
@@ -1,0 +1,36 @@
+---
+"@osn/api": patch
+"@osn/client": patch
+"@pulse/api": patch
+"@zap/api": patch
+---
+
+Migrate the Effect Schema surface of the four service packages to v4.
+
+v3's constraint combinators are v4 *checks*, applied through a schema's
+`.check(...)` rather than `.pipe(...)`: `maxLength`/`minLength`/`minItems`/
+`maxItems` collapse onto `isMaxLength`/`isMinLength`, `int` becomes `isInt`, and
+`between(a, b)` becomes `isBetween({ minimum, maximum })` — still inclusive at
+both ends, so no range moved. `Schema.filter` becomes
+`Schema.check(Schema.makeFilter(…))`, and because a v4 filter carries its own
+failure message in its return value, the `{ message: () => "…" }` option becomes
+the predicate returning that string; every validator keeps its exact wording.
+`Schema.Literal` takes a single literal, so enums (and the spreads over
+`SUPPORTED_CURRENCIES`, `SHARE_SOURCES` and `INTEREST_CATEGORIES`) become
+`Schema.Literals([…])`. `Schema.decodeUnknown` becomes
+`Schema.decodeUnknownEffect`, and `Schema.Record` takes its key and value
+positionally.
+
+Three copies of a workaround are deleted rather than ported. `@pulse/api`'s
+events, series and discovery services each carried a hand-rolled "validate the
+string, then transform to a Date" pair because v3's `DateFromString` accepted a
+string that parses to an Invalid Date. v4's rejects it, so all three are now
+`Schema.DateFromString`.
+
+`@osn/client`'s `isAuthExpiredError` keeps all three of its arms, but the
+comments no longer claim a `FiberFailure` is what arrives: v4 removed the
+wrapper and `runPromise` rejects with the squashed error itself, so `instanceof`
+now carries the common path. The printout arm stays for a consumer bundle built
+against v3, and for any boundary that strips both the prototype and the `_tag`.
+
+Every migrated check was verified to still *reject*, not merely type-check.

--- a/osn/api/src/services/auth/email-change.ts
+++ b/osn/api/src/services/auth/email-change.ts
@@ -49,7 +49,7 @@ export function createEmailChangeModule(ctx: AuthContext, stepUp: StepUpModule) 
     Db | EmailService
   > =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(EmailSchema)(newEmail).pipe(
+      yield* Schema.decodeUnknownEffect(EmailSchema)(newEmail).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
       const normalised = newEmail.toLowerCase();

--- a/osn/api/src/services/auth/helpers.ts
+++ b/osn/api/src/services/auth/helpers.ts
@@ -324,16 +324,18 @@ export function sessionHandleFromHash(sessionHash: string): string {
 // Copenhagen Book M3: cap length at 255 (the practical RFC 5321 mailbox
 // ceiling) BEFORE the regex runs — rejects absurd payloads outright and
 // keeps the stored `accounts.email` column bounded.
-export const EmailSchema = Schema.String.pipe(
-  Schema.filter((s) => s.length <= 255 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s), {
-    message: () => "Invalid email",
-  }),
+export const EmailSchema = Schema.String.check(
+  Schema.makeFilter((s) =>
+    s.length <= 255 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s) ? undefined : "Invalid email",
+  ),
 );
 
-export const HandleSchema = Schema.String.pipe(
-  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
-    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
-  }),
+export const HandleSchema = Schema.String.check(
+  Schema.makeFilter((s) =>
+    /^[a-z0-9_]{1,30}$/.test(s)
+      ? undefined
+      : "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
+  ),
 );
 
 /**
@@ -344,19 +346,17 @@ export const HandleSchema = Schema.String.pipe(
  * COPPA-specific 422 rather than a generic 400. The value is never persisted.
  * See [[compliance/coppa]].
  */
-export const BirthdateSchema = Schema.String.pipe(
-  Schema.filter(
-    (s) => {
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
-      const d = new Date(`${s}T00:00:00.000Z`);
-      if (Number.isNaN(d.getTime())) return false;
-      // Reject dates that don't round-trip (e.g. 2021-02-30 → 2021-03-02).
-      if (d.toISOString().slice(0, 10) !== s) return false;
-      // A birthdate in the future is nonsensical.
-      return d.getTime() <= Date.now();
-    },
-    { message: () => "Invalid birthdate" },
-  ),
+export const BirthdateSchema = Schema.String.check(
+  Schema.makeFilter((s) => {
+    const invalid = "Invalid birthdate";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return invalid;
+    const d = new Date(`${s}T00:00:00.000Z`);
+    if (Number.isNaN(d.getTime())) return invalid;
+    // Reject dates that don't round-trip (e.g. 2021-02-30 → 2021-03-02).
+    if (d.toISOString().slice(0, 10) !== s) return invalid;
+    // A birthdate in the future is nonsensical.
+    return d.getTime() <= Date.now() ? undefined : invalid;
+  }),
 );
 
 /**
@@ -381,10 +381,10 @@ export function ageInYears(birthdate: string, at: Date = new Date()): number {
  * settings-row display without having to `LIKE …%` truncate at read time.
  * Empty strings aren't valid — the caller should PATCH `null` to clear.
  */
-export const PasskeyLabelSchema = Schema.String.pipe(
-  Schema.filter((s) => s.trim().length > 0 && s.length <= 64, {
-    message: () => "Passkey label must be 1–64 characters",
-  }),
+export const PasskeyLabelSchema = Schema.String.check(
+  Schema.makeFilter((s) =>
+    s.trim().length > 0 && s.length <= 64 ? undefined : "Passkey label must be 1–64 characters",
+  ),
 );
 
 /**

--- a/osn/api/src/services/auth/passkey-management.ts
+++ b/osn/api/src/services/auth/passkey-management.ts
@@ -90,7 +90,7 @@ export function createPasskeyManagementModule(
   ): Effect.Effect<void, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
       const trimmed = label.trim();
-      yield* Schema.decodeUnknown(PasskeyLabelSchema)(trimmed).pipe(
+      yield* Schema.decodeUnknownEffect(PasskeyLabelSchema)(trimmed).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
       if (!/^pk_[a-f0-9]{12}$/.test(passkeyId)) {

--- a/osn/api/src/services/auth/registration.ts
+++ b/osn/api/src/services/auth/registration.ts
@@ -53,10 +53,10 @@ export function createRegistrationModule(
     displayName?: string,
   ): Effect.Effect<ProfileWithEmail, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
+      yield* Schema.decodeUnknownEffect(EmailSchema)(email).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
-      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+      yield* Schema.decodeUnknownEffect(HandleSchema)(handle).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
 
@@ -173,13 +173,13 @@ export function createRegistrationModule(
     Db | EmailService
   > =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(EmailSchema)(email).pipe(
+      yield* Schema.decodeUnknownEffect(EmailSchema)(email).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
-      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+      yield* Schema.decodeUnknownEffect(HandleSchema)(handle).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
-      yield* Schema.decodeUnknown(BirthdateSchema)(birthdate).pipe(
+      yield* Schema.decodeUnknownEffect(BirthdateSchema)(birthdate).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
 
@@ -432,7 +432,7 @@ export function createRegistrationModule(
     handle: string,
   ): Effect.Effect<{ available: boolean }, ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+      yield* Schema.decodeUnknownEffect(HandleSchema)(handle).pipe(
         Effect.tapError(() => Effect.sync(() => metricAuthHandleCheck("invalid"))),
         Effect.mapError((cause) => new ValidationError({ cause })),
       );

--- a/osn/api/src/services/profile.ts
+++ b/osn/api/src/services/profile.ts
@@ -42,10 +42,12 @@ function now(): Date {
   return new Date();
 }
 
-const HandleSchema = Schema.String.pipe(
-  Schema.filter((s) => /^[a-z0-9_]{1,30}$/.test(s), {
-    message: () => "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
-  }),
+const HandleSchema = Schema.String.check(
+  Schema.makeFilter((s) =>
+    /^[a-z0-9_]{1,30}$/.test(s)
+      ? undefined
+      : "Handle must be 1–30 characters: lowercase letters, numbers, underscores only",
+  ),
 );
 
 const RESERVED_HANDLES = new Set([
@@ -93,7 +95,7 @@ export function createProfileService(authService: AuthService) {
     displayName?: string,
   ): Effect.Effect<PublicProfile, AuthError | ValidationError | DatabaseError, Db> =>
     Effect.gen(function* () {
-      yield* Schema.decodeUnknown(HandleSchema)(handle).pipe(
+      yield* Schema.decodeUnknownEffect(HandleSchema)(handle).pipe(
         Effect.mapError((cause) => new ValidationError({ cause })),
       );
       if (RESERVED_HANDLES.has(handle)) {

--- a/osn/api/tests/lib/email-layer.test.ts
+++ b/osn/api/tests/lib/email-layer.test.ts
@@ -80,8 +80,12 @@ describe("selectEmailLayer", () => {
     // It must name the affected mail classes so an operator understands impact.
     expect(joined.toLowerCase()).toContain("otp");
     expect(joined.toLowerCase()).toContain("security");
-    // It must be at least WARN level (loud).
-    expect(joined).toMatch(/\[(WARN|ERROR|FATAL)\]/);
+    // It must be at least WARN level (loud). v4 log levels are capitalised
+    // string literals ("Warn", not v3's "WARN"), and the capture layer above
+    // interpolates the level verbatim — so the set is spelled the v4 way
+    // rather than matched case-insensitively, which would also accept a level
+    // that does not exist.
+    expect(joined).toMatch(/\[(Warn|Error|Fatal)\]/);
     // No sensitive-token shapes (there is no recipient/code at startup anyway).
     expect(joined).not.toMatch(/\b\d{6}\b/);
   });

--- a/osn/client/src/errors.ts
+++ b/osn/client/src/errors.ts
@@ -21,34 +21,37 @@ export class AuthExpiredError extends Data.TaggedError("AuthExpiredError")<{
 }> {}
 
 /**
- * The tag as an error NAME at the head of the printout — bare, or behind
- * Effect's `(FiberFailure)` prefix. Not "anywhere in the string".
+ * The tag as an error NAME at the head of the printout — bare, or behind the
+ * `(FiberFailure)` prefix Effect v3 used to add. Not "anywhere in the string".
  */
-const FIBER_FAILURE_PRINTOUT = /^(?:\(FiberFailure\)\s*)?AuthExpiredError\b/;
+const TAGGED_ERROR_PRINTOUT = /^(?:\(FiberFailure\)\s*)?AuthExpiredError\b/;
 
 /**
  * True when `err` is — or wraps — an {@link AuthExpiredError}. Callers use it
  * to decide "bounce to sign-in" versus "show an error".
  *
- * `instanceof AuthExpiredError` is not enough on its own. An `authFetch`
- * rejection that crosses an Effect boundary arrives as a `FiberFailure`, whose
- * own prototype is not the error class and whose cause chain is not part of
- * the public surface — so consumers were left string-matching the printout by
- * hand (`cire/host/src/lib/api.ts`). This is that predicate, kept next to
- * the class so the two can't drift.
+ * `instanceof AuthExpiredError` is not enough on its own, so consumers were
+ * left string-matching the printout by hand (`cire/host/src/lib/api.ts`).
+ * This is that predicate, kept next to the class so the two can't drift.
  *
  * Three probes, cheapest first:
  *
- *  1. `instanceof` — the unwrapped error.
+ *  1. `instanceof` — the unwrapped error. Effect v4 rejects a `runPromise`
+ *     with `Cause.squash(cause)`, which for a typed failure IS this instance,
+ *     so this arm now carries the common path.
  *  2. the `_tag` discriminant — a structurally-equal error from another copy
  *     of this package (two versions in one `node_modules` tree defeat
  *     `instanceof`).
- *  3. the printout — the FiberFailure case. Effect renders it as
- *     `(FiberFailure) AuthExpiredError: …`, so the match is ANCHORED to that
- *     shape (S-L2) rather than scanning the whole string for the tag name.
- *     An unanchored `includes` would classify any error whose message merely
- *     quotes the tag — including one echoing a server-supplied code — as an
- *     expiry, which is a sign-out decision taken on someone else's input.
+ *  3. the printout. Effect v3 wrapped an escaping error in a `FiberFailure`
+ *     whose prototype was not the error class, rendering it as
+ *     `(FiberFailure) AuthExpiredError: …`; v4 removed that wrapper, but a
+ *     bundle built against v3 still produces the string, and any boundary
+ *     that loses the prototype and the `_tag` leaves only the printout. The
+ *     match is ANCHORED to that shape (S-L2) rather than scanning the whole
+ *     string for the tag name. An unanchored `includes` would classify any
+ *     error whose message merely quotes the tag — including one echoing a
+ *     server-supplied code — as an expiry, which is a sign-out decision taken
+ *     on someone else's input.
  */
 export function isAuthExpiredError(err: unknown): boolean {
   if (err instanceof AuthExpiredError) return true;
@@ -59,7 +62,7 @@ export function isAuthExpiredError(err: unknown): boolean {
   // reach. This predicate runs inside `catch` blocks, so a throw here would
   // swap a recoverable expiry for an unhandled rejection.
   try {
-    return FIBER_FAILURE_PRINTOUT.test(String(err));
+    return TAGGED_ERROR_PRINTOUT.test(String(err));
   } catch {
     return false;
   }

--- a/osn/client/src/tokens.ts
+++ b/osn/client/src/tokens.ts
@@ -84,7 +84,7 @@ const ProfileTokenSchema = Schema.Struct({
 const AccountSessionSchema = Schema.Struct({
   hasSession: Schema.Boolean,
   activeProfileId: Schema.String,
-  profileTokens: Schema.Record({ key: Schema.String, value: ProfileTokenSchema }),
+  profileTokens: Schema.Record(Schema.String, ProfileTokenSchema),
   scopes: Schema.Array(Schema.String),
   idToken: Schema.NullOr(Schema.String),
 });

--- a/osn/client/tests/errors.test.ts
+++ b/osn/client/tests/errors.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, it } from "vitest";
 import { AuthExpiredError, isAuthExpiredError, TokenRefreshError } from "../src/errors";
 
 /**
- * The whole reason this predicate exists is that `instanceof` does not survive
- * the trip out of an Effect. These pin each arm — including the real
- * FiberFailure, produced here rather than hand-written, so an Effect upgrade
- * that changes the printout fails this test instead of a consumer's redirect.
+ * This predicate exists because the error reaching a consumer's `catch` is not
+ * reliably the class. These pin each arm — including the escape from a real
+ * Effect, produced here rather than hand-written, so an Effect upgrade that
+ * changes the rejection shape fails this test instead of a consumer's
+ * redirect.
  */
 describe("isAuthExpiredError", () => {
   it("accepts the unwrapped error", () => {
@@ -23,9 +24,23 @@ describe("isAuthExpiredError", () => {
       () => null,
       (err: unknown) => err,
     );
-    // The premise of the finding: the wrapper is not the error class.
-    expect(escaped instanceof AuthExpiredError).toBe(false);
+    // Effect v4 rejects with `Cause.squash(cause)` — for a typed failure that
+    // is the error itself, where v3 handed back a `FiberFailure` wrapper whose
+    // prototype was not the error class. Pinned so a future change back to a
+    // wrapper is caught here.
+    expect(escaped).toBeInstanceOf(AuthExpiredError);
     expect(isAuthExpiredError(escaped)).toBe(true);
+  });
+
+  // v4 no longer produces this string, but a consumer bundle built against v3
+  // still can, and it is the only arm left once a boundary has stripped both
+  // the prototype and the `_tag`.
+  it("still accepts a v3 FiberFailure printout", () => {
+    expect(
+      isAuthExpiredError({
+        toString: () => "(FiberFailure) AuthExpiredError: Your session has expired.",
+      }),
+    ).toBe(true);
   });
 
   it("rejects a sibling client error", () => {

--- a/osn/client/tests/tokens.test.ts
+++ b/osn/client/tests/tokens.test.ts
@@ -63,16 +63,21 @@ describe("parseTokenResponse", () => {
     });
   });
 
+  // Each of these pins BOTH halves of the decode failure — which key, and why
+  // — so a schema change that starts rejecting the wrong field still fails
+  // here. Effect v4 renders that as a reason line and an `at [path]` line, and
+  // no longer echoes the offending value (v3 wrote `actual "not_a_number"`),
+  // so the assertions match the reason and the path rather than the input.
   describe("invalid input", () => {
     it("throws on missing access_token", () => {
       expect(() => parseTokenResponse({ expires_in: 3600, token_type: "Bearer" })).toThrow(
-        /\["access_token"\][\s\S]*is missing/,
+        /Missing key[\s\S]*\["access_token"\]/,
       );
     });
 
     it("throws on missing expires_in", () => {
       expect(() => parseTokenResponse({ access_token: "at_abc", token_type: "Bearer" })).toThrow(
-        /\["expires_in"\][\s\S]*is missing/,
+        /Missing key[\s\S]*\["expires_in"\]/,
       );
     });
 
@@ -83,15 +88,15 @@ describe("parseTokenResponse", () => {
           expires_in: "not_a_number",
           token_type: "Bearer",
         }),
-      ).toThrow(/Expected number, actual "not_a_number"/);
+      ).toThrow(/Expected number[\s\S]*\["expires_in"\]/);
     });
 
     it("throws on null input", () => {
-      expect(() => parseTokenResponse(null)).toThrow(/actual null/);
+      expect(() => parseTokenResponse(null)).toThrow(/Expected object/);
     });
 
     it("throws on empty object", () => {
-      expect(() => parseTokenResponse({})).toThrow(/\["access_token"\][\s\S]*is missing/);
+      expect(() => parseTokenResponse({})).toThrow(/Missing key[\s\S]*\["access_token"\]/);
     });
   });
 });

--- a/pulse/api/src/lib/shareSource.ts
+++ b/pulse/api/src/lib/shareSource.ts
@@ -39,7 +39,7 @@ export const isShareSource = (value: unknown): value is ShareSource =>
   typeof value === "string" && SHARE_SOURCE_SET.has(value);
 
 /** Effect Schema literal — for service-layer decode. */
-export const ShareSourceSchema = Schema.Literal(...SHARE_SOURCES);
+export const ShareSourceSchema = Schema.Literals(SHARE_SOURCES);
 
 /**
  * TypeBox union over the share-source enum — for the HTTP boundary.

--- a/pulse/api/src/services/comms.ts
+++ b/pulse/api/src/services/comms.ts
@@ -22,7 +22,7 @@ export class NotEventOwner extends Data.TaggedError("NotEventOwner")<{
 // Schemas
 // ---------------------------------------------------------------------------
 
-export const CommsChannelSchema = Schema.Literal("sms", "email");
+export const CommsChannelSchema = Schema.Literals(["sms", "email"]);
 export type CommsChannel = Schema.Schema.Type<typeof CommsChannelSchema>;
 
 export const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(

--- a/pulse/api/src/services/comms.ts
+++ b/pulse/api/src/services/comms.ts
@@ -25,16 +25,18 @@ export class NotEventOwner extends Data.TaggedError("NotEventOwner")<{
 export const CommsChannelSchema = Schema.Literals(["sms", "email"]);
 export type CommsChannel = Schema.Schema.Type<typeof CommsChannelSchema>;
 
-export const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(
-  Schema.minItems(1),
-  Schema.filter((channels) => new Set(channels).size === channels.length, {
-    message: () => "commsChannels must not contain duplicates",
-  }),
+export const CommsChannelsSchema = Schema.Array(CommsChannelSchema).check(
+  Schema.isMinLength(1),
+  Schema.makeFilter((channels) =>
+    new Set(channels).size === channels.length
+      ? undefined
+      : "commsChannels must not contain duplicates",
+  ),
 );
 
 const SendBlastSchema = Schema.Struct({
   channels: CommsChannelsSchema,
-  body: Schema.NonEmptyString.pipe(Schema.maxLength(1600)),
+  body: Schema.NonEmptyString.check(Schema.isMaxLength(1600)),
 });
 
 // ---------------------------------------------------------------------------
@@ -101,7 +103,7 @@ export const sendBlast = (
   Db
 > =>
   Effect.gen(function* () {
-    const validated = yield* Schema.decodeUnknown(SendBlastSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(SendBlastSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/discovery.ts
+++ b/pulse/api/src/services/discovery.ts
@@ -26,21 +26,19 @@ export class DiscoveryError extends Data.TaggedError("DiscoveryError")<{
 // Schema
 // ---------------------------------------------------------------------------
 
-const CategoryString = Schema.String.pipe(Schema.maxLength(100));
-const DateFromISOString = Schema.transform(
-  Schema.String.pipe(Schema.filter((s) => !Number.isNaN(new Date(s).getTime()))),
-  Schema.DateFromSelf,
-  { strict: true, decode: (s) => new Date(s), encode: (d) => d.toISOString() },
-);
-const Latitude = Schema.Number.pipe(Schema.between(-90, 90));
-const Longitude = Schema.Number.pipe(Schema.between(-180, 180));
+const CategoryString = Schema.String.check(Schema.isMaxLength(100));
+// v4's DateFromString rejects an Invalid Date, which is all the removed
+// validate-then-transform was for.
+const DateFromISOString = Schema.DateFromString;
+const Latitude = Schema.Number.check(Schema.isBetween({ minimum: -90, maximum: 90 }));
+const Longitude = Schema.Number.check(Schema.isBetween({ minimum: -180, maximum: 180 }));
 // 500 km is plenty for "events near me" — Earth's largest metros are
 // well inside this, and bigger radii stop being a discovery query and
 // become a full city-list query that's better served a different way.
-const RadiusKm = Schema.Number.pipe(Schema.between(0.1, 500));
+const RadiusKm = Schema.Number.check(Schema.isBetween({ minimum: 0.1, maximum: 500 }));
 // Shared cap across currencies; matches `MAX_PRICE_MAJOR` in lib/currency.
-const PriceMajor = Schema.Number.pipe(Schema.between(0, 99999.99));
-const CurrencySchema = Schema.Literal(...SUPPORTED_CURRENCIES);
+const PriceMajor = Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 99999.99 }));
+const CurrencySchema = Schema.Literals(SUPPORTED_CURRENCIES);
 
 export const DiscoveryParamsSchema = Schema.Struct({
   category: Schema.optional(CategoryString),
@@ -55,9 +53,9 @@ export const DiscoveryParamsSchema = Schema.Struct({
   priceMax: Schema.optional(PriceMajor),
   cursorStartTime: Schema.optional(DateFromISOString),
   cursorId: Schema.optional(Schema.String),
-  limit: Schema.optional(Schema.Number.pipe(Schema.between(1, 50))),
-}).pipe(
-  Schema.filter((p) => {
+  limit: Schema.optional(Schema.Number.check(Schema.isBetween({ minimum: 1, maximum: 50 }))),
+}).check(
+  Schema.makeFilter((p) => {
     // Location triangle: lat/lng/radius must all be set together.
     const locBits = [p.lat != null, p.lng != null, p.radiusKm != null];
     const locCount = locBits.filter(Boolean).length;
@@ -159,7 +157,7 @@ export const discoverEvents = (
     const startedAt = performance.now();
     const { db } = yield* Db;
 
-    const params = yield* Schema.decodeUnknown(DiscoveryParamsSchema)(input).pipe(
+    const params = yield* Schema.decodeUnknownEffect(DiscoveryParamsSchema)(input).pipe(
       Effect.mapError((cause) => new DiscoveryValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -64,45 +64,46 @@ const VisibilityEnum = Schema.Literals(["public", "private"]);
 const GuestListVisibilityEnum = Schema.Literals(["public", "connections", "private"]);
 const JoinPolicyEnum = Schema.Literals(["open", "guest_list"]);
 const CommsChannelSchema = Schema.Literals(["sms", "email"]);
-const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(
-  Schema.minItems(1),
-  Schema.filter((channels) => new Set(channels).size === channels.length, {
-    message: () => "commsChannels must not contain duplicates",
-  }),
+const CommsChannelsSchema = Schema.Array(CommsChannelSchema).check(
+  Schema.isMinLength(1),
+  Schema.makeFilter((channels) =>
+    new Set(channels).size === channels.length
+      ? undefined
+      : "commsChannels must not contain duplicates",
+  ),
 );
 
-// Schema.DateFromString in this Effect version allows Invalid Date — use a validated transform
-const ValidDateString = Schema.String.pipe(Schema.filter((s) => !isNaN(new Date(s).getTime())));
-const DateFromISOString = Schema.transform(ValidDateString, Schema.DateFromSelf, {
-  strict: true,
-  decode: (s) => new Date(s),
-  encode: (d) => d.toISOString(),
-});
+// Effect v3's DateFromString allowed Invalid Date, so this was a validated
+// transform. v4's rejects it ("Expected a valid Date"), so the schema is the
+// stock one again.
+const DateFromISOString = Schema.DateFromString;
 
-const ValidUrl = Schema.String.pipe(Schema.filter((s) => URL.parse(s) !== null));
+const ValidUrl = Schema.String.check(Schema.makeFilter((s) => URL.parse(s) !== null));
 
-const LatitudeSchema = Schema.Number.pipe(Schema.between(-90, 90));
-const LongitudeSchema = Schema.Number.pipe(Schema.between(-180, 180));
+const LatitudeSchema = Schema.Number.check(Schema.isBetween({ minimum: -90, maximum: 90 }));
+const LongitudeSchema = Schema.Number.check(Schema.isBetween({ minimum: -180, maximum: 180 }));
 
 // Length caps on user-provided text fields. Without these, an
 // authenticated user can POST an event with a 10MB description and bloat
 // every discovery response that returns it. The numbers are deliberately
 // generous — they cap abuse without constraining real events.
-const TitleString = Schema.NonEmptyString.pipe(Schema.maxLength(200));
-const DescriptionString = Schema.String.pipe(Schema.maxLength(5000));
-const LocationString = Schema.String.pipe(Schema.maxLength(500));
-const VenueString = Schema.String.pipe(Schema.maxLength(500));
-const CategoryString = Schema.String.pipe(Schema.maxLength(100));
+const TitleString = Schema.NonEmptyString.check(Schema.isMaxLength(200));
+const DescriptionString = Schema.String.check(Schema.isMaxLength(5000));
+const LocationString = Schema.String.check(Schema.isMaxLength(500));
+const VenueString = Schema.String.check(Schema.isMaxLength(500));
+const CategoryString = Schema.String.check(Schema.isMaxLength(100));
 
 // Price input is a major-unit decimal (e.g. 18.50 USD). The service
 // converts to minor units before INSERT. Cap at MAX_PRICE_MAJOR shared
 // across all currencies.
-const PriceAmountMajor = Schema.Number.pipe(
-  Schema.between(0, MAX_PRICE_MAJOR, {
-    message: () => `price must be between 0 and ${MAX_PRICE_MAJOR}`,
-  }),
+const PriceAmountMajor = Schema.Number.check(
+  // v4 filter annotations take `message` as a plain string, not a thunk.
+  Schema.isBetween(
+    { minimum: 0, maximum: MAX_PRICE_MAJOR },
+    { message: `price must be between 0 and ${MAX_PRICE_MAJOR}` },
+  ),
 );
-const CurrencySchema = Schema.Literal(...SUPPORTED_CURRENCIES);
+const CurrencySchema = Schema.Literals(SUPPORTED_CURRENCIES);
 
 // Enforce "both set or both null" invariant. `undefined` on both is fine
 // (price not being changed); otherwise they must pair up.
@@ -138,10 +139,12 @@ const InsertEventSchema = Schema.Struct({
   commsChannels: Schema.optional(CommsChannelsSchema),
   priceAmount: Schema.optional(Schema.NullOr(PriceAmountMajor)),
   priceCurrency: Schema.optional(Schema.NullOr(CurrencySchema)),
-}).pipe(
-  Schema.filter(priceInvariant, {
-    message: () => "priceAmount and priceCurrency must both be set or both be null",
-  }),
+}).check(
+  Schema.makeFilter((v) =>
+    priceInvariant(v)
+      ? undefined
+      : "priceAmount and priceCurrency must both be set or both be null",
+  ),
 );
 
 const UpdateEventSchema = Schema.Struct({
@@ -163,10 +166,12 @@ const UpdateEventSchema = Schema.Struct({
   commsChannels: Schema.optional(CommsChannelsSchema),
   priceAmount: Schema.optional(Schema.NullOr(PriceAmountMajor)),
   priceCurrency: Schema.optional(Schema.NullOr(CurrencySchema)),
-}).pipe(
-  Schema.filter(priceInvariant, {
-    message: () => "priceAmount and priceCurrency must both be set or both be null",
-  }),
+}).check(
+  Schema.makeFilter((v) =>
+    priceInvariant(v)
+      ? undefined
+      : "priceAmount and priceCurrency must both be set or both be null",
+  ),
 );
 
 interface ListEventsParams {
@@ -609,7 +614,7 @@ export const createEvent = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    const validated = yield* Schema.decodeUnknown(InsertEventSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(InsertEventSchema)(data).pipe(
       Effect.tapError(() => Effect.sync(() => metricEventValidationFailure("create", "schema"))),
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
@@ -685,7 +690,7 @@ export const updateEvent = (
       return yield* Effect.fail(new NotEventOwner({ id }));
     }
 
-    const validated = yield* Schema.decodeUnknown(UpdateEventSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(UpdateEventSchema)(data).pipe(
       Effect.tapError(() => Effect.sync(() => metricEventValidationFailure("update", "schema"))),
       Effect.mapError((cause) => new ValidationError({ cause })),
     );

--- a/pulse/api/src/services/events.ts
+++ b/pulse/api/src/services/events.ts
@@ -53,11 +53,17 @@ export class NotEventOwner extends Data.TaggedError("NotEventOwner")<{
   readonly id: string;
 }> {}
 
-const StatusEnum = Schema.Literal("upcoming", "ongoing", "maybe_finished", "finished", "cancelled");
-const VisibilityEnum = Schema.Literal("public", "private");
-const GuestListVisibilityEnum = Schema.Literal("public", "connections", "private");
-const JoinPolicyEnum = Schema.Literal("open", "guest_list");
-const CommsChannelSchema = Schema.Literal("sms", "email");
+const StatusEnum = Schema.Literals([
+  "upcoming",
+  "ongoing",
+  "maybe_finished",
+  "finished",
+  "cancelled",
+]);
+const VisibilityEnum = Schema.Literals(["public", "private"]);
+const GuestListVisibilityEnum = Schema.Literals(["public", "connections", "private"]);
+const JoinPolicyEnum = Schema.Literals(["open", "guest_list"]);
+const CommsChannelSchema = Schema.Literals(["sms", "email"]);
 const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(
   Schema.minItems(1),
   Schema.filter((channels) => new Set(channels).size === channels.length, {

--- a/pulse/api/src/services/onboarding.ts
+++ b/pulse/api/src/services/onboarding.ts
@@ -57,10 +57,10 @@ export type InterestCategory = (typeof INTEREST_CATEGORIES)[number];
 const PermOutcomeSchema = Schema.Literals(["granted", "denied", "prompt", "unsupported"]);
 export type PermOutcome = Schema.Schema.Type<typeof PermOutcomeSchema>;
 
-const InterestSchema = Schema.Literal(...INTEREST_CATEGORIES);
+const InterestSchema = Schema.Literals(INTEREST_CATEGORIES);
 
 const CompleteOnboardingSchema = Schema.Struct({
-  interests: Schema.Array(InterestSchema).pipe(Schema.maxItems(8)),
+  interests: Schema.Array(InterestSchema).check(Schema.isMaxLength(8)),
   notificationsOptIn: Schema.Boolean,
   eventRemindersOptIn: Schema.Boolean,
   notificationsPerm: PermOutcomeSchema,
@@ -223,7 +223,7 @@ export const completeOnboarding = (
   Db
 > =>
   Effect.gen(function* () {
-    const validated = yield* Schema.decodeUnknown(CompleteOnboardingSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(CompleteOnboardingSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/onboarding.ts
+++ b/pulse/api/src/services/onboarding.ts
@@ -54,7 +54,7 @@ export const INTEREST_CATEGORIES = [
 
 export type InterestCategory = (typeof INTEREST_CATEGORIES)[number];
 
-const PermOutcomeSchema = Schema.Literal("granted", "denied", "prompt", "unsupported");
+const PermOutcomeSchema = Schema.Literals(["granted", "denied", "prompt", "unsupported"]);
 export type PermOutcome = Schema.Schema.Type<typeof PermOutcomeSchema>;
 
 const InterestSchema = Schema.Literal(...INTEREST_CATEGORIES);

--- a/pulse/api/src/services/pulseUsers.ts
+++ b/pulse/api/src/services/pulseUsers.ts
@@ -135,7 +135,7 @@ export const updateSettings = (
   data: unknown,
 ): Effect.Effect<PulseProfile, ValidationError | DatabaseError, Db> =>
   Effect.gen(function* () {
-    const validated = yield* Schema.decodeUnknown(UpdateSettingsSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(UpdateSettingsSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/pulseUsers.ts
+++ b/pulse/api/src/services/pulseUsers.ts
@@ -21,7 +21,7 @@ export const DEFAULT_ATTENDANCE_VISIBILITY = "connections" as const;
 
 export type AttendanceVisibility = PulseProfile["attendanceVisibility"];
 
-const AttendanceVisibilitySchema = Schema.Literal("connections", "no_one");
+const AttendanceVisibilitySchema = Schema.Literals(["connections", "no_one"]);
 
 const UpdateSettingsSchema = Schema.Struct({
   attendanceVisibility: Schema.optional(AttendanceVisibilitySchema),

--- a/pulse/api/src/services/rsvps.ts
+++ b/pulse/api/src/services/rsvps.ts
@@ -71,9 +71,9 @@ const InviteGuestsSchema = Schema.Struct({
   // Bulk-invite batch is capped at the same MAX_EVENT_GUESTS platform
   // limit — an organiser can't invite more people than the event itself
   // can hold. See `lib/limits.ts` for the rationale.
-  profileIds: Schema.Array(Schema.NonEmptyString).pipe(
-    Schema.minItems(1),
-    Schema.maxItems(MAX_EVENT_GUESTS),
+  profileIds: Schema.Array(Schema.NonEmptyString).check(
+    Schema.isMinLength(1),
+    Schema.isMaxLength(MAX_EVENT_GUESTS),
   ),
 });
 
@@ -300,7 +300,7 @@ export const upsertRsvp = (
   data: unknown,
 ): Effect.Effect<EventRsvp, EventNotFound | ValidationError | NotInvited | DatabaseError, Db> =>
   Effect.gen(function* () {
-    const validated = yield* Schema.decodeUnknown(UpsertRsvpSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(UpsertRsvpSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 
@@ -424,7 +424,7 @@ export const inviteGuests = (
   Db
 > =>
   Effect.gen(function* () {
-    const validated = yield* Schema.decodeUnknown(InviteGuestsSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(InviteGuestsSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/rsvps.ts
+++ b/pulse/api/src/services/rsvps.ts
@@ -53,7 +53,7 @@ export class NotEventOwner extends Data.TaggedError("NotEventOwner")<{
  * Wire-level statuses accepted from clients. "invited" is reserved for the
  * organiser invite flow and is rejected on upsertRsvp.
  */
-const RsvpStatusSchema = Schema.Literal("going", "maybe", "not_going");
+const RsvpStatusSchema = Schema.Literals(["going", "maybe", "not_going"]);
 export type RsvpStatus = Schema.Schema.Type<typeof RsvpStatusSchema>;
 
 const UpsertRsvpSchema = Schema.Struct({

--- a/pulse/api/src/services/series.ts
+++ b/pulse/api/src/services/series.ts
@@ -287,40 +287,41 @@ const VisibilityEnum = Schema.Literals(["public", "private"]);
 const GuestListVisibilityEnum = Schema.Literals(["public", "connections", "private"]);
 const JoinPolicyEnum = Schema.Literals(["open", "guest_list"]);
 const CommsChannelSchema = Schema.Literals(["sms", "email"]);
-const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(
-  Schema.minItems(1),
-  Schema.filter((channels) => new Set(channels).size === channels.length, {
-    message: () => "commsChannels must not contain duplicates",
-  }),
+const CommsChannelsSchema = Schema.Array(CommsChannelSchema).check(
+  Schema.isMinLength(1),
+  Schema.makeFilter((channels) =>
+    new Set(channels).size === channels.length
+      ? undefined
+      : "commsChannels must not contain duplicates",
+  ),
 );
 
-const ValidDateString = Schema.String.pipe(Schema.filter((s) => !isNaN(new Date(s).getTime())));
-const DateFromISOString = Schema.transform(ValidDateString, Schema.DateFromSelf, {
-  strict: true,
-  decode: (s) => new Date(s),
-  encode: (d) => d.toISOString(),
-});
-const ValidUrl = Schema.String.pipe(Schema.filter((s) => URL.parse(s) !== null));
+// v4's DateFromString rejects a string that parses to an Invalid Date — the
+// exact gap the hand-rolled validate-then-transform above it used to close.
+const DateFromISOString = Schema.DateFromString;
+const ValidUrl = Schema.String.check(Schema.makeFilter((s) => URL.parse(s) !== null));
 
-const TitleString = Schema.NonEmptyString.pipe(Schema.maxLength(200));
-const DescriptionString = Schema.String.pipe(Schema.maxLength(5000));
-const LocationString = Schema.String.pipe(Schema.maxLength(500));
-const VenueString = Schema.String.pipe(Schema.maxLength(500));
-const CategoryString = Schema.String.pipe(Schema.maxLength(100));
-const RRuleString = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(500));
-const TimezoneString = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100));
+const TitleString = Schema.NonEmptyString.check(Schema.isMaxLength(200));
+const DescriptionString = Schema.String.check(Schema.isMaxLength(5000));
+const LocationString = Schema.String.check(Schema.isMaxLength(500));
+const VenueString = Schema.String.check(Schema.isMaxLength(500));
+const CategoryString = Schema.String.check(Schema.isMaxLength(100));
+const RRuleString = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(500));
+const TimezoneString = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(100));
 
 const CreateSeriesSchema = Schema.Struct({
   title: TitleString,
   description: Schema.optional(DescriptionString),
   location: Schema.optional(LocationString),
   venue: Schema.optional(VenueString),
-  latitude: Schema.optional(Schema.Number.pipe(Schema.between(-90, 90))),
-  longitude: Schema.optional(Schema.Number.pipe(Schema.between(-180, 180))),
+  latitude: Schema.optional(Schema.Number.check(Schema.isBetween({ minimum: -90, maximum: 90 }))),
+  longitude: Schema.optional(
+    Schema.Number.check(Schema.isBetween({ minimum: -180, maximum: 180 })),
+  ),
   category: Schema.optional(CategoryString),
   imageUrl: Schema.optional(ValidUrl),
   durationMinutes: Schema.optional(
-    Schema.Number.pipe(Schema.int(), Schema.between(1, 60 * 24 * 14)),
+    Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 60 * 24 * 14 })),
   ),
   visibility: Schema.optional(VisibilityEnum),
   guestListVisibility: Schema.optional(GuestListVisibilityEnum),
@@ -339,12 +340,14 @@ const UpdateSeriesSchema = Schema.Struct({
   description: Schema.optional(DescriptionString),
   location: Schema.optional(LocationString),
   venue: Schema.optional(VenueString),
-  latitude: Schema.optional(Schema.Number.pipe(Schema.between(-90, 90))),
-  longitude: Schema.optional(Schema.Number.pipe(Schema.between(-180, 180))),
+  latitude: Schema.optional(Schema.Number.check(Schema.isBetween({ minimum: -90, maximum: 90 }))),
+  longitude: Schema.optional(
+    Schema.Number.check(Schema.isBetween({ minimum: -180, maximum: 180 })),
+  ),
   category: Schema.optional(CategoryString),
   imageUrl: Schema.optional(ValidUrl),
   durationMinutes: Schema.optional(
-    Schema.Number.pipe(Schema.int(), Schema.between(1, 60 * 24 * 14)),
+    Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 60 * 24 * 14 })),
   ),
   visibility: Schema.optional(VisibilityEnum),
   guestListVisibility: Schema.optional(GuestListVisibilityEnum),
@@ -476,7 +479,7 @@ export const createSeries = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    const validated = yield* Schema.decodeUnknown(CreateSeriesSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(CreateSeriesSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 
@@ -608,7 +611,7 @@ export const updateSeries = (
       return yield* Effect.fail(new NotEventOwner({ id }));
     }
 
-    const validated = yield* Schema.decodeUnknown(UpdateSeriesSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(UpdateSeriesSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/pulse/api/src/services/series.ts
+++ b/pulse/api/src/services/series.ts
@@ -283,10 +283,10 @@ export const expandRRule = (rule: ParsedRRule, dtstart: Date, maxThrough: Date):
 // Service input schemas
 // ---------------------------------------------------------------------------
 
-const VisibilityEnum = Schema.Literal("public", "private");
-const GuestListVisibilityEnum = Schema.Literal("public", "connections", "private");
-const JoinPolicyEnum = Schema.Literal("open", "guest_list");
-const CommsChannelSchema = Schema.Literal("sms", "email");
+const VisibilityEnum = Schema.Literals(["public", "private"]);
+const GuestListVisibilityEnum = Schema.Literals(["public", "connections", "private"]);
+const JoinPolicyEnum = Schema.Literals(["open", "guest_list"]);
+const CommsChannelSchema = Schema.Literals(["sms", "email"]);
 const CommsChannelsSchema = Schema.Array(CommsChannelSchema).pipe(
   Schema.minItems(1),
   Schema.filter((channels) => new Set(channels).size === channels.length, {
@@ -332,7 +332,7 @@ const CreateSeriesSchema = Schema.Struct({
   timezone: Schema.optional(TimezoneString),
 });
 
-const UpdateSeriesScope = Schema.Literal("this_and_following", "all_future");
+const UpdateSeriesScope = Schema.Literals(["this_and_following", "all_future"]);
 
 const UpdateSeriesSchema = Schema.Struct({
   title: Schema.optional(TitleString),

--- a/zap/api/src/services/chats.ts
+++ b/zap/api/src/services/chats.ts
@@ -87,13 +87,13 @@ export class NotC2cChat extends Data.TaggedError("NotC2cChat")<{
 // Effect schemas (service-layer validation)
 // ---------------------------------------------------------------------------
 
-const ChatTypeEnum = Schema.Literal("dm", "group", "event");
-const TitleString = Schema.String.pipe(Schema.maxLength(MAX_CHAT_TITLE_LENGTH));
+const ChatTypeEnum = Schema.Literals(["dm", "group", "event"]);
+const TitleString = Schema.String.check(Schema.isMaxLength(MAX_CHAT_TITLE_LENGTH));
 
 const ProvisionC2bChatSchema = Schema.Struct({
-  memberProfileIds: Schema.Array(Schema.String).pipe(
-    Schema.minItems(2),
-    Schema.maxItems(MAX_CHAT_MEMBERS),
+  memberProfileIds: Schema.Array(Schema.String).check(
+    Schema.isMinLength(2),
+    Schema.isMaxLength(MAX_CHAT_MEMBERS),
   ),
   createdByProfileId: Schema.String,
   title: Schema.optional(TitleString),
@@ -104,7 +104,7 @@ const CreateChatSchema = Schema.Struct({
   title: Schema.optional(TitleString),
   eventId: Schema.optional(Schema.String),
   memberProfileIds: Schema.optional(
-    Schema.Array(Schema.String).pipe(Schema.maxItems(MAX_CHAT_MEMBERS)),
+    Schema.Array(Schema.String).check(Schema.isMaxLength(MAX_CHAT_MEMBERS)),
   ),
 });
 
@@ -258,7 +258,7 @@ export const createChat = (
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    const validated = yield* Schema.decodeUnknown(CreateChatSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(CreateChatSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 
@@ -420,7 +420,7 @@ export const updateChat = (
     // them the id names a commercial conversation.
     yield* assertC2c(chat);
 
-    const validated = yield* Schema.decodeUnknown(UpdateChatSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(UpdateChatSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 
@@ -714,7 +714,7 @@ export const provisionC2bChat = (input: {
   Effect.gen(function* () {
     const { db } = yield* Db;
 
-    const validated = yield* Schema.decodeUnknown(ProvisionC2bChatSchema)(input).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(ProvisionC2bChatSchema)(input).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 

--- a/zap/api/src/services/messages.ts
+++ b/zap/api/src/services/messages.ts
@@ -40,8 +40,8 @@ export class ValidationError extends Data.TaggedError("ValidationError")<{
 // Effect schemas
 // ---------------------------------------------------------------------------
 
-const CiphertextString = Schema.String.pipe(Schema.maxLength(MAX_CIPHERTEXT_LENGTH));
-const NonceString = Schema.String.pipe(Schema.maxLength(MAX_NONCE_LENGTH));
+const CiphertextString = Schema.String.check(Schema.isMaxLength(MAX_CIPHERTEXT_LENGTH));
+const NonceString = Schema.String.check(Schema.isMaxLength(MAX_NONCE_LENGTH));
 
 const SendMessageSchema = Schema.Struct({
   ciphertext: CiphertextString,
@@ -49,7 +49,7 @@ const SendMessageSchema = Schema.Struct({
 });
 
 const SendC2bMessageSchema = Schema.Struct({
-  body: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_BODY_LENGTH)),
+  body: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_BODY_LENGTH)),
 });
 
 // ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ export const sendMessage = (
       return yield* Effect.fail(new NotC2cChat({ chatId }));
     }
 
-    const validated = yield* Schema.decodeUnknown(SendMessageSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(SendMessageSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 
@@ -279,7 +279,7 @@ export const sendC2bMessage = (
       return yield* Effect.fail(new NotChatMember({ chatId }));
     }
 
-    const validated = yield* Schema.decodeUnknown(SendC2bMessageSchema)(data).pipe(
+    const validated = yield* Schema.decodeUnknownEffect(SendC2bMessageSchema)(data).pipe(
       Effect.mapError((cause) => new ValidationError({ cause })),
     );
 


### PR DESCRIPTION
Phase 4 of the Effect v4 migration (#901), stacked on #909.

After this, **36 of 37 packages type-check**. The only one left is `@cire/api`, which is phase 5 (#902).

## Issues

- Closes #901 (Schema in osn/api, pulse/api, zap/api, cire/theme, osn/client)
- Part of #895; follows #900 (#909)

> [!note] This keyword will not auto-close #901 from here
> GitHub only creates the linked-PR relationship for a pull request targeting the repository's **default branch**. This one targets `claude/effect-v4-phase-3`, so the keyword records intent and nothing more — which is why the sub-issues still show as open with no linked PR. The `effect-v4` → `main` PR at the top of the stack is what has to carry the full `Closes #896`…`#903` set, and it is what will actually close them.

## What changed

### Checks replace the constraint combinators

v3's constraint combinators are v4 *checks*, applied through a schema's `.check(...)` rather than `.pipe(...)`:

| v3 | v4 |
|---|---|
| `Schema.maxLength(n)` / `minLength(n)` | `Schema.isMaxLength(n)` / `isMinLength(n)` |
| `Schema.maxItems(n)` / `minItems(n)` | the same two — `isMinLength` doubles as the collection-size check |
| `Schema.int()` | `Schema.isInt()` |
| `Schema.between(a, b)` | `Schema.isBetween({ minimum: a, maximum: b })` |
| `Schema.filter(pred)` | `Schema.check(Schema.makeFilter(pred))` |
| `Schema.Literal(a, b, …)` | `Schema.Literals([a, b, …])` |
| `Schema.decodeUnknown` | `Schema.decodeUnknownEffect` |
| `Schema.Record({ key, value })` | `Schema.Record(key, value)` |

`isBetween` is inclusive at both ends, same as v3's `between`, so **no range moved**.

A v4 filter carries its own failure message in its return value — `undefined`/`true` is success, a string is the message — so `{ message: () => "…" }` becomes the predicate returning that string. **Every validator keeps its exact wording.** `BirthdateSchema`'s multi-branch predicate returns the message from each rejecting branch rather than `false`. Where a `message` annotation genuinely belongs on the check itself (`PriceAmountMajor`), v4 takes it as a plain string rather than a thunk.

### Three copies of a workaround are deleted, not ported

`@pulse/api`'s events, series and discovery services each carried a hand-rolled "validate the string, then transform to a Date" pair. The comment in `events.ts` said why:

> `Schema.DateFromString` in this Effect version allows Invalid Date — use a validated transform

v4's rejects it. Verified directly against the resolved package: `"not-a-date"` and `""` both fail with `Expected a valid Date`, a valid string still decodes, and encoding still yields an ISO string. So all three collapse back to the stock `Schema.DateFromString`, and the `Schema.transform` → `decodeTo`/`SchemaTransformation` migration is not needed here at all.

### `isAuthExpiredError` and the missing wrapper

v4 removed `FiberFailure`. `runPromise` now rejects with `Cause.squash(cause)`, which for a typed failure is the error instance itself — so `escaped instanceof AuthExpiredError` is `true` where the test asserted `false`.

The predicate keeps all three arms, but the comments no longer claim the wrapper is what arrives: `instanceof` now carries the common path, and the printout arm stays for a consumer bundle built against v3 (`cire/host`, `cire/vendor`) and for any boundary that strips both the prototype and the `_tag`. The escape test pins the v4 shape, with an explicit v3-printout case beside it so that arm keeps its coverage.

### Test assertions that were pinned to v3 output

- `osn/client/tests/tokens.test.ts` — v4 decode errors render a reason line plus an `at [path]` line, and no longer echo the offending value (v3 wrote `actual "not_a_number"`). All five assertions still pin **both halves** — which key, and why — so a schema change that starts rejecting the wrong field still fails here.
- `osn/api/tests/lib/email-layer.test.ts` — v4 log levels are capitalised string literals, so the rendered label is `[Warn]`, not `[WARN]`. Respelled the alternation rather than making it case-insensitive; a loose match would also accept a level that does not exist in v4's set.

`cire/theme` was on the phase-4 list but imports Effect nowhere — only three comments mention Schema. Nothing to migrate; it type-checks clean as-is.

## Verification

Type-checking a check proves nothing about whether it still *rejects*, so each was exercised against its package's own resolved `effect`:

| Package | Checked |
|---|---|
| `@zap/api` | over-long body, empty body, too few / too many array items |
| `@pulse/api` | duplicate `commsChannels`, empty channels, unknown channel, each arm of the discovery composite filter (partial location triangle, price without currency, min > max, half a cursor), lat/limit ranges, invalid date |
| `@osn/api` | address with no `@`, address over the 255-char RFC 5321 ceiling, uppercase / over-length / empty handle, `2021-02-30`, a future birthdate, a non-zero-padded date, blank / over-64-char passkey label — each with its original message |

Suites:

| Package | Result |
|---|---|
| `@osn/api` | 1141 passed |
| `@pulse/api` | 647 passed |
| `@zap/api` | 179 passed |
| `@osn/client` | 228 passed |
| `@osn/ui` | 143 passed |
| `@osn/social` | 147 passed |

`@osn/ui` and `@osn/social` import Effect nowhere and were red only because they load it through `@osn/client`; the one-line `Schema.Record` fix unblocked both, as #901 predicted.

## Still red by design

`@cire/api` — phase 5 (#902). CI on this branch will fail on it, as it did on #906, #908 and #909. The tree goes green when phase 5 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH)_