### PR TITLE
docs(wiki): record how to drive the built app by hand

### DIFF
--- a/wiki/apps/cire-landing.md
+++ b/wiki/apps/cire-landing.md
@@ -11,7 +11,7 @@ related:
   - "[[production-deploy]]"
   - "[[free-tier-limits]]"
   - "[[dev-environment]]"
-last-reviewed: 2026-08-13
+last-reviewed: 2026-09-07
 ---
 
 # Cire Landing
@@ -242,8 +242,10 @@ platform is a product decision, not a migration — see [[cire]].
   richer still; deferred until there is an asset pipeline for it. Swap point is
   `makeSealMesh()` — the lighting, pointer lean and PE fallback all stay. The
   seal is now visually verified: headless Chrome renders WebGL, so screenshot
-  `bun run dev:landing` (`--headless=new --screenshot --virtual-time-budget`)
-  when tuning `bumpScale` / lights / pour parameters.
+  `bun run dev:cire-landing` at `https://cire.localhost`
+  (`--headless=new --screenshot --virtual-time-budget`) when tuning `bumpScale` /
+  lights / pour parameters. The recipe is in [[browser-tests]] § Driving the
+  whole app by hand. (`dev:landing` is `@osn/landing`, a different site.)
 - **Real photography** — imagery is still hotlinked Unsplash placeholders
   (`lib/site.ts` `IMAGES`); swap for the brand's own art when it exists.
 

--- a/wiki/conventions/browser-tests.md
+++ b/wiki/conventions/browser-tests.md
@@ -82,58 +82,20 @@ there is a genuinely useful complement, because it names the mechanism while the
 browser test proves the outcome. `RsvpModal.test.tsx` and
 `RsvpModal.browser.test.tsx` are the worked example of that pairing.
 
-## Driving the whole app by hand
-
-This tier proves a component in isolation. The other half — seeing the built app
-the way a guest sees it — has no automated home and is worth writing down,
-because both cire invite reveal bugs were found this way after the whole test
-suite stayed green through them.
-
-For a still frame, headless Chrome needs nothing installed and renders WebGL
-through SwiftShader:
-
-```bash
-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new \
-  --screenshot=out.png --window-size=1440,900 --hide-scrollbars \
-  --virtual-time-budget=15000 "https://invite.cire.localhost/"
-```
-
-`--virtual-time-budget` fast-forwards timers and `requestAnimationFrame`, so a
-lazy scene or a fade-in has finished by the time the frame is taken. Vary
-`--window-size` for the phone case (390×844). This is how [[cire-landing]]'s wax
-seal was checked.
-
-**A still frame cannot see an animation bug.** Both reveal failures were single
-frames — one full-brightness paint before a snap to `opacity: 0` — invisible to
-happy-dom and to any assertion made after the fact. Drive the page with
-Playwright (already a devDependency of `@cire/invites`) and sample
-`getComputedStyle` on every `requestAnimationFrame`.
-
-Four traps, each of which has cost an hour or more:
-
-| Trap | What it looks like | What to do |
-|---|---|---|
-| `astro dev` never reaches `networkidle` | `page.goto` hangs until it times out | The HMR socket stays open by design — use `waitUntil: "load"` |
-| Below-the-fold islands hydrate on visibility | The component under test never mounts, and the page looks broken rather than un-hydrated | Both invite designs mount everything past the header as `client:visible={{ rootMargin: "600px" }}` — scroll it into view, or assert against the `client:load` header only |
-| The claim endpoint allows **5 attempts per minute per IP** | Back-to-back scenario runs 429, and the invite renders "Something went wrong" with no events — identical to the reveal regression you are chasing | `defaultClaimLimiter` in `cire/api/src/app.ts`. Space the runs out before believing a result |
-| A credentialed stub API echoing `*` | `…/registry/mine` silently reads as signed out | A CORS stub for a credentialed fetch must echo the exact origin |
-
-Anything proved this way that can be pinned belongs back in the tier above — the
-`EventCard` and `InvitePage` browser tests are both the settled form of a bug
-first seen by hand.
-
 ## How it is wired
 
 `cire/invites/vitest.config.ts` and `cire/host/vitest.config.ts` each define two
 projects:
 
 - **`unit`** — jsdom, `exclude`s `**/*.browser.test.{ts,tsx}`
