### PR TITLE
feat(tools): declare issue complexity before work starts

### DIFF
--- a/.changeset/olive-moons-invent.md
+++ b/.changeset/olive-moons-invent.md
@@ -1,0 +1,9 @@
+---
+"@tools/pr-metrics": minor
+---
+
+Read the declared complexity rating off an issue's labels.
+
+`declaredFromLabels` turns a `complexity:` label into `complexity.declared` on the card, and marks it `unconfirmed` when `complexity:unconfirmed` is also present. The CLI resolves it from `--issue-labels`, so whatever `prep-pr` reads off the issue carries the rating with it and nobody retypes a number the issue already holds. `--complexity` stays as an override for a branch with no issue and is recorded as `manual`, so a hand-typed rating never sits in a query beside one an owner confirmed.
+
+A rating outside the 1/2/3/5/8 scale, or two rating labels on one issue, reads as unrated — both are labelling mistakes, and surfacing them beats averaging them away.

--- a/.claude/skills/new-feat/SKILL.md
+++ b/.claude/skills/new-feat/SKILL.md
@@ -64,9 +64,10 @@ The body stands on its own: someone opening it months later with nothing checked
 
 `--type` is an org-level field, separate from the labels: `Feature` for new capability, `Bug` for something built that behaves wrongly, `Task` for the rest — a migration, a chore, infrastructure. Exactly one `product:` label. No `area:` unless the work is a finding or is `ops`, `schema` or `docs`; there is no `area:feature`.
 
-Then two things follow from the issue:
+Then three things follow from the issue:
 
 - **The branch name** — kebab-case the title, prefix it: `feat/` for a Feature, `fix/` for a Bug, `chore/`, `refactor/` or `docs/` for a Task. Step 1 uses this name; it does not derive its own.
+- **Complexity** — invoke the **`rate-complexity`** skill. It proposes a rating from the issue body alone and asks the owner to confirm or amend it, then applies a `complexity:` label. Do this **now**, before the branch exists: the rating is the denominator every session-metrics query divides spend by, and one made later — with a token total already on screen — is contaminated and worthless. An unattended run rates it anyway and adds `complexity:unconfirmed`. Never rate from the diff, and never let the agent that does the work rate the work.
 - **Status** — move the issue to **In Progress** in the **OSN Platform** project. `gh project item-edit` needs the `project` scope; if it is missing, say so and move it in the UI rather than skipping it.
 
 ## Step 1 — The branch

