### PR TITLE
feat(effect): migrate @cire/api to v4 — the monorepo is green on Effect 4

### DIFF
--- a/.changeset/effect-v4-phase-5-cire.md
+++ b/.changeset/effect-v4-phase-5-cire.md
@@ -1,0 +1,40 @@
+---
+"@cire/api": patch
+---
+
+Migrate `@cire/api`'s Effect Schema surface to v4 — the last package on v3.
+**The whole monorepo now type-checks and passes its tests under Effect v4.**
+
+Everything phase 4 established applies here too (checks via `.check(...)`,
+`makeFilter` carrying its own message, `Literals([…])`, `decodeUnknownEffect`),
+plus four things cire hit first:
+
+- **`Schema.Union` takes one array**, not variadic members. Silent when it slips
+  through — a two-member union read as a single member, and the inference
+  degrades to `{}` rather than erroring at the call.
+- **`Schema.optionalWith(S, { default: () => v })` becomes
+  `S.pipe(Schema.withDecodingDefaultType(Effect.succeed(v)))`** — 22 sites, all
+  the same shape.
+- **A decode failure is tagged `SchemaError`, not `ParseError`.** Upstream's
+  generated reference leaves `ParseResult.ParseError` as "TODO: needs
+  guidance"; the compiler answers it. 41 `catchTag`/`catchTags` sites and one
+  type annotation in `services/changes.ts`.
+- **`Cause` is a list of reasons**, so `cause._tag === "Fail" && cause.error
+  instanceof X` becomes `Option.getOrUndefined(Cause.findErrorOption(cause))
+  instanceof X`. That still refuses a defect, exactly as the `Fail` check did.
+
+`Schema.transform` → `Schema.decodeTo(target, SchemaTransformation.transform(…))`
+was needed only twice (the time-zone canonicaliser and the URL normaliser) and
+once for a clamp. Three "trim, then bound the length" pairs collapse to
+`Schema.Trim.check(isMinLength(1), isMaxLength(n))` — verified to trim before
+checking, so `"   "` is still rejected as blank. v4 short-circuits a `.check(…)`
+list on the first failure, so `TimeZone`'s length cap still runs before the ICU
+lookup it exists to protect.
+
+Two test fixes are consequences of phase 3's logger rework rather than of
+Schema. `cire/api`'s unhandled-error log test isolated its line by
+`startsWith('{"')`; the local renderer is indented now, so that filter caught a
+fragment. `Logger.layer` also replaces the whole active set, so there is no
+default logger left emitting the stack dump the filter existed to exclude — the
+whole capture is that one entry, which makes the "no raw SQLite message" check
+strictly stronger. Also drops five `Logger` imports left dead by phase 3.

--- a/.changeset/effect-v4-phase-5-versioned.md
+++ b/.changeset/effect-v4-phase-5-versioned.md
@@ -1,0 +1,15 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+"@zap/api": patch
+"@shared/observability": patch
+---
+
+Drop five `Logger` imports left dead by the v4 logger rework, and finish the
+Effect v4 migration: with `@cire/api` moved off v3 in the same change, the
+whole monorepo type-checks and passes its tests under Effect v4.
+
+The observability change is the test-only one: `Logger.layer` replaces the
+whole active logger set, so the default logger that used to emit a separate
+"Fiber terminated…" stack dump is gone, and a capture is now exactly the
+entry under test.