-- **`browser`** — `include`s only `src/**/*.browser.test.{ts,tsx}`, Playwright
+- **`browser`** — `include`s only `tests/**/*.browser.test.{ts,tsx}`, Playwright
   provider, headless Chromium
 
 Naming rather than directory placement decides the project, so a file lands in
-exactly one and neither glob can swallow the other's files. Browser tests sit
-next to the code they cover, like every other test in the repo.
+exactly one and neither glob can swallow the other's files. Browser tests live
+in the package's `tests/` tree beside their fast-tier siblings, like every other
+test in the repo — #867 moved the whole cire suite there, and a browser test
+left next to its component matches no glob and silently never runs.
 
 Both projects share `solidPlugin()` and `tailwindcss()`, so a browser test gets
 the **same Tailwind build the app ships**. Import `../styles/global.css` at the
@@ -271,3 +233,53 @@ hit test.
   failure is the worst combination — it gets skipped rather than fixed. Assert
   `transitionDuration` first, so a clamped transition fails on its cause rather
   than as a confusing `scale === 1`.
+
+## Driving the whole app by hand
+
+This tier proves a component in isolation. The other half — opening the built
+app and watching it — has no automated home, and is worth writing down because
+the two reveal bugs on the guest invite were both found that way while the whole
+suite stayed green: **#296**, where the unlock reveal broke under motion v12 and
+guests saw no events after a successful claim, and **#742**, where the reveal
+flashed at full brightness before snapping back and then animated a section
+whose cards had not arrived.
+
+For a still frame, headless Chrome needs nothing installed:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new \
+  --screenshot=out.png --window-size=1440,900 --hide-scrollbars \
+  --virtual-time-budget=15000 "https://invite.cire.localhost/<slug>"
+```
+
+Point it at a wedding slug, never the bare host: `src/pages/index.astro` 302s
+`/` to `MARKETING_URL`, which falls back to the **live** `cireweddings.com` when
+`PUBLIC_MARKETING_URL` is unset — which is what copying `.env.example` gives
+you. A screenshot of `/` is a picture of the marketing site, with no error to
+say so.
+
+`--virtual-time-budget` fast-forwards timers and `requestAnimationFrame`, so a
+lazy scene or a fade-in has finished by the time the frame is taken. Vary
+`--window-size` for the phone case (390×844). The same command renders WebGL
+through SwiftShader, which is how [[cire-landing]]'s wax seal is checked — at
+`https://cire.localhost`, the landing site's own host.
+
+**A still frame cannot see an animation bug.** #742 was a single frame, and a
+one-frame flash is invisible both to jsdom and to any assertion made after the
+animation has settled. Drive the page with Playwright (see
+[Running it locally](#running-it-locally)) and sample `getComputedStyle` on
+every `requestAnimationFrame`.
+
+Five traps, each of which has cost an hour or more:
+
+| Trap | What it looks like | What to do |
+|---|---|---|
+| `astro dev` backgrounds itself under an agent | The URL 404s seconds after `bun run dev` reported success, while a stray daemon still holds the port | Astro 7 detects the agent environment and portless deregisters the route when its child exits. Run `CLAUDECODE= bun run dev`; clear a stray with `bunx astro dev stop` |
+| `astro dev` never reaches `networkidle` | `page.goto` hangs until it times out | The HMR socket stays open by design — use `waitUntil: "load"` |
+| Below-the-fold islands hydrate on visibility | The component under test never mounts, and the page reads as broken rather than un-hydrated | Both invite designs mount `InvitePage` and `GiftRegistryTeaser` as `client:visible={{ rootMargin: "600px" }}` (`ConsentBanner` is `client:idle`) — scroll them into view, or assert against the `client:load` header only |
+| The claim endpoint allows **5 attempts per minute per IP** | Back-to-back runs 429, and the invite renders "Something went wrong" with no events — identical to the reveal regression you are chasing | `defaultClaimLimiter` in `cire/api/src/app.ts`. Space the runs out before believing a result |
+| A credentialed stub API echoing `*` | `…/registry/mine` silently reads as signed out | A CORS stub for a credentialed fetch must echo the exact origin |
+
+Anything proved this way that can be pinned belongs back in the tier above:
+`InvitePage.browser.test.tsx` covers the first-visit reveal path precisely
+because that is where the reveal left its inline `transform` behind.

--- a/wiki/conventions/browser-tests.md
+++ b/wiki/conventions/browser-tests.md
@@ -8,7 +8,7 @@ related:
 packages:
   - "@cire/invites"
   - "@cire/host"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-09-07
 ---
 # Browser Tests
 
@@ -81,6 +81,46 @@ strings. Those all belong in the fast tier — and a class-contract assertion
 there is a genuinely useful complement, because it names the mechanism while the
 browser test proves the outcome. `RsvpModal.test.tsx` and
 `RsvpModal.browser.test.tsx` are the worked example of that pairing.
+
+## Driving the whole app by hand
+
+This tier proves a component in isolation. The other half — seeing the built app
+the way a guest sees it — has no automated home and is worth writing down,
+because both cire invite reveal bugs were found this way after the whole test
+suite stayed green through them.
+
+For a still frame, headless Chrome needs nothing installed and renders WebGL
+through SwiftShader:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new \
+  --screenshot=out.png --window-size=1440,900 --hide-scrollbars \
+  --virtual-time-budget=15000 "https://invite.cire.localhost/"
+```
+
+`--virtual-time-budget` fast-forwards timers and `requestAnimationFrame`, so a
+lazy scene or a fade-in has finished by the time the frame is taken. Vary
+`--window-size` for the phone case (390×844). This is how [[cire-landing]]'s wax
+seal was checked.
+
+**A still frame cannot see an animation bug.** Both reveal failures were single
+frames — one full-brightness paint before a snap to `opacity: 0` — invisible to
+happy-dom and to any assertion made after the fact. Drive the page with
+Playwright (already a devDependency of `@cire/invites`) and sample
+`getComputedStyle` on every `requestAnimationFrame`.
+
+Four traps, each of which has cost an hour or more:
+
+| Trap | What it looks like | What to do |
+|---|---|---|
+| `astro dev` never reaches `networkidle` | `page.goto` hangs until it times out | The HMR socket stays open by design — use `waitUntil: "load"` |
+| Below-the-fold islands hydrate on visibility | The component under test never mounts, and the page looks broken rather than un-hydrated | Both invite designs mount everything past the header as `client:visible={{ rootMargin: "600px" }}` — scroll it into view, or assert against the `client:load` header only |
+| The claim endpoint allows **5 attempts per minute per IP** | Back-to-back scenario runs 429, and the invite renders "Something went wrong" with no events — identical to the reveal regression you are chasing | `defaultClaimLimiter` in `cire/api/src/app.ts`. Space the runs out before believing a result |
+| A credentialed stub API echoing `*` | `…/registry/mine` silently reads as signed out | A CORS stub for a credentialed fetch must echo the exact origin |
+
+Anything proved this way that can be pinned belongs back in the tier above — the
+`EventCard` and `InvitePage` browser tests are both the settled form of a bug
+first seen by hand.
 
 ## How it is wired
 


### PR DESCRIPTION
## Summary

`wiki/conventions/browser-tests.md` documents the Chromium Vitest tier, which proves a
component in isolation. Nothing documented the other half — opening the built app and
watching it — even though both cire invite reveal bugs were found that way while the whole
suite stayed green. This adds a section covering it.

- The headless Chrome screenshot recipe, which needs nothing installed and renders WebGL.
- Why a still frame cannot catch an animation bug, and the per-`requestAnimationFrame`
  Playwright sampling that can.
- Four traps that have each cost an hour: `astro dev` never reaching `networkidle`, islands
  that hydrate on visibility, the claim endpoint's five attempts a minute rendering as a fake
  reveal regression, and a credentialed CORS stub that echoes a wildcard.
- A closing line pointing anything provable back into the tier above.

The `review-docs` pass then found nine things, all fixed here rather than filed — including
one worked command that would have screenshotted production, and two errors that predate the
branch on pages it touches. They are itemised under **Decisions**.

## Workspaces affected

None. The diff is two files under `wiki/`, which is on the changeset allowlist —
`scripts/changeset-required.sh` prints `skip`, so no changeset is owed.

- `wiki/conventions/browser-tests.md` — the new section, plus the `tests/` layout fix.
- `wiki/apps/cire-landing.md` — the wrong dev script, corrected.

## Issues

This branch closes no issue.

**Opened**

None.

## Decisions

### The worked screenshot command names a slug, not the bare host — `D-C1`

- **Issue** — the example pointed at `https://invite.cire.localhost/`. That route is a
  302: `src/pages/index.astro` redirects `/` to `MARKETING_URL`, which falls back to the
  live `https://cireweddings.com` whenever `PUBLIC_MARKETING_URL` is unset — which is what
  copying `.env.example` produces.
- **Why** — Chrome follows the redirect, so the reader gets a plausible frame of the wrong
  app, or of production, with no error to say so. That is exactly the failure mode the
  section exists to warn about.
- **Solution** — the command names `…/<slug>`, and a short paragraph says why the bare host
  is never an invite.
- **Rationale** — `[slug].astro` is the only server-rendered invite route, so a slug
  placeholder pins the example to the route the rest of the section is about.

### The wiring bullet described the pre-#867 test layout — `D-H1`

- **Issue** — "How it is wired" said the browser project `include`s `src/**/*.browser.test`
  and that browser tests "sit next to the code they cover". The config has
  `tests/**/*.browser.test.{ts,tsx}`, and all nine browser tests live under
  `cire/{invites,host}/tests/`.
- **Why** — it contradicts `CLAUDE.md`'s rule that tests live in `tests/`, and a browser test
  written next to its component matches no glob and silently never runs. This branch bumps
  `last-reviewed`, which asserts the page was checked.
- **Solution** — quote the real glob, and say where the files live and what happens if you
  get it wrong.
- **Rationale** — pre-existing, missed by #867 and by 7a77cbdc's test-layout correction.
  Fixing it here is cheaper than an issue, and the alternative was to bump `last-reviewed`
  over a known-wrong paragraph.

### Six accuracy fixes to the new section — `D-M1`–`D-M3`, `D-L1`–`D-L4`

- **Issue** — it credited happy-dom for a guest-site bug (`@cire/invites` runs jsdom);
  claimed "both cire invite reveal bugs" with no antecedent and attributed both named tests
  to bugs "first seen by hand", which the page's own account does not support; sat mid-page
  and forward-referenced a table 100 lines below; said "everything past the header" is
  `client:visible` when `ConsentBanner` is `client:idle`; attached the WebGL/SwiftShader
  claim to a command aimed at a site that ships no WebGL; and restated the Playwright
  devDependency the page already carries.
- **Why** — a reader following any of these lands on the wrong config, the wrong test, or
  the wrong host, and the section's whole justification is that it saves that trip.
- **Solution** — jsdom; the two reveal bugs named as #296 and #742; the section moved to the
  end so both test references resolve backwards; the two islands named; the WebGL clause
  moved to the `[[cire-landing]]` sentence with its own host; the Playwright line reduced to
  a link to *Running it locally*. A fifth trap row was added for `astro dev` backgrounding
  itself under an agent, which fires before any of the other four.
- **Rationale** — every other bug story on this page carries an identifier and stays
  checkable; an unnamed "both" is the claim that rots first.

### Drive-by: `wiki/apps/cire-landing.md` named the wrong dev script

- **Issue** — it told the reader to screenshot `bun run dev:landing`. That script is
  `turbo dev --filter=@osn/landing`; the cire landing site is `dev:cire-landing`.
- **Why** — it is the page the new section points at for the WebGL case, so the pointer led
  to a command that starts a different site.
- **Solution** — corrected the script, named `https://cire.localhost`, and linked back to the
  new section.
- **Rationale** — one line, same subject, found while verifying this branch's own claims.
  Splitting it into its own PR would cost more than it saves.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Type check | `bun run check` | 37 successful, 37 total (all cached — no source changed) |
| Changeset needed? | `bash scripts/changeset-required.sh` | `skip` — `wiki/` is allowlisted |
| Changeset validity | `bash scripts/validate-changesets.sh` | ✅ all package references valid |
| Tests | `bun run test` | not run — the diff is prose only; no source, test or config changed |
| Docs review | `review-docs` skill, as an agent | 9 findings (1 critical, 1 high, 3 medium, 4 low), all fixed on branch |
| Wiki markdown gate | — | none exists; `.github/workflows/ci.yml` has no job over `wiki/` |

Every factual claim in the new section was checked against the code on this branch rather
than against memory: the claim limiter's 5-per-60s window in `cire/api/src/app.ts`, the
`client:load` / `client:visible={{ rootMargin: "600px" }}` split in both designs'
`Document.astro`, `playwright` in `cire/invites/package.json`, and the
`invite.cire.localhost` host in `CLAUDE.md`'s portless table.

A reviewer should read the new section against their own memory of driving the invite by
hand — the traps are only worth the space if they match what actually bites.