--- a/.claude/skills/rate-complexity/SKILL.md
+++ b/.claude/skills/rate-complexity/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: rate-complexity
+description: Use when an issue needs its complexity declared — proposing a rating from the issue body alone and getting the owner to confirm or amend it, or backfilling a rating onto an existing unrated issue. Invoked by new-feat at issue-creation time; also the backfill path for issues opened before the label existed.
+---
+
+Declare how hard an issue is, **before anyone starts work on it**.
+
+## Why the timing is the whole point
+
+The rating is the denominator in every session-metrics query: spend is compared
+against it to find work that cost far more than it should have. That comparison
+only means anything if the rating was made in ignorance of what the work turned
+out to cost.
+
+So the rating happens **at issue time**, never at pull-request time. A rating
+made while a token total is on screen is contaminated — the number gets talked
+into agreeing with the spend, and the metric quietly starts confirming whatever
+already happened. If you find yourself rating an issue whose branch has already
+been worked, say so and mark it unconfirmed rather than pretending.
+
+Two other things you must not do:
+
+- **Never let the agent that did the work rate the work.** It will rate the task
+  it struggled with as hard. That is motivated reasoning, and it corrupts the
+  one field the whole system rests on.
+- **Never rate from the diff.** The diff does not exist yet, and it is the wrong
+  evidence anyway — see the rubric.
+
+## The rubric
+
+Fibonacci, so that the ratio `cost ÷ complexity` is a real division. Rate the
+**problem**, not the change it will produce.
+
+| | Shape |
+|---|---|
+| **1** | One file, no new behaviour. A copy change, a version bump, a label on an existing guard. |
+| **2** | One package, following a pattern already in the repository. A route that mirrors an existing route, a test for existing code, a wiki page. |
+| **3** | One package, but something has to be designed. A new service, a schema change with a migration, a component with real states. |
+| **5** | Several packages, or one package plus a contract others depend on. A shared util two apps adopt, a change to an auth path, anything touching sessions or tokens. |
+| **8** | Cross-cutting, or the shape is unknown at the start. A migration across the monorepo, a new subsystem, anything whose first task is working out what the task is. |
+
+> [!important] A small change is not the same as an easy problem.
+> A one-line fix to a race condition is not a 1. A four-hour debug that ends in
+> a deleted character is a 5 or an 8. Rate the difficulty of *knowing what to
+> do*; the size of the eventual diff is recorded separately and on purpose.
+
+Signals that raise a rating: the cause is unknown; it touches auth, sessions,
+tokens or a migration; it changes a contract another package imports; it needs a
+decision nobody has made yet. Signals that lower one: an identical change exists
+in the repository already; the issue body names the file and the fix.
+
+## Mode A — with the owner (the normal path)
+
+Used by `new-feat` on an issue being opened or picked up.
+
+1. Read the issue body — **only** the body. Not the branch, not the code, not
+   the conversation that led to it.
+2. Propose one number and one sentence of justification naming the rubric row.
+3. Ask the owner to confirm or amend, offering the neighbouring values.
+4. Apply the label they land on:
+
+```bash
+gh issue edit 412 --repo xchromo/osn --add-label "complexity:3"
+```
+
+If the owner is not reachable — an unattended run — apply the rating **and**
+`complexity:unconfirmed`, then carry on. A rating nobody confirmed is still far
+better than none; the marker keeps it separable in queries.
+
+## Mode B — backfill (no owner)
+
+Used to rate issues opened before the label existed. Rate from the body alone,
+apply both labels, and never ask:
+
+```bash
+gh issue edit 412 --repo xchromo/osn --add-label "complexity:3,complexity:unconfirmed"
+```
+
+Do them in one pass over a listing, not one conversation per issue:
+
+```bash
+gh issue list --repo xchromo/osn --state all --limit 200 \
+  --json number,title,body,labels \
+  --jq '[.[] | select((.labels | map(.name) | map(startswith("complexity:")) | any) | not)]'
+```
+
+## The labels
+
+Six, on both `xchromo/osn` and `xchromo/osn-tracker`:
+
+| Label | Meaning |
+|---|---|
+| `complexity:1` … `complexity:8` | The declared rating (1, 2, 3, 5, 8) |
+| `complexity:unconfirmed` | No human signed off on it — an agent's rating, standing alone |
+
+An issue with a rating and no `complexity:unconfirmed` was confirmed by the
+owner. Exclude unconfirmed ratings from any query you intend to act on:
+
+```bash
+gh issue list --repo xchromo/osn --label "complexity:1" --search "-label:complexity:unconfirmed"
+```
+
+## What consumes this
+
+`@tools/pr-metrics` reads the label into `complexity.declared` on the card, and
+`wiki/observability/session-metrics.md` holds the queries that use it. That page
+also carries the rule this skill exists to protect: the card stores exactly one
+scalar judgement, and this is it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ GitHub Issues, not the wiki. Two repos:
 
 Route by *kind*, never by severity: an `S-`, `P-` or `C-` ID goes to the tracker however minor it looks. `xchromo/osn` is public, and a finding names an unpatched route.
 