--- a/cire/api/src/routes/account-link.ts
+++ b/cire/api/src/routes/account-link.ts
@@ -162,7 +162,7 @@ export const createAccountLinkPostRoute = (
 
         return runCire(
           Effect.gen(function* () {
-            const body = yield* Schema.decodeUnknown(LinkAccountBody)(raw);
+            const body = yield* Schema.decodeUnknownEffect(LinkAccountBody)(raw);
 
             const resolution = yield* Effect.tryPromise({
               try: () => resolveAccount(profileId),
@@ -209,7 +209,7 @@ export const createAccountLinkPostRoute = (
           }).pipe(
             Effect.provideService(DbService, db),
             Effect.catchTags({
-              ParseError: () =>
+              SchemaError: () =>
                 Effect.sync(() => {
                   metricAccountLinkRequest("error");
                   set.status = 400;

--- a/cire/api/src/routes/budget.ts
+++ b/cire/api/src/routes/budget.ts
@@ -120,12 +120,12 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(CreateBudgetItemBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(CreateBudgetItemBody)(raw);
                 const item = yield* budgetService.createItem({ weddingId, ...body });
                 return { item };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
             );
@@ -139,12 +139,12 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ReorderBudgetItemsBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ReorderBudgetItemsBody)(raw);
                 yield* budgetService.reorderItems(weddingId, body.category, body.orderedIds);
                 return { ok: true as const };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
             );
@@ -158,7 +158,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateBudgetItemBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateBudgetItemBody)(raw);
                 const item = yield* budgetService.updateItem({
                   weddingId,
                   itemId: params.itemId,
@@ -167,7 +167,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
                 return { item };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
@@ -193,7 +193,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(CreatePaymentBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(CreatePaymentBody)(raw);
                 const payment = yield* budgetService.addPayment({
                   weddingId,
                   itemId: params.itemId,
@@ -204,7 +204,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
                 return { payment };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
@@ -219,7 +219,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdatePaymentBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdatePaymentBody)(raw);
                 const payment = yield* budgetService.updatePayment({
                   weddingId,
                   itemId: params.itemId,
@@ -229,7 +229,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
                 return { payment };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("BudgetItemNotInWedding", () => itemNotFound(set)),
                 Effect.catchTag("PaymentNotInItem", () => paymentNotFound(set)),
                 Effect.catchDefect(() => internal(set)),
@@ -267,7 +267,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
           const raw: unknown = await request.json().catch(() => null);
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(SetBudgetTotalBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(SetBudgetTotalBody)(raw);
               const settings = yield* weddingSettingsService.update(
                 weddingId,
                 { budgetTotalMinor: body.budgetTotalMinor },
@@ -276,7 +276,7 @@ export const createBudgetWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) 
               return { budgetTotalMinor: settings.budgetTotalMinor };
             }).pipe(
               Effect.provideService(DbService, db),
-              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("SchemaError", () => badRequest(set)),
               Effect.catchTag("WeddingNotFound", () => weddingNotFound(set)),
               Effect.catchTag("SettingsWriteError", () => internal(set)),
               // Unreachable: this patch never names the deadline. Handled so

--- a/cire/api/src/routes/claim.ts
+++ b/cire/api/src/routes/claim.ts
@@ -49,7 +49,7 @@ export const createClaimRoutes = (
 
       return runCire(
         Effect.gen(function* () {
-          const { publicId } = yield* Schema.decodeUnknown(ClaimBody)(raw);
+          const { publicId } = yield* Schema.decodeUnknownEffect(ClaimBody)(raw);
           const result = yield* claimService.lookup(publicId.trim().toUpperCase());
           // Session write may fail (DB transient error) — we still hand the user
           // their invite payload and skip Set-Cookie. Error is logged inside the
@@ -66,7 +66,7 @@ export const createClaimRoutes = (
           return result;
         }).pipe(
           Effect.provideService(DbService, db),
-          Effect.catchTag("ParseError", () =>
+          Effect.catchTag("SchemaError", () =>
             Effect.sync(() => {
               set.status = 400;
               return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/invite.ts
+++ b/cire/api/src/routes/invite.ts
@@ -344,12 +344,12 @@ export const createInviteOrganiserRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(InviteTextBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(InviteTextBody)(raw);
                 yield* inviteService.upsertText(weddingId, body);
                 return yield* inviteService.getForWeddingId(weddingId);
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -383,14 +383,14 @@ export const createInviteOrganiserRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(InviteThemeBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(InviteThemeBody)(raw);
                 yield* inviteService.upsertTheme(weddingId, body);
                 return yield* inviteService.getForWeddingId(weddingId);
               }).pipe(
                 Effect.provideService(DbService, db),
                 // A bad colour (allow-list miss) or unknown font (enum miss) both
                 // surface here as a ParseError → 400, never persisted.
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Invalid colour or font" };
@@ -429,7 +429,7 @@ export const createInviteOrganiserRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(InviteDesignBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(InviteDesignBody)(raw);
                 const design = designs.find((d) => d.id === body.designId);
                 if (!design) {
                   set.status = 422;
@@ -446,7 +446,7 @@ export const createInviteOrganiserRoutes = (
                 return yield* inviteService.getForWeddingId(weddingId);
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -612,7 +612,7 @@ export const createInviteOrganiserRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ImageCropBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ImageCropBody)(raw);
                 const screen = body.screen ?? "desktop";
                 if (screen === "mobile" && slot !== "hero") {
                   set.status = 400;
@@ -622,7 +622,7 @@ export const createInviteOrganiserRoutes = (
                 return yield* inviteService.getForWeddingId(weddingId);
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Invalid crop rectangle" };
@@ -783,7 +783,7 @@ export const createInviteOrganiserRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ImageCropBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ImageCropBody)(raw);
                 // Event images render at a single aspect — only the hero has a
                 // phone rectangle (0046), so a mobile-targeted save here is a 400.
                 if (body.screen === "mobile") {
@@ -794,7 +794,7 @@ export const createInviteOrganiserRoutes = (
                 return { eventId, crop: body.crop };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Invalid crop rectangle" };

--- a/cire/api/src/routes/organiser-changes.ts
+++ b/cire/api/src/routes/organiser-changes.ts
@@ -204,7 +204,7 @@ function desiredStateFromRow(
   return Effect.gen(function* () {
     if (row.kind === "editor") {
       const json = yield* fetchUpload(row.eventsR2Key);
-      return yield* Schema.decodeUnknown(Schema.parseJson(DesiredState))(json);
+      return yield* Schema.decodeUnknownEffect(Schema.fromJsonString(DesiredState))(json);
     }
     const events =
       scope === "guests"
@@ -384,7 +384,7 @@ export const createOrganiserChangeRoutes = (
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.provideService(R2Service, r2 as R2Bucket),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -435,7 +435,7 @@ export const createOrganiserChangeRoutes = (
 
             return runCire(
               Effect.gen(function* () {
-                const { changeId } = yield* Schema.decodeUnknown(ApplyBody)(raw);
+                const { changeId } = yield* Schema.decodeUnknownEffect(ApplyBody)(raw);
                 const dbService = yield* DbService;
 
                 const [row] = yield* dbQuery(() =>
@@ -555,7 +555,7 @@ export const createOrganiserChangeRoutes = (
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.provideService(R2Service, r2 as R2Bucket),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -624,13 +624,13 @@ export const createOrganiserChangeRoutes = (
 
             return runCire(
               Effect.gen(function* () {
-                const { changeId } = yield* Schema.decodeUnknown(RevertBody)(raw);
+                const { changeId } = yield* Schema.decodeUnknownEffect(RevertBody)(raw);
                 const summary = yield* revertImport(changeId, weddingId);
                 return { summary };
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.provideService(R2Service, r2 as R2Bucket),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/organiser-enquiries.ts
+++ b/cire/api/src/routes/organiser-enquiries.ts
@@ -24,14 +24,14 @@ const manualParse = { parse: () => ({}) };
 
 /** POST /enquiries — open a thread. */
 const OpenBody = Schema.Struct({
-  directoryVendorId: Schema.String.pipe(Schema.minLength(1)),
-  category: Schema.String.pipe(Schema.minLength(1)),
-  message: Schema.String.pipe(Schema.minLength(1)),
+  directoryVendorId: Schema.String.check(Schema.isMinLength(1)),
+  category: Schema.String.check(Schema.isMinLength(1)),
+  message: Schema.String.check(Schema.isMinLength(1)),
 });
 
 /** POST /enquiries/:id/messages — reply. */
 const ReplyBody = Schema.Struct({
-  message: Schema.String.pipe(Schema.minLength(1)),
+  message: Schema.String.check(Schema.isMinLength(1)),
 });
 
 export interface EnquiryRoutesDeps {
@@ -165,7 +165,7 @@ export const createOrganiserEnquiriesRoutes = (
               const raw: unknown = await request.json().catch(() => null);
               return runCire(
                 Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(OpenBody)(raw);
+                  const body = yield* Schema.decodeUnknownEffect(OpenBody)(raw);
                   // Single read of the listing — the union of what the claim
                   // gate, enquiry-open, and the email fields each need. The row
                   // is passed down; the claim-mint gate (ownerOrgId !== null)
@@ -216,7 +216,7 @@ export const createOrganiserEnquiriesRoutes = (
                   return { enquiry };
                 }).pipe(
                   Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () =>
+                  Effect.catchTag("SchemaError", () =>
                     Effect.sync(() => {
                       set.status = 400;
                       return { error: "Missing or invalid fields" };
@@ -248,7 +248,7 @@ export const createOrganiserEnquiriesRoutes = (
               const raw: unknown = await request.json().catch(() => null);
               return runCire(
                 Effect.gen(function* () {
-                  const body = yield* Schema.decodeUnknown(ReplyBody)(raw);
+                  const body = yield* Schema.decodeUnknownEffect(ReplyBody)(raw);
                   const enquiry = yield* loadEnquiryInWedding(weddingId, params.id);
                   if (!enquiry) return yield* notFound(set);
                   const message = yield* enquiryService.reply({
@@ -266,7 +266,7 @@ export const createOrganiserEnquiriesRoutes = (
                   return { message };
                 }).pipe(
                   Effect.provideService(DbService, db),
-                  Effect.catchTag("ParseError", () =>
+                  Effect.catchTag("SchemaError", () =>
                     Effect.sync(() => {
                       set.status = 400;
                       return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/organiser-hosts.ts
+++ b/cire/api/src/routes/organiser-hosts.ts
@@ -206,7 +206,7 @@ export const createOrganiserHostsWriteRoutes = (
 
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(AddHostBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(AddHostBody)(raw);
 
                 const resolution = yield* Effect.tryPromise({
                   try: () => resolveHandle(body.handle),
@@ -239,7 +239,7 @@ export const createOrganiserHostsWriteRoutes = (
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.catchTags({
-                  ParseError: () =>
+                  SchemaError: () =>
                     Effect.sync(() => {
                       metricHostAdded("error");
                       set.status = 400;
@@ -310,7 +310,7 @@ export const createOrganiserHostsWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateHostRoleBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateHostRoleBody)(raw);
                 const host = yield* hostsService.setRole({
                   weddingId,
                   osnProfileId: params.osnProfileId,
@@ -327,7 +327,7 @@ export const createOrganiserHostsWriteRoutes = (
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.catchTags({
-                  ParseError: () =>
+                  SchemaError: () =>
                     Effect.sync(() => {
                       metricHostRoleChanged("error");
                       set.status = 400;

--- a/cire/api/src/routes/organiser-rsvp.ts
+++ b/cire/api/src/routes/organiser-rsvp.ts
@@ -54,7 +54,7 @@ export const createOrganiserRsvpRoutes = (db: Db, osnAuthOptions: OsnAuthOptions
           const raw: unknown = await request.json().catch(() => null);
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(OrganiserRsvpBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(OrganiserRsvpBody)(raw);
 
               // Art. 9(2)(a) gate (mirrors the guest path): the special-category
               // dietary free-text may only be stored WITH consent — here the
@@ -78,7 +78,7 @@ export const createOrganiserRsvpRoutes = (db: Db, osnAuthOptions: OsnAuthOptions
             }).pipe(
               Effect.provideService(DbService, db),
               Effect.catchTags({
-                ParseError: () =>
+                SchemaError: () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/organiser-settings.ts
+++ b/cire/api/src/routes/organiser-settings.ts
@@ -77,7 +77,7 @@ export const createOrganiserSettingsRoutes = (db: Db, osnAuthOptions: OsnAuthOpt
           const raw: unknown = await request.json().catch(() => null);
           return runCire(
             Effect.gen(function* () {
-              const patch = yield* Schema.decodeUnknown(UpdateSettingsBody)(raw);
+              const patch = yield* Schema.decodeUnknownEffect(UpdateSettingsBody)(raw);
               // Shape first, then privilege: a malformed body is a 400 whoever
               // sent it, so a co-host debugging a typo isn't told "forbidden".
               const ownerOnly = weddingIsOwner ? [] : ownerOnlySettingsIn(patch);
@@ -101,7 +101,7 @@ export const createOrganiserSettingsRoutes = (db: Db, osnAuthOptions: OsnAuthOpt
             }).pipe(
               Effect.provideService(DbService, db),
               Effect.catchTags({
-                ParseError: () =>
+                SchemaError: () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/organiser-weddings.ts
+++ b/cire/api/src/routes/organiser-weddings.ts
@@ -497,7 +497,7 @@ export const createOrganiserWeddingCreateRoute = (
 
         return runCire(
           Effect.gen(function* () {
-            const body = yield* Schema.decodeUnknown(CreateWeddingBody)(raw);
+            const body = yield* Schema.decodeUnknownEffect(CreateWeddingBody)(raw);
             const wedding = yield* weddingsService.createForOwner(
               osnProfileId,
               body.displayName,
@@ -507,7 +507,7 @@ export const createOrganiserWeddingCreateRoute = (
             return { wedding };
           }).pipe(
             Effect.provideService(DbService, db),
-            Effect.catchTag("ParseError", () =>
+            Effect.catchTag("SchemaError", () =>
               Effect.sync(() => {
                 set.status = 400;
                 return { error: "Missing or invalid fields" };
@@ -612,12 +612,12 @@ export const createOrganiserRemintRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(RemintBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(RemintBody)(raw);
                 return yield* remintCodesService.remint(weddingId, body.codeStyle);
               }).pipe(
                 Effect.provideService(DbService, db),
                 Effect.map((r) => ({ codeStyle: r.codeStyle, reminted: r.reminted })),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/registry-guest.ts
+++ b/cire/api/src/routes/registry-guest.ts
@@ -278,7 +278,7 @@ export const createRegistryGuestClaimRoutes = (db: Db, deps: RegistryGuestClaimD
         const raw: unknown = await request.json().catch(() => null);
         return runCire(
           Effect.gen(function* () {
-            const body = yield* Schema.decodeUnknown(ClaimItemBody)(raw);
+            const body = yield* Schema.decodeUnknownEffect(ClaimItemBody)(raw);
             // Resolve the wedding from the SLUG and hand THAT id to the service.
             // The cookie names a household, not a wedding, so this is what stops
             // a family of wedding A acting on wedding B: `claim` proves the
@@ -297,7 +297,7 @@ export const createRegistryGuestClaimRoutes = (db: Db, deps: RegistryGuestClaimD
             return { ok: true };
           }).pipe(
             Effect.provideService(DbService, db),
-            Effect.catchTag("ParseError", () => badRequest(set)),
+            Effect.catchTag("SchemaError", () => badRequest(set)),
             Effect.catchTag("RegistryNotVisible", () => notVisible(set)),
             Effect.catchTag("RegistryItemNotInWedding", () => itemNotFound(set)),
             Effect.catchTag("FamilyNotInWedding", () => notVisible(set)),

--- a/cire/api/src/routes/registry.ts
+++ b/cire/api/src/routes/registry.ts
@@ -225,7 +225,7 @@ export const createRegistryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateRegistrySettingsBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateRegistrySettingsBody)(raw);
                 // The cash-gifts/Stripe invariant lives in the service (S-M3),
                 // not here: this route used to load the WHOLE snapshot — items,
                 // gift log, currency — to read one boolean off it (P-C2).
@@ -233,7 +233,7 @@ export const createRegistryWriteRoutes = (
                 return { settings };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("StripeNotReady", () => conflict(set, "stripe_not_ready")),
                 Effect.tapDefect(logDefect(weddingId)),
                 Effect.catchDefect(() => internal(set)),
@@ -249,13 +249,13 @@ export const createRegistryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(CreateRegistryItemBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(CreateRegistryItemBody)(raw);
                 const item = yield* registryService.createItem({ weddingId, ...body });
                 yield* Effect.sync(() => metricRegistryItemWrite("create"));
                 return { item };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("InvalidQuantity", () => badRequest(set)),
                 Effect.catchTag("ImageKeyNotInWedding", () =>
                   badRequestCode(set, "image_key_not_in_wedding"),
@@ -277,12 +277,12 @@ export const createRegistryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ReorderRegistryItemsBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ReorderRegistryItemsBody)(raw);
                 yield* registryService.reorderItems(weddingId, body.orderedIds);
                 return { ok: true as const };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.tapDefect(logDefect(weddingId)),
                 Effect.catchDefect(() => internal(set)),
               ),
@@ -297,7 +297,7 @@ export const createRegistryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateRegistryItemBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateRegistryItemBody)(raw);
                 const item = yield* registryService.updateItem({
                   weddingId,
                   itemId: params.itemId,
@@ -307,7 +307,7 @@ export const createRegistryWriteRoutes = (
                 return { item };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("InvalidQuantity", () => badRequest(set)),
                 Effect.catchTag("ImageKeyNotInWedding", () =>
                   badRequestCode(set, "image_key_not_in_wedding"),
@@ -353,11 +353,11 @@ export const createRegistryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(SetThankedBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(SetThankedBody)(raw);
                 // The kind comes off the PATH, so it is validated as strictly
                 // as a body field would be — an unknown value must 400, never
                 // fall through to a table by coincidence.
-                const kind = yield* Schema.decodeUnknown(GiftKindSchema)(params.kind);
+                const kind = yield* Schema.decodeUnknownEffect(GiftKindSchema)(params.kind);
                 yield* registryService.setThanked({
                   weddingId,
                   kind,
@@ -371,7 +371,7 @@ export const createRegistryWriteRoutes = (
                 return { ok: true as const };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("GiftNotInWedding", () => giftNotFound(set)),
                 Effect.tapDefect(logDefect(weddingId)),
                 Effect.catchDefect(() => internal(set)),
@@ -440,7 +440,7 @@ export const createRegistryLinkPreviewRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(RegistryLinkPreviewBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(RegistryLinkPreviewBody)(raw);
                 const preview = yield* linkPreviewService.preview(
                   body.url,
                   deps.linkPreviewOptions,
@@ -452,7 +452,7 @@ export const createRegistryLinkPreviewRoutes = (
                   images: preview.imageUrls,
                 };
               }).pipe(
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("LinkPreviewBlocked", () =>
                   Effect.sync(() => metricRegistryLinkPreview("blocked")).pipe(
                     Effect.andThen(badRequestCode(set, "blocked_url")),
@@ -591,7 +591,7 @@ export const createRegistryImageRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(RegistrySaveImageFromUrlBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(RegistrySaveImageFromUrlBody)(raw);
                 return yield* registryImageService.storeFromUrl(
                   weddingId,
                   body.url,
@@ -599,7 +599,7 @@ export const createRegistryImageRoutes = (
                 );
               }).pipe(
                 Effect.provideService(AssetsR2Service, deps.assets as AssetsBucket),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 registryImageErrors(set, weddingId),
               ),
             );

--- a/cire/api/src/routes/rsvp.ts
+++ b/cire/api/src/routes/rsvp.ts
@@ -64,7 +64,7 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
 
         return runCire(
           Effect.gen(function* () {
-            const body = yield* Schema.decodeUnknown(BulkRsvpBody)(raw);
+            const body = yield* Schema.decodeUnknownEffect(BulkRsvpBody)(raw);
 
             const dbService = yield* DbService;
 
@@ -214,7 +214,7 @@ export const createRsvpRoutes = (db: Db, { turnstileVerifier = null }: RsvpRoute
             return { rsvps: updatedRsvps };
           }).pipe(
             Effect.provideService(DbService, db),
-            Effect.catchTag("ParseError", () =>
+            Effect.catchTag("SchemaError", () =>
               Effect.sync(() => {
                 set.status = 400;
                 return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/tasks.ts
+++ b/cire/api/src/routes/tasks.ts
@@ -79,7 +79,7 @@ export const createTaskWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(CreateTaskBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(CreateTaskBody)(raw);
                 const task = yield* tasksService.create({
                   weddingId,
                   title: body.title,
@@ -90,7 +90,7 @@ export const createTaskWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
                 return { task };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -117,12 +117,12 @@ export const createTaskWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ReorderTasksBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ReorderTasksBody)(raw);
                 yield* tasksService.reorder(weddingId, body.timeframeBucket, body.orderedIds);
                 return { ok: true as const };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };
@@ -149,7 +149,7 @@ export const createTaskWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateTaskBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateTaskBody)(raw);
                 const task = yield* tasksService.update({
                   weddingId,
                   taskId: params.taskId,
@@ -158,7 +158,7 @@ export const createTaskWriteRoutes = (db: Db, osnAuthOptions: OsnAuthOptions) =>
                 return { task };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () =>
+                Effect.catchTag("SchemaError", () =>
                   Effect.sync(() => {
                     set.status = 400;
                     return { error: "Missing or invalid fields" };

--- a/cire/api/src/routes/vendor-directory.ts
+++ b/cire/api/src/routes/vendor-directory.ts
@@ -116,7 +116,7 @@ export const createVendorDirectoryWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(AddFromDirectoryBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(AddFromDirectoryBody)(raw);
                 const listing = yield* directoryService.getLiveListingById(
                   params.directoryVendorId,
                 );
@@ -143,7 +143,7 @@ export const createVendorDirectoryWriteRoutes = (
                 return { vendor };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchDefect((d) => (isUniqueViolation(d) ? conflict(set) : internal(set))),
               ),
             );

--- a/cire/api/src/routes/vendor-enquiries.ts
+++ b/cire/api/src/routes/vendor-enquiries.ts
@@ -20,12 +20,12 @@ const manualParse = { parse: () => ({}) };
 
 /** POST /enquiries/:id/messages — reply. */
 const ReplyBody = Schema.Struct({
-  message: Schema.String.pipe(Schema.minLength(1)),
+  message: Schema.String.check(Schema.isMinLength(1)),
 });
 
 /** POST /enquiries/:id/quote — structured quote. */
 const QuoteBody = Schema.Struct({
-  amountMinor: Schema.Number.pipe(Schema.int(), Schema.greaterThan(0)),
+  amountMinor: Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0)),
   note: Schema.optional(Schema.String),
 });
 
@@ -242,7 +242,7 @@ export function createVendorEnquiriesRoutes(
 
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(ReplyBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(ReplyBody)(raw);
               const enquiry = yield* loadEnquiryForVendor(db, orgMembership, params.id, profileId);
               if (!enquiry) return yield* notFound(set);
               const message = yield* enquiryService.reply({
@@ -260,7 +260,7 @@ export function createVendorEnquiriesRoutes(
               return { message };
             }).pipe(
               Effect.provideService(DbService, db),
-              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("SchemaError", () => badRequest(set)),
               Effect.catchTags(catchEnquiryTags(set)),
               Effect.catchDefect(() => internal(set)),
             ),
@@ -276,7 +276,7 @@ export function createVendorEnquiriesRoutes(
 
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(QuoteBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(QuoteBody)(raw);
               const enquiry = yield* loadEnquiryForVendor(db, orgMembership, params.id, profileId);
               if (!enquiry) return yield* notFound(set);
               // The vendor name and the wedding currency are independent single-row
@@ -321,7 +321,7 @@ export function createVendorEnquiriesRoutes(
               return { enquiry: enquiryDto };
             }).pipe(
               Effect.provideService(DbService, db),
-              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("SchemaError", () => badRequest(set)),
               Effect.catchTags(catchEnquiryTags(set)),
               Effect.catchDefect(() => internal(set)),
             ),

--- a/cire/api/src/routes/vendor-portal.ts
+++ b/cire/api/src/routes/vendor-portal.ts
@@ -123,7 +123,7 @@ export function createVendorPortalRoutes(
 
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(ConsumeClaimBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(ConsumeClaimBody)(raw);
               const { orgId } = body;
 
               // Org-member gate (inline: orgId from body, not URL)
@@ -144,7 +144,7 @@ export function createVendorPortalRoutes(
               return { listing };
             }).pipe(
               Effect.provideService(DbService, db),
-              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("SchemaError", () => badRequest(set)),
               Effect.catchTag("ClaimInvalid", () => claimInvalid(set)),
               Effect.catchDefect(() => internal(set)),
             ),
@@ -191,7 +191,7 @@ export function createVendorPortalRoutes(
 
           return runCire(
             Effect.gen(function* () {
-              const body = yield* Schema.decodeUnknown(UpsertListingBody)(raw);
+              const body = yield* Schema.decodeUnknownEffect(UpsertListingBody)(raw);
               const listing = yield* directoryService.upsertListingForOrg(params.orgId, {
                 name: body.name,
                 description: body.description ?? null,
@@ -208,7 +208,7 @@ export function createVendorPortalRoutes(
               return { listing };
             }).pipe(
               Effect.provideService(DbService, db),
-              Effect.catchTag("ParseError", () => badRequest(set)),
+              Effect.catchTag("SchemaError", () => badRequest(set)),
               Effect.catchDefect(() => internal(set)),
             ),
           );

--- a/cire/api/src/routes/vendors.ts
+++ b/cire/api/src/routes/vendors.ts
@@ -118,7 +118,7 @@ export const createVendorWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(CreateVendorBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(CreateVendorBody)(raw);
                 const vendor = yield* vendorsService.create({
                   weddingId,
                   name: body.name,
@@ -133,7 +133,7 @@ export const createVendorWriteRoutes = (
                 return { vendor };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
             );
@@ -148,12 +148,12 @@ export const createVendorWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(ReorderVendorsBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(ReorderVendorsBody)(raw);
                 yield* vendorsService.reorder(weddingId, body.status, body.orderedIds);
                 return { ok: true as const };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
             );
@@ -167,7 +167,7 @@ export const createVendorWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(UpdateVendorBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(UpdateVendorBody)(raw);
                 const vendor = yield* vendorsService.update(weddingId, params.vendorId, {
                   name: body.name,
                   category: body.category,
@@ -181,7 +181,7 @@ export const createVendorWriteRoutes = (
                 return { vendor };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
                 Effect.catchDefect(() => internal(set)),
               ),
@@ -207,7 +207,7 @@ export const createVendorWriteRoutes = (
             const raw: unknown = await request.json().catch(() => null);
             return runCire(
               Effect.gen(function* () {
-                const body = yield* Schema.decodeUnknown(SeedListingBody)(raw);
+                const body = yield* Schema.decodeUnknownEffect(SeedListingBody)(raw);
                 const result = yield* directoryService.seedFromCrm(weddingId, params.vendorId, {
                   name: body.name,
                   email: body.email,
@@ -234,7 +234,7 @@ export const createVendorWriteRoutes = (
                 };
               }).pipe(
                 Effect.provideService(DbService, db),
-                Effect.catchTag("ParseError", () => badRequest(set)),
+                Effect.catchTag("SchemaError", () => badRequest(set)),
                 Effect.catchTag("VendorNotInWedding", () => vendorNotFound(set)),
                 Effect.catchDefect(() => internal(set)),
               ),

--- a/cire/api/src/schemas/budget.ts
+++ b/cire/api/src/schemas/budget.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 import { SERVICE_CATEGORIES } from "../lib/service-categories";
 import type { ServiceCategory } from "../lib/service-categories";
@@ -15,18 +15,18 @@ const categoryKeys = SERVICE_CATEGORIES.map((c) => c.key) as [
   ServiceCategory,
   ...ServiceCategory[],
 ];
-const CategorySchema = Schema.Literal(...categoryKeys);
+const CategorySchema = Schema.Literals(categoryKeys);
 
-const Name = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_NAME_CHARS));
-const Label = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_LABEL_CHARS));
-const Notes = Schema.String.pipe(Schema.maxLength(MAX_NOTES_CHARS));
+const Name = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_NAME_CHARS));
+const Label = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_LABEL_CHARS));
+const Notes = Schema.String.check(Schema.isMaxLength(MAX_NOTES_CHARS));
 // A loose ISO date string (YYYY-MM-DD from the date input). Stored as text.
-const DueAt = Schema.String.pipe(Schema.maxLength(32));
+const DueAt = Schema.String.check(Schema.isMaxLength(32));
 // A money amount in minor units: a non-negative integer, capped for sanity.
-const Minor = Schema.Number.pipe(
-  Schema.int(),
-  Schema.greaterThanOrEqualTo(0),
-  Schema.lessThanOrEqualTo(MAX_MINOR),
+const Minor = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isGreaterThanOrEqualTo(0),
+  Schema.isLessThanOrEqualTo(MAX_MINOR),
 );
 
 // Create item: category + name required; the three money figures + notes are
@@ -34,10 +34,10 @@ const Minor = Schema.Number.pipe(
 export const CreateBudgetItemBody = Schema.Struct({
   category: CategorySchema,
   name: Name,
-  estimateMinor: Schema.optionalWith(Schema.NullOr(Minor), { default: () => null }),
-  quotedMinor: Schema.optionalWith(Schema.NullOr(Minor), { default: () => null }),
-  actualMinor: Schema.optionalWith(Schema.NullOr(Minor), { default: () => null }),
-  notes: Schema.optionalWith(Schema.NullOr(Notes), { default: () => null }),
+  estimateMinor: Schema.NullOr(Minor).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  quotedMinor: Schema.NullOr(Minor).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  actualMinor: Schema.NullOr(Minor).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  notes: Schema.NullOr(Notes).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
 });
 export type CreateBudgetItemBody = Schema.Schema.Type<typeof CreateBudgetItemBody>;
 
@@ -56,7 +56,7 @@ export type UpdateBudgetItemBody = Schema.Schema.Type<typeof UpdateBudgetItemBod
 // Reorder: the new order of item ids within one category.
 export const ReorderBudgetItemsBody = Schema.Struct({
   category: CategorySchema,
-  orderedIds: Schema.Array(Schema.NonEmptyString).pipe(Schema.maxItems(500)),
+  orderedIds: Schema.Array(Schema.NonEmptyString).check(Schema.isMaxLength(500)),
 });
 export type ReorderBudgetItemsBody = Schema.Schema.Type<typeof ReorderBudgetItemsBody>;
 
@@ -64,7 +64,7 @@ export type ReorderBudgetItemsBody = Schema.Schema.Type<typeof ReorderBudgetItem
 export const CreatePaymentBody = Schema.Struct({
   label: Label,
   amountMinor: Minor,
-  dueAt: Schema.optionalWith(Schema.NullOr(DueAt), { default: () => null }),
+  dueAt: Schema.NullOr(DueAt).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
 });
 export type CreatePaymentBody = Schema.Schema.Type<typeof CreatePaymentBody>;
 
@@ -82,7 +82,10 @@ export type UpdatePaymentBody = Schema.Schema.Type<typeof UpdatePaymentBody>;
 // The bound MATCHES the settings schema's BudgetTotalMinor (0..100_000_000_000)
 // because the settings service does not re-validate the delegated patch — the
 // two writers of weddings.budget_total_minor must accept the exact same range.
-const BudgetTotal = Schema.Number.pipe(Schema.int(), Schema.between(0, 100_000_000_000));
+const BudgetTotal = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 0, maximum: 100_000_000_000 }),
+);
 export const SetBudgetTotalBody = Schema.Struct({
   budgetTotalMinor: Schema.NullOr(BudgetTotal),
 });

--- a/cire/api/src/schemas/host.ts
+++ b/cire/api/src/schemas/host.ts
@@ -1,9 +1,9 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 /** A co-host's assignable role — mirrors `HostRole` in `services/hosts.ts`.
  *  `owner` is not assignable (the owner is never rowed into `wedding_hosts`)
  *  and the legacy `host` value is not accepted from clients. */
-export const HostRoleSchema = Schema.Literal("editor", "viewer");
+export const HostRoleSchema = Schema.Literals(["editor", "viewer"]);
 export type HostRoleSchema = Schema.Schema.Type<typeof HostRoleSchema>;
 
 /**
@@ -17,16 +17,8 @@ export type HostRoleSchema = Schema.Schema.Type<typeof HostRoleSchema>;
  * keep working unchanged.
  */
 export const AddHostBody = Schema.Struct({
-  handle: Schema.String.pipe(
-    Schema.transform(Schema.String, {
-      strict: true,
-      decode: (s) => s.trim(),
-      encode: (s) => s,
-    }),
-    Schema.minLength(1),
-    Schema.maxLength(64),
-  ),
-  role: Schema.optionalWith(HostRoleSchema, { default: () => "editor" as const }),
+  handle: Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(64)),
+  role: HostRoleSchema.pipe(Schema.withDecodingDefaultType(Effect.succeed("editor" as const))),
 });
 export type AddHostBody = Schema.Schema.Type<typeof AddHostBody>;
 

--- a/cire/api/src/schemas/import.ts
+++ b/cire/api/src/schemas/import.ts
@@ -61,10 +61,12 @@ export const ParsedFamily = Schema.Struct({
    *  front door, which previously accepted a blank or multi-hundred-KB name
    *  straight onto rows the guest invite renders (S-L2). Validation only — no
    *  trim transform, so the diff still compares the exact submitted value. */
-  familyName: Schema.String.pipe(
-    Schema.filter((s) => s.trim().length > 0 && s.length <= 10_000, {
-      message: () => "familyName must be non-blank and at most 10000 characters",
-    }),
+  familyName: Schema.String.check(
+    Schema.makeFilter((s) =>
+      s.trim().length > 0 && s.length <= 10_000
+        ? undefined
+        : "familyName must be non-blank and at most 10000 characters",
+    ),
   ),
   guests: Schema.Array(ParsedGuest),
 });
@@ -106,7 +108,7 @@ export type DesiredState = Schema.Schema.Type<typeof DesiredState>;
  *    left as it is, and the guest sheet's attendance columns are matched against
  *    the events that already exist.
  */
-export const ChangeScope = Schema.Literal("both", "events", "guests");
+export const ChangeScope = Schema.Literals(["both", "events", "guests"]);
 export type ChangeScope = Schema.Schema.Type<typeof ChangeScope>;
 
 // ── Diff plan ─────────────────────────────────────────────────────────────────

--- a/cire/api/src/schemas/invite.ts
+++ b/cire/api/src/schemas/invite.ts
@@ -8,7 +8,7 @@ import {
   PALETTE_SEED_KEYS,
   SECTION_TONES,
 } from "@cire/theme";
-import { Schema } from "effect";
+import { Schema, SchemaTransformation } from "effect";
 
 // ── Image slots ───────────────────────────────────────────────────────────────
 
@@ -156,10 +156,12 @@ const CropField = Schema.NullOr(
     h: Schema.Number,
     natW: Schema.optional(Schema.Number),
     natH: Schema.optional(Schema.Number),
-  }).pipe(
-    Schema.filter((c) => isValidCrop(c), {
-      message: () => "Invalid crop rectangle (each value 0..1, w/h > 0, x+w ≤ 1, y+h ≤ 1)",
-    }),
+  }).check(
+    Schema.makeFilter((c) =>
+      isValidCrop(c)
+        ? undefined
+        : "Invalid crop rectangle (each value 0..1, w/h > 0, x+w ≤ 1, y+h ≤ 1)",
+    ),
   ),
 );
 
@@ -187,7 +189,7 @@ export type CropScreen = (typeof CROP_SCREENS)[number];
  */
 export const ImageCropBody = Schema.Struct({
   crop: CropField,
-  screen: Schema.optional(Schema.Literal(...CROP_SCREENS)),
+  screen: Schema.optional(Schema.Literals(CROP_SCREENS)),
 });
 export type ImageCropBody = Schema.Schema.Type<typeof ImageCropBody>;
 
@@ -213,7 +215,7 @@ export function decodeCrop(raw: string | null): ImageCrop | null {
 // service normalises to null) means "fall back to the built-in default". Caps
 // keep a compromised/abusive organiser token from stuffing the public invite
 // with unbounded text.
-const copyField = (max: number) => Schema.NullOr(Schema.String.pipe(Schema.maxLength(max)));
+const copyField = (max: number) => Schema.NullOr(Schema.String.check(Schema.isMaxLength(max)));
 
 /**
  * Full set of text overrides. The builder form always submits every field, so
@@ -295,11 +297,15 @@ export function clampInt(value: number, min: number, max: number): number {
  * regardless of what the client sends.
  */
 const sliderField = (min: number, max: number) =>
-  Schema.transform(Schema.Int, Schema.Int, {
-    strict: true,
-    decode: (n) => clampInt(n, min, max),
-    encode: (n) => n,
-  });
+  Schema.Int.pipe(
+    Schema.decodeTo(
+      Schema.Int,
+      SchemaTransformation.transform({
+        decode: (n) => clampInt(n, min, max),
+        encode: (n) => n,
+      }),
+    ),
+  );
 
 // ── Theme (per-section colours + fonts) ─────────────────────────────────────────
 
@@ -328,25 +334,25 @@ export {
   SECTION_TONES,
 };
 
-const FontField = Schema.NullOr(Schema.Literal(...FONT_CHOICES));
+const FontField = Schema.NullOr(Schema.Literals(FONT_CHOICES));
 
 // Global typography options (migration 0048). Closed enum KEYS from
 // `@cire/theme` — each resolves there to a fixed CSS value (scale factor /
 // numeric weight / `normal`|`italic`), so free text can never reach a rendered
 // `style`. `null` ⇒ the design pack's built-in look.
-const HeadingSizeField = Schema.NullOr(Schema.Literal(...HEADING_SIZE_CHOICES));
-const WeightField = Schema.NullOr(Schema.Literal(...FONT_WEIGHT_CHOICES));
-const StyleField = Schema.NullOr(Schema.Literal(...FONT_STYLE_CHOICES));
+const HeadingSizeField = Schema.NullOr(Schema.Literals(HEADING_SIZE_CHOICES));
+const WeightField = Schema.NullOr(Schema.Literals(FONT_WEIGHT_CHOICES));
+const StyleField = Schema.NullOr(Schema.Literals(FONT_STYLE_CHOICES));
 
 /** Which derived surface a section sits on. `null` ⇒ the page ground. */
-const ToneField = Schema.NullOr(Schema.Literal(...SECTION_TONES));
+const ToneField = Schema.NullOr(Schema.Literals(SECTION_TONES));
 
 /**
  * Which curated scheme the organiser started from. Presentation only — the five
  * seeds are what actually render — so an unknown/stale key is harmless, but it
  * is still bounded so it can never carry free text into the builder's UI.
  */
-const PresetField = Schema.NullOr(Schema.Literal(...PALETTE_PRESET_KEYS));
+const PresetField = Schema.NullOr(Schema.Literals(PALETTE_PRESET_KEYS));
 
 /**
  * Strict CSS-colour allow-list — the write-time half of the CSS-injection
@@ -359,10 +365,10 @@ export const isThemeColor = isSafeCssColor;
 // A nullable colour field: `null` clears back to the default token; a present
 // value must pass the allow-list or the whole body is rejected with a 400.
 const ColorField = Schema.NullOr(
-  Schema.String.pipe(
-    Schema.filter((s) => isThemeColor(s), {
-      message: () => "Invalid colour (use hex, rgb(a), hsl(a) or oklch)",
-    }),
+  Schema.String.check(
+    Schema.makeFilter((s) =>
+      isThemeColor(s) ? undefined : "Invalid colour (use hex, rgb(a), hsl(a) or oklch)",
+    ),
   ),
 );
 

--- a/cire/api/src/schemas/registry.ts
+++ b/cire/api/src/schemas/registry.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema, SchemaTransformation } from "effect";
 
 import { REGISTRY_IMAGE_KEY } from "../services/invite-assets";
 
@@ -52,28 +52,33 @@ function parseHttpsUrl(value: string): URL | null {
  * column holds is what the parser saw — one normal form per link, and no gap
  * between the string that passed validation and the string that gets rendered.
  */
-export const HttpsUrl = Schema.String.pipe(
-  Schema.maxLength(MAX_URL_CHARS),
-  Schema.filter((value) => parseHttpsUrl(value) !== null, {
-    message: () => "must be an absolute https:// URL without embedded credentials",
-  }),
-  Schema.transform(Schema.String, {
-    strict: true,
-    // The filter above already rejected anything unparseable, so the fallback is
-    // unreachable — it exists only to keep this total.
-    decode: (value) => parseHttpsUrl(value)?.href ?? value,
-    encode: (value) => value,
-  }),
+export const HttpsUrl = Schema.String.check(
+  Schema.isMaxLength(MAX_URL_CHARS),
+  Schema.makeFilter((value) =>
+    parseHttpsUrl(value) !== null
+      ? undefined
+      : "must be an absolute https:// URL without embedded credentials",
+  ),
+).pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transform({
+      // The filter above already rejected anything unparseable, so the fallback is
+      // unreachable — it exists only to keep this total.
+      decode: (value) => parseHttpsUrl(value)?.href ?? value,
+      encode: (value) => value,
+    }),
+  ),
 );
 
-const Title = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_TITLE_CHARS));
-const Headline = Schema.String.pipe(Schema.maxLength(MAX_HEADLINE_CHARS));
-const Description = Schema.String.pipe(Schema.maxLength(MAX_DESCRIPTION_CHARS));
-const Message = Schema.String.pipe(Schema.maxLength(MAX_MESSAGE_CHARS));
-const Note = Schema.String.pipe(Schema.maxLength(MAX_NOTE_CHARS));
-const DisplayName = Schema.String.pipe(Schema.maxLength(MAX_DISPLAY_NAME_CHARS));
-const Category = Schema.String.pipe(Schema.maxLength(MAX_CATEGORY_CHARS));
-const ShippingAddress = Schema.String.pipe(Schema.maxLength(MAX_ADDRESS_CHARS));
+const Title = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_TITLE_CHARS));
+const Headline = Schema.String.check(Schema.isMaxLength(MAX_HEADLINE_CHARS));
+const Description = Schema.String.check(Schema.isMaxLength(MAX_DESCRIPTION_CHARS));
+const Message = Schema.String.check(Schema.isMaxLength(MAX_MESSAGE_CHARS));
+const Note = Schema.String.check(Schema.isMaxLength(MAX_NOTE_CHARS));
+const DisplayName = Schema.String.check(Schema.isMaxLength(MAX_DISPLAY_NAME_CHARS));
+const Category = Schema.String.check(Schema.isMaxLength(MAX_CATEGORY_CHARS));
+const ShippingAddress = Schema.String.check(Schema.isMaxLength(MAX_ADDRESS_CHARS));
 /**
  * A calendar date (`YYYY-MM-DD` from a date input), stored as text.
  *
@@ -84,15 +89,14 @@ const ShippingAddress = Schema.String.pipe(Schema.maxLength(MAX_ADDRESS_CHARS));
  * the pattern admits impossible days (2026-02-31), so the filter round-trips
  * through `Date` and requires the same calendar day back.
  */
-const IsoDate = Schema.String.pipe(
-  Schema.pattern(/^\d{4}-\d{2}-\d{2}$/),
-  Schema.filter(
-    (s) => {
-      const t = Date.parse(`${s}T00:00:00Z`);
-      return !Number.isNaN(t) && new Date(t).toISOString().slice(0, 10) === s;
-    },
-    { message: () => "not a real calendar date" },
-  ),
+const IsoDate = Schema.String.check(
+  Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/),
+  Schema.makeFilter((s) => {
+    const t = Date.parse(`${s}T00:00:00Z`);
+    return !Number.isNaN(t) && new Date(t).toISOString().slice(0, 10) === s
+      ? undefined
+      : "not a real calendar date";
+  }),
 );
 
 /**
@@ -114,14 +118,17 @@ const IsoDate = Schema.String.pipe(
  * the module that mints these keys, so the schema, the ownership check and the
  * serve route cannot drift apart.
  */
-const ImageKey = Schema.String.pipe(Schema.maxLength(512), Schema.pattern(REGISTRY_IMAGE_KEY));
+const ImageKey = Schema.String.check(Schema.isMaxLength(512), Schema.isPattern(REGISTRY_IMAGE_KEY));
 
-const Minor = Schema.Number.pipe(
-  Schema.int(),
-  Schema.greaterThanOrEqualTo(0),
-  Schema.lessThanOrEqualTo(MAX_MINOR),
+const Minor = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isGreaterThanOrEqualTo(0),
+  Schema.isLessThanOrEqualTo(MAX_MINOR),
 );
-const Quantity = Schema.Number.pipe(Schema.int(), Schema.between(1, MAX_QUANTITY));
+const Quantity = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 1, maximum: MAX_QUANTITY }),
+);
 
 /**
  * Settings patch. Every field optional; an absent field is unchanged.
@@ -150,12 +157,14 @@ export type UpdateRegistrySettingsBody = Schema.Schema.Type<typeof UpdateRegistr
  */
 export const CreateRegistryItemBody = Schema.Struct({
   title: Title,
-  description: Schema.optionalWith(Schema.NullOr(Description), { default: () => null }),
-  imageKey: Schema.optionalWith(Schema.NullOr(ImageKey), { default: () => null }),
-  externalUrl: Schema.optionalWith(Schema.NullOr(HttpsUrl), { default: () => null }),
-  priceMinor: Schema.optionalWith(Schema.NullOr(Minor), { default: () => null }),
-  quantityWanted: Schema.optionalWith(Quantity, { default: () => 1 }),
-  category: Schema.optionalWith(Schema.NullOr(Category), { default: () => null }),
+  description: Schema.NullOr(Description).pipe(
+    Schema.withDecodingDefaultType(Effect.succeed(null)),
+  ),
+  imageKey: Schema.NullOr(ImageKey).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  externalUrl: Schema.NullOr(HttpsUrl).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  priceMinor: Schema.NullOr(Minor).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  quantityWanted: Quantity.pipe(Schema.withDecodingDefaultType(Effect.succeed(1))),
+  category: Schema.NullOr(Category).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
 });
 export type CreateRegistryItemBody = Schema.Schema.Type<typeof CreateRegistryItemBody>;
 
@@ -202,7 +211,7 @@ export type RegistrySaveImageFromUrlBody = Schema.Schema.Type<typeof RegistrySav
 
 /** Reorder: the new order of item ids across the whole wedding's list. */
 export const ReorderRegistryItemsBody = Schema.Struct({
-  orderedIds: Schema.Array(Schema.NonEmptyString).pipe(Schema.maxItems(500)),
+  orderedIds: Schema.Array(Schema.NonEmptyString).check(Schema.isMaxLength(500)),
 });
 export type ReorderRegistryItemsBody = Schema.Schema.Type<typeof ReorderRegistryItemsBody>;
 
@@ -212,17 +221,19 @@ export const SetThankedBody = Schema.Struct({
 });
 export type SetThankedBody = Schema.Schema.Type<typeof SetThankedBody>;
 
-export const GiftKindSchema = Schema.Literal("claim", "contribution");
+export const GiftKindSchema = Schema.Literals(["claim", "contribution"]);
 
 /** Guest claim — the honour-system "we've got this". */
 export const ClaimItemBody = Schema.Struct({
-  quantity: Schema.optionalWith(Quantity, { default: () => 1 }),
+  quantity: Quantity.pipe(Schema.withDecodingDefaultType(Effect.succeed(1))),
   // `purchased` is the "I already bought it elsewhere" path; `reserved` is the
   // intent to. Both hold quantity, so both count against `quantity_wanted`.
-  status: Schema.optionalWith(Schema.Literal("reserved", "purchased"), {
-    default: () => "reserved" as const,
-  }),
-  note: Schema.optionalWith(Schema.NullOr(Note), { default: () => null }),
-  displayName: Schema.optionalWith(Schema.NullOr(DisplayName), { default: () => null }),
+  status: Schema.Literals(["reserved", "purchased"]).pipe(
+    Schema.withDecodingDefaultType(Effect.succeed("reserved" as const)),
+  ),
+  note: Schema.NullOr(Note).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  displayName: Schema.NullOr(DisplayName).pipe(
+    Schema.withDecodingDefaultType(Effect.succeed(null)),
+  ),
 });
 export type ClaimItemBody = Schema.Schema.Type<typeof ClaimItemBody>;

--- a/cire/api/src/schemas/rsvp.ts
+++ b/cire/api/src/schemas/rsvp.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 // S-L2: free-text + array bounds. `dietary` is stored unbounded otherwise, and
 // the batch array had no length cap — a single request could push an arbitrary
@@ -16,7 +16,7 @@ const MAX_RSVP_BATCH = 200;
 export const DIETARY_CONSENT_VERSION = "2026-06-17";
 
 // Free-text dietary field, capped at MAX_DIETARY_CHARS.
-const DietaryText = Schema.String.pipe(Schema.maxLength(MAX_DIETARY_CHARS));
+const DietaryText = Schema.String.check(Schema.isMaxLength(MAX_DIETARY_CHARS));
 
 // Per-RSVP shape shared by the single + bulk bodies. `dietaryConsent` is the
 // guest's explicit opt-in for the special-category dietary field; the route
@@ -24,16 +24,16 @@ const DietaryText = Schema.String.pipe(Schema.maxLength(MAX_DIETARY_CHARS));
 const RsvpItem = Schema.Struct({
   guestId: Schema.NonEmptyString,
   eventId: Schema.NonEmptyString,
-  status: Schema.Literal("attending", "declined", "maybe"),
-  dietary: Schema.optionalWith(DietaryText, { default: () => "" }),
-  dietaryConsent: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  status: Schema.Literals(["attending", "declined", "maybe"]),
+  dietary: DietaryText.pipe(Schema.withDecodingDefaultType(Effect.succeed(""))),
+  dietaryConsent: Schema.Boolean.pipe(Schema.withDecodingDefaultType(Effect.succeed(false))),
 });
 
 export const RsvpBody = RsvpItem;
 export type RsvpBody = Schema.Schema.Type<typeof RsvpBody>;
 
 export const BulkRsvpBody = Schema.Struct({
-  rsvps: Schema.Array(RsvpItem).pipe(Schema.maxItems(MAX_RSVP_BATCH)),
+  rsvps: Schema.Array(RsvpItem).check(Schema.isMaxLength(MAX_RSVP_BATCH)),
 });
 export type BulkRsvpBody = Schema.Schema.Type<typeof BulkRsvpBody>;
 
@@ -45,9 +45,9 @@ export type BulkRsvpBody = Schema.Schema.Type<typeof BulkRsvpBody>;
 // — see [[wiki/compliance/dpia/cire-guest-data]] → C-H2 organiser-attested
 // variant). Same 500-char dietary cap + consent gate as the guest path.
 export const OrganiserRsvpBody = Schema.Struct({
-  status: Schema.Literal("attending", "declined", "maybe"),
-  dietary: Schema.optionalWith(DietaryText, { default: () => "" }),
-  dietaryConsent: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  status: Schema.Literals(["attending", "declined", "maybe"]),
+  dietary: DietaryText.pipe(Schema.withDecodingDefaultType(Effect.succeed(""))),
+  dietaryConsent: Schema.Boolean.pipe(Schema.withDecodingDefaultType(Effect.succeed(false))),
 });
 export type OrganiserRsvpBody = Schema.Schema.Type<typeof OrganiserRsvpBody>;
 

--- a/cire/api/src/schemas/settings.ts
+++ b/cire/api/src/schemas/settings.ts
@@ -1,19 +1,10 @@
-import { Schema } from "effect";
+import { Schema, SchemaTransformation } from "effect";
 
 import { canonicalTimeZone } from "../lib/rsvp-deadline";
 import { MAX_DISPLAY_NAME } from "../services/weddings";
 
 /** Trim then require non-empty — same idiom as `CreateWeddingBody.displayName`. */
-const trimmed = (max: number) =>
-  Schema.String.pipe(
-    Schema.transform(Schema.String, {
-      strict: true,
-      decode: (s) => s.trim(),
-      encode: (s) => s,
-    }),
-    Schema.minLength(1),
-    Schema.maxLength(max),
-  );
+const trimmed = (max: number) => Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(max));
 
 /**
  * Date-only ISO string (`YYYY-MM-DD`). The pattern alone admits impossible
@@ -21,19 +12,18 @@ const trimmed = (max: number) =>
  * same calendar day back — engine-lenient parses that silently roll over are
  * rejected too. Shared by the wedding date and the RSVP deadline.
  */
-const CalendarDate = Schema.String.pipe(
-  Schema.pattern(/^\d{4}-\d{2}-\d{2}$/),
-  Schema.filter(
-    (s) => {
-      const t = Date.parse(`${s}T00:00:00Z`);
-      return !Number.isNaN(t) && new Date(t).toISOString().slice(0, 10) === s;
-    },
-    { message: () => "not a real calendar date" },
-  ),
+const CalendarDate = Schema.String.check(
+  Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/),
+  Schema.makeFilter((s) => {
+    const t = Date.parse(`${s}T00:00:00Z`);
+    return !Number.isNaN(t) && new Date(t).toISOString().slice(0, 10) === s
+      ? undefined
+      : "not a real calendar date";
+  }),
 );
 
 /** ISO 4217 alpha code. Uppercase-only — the form normalises before submit. */
-const Currency = Schema.String.pipe(Schema.pattern(/^[A-Z]{3}$/));
+const Currency = Schema.String.check(Schema.isPattern(/^[A-Z]{3}$/));
 
 /**
  * IANA time-zone identifier (`Australia/Sydney`), validated against the
@@ -48,23 +38,32 @@ const Currency = Schema.String.pipe(Schema.pattern(/^[A-Z]{3}$/));
  * `maxLength` runs FIRST and Effect Schema short-circuits on it, so an
  * oversized blob never reaches the ICU lookup.
  */
-const TimeZone = Schema.String.pipe(
-  Schema.maxLength(64),
-  Schema.filter((s) => canonicalTimeZone(s) !== null, { message: () => "not a known time zone" }),
-  Schema.transform(Schema.String, {
-    strict: true,
-    // The filter above already rejected anything unresolvable, so the fallback
-    // is unreachable — it exists only to keep this total.
-    decode: (s) => canonicalTimeZone(s) ?? s,
-    encode: (s) => s,
-  }),
+const TimeZone = Schema.String.check(
+  Schema.isMaxLength(64),
+  Schema.makeFilter((s) => (canonicalTimeZone(s) !== null ? undefined : "not a known time zone")),
+).pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transform({
+      // The filter above already rejected anything unresolvable, so the fallback
+      // is unreachable — it exists only to keep this total.
+      decode: (s) => canonicalTimeZone(s) ?? s,
+      encode: (s) => s,
+    }),
+  ),
 );
 
-const GuestCountEstimate = Schema.Number.pipe(Schema.int(), Schema.between(1, 10_000));
+const GuestCountEstimate = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 1, maximum: 10_000 }),
+);
 
 /** Budget in MINOR units. Bounded well past any real wedding ($1B in cents)
  *  but inside the integer-safe range. */
-const BudgetTotalMinor = Schema.Number.pipe(Schema.int(), Schema.between(0, 100_000_000_000));
+const BudgetTotalMinor = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 0, maximum: 100_000_000_000 }),
+);
 
 /**
  * Body for `PUT /api/organiser/weddings/:weddingId/settings`. PATCH semantics

--- a/cire/api/src/schemas/tasks.ts
+++ b/cire/api/src/schemas/tasks.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 import { TIMEFRAME_BUCKETS } from "../lib/checklist-buckets";
 import type { TimeframeBucket } from "../lib/checklist-buckets";
@@ -8,20 +8,20 @@ const MAX_NOTES_CHARS = 2000;
 
 // The bucket enum, sourced from the single list so the two never drift.
 const bucketKeys = TIMEFRAME_BUCKETS.map((b) => b.key) as [TimeframeBucket, ...TimeframeBucket[]];
-const TimeframeBucketSchema = Schema.Literal(...bucketKeys);
+const TimeframeBucketSchema = Schema.Literals(bucketKeys);
 
-const Title = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(MAX_TITLE_CHARS));
-const Notes = Schema.String.pipe(Schema.maxLength(MAX_NOTES_CHARS));
+const Title = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_TITLE_CHARS));
+const Notes = Schema.String.check(Schema.isMaxLength(MAX_NOTES_CHARS));
 // A loose date string (YYYY-MM-DD from the date input). Stored as text; null clears it.
-const DueAt = Schema.String.pipe(Schema.maxLength(32));
-const Status = Schema.Literal("open", "done");
+const DueAt = Schema.String.check(Schema.isMaxLength(32));
+const Status = Schema.Literals(["open", "done"]);
 
 // Create: title + bucket required; notes/dueAt optional, absent → null.
 export const CreateTaskBody = Schema.Struct({
   title: Title,
   timeframeBucket: TimeframeBucketSchema,
-  notes: Schema.optionalWith(Schema.NullOr(Notes), { default: () => null }),
-  dueAt: Schema.optionalWith(Schema.NullOr(DueAt), { default: () => null }),
+  notes: Schema.NullOr(Notes).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  dueAt: Schema.NullOr(DueAt).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
 });
 export type CreateTaskBody = Schema.Schema.Type<typeof CreateTaskBody>;
 
@@ -40,6 +40,6 @@ export type UpdateTaskBody = Schema.Schema.Type<typeof UpdateTaskBody>;
 // Reorder: the new left-to-right order of task ids within one bucket.
 export const ReorderTasksBody = Schema.Struct({
   timeframeBucket: TimeframeBucketSchema,
-  orderedIds: Schema.Array(Schema.NonEmptyString).pipe(Schema.maxItems(500)),
+  orderedIds: Schema.Array(Schema.NonEmptyString).check(Schema.isMaxLength(500)),
 });
 export type ReorderTasksBody = Schema.Schema.Type<typeof ReorderTasksBody>;

--- a/cire/api/src/schemas/vendors.ts
+++ b/cire/api/src/schemas/vendors.ts
@@ -11,21 +11,21 @@ export const VENDOR_STATUSES = [
   "declined",
 ] as const;
 
-const CategoryKey = Schema.Literal(...SERVICE_CATEGORIES.map((c) => c.key));
-const Status = Schema.Literal(...VENDOR_STATUSES);
-const NonEmpty = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(200));
+const CategoryKey = Schema.Literals(SERVICE_CATEGORIES.map((c) => c.key));
+const Status = Schema.Literals(VENDOR_STATUSES);
+const NonEmpty = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(200));
 const OptText = Schema.optional(
-  Schema.Union(Schema.String.pipe(Schema.maxLength(2000)), Schema.Null),
+  Schema.Union([Schema.String.check(Schema.isMaxLength(2000)), Schema.Null]),
 );
-const Email = Schema.String.pipe(Schema.minLength(3), Schema.maxLength(200));
-const Minor = Schema.Number.pipe(
-  Schema.int(),
-  Schema.greaterThanOrEqualTo(0),
-  Schema.lessThanOrEqualTo(9_000_000_000_000),
+const Email = Schema.String.check(Schema.isMinLength(3), Schema.isMaxLength(200));
+const Minor = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isGreaterThanOrEqualTo(0),
+  Schema.isLessThanOrEqualTo(9_000_000_000_000),
 );
-const OptMinor = Schema.optional(Schema.Union(Minor, Schema.Null));
+const OptMinor = Schema.optional(Schema.Union([Minor, Schema.Null]));
 const PriceBand = Schema.optional(
-  Schema.Union(Schema.Literal("$", "$$", "$$$", "$$$$"), Schema.Null),
+  Schema.Union([Schema.Literals(["$", "$$", "$$$", "$$$$"]), Schema.Null]),
 );
 
 // --- Organiser CRM ---
@@ -55,14 +55,16 @@ export const ReorderVendorsBody = Schema.Struct({
   status: Status,
   // Capped like tasks/budget (P-W1): the reorder builds one UPDATE per id, so
   // an unbounded array is an unbounded write set.
-  orderedIds: Schema.Array(Schema.String.pipe(Schema.minLength(1))).pipe(Schema.maxItems(500)),
+  orderedIds: Schema.Array(Schema.String.check(Schema.isMinLength(1))).check(
+    Schema.isMaxLength(500),
+  ),
 });
 
 /** Organiser seeds a directory listing + invites a vendor by email to claim it. */
 export const SeedListingBody = Schema.Struct({
   name: NonEmpty,
   email: Email,
-  categories: Schema.Array(CategoryKey).pipe(Schema.minItems(1)),
+  categories: Schema.Array(CategoryKey).check(Schema.isMinLength(1)),
   description: OptText,
   phone: OptText,
   website: OptText,
@@ -73,7 +75,7 @@ export const SeedListingBody = Schema.Struct({
 /** Vendor create/update of their own listing (one per org). */
 export const UpsertListingBody = Schema.Struct({
   name: NonEmpty,
-  categories: Schema.Array(CategoryKey).pipe(Schema.minItems(1)),
+  categories: Schema.Array(CategoryKey).check(Schema.isMinLength(1)),
   description: OptText,
   email: OptText,
   phone: OptText,
@@ -87,7 +89,7 @@ export const UpsertListingBody = Schema.Struct({
 
 /** Vendor consumes a claim token, binding the listing to their chosen org. */
 export const ConsumeClaimBody = Schema.Struct({
-  orgId: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(50)),
+  orgId: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(50)),
 });
 
 /** Organiser adds a directory listing to their wedding CRM under one category. */

--- a/cire/api/src/schemas/wedding.ts
+++ b/cire/api/src/schemas/wedding.ts
@@ -9,7 +9,7 @@ import { MAX_DISPLAY_NAME } from "../services/weddings";
  *  - `simple` — 6-char hash, shorter friendlier codes.
  *  - `secure` — 10-char hash, harder to guess (default).
  */
-export const CodeStyle = Schema.Literal("simple", "secure");
+export const CodeStyle = Schema.Literals(["simple", "secure"]);
 export type CodeStyle = Schema.Schema.Type<typeof CodeStyle>;
 
 /**
@@ -19,15 +19,7 @@ export type CodeStyle = Schema.Schema.Type<typeof CodeStyle>;
  * `codeStyle` (default `secure` applied in the service when omitted).
  */
 export const CreateWeddingBody = Schema.Struct({
-  displayName: Schema.String.pipe(
-    Schema.transform(Schema.String, {
-      strict: true,
-      decode: (s) => s.trim(),
-      encode: (s) => s,
-    }),
-    Schema.minLength(1),
-    Schema.maxLength(MAX_DISPLAY_NAME),
-  ),
+  displayName: Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_DISPLAY_NAME)),
   codeStyle: Schema.optional(CodeStyle),
 });
 export type CreateWeddingBody = Schema.Schema.Type<typeof CreateWeddingBody>;

--- a/cire/api/src/services/changes.ts
+++ b/cire/api/src/services/changes.ts
@@ -1,6 +1,6 @@
 import { events, imports } from "@cire/db";
 import { and, asc, eq, or } from "drizzle-orm";
-import { Effect, ParseResult, Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 import { DbService, dbQuery } from "../db";
 import { ChangeScope, DesiredState } from "../schemas/import";
@@ -59,10 +59,12 @@ export const CsvChangeBody = Schema.Struct({
   guestsCsv: Schema.optional(Schema.String),
   /** Provenance toggle (§6): widen the diff to also remove manually-added rows. */
   removeManual: Schema.optional(Schema.Boolean),
-}).pipe(
-  Schema.filter((body) => CSV_SLOTS.some((slot) => body[slot] !== undefined), {
-    message: () => "at least one of eventsCsv / guestsCsv is required",
-  }),
+}).check(
+  Schema.makeFilter((body) =>
+    CSV_SLOTS.some((slot) => body[slot] !== undefined)
+      ? undefined
+      : "at least one of eventsCsv / guestsCsv is required",
+  ),
 );
 export type CsvChangeBody = Schema.Schema.Type<typeof CsvChangeBody>;
 
@@ -87,7 +89,7 @@ export type DesiredStateChangeBody = Schema.Schema.Type<typeof DesiredStateChang
  * are disjoint (`desiredState` vs `eventsCsv`/`guestsCsv`), so a body decodes to
  * exactly one. A malformed body fails both and surfaces as the shared 400.
  */
-export const ChangeBody = Schema.Union(DesiredStateChangeBody, CsvChangeBody);
+export const ChangeBody = Schema.Union([DesiredStateChangeBody, CsvChangeBody]);
 export type ChangeBody = Schema.Schema.Type<typeof ChangeBody>;
 
 /**
@@ -106,19 +108,14 @@ export type ChangeBody = Schema.Schema.Type<typeof ChangeBody>;
  * A separate pre-pass rather than a `Schema.filter` on either member, because a
  * `Schema.Struct` strips the other door's keys before a filter can see them.
  */
-const ExclusiveFrontDoor = Schema.Unknown.pipe(
-  Schema.filter(
-    (raw) =>
-      !(
-        typeof raw === "object" &&
-        raw !== null &&
-        "desiredState" in raw &&
-        CSV_SLOTS.some((slot) => slot in raw)
-      ),
-    {
-      message: () =>
-        "a change is either an editor draft (desiredState) or a spreadsheet upload (eventsCsv/guestsCsv), never both",
-    },
+const ExclusiveFrontDoor = Schema.Unknown.check(
+  Schema.makeFilter((raw) =>
+    typeof raw === "object" &&
+    raw !== null &&
+    "desiredState" in raw &&
+    CSV_SLOTS.some((slot) => slot in raw)
+      ? "a change is either an editor draft (desiredState) or a spreadsheet upload (eventsCsv/guestsCsv), never both"
+      : undefined,
   ),
 );
 
@@ -250,10 +247,10 @@ export function currentEventsAsParsed(
 export function decodeChangeBody(
   raw: unknown,
   weddingId: string,
-): Effect.Effect<DecodedChange, SpreadsheetParseError | ParseResult.ParseError, DbService> {
+): Effect.Effect<DecodedChange, SpreadsheetParseError | Schema.SchemaError, DbService> {
   return Effect.gen(function* () {
-    const body = yield* Schema.decodeUnknown(ChangeBody)(
-      yield* Schema.decodeUnknown(ExclusiveFrontDoor)(raw),
+    const body = yield* Schema.decodeUnknownEffect(ChangeBody)(
+      yield* Schema.decodeUnknownEffect(ExclusiveFrontDoor)(raw),
     );
 
     if ("desiredState" in body) {

--- a/cire/api/tests/app.test.ts
+++ b/cire/api/tests/app.test.ts
@@ -143,22 +143,22 @@ describe("unhandled errors", () => {
       }),
     );
 
-    // Isolate OUR structured `onError` line. (Effect's *default* logger also
-    // emits a separate DEBUG "Fiber terminated…" stack dump — local-only, not
-    // the operator log line this finding is about — so we assert on our line,
-    // not the whole capture.)
-    const ourLine = out
-      .split("\n")
-      .filter((l) => l.includes("unhandled request error") || l.startsWith('{"'))
-      .join(" ");
+    // This used to isolate our `onError` line out of the capture, because
+    // Effect v3's *default* logger also emitted a separate DEBUG "Fiber
+    // terminated…" stack dump. Two things changed under v4: `Logger.layer`
+    // replaces the whole active set, so there is no default logger left to
+    // emit that dump; and the local renderer is indented, so our own entry is
+    // no longer one line and a line filter would only ever catch a fragment of
+    // it. The whole capture IS our entry now — which makes the negative
+    // assertion below strictly stronger, since nothing is filtered out of it.
 
-    // The structured line + the error NAME are present (triage signal).
-    expect(ourLine).toContain("unhandled request error");
-    expect(ourLine).toContain("name");
-    expect(ourLine).toContain("SQLiteError"); // the error NAME survives
-    // The raw SQLite message (a D1-internal echo) must NOT appear in our line —
+    // The structured entry + the error NAME are present (triage signal).
+    expect(out).toContain("unhandled request error");
+    expect(out).toContain("name");
+    expect(out).toContain("SQLiteError"); // the error NAME survives
+    // The raw SQLite message (a D1-internal echo) must NOT appear anywhere —
     // "no such table: families" is exactly what would have leaked under the old
     // `message: error.message` log.
-    expect(ourLine).not.toContain("no such table");
+    expect(out).not.toContain("no such table");
   });
 });

--- a/cire/api/tests/db/d1-session.test.ts
+++ b/cire/api/tests/db/d1-session.test.ts
@@ -143,7 +143,7 @@ describe("session routing", () => {
         Effect.runPromise(
           Effect.gen(function* () {
             yield* query("first");
-            yield* Effect.yieldNow();
+            yield* Effect.yieldNow;
             yield* query("second");
           }),
         ),

--- a/cire/api/tests/schemas/budget.test.ts
+++ b/cire/api/tests/schemas/budget.test.ts
@@ -12,8 +12,8 @@ import {
   UpdatePaymentBody,
 } from "../../src/schemas/budget";
 
-const decode = <A, I>(s: Schema.Schema<A, I>, v: unknown) =>
-  Effect.runSync(Effect.result(Schema.decodeUnknown(s)(v)));
+const decode = <A, I>(s: Schema.Codec<A, I>, v: unknown) =>
+  Effect.runSync(Effect.result(Schema.decodeUnknownEffect(s)(v)));
 
 describe("service categories", () => {
   it("has the fourteen ordered keys ending in 'other'", () => {

--- a/cire/api/tests/schemas/invite-crop.test.ts
+++ b/cire/api/tests/schemas/invite-crop.test.ts
@@ -8,8 +8,8 @@ import { cropAspect, decodeCrop, ImageCropBody, isValidCrop } from "../../src/sc
 // the ParseError so a test can assert acceptance/rejection.
 function decodeBody(raw: unknown) {
   return Effect.runSync(
-    Schema.decodeUnknown(ImageCropBody)(raw).pipe(
-      Effect.catchTag("ParseError", () => Effect.fail("reject" as const)),
+    Schema.decodeUnknownEffect(ImageCropBody)(raw).pipe(
+      Effect.catchTag("SchemaError", () => Effect.fail("reject" as const)),
       Effect.result,
     ),
   );

--- a/cire/api/tests/schemas/tasks.test.ts
+++ b/cire/api/tests/schemas/tasks.test.ts
@@ -5,8 +5,8 @@ import { Effect, Schema } from "effect";
 import { isTimeframeBucket, TIMEFRAME_BUCKET_KEYS } from "../../src/lib/checklist-buckets";
 import { CreateTaskBody, ReorderTasksBody, UpdateTaskBody } from "../../src/schemas/tasks";
 
-const decode = <A, I>(s: Schema.Schema<A, I>, v: unknown) =>
-  Effect.runSync(Effect.result(Schema.decodeUnknown(s)(v)));
+const decode = <A, I>(s: Schema.Codec<A, I>, v: unknown) =>
+  Effect.runSync(Effect.result(Schema.decodeUnknownEffect(s)(v)));
 
 describe("checklist buckets", () => {
   it("has the eight ordered lead-time keys", () => {

--- a/cire/api/tests/schemas/vendors.test.ts
+++ b/cire/api/tests/schemas/vendors.test.ts
@@ -11,32 +11,34 @@ import {
   VENDOR_STATUSES,
 } from "../../src/schemas/vendors";
 
-const dec = <A>(s: Schema.Schema<A>, v: unknown) => Schema.decodeUnknownEither(s)(v);
+// v4 replaces Either with Result: the tags are "Success"/"Failure", not
+// "Right"/"Left".
+const dec = <A>(s: Schema.Codec<A>, v: unknown) => Schema.decodeUnknownResult(s)(v);
 
 describe("vendor schemas", () => {
   it("accepts a valid CRM vendor and rejects a bad category/status", () => {
     expect(
       dec(CreateVendorBody, { name: "Bloom", category: "florals", status: "researching" })._tag,
-    ).toBe("Right");
+    ).toBe("Success");
     expect(
       dec(CreateVendorBody, { name: "Bloom", category: "not_a_cat", status: "researching" })._tag,
-    ).toBe("Left");
+    ).toBe("Failure");
     expect(dec(CreateVendorBody, { name: "Bloom", category: "florals", status: "nope" })._tag).toBe(
-      "Left",
+      "Failure",
     );
     expect(
       dec(CreateVendorBody, { name: "", category: "florals", status: "researching" })._tag,
-    ).toBe("Left");
+    ).toBe("Failure");
   });
 
   it("SeedListingBody requires an email and >=1 category", () => {
     expect(
       dec(SeedListingBody, { name: "Bloom", email: "a@b.co", categories: ["florals"] })._tag,
-    ).toBe("Right");
+    ).toBe("Success");
     expect(dec(SeedListingBody, { name: "Bloom", email: "a@b.co", categories: [] })._tag).toBe(
-      "Left",
+      "Failure",
     );
-    expect(dec(SeedListingBody, { name: "Bloom", categories: ["florals"] })._tag).toBe("Left");
+    expect(dec(SeedListingBody, { name: "Bloom", categories: ["florals"] })._tag).toBe("Failure");
   });
 
   it("UpsertListingBody accepts multi-category + optional price band", () => {
@@ -46,18 +48,20 @@ describe("vendor schemas", () => {
         categories: ["florals", "decor_styling"],
         priceBand: "$$",
       })._tag,
-    ).toBe("Right");
-    expect(dec(UpsertListingBody, { name: "Bloom", categories: ["bad"] })._tag).toBe("Left");
+    ).toBe("Success");
+    expect(dec(UpsertListingBody, { name: "Bloom", categories: ["bad"] })._tag).toBe("Failure");
   });
 
   it("ReorderVendorsBody requires a status + id list", () => {
-    expect(dec(ReorderVendorsBody, { status: "booked", orderedIds: ["ven_1"] })._tag).toBe("Right");
-    expect(dec(ReorderVendorsBody, { status: "bad", orderedIds: [] })._tag).toBe("Left");
+    expect(dec(ReorderVendorsBody, { status: "booked", orderedIds: ["ven_1"] })._tag).toBe(
+      "Success",
+    );
+    expect(dec(ReorderVendorsBody, { status: "bad", orderedIds: [] })._tag).toBe("Failure");
   });
 
   it("ConsumeClaimBody requires an orgId", () => {
-    expect(dec(ConsumeClaimBody, { orgId: "org_1" })._tag).toBe("Right");
-    expect(dec(ConsumeClaimBody, {})._tag).toBe("Left");
+    expect(dec(ConsumeClaimBody, { orgId: "org_1" })._tag).toBe("Success");
+    expect(dec(ConsumeClaimBody, {})._tag).toBe("Failure");
   });
 
   it("exposes the five statuses in order", () => {

--- a/cire/api/tests/services/budget.test.ts
+++ b/cire/api/tests/services/budget.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { BOOTSTRAP_WEDDING_ID, budgetItems, payments, weddings } from "@cire/db";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import { DbService } from "../../src/db";
 import { createDb, seedDb } from "../../src/db/setup";
@@ -100,7 +100,8 @@ describe("budgetService", () => {
     expect(Exit.isFailure(foreign)).toBe(true);
     if (Exit.isFailure(foreign)) {
       expect(
-        foreign.cause._tag === "Fail" && foreign.cause.error instanceof BudgetItemNotInWedding,
+        Option.getOrUndefined(Cause.findErrorOption(foreign.cause)) instanceof
+          BudgetItemNotInWedding,
       ).toBe(true);
     }
     const row = db
@@ -193,7 +194,8 @@ describe("budgetService", () => {
     expect(Exit.isFailure(foreign)).toBe(true);
     if (Exit.isFailure(foreign)) {
       expect(
-        foreign.cause._tag === "Fail" && foreign.cause.error instanceof BudgetItemNotInWedding,
+        Option.getOrUndefined(Cause.findErrorOption(foreign.cause)) instanceof
+          BudgetItemNotInWedding,
       ).toBe(true);
     }
   });
@@ -226,9 +228,9 @@ describe("budgetService", () => {
     );
     expect(Exit.isFailure(wrong)).toBe(true);
     if (Exit.isFailure(wrong)) {
-      expect(wrong.cause._tag === "Fail" && wrong.cause.error instanceof PaymentNotInItem).toBe(
-        true,
-      );
+      expect(
+        Option.getOrUndefined(Cause.findErrorOption(wrong.cause)) instanceof PaymentNotInItem,
+      ).toBe(true);
     }
   });
 

--- a/cire/api/tests/services/directory.test.ts
+++ b/cire/api/tests/services/directory.test.ts
@@ -9,7 +9,7 @@ import {
   weddings,
 } from "@cire/db";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import { DbService } from "../../src/db";
 import { createDb, seedDb } from "../../src/db/setup";
@@ -346,8 +346,7 @@ describe("directoryService.seedFromCrm", () => {
     );
     expect(
       Exit.isFailure(res) &&
-        res.cause._tag === "Fail" &&
-        res.cause.error instanceof VendorNotInWedding,
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof VendorNotInWedding,
     ).toBe(true);
   });
 });
@@ -510,8 +509,7 @@ describe("directoryService.consumeClaim", () => {
     );
     expect(
       Exit.isFailure(second) &&
-        second.cause._tag === "Fail" &&
-        second.cause.error instanceof ClaimInvalid,
+        Option.getOrUndefined(Cause.findErrorOption(second.cause)) instanceof ClaimInvalid,
     ).toBe(true);
   });
 
@@ -549,8 +547,7 @@ describe("directoryService.consumeClaim", () => {
     );
     expect(
       Exit.isFailure(reuse) &&
-        reuse.cause._tag === "Fail" &&
-        reuse.cause.error instanceof ClaimInvalid,
+        Option.getOrUndefined(Cause.findErrorOption(reuse.cause)) instanceof ClaimInvalid,
     ).toBe(true);
   });
 
@@ -598,7 +595,8 @@ describe("directoryService.consumeClaim", () => {
 
     const res = await run(db, directoryService.consumeClaim(fakeToken, "org_late", "usr_late"));
     expect(
-      Exit.isFailure(res) && res.cause._tag === "Fail" && res.cause.error instanceof ClaimInvalid,
+      Exit.isFailure(res) &&
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof ClaimInvalid,
     ).toBe(true);
   });
 
@@ -606,7 +604,8 @@ describe("directoryService.consumeClaim", () => {
     const db = db0();
     const res = await run(db, directoryService.consumeClaim("no-such-token", "org_x", "usr_x"));
     expect(
-      Exit.isFailure(res) && res.cause._tag === "Fail" && res.cause.error instanceof ClaimInvalid,
+      Exit.isFailure(res) &&
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof ClaimInvalid,
     ).toBe(true);
   });
 });

--- a/cire/api/tests/services/enquiries.test.ts
+++ b/cire/api/tests/services/enquiries.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@cire/db";
 import type { SendEmailInput } from "@shared/email";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import { DbService } from "../../src/db";
 import { createDb, seedDb } from "../../src/db/setup";
@@ -278,7 +278,9 @@ describe("enquiryService.open", () => {
     // no future onVendorClaimed flush), so the route surfaces 503 to retry.
     expect(Exit.isFailure(res)).toBe(true);
     if (Exit.isFailure(res)) {
-      expect(res.cause._tag === "Fail" && res.cause.error instanceof ZapUnavailable).toBe(true);
+      expect(
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof ZapUnavailable,
+      ).toBe(true);
     }
 
     // No orphaned rows: the failure happens BEFORE the enquiry INSERT, and no
@@ -344,9 +346,9 @@ describe("enquiryService.reply", () => {
     );
     expect(Exit.isFailure(res)).toBe(true);
     if (Exit.isFailure(res)) {
-      expect(res.cause._tag === "Fail" && res.cause.error instanceof EnquiryAwaitingVendor).toBe(
-        true,
-      );
+      expect(
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof EnquiryAwaitingVendor,
+      ).toBe(true);
     }
   });
 
@@ -509,9 +511,9 @@ describe("enquiryService.quote", () => {
     );
     expect(Exit.isFailure(res)).toBe(true);
     if (Exit.isFailure(res)) {
-      expect(res.cause._tag === "Fail" && res.cause.error instanceof EnquiryAwaitingVendor).toBe(
-        true,
-      );
+      expect(
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof EnquiryAwaitingVendor,
+      ).toBe(true);
     }
   });
 });

--- a/cire/api/tests/services/registry-image.test.ts
+++ b/cire/api/tests/services/registry-image.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import {
   AssetsR2Service,
@@ -53,7 +53,11 @@ function runFromUrl(url: string, opts: LinkPreviewOptions, stub = createAssetsSt
 /** The tag of the failure an exit carries, or `null` if it succeeded. */
 function failureTag(exit: Exit.Exit<unknown, { readonly _tag: string }>): string | null {
   if (!Exit.isFailure(exit)) return null;
-  return exit.cause._tag === "Fail" ? exit.cause.error._tag : exit.cause._tag;
+  // v4's Cause is a list of reasons rather than a tagged node, so a typed
+  // failure is read out of it; anything else (a defect, an interrupt) has no
+  // error to name and reports the reason's own tag.
+  const error = Option.getOrUndefined(Cause.findErrorOption(exit.cause));
+  return error?._tag ?? exit.cause.reasons[0]?._tag ?? null;
 }
 
 describe("registryImageService.storeUpload", () => {

--- a/cire/api/tests/services/spreadsheet.test.ts
+++ b/cire/api/tests/services/spreadsheet.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import { Effect } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import {
   parseEventsCsv,
@@ -652,18 +652,29 @@ describe("UTF-8 BOM tolerance", () => {
  * Every parse rejection says WHICH sheet it came from — with two files in one
  * request, "Malformed spreadsheet" alone doesn't tell an organiser which to open.
  */
+/**
+ * The typed error an exit failed with. v4's Cause is a list of reasons rather
+ * than a tagged node, so the error is read out with `findErrorOption` instead
+ * of matching a `Fail`; a success or a defect throws here rather than letting
+ * the assertions below run against `undefined`.
+ */
+function failureOf<E>(exit: Exit.Exit<unknown, E>): E {
+  if (!Exit.isFailure(exit)) throw new Error("expected the effect to fail");
+  return Option.getOrThrow(Cause.findErrorOption(exit.cause));
+}
+
 describe("parse errors carry their sheet", () => {
   it("stamps sheet='events' on an events-sheet rejection", async () => {
     const exit = await Effect.runPromiseExit(parseEventsCsv("Event Name,Start\nx,not-a-date"));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: MissingRequiredColumn } }).cause.error;
+    const err = failureOf(exit) as MissingRequiredColumn;
     expect(err.sheet).toBe("events");
   });
 
   it("stamps sheet='guests' on a guests-sheet rejection", async () => {
     const exit = await Effect.runPromiseExit(parseGuestsCsv("Family Name\nSmith", []));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: MissingRequiredColumn } }).cause.error;
+    const err = failureOf(exit) as MissingRequiredColumn;
     expect(err.sheet).toBe("guests");
   });
 
@@ -679,7 +690,7 @@ describe("parse errors carry their sheet", () => {
     ].join("\n");
     const exit = await Effect.runPromiseExit(parseGuestsCsv(csv, events));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: UnmatchedEventColumn } }).cause.error;
+    const err = failureOf(exit) as UnmatchedEventColumn;
     // withSheet rebuilds the error by copying fields explicitly; a dropped field
     // here would leave the organiser's message with no location at all.
     expect(err.column).toBe("Sangeet");
@@ -692,7 +703,7 @@ describe("parse errors carry their sheet", () => {
     );
     const exit = await Effect.runPromiseExit(parseEventsCsv(csv));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: FormulaInjectionDetected } }).cause.error;
+    const err = failureOf(exit) as FormulaInjectionDetected;
     expect(err.row).toBe(2);
     expect(err.column).toBe(1);
     expect(err.snippet).toContain("=SUM");
@@ -706,7 +717,7 @@ describe("parse errors carry their sheet", () => {
     // organiser's spreadsheet column.
     const exit = await Effect.runPromiseExit(parseEventsCsv(""));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: MalformedSpreadsheet } }).cause.error;
+    const err = failureOf(exit) as MalformedSpreadsheet;
     expect(err.reason).toBe("empty events sheet");
     expect(err.atRow).toBeUndefined();
     expect(err.atColumn).toBeUndefined();
@@ -716,7 +727,7 @@ describe("parse errors carry their sheet", () => {
     const csv = [EVENTS_HEADER, "Mehndi,14/11/2026 15:00,,Australia/Sydney,,,,,,"].join("\n");
     const exit = await Effect.runPromiseExit(parseEventsCsv(csv));
     expect(exit._tag).toBe("Failure");
-    const err = (exit as { cause: { error: MalformedSpreadsheet } }).cause.error;
+    const err = failureOf(exit) as MalformedSpreadsheet;
     expect(err.reason).toBe("Start must be an ISO-8601 timestamp");
     expect(err.atRow).toBe(2);
     expect(err.atColumn).toBe(2);

--- a/cire/api/tests/services/tasks.test.ts
+++ b/cire/api/tests/services/tasks.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { BOOTSTRAP_WEDDING_ID, tasks, weddings } from "@cire/db";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import { DbService } from "../../src/db";
 import { createDb, seedDb } from "../../src/db/setup";
@@ -123,7 +123,9 @@ describe("tasksService", () => {
     );
     expect(Exit.isFailure(res)).toBe(true);
     if (Exit.isFailure(res)) {
-      expect(res.cause._tag === "Fail" && res.cause.error instanceof TaskNotInWedding).toBe(true);
+      expect(
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof TaskNotInWedding,
+      ).toBe(true);
     }
     // The task is untouched.
     const row = db

--- a/cire/api/tests/services/vendors.test.ts
+++ b/cire/api/tests/services/vendors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { BOOTSTRAP_WEDDING_ID, vendors, weddings } from "@cire/db";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 
 import { DbService } from "../../src/db";
 import { createDb, seedDb } from "../../src/db/setup";
@@ -71,8 +71,7 @@ describe("vendorsService", () => {
     const res = await run(db, vendorsService.update(OTHER, mine.value.id, { status: "booked" }));
     expect(
       Exit.isFailure(res) &&
-        res.cause._tag === "Fail" &&
-        res.cause.error instanceof VendorNotInWedding,
+        Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof VendorNotInWedding,
     ).toBe(true);
     // unchanged
     const row = db.select().from(vendors).where(eq(vendors.id, mine.value.id)).get();

--- a/osn/api/src/local.ts
+++ b/osn/api/src/local.ts
@@ -1,6 +1,6 @@
 import { DbLive } from "@osn/db/service";
 import { initObservability, PrettyLoggerLive } from "@shared/observability";
-import { Effect, Layer, Logger } from "effect";
+import { Effect, Layer } from "effect";
 
 import { createApp, type App } from "./app";
 import { buildAppDeps, type BuiltDeps, SERVICE_NAME } from "./build-deps";

--- a/pulse/api/src/local.ts
+++ b/pulse/api/src/local.ts
@@ -1,7 +1,7 @@
 import { DbLive } from "@pulse/db/service";
 import { initObservability, PrettyLoggerLive } from "@shared/observability";
 import type { ClientIpOptions } from "@shared/rate-limit";
-import { Effect, Logger } from "effect";
+import { Effect } from "effect";
 
 import { createApp, SERVICE_NAME, type AppOptions } from "./app";
 import { assertCorsOriginsConfigured, resolveCorsOrigins } from "./lib/cors-config";

--- a/shared/observability/tests/layer.test.ts
+++ b/shared/observability/tests/layer.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Logger } from "effect";
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 import type { DeploymentEnvironment } from "../src/config";

--- a/zap/api/src/index.ts
+++ b/zap/api/src/index.ts
@@ -1,7 +1,7 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { PrettyLoggerLive } from "@shared/observability";
 import { makeDbD1Live } from "@zap/db/service";
-import { Effect, Logger } from "effect";
+import { Effect } from "effect";
 
 import { createApp, SERVICE_NAME, type App } from "./app";
 import { assertCorsOriginsConfigured, isNonLocalEnv, resolveCorsOrigins } from "./lib/cors-config";

--- a/zap/api/src/local.ts
+++ b/zap/api/src/local.ts
@@ -1,5 +1,5 @@
 import { initObservability, PrettyLoggerLive } from "@shared/observability";
-import { Effect, Logger } from "effect";
+import { Effect } from "effect";
 
 import { createApp, SERVICE_NAME } from "./app";
 import { assertCorsOriginsConfigured, isNonLocalEnv, resolveCorsOrigins } from "./lib/cors-config";


### PR DESCRIPTION
Phase 5 of the Effect v4 migration (#902), stacked on #911. `@cire/api` was the last package on v3.

**With this branch, the whole monorepo type-checks (37/37 packages) and passes its tests (38/38 tasks) under `effect@4.0.0-rc.112`.** This is the first green state since #906 — the tree has been red by design since phase 1.

## Issues

- Closes #902 (Schema in cire/api's 38 files)
- Part of #895; follows #901 (#911)

> [!note] This keyword will not auto-close #902 from here
> GitHub only creates the linked-PR relationship for a pull request targeting the repository's **default branch**. This one targets `claude/effect-v4-phase-4`, so the keyword records intent and nothing more. The `effect-v4` → `main` PR at the top of the stack is what has to carry the full `Closes #896`…`#903` set.

## Four things cire hit that the earlier phases did not

### `Schema.Union` takes one array

```diff
-Schema.Union(Schema.String, Schema.Null)
+Schema.Union([Schema.String, Schema.Null])
```

This is the quiet one. It does not error at the call site — the second member is simply dropped, and the failure surfaces somewhere downstream as `{} | null` where a `string | null` was expected. Worth knowing about because a union that silently loses a member is a validator that silently stops rejecting.

`Schema.Literal` behaves the same way (one literal in v4, several via `Schema.Literals([…])`), and it bit here in two forms the phase-4 regex didn't cover: `Schema.Literal("both", "events", "guests")` narrowed to `"both"`, and `Schema.Literal(...SERVICE_CATEGORIES.map((c) => c.key))` — a spread of a *computed* array, not an identifier.

### `optionalWith` with a default

22 sites, all the same shape:

```diff
-quantityWanted: Schema.optionalWith(Quantity, { default: () => 1 })
+quantityWanted: Quantity.pipe(Schema.withDecodingDefaultType(Effect.succeed(1)))
```

`withDecodingDefaultType` is the non-`exact` variant, so — as in v3 without `exact: true` — the default also applies when the key is present but `undefined`.

### The `ParseError` gap is answerable

Upstream's generated reference leaves `ParseResult.ParseError` as **"TODO: needs guidance"**, which is why phase 2 deferred it. The compiler answers it: v4 tags a decode failure `SchemaError`.

```diff
-Effect.catchTag("ParseError", () => badRequest(set))
+Effect.catchTag("SchemaError", () => badRequest(set))
```

41 `catchTag`/`catchTags` keys, plus one type annotation in `services/changes.ts` (`ParseResult.ParseError` → `Schema.SchemaError`).

### `Cause` is a list of reasons

```diff
-res.cause._tag === "Fail" && res.cause.error instanceof VendorNotInWedding
+Option.getOrUndefined(Cause.findErrorOption(res.cause)) instanceof VendorNotInWedding
```

`findErrorOption` returns `None` for a defect, so `undefined instanceof X` is `false` — the new form refuses a defect exactly as the `Fail` check did. This is the idiom `link-preview.test.ts` and `import.identity.test.ts` already use.

## Three workarounds deleted, and the guarantees they had

`Schema.transform` → `Schema.decodeTo(target, SchemaTransformation.transform(…))` was needed only three times: the time-zone canonicaliser, the HTTPS-URL normaliser, and the slider clamp. Three *other* uses were "trim, then bound the length", which collapse to a stock schema:

```diff
-Schema.String.pipe(
-  Schema.transform(Schema.String, { strict: true, decode: (s) => s.trim(), encode: (s) => s }),
-  Schema.minLength(1),
-  Schema.maxLength(64),
-)
+Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(64))
```

Two properties had to hold for that to be honest, and both were checked against the resolved package rather than assumed:

- **The checks run on the trimmed value.** `"   "` is rejected as blank, `"  abcde  "` passes a 5-char cap. If the checks ran on the input, both would be wrong in opposite directions.
- **`.check(a, b)` short-circuits on the first failure.** `settings.ts` documents why this matters: `TimeZone`'s `maxLength` runs before the ICU lookup precisely so an oversized blob never reaches it. v4 short-circuits — verified by counting calls into the second check after the first fails: zero.

## Two test fixes that are phase 3's, not Schema's

- `cire/api/tests/app.test.ts` isolated its `onError` log entry with `startsWith('{"')`. The local renderer is indented now, so that filter caught the string `"unhandled request error",` and nothing else. `Logger.layer` also **replaces** the whole active set, so the default logger whose `Fiber terminated…` stack dump the filter existed to exclude no longer exists — the whole capture *is* that one entry. Asserting on the capture makes the "no raw SQLite message leaked" check strictly stronger, since nothing is filtered out of it any more.
- Five `Logger` imports left dead by phase 3's move to `PrettyLoggerLive` (`osn/api`, `pulse/api`, `zap/api` × 2, `shared/observability` tests).

## Verification

| | |
|---|---|
| `bun run check` | **37 / 37 packages** |
| `bun run test` | **38 / 38 tasks** |
| `bun run lint` | clean (warnings only, none new) |
| `bun run fmt:check` | clean |
| `@cire/api` | 1752 passed, 0 failed |

No `^3.22` pin is left anywhere: 7 packages on `effect@4.0.0-rc.112`, 11 on `@effect/vitest@4.0.0-rc.112`.

## What is left

Phase 6 (#903): merge the stack into `effect-v4`, then `effect-v4` → `main`, dev-tier smoke, and the teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnGXMhPoA7zsgPLnYiDUcH)_