### PR TITLE
docs: correct six stale CLAUDE.md facts and add the guard-threshold and lockfile rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ AI coding assistant ref. Full spec in README.md. Work tracked in GitHub Issues �
 
 OSN: Modular social platform. Users own identity + social graph. Apps opt-in/out independently.
 
-**Deployed (2026-06-18):** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. **Identity moved to its own zone 2026-07-27:** `osn-api` is a deployed **Cloudflare Worker** on `id.musubi.social`, `@osn/social` (identity app + the OIDC consent screen) is on the apex `musubi.social`, and the WebAuthn RP ID is `musubi.social` — so the cireweddings.com origins can no longer run passkey ceremonies and sign in through the OIDC redirect flow instead (see `[[wiki/runbooks/musubi-identity-migration]]`). osn-api has Upstash prod secrets set; email is live over Resend from `hello@cireweddings.com` (the `OSN_EMAIL_OPTIONAL` degraded mode was dropped in #160). `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. **Two tiers since 2026-08-13:** a merge to `main` auto-deploys the isolated **dev** tier (`*.dev.cireweddings.com`, `id.dev`/`dev.musubi.social`), and the production jobs in the same run wait on a human approving the `production` GitHub Environment — no more unattended deploys to live weddings. Path filters mean only changed surfaces deploy. See `[[wiki/runbooks/dev-environment]]`. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
+**Deployed:** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. **Identity moved to its own zone 2026-07-27:** `osn-api` is a deployed **Cloudflare Worker** on `id.musubi.social`, `@osn/social` (identity app + the OIDC consent screen) is on the apex `musubi.social`, and the WebAuthn RP ID is `musubi.social` — so the cireweddings.com origins can no longer run passkey ceremonies and sign in through the OIDC redirect flow instead (see `[[wiki/runbooks/musubi-identity-migration]]`). osn-api has Upstash prod secrets set; email is live over Resend from `hello@cireweddings.com` (`OSN_EMAIL_OPTIONAL` still exists as the degraded-boot opt-in — `selectEmailLayer` in `osn/api/src/lib/email-layer.ts` — and is unneeded once `RESEND_API_KEY` is set). `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. **Two tiers since 2026-08-13:** a merge to `main` auto-deploys the isolated **dev** tier (`*.dev.cireweddings.com`, `id.dev`/`dev.musubi.social`), and the production jobs in the same run wait on a human approving the `production` GitHub Environment — no more unattended deploys to live weddings. Path filters mean only changed surfaces deploy. See `[[wiki/runbooks/dev-environment]]`. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
 
 Phase 1 surfaces:
 
@@ -17,6 +17,7 @@ Phase 1 surfaces:
 | Events | `@pulse/web` + `@pulse/api` (port 3001) + `@pulse/db` | Active |
 | Messaging | `@zap/api` (port 3002) + `@zap/db` | M0 scaffolded; M1 in flight; client app not started |
 | Wedding invites | @cire/api (:8787, prod `api.cireweddings.com`) + @cire/invites (:4321, prod `invite.cireweddings.com`) + @cire/host (:4322, prod `host.cireweddings.com`) + @cire/db + @cire/theme | Active — **deployed** (domain reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; package rename 2026-08-07: `@cire/web`→`@cire/invites`, `@cire/organiser`→`@cire/host`) |
+| Wedding vendor portal | `@cire/vendor` (`https://vendor.cire.localhost`) | Active — the vendor-facing surface for the enquiry flow. See `[[wiki/systems/cire-vendors]]` |
 | Wedding marketing site | `@cire/landing` (:4323) | Active — serves the **apex `cireweddings.com`** (reshuffle 2026-07-16). See `[[wiki/apps/cire-landing]]` |
 | OSN marketing site | `@osn/landing` (:4324) | Active — built (dark/dotted, connections-led). See `[[wiki/apps/osn-landing]]` |
 | Pulse marketing site | `@pulse/landing` (:4325) | Active — built (colourful + fun). See `[[wiki/apps/pulse-landing]]` |
@@ -224,7 +225,7 @@ Monorepo by domain. Five dirs, five prefixes — see `[[wiki/architecture/monore
 
 ## Tech (one-liner)
 
-Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, SQLite→Supabase, Eden+REST, WebSockets, Signal Protocol, SolidJS, Astro, Turborepo, oxlint, oxfmt, Vitest + @effect/vitest
+Bun, TypeScript, Elysia, Effect.ts (trial), Drizzle, `bun:sqlite` locally → Cloudflare D1 deployed, Eden+REST, WebSockets, Signal Protocol, SolidJS, Astro, Turborepo, oxlint, oxfmt, Vitest + @effect/vitest (`@cire/api` runs on `bun test`)
 
 ## Key Patterns
 
@@ -242,7 +243,7 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 | Recovery Codes | Copenhagen Book M2 — 10 × 64-bit single-use codes, hashed at rest. Generate/consume both in `security_events` and surfaced via in-app banner. | `[[wiki/systems/recovery-codes]]` |
 | Session Introspection | `GET/DELETE /sessions[/:id]`, `POST /sessions/revoke-all-other`. Coarse UA labels + HMAC-peppered IP hashes. | `[[wiki/systems/sessions]]` |
 | OIDC Provider | `@osn/api` is an OpenID Connect provider, so other apps recognise an OSN account without holding a passkey. Authorization code + PKCE (S256 only), pairwise `sub` per client sector, consent stored per (account, client). Invalid client / redirect URI **renders** an error, never redirects (open-redirect guard). Codes hashed, single use, 60s TTL. No refresh tokens, never an `osn-access` audience. Hardened 2026-07-24: real `auth_time` + `max_age`/`prompt=login` enforcement, per-request browser-binding cookie, reserved client-id deny-list + `typ: at+jwt`, `GET/DELETE /oidc/connections` (revoke kills in-flight codes). Hardened 2026-07-29: self-serve client sector = its own `client_id` (colluding clients can't share a sector); `auth_time` survives silent rotation via `sessions.authenticated_at`; consent-screen anti-impersonation (name confusable-skeleton block + verified-app/third-party-host signal); RFC 9207 `iss`; required browser-binding on every parked request; consent revocation is now a live Settings surface (`@osn/social` "Connected apps"). | `[[wiki/systems/oidc-provider]]` |
-| Cross-Device Login | QR-code mediated session transfer. Device B begins + polls; device A scans QR, approves. 256-bit secret, SHA-256 hashed at rest, one-time consumption, 5-min TTL. In-memory store (Redis Phase 4). | `[[wiki/systems/sessions]]` |
+| Cross-Device Login | QR-code mediated session transfer. Device B begins + polls; device A scans QR, approves. 256-bit secret, SHA-256 hashed at rest, one-time consumption, 5-min TTL. Stored in the shared ceremony-store bundle — Redis-backed where a client is configured (`osn/api/src/lib/redis-ceremony-stores.ts`), in-memory otherwise. | `[[wiki/systems/sessions]]` |
 | Email Change | Step-up gated; OTP to NEW address; atomically swaps email + revokes other sessions. Cap 2 changes / 7 days. | `[[wiki/systems/identity-model]]` |
 | Email Transport | Transactional-only (OTPs + security notices). `EmailService` Effect Tag in `@shared/email`; `ResendEmailLive` POSTs to Resend's HTTP API (`api.resend.com/emails`, bearer-authed) — **preferred live transport** (works on workerd); `CloudflareEmailLive` is a legacy fallback; `LogEmailLive` captures in-memory for dev + tests. Selection precedence Resend → Cloudflare → Log (local) → Noop (`OSN_EMAIL_OPTIONAL`) → throw. With `RESEND_API_KEY` set the opt-in is unneeded. | `[[wiki/systems/email]]` |
 | Origin Guard (M1) | Origin header validation on POST/PUT/PATCH/DELETE. ARC-protected internal routes exempt. | `osn/api/src/lib/origin-guard.ts` |
@@ -271,6 +272,7 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 | Map-membership guards | A guard that narrows to `keyof typeof MAP` must test `Object.hasOwn(MAP, key)`, never `key in MAP`. `in` walks the prototype chain, so `constructor`, `toString` and `__proto__` pass and the predicate then asserts an inherited `Object.prototype` member is a real entry. `house/no-in-operator-key-guard` (in `tools/oxlint/house`) is an error, and it matches the narrowed parameter rather than the literal `keyof typeof` syntax, so an aliased predicate is caught too — see `cire/theme/src/palette.ts` for the house form |
 | Non-subscribing store reads | In a `*-store.ts` organiser cache (cire only), `entryFor(id).accessor()` is the subscribing read — it mints the cache entry, so a tracked read always has something to register a dependency on. `cache.get(id)?.accessor()` does not mint the entry: when it is absent the read short-circuits before `accessor` ever runs, so a tracked read registers zero dependencies and never re-runs once the entry is created. That non-minting form is confined to `peekCached*`/`hasCached*` functions, whether written as the direct `cache.get(id)?.accessor()` chain or split across a `const entry = cache.get(id)` and a later `entry?.accessor()` / guarded `entry.accessor()`. `house/no-non-subscribing-store-read` (in `tools/oxlint/house`) enforces it as an error, scoped to `cire/**/*-store.ts` |
 | Where tests live | `tests/` at the package root, mirroring `src/` — **never** beside the source. Test-only support code (mocks, request harnesses, fixtures) lives there too, so `src/` holds nothing test-shaped: `cire/api/tests/test-helpers/`, `cire/host/tests/test-support/`. `scripts/` is not a workspace but follows the same rule (`scripts/tests/`, shell tests included). The one deliberate carve-out is the Miniflare-backed D1 tier at `tests/d1/` (cire's at `tests/db/`), which the vitest configs exclude by path because it imports `bun:test` and boots workerd — `bun run test:d1` is the only thing that runs it. See `[[wiki/conventions/testing-patterns]]` |
+| Guard thresholds | A guard that gates on a number — a bundle budget, a query-count cap, a timing ceiling — obeys two rules. **The number lives in one committed file the guard reads**, never as an argument at each call site: `scripts/bundle-size-budgets.txt` is the worked example, and it replaced the same threshold copied into six `package.json` scripts, one `ci.yml` step and eight `deploy.yml` steps, any one of which could be missed on a re-baseline. **The headroom is smaller than the smallest mistake the guard exists to catch**, measured against the current build rather than carried over from an older one — a guard whose slack exceeds the mistake can never fire, which is how a bundle budget once carried 47657 bytes of headroom against a 21261-byte dependency. Both rules, and the re-baselining recipe, are in `[[wiki/conventions/bundle-size-guards]]` |
 | Pre-commit | lefthook runs oxlint + oxfmt (auto-fix + re-stage) on staged files |
 | Pre-push | lefthook runs type check |
 | oxlint | `oxlintrc.json` — plugins: typescript, unicorn, oxc, import, promise, vitest, node, jsx-a11y (React plugin disabled — SolidJS) |
@@ -288,15 +290,26 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 ```bash
 # Development
 bun run dev              # Start all dev servers (turbo)
-bun run dev:pulse        # Pulse work: pulse API + app, osn core, zap API
-bun run dev:zap          # Zap work: zap API, osn core
-bun run dev:osn          # OSN work: osn core + app
-bun run dev:apis         # All backends only: osn core, pulse API, zap API
-bun run dev:cire         # Cire work: cire API + web + organiser, osn core
-bun run dev:landing      # Landing site only
+bun run dev:pulse        # @pulse/api + @pulse/web + @osn/api + @zap/api
+bun run dev:zap          # @zap/api + @osn/api
+bun run dev:osn          # @osn/api alone
+bun run dev:social       # @osn/social + @osn/api
+bun run dev:apis         # backends only: @osn/api + @pulse/api + @zap/api
+bun run dev:cire         # @cire/api + @cire/invites + @cire/host + @osn/api
+                         # (NOT @cire/vendor — run that one on its own)
+bun run dev:landing      # @osn/landing        (dev:cire-landing, dev:pulse-landing for the others)
+bun run dev:lab          # @tools/lab — component/three.js prototyping
 bun run build            # Build all packages (turbo)
 bun run check            # Type-check all packages (turbo)
 ```
+
+The shell is **fish** on the local machine and **bash** in Claude Code's remote
+environments, so a command that works in one can fail to parse in the other.
+Two that bite: an unquoted glob argument (`grep --include=*.ts`) is expanded by
+fish and errors when nothing matches, and a heredoc inside `bash -c '…'` is
+read by fish first. Both are fine under bash. Where a command has a glob or a
+heredoc and has to work in either place, quote the glob (`--include='*.ts'`) or
+put the whole thing in a script file rather than a `-c` string.
 
 ### Local URLs
 
@@ -348,14 +361,16 @@ One trap for agents: Astro 7 detects an agent environment and puts `astro dev` i
 
 # Testing
 bun run test                          # run all tests (turbo, skips packages without test script)
-bun run --cwd pulse/api test:run          # run Pulse events API tests once
-bun run --cwd osn/api test:run            # run OSN API (auth + graph) tests once
-bun run --cwd osn/client test:run         # run OSN client SDK tests once
-bun run --cwd osn/ui test:run             # run shared auth component tests once
-bun run --cwd pulse/db test:run           # run Pulse DB schema tests once
-bun run --cwd pulse/api test              # watch mode
-bun run --cwd zap/db test:run             # run Zap DB schema tests once
-bun run --cwd zap/api test:run            # run Zap API service tests once
+bun run test:d1                       # the Miniflare/workerd D1 tier (excluded from `test`)
+bun run test:browser                  # the real-Chromium tier
+bun run test:scripts                  # bun tests under scripts/ — TypeScript only. `bun test`
+                                      # never collects a *.test.sh, so the three shell tests
+                                      # get their own CI steps (changeset-check.yml, ci.yml);
+                                      # a new one needs a step or it runs nowhere
+bun run --cwd <pkg> test:run          # one package, once   (vitest packages)
+bun run --cwd <pkg> test              # one package, watch mode
+bun run --cwd cire/api test           # @cire/api is the exception — bun test, no test:run,
+                                      # and it picks up its own tests/db/ D1 tier
 
 # Code quality
 bun run lint             # oxlint
@@ -384,6 +399,18 @@ bun run reset            # clean + reinstall
 bun add solid-js --cwd osn/landing
 bun add drizzle-orm --cwd pulse/db
 ```
+
+**Never a bare `bun install` here.** Resolving on one machine drops every
+entry for a platform it is not running on — on a Mac that is 46 entries,
+including all the non-darwin binaries CI needs — and the diff then reads as a
+dependency change nobody asked for. Use `bun install --frozen-lockfile` to
+install, and when a dependency genuinely changes, splice the `bun.lock` entry
+by hand and prove it with `bun install --frozen-lockfile`. A lockfile diff
+larger than the dependency you changed is the tell.
+
+`bun run reset` (`bun run clean && bun i`) is the one script that still chains
+a bare install, so check `git diff bun.lock` after running it and discard the
+pruning it does.
 
 ## Cloudflare Workers debugging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ AI coding assistant ref. Full spec in README.md. Work tracked in GitHub Issues �
 
 OSN: Modular social platform. Users own identity + social graph. Apps opt-in/out independently.
 
-**Deployed:** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal. **Identity moved to its own zone 2026-07-27:** `osn-api` is a deployed **Cloudflare Worker** on `id.musubi.social`, `@osn/social` (identity app + the OIDC consent screen) is on the apex `musubi.social`, and the WebAuthn RP ID is `musubi.social` — so the cireweddings.com origins can no longer run passkey ceremonies and sign in through the OIDC redirect flow instead (see `[[wiki/runbooks/musubi-identity-migration]]`). osn-api has Upstash prod secrets set; email is live over Resend from `hello@cireweddings.com` (`OSN_EMAIL_OPTIONAL` still exists as the degraded-boot opt-in — `selectEmailLayer` in `osn/api/src/lib/email-layer.ts` — and is unneeded once `RESEND_API_KEY` is set). `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. **Two tiers since 2026-08-13:** a merge to `main` auto-deploys the isolated **dev** tier (`*.dev.cireweddings.com`, `id.dev`/`dev.musubi.social`), and the production jobs in the same run wait on a human approving the `production` GitHub Environment — no more unattended deploys to live weddings. Path filters mean only changed surfaces deploy. See `[[wiki/runbooks/dev-environment]]`. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
+**Deployed:** the cire stack is **live on the `cireweddings.com` zone** (all Cloudflare Free tier). Domain reshuffle 2026-07-16: apex `cireweddings.com` = marketing landing, `invite.cireweddings.com` = guest site, `host.cireweddings.com` = organiser portal; `vendor.cireweddings.com` joined them with the vendor portal (`cire/vendor`, its own Pages project and deploy job). **Identity moved to its own zone 2026-07-27:** `osn-api` is a deployed **Cloudflare Worker** on `id.musubi.social`, `@osn/social` (identity app + the OIDC consent screen) is on the apex `musubi.social`, and the WebAuthn RP ID is `musubi.social` — so the cireweddings.com origins can no longer run passkey ceremonies and sign in through the OIDC redirect flow instead (see `[[wiki/runbooks/musubi-identity-migration]]`). osn-api has Upstash prod secrets set; email is live over Resend from `hello@cireweddings.com` (`OSN_EMAIL_OPTIONAL` still exists as the degraded-boot opt-in — `selectEmailLayer` in `osn/api/src/lib/email-layer.ts` — and is unneeded once `RESEND_API_KEY` is set). `cire-api` on `api.cireweddings.com`; guest + organiser sites on Pages with custom domains. **Two tiers since 2026-08-13:** a merge to `main` auto-deploys the isolated **dev** tier (`*.dev.cireweddings.com`, `id.dev`/`dev.musubi.social`), and the production jobs in the same run wait on a human approving the `production` GitHub Environment — no more unattended deploys to live weddings. Path filters mean only changed surfaces deploy. See `[[wiki/runbooks/dev-environment]]`. Architectural decision: **osn-api stays a single Worker** (split deferred). See `[[wiki/runbooks/production-deploy]]`, `[[wiki/runbooks/free-tier-limits]]`.
 
 Phase 1 surfaces:
 
@@ -17,7 +17,7 @@ Phase 1 surfaces:
 | Events | `@pulse/web` + `@pulse/api` (port 3001) + `@pulse/db` | Active |
 | Messaging | `@zap/api` (port 3002) + `@zap/db` | M0 scaffolded; M1 in flight; client app not started |
 | Wedding invites | @cire/api (:8787, prod `api.cireweddings.com`) + @cire/invites (:4321, prod `invite.cireweddings.com`) + @cire/host (:4322, prod `host.cireweddings.com`) + @cire/db + @cire/theme | Active — **deployed** (domain reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; package rename 2026-08-07: `@cire/web`→`@cire/invites`, `@cire/organiser`→`@cire/host`) |
-| Wedding vendor portal | `@cire/vendor` (`https://vendor.cire.localhost`) | Active — the vendor-facing surface for the enquiry flow. See `[[wiki/systems/cire-vendors]]` |
+| Wedding vendor portal | `@cire/vendor` (:4326, prod `vendor.cireweddings.com`) | Active — **deployed (Pages)**. The vendor self-service portal: claim flow and directory listing. See `[[wiki/systems/cire-vendors]]` |
 | Wedding marketing site | `@cire/landing` (:4323) | Active — serves the **apex `cireweddings.com`** (reshuffle 2026-07-16). See `[[wiki/apps/cire-landing]]` |
 | OSN marketing site | `@osn/landing` (:4324) | Active — built (dark/dotted, connections-led). See `[[wiki/apps/osn-landing]]` |
 | Pulse marketing site | `@pulse/landing` (:4325) | Active — built (colourful + fun). See `[[wiki/apps/pulse-landing]]` |
@@ -305,11 +305,15 @@ bun run check            # Type-check all packages (turbo)
 
 The shell is **fish** on the local machine and **bash** in Claude Code's remote
 environments, so a command that works in one can fail to parse in the other.
-Two that bite: an unquoted glob argument (`grep --include=*.ts`) is expanded by
-fish and errors when nothing matches, and a heredoc inside `bash -c '…'` is
-read by fish first. Both are fine under bash. Where a command has a glob or a
-heredoc and has to work in either place, quote the glob (`--include='*.ts'`) or
-put the whole thing in a script file rather than a `-c` string.
+Two that bite. An unquoted glob argument (`grep --include=*.ts`) is expanded by
+fish, which errors when nothing matches; quote it (`--include='*.ts'`). And a
+heredoc is parsed by fish before the command runs unless it is sealed inside
+single quotes: `bash -c 'cat <<EOF … EOF'` is safe, because fish never looks
+inside single quotes, while `bash -c "$(cat <<'EOF' … EOF)"` fails at the bare
+`<<` with `Expected a string, but found a redirection` — and command
+substitution is the shape a long commit message reaches for. Both forms are
+fine under bash. Where a heredoc has to work in either place, write it to a
+file and run the file.
 
 ### Local URLs
 
@@ -369,8 +373,9 @@ bun run test:scripts                  # bun tests under scripts/ — TypeScript 
                                       # a new one needs a step or it runs nowhere
 bun run --cwd <pkg> test:run          # one package, once   (vitest packages)
 bun run --cwd <pkg> test              # one package, watch mode
-bun run --cwd cire/api test           # @cire/api is the exception — bun test, no test:run,
-                                      # and it picks up its own tests/db/ D1 tier
+bun run --cwd cire/api test           # three packages run on `bun test` and have no test:run
+                                      # at all: @cire/api (which also picks up its own
+                                      # tests/db/ D1 tier), @cire/db, @tools/oxlint-house
 
 # Code quality
 bun run lint             # oxlint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Phase 1 surfaces:
 | Identity / auth API | `@osn/api` (port 4000; prod Worker `id.musubi.social`) | Active — **deployed (Worker)** |
 | Identity & graph UI | `@osn/social` (port 1422; prod Pages `musubi.social`) | Active — **deployed (Pages)** |
 | Events | `@pulse/web` + `@pulse/api` (port 3001) + `@pulse/db` | Active |
-| Messaging | `@zap/api` (port 3002) + `@zap/db` | M0 scaffolded; M1 in flight; client app not started |
+| Messaging | `@zap/api` (port 3002) + `@zap/db` | Backend only — per-package milestone status is on `[[wiki/apps/zap]]` |
 | Wedding invites | @cire/api (:8787, prod `api.cireweddings.com`) + @cire/invites (:4321, prod `invite.cireweddings.com`) + @cire/host (:4322, prod `host.cireweddings.com`) + @cire/db + @cire/theme | Active — **deployed** (domain reshuffle 2026-07-16: guest→`invite.`, organiser→`host.`; package rename 2026-08-07: `@cire/web`→`@cire/invites`, `@cire/organiser`→`@cire/host`) |
 | Wedding vendor portal | `@cire/vendor` (:4326, prod `vendor.cireweddings.com`) | Active — **deployed (Pages)**. The vendor self-service portal: claim flow and directory listing. See `[[wiki/systems/cire-vendors]]` |
 | Wedding marketing site | `@cire/landing` (:4323) | Active — serves the **apex `cireweddings.com`** (reshuffle 2026-07-16). See `[[wiki/apps/cire-landing]]` |
@@ -83,7 +83,7 @@ One label is orthogonal to all of that: **`needs:decision`**, on both repos. It 
 | Write or review tests | `[[wiki/conventions/testing-patterns]]` |
 | Run the devloop (named HTTPS hosts per app, a stack per worktree, adding an app to it) | `[[wiki/conventions/devloop-urls]]` |
 | Split one goal across several PRs (stacked PRs — setting the base with the gh CLI, merge order, rebasing a stack) | `[[wiki/conventions/stacked-prs]]` |
-| Add or re-baseline an Astro app's bundle-size guard, or check the src/pages test-route check | `[[wiki/conventions/bundle-size-guards]]` |
+| Write, re-baseline or debug a guard that gates on a number (bundle budgets, and the two rules any such threshold obeys) | `[[wiki/conventions/bundle-size-guards]]` |
 | Add or use UI component (Button, Card, Dialog…) | `[[wiki/architecture/component-library]]` |
 | Raise a toast, theme one for an app, or debug a toast's stacking/contrast | `[[wiki/systems/toast]]` |
 | Add drag-to-reorder to a list (and get the keyboard + screen-reader path for free) | `[[wiki/architecture/drag-and-drop]]` |
@@ -108,77 +108,35 @@ One label is orthogonal to all of that: **`needs:decision`**, on both repos. It 
 
 ### Searching the wiki
 
-Three ways, in order. Try each; drop to the next when it isn't there.
+Three tiers. Try each, drop to the next when it isn't there:
 
-**1. Obsidian MCP (`mcp__obsidian-wiki__*`) — preferred, local sessions only.** The MCP Connector plugin (`mcp-tools-istefox`) serving the `wiki` vault. Reachable when the `mcp__obsidian-wiki__*` tools are listed and a call returns; an error ending `is Obsidian open with the vault loaded?` means it isn't — drop to step 2.
-
-Where it exists:
-
-| Where you're running | Obsidian MCP? |
-|---|---|
-| Claude Code on Aniket's Mac, Obsidian open with the `wiki` vault | Yes — registered at user scope |
-| Claude Code on that Mac, Obsidian shut | No — the server can't resolve a port |
-| Claude Desktop | Only if the `.mcpb` is installed there as well; the Claude Code registration doesn't carry over |
-| Remote or cloud session, cloud agent, CI, another machine | **Never.** It reaches a local Obsidian over `127.0.0.1`. Skip to step 3 — the `obsidian` CLI is local-only too. |
-
-Don't hunt for it, retry it, or ask for it to be started when the tools aren't listed. Absent means absent: go to grep.
-
-| To... | Call |
-|---|---|
-| Search by meaning, not wording | `search_vault_smart` (semantic index over the vault) |
-| Search for an exact string | `search_vault_simple` (substring + surrounding context) |
-| Read one page / up to 20 pages | `get_vault_file`, `get_vault_files` |
-| Read one heading, field, or the outline only | `get_vault_file_partial`, `get_note_outline` |
-| Follow the graph | `get_backlinks`, `get_outgoing_links` |
-| Find pages by tag | `get_files_by_tag`, `list_tags` |
-| Orient in an unfamiliar area | `get_vault_overview`, `list_vault_files` |
-
-Some tools start inactive — `tool_catalog` lists them, `activate_tools` promotes several in one call.
-
-**It always shows you `main`, not your branch.** The vault path is baked into the connector as the `main` worktree's `wiki/`. Obsidian stays open on that one vault; nobody re-points it per branch. Two consequences:
-
-- **Read only.** The write tools (`create_vault_file`, `patch_vault_file`, `search_and_replace`, …) would edit `main`'s working tree, not your branch. Retrieve over MCP; edit wiki pages in your own worktree with Edit/Write.
-- **Your branch's own wiki edits are invisible to it.** Before trusting a page the branch might have changed, run the guard — one command, not a re-read of the wiki:
-
-  ```bash
-  git diff --name-only origin/main...HEAD -- wiki/   # pages this branch changed
-  ```
-
-  Empty output (the usual case) → MCP results are authoritative, use them. Any page you need in that list → read the branch copy with Read; MCP has the pre-branch version.
-
-Keep the vault fresh, since a stale `main` worktree means stale answers. Obsidian re-indexes on file change, and a fast-forward of a clean worktree is safe:
-
-```bash
-git -C ~/.work/osn.git/main pull --ff-only
-```
-
-If it refuses, leave it alone — never force or reset another worktree. Grep your own `wiki/` instead.
-
-That's the whole protocol: freshen, one guard command, then lean on semantic search instead of grepping and reading whole pages.
-
-**2. Obsidian CLI** — same limits: local machine, app running. Invoke the **`obsidian:obsidian-cli` skill** for the command surface; it wraps `obsidian help`, which is authoritative and stays current. Quick reference:
-
-```bash
-which obsidian 2>/dev/null || echo "not installed"
-obsidian search vault=wiki query="arc tokens"          # full-text search
-obsidian search:context vault=wiki query="arc tokens"  # search with line context
-obsidian tag vault=wiki name=systems verbose           # list files tagged #systems
-obsidian read vault=wiki path=systems/arc-tokens.md    # read a page
-obsidian backlinks vault=wiki file=arc-tokens          # find pages linking to it
-obsidian files vault=wiki folder=systems               # list files in a folder
-```
-
-Two repo-specific rules the skill can't know:
-
-- **Paths are vault-root-relative, and the vault root is `wiki/`.** `path=systems/arc-tokens.md`, not `path=wiki/systems/...` — the latter errors with `File not found`. `file=` takes a wikilink target (`file=arc-tokens`) instead.
-- **Read only, same as the MCP and for the same reason.** The CLI acts on the vault, and the vault is `main`'s `wiki/`. `create`, `append`, and `property:set` would write to `main`'s working tree, not your branch. There are three vaults registered (`wiki`, `echo_chamber`, `vault_india_22`) — always pass `vault=wiki` rather than trusting the default.
-
-**3. grep** — works everywhere, including remote and CI. Reads your worktree's own `wiki/`:
+1. **Obsidian MCP** (`mcp__obsidian-wiki__*`) — semantic search, outlines,
+   backlinks. **Local machine with Obsidian open, and nowhere else.**
+2. **The `obsidian` CLI** — same limits: local machine, app running.
+3. **grep** — works everywhere, including remote and CI.
 
 ```bash
 grep -r "arc token" wiki/ --include="*.md" -l          # find matching pages
 grep -r "arc token" wiki/ --include="*.md" -n          # with line numbers
 ```
+
+Two rules that apply to the first two tiers and cost real time when missed.
+**Both are read-only**: they act on the `main` worktree's `wiki/`, so a write
+through either edits `main`'s working tree instead of your branch. And **both
+show you `main`, not your branch** — before trusting a page this branch might
+have changed, run the guard, not a re-read:
+
+```bash
+git diff --name-only origin/main...HEAD -- wiki/   # pages this branch changed
+```
+
+Empty output, the usual case, means the results are authoritative. Anything in
+that list, read with Read instead.
+
+The rest — which tool answers which kind of question, where each tier does and
+does not exist, vault-relative paths, keeping the vault fresh — is in
+`[[wiki/conventions/wiki-search]]`. Grep can read that page from any session,
+which is why the grep tier is written out here rather than only there.
 
 ### Writing to the wiki
 
@@ -272,7 +230,6 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 | Map-membership guards | A guard that narrows to `keyof typeof MAP` must test `Object.hasOwn(MAP, key)`, never `key in MAP`. `in` walks the prototype chain, so `constructor`, `toString` and `__proto__` pass and the predicate then asserts an inherited `Object.prototype` member is a real entry. `house/no-in-operator-key-guard` (in `tools/oxlint/house`) is an error, and it matches the narrowed parameter rather than the literal `keyof typeof` syntax, so an aliased predicate is caught too — see `cire/theme/src/palette.ts` for the house form |
 | Non-subscribing store reads | In a `*-store.ts` organiser cache (cire only), `entryFor(id).accessor()` is the subscribing read — it mints the cache entry, so a tracked read always has something to register a dependency on. `cache.get(id)?.accessor()` does not mint the entry: when it is absent the read short-circuits before `accessor` ever runs, so a tracked read registers zero dependencies and never re-runs once the entry is created. That non-minting form is confined to `peekCached*`/`hasCached*` functions, whether written as the direct `cache.get(id)?.accessor()` chain or split across a `const entry = cache.get(id)` and a later `entry?.accessor()` / guarded `entry.accessor()`. `house/no-non-subscribing-store-read` (in `tools/oxlint/house`) enforces it as an error, scoped to `cire/**/*-store.ts` |
 | Where tests live | `tests/` at the package root, mirroring `src/` — **never** beside the source. Test-only support code (mocks, request harnesses, fixtures) lives there too, so `src/` holds nothing test-shaped: `cire/api/tests/test-helpers/`, `cire/host/tests/test-support/`. `scripts/` is not a workspace but follows the same rule (`scripts/tests/`, shell tests included). The one deliberate carve-out is the Miniflare-backed D1 tier at `tests/d1/` (cire's at `tests/db/`), which the vitest configs exclude by path because it imports `bun:test` and boots workerd — `bun run test:d1` is the only thing that runs it. See `[[wiki/conventions/testing-patterns]]` |
-| Guard thresholds | A guard that gates on a number — a bundle budget, a query-count cap, a timing ceiling — obeys two rules. **The number lives in one committed file the guard reads**, never as an argument at each call site: `scripts/bundle-size-budgets.txt` is the worked example, and it replaced the same threshold copied into six `package.json` scripts, one `ci.yml` step and eight `deploy.yml` steps, any one of which could be missed on a re-baseline. **The headroom is smaller than the smallest mistake the guard exists to catch**, measured against the current build rather than carried over from an older one — a guard whose slack exceeds the mistake can never fire, which is how a bundle budget once carried 47657 bytes of headroom against a 21261-byte dependency. Both rules, and the re-baselining recipe, are in `[[wiki/conventions/bundle-size-guards]]` |
 | Pre-commit | lefthook runs oxlint + oxfmt (auto-fix + re-stage) on staged files |
 | Pre-push | lefthook runs type check |
 | oxlint | `oxlintrc.json` — plugins: typescript, unicorn, oxc, import, promise, vitest, node, jsx-a11y (React plugin disabled — SolidJS) |
@@ -352,7 +309,7 @@ The names mirror production hostnames, and the nesting is load-bearing: a WebAut
 
 Because those hostnames differ per worktree, no app can be told where its siblings live from a committed `.env`. Each `dev:app` runs through the `dev-env` launcher (`@shared/dev-urls`), which derives every sibling's origin from the app's own `PORTLESS_URL` and exports the same env vars the deployed tiers set (`OSN_ISSUER_URL`, `WEB_ORIGIN`, `PUBLIC_API_URL`, …). Those values win over `.env`. Adding an app means the `"portless"` key in its `package.json` and an entry in `DEV_APPS` (`shared/dev-urls/src/index.ts`), plus its env-var map in `src/app-env.ts`; a test asserts the first two agree.
 
-**What it costs.** A steady-state page load is 15–40 ms slower through the proxy — the TLS handshake and the hop. The *first* load after a cold start is the one to know about: about 3× slower on `@pulse/web` (~2.9 s vs ~0.87 s), because HTTP/2 drops the browser's per-origin connection cap and Vite's whole unbundled module graph arrives at a single-threaded dev server at once. Numbers and method are in `[[wiki/conventions/devloop-urls]]`.
+**What it costs.** Tens of milliseconds in the steady state, and a markedly slower *first* load after a cold start. Numbers, method and the reason are in `[[wiki/conventions/devloop-urls]]`.
 
 To run without the proxy, on the fixed ports the repo used before (`:4000` osn-api, `:8787` cire-api, `:1422` musubi, …):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,13 +307,15 @@ The shell is **fish** on the local machine and **bash** in Claude Code's remote
 environments, so a command that works in one can fail to parse in the other.
 Two that bite. An unquoted glob argument (`grep --include=*.ts`) is expanded by
 fish, which errors when nothing matches; quote it (`--include='*.ts'`). And a
-heredoc is parsed by fish before the command runs unless it is sealed inside
-single quotes: `bash -c 'cat <<EOF … EOF'` is safe, because fish never looks
-inside single quotes, while `bash -c "$(cat <<'EOF' … EOF)"` fails at the bare
-`<<` with `Expected a string, but found a redirection` — and command
-substitution is the shape a long commit message reaches for. Both forms are
-fine under bash. Where a heredoc has to work in either place, write it to a
-file and run the file.
+heredoc fails whenever its `<<` reaches fish's own tokenizer, which fish reads
+as a redirection: `fish: Expected a string, but found a redirection`. Quoting
+style is not what decides that — `bash -c 'cat <<EOF … EOF'` and
+`bash -c "cat <<EOF … EOF"` both run, because fish passes a quoted argument
+through as text and bash does the parsing. What breaks it is a `$(…)` command
+substitution, whose body fish parses itself: `bash -c "$(cat <<EOF … EOF)"`
+errors before bash is ever reached, with or without a quoted delimiter. That
+is the shape a long commit message reaches for, so write those to a file and
+pass the file (`git commit -F <file>`). All of it is fine under bash.
 
 ### Local URLs
 

--- a/scripts/guard-bundle-size.sh
+++ b/scripts/guard-bundle-size.sh
@@ -30,7 +30,7 @@
 # single source of truth. A threshold living in one place is the whole point:
 # it used to be a `<package-dir> <mode> <threshold>` argument, copied by hand
 # into six package.json build scripts, a ci.yml step and eight deploy.yml
-# steps — eight to fourteen copies of the same number, silently divergeable by
+# steps — fifteen copies of the same number, silently divergeable by
 # missing one on a re-baseline. There is deliberately no way to pass a
 # threshold on the command line any more.
 #

--- a/wiki/apps/zap.md
+++ b/wiki/apps/zap.md
@@ -10,7 +10,7 @@ related:
   - "[[social-graph]]"
   - "[[arc-tokens]]"
   - "[[monorepo-structure]]"
-last-reviewed: 2026-08-17
+last-reviewed: 2026-09-07
 ---
 
 # Zap
@@ -97,7 +97,7 @@ This split is by design: c2b body content is server-visible, user-attributed dat
 
 ### CI pipeline
 
-A `deploy-zap-api` job exists in `.github/workflows/deploy.yml` but is **dormant**: it activates once the prod D1 `database_id` is filled in `zap/api/wrangler.toml` `[env.production]`. See the zap-api production bring-up runbook for the manual steps to activate it.
+`deploy-zap-api` in `.github/workflows/deploy.yml` is **live**. It was written to stay dormant until the production D1 existed, and that condition is met: `[[env.production.d1_databases]]` in `zap/api/wrangler.toml` carries a real `database_id`, so the job's `zapcheck` step sets `provisioned=true` and deploys instead of skipping. Only dev and staging still hold `placeholder-replace-after-d1-create`, which the check ignores on purpose. It runs on a merge to `main` that touches `zap/api`, and like every production job it waits on a human approving the `production` GitHub Environment — see [[production-deploy]].
 
 ## Authentication & authorization
 

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -7,7 +7,7 @@ related:
   - "[[frontend-patterns]]"
   - "[[testing-patterns]]"
   - "[[review-findings]]"
-last-reviewed: 2026-09-06
+last-reviewed: 2026-09-07
 ---
 
 # Astro bundle-size guards
@@ -20,6 +20,34 @@ fix cire/invites got: both mistakes can happen in any of the repo's six Astro
 apps, and both are now checked on every one of them.
 
 Two separate scripts, because the two mistakes are different shapes.
+
+## Two rules for any guard that gates on a number
+
+These are not about bundles. They apply to any guard with a threshold in it —
+a size budget, a query-count cap, a timing ceiling — and both were learned here
+by getting them wrong first.
+
+**The number lives in one committed file the guard reads.** Never as an
+argument at each call site. `scripts/bundle-size-budgets.txt` is the worked
+example, and what it replaced was the same threshold typed into six
+`package.json` build scripts, one `ci.yml` step and eight `deploy.yml` steps —
+fifteen copies, and a re-baseline that missed one left a guard enforcing a
+number nobody meant. One file also means the guard can refuse to run for a
+package with no row, rather than passing silently.
+
+**The headroom is smaller than the smallest mistake the guard exists to
+catch**, measured against the current build rather than carried over from an
+older one. A guard whose slack exceeds the mistake cannot fire, whatever it
+prints. This one nearly shipped: the invites threshold budgeted 47657 bytes of
+headroom, which was `motion`'s cost back when that build was *unminified*. In
+the minified build the same library costs 21261 bytes, so a fresh dependency of
+exactly the class the guard was written for would have landed under the line
+and deployed. The fix was to re-measure against the build as it is now and set
+the headroom to ~11.7 KB, roughly half the mistake.
+
+The corollary is a check, not a rule: **you have not verified a guard until you
+have seen it fail.** Break the input, watch the non-zero exit. A guard that
+only ever passes is indistinguishable from one that cannot fail.
 
 ## `scripts/guard-bundle-size.sh` — the size guard
 

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -62,7 +62,7 @@ for a human reading the wiki. If the two ever disagree, the `.txt` file is
 right and this page is stale; re-read it rather than trusting the table below.
 That split used to not exist: the threshold was a third command-line argument,
 copied by hand into six `package.json` build scripts, one `ci.yml` step and
-eight `deploy.yml` steps — eight-plus copies of the same number, silently
+eight `deploy.yml` steps — fifteen copies of the same number, silently
 divergeable by missing one on a re-baseline. There is now exactly one place to
 edit.
 

--- a/wiki/conventions/wiki-search.md
+++ b/wiki/conventions/wiki-search.md
@@ -91,6 +91,7 @@ Two repo-specific rules the skill can't know:
 grep -r "arc token" wiki/ --include="*.md" -l          # find matching pages
 grep -r "arc token" wiki/ --include="*.md" -n          # with line numbers
 ```
+
 ## Related
 
 - [[index]] — the full page-by-page map this search protocol is for

--- a/wiki/conventions/wiki-search.md
+++ b/wiki/conventions/wiki-search.md
@@ -1,0 +1,97 @@
+---
+title: Searching the wiki
+description: The three ways to search this vault — the Obsidian MCP, the obsidian CLI, and grep — which exist where, and the one guard that stops a branch reading stale
+tags: [convention, wiki, obsidian, search]
+related:
+  - "[[index]]"
+  - "[[contributing]]"
+last-reviewed: 2026-09-07
+---
+
+# Searching the wiki
+
+`CLAUDE.md` carries the short version: three tiers, and grep is the one that
+works everywhere. This page is the long version — what each tier can do, where
+it exists, and the traps in the two that talk to a running Obsidian.
+
+**Read this page with grep if you are anywhere but the local machine.** The
+first two tiers below reach a local Obsidian over `127.0.0.1` and are simply
+absent in a remote or CI session, which is exactly the session most likely to
+need a search protocol. That is why the grep tier stays written out in
+`CLAUDE.md` itself rather than only here.
+
+Three ways, in order. Try each; drop to the next when it isn't there.
+
+**1. Obsidian MCP (`mcp__obsidian-wiki__*`) — preferred, local sessions only.** The MCP Connector plugin (`mcp-tools-istefox`) serving the `wiki` vault. Reachable when the `mcp__obsidian-wiki__*` tools are listed and a call returns; an error ending `is Obsidian open with the vault loaded?` means it isn't — drop to step 2.
+
+Where it exists:
+
+| Where you're running | Obsidian MCP? |
+|---|---|
+| Claude Code on Aniket's Mac, Obsidian open with the `wiki` vault | Yes — registered at user scope |
+| Claude Code on that Mac, Obsidian shut | No — the server can't resolve a port |
+| Claude Desktop | Only if the `.mcpb` is installed there as well; the Claude Code registration doesn't carry over |
+| Remote or cloud session, cloud agent, CI, another machine | **Never.** It reaches a local Obsidian over `127.0.0.1`. Skip to step 3 — the `obsidian` CLI is local-only too. |
+
+Don't hunt for it, retry it, or ask for it to be started when the tools aren't listed. Absent means absent: go to grep.
+
+| To... | Call |
+|---|---|
+| Search by meaning, not wording | `search_vault_smart` (semantic index over the vault) |
+| Search for an exact string | `search_vault_simple` (substring + surrounding context) |
+| Read one page / up to 20 pages | `get_vault_file`, `get_vault_files` |
+| Read one heading, field, or the outline only | `get_vault_file_partial`, `get_note_outline` |
+| Follow the graph | `get_backlinks`, `get_outgoing_links` |
+| Find pages by tag | `get_files_by_tag`, `list_tags` |
+| Orient in an unfamiliar area | `get_vault_overview`, `list_vault_files` |
+
+Some tools start inactive — `tool_catalog` lists them, `activate_tools` promotes several in one call.
+
+**It always shows you `main`, not your branch.** The vault path is baked into the connector as the `main` worktree's `wiki/`. Obsidian stays open on that one vault; nobody re-points it per branch. Two consequences:
+
+- **Read only.** The write tools (`create_vault_file`, `patch_vault_file`, `search_and_replace`, …) would edit `main`'s working tree, not your branch. Retrieve over MCP; edit wiki pages in your own worktree with Edit/Write.
+- **Your branch's own wiki edits are invisible to it.** Before trusting a page the branch might have changed, run the guard — one command, not a re-read of the wiki:
+
+  ```bash
+  git diff --name-only origin/main...HEAD -- wiki/   # pages this branch changed
+  ```
+
+  Empty output (the usual case) → MCP results are authoritative, use them. Any page you need in that list → read the branch copy with Read; MCP has the pre-branch version.
+
+Keep the vault fresh, since a stale `main` worktree means stale answers. Obsidian re-indexes on file change, and a fast-forward of a clean worktree is safe:
+
+```bash
+git -C ~/.work/osn.git/main pull --ff-only
+```
+
+If it refuses, leave it alone — never force or reset another worktree. Grep your own `wiki/` instead.
+
+That's the whole protocol: freshen, one guard command, then lean on semantic search instead of grepping and reading whole pages.
+
+**2. Obsidian CLI** — same limits: local machine, app running. Invoke the **`obsidian:obsidian-cli` skill** for the command surface; it wraps `obsidian help`, which is authoritative and stays current. Quick reference:
+
+```bash
+which obsidian 2>/dev/null || echo "not installed"
+obsidian search vault=wiki query="arc tokens"          # full-text search
+obsidian search:context vault=wiki query="arc tokens"  # search with line context
+obsidian tag vault=wiki name=systems verbose           # list files tagged #systems
+obsidian read vault=wiki path=systems/arc-tokens.md    # read a page
+obsidian backlinks vault=wiki file=arc-tokens          # find pages linking to it
+obsidian files vault=wiki folder=systems               # list files in a folder
+```
+
+Two repo-specific rules the skill can't know:
+
+- **Paths are vault-root-relative, and the vault root is `wiki/`.** `path=systems/arc-tokens.md`, not `path=wiki/systems/...` — the latter errors with `File not found`. `file=` takes a wikilink target (`file=arc-tokens`) instead.
+- **Read only, same as the MCP and for the same reason.** The CLI acts on the vault, and the vault is `main`'s `wiki/`. `create`, `append`, and `property:set` would write to `main`'s working tree, not your branch. There are three vaults registered (`wiki`, `echo_chamber`, `vault_india_22`) — always pass `vault=wiki` rather than trusting the default.
+
+**3. grep** — works everywhere, including remote and CI. Reads your worktree's own `wiki/`:
+
+```bash
+grep -r "arc token" wiki/ --include="*.md" -l          # find matching pages
+grep -r "arc token" wiki/ --include="*.md" -n          # with line numbers
+```
+## Related
+
+- [[index]] — the full page-by-page map this search protocol is for
+- [[contributing]] — the PR workflow the wiki edits ride in on

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -103,6 +103,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[stacked-prs]] — basing one PR on another with the gh CLI, and merging the stack
 - [[component-lab]] — the in-repo Storybook replacement: prototyping components, three.js and canvas
 - [[bundle-size-guards]] — per-app Astro bundle-size guard + the src/pages test-route check, across all six apps
+- [[wiki-search]] — the three ways to search this vault, which exist where, and the guard that stops a branch reading stale
 
 ## Compliance
 


### PR DESCRIPTION
## Summary

Two jobs on one file. Six things `CLAUDE.md` said about this repo were no
longer true, and four blocks in it did not need to be there at all — it loads
in full every session, so occasional detail costs context every time it is not
needed. The corrections are below; the four blocks moved to wiki pages that are
pulled on demand, and `CLAUDE.md` is about 4.4 KB lighter for it.

A reader would have acted on all six errors. The worst was self-contradictory: the deployment
paragraph said the `OSN_EMAIL_OPTIONAL` degraded-boot mode "was dropped in
#160" while the Key Patterns table three sections later still described it as
live — and the code agrees with the table. This corrects all six against the
code, adds two rules the file never carried, and drops nine command lines that
had drifted.

Corrections:

- `OSN_EMAIL_OPTIONAL` still exists, is what `selectEmailLayer`
  (`osn/api/src/lib/email-layer.ts`) reads, and has its own tests.
- The database is `bun:sqlite` locally and Cloudflare D1 deployed. The Tech
  line read "SQLite→Supabase"; Supabase is a deferred decision in the wiki
  (`wiki/deferred-decisions.md`), not the stack.
- Cross-device login is no longer in-memory only — it sits in the shared
  ceremony-store bundle, Redis-backed where a client is configured.
- `@cire/vendor` was missing from the Phase 1 surfaces table.
- `dev:cire` was described in terms of `@cire/web` and `@cire/organiser`,
  renamed a month ago, and four dev scripts were undocumented. It also does
  not start `@cire/vendor`, which is worth knowing before debugging why the
  vendor site is not up.
- The deployment paragraph was labelled `2026-06-18` and covers events to
  `2026-08-13`.

Additions, both learned the expensive way in #894 and #904 and until now
living only in one script's comments or in an agent's memory:

- **Guard thresholds** — the number lives in one committed file the guard
  reads, never at each call site; and the headroom is smaller than the
  smallest mistake the guard exists to catch. A guard whose slack exceeds the
  mistake cannot fire.
- **Never a bare `bun install`** — resolving on one machine prunes every entry
  for a platform it is not running on.

Also documents that the shell is fish locally and bash in the remote
environments, which decides whether a glob or a heredoc in a command parses at
all.

## Workspaces affected

None. The diff is `CLAUDE.md`, three wiki pages and one comment in
`scripts/guard-bundle-size.sh`.
`scripts/changeset-required.sh` returns `skip` — top-level prose, `wiki/` and `scripts/` are all on
the allowlist — so this PR carries no changeset by design, not by omission.

## Issues

This branch closes no issue.

**Opened**

None.

## Decisions

### The email row contradicted the email paragraph — `approach`

- **Issue** — the deployment paragraph said `OSN_EMAIL_OPTIONAL` "was dropped
  in #160"; the Key Patterns table said it is the last step in the transport
  selection chain. Both sentences were in the same file.
- **Why** — a contradiction inside one document is worse than either sentence
  being wrong on its own, because a reader has no way to tell which half to
  trust and the file stops being an authority.
- **Solution** — checked `osn/api/src/lib/email-layer.ts`. `selectEmailLayer`
  still reads the variable and `osn/api/tests/lib/email-layer.test.ts` still
  covers it. The table was right; the paragraph is corrected.
- **Rationale** — the code decides. What #160 changed was the production
  config, not the code path, and the paragraph recorded the deploy as if it
  were a removal.

### Four blocks left CLAUDE.md for the wiki — `approach`

- **Issue** — `CLAUDE.md` loads in full every session, so anything in it that
  is needed only occasionally costs context every time it is not needed. Four
  blocks were paying that rent: the guard-threshold rules, the 74-line wiki
  search protocol, a portless benchmark paragraph, and Zap's milestone status.
- **Why** — a file that is always loaded should hold what is always needed.
  Detail that is needed on demand should be pulled on demand, and this repo
  already has the mechanism: a wiki page and a navigation row pointing at it.
- **Solution** — the guard-threshold rules now open
  `wiki/conventions/bundle-size-guards.md` as rules about any threshold guard
  rather than a bundle-only one, with the corollary that a guard is not
  verified until it has been seen to fail; the search protocol became
  `wiki/conventions/wiki-search.md`, leaving the tier names, the grep commands
  in full and the two rules that cost real time; the portless paragraph became
  one sentence and the link to `wiki/conventions/devloop-urls.md` that was
  already two lines below it; and the Messaging row defers to
  `wiki/apps/zap.md`, which tracks that status per package.
- **Rationale** — grep stays written out inline on purpose. It is the tier
  that reads the new page from a remote session, where the other two do not
  exist, so moving it would have made the protocol unreachable exactly where
  it is most needed.

### The threshold count disagreed with itself — `D-M1`

- **Issue** — the moved guard-threshold text counted fifteen hand-copied call
  sites. Thirty lines below on the same page the older text said "eight-plus",
  and `scripts/guard-bundle-size.sh` said "eight to fourteen" — an upper bound
  below the real figure.
- **Why** — one page stating a fact two ways teaches a reader to distrust the
  more precise version.
- **Solution** — counted it against the commit that removed them: six
  `package.json` build scripts, one `ci.yml` step, eight `deploy.yml` steps.
  Both older copies now say fifteen.
- **Rationale** — the number is the argument for the rule. A vague one makes
  the rule sound like a preference.

### `wiki/apps/zap.md` said a live deploy job was dormant — `D-L1`

- **Issue** — the page said `deploy-zap-api` waits on a production D1 id being
  filled. It was filled on 2026-07-19, so the job's `zapcheck` step sets
  `provisioned=true` and deploys rather than skipping. The page also cited a
  zap-api bring-up runbook that does not exist.
- **Why** — this PR makes that page the single copy of Zap's status, so its
  being wrong is the cost of the move rather than a pre-existing nit. A reader
  routed there would have concluded zap-api is not live.
- **Solution** — corrected against `zap/api/wrangler.toml` and the workflow,
  including what actually gates the deploy: the `production` Environment
  approval. The dangling runbook reference now points at `production-deploy`.
- **Rationale** — deferring a fact to a page only pays off if the page is
  right. Checking it was part of the move, not extra scope.

### The shell paragraph was wrong twice before it was right — `D-M3`

- **Issue** — the first version said a heredoc inside `bash -c '…'` is read by
  fish first. That is the *safe* form. The fix then said a heredoc is parsed by
  fish "unless it is sealed inside single quotes", which is also false —
  `bash -c "cat <<EOF … EOF"` works.
- **Why** — either version would have sent a reader to rewrite a command that
  already works, while saying nothing about the shape that actually fails.
- **Solution** — the trigger is a `$(…)` command substitution, whose body fish
  parses itself, so the bare `<<` inside it is read as a fish redirection. All
  four shapes were run against fish 4.9.2: both quoted forms pass, both
  substitution forms fail with `Expected a string, but found a redirection`.
- **Rationale** — this was caught by the review, then the re-review caught the
  fix. It is the argument for the re-review pass in one finding: a fix is new
  unreviewed text, and this one closed its finding while introducing a broader
  wrong claim.

### `bun run reset` still chains a bare install — `approach`

- **Issue** — the lockfile rule this PR adds says never a bare `bun install`,
  and `bun run reset` is `bun run clean && bun i`.
- **Why** — a rule that a shipped script contradicts teaches a reader to
  ignore the rule.
- **Solution** — documented as the exception, with what to do about it (check
  `git diff bun.lock` afterwards and discard the pruning), rather than changed.
- **Rationale** — fixing the script drags the root `package.json` into the
  diff, and `scripts/changeset-required.sh` then requires a changeset naming a
  package that ships nothing from this change. Worth its own PR, not worth
  turning a prose correction into a versioning problem.

**Out of scope** — three trims identified and left alone, all judgment calls
about what belongs in `CLAUDE.md` rather than factual errors: the ~90-line
`### Searching the wiki` section, two of whose three tiers are local-only; the
portless benchmark paragraph, which duplicates
`wiki/conventions/devloop-urls.md`; and the Messaging status line, not
re-checked in this pass.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Changeset needed? | `git diff --name-only origin/main...HEAD \| ./scripts/changeset-required.sh` | `skip` — top-level prose is on the allowlist |
| Changeset validity | `bash scripts/validate-changesets.sh` | pass |
| Type check | `bun run check` | not run — no `node_modules` in this worktree |
| Tests | `bun run test` | not run — same reason |
| Lint / format | `bun run lint`, `bun run fmt:check` | not run — same reason |

Installing here would mean a bare `bun install`, which is the thing this PR
documents as forbidden. The diff is one prose file: it touches no source, no
config, no workflow and no `package.json`, and no CI gate reads `CLAUDE.md`,
so none of those gates can change verdict because of it.

What was actually verified, by running it rather than by reasoning:

| Claim | How |
|---|---|
| `OSN_EMAIL_OPTIONAL` is live | read `selectEmailLayer` and its tests |
| Cross-device store is Redis-backed | `osn/api/src/lib/redis-ceremony-stores.ts` carries `CrossDeviceRequest` |
| `@cire/vendor` is `:4326` / `vendor.cireweddings.com` | `shared/dev-urls/src/index.ts:56`, `deploy.yml` deploy jobs |
| Three packages run `bun test` with no `test:run` | read every workspace `package.json` with a `test*` script |
| `bun test` never collects a `*.test.sh` | ran `bun test ./scripts/` — 13 files, none of the three shell tests |
| All three shell tests still run in CI | grepped `.github/workflows/` for each by name |
| The four fish heredoc shapes | ran all four under fish 4.9.2 |
| Fifteen threshold call sites | counted against the commit that removed them |
| `deploy-zap-api` is live, not dormant | ran the workflow's own `zapcheck` awk against `zap/api/wrangler.toml` |
| `guard-bundle-size.sh` still parses | `bash -n` |
| Every wikilink added | `test -e` on each target under `wiki/` |

Reviews, three rounds, each scoped to what the last one produced:
`review-docs` on the first commit (3 Medium → `fe895094`), a re-review of that
fix commit (1 Medium → `46e8eb1d`), and a review of the move commit
(1 Medium, 2 Low → `dabb5568`). Every round found something, and two of the
three found a defect in the previous round's fix rather than in the original
work. Performance and security reviews were deliberately not run — a
prose diff introduces no query, route, token or dependency for either to
examine.