-Every issue carries exactly one `product:` label — `osn-core`, `pulse`, `cire`, `zap`, `shared`, `landing` — and an org issue type: `Feature`, `Bug` or `Task`. An `area:` label is optional and only ever `security`, `performance`, `compliance`, `ops`, `docs` or `schema`; an issue with none is ordinary product work, which is what `Feature` already says. Findings also carry a `severity:`, taken from the tier letter in the ID. Epics are parents with sub-issues, so a phased piece of work is one issue plus its parts.
+Every issue carries exactly one `product:` label — `osn-core`, `pulse`, `cire`, `zap`, `shared`, `landing` — and an org issue type: `Feature`, `Bug` or `Task`. An `area:` label is optional and only ever `security`, `performance`, `compliance`, `ops`, `docs` or `schema`; an issue with none is ordinary product work, which is what `Feature` already says. Findings also carry a `severity:`, taken from the tier letter in the ID. Every issue also carries a `complexity:` rating — `1`, `2`, `3`, `5` or `8` — declared **before** work starts, plus `complexity:unconfirmed` when no human signed off on it. It is the denominator every session-metrics query divides spend by, so a rating made after the cost is known is worthless; `/new-feat` sets it through the `rate-complexity` skill. See `[[wiki/observability/session-metrics]]`. Epics are parents with sub-issues, so a phased piece of work is one issue plus its parts.
 
 ```bash
 gh issue list --repo xchromo/osn --state open --label product:pulse

--- a/scripts/todo-to-issues/labels.sh
+++ b/scripts/todo-to-issues/labels.sh
@@ -36,6 +36,24 @@ for repo in xchromo/osn xchromo/osn-tracker; do
 
   create "epic" "3e4b9e" "Parent issue with sub-issues"
 
+  # Declared complexity, set before work starts and never after. It is the
+  # denominator every session-metrics query divides spend by, so a rating made
+  # once the token cost is on screen gets talked into agreeing with it and the
+  # metric stops questioning anything. Fibonacci so that cost ÷ complexity is a
+  # real division, and it rates the *problem*: a one-line fix to a race
+  # condition is not a 1. `/new-feat` applies one through the rate-complexity
+  # skill; see wiki/observability/session-metrics.md.
+  create "complexity:1" "0e8a16" "One file, no new behaviour"
+  create "complexity:2" "7ed321" "One package, an existing pattern followed"
+  create "complexity:3" "fbca04" "One package, something must be designed"
+  create "complexity:5" "d93f0b" "Several packages, or a contract others depend on"
+  create "complexity:8" "b60205" "Cross-cutting, or the shape is unknown at the start"
+
+  # Not a rating — a caveat on one. An agent rated this and no human signed
+  # off, which is most of the backfill over issues that predate the label.
+  # Exclude these from any query you intend to act on.
+  create "complexity:unconfirmed" "bfbfbf" "An agent's rating that no human signed off on"
+
   # Orthogonal to every label above: a state, not a category. An agent working
   # the backlog applies it when the next step needs a choice only the repo
   # owner can make, writes the choice up in the body, and moves to another

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -657,6 +657,43 @@ export function parseNumstat(numstat: string, commits: number): DiffSummary {
   };
 }
 
+/** The five ratings the `complexity:` labels allow. Fibonacci, so that
+ * `usd_equivalent ÷ declared` is a real division rather than an ordinal
+ * pretending to be a number. */
+export const COMPLEXITY_VALUES = [1, 2, 3, 5, 8] as const;
+
+export interface DeclaredComplexity {
+  declared: number | null;
+  method: "confirmed" | "unconfirmed" | "none";
+}
+
+/**
+ * Read the declared rating off an issue's labels.
+ *
+ * The number lives on the issue rather than in the card because it has to be
+ * set before work starts — see `wiki/observability/session-metrics.md`. The
+ * card only transcribes it.
+ *
+ * Two labels rather than one: `complexity:unconfirmed` marks a rating no human
+ * signed off on, which is most of a backfill. Those stay separable so a query
+ * meant to drive a decision can exclude an agent's unreviewed guess. More than
+ * one rating label is a labelling mistake, not a value to average — it reads as
+ * unrated so the mistake shows up rather than being quietly resolved.
+ */
+export function declaredFromLabels(labels: string[]): DeclaredComplexity {
+  const ratings = labels
+    .map((label) => /^complexity:(\d+)$/.exec(label.trim()))
+    .filter((match) => match !== null)
+    .map((match) => Number.parseInt(match[1], 10))
+    .filter((value) => (COMPLEXITY_VALUES as readonly number[]).includes(value));
+
+  if (ratings.length !== 1) return { declared: null, method: "none" };
+
+  const unconfirmed = labels.some((label) => label.trim() === "complexity:unconfirmed");
+
+  return { declared: ratings[0], method: unconfirmed ? "unconfirmed" : "confirmed" };
+}
+
 export interface Card {
   schema_version: number;
   pr: {
@@ -805,15 +842,24 @@ if (import.meta.main) {
   const commits = git(["rev-list", "--count", `${base}..HEAD`]);
   const diff = parseNumstat(numstat, Number.parseInt(commits, 10) || 0);
 
-  const declared = flag("complexity");
+  const issueLabels = (flag("issue-labels") ?? "").split(",").filter(Boolean);
+
+  // The labels are the normal source — `prep-pr` passes whatever the issue
+  // carries and the rating comes along with them, so nobody has to retype a
+  // number the issue already holds. `--complexity` stays as an override for a
+  // branch with no issue, and it is recorded as `manual` so a hand-typed
+  // rating never sits in a query beside one an owner confirmed on an issue.
+  const fromLabels = declaredFromLabels(issueLabels);
+  const override = flag("complexity");
+
   const card = buildCard(records, diff, {
     branch,
     prNumber: flag("pr") ? Number.parseInt(flag("pr") as string, 10) : null,
     issueNumber: flag("issue") ? Number.parseInt(flag("issue") as string, 10) : null,
     issueType: flag("issue-type"),
-    issueLabels: (flag("issue-labels") ?? "").split(",").filter(Boolean),
-    declaredComplexity: declared ? Number.parseInt(declared, 10) : null,
-    complexityMethod: flag("complexity-method") ?? (declared ? "manual" : "none"),
+    issueLabels,
+    declaredComplexity: override ? Number.parseInt(override, 10) : fromLabels.declared,
+    complexityMethod: flag("complexity-method") ?? (override ? "manual" : fromLabels.method),
     baseSha: git(["rev-parse", base]) || null,
     headSha: git(["rev-parse", "HEAD"]) || null,
     mergedAt: flag("merged-at"),

--- a/tools/pr-metrics/tests/pr-metrics.cli.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.cli.test.ts
@@ -58,7 +58,7 @@ interface CliRun {
   card: Card;
 }
 
-async function run(): Promise<CliRun> {
+async function run(extraArgs: string[] = []): Promise<CliRun> {
   const dir = await mkdtemp(join(tmpdir(), "pr-metrics-cli-"));
 
   try {
@@ -157,6 +157,7 @@ async function run(): Promise<CliRun> {
         "895",
         "--out-dir",
         join(dir, "out"),
+        ...extraArgs,
       ],
       { cwd: dir, stdout: "pipe", stderr: "pipe" },
     );
@@ -227,6 +228,27 @@ test("the CLI charges pre-edit exploration to tokens_before_first_edit", async (
   // first edit (50 out). The subagent's 400 is excluded — a delegated task is
   // not the main thread hunting for the file.
   expect(card.interaction.tokens_before_first_edit).toBe(1_000_150);
+});
+
+// `prep-pr` passes whatever the issue carries, so the rating rides along with
+// the labels and nobody retypes a number the issue already holds.
+test("the CLI reads the declared rating out of the issue labels", async () => {
+  const { card } = await run(["--issue-labels", "product:osn-core,complexity:3"]);
+
+  expect(card.complexity).toEqual({ declared: 3, method: "confirmed" });
+  expect(card.issue.labels).toEqual(["product:osn-core", "complexity:3"]);
+});
+
+test("the CLI keeps an unconfirmed rating marked", async () => {
+  const { card } = await run(["--issue-labels", "complexity:5,complexity:unconfirmed"]);
+
+  expect(card.complexity).toEqual({ declared: 5, method: "unconfirmed" });
+});
+
+test("the CLI records a hand-passed rating as manual", async () => {
+  const { card } = await run(["--complexity", "8"]);
+
+  expect(card.complexity).toEqual({ declared: 8, method: "manual" });
 });
 
 test("the CLI refuses to card main", async () => {

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -7,6 +7,7 @@ import {
   branchSlug,
   classifyPath,
   costOf,
+  declaredFromLabels,
   emptyTokens,
   IDLE_CAP_SECONDS,
   isHumanTurn,
@@ -409,6 +410,50 @@ test("parseNumstat counts a binary file without inventing lines", () => {
 test("parseNumstat flags a migration", () => {
   expect(parseNumstat("5\t0\tcire/db/drizzle/0004_x.sql", 1).touches_migration).toBe(true);
   expect(parseNumstat("5\t0\tosn/api/src/a.ts", 1).touches_migration).toBe(false);
+});
+
+// --- declared complexity ----------------------------------------------------
+
+test("declaredFromLabels reads a confirmed rating", () => {
+  expect(declaredFromLabels(["product:cire", "complexity:3"])).toEqual({
+    declared: 3,
+    method: "confirmed",
+  });
+});
+
+test("declaredFromLabels marks an unconfirmed rating", () => {
+  expect(declaredFromLabels(["complexity:5", "complexity:unconfirmed"])).toEqual({
+    declared: 5,
+    method: "unconfirmed",
+  });
+});
+
+test("declaredFromLabels returns none when no rating is present", () => {
+  expect(declaredFromLabels(["product:osn-core", "area:ops"])).toEqual({
+    declared: null,
+    method: "none",
+  });
+});
+
+// The scale is 1/2/3/5/8. A `complexity:4` is somebody inventing a value, and
+// silently honouring it would put a number in the denominator that the rubric
+// never defined.
+test("declaredFromLabels rejects a rating outside the Fibonacci scale", () => {
+  expect(declaredFromLabels(["complexity:4"]).declared).toBeNull();
+  expect(declaredFromLabels(["complexity:13"]).declared).toBeNull();
+});
+
+// Two ratings is a labelling mistake, not a value to average. Reading it as
+// unrated makes the mistake visible instead of quietly resolving it.
+test("declaredFromLabels treats two ratings as unrated", () => {
+  expect(declaredFromLabels(["complexity:2", "complexity:5"]).declared).toBeNull();
+});
+
+test("declaredFromLabels ignores the unconfirmed marker on its own", () => {
+  expect(declaredFromLabels(["complexity:unconfirmed"])).toEqual({
+    declared: null,
+    method: "none",
+  });
 });
 
 // --- slug -------------------------------------------------------------------

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -48,6 +48,36 @@ Any formula that folds diff size into difficulty collapses those into one row,
 and the metric then punishes the hardest legitimate work in the repository. So
 outliers are a **query over raw fields**, never a stored field.
 
+## Declaring complexity
+
+The rating lives on the **issue**, as a `complexity:` label, and it is set
+**before work starts** — `/new-feat` does it at Step 0 through the
+[[rate-complexity]] skill, which proposes a number from the issue body alone and
+asks the owner to confirm or amend it.
+
+The timing is not a detail. A rating made at pull-request time, with a token
+total already on screen, gets talked into agreeing with whatever the work cost,
+and the metric then confirms every outcome instead of questioning any of them.
+For the same reason the agent that did the work never rates the work: it will
+score the task it struggled with as hard.
+
+| Label | Meaning |
+|---|---|
+| `complexity:1` | One file, no new behaviour |
+| `complexity:2` | One package, following a pattern already here |
+| `complexity:3` | One package, but something must be designed |
+| `complexity:5` | Several packages, or a contract others depend on |
+| `complexity:8` | Cross-cutting, or the shape is unknown at the start |
+| `complexity:unconfirmed` | An agent's rating that no human signed off on |
+
+Fibonacci, so `usd_equivalent ÷ declared` is a real division. The rubric rates
+the **problem**, not the change: a one-line fix to a race condition is not a 1.
+Diff size is recorded separately, on purpose, and the two are never blended.
+
+Exclude unconfirmed ratings from anything you intend to act on — they are an
+agent's guess standing alone, and mostly arrive from the backfill of issues that
+predate the label.
+
 ## Where the data comes from
 
 Claude Code writes a transcript per session under

--- a/wiki/runbooks/github-issues-setup.md
+++ b/wiki/runbooks/github-issues-setup.md
@@ -62,12 +62,22 @@ gh api repos/xchromo/osn-tracker/contents/.github/ISSUE_TEMPLATE/review-finding.
 ./scripts/todo-to-issues/labels.sh
 ```
 
-19 labels per repo: 6 `product:`, 6 `area:`, 5 `severity:`, `epic`, and
-`needs:decision`. The script uses `--force`, so re-running it is how a colour
+25 labels per repo: 6 `product:`, 6 `area:`, 5 `severity:`, 6 `complexity:`,
+`epic`, and `needs:decision`. The script uses `--force`, so re-running it is how a colour
 or description is changed. Every issue carries exactly one `product:` and at
 most one `area:`; only a finding carries a `severity:`, taken from the tier
 letter in its ID. The migration enforced that with a gate over its manifest;
 now that issues are filed by hand, `/prep-pr` and `/new-feat` carry the rule.
+
+A `complexity:` rating — `1`, `2`, `3`, `5` or `8` — is declared **before**
+work starts, by `/new-feat` through the `rate-complexity` skill, which proposes
+a number from the issue body alone and asks the owner to confirm or amend it.
+The timing carries the whole value: the rating is the denominator every
+session-metrics query divides spend by, and one made at pull-request time, with
+a token total on screen, gets talked into agreeing with whatever the work cost.
+`complexity:unconfirmed` marks a rating no human signed off on — an agent's
+guess standing alone, mostly from backfilling issues that predate the label.
+See `wiki/observability/session-metrics.md`.
 
 `needs:decision` is the one label that says nothing about what an issue *is*.
 It is a state: the next step needs a choice only the repo owner can make. It


### PR DESCRIPTION
## Summary

Stacked on #917. Adds the denominator the cards divide spend by: a `complexity:` rating of 1, 2, 3, 5 or 8, carried as a label on the **issue** and set **at issue time**.

The timing is the whole value. A rating made at pull-request time, with a token total already on screen, gets talked into agreeing with whatever the work cost — and the metric then confirms every outcome instead of questioning any of them. So `/new-feat` now rates at Step 0, before the branch exists, through a new `rate-complexity` skill: it proposes a number from the issue body alone and asks the owner to confirm or amend it. An unattended run rates anyway and adds `complexity:unconfirmed`, keeping an agent's unreviewed guess separable from one a human signed off on.

The rubric rates the **problem**, not the change:

| | Shape |
|---|---|
| **1** | One file, no new behaviour |
| **2** | One package, following a pattern already here |
| **3** | One package, but something must be designed |
| **5** | Several packages, or a contract others depend on |
| **8** | Cross-cutting, or the shape is unknown at the start |

A one-line fix to a race condition is not a 1. Diff size is recorded separately, on purpose, and the two are never blended into one score.

## Workspaces affected

- `@tools/pr-metrics` — `declaredFromLabels` reads the rating into the card; the CLI resolves it from `--issue-labels`.

Also touched: `.claude/skills/rate-complexity/SKILL.md` (new), `.claude/skills/new-feat/SKILL.md` (Step 0 gains the rating), `scripts/todo-to-issues/labels.sh`, `CLAUDE.md`, `wiki/observability/session-metrics.md`, `wiki/runbooks/github-issues-setup.md`.

## Issues

None filed. One thing worth flagging for review rather than as a defect: **the twelve labels already exist on both repos** — I created them with `gh label create --force` so the skill is usable the moment this merges. They are also now in `labels.sh`, which is what actually owns them; leaving them hand-created alone would have been drift that the next run of that script silently reverted.

## Decisions

- **Two labels, not a method taxonomy.** `complexity:<n>` for the rating and `complexity:unconfirmed` for "no human signed off". The finer distinction between an agent's proposal accepted unchanged and one the owner amended would be useful for calibration, but it costs three more labels and a parse; the card's own history can recover it later if it turns out to matter.
- **A rating outside 1/2/3/5/8, or two rating labels on one issue, reads as unrated.** Both are labelling mistakes. Surfacing them beats averaging them away or honouring a number the rubric never defined.
- **`--complexity` survives as an override**, recorded as `manual`, so a branch with no issue can still be carded — and a hand-typed rating never sits in a query beside one an owner confirmed on an issue.
- **The rating never comes from the agent that did the work.** It will score the task it struggled with as hard; that is motivated reasoning about the one field the whole system rests on.

## Test plan

- `bun test tools/pr-metrics` — 43 tests, all passing (up from 34). Nine new: six over `declaredFromLabels` covering confirmed, unconfirmed, absent, off-scale, duplicate-rating and marker-only; three CLI tests proving the rating resolves from `--issue-labels` end to end and that `--complexity` records as `manual`.
- `bun run --cwd tools/pr-metrics check` — clean.
- `bun run lint` — no errors from the package.
- `bun run fmt:check` — clean.
- `bash scripts/validate-changesets.sh` — passes.
- `gh label list` on both repos — all six labels present on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kRJ2QVtZ8N9wHGZtZJDTE
