### PR TITLE
feat(tools): surface session cards in PR bodies, backfill, and query them

### DIFF
--- a/.changeset/brave-otters-listen.md
+++ b/.changeset/brave-otters-listen.md
@@ -1,0 +1,11 @@
+---
+"@tools/pr-metrics": minor
+---
+
+Make cards work from remote sessions: a `report` command that needs nothing installed, a `SessionEnd` hook that writes the card in any environment, and a `merged` view that no longer excludes remote work.
+
+`bun run --cwd tools/pr-metrics report` computes the seven analyses over the committed cards in TypeScript. DuckDB does not exist in a remote session — none of the `duckdb` npm packages ship a binary, and a cloud container has no `brew` — so a report that only ran under `queries.sql` could only ever describe one laptop. The SQL stays as the optional local tool for questions nobody anticipated; both carry the same ratio definitions.
+
+A `SessionEnd` hook in `.claude/settings.json` writes the card at the end of every session. A remote container is destroyed when its session ends and takes its transcripts with it, so a card that was never written is gone for good; the hook removes the dependency on anyone reaching `prep-pr`. It is idempotent, already refuses `main`, and ends in `|| true` so it can never fail a session.
+
+The `merged` view now filters on merge status rather than `phase = 'at-merge'`. A remote card can never be refreshed past `at-open`, so the old filter would have silently dropped every pull request not worked on a machine you still own — biasing every trend toward local work while looking like caution. `phase` is a visible column instead, and the coverage query reports the split.

--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,11 @@
+---
+"@tools/pr-metrics": minor
+---
+
+Put cards in front of people: a PR-body block, a backfill for merged pull requests, and the queries that read the cards back.
+
+`--format markdown` renders the card as a collapsed `<details>` block for a pull-request body, and `prep-pr` now appends one after `## Test plan`. It is a `<details>` block rather than a section because that skill permits exactly five `##` headings and checks the count — a metrics section would fail a body that is otherwise correct.
+
+`bun run --cwd tools/pr-metrics backfill` writes cards for pull requests that merged before cards existed. A merged branch is usually deleted, so the file list comes from the GitHub API rather than a local diff; spend still comes from local transcripts, and a pull request with none is skipped rather than written as zero, because a zero-cost card is indistinguishable from a genuinely cheap one once it is in the datalake.
+
+`queries.sql` defines the `cards`, `merged` and `metrics` views and seven queries: where agents cost too much for the job, which packages need a skill or a wiki page, whether briefs are getting clearer, whether the context surface is bloating, cost per unit of declared difficulty, whether delegation pays off, and how much of the history can be trusted at all.

--- a/.changeset/tall-jokes-repeat.md
+++ b/.changeset/tall-jokes-repeat.md
@@ -1,0 +1,11 @@
+---
+"@tools/pr-metrics": minor
+---
+
+Fix three defects that made the first real report misleading.
+
+**An edit is not only an `Edit` call.** This repository's agent instructions tell agents to change files with `sed`, heredocs and short scripts rather than the dedicated tools, so counting only `Edit`/`Write` missed most edits. In the first 34 cards, 15 pull requests changed real source with zero `Edit` calls, and every one reported that 100% of its tokens went on exploration. Shell writes now count — `sed -i`, heredoc redirects, `tee`, `mv` — detected conservatively, since a false positive moves the boundary too early and under-reports exploration.
+
+**An unobserved boundary is `null`, not 100%.** A session that never shows an edit now banks nothing, the card reports `tokens_before_first_edit: null`, and every ranking drops it; `sessions_with_observed_edit` says how many sessions contributed so a partial reading reads as partial. The old behaviour sorted the per-package ranking by which branches happened to avoid the Edit tool — `cire/host` appeared worst in the repository at 62% and reads 5% once fixed.
+
+**Median, never mean.** Every per-pull-request distribution is right-skewed: across those 34 cards the median was 3.6M tokens, the mean 15.4M and the maximum 92.7M. The mean described the three largest pull requests and showed 8.5× month-over-month token growth where the median shows about 2×. Both the `report` command and `queries.sql` now use medians, and the column headings say so.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,18 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && bun run --cwd tools/pr-metrics card >/dev/null 2>&1 || true",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/prep-pr/SKILL.md
+++ b/.claude/skills/prep-pr/SKILL.md
@@ -392,6 +392,34 @@ says.
 **Test plan.** The gates that ran, with their real results, and below the table
 anything a reviewer must exercise by hand — including the honest negatives.
 
+### Append the session metrics
+
+After `## Test plan` and before the shape check, append the card for this
+branch — what the session that produced this pull request cost, what it
+changed, and how much steering it needed:
+
+```bash
+bun run --cwd tools/pr-metrics card -- \
+  --issue-labels "$(gh issue view "$ISSUE" --repo xchromo/osn --json labels --jq '[.labels[].name] | join(",")')" \
+  --pr "$PR" --issue "$ISSUE"                       # writes .claude/metrics/<branch>.json
+
+bun run --cwd tools/pr-metrics card -- \
+  --issue-labels "…" --format markdown >> <body-file>   # appends the block
+```
+
+Two runs on purpose: the first writes the committed card, the second prints the
+`<details>` block on stdout with none of the warnings in it. **Commit the JSON
+file with the branch** — the card is the durable record and
+`~/.claude/projects` is neither committed nor shared.
+
+It is a `<details>` block and not a section, and that is a constraint rather
+than a preference: the shape check below permits exactly five `##` headings, so
+a metrics section would fail a body that is otherwise correct. `<details>` adds
+no heading.
+
+If the collector cannot run — no transcripts on this machine, no `gh` — say so
+under `## Decisions` and carry on. A missing card never blocks a pull request.
+
 ### Check the body before you finish
 
 ```bash

--- a/tools/pr-metrics/README.md
+++ b/tools/pr-metrics/README.md
@@ -9,8 +9,14 @@ bun run --cwd tools/pr-metrics card                          # current branch
 bun run --cwd tools/pr-metrics card -- --pr 908 --issue 895
 bun run --cwd tools/pr-metrics card -- --format markdown     # the PR-body block
 bun run --cwd tools/pr-metrics backfill -- --dry-run         # merged PRs, retroactively
-duckdb -init tools/pr-metrics/queries.sql                    # read the cards back
+bun run --cwd tools/pr-metrics report                        # read the cards back
+bun run --cwd tools/pr-metrics report -- --waste             # just one analysis
 ```
+
+`report` needs nothing installed and runs in every environment, including a
+remote session — which `queries.sql` cannot, since no `duckdb` npm package
+ships a binary and a cloud container has no `brew`. SQL stays for ad-hoc local
+questions.
 
 | Flag                                                | Default                        |
 | --------------------------------------------------- | ------------------------------ |

--- a/tools/pr-metrics/README.md
+++ b/tools/pr-metrics/README.md
@@ -43,6 +43,23 @@ blended from diff size cannot separate a wasteful PR from a hard debug that
 ended in a one-line fix, and folding the two together makes the metric punish
 the hardest legitimate work in the repository.
 
+## Two rules the metrics depend on
+
+**An edit is not only an `Edit` call.** Agents here are told to change files
+with `sed`, heredocs and short scripts, so `isFileWritingCommand` counts shell
+writes too — conservatively, because a false positive moves the first-edit
+boundary too early and under-reports exploration.
+
+**An unobserved boundary is `null`.** A session that never shows an edit banks
+nothing and every ranking drops it. Reporting 100% instead once made
+`cire/host` look like the worst-mapped package in the repository at 62%; it
+reads 5% correctly. "We did not see the boundary" and "all of it was
+exploration" are different claims.
+
+And in the reports: **median, never mean.** These distributions are severely
+right-skewed — median 3.6M tokens against a mean of 15.4M and a maximum of
+92.7M across the first 34 cards.
+
 ## Layout
 
 | Path                           | What                                                                                          |

--- a/tools/pr-metrics/README.md
+++ b/tools/pr-metrics/README.md
@@ -5,8 +5,11 @@ produced a pull request cost, what it changed, and how much steering it needed.
 Writes one JSON file per branch to `.claude/metrics/<branch-slug>.json`.
 
 ```bash
-bun run --cwd tools/pr-metrics card                        # current branch
+bun run --cwd tools/pr-metrics card                          # current branch
 bun run --cwd tools/pr-metrics card -- --pr 908 --issue 895
+bun run --cwd tools/pr-metrics card -- --format markdown     # the PR-body block
+bun run --cwd tools/pr-metrics backfill -- --dry-run         # merged PRs, retroactively
+duckdb -init tools/pr-metrics/queries.sql                    # read the cards back
 ```
 
 | Flag                                                | Default                        |
@@ -38,7 +41,10 @@ the hardest legitimate work in the repository.
 
 | Path                           | What                                                                                          |
 | ------------------------------ | --------------------------------------------------------------------------------------------- |
-| `index.ts`                     | Pure aggregation functions, plus the CLI under `import.meta.main`                             |
+| `index.ts`                     | Pure aggregation functions, the `<details>` renderer, and the CLI under `import.meta.main`    |
+| `backfill.ts`                  | Cards for pull requests that merged before cards existed                                      |
+| `queries.sql`                  | The seven DuckDB queries worth having                                                         |
+| `tests/render.test.ts`         | The `<details>` block — including that it contributes no `##` heading                         |
 | `tests/pr-metrics.test.ts`     | The pure functions, against synthetic records                                                 |
 | `tests/pr-metrics.cli.test.ts` | The real script as a subprocess, against a throwaway git repo and a fake `~/.claude/projects` |
 

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env bun
+/**
+ * Write cards for pull requests that merged before cards existed.
+ *
+ * Two things make a backfill different from a live run, and both shape this
+ * file:
+ *
+ * **The branch is usually gone.** A merged branch is deleted, so
+ * `git diff base...head` has nothing to resolve locally. The file list comes
+ * from the GitHub API instead (`repos/:owner/:repo/pulls/:n/files`), which
+ * returns per-file additions and deletions and does not care that the ref no
+ * longer exists.
+ *
+ * **The rating is not trustworthy the same way.** A card backfilled today is
+ * describing work whose cost is already known, so any rating attached to it now
+ * has seen the answer. `rate-complexity` handles that by marking a backfilled
+ * rating `complexity:unconfirmed`; this script simply transcribes whatever the
+ * issue carries and never invents one. Cards it writes are `phase: "at-merge"`.
+ *
+ * The spend still comes from local transcripts, so a backfill only reaches as
+ * far back as `~/.claude/projects` on this machine, and only for branches this
+ * machine did the work on. Pull requests it cannot cost are reported and
+ * skipped rather than written as zero — a card claiming a PR cost nothing is
+ * worse than no card, because a query cannot tell it from a cheap one.
+ */
+
+import { buildCard, declaredFromLabels, parseNumstat, type SessionRecord } from "./index.ts";
+
+interface PullRequest {
+  number: number;
+  headRefName: string;
+  mergedAt: string;
+  baseRefOid: string;
+  headRefOid: string;
+  labels: { name: string }[];
+  closingIssuesReferences: { number: number }[];
+}
+
+interface ChangedFile {
+  filename: string;
+  additions: number;
+  deletions: number;
+}
+
+interface CommandResult {
+  ok: boolean;
+  out: string;
+}
+
+function sh(command: string[]): CommandResult {
+  const result = Bun.spawnSync(command, { stdout: "pipe", stderr: "pipe" });
+
+  return { ok: result.success, out: result.stdout.toString() };
+}
+
+function flag(name: string): string | null {
+  const index = Bun.argv.indexOf(`--${name}`);
+
+  return index >= 0 && Bun.argv[index + 1] ? Bun.argv[index + 1] : null;
+}
+
+/** Every branch that appears in a transcript, with its records. One pass over
+ * the logs; a per-PR scan would re-read gigabytes once per pull request. */
+function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[]> {
+  const byBranch = new Map<string, SessionRecord[]>();
+  const patterns = [`${sessionsDir}/*/*.jsonl`, `${sessionsDir}/*/*/subagents/*.jsonl`];
+
+  for (const pattern of patterns) {
+    const found = sh(["sh", "-c", `ls -1 ${pattern} 2>/dev/null || true`]);
+
+    for (const file of found.out.split("\n").filter(Boolean)) {
+      let text: string;
+      try {
+        text = require("node:fs").readFileSync(file, "utf8") as string;
+      } catch {
+        continue;
+      }
+
+      for (const line of text.split("\n")) {
+        if (!line.includes('"gitBranch"')) continue;
+
+        let record: SessionRecord;
+        try {
+          record = JSON.parse(line) as SessionRecord;
+        } catch {
+          continue;
+        }
+
+        const branch = record.gitBranch;
+        if (!branch || branch === "main") continue;
+
+        const existing = byBranch.get(branch);
+        if (existing) existing.push(record);
+        else byBranch.set(branch, [record]);
+      }
+    }
+  }
+
+  return byBranch;
+}
+
+/** GitHub's per-file additions and deletions, reshaped into the `git diff
+ * --numstat` lines `parseNumstat` already understands. */
+function numstatFromApi(files: ChangedFile[]): string {
+  return files.map((f) => `${f.additions}\t${f.deletions}\t${f.filename}`).join("\n");
+}
+
+if (import.meta.main) {
+  const repo = flag("repo") ?? "xchromo/osn";
+  const limit = flag("limit") ?? "100";
+  const outDir = flag("out-dir") ?? ".claude/metrics";
+  const sessionsDir = flag("sessions-dir") ?? `${process.env.HOME}/.claude/projects`;
+  const dryRun = Bun.argv.includes("--dry-run");
+
+  const listed = sh([
+    "gh",
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "merged",
+    "--limit",
+    limit,
+    "--json",
+    "number,headRefName,mergedAt,baseRefOid,headRefOid,labels,closingIssuesReferences",
+  ]);
+
+  if (!listed.ok) {
+    console.error("❌ pr-metrics backfill: `gh pr list` failed. Is `gh` authenticated?");
+    process.exit(1);
+  }
+
+  const pulls = JSON.parse(listed.out) as PullRequest[];
+  const byBranch = recordsByBranch(sessionsDir);
+
+  console.log(
+    `pr-metrics backfill: ${pulls.length} merged PR(s), ${byBranch.size} branch(es) with transcripts.`,
+  );
+
+  const skipped: number[] = [];
+  let written = 0;
+
+  for (const pull of pulls) {
+    const records = byBranch.get(pull.headRefName);
+
+    // No transcript means the work happened on another machine, or before this
+    // machine's logs begin. Writing a zero-cost card would put a row in the
+    // datalake that reads exactly like a genuinely cheap pull request.
+    if (!records || records.length === 0) {
+      skipped.push(pull.number);
+      continue;
+    }
+
+    const filesResult = sh([
+      "gh",
+      "api",
+      "--paginate",
+      `repos/${repo}/pulls/${pull.number}/files`,
+      "--jq",
+      ".[] | {filename, additions, deletions}",
+    ]);
+
+    const files = filesResult.out
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as ChangedFile);
+
+    const labels = pull.labels.map((label) => label.name);
+    const complexity = declaredFromLabels(labels);
+    const commits = sh(["gh", "api", `repos/${repo}/pulls/${pull.number}`, "--jq", ".commits"]);
+
+    const card = buildCard(records, parseNumstat(numstatFromApi(files), Number(commits.out) || 0), {
+      branch: pull.headRefName,
+      prNumber: pull.number,
+      issueNumber: pull.closingIssuesReferences[0]?.number ?? null,
+      issueType: null,
+      issueLabels: labels,
+      declaredComplexity: complexity.declared,
+      complexityMethod: complexity.method,
+      baseSha: pull.baseRefOid,
+      headSha: pull.headRefOid,
+      mergedAt: pull.mergedAt,
+      phase: "at-merge",
+      generatedAt: new Date().toISOString(),
+    });
+
+    const path = `${outDir}/${pull.headRefName.replace(/[^a-zA-Z0-9._-]/g, "-")}.json`;
+
+    if (dryRun) {
+      console.log(
+        `  would write #${pull.number} ${pull.headRefName} — $${card.spend.usd_equivalent.toFixed(2)}`,
+      );
+    } else {
+      require("node:fs").mkdirSync(outDir, { recursive: true });
+      require("node:fs").writeFileSync(path, `${JSON.stringify(card, null, 2)}\n`);
+      console.log(
+        `  #${pull.number} ${pull.headRefName} — $${card.spend.usd_equivalent.toFixed(2)}`,
+      );
+    }
+
+    written += 1;
+  }
+
+  console.log(`\n${dryRun ? "would write" : "wrote"} ${written} card(s).`);
+
+  if (skipped.length > 0) {
+    console.log(
+      `skipped ${skipped.length} PR(s) with no local transcript: ${skipped.slice(0, 10).join(", ")}${
+        skipped.length > 10 ? ", …" : ""
+      }`,
+    );
+    console.log(
+      "A card is only written where the spend is real — a zero-cost card reads like a cheap PR.",
+    );
+  }
+}

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -553,6 +553,8 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
   };
 }
 
+const WORKSPACE_ROOTS = ["osn", "pulse", "zap", "cire", "shared", "tools"];
+
 export type PathBucket = "generated" | "test" | "docs" | "config" | "source";
 
 /**
@@ -642,8 +644,12 @@ export function parseNumstat(numstat: string, commits: number): DiffSummary {
 
     if (path.includes("/drizzle/") || path.includes("/migrations/")) touchesMigration = true;
 
+    // The workspace globs are `<dir>/*` for the five product directories and
+    // for `tools`, so the first two segments name the package. `tools/oxlint`
+    // is the one place that resolves to a parent of the real workspace
+    // (`tools/oxlint/house`) — still the right grouping for a card.
     const parts = path.split("/");
-    if (parts.length >= 2 && ["osn", "pulse", "zap", "cire", "shared"].includes(parts[0])) {
+    if (parts.length >= 2 && WORKSPACE_ROOTS.includes(parts[0])) {
       packages.add(`${parts[0]}/${parts[1]}`);
     }
   }
@@ -754,6 +760,116 @@ export function buildCard(records: SessionRecord[], diff: DiffSummary, context: 
     diff,
     interaction: aggregateInteraction(records),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** 66_000_000 → "66.0M". Cards run to tens of millions of tokens and a raw
+ * digit string at that size is unreadable in a table. */
+export function compactTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+
+  return String(value);
+}
+
+export function humanDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+
+  const hours = Math.floor(seconds / 3600);
+
+  return `${hours}h ${Math.round((seconds % 3600) / 60)}m`;
+}
+
+function share(part: number, whole: number): string {
+  return whole > 0 ? `${Math.round((part / whole) * 100)}%` : "0%";
+}
+
+/**
+ * The card as a collapsed block for a pull-request body.
+ *
+ * A `<details>` block rather than a section, and that is a constraint rather
+ * than a preference: `prep-pr` permits exactly five `##` headings and checks
+ * the count before it finishes, so a sixth would fail a body that is otherwise
+ * correct. `<details>` adds no heading.
+ *
+ * The summary line carries the four figures worth seeing without expanding.
+ * "API-equivalent" is spelled out every time because this work runs on a
+ * subscription and the number must never be read as a bill.
+ */
+export function renderDetails(card: Card): string {
+  const { spend, diff, interaction, window: session, complexity } = card;
+  const tokens = spend.tokens;
+  const total =
+    tokens.input +
+    tokens.output +
+    tokens.cache_write_5m +
+    tokens.cache_write_1h +
+    tokens.cache_read;
+
+  const declared =
+    complexity.declared === null
+      ? "unrated"
+      : `${complexity.declared}${complexity.method === "unconfirmed" ? " (unconfirmed)" : ""}`;
+
+  const source = `+${diff.loc.source.added}/-${diff.loc.source.deleted}`;
+  const models = Object.entries(spend.by_model)
+    .sort((a, b) => b[1].usd_equivalent - a[1].usd_equivalent)
+    .map(([model, bucket]) => `${model} (${share(bucket.usd_equivalent, spend.usd_equivalent)})`)
+    .join(", ");
+
+  const rows: [string, string][] = [
+    ["Cost (API-equivalent)", `$${spend.usd_equivalent.toFixed(2)}`],
+    [
+      "Tokens",
+      `${compactTokens(total)} — out ${compactTokens(tokens.output)} · cache-w ${compactTokens(
+        tokens.cache_write_5m + tokens.cache_write_1h,
+      )} · cache-r ${compactTokens(tokens.cache_read)} (${share(tokens.cache_read, total)})`,
+    ],
+    ["Models", models || "—"],
+    ["Active time", `${humanDuration(session.active_seconds)} over ${session.sessions} session(s)`],
+    ["Declared complexity", declared],
+    [
+      "Source diff",
+      `${source} across ${diff.files.source} file(s), ${diff.packages.length} package(s)`,
+    ],
+    ["Turns", `${interaction.user_turns} (${interaction.corrective_turns} corrective)`],
+    [
+      "Before first edit",
+      `${compactTokens(interaction.tokens_before_first_edit)} (${share(
+        interaction.tokens_before_first_edit,
+        total,
+      )})`,
+    ],
+    [
+      "Subagents",
+      Object.keys(interaction.subagents).length === 0
+        ? "none"
+        : `${Object.entries(interaction.subagents)
+            .map(([kind, n]) => `${n}× ${kind}`)
+            .join(
+              ", ",
+            )} (${share(spend.by_actor.subagent.usd_equivalent, spend.usd_equivalent)} of spend)`,
+    ],
+  ];
+
+  const summary =
+    `Session metrics — $${spend.usd_equivalent.toFixed(2)} · ${compactTokens(total)} tok · ` +
+    `complexity ${declared} · ${source} source`;
+
+  return [
+    `<details><summary>${summary}</summary>`,
+    "",
+    "| | |",
+    "|---|---|",
+    ...rows.map(([label, value]) => `| ${label} | ${value} |`),
+    "",
+    `<sub>Card: \`.claude/metrics/${branchSlug(card.pr.branch)}.json\` · phase \`${card.pr.phase}\` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>`,
+    "</details>",
+  ].join("\n");
 }
 
 /**
@@ -867,6 +983,14 @@ if (import.meta.main) {
     generatedAt: new Date().toISOString(),
   });
 
+  // `--format markdown` prints the `<details>` block on stdout and writes
+  // nothing, so `prep-pr` can append it to a body without a temporary file and
+  // without the warnings below landing in the middle of the markdown.
+  if (flag("format") === "markdown") {
+    console.log(renderDetails(card));
+    process.exit(0);
+  }
+
   const outDir = flag("out-dir") ?? ".claude/metrics";
   const outPath = `${outDir}/${branchSlug(branch)}.json`;
   require("node:fs").mkdirSync(outDir, { recursive: true });
@@ -883,7 +1007,7 @@ if (import.meta.main) {
     console.warn(
       `⚠️  pr-metrics: no rate for ${card.spend.unpriced_models.join(", ")} — cost excludes it.`,
     );
-    console.warn("   Add it to MODEL_RATES in scripts/pr-metrics.ts.");
+    console.warn("   Add it to MODEL_RATES in tools/pr-metrics/index.ts.");
   }
 
   console.log(`✅ pr-metrics: wrote ${outPath}`);

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -125,6 +125,7 @@ export interface ToolUseInput {
   skill?: string;
   subagent_type?: string;
   file_path?: string;
+  command?: string;
 }
 
 export interface ContentBlock {
@@ -228,6 +229,43 @@ export function costOf(tokens: TokenTotals, model: string): number {
 }
 
 const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "MultiEdit"]);
+
+/**
+ * A shell command that writes to a file in the working tree.
+ *
+ * Counting only `Edit` and `Write` was a real defect, not a gap: this
+ * repository's own agent instructions tell agents to make file changes "with
+ * sed, heredocs, or short scripts, rather than using the dedicated Read, Edit,
+ * or Write tools". In the first 34 cards, 15 pull requests changed real source
+ * with **zero** `Edit` calls — so the first-edit boundary never moved and every
+ * one of them reported that 100% of its tokens went on exploration. The
+ * per-package exploration ranking was then sorted by which branches happened to
+ * avoid the Edit tool, which is not a fact about anything.
+ *
+ * Deliberately conservative — a false positive here moves the boundary too
+ * early and under-reports exploration, which is the more misleading direction.
+ * `>` and `>>` must name a real path, so `2>&1` and `>/dev/null` do not count.
+ * A heredoc feeding an interpreter that writes files from inside the script
+ * (`python3 - <<'PY' … open(p,"w") … PY`) is still missed; there is no honest
+ * way to see that from the command line alone, and `null` handles it.
+ */
+export function isFileWritingCommand(command: string): boolean {
+  if (/\bsed\s+(-[a-zA-Z]*i|--in-place)\b/.test(command)) return true;
+  if (/\btee\s+(?!\/dev\/null)[^\s|;&]+/.test(command)) return true;
+  if (/\b(?:mv|cp|install)\s+[^\s|;&]+\s+[^\s|;&]+/.test(command)) return true;
+
+  // A redirect naming a path. `2>&1`, `>&2` and `/dev/null` are excluded, and
+  // the target must look like a filename rather than a descriptor.
+  return /(?<![0-9&])>>?\s*(?!\/dev\/null\b)(?!&)[\w./~$-]*[\w.-]/.test(command);
+}
+
+function isEditingUse(use: ToolUse): boolean {
+  if (EDIT_TOOLS.has(use.name)) return true;
+
+  return use.name === "Bash" && typeof use.input.command === "string"
+    ? isFileWritingCommand(use.input.command)
+    : false;
+}
 
 interface ToolUse {
   name: string;
@@ -432,7 +470,12 @@ export function aggregateWindow(records: SessionRecord[]): WindowSummary {
 export interface InteractionSummary {
   user_turns: number;
   corrective_turns: number;
-  tokens_before_first_edit: number;
+  /** `null` when no session showed an edit the collector could see — unknown,
+   *  never "all of it was exploration". */
+  tokens_before_first_edit: number | null;
+  /** How many sessions contributed to the figure above, so a partial reading
+   *  is visible as partial. */
+  sessions_with_observed_edit: number;
   tool_calls: Record<string, number>;
   edit_churn: { files_edited_3plus: number; max_edits_one_file: number };
   skills: Record<string, number>;
@@ -463,9 +506,17 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
   const sessionsWithWork = new Set<string>();
   const sessionsPastFirstEdit = new Set<string>();
 
+  // Accumulated per session, not globally, and only banked once that session
+  // actually shows an edit. A session that never edited anything the collector
+  // could see contributes nothing rather than contributing all of its tokens —
+  // "we did not observe the boundary" and "every token was exploration" are
+  // very different claims, and only one of them is true.
+  const pendingBySession = new Map<string, number>();
+  let tokensBeforeFirstEdit = 0;
+  let sessionsWithObservedEdit = 0;
+
   let userTurns = 0;
   let correctiveTurns = 0;
-  let tokensBeforeFirstEdit = 0;
 
   const ordered = [...records].sort((a, b) => (a.timestamp ?? "").localeCompare(b.timestamp ?? ""));
 
@@ -508,12 +559,14 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
 
     if (!record.isSidechain && !sessionsPastFirstEdit.has(session)) {
       const tokens = readUsage(record.message?.usage);
-      tokensBeforeFirstEdit +=
+      const spent =
         tokens.input +
         tokens.output +
         tokens.cache_write_5m +
         tokens.cache_write_1h +
         tokens.cache_read;
+
+      pendingBySession.set(session, (pendingBySession.get(session) ?? 0) + spent);
     }
 
     for (const use of uses) {
@@ -529,8 +582,13 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
         subagents[kind] = (subagents[kind] ?? 0) + 1;
       }
 
-      if (EDIT_TOOLS.has(use.name)) {
-        if (!record.isSidechain) sessionsPastFirstEdit.add(session);
+      if (isEditingUse(use)) {
+        if (!record.isSidechain && !sessionsPastFirstEdit.has(session)) {
+          sessionsPastFirstEdit.add(session);
+          sessionsWithObservedEdit += 1;
+          tokensBeforeFirstEdit += pendingBySession.get(session) ?? 0;
+        }
+
         const path = use.input.file_path;
         if (path) editsPerFile.set(path, (editsPerFile.get(path) ?? 0) + 1);
       }
@@ -542,7 +600,8 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
   return {
     user_turns: userTurns,
     corrective_turns: correctiveTurns,
-    tokens_before_first_edit: tokensBeforeFirstEdit,
+    tokens_before_first_edit: sessionsWithObservedEdit > 0 ? tokensBeforeFirstEdit : null,
+    sessions_with_observed_edit: sessionsWithObservedEdit,
     tool_calls: Object.fromEntries(Object.entries(tools).sort((a, b) => b[1] - a[1])),
     edit_churn: {
       files_edited_3plus: counts.filter((n) => n >= 3).length,
@@ -839,10 +898,12 @@ export function renderDetails(card: Card): string {
     ["Turns", `${interaction.user_turns} (${interaction.corrective_turns} corrective)`],
     [
       "Before first edit",
-      `${compactTokens(interaction.tokens_before_first_edit)} (${share(
-        interaction.tokens_before_first_edit,
-        total,
-      )})`,
+      interaction.tokens_before_first_edit === null
+        ? "not observed (no edit seen in the transcript)"
+        : `${compactTokens(interaction.tokens_before_first_edit)} (${share(
+            interaction.tokens_before_first_edit,
+            total,
+          )})`,
     ],
     [
       "Subagents",

--- a/tools/pr-metrics/package.json
+++ b/tools/pr-metrics/package.json
@@ -7,7 +7,8 @@
     "card": "bun run index.ts",
     "check": "tsc --noEmit",
     "test": "bun test",
-    "backfill": "bun run backfill.ts"
+    "backfill": "bun run backfill.ts",
+    "report": "bun run report.ts"
   },
   "devDependencies": {
     "@shared/typescript-config": "workspace:*",

--- a/tools/pr-metrics/package.json
+++ b/tools/pr-metrics/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "card": "bun run index.ts",
     "check": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "backfill": "bun run backfill.ts"
   },
   "devDependencies": {
     "@shared/typescript-config": "workspace:*",

--- a/tools/pr-metrics/queries.sql
+++ b/tools/pr-metrics/queries.sql
@@ -1,0 +1,152 @@
+-- Session-metrics queries. Run with DuckDB from the repository root:
+--
+--   duckdb -init tools/pr-metrics/queries.sql
+--
+-- The committed cards are the datalake. There is no service to run: DuckDB
+-- reads .claude/metrics/*.json where they sit, git supplies the versioning, and
+-- nothing here has a free-tier cap to watch.
+--
+-- Full schema and the reasoning behind it: wiki/observability/session-metrics.md
+
+CREATE OR REPLACE VIEW cards AS
+  SELECT * FROM read_json_auto('.claude/metrics/*.json', union_by_name := true);
+
+-- A card written at PR-open time cannot see review-cycle cost, so any query
+-- that compares totals has to filter on phase or it is adding two different
+-- measurements together.
+CREATE OR REPLACE VIEW merged AS
+  SELECT * FROM cards WHERE pr.phase = 'at-merge';
+
+-- Ratios everything below shares. Kept as a view rather than stored on the
+-- card: a definition that lives in one file can be changed and re-run over
+-- history, and a stored ratio cannot.
+CREATE OR REPLACE VIEW metrics AS
+  SELECT
+    pr.number                                       AS pr,
+    pr.branch                                       AS branch,
+    pr.generated_at::TIMESTAMP                      AS at,
+    complexity.declared                             AS declared,
+    complexity.method                               AS rating_method,
+    spend.usd_equivalent                            AS usd,
+    diff.loc.source.added + diff.loc.source.deleted AS source_loc,
+    diff.files.source                               AS source_files,
+    interaction.user_turns                          AS turns,
+    interaction.corrective_turns                    AS corrections,
+    window.active_seconds                           AS active_s,
+    spend.tokens.output
+      + spend.tokens.cache_read
+      + spend.tokens.cache_write_5m
+      + spend.tokens.cache_write_1h                 AS total_tokens,
+    spend.tokens.cache_read
+      / nullif(spend.tokens.output + spend.tokens.cache_read
+               + spend.tokens.cache_write_5m + spend.tokens.cache_write_1h, 0) AS cache_read_share,
+    interaction.tokens_before_first_edit
+      / nullif(spend.tokens.output + spend.tokens.cache_read
+               + spend.tokens.cache_write_5m + spend.tokens.cache_write_1h, 0) AS explore_share,
+    spend.by_actor.subagent.usd_equivalent
+      / nullif(spend.usd_equivalent, 0)             AS subagent_share
+  FROM merged;
+
+--------------------------------------------------------------------------------
+-- 1. Where agents cost too much for the job
+--------------------------------------------------------------------------------
+-- The query this whole system exists for. A small, low-rated task that cost a
+-- lot is either a missing skill or an unclear brief — the next two queries say
+-- which. Unconfirmed ratings are excluded: acting on an agent's unreviewed
+-- guess about how hard something was is the one thing that would make this
+-- circular.
+
+SELECT pr, declared, source_loc, round(usd, 2) AS usd, turns, corrections
+FROM metrics
+WHERE declared <= 2 AND source_loc < 100 AND rating_method = 'confirmed'
+ORDER BY usd DESC
+LIMIT 20;
+
+--------------------------------------------------------------------------------
+-- 2. Which areas need a skill or a wiki page
+--------------------------------------------------------------------------------
+-- `explore_share` is what the agent spent working out where the code lives
+-- before changing any of it. High and repeated in one package means that
+-- package has no usable map, and the fix is a wiki page or a skill — not a
+-- cheaper model.
+
+SELECT package, count(*) AS prs, round(avg(explore_share) * 100, 1) AS explore_pct
+FROM merged, unnest(diff.packages) AS t(package)
+JOIN metrics USING (pr)
+GROUP BY package
+HAVING count(*) >= 3
+ORDER BY explore_pct DESC;
+
+--------------------------------------------------------------------------------
+-- 3. Are briefs getting clearer?
+--------------------------------------------------------------------------------
+-- `corrections` counts turns that arrived after the agent had already started
+-- work. This is the one number here that measures the person rather than the
+-- model: one turn and a large spend is a clear brief; nine turns is a brief
+-- that needed nine patches.
+
+SELECT date_trunc('month', at) AS month,
+       count(*)                AS prs,
+       round(avg(turns), 1)    AS avg_turns,
+       round(avg(corrections), 1) AS avg_corrections
+FROM metrics
+GROUP BY month
+ORDER BY month;
+
+--------------------------------------------------------------------------------
+-- 4. Is the context surface bloating?
+--------------------------------------------------------------------------------
+-- Cache reads are the agent re-reading the same context. A share that climbs
+-- month over month means CLAUDE.md, the skills and the wiki pages an agent
+-- opens are growing faster than the work is.
+
+SELECT date_trunc('month', at) AS month,
+       round(avg(cache_read_share) * 100, 1) AS cache_read_pct,
+       round(avg(total_tokens) / 1e6, 1)     AS avg_mtok
+FROM metrics
+GROUP BY month
+ORDER BY month;
+
+--------------------------------------------------------------------------------
+-- 5. Cost per unit of declared difficulty
+--------------------------------------------------------------------------------
+-- The headline ratio. Read it as a trend, never as a target: driving it down
+-- by rating everything an 8 is trivial, and the rating is set before the work
+-- precisely so that cannot happen quietly.
+
+SELECT declared,
+       count(*)                     AS prs,
+       round(avg(usd), 2)           AS avg_usd,
+       round(avg(usd) / declared, 2) AS usd_per_point,
+       round(avg(active_s) / 60)    AS avg_active_min
+FROM metrics
+WHERE rating_method = 'confirmed'
+GROUP BY declared
+ORDER BY declared;
+
+--------------------------------------------------------------------------------
+-- 6. Is delegation paying off?
+--------------------------------------------------------------------------------
+-- Subagent share against cost at the same declared difficulty. If the heavily
+-- delegated PRs are not cheaper at equal difficulty, the delegation is
+-- re-reading context rather than saving it.
+
+SELECT declared,
+       round(avg(subagent_share) * 100) AS subagent_pct,
+       round(avg(usd), 2)               AS avg_usd,
+       count(*)                         AS prs
+FROM metrics
+WHERE rating_method = 'confirmed'
+GROUP BY declared
+ORDER BY declared;
+
+--------------------------------------------------------------------------------
+-- 7. Coverage — how much of the history can actually be trusted
+--------------------------------------------------------------------------------
+-- Run this before believing any of the above. A confirmed-rating count in the
+-- single digits means every trend above is noise.
+
+SELECT rating_method, count(*) AS prs, round(sum(usd), 2) AS total_usd
+FROM metrics
+GROUP BY rating_method
+ORDER BY prs DESC;

--- a/tools/pr-metrics/queries.sql
+++ b/tools/pr-metrics/queries.sql
@@ -6,6 +6,11 @@
 -- reads .claude/metrics/*.json where they sit, git supplies the versioning, and
 -- nothing here has a free-tier cap to watch.
 --
+-- Median, never mean, for any per-pull-request distribution. These are
+-- severely right-skewed: across the first 34 cards the median was 3.6M tokens,
+-- the mean 15.4M and the maximum 92.7M, so a mean describes the three largest
+-- pull requests and invents month-over-month growth that is not there.
+--
 -- Full schema and the reasoning behind it: wiki/observability/session-metrics.md
 
 CREATE OR REPLACE VIEW cards AS
@@ -45,9 +50,13 @@ CREATE OR REPLACE VIEW metrics AS
     spend.tokens.cache_read
       / nullif(spend.tokens.output + spend.tokens.cache_read
                + spend.tokens.cache_write_5m + spend.tokens.cache_write_1h, 0) AS cache_read_share,
+    -- NULL when the transcript showed no edit: the boundary is unknown, not
+    -- zero and certainly not 100%. Counting those as pure exploration sorted
+    -- this ranking by which branches avoided the Edit tool.
     interaction.tokens_before_first_edit
       / nullif(spend.tokens.output + spend.tokens.cache_read
                + spend.tokens.cache_write_5m + spend.tokens.cache_write_1h, 0) AS explore_share,
+    interaction.sessions_with_observed_edit                                    AS edited_sessions,
     spend.by_actor.subagent.usd_equivalent
       / nullif(spend.usd_equivalent, 0)             AS subagent_share
   FROM merged;
@@ -75,9 +84,10 @@ LIMIT 20;
 -- package has no usable map, and the fix is a wiki page or a skill — not a
 -- cheaper model.
 
-SELECT package, count(*) AS prs, round(avg(explore_share) * 100, 1) AS explore_pct
+SELECT package, count(*) AS prs, round(median(explore_share) * 100, 1) AS explore_pct
 FROM merged, unnest(diff.packages) AS t(package)
 JOIN metrics USING (pr)
+WHERE explore_share IS NOT NULL
 GROUP BY package
 HAVING count(*) >= 3
 ORDER BY explore_pct DESC;
@@ -92,8 +102,8 @@ ORDER BY explore_pct DESC;
 
 SELECT date_trunc('month', at) AS month,
        count(*)                AS prs,
-       round(avg(turns), 1)    AS avg_turns,
-       round(avg(corrections), 1) AS avg_corrections
+       round(median(turns), 1)    AS median_turns,
+       round(median(corrections), 1) AS median_corrections
 FROM metrics
 GROUP BY month
 ORDER BY month;
@@ -106,8 +116,8 @@ ORDER BY month;
 -- opens are growing faster than the work is.
 
 SELECT date_trunc('month', at) AS month,
-       round(avg(cache_read_share) * 100, 1) AS cache_read_pct,
-       round(avg(total_tokens) / 1e6, 1)     AS avg_mtok
+       round(median(cache_read_share) * 100, 1) AS cache_read_pct,
+       round(median(total_tokens) / 1e6, 1)     AS median_mtok
 FROM metrics
 GROUP BY month
 ORDER BY month;
@@ -121,9 +131,9 @@ ORDER BY month;
 
 SELECT declared,
        count(*)                     AS prs,
-       round(avg(usd), 2)           AS avg_usd,
-       round(avg(usd) / declared, 2) AS usd_per_point,
-       round(avg(active_s) / 60)    AS avg_active_min
+       round(median(usd), 2)           AS median_usd,
+       round(median(usd) / declared, 2) AS usd_per_point,
+       round(median(active_s) / 60)    AS median_active_min
 FROM metrics
 WHERE rating_method = 'confirmed'
 GROUP BY declared
@@ -137,8 +147,8 @@ ORDER BY declared;
 -- re-reading context rather than saving it.
 
 SELECT declared,
-       round(avg(subagent_share) * 100) AS subagent_pct,
-       round(avg(usd), 2)               AS avg_usd,
+       round(median(subagent_share) * 100) AS subagent_pct,
+       round(median(usd), 2)               AS median_usd,
        count(*)                         AS prs
 FROM metrics
 WHERE rating_method = 'confirmed'

--- a/tools/pr-metrics/queries.sql
+++ b/tools/pr-metrics/queries.sql
@@ -11,11 +11,15 @@
 CREATE OR REPLACE VIEW cards AS
   SELECT * FROM read_json_auto('.claude/metrics/*.json', union_by_name := true);
 
--- A card written at PR-open time cannot see review-cycle cost, so any query
--- that compares totals has to filter on phase or it is adding two different
--- measurements together.
+-- Merged pull requests. Filtered on merge status, deliberately NOT on
+-- `phase = 'at-merge'`: a remote session's container is destroyed when it ends,
+-- taking its transcripts with it, so remotely-produced cards can never be
+-- refreshed past `at-open`. Filtering on phase would silently drop every pull
+-- request that was not worked on a machine you still own — which biases every
+-- analysis below toward local work while looking like it is simply being
+-- careful. `phase` stays a visible column instead; query 7 reports the split.
 CREATE OR REPLACE VIEW merged AS
-  SELECT * FROM cards WHERE pr.phase = 'at-merge';
+  SELECT * FROM cards WHERE pr.merged_at IS NOT NULL;
 
 -- Ratios everything below shares. Kept as a view rather than stored on the
 -- card: a definition that lives in one file can be changed and re-run over
@@ -27,6 +31,7 @@ CREATE OR REPLACE VIEW metrics AS
     pr.generated_at::TIMESTAMP                      AS at,
     complexity.declared                             AS declared,
     complexity.method                               AS rating_method,
+    pr.phase                                        AS phase,
     spend.usd_equivalent                            AS usd,
     diff.loc.source.added + diff.loc.source.deleted AS source_loc,
     diff.files.source                               AS source_files,
@@ -144,9 +149,12 @@ ORDER BY declared;
 -- 7. Coverage — how much of the history can actually be trusted
 --------------------------------------------------------------------------------
 -- Run this before believing any of the above. A confirmed-rating count in the
--- single digits means every trend above is noise.
+-- single digits means every trend above is noise. The phase split matters just
+-- as much: an `at-open` card is missing its review-cycle cost, and every card
+-- produced by a remote session stays `at-open` forever, so a corpus that is
+-- mostly `at-open` under-reports the true cost of the work it describes.
 
-SELECT rating_method, count(*) AS prs, round(sum(usd), 2) AS total_usd
+SELECT rating_method, phase, count(*) AS prs, round(sum(usd), 2) AS total_usd
 FROM metrics
-GROUP BY rating_method
+GROUP BY rating_method, phase
 ORDER BY prs DESC;

--- a/tools/pr-metrics/report.ts
+++ b/tools/pr-metrics/report.ts
@@ -38,7 +38,8 @@ export interface CardRow {
   activeSeconds: number;
   totalTokens: number;
   cacheReadShare: number;
-  exploreShare: number;
+  /** `null` when the transcript showed no edit — unknown, not 100%. */
+  exploreShare: number | null;
   subagentShare: number;
 }
 
@@ -67,7 +68,10 @@ export function toRow(card: Card): CardRow {
     activeSeconds: card.window.active_seconds,
     totalTokens: total,
     cacheReadShare: ratio(t.cache_read, total),
-    exploreShare: ratio(card.interaction.tokens_before_first_edit, total),
+    exploreShare:
+      card.interaction.tokens_before_first_edit === null
+        ? null
+        : ratio(card.interaction.tokens_before_first_edit, total),
     subagentShare: ratio(card.spend.by_actor.subagent.usd_equivalent, card.spend.usd_equivalent),
   };
 }
@@ -87,8 +91,21 @@ export function merged(rows: CardRow[]): CardRow[] {
 
 const monthOf = (iso: string): string => iso.slice(0, 7);
 
-function mean(values: number[]): number {
-  return values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length;
+/**
+ * Median, not mean, everywhere a per-pull-request distribution is summarised.
+ *
+ * These distributions are severely right-skewed: across the first 34 cards the
+ * median was 3.6M tokens, the mean 15.4M and the maximum 92.7M. A mean over
+ * that describes the three biggest pull requests and nothing else, and reading
+ * it as a trend invents month-over-month growth that is not there.
+ */
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
 
 function groupBy<K>(rows: CardRow[], key: (row: CardRow) => K): Map<K, CardRow[]> {
@@ -143,8 +160,18 @@ export function waste(rows: CardRow[]): Table {
 
 /** 2. Which packages need a skill or a wiki page. */
 export function exploration(rows: CardRow[], minPrs = 3): Table {
+  // Only cards where an edit was actually observed. A card whose transcript
+  // showed no edit has an unknown boundary, not a 100% one — counting those as
+  // pure exploration is what made this ranking sort by "which branches avoided
+  // the Edit tool" rather than by anything about the packages.
   const byPackage = new Map<string, number[]>();
+  let skipped = 0;
   for (const row of rows) {
+    if (row.exploreShare === null) {
+      skipped += 1;
+      continue;
+    }
+
     for (const pkg of row.packages) {
       const bucket = byPackage.get(pkg);
       if (bucket) bucket.push(row.exploreShare);
@@ -154,12 +181,16 @@ export function exploration(rows: CardRow[], minPrs = 3): Table {
 
   const ranked = [...byPackage.entries()]
     .filter(([, shares]) => shares.length >= minPrs)
-    .map(([pkg, shares]) => ({ pkg, prs: shares.length, share: mean(shares) }))
+    .map(([pkg, shares]) => ({ pkg, prs: shares.length, share: median(shares) }))
     .sort((a, b) => b.share - a.share);
 
   return {
     title: "2. Which packages need a skill or a wiki page",
-    note: "Share of spend before the first edit — the agent working out where the code lives. High and repeated means that package has no usable map.",
+    note:
+      "Share of spend before the first edit — the agent working out where the code lives. High and repeated means that package has no usable map." +
+      (skipped > 0
+        ? ` ${skipped} card(s) excluded: no edit observed in the transcript, so the boundary is unknown.`
+        : ""),
     headers: ["package", "PRs", "explore share"],
     rows: ranked.map((r) => [r.pkg, String(r.prs), pct(r.share)]),
   };
@@ -172,14 +203,14 @@ export function briefs(rows: CardRow[]): Table {
   return {
     title: "3. Are briefs getting clearer?",
     note: "Corrections are turns that arrived after work had started. The one number here that measures the brief rather than the model.",
-    headers: ["month", "PRs", "avg turns", "avg corrections"],
+    headers: ["month", "PRs", "median turns", "median corrections"],
     rows: [...byMonth.entries()]
       .sort((a, b) => a[0].localeCompare(b[0]))
       .map(([month, group]) => [
         month,
         String(group.length),
-        mean(group.map((r) => r.turns)).toFixed(1),
-        mean(group.map((r) => r.corrections)).toFixed(1),
+        median(group.map((r) => r.turns)).toFixed(1),
+        median(group.map((r) => r.corrections)).toFixed(1),
       ]),
   };
 }
@@ -191,14 +222,14 @@ export function context(rows: CardRow[]): Table {
   return {
     title: "4. Is the context surface bloating?",
     note: "Cache reads are the agent re-reading context. A share climbing month over month means CLAUDE.md, the skills and the wiki are growing faster than the work.",
-    headers: ["month", "PRs", "cache-read share", "avg tokens"],
+    headers: ["month", "PRs", "cache-read share", "median tokens"],
     rows: [...byMonth.entries()]
       .sort((a, b) => a[0].localeCompare(b[0]))
       .map(([month, group]) => [
         month,
         String(group.length),
-        pct(mean(group.map((r) => r.cacheReadShare))),
-        compactTokens(Math.round(mean(group.map((r) => r.totalTokens)))),
+        pct(median(group.map((r) => r.cacheReadShare))),
+        compactTokens(Math.round(median(group.map((r) => r.totalTokens)))),
       ]),
   };
 }
@@ -211,15 +242,15 @@ export function costByComplexity(rows: CardRow[]): Table {
   return {
     title: "5. Cost per unit of declared difficulty",
     note: "A trend, never a target: rating everything an 8 would drive it down, which is why the rating is set before the work.",
-    headers: ["declared", "PRs", "avg cost", "cost per point", "avg active"],
+    headers: ["declared", "PRs", "median cost", "cost per point", "median active"],
     rows: [...byDeclared.entries()]
       .sort((a, b) => a[0] - b[0])
       .map(([declared, group]) => [
         String(declared),
         String(group.length),
-        usd(mean(group.map((r) => r.usd))),
-        usd(mean(group.map((r) => r.usd)) / declared),
-        `${Math.round(mean(group.map((r) => r.activeSeconds)) / 60)}m`,
+        usd(median(group.map((r) => r.usd))),
+        usd(median(group.map((r) => r.usd)) / declared),
+        `${Math.round(median(group.map((r) => r.activeSeconds)) / 60)}m`,
       ]),
   };
 }
@@ -232,14 +263,14 @@ export function delegation(rows: CardRow[]): Table {
   return {
     title: "6. Is delegation paying off?",
     note: "Subagent share against cost at equal difficulty. If delegated PRs are not cheaper, the delegation is re-reading context rather than saving it.",
-    headers: ["declared", "PRs", "subagent share", "avg cost"],
+    headers: ["declared", "PRs", "subagent share", "median cost"],
     rows: [...byDeclared.entries()]
       .sort((a, b) => a[0] - b[0])
       .map(([declared, group]) => [
         String(declared),
         String(group.length),
-        pct(mean(group.map((r) => r.subagentShare))),
-        usd(mean(group.map((r) => r.usd))),
+        pct(median(group.map((r) => r.subagentShare))),
+        usd(median(group.map((r) => r.usd))),
       ]),
   };
 }

--- a/tools/pr-metrics/report.ts
+++ b/tools/pr-metrics/report.ts
@@ -1,0 +1,346 @@
+#!/usr/bin/env bun
+/**
+ * Read the cards back, without needing anything installed.
+ *
+ * `queries.sql` is the same seven analyses in SQL, and it is the better tool
+ * for a question nobody anticipated. It is not the better tool for the common
+ * case, because **DuckDB does not exist in a remote session** — none of the
+ * `duckdb` npm packages ship a binary (they are all libraries), so `bunx` is no
+ * help and there is no `brew` in a cloud container. A report that only runs on
+ * one laptop is not a report on how the fleet is doing.
+ *
+ * So the seven queries live here too, in TypeScript, over the same committed
+ * JSON. That runs in every environment the repository runs in — local, cloud,
+ * CI — with no dependency at all. A few hundred small JSON files do not need an
+ * OLAP engine; calling the directory a datalake oversold it.
+ *
+ * The two must agree. When a definition changes, change it in both — the
+ * ratios are duplicated on purpose rather than generated, because generating
+ * SQL from TypeScript would cost more than it saves at this size.
+ */
+
+import { type Card, compactTokens } from "./index.ts";
+
+export interface CardRow {
+  pr: number | null;
+  branch: string;
+  at: string;
+  mergedAt: string | null;
+  phase: string;
+  declared: number | null;
+  ratingMethod: string;
+  usd: number;
+  sourceLoc: number;
+  sourceFiles: number;
+  packages: string[];
+  turns: number;
+  corrections: number;
+  activeSeconds: number;
+  totalTokens: number;
+  cacheReadShare: number;
+  exploreShare: number;
+  subagentShare: number;
+}
+
+function ratio(part: number, whole: number): number {
+  return whole > 0 ? part / whole : 0;
+}
+
+export function toRow(card: Card): CardRow {
+  const t = card.spend.tokens;
+  const total = t.output + t.cache_read + t.cache_write_5m + t.cache_write_1h;
+
+  return {
+    pr: card.pr.number,
+    branch: card.pr.branch,
+    at: card.pr.merged_at ?? card.pr.generated_at,
+    mergedAt: card.pr.merged_at,
+    phase: card.pr.phase,
+    declared: card.complexity.declared,
+    ratingMethod: card.complexity.method,
+    usd: card.spend.usd_equivalent,
+    sourceLoc: card.diff.loc.source.added + card.diff.loc.source.deleted,
+    sourceFiles: card.diff.files.source,
+    packages: card.diff.packages,
+    turns: card.interaction.user_turns,
+    corrections: card.interaction.corrective_turns,
+    activeSeconds: card.window.active_seconds,
+    totalTokens: total,
+    cacheReadShare: ratio(t.cache_read, total),
+    exploreShare: ratio(card.interaction.tokens_before_first_edit, total),
+    subagentShare: ratio(card.spend.by_actor.subagent.usd_equivalent, card.spend.usd_equivalent),
+  };
+}
+
+/**
+ * Merged pull requests, by merge status — never by `phase === "at-merge"`.
+ *
+ * A remote session's container is destroyed when it ends and takes its
+ * transcripts with it, so a remotely-produced card can never be refreshed past
+ * `at-open`. Filtering on phase would drop every pull request not worked on a
+ * machine you still own, and would look like caution while quietly biasing
+ * every number below toward local work.
+ */
+export function merged(rows: CardRow[]): CardRow[] {
+  return rows.filter((row) => row.mergedAt !== null);
+}
+
+const monthOf = (iso: string): string => iso.slice(0, 7);
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function groupBy<K>(rows: CardRow[], key: (row: CardRow) => K): Map<K, CardRow[]> {
+  const groups = new Map<K, CardRow[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const bucket = groups.get(k);
+    if (bucket) bucket.push(row);
+    else groups.set(k, [row]);
+  }
+
+  return groups;
+}
+
+export interface Table {
+  title: string;
+  note?: string;
+  headers: string[];
+  rows: string[][];
+}
+
+const pct = (value: number): string => `${(value * 100).toFixed(0)}%`;
+const usd = (value: number): string => `$${value.toFixed(2)}`;
+
+/** 1. Where agents cost too much for the job. */
+export function waste(rows: CardRow[]): Table {
+  const candidates = rows
+    .filter(
+      (row) =>
+        row.declared !== null &&
+        row.declared <= 2 &&
+        row.sourceLoc < 100 &&
+        row.ratingMethod === "confirmed",
+    )
+    .sort((a, b) => b.usd - a.usd)
+    .slice(0, 20);
+
+  return {
+    title: "1. Where agents cost too much for the job",
+    note: "Small, low-rated, expensive. Unconfirmed ratings excluded — acting on an agent's own guess about difficulty is what would make this circular.",
+    headers: ["PR", "declared", "source LOC", "cost", "turns", "corrections"],
+    rows: candidates.map((r) => [
+      `#${r.pr}`,
+      String(r.declared),
+      String(r.sourceLoc),
+      usd(r.usd),
+      String(r.turns),
+      String(r.corrections),
+    ]),
+  };
+}
+
+/** 2. Which packages need a skill or a wiki page. */
+export function exploration(rows: CardRow[], minPrs = 3): Table {
+  const byPackage = new Map<string, number[]>();
+  for (const row of rows) {
+    for (const pkg of row.packages) {
+      const bucket = byPackage.get(pkg);
+      if (bucket) bucket.push(row.exploreShare);
+      else byPackage.set(pkg, [row.exploreShare]);
+    }
+  }
+
+  const ranked = [...byPackage.entries()]
+    .filter(([, shares]) => shares.length >= minPrs)
+    .map(([pkg, shares]) => ({ pkg, prs: shares.length, share: mean(shares) }))
+    .sort((a, b) => b.share - a.share);
+
+  return {
+    title: "2. Which packages need a skill or a wiki page",
+    note: "Share of spend before the first edit — the agent working out where the code lives. High and repeated means that package has no usable map.",
+    headers: ["package", "PRs", "explore share"],
+    rows: ranked.map((r) => [r.pkg, String(r.prs), pct(r.share)]),
+  };
+}
+
+/** 3. Are briefs getting clearer? */
+export function briefs(rows: CardRow[]): Table {
+  const byMonth = groupBy(rows, (row) => monthOf(row.at));
+
+  return {
+    title: "3. Are briefs getting clearer?",
+    note: "Corrections are turns that arrived after work had started. The one number here that measures the brief rather than the model.",
+    headers: ["month", "PRs", "avg turns", "avg corrections"],
+    rows: [...byMonth.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([month, group]) => [
+        month,
+        String(group.length),
+        mean(group.map((r) => r.turns)).toFixed(1),
+        mean(group.map((r) => r.corrections)).toFixed(1),
+      ]),
+  };
+}
+
+/** 4. Is the context surface bloating? */
+export function context(rows: CardRow[]): Table {
+  const byMonth = groupBy(rows, (row) => monthOf(row.at));
+
+  return {
+    title: "4. Is the context surface bloating?",
+    note: "Cache reads are the agent re-reading context. A share climbing month over month means CLAUDE.md, the skills and the wiki are growing faster than the work.",
+    headers: ["month", "PRs", "cache-read share", "avg tokens"],
+    rows: [...byMonth.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([month, group]) => [
+        month,
+        String(group.length),
+        pct(mean(group.map((r) => r.cacheReadShare))),
+        compactTokens(Math.round(mean(group.map((r) => r.totalTokens)))),
+      ]),
+  };
+}
+
+/** 5. Cost per unit of declared difficulty. */
+export function costByComplexity(rows: CardRow[]): Table {
+  const rated = rows.filter((row) => row.declared !== null && row.ratingMethod === "confirmed");
+  const byDeclared = groupBy(rated, (row) => row.declared as number);
+
+  return {
+    title: "5. Cost per unit of declared difficulty",
+    note: "A trend, never a target: rating everything an 8 would drive it down, which is why the rating is set before the work.",
+    headers: ["declared", "PRs", "avg cost", "cost per point", "avg active"],
+    rows: [...byDeclared.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([declared, group]) => [
+        String(declared),
+        String(group.length),
+        usd(mean(group.map((r) => r.usd))),
+        usd(mean(group.map((r) => r.usd)) / declared),
+        `${Math.round(mean(group.map((r) => r.activeSeconds)) / 60)}m`,
+      ]),
+  };
+}
+
+/** 6. Is delegation paying off? */
+export function delegation(rows: CardRow[]): Table {
+  const rated = rows.filter((row) => row.declared !== null && row.ratingMethod === "confirmed");
+  const byDeclared = groupBy(rated, (row) => row.declared as number);
+
+  return {
+    title: "6. Is delegation paying off?",
+    note: "Subagent share against cost at equal difficulty. If delegated PRs are not cheaper, the delegation is re-reading context rather than saving it.",
+    headers: ["declared", "PRs", "subagent share", "avg cost"],
+    rows: [...byDeclared.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([declared, group]) => [
+        String(declared),
+        String(group.length),
+        pct(mean(group.map((r) => r.subagentShare))),
+        usd(mean(group.map((r) => r.usd))),
+      ]),
+  };
+}
+
+/** 7. How much of the history can be trusted. Run this one first. */
+export function coverage(rows: CardRow[]): Table {
+  const byKey = groupBy(rows, (row) => `${row.ratingMethod} ${row.phase}`);
+
+  return {
+    title: "7. Coverage — how much of this can be trusted",
+    note: "Read before anything above. A single-digit confirmed count makes every trend noise. Cards from remote sessions stay at-open forever, so an at-open-heavy corpus under-reports true cost.",
+    headers: ["rating", "phase", "PRs", "total cost"],
+    rows: [...byKey.entries()]
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([key, group]) => {
+        const [method, phase] = key.split(" ");
+
+        return [method, phase, String(group.length), usd(group.reduce((sum, r) => sum + r.usd, 0))];
+      }),
+  };
+}
+
+export function formatTable(table: Table): string {
+  const lines = [`\n${table.title}`, "─".repeat(Math.min(table.title.length, 78))];
+
+  if (table.rows.length === 0) {
+    lines.push("  (no rows)");
+    if (table.note) lines.push(`  ${table.note}`);
+
+    return lines.join("\n");
+  }
+
+  const widths = table.headers.map((header, i) =>
+    Math.max(header.length, ...table.rows.map((row) => (row[i] ?? "").length)),
+  );
+  const render = (cells: string[]): string =>
+    cells
+      .map((cell, i) => (cell ?? "").padEnd(widths[i]))
+      .join("  ")
+      .trimEnd();
+
+  lines.push(`  ${render(table.headers)}`, `  ${widths.map((w) => "─".repeat(w)).join("  ")}`);
+  for (const row of table.rows) lines.push(`  ${render(row)}`);
+  if (table.note) lines.push(`\n  ${table.note}`);
+
+  return lines.join("\n");
+}
+
+export function loadCards(dir: string): Card[] {
+  const fs = require("node:fs") as typeof import("node:fs");
+
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir).filter((name) => name.endsWith(".json"));
+  } catch {
+    return [];
+  }
+
+  const cards: Card[] = [];
+  for (const name of names) {
+    try {
+      cards.push(JSON.parse(fs.readFileSync(`${dir}/${name}`, "utf8")) as Card);
+    } catch {
+      console.warn(`⚠️  pr-metrics report: skipping unreadable card ${name}`);
+    }
+  }
+
+  return cards;
+}
+
+const REPORTS = {
+  coverage,
+  waste,
+  exploration,
+  briefs,
+  context,
+  "cost-by-complexity": costByComplexity,
+  delegation,
+} as const;
+
+if (import.meta.main) {
+  const dirIndex = Bun.argv.indexOf("--dir");
+  const dir = dirIndex >= 0 && Bun.argv[dirIndex + 1] ? Bun.argv[dirIndex + 1] : ".claude/metrics";
+  const cards = loadCards(dir);
+
+  if (cards.length === 0) {
+    console.error(`❌ pr-metrics report: no cards under ${dir}.`);
+    console.error("   Run `bun run --cwd tools/pr-metrics backfill` to populate it.");
+    process.exit(1);
+  }
+
+  const rows = merged(cards.map(toRow));
+  const asked = Object.keys(REPORTS).filter((name) => Bun.argv.includes(`--${name}`));
+  const selected = asked.length > 0 ? asked : Object.keys(REPORTS);
+
+  console.log(`pr-metrics report: ${cards.length} card(s) in ${dir}, ${rows.length} merged.`);
+
+  for (const name of selected) {
+    console.log(formatTable(REPORTS[name as keyof typeof REPORTS](rows)));
+  }
+
+  console.log("\nAd-hoc SQL over the same cards (needs DuckDB, local only):");
+  console.log("  duckdb -init tools/pr-metrics/queries.sql");
+}

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -10,6 +10,7 @@ import {
   declaredFromLabels,
   emptyTokens,
   IDLE_CAP_SECONDS,
+  isFileWritingCommand,
   isHumanTurn,
   parseNumstat,
   readUsage,
@@ -316,8 +317,11 @@ test("aggregateInteraction stops counting exploration at the first edit", () => 
 
 // A second session re-reading the same files to find its feet is exactly the
 // waste this field exists to surface, so it is charged again rather than being
-// hidden behind the first session's answer.
-test("aggregateInteraction charges exploration once per session", () => {
+// hidden behind the first session's answer — but only once that session shows
+// an edit of its own. Session `b` below never edits anything, so its boundary
+// is unknown and its tokens are not banked. Counting them would assert that
+// every token it spent was exploration, which is a different claim entirely.
+test("aggregateInteraction banks a session's exploration only once it edits", () => {
   const interaction = aggregateInteraction([
     assistant({
       sessionId: "a",
@@ -339,7 +343,8 @@ test("aggregateInteraction charges exploration once per session", () => {
     }),
   ]);
 
-  expect(interaction.tokens_before_first_edit).toBe(80);
+  expect(interaction.tokens_before_first_edit).toBe(10);
+  expect(interaction.sessions_with_observed_edit).toBe(1);
 });
 
 test("aggregateInteraction records skills, subagents and edit churn", () => {
@@ -463,4 +468,78 @@ test("branchSlug flattens a branch into one filename", () => {
   expect(branchSlug("feat/pr-session-metrics")).toBe("feat-pr-session-metrics");
   expect(branchSlug("fix/osn-api/bot~traffic")).toBe("fix-osn-api-bot-traffic");
   expect(branchSlug("///")).toBe("unknown");
+});
+
+// --- edits made through the shell ------------------------------------------
+
+// This repository's own agent instructions tell agents to change files "with
+// sed, heredocs, or short scripts, rather than using the dedicated Edit tool".
+// Counting only Edit/Write meant 15 of the first 34 pull requests changed real
+// source with no observed edit at all, and each reported 100% exploration.
+test("isFileWritingCommand sees the shell forms that write files", () => {
+  expect(isFileWritingCommand("sed -i '' 's/a/b/' src/x.ts")).toBe(true);
+  expect(isFileWritingCommand("cat > src/x.ts <<'EOF'")).toBe(true);
+  expect(isFileWritingCommand("echo hi >> notes.md")).toBe(true);
+  expect(isFileWritingCommand("printf '%s' x | tee config.json")).toBe(true);
+  expect(isFileWritingCommand("mv old.ts new.ts")).toBe(true);
+});
+
+// A false positive moves the boundary too early and under-reports exploration,
+// which is the more misleading direction — so the read-only shapes that appear
+// in almost every command must not count.
+test("isFileWritingCommand ignores redirects that write nothing", () => {
+  expect(isFileWritingCommand("bun test 2>&1 | tail -5")).toBe(false);
+  expect(isFileWritingCommand("command -v gh >/dev/null")).toBe(false);
+  expect(isFileWritingCommand("ls -la")).toBe(false);
+  expect(isFileWritingCommand("grep -rn 'x' src/")).toBe(false);
+});
+
+test("aggregateInteraction treats a shell write as the first edit", () => {
+  const interaction = aggregateInteraction([
+    assistant({
+      timestamp: "…01",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Grep")],
+        usage: usage({ output_tokens: 100 }),
+      },
+    }),
+    assistant({
+      timestamp: "…02",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Bash", { command: "sed -i '' 's/a/b/' src/x.ts" })],
+        usage: usage({ output_tokens: 20 }),
+      },
+    }),
+    assistant({
+      timestamp: "…03",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Bash", { command: "bun test" })],
+        usage: usage({ output_tokens: 9000 }),
+      },
+    }),
+  ]);
+
+  expect(interaction.tokens_before_first_edit).toBe(120);
+});
+
+// "We never saw the boundary" and "every token was exploration" are different
+// claims. Reporting the second when only the first is true is what broke the
+// per-package ranking.
+test("aggregateInteraction reports null when no edit was ever observed", () => {
+  const interaction = aggregateInteraction([
+    assistant({
+      timestamp: "…01",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Read"), toolUse("Grep")],
+        usage: usage({ output_tokens: 5000 }),
+      },
+    }),
+  ]);
+
+  expect(interaction.tokens_before_first_edit).toBeNull();
+  expect(interaction.sessions_with_observed_edit).toBe(0);
 });

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -397,6 +397,7 @@ test("parseNumstat buckets lines and collects packages", () => {
   expect(diff.loc.generated).toEqual({ added: 800, deleted: 60 });
   expect(diff.files.source).toBe(2);
   expect(diff.packages).toEqual(["osn/api", "shared/crypto"]);
+  expect(parseNumstat("1\t0\ttools/pr-metrics/index.ts", 1).packages).toEqual(["tools/pr-metrics"]);
   expect(diff.commits).toBe(6);
 });
 

--- a/tools/pr-metrics/tests/render.test.ts
+++ b/tools/pr-metrics/tests/render.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+
+import {
+  buildCard,
+  type Card,
+  compactTokens,
+  humanDuration,
+  parseNumstat,
+  renderDetails,
+  type SessionRecord,
+} from "../index";
+
+function card(overrides: { records?: SessionRecord[]; declared?: number | null } = {}): Card {
+  const records: SessionRecord[] = overrides.records ?? [
+    { type: "user", sessionId: "s1", timestamp: "…01", message: { content: "go" } },
+    {
+      type: "assistant",
+      sessionId: "s1",
+      timestamp: "…02",
+      message: {
+        model: "claude-opus-5",
+        content: [{ type: "tool_use", name: "Edit", input: { file_path: "a.ts" } }],
+        usage: {
+          input_tokens: 0,
+          output_tokens: 360_280,
+          cache_creation_input_tokens: 2_105_301,
+          cache_read_input_tokens: 63_448_693,
+        },
+      },
+    },
+  ];
+
+  return buildCard(records, parseNumstat("312\t88\tosn/api/src/a.ts", 6), {
+    branch: "feat/x",
+    prNumber: 908,
+    issueNumber: 895,
+    issueType: "Feature",
+    issueLabels: [],
+    declaredComplexity: overrides.declared === undefined ? 3 : overrides.declared,
+    complexityMethod: "confirmed",
+    baseSha: "abc",
+    headSha: "def",
+    mergedAt: null,
+    phase: "at-open",
+    generatedAt: "2026-09-07T00:00:00.000Z",
+  });
+}
+
+test("compactTokens keeps large counts readable", () => {
+  expect(compactTokens(66_000_000)).toBe("66.0M");
+  expect(compactTokens(1_500)).toBe("1.5K");
+  expect(compactTokens(42)).toBe("42");
+});
+
+test("humanDuration reads in the unit that fits", () => {
+  expect(humanDuration(45)).toBe("45s");
+  expect(humanDuration(1_200)).toBe("20m");
+  expect(humanDuration(7_500)).toBe("2h 5m");
+});
+
+// `prep-pr` permits exactly five `##` headings and counts them before it
+// finishes. A metrics *section* would fail a body that is otherwise correct, so
+// the block must contribute no heading at all.
+test("renderDetails adds no markdown heading", () => {
+  const block = renderDetails(card());
+
+  expect(block).not.toMatch(/^#/m);
+  expect(block.startsWith("<details>")).toBe(true);
+  expect(block.trimEnd().endsWith("</details>")).toBe(true);
+});
+
+test("renderDetails puts the four headline figures in the summary line", () => {
+  const summary = renderDetails(card()).split("\n")[0];
+
+  expect(summary).toContain("$");
+  expect(summary).toContain("65.9M tok");
+  expect(summary).toContain("complexity 3");
+  expect(summary).toContain("+312/-88 source");
+});
+
+// The work runs on a subscription. A column headed "Cost" invites the number
+// to be read as a bill, which it is not.
+test("renderDetails labels the cost as API-equivalent", () => {
+  expect(renderDetails(card())).toContain("Cost (API-equivalent)");
+});
+
+test("renderDetails says unrated rather than inventing a number", () => {
+  const block = renderDetails(card({ declared: null }));
+
+  expect(block).toContain("| Declared complexity | unrated |");
+  expect(block.split("\n")[0]).toContain("complexity unrated");
+});
+
+test("renderDetails reports no subagents without pretending there were some", () => {
+  expect(renderDetails(card())).toContain("| Subagents | none |");
+});
+
+test("renderDetails survives a card with no spend at all", () => {
+  const block = renderDetails(card({ records: [] }));
+
+  expect(block).toContain("$0.00");
+  expect(block).toContain("| Models | — |");
+});

--- a/tools/pr-metrics/tests/report.test.ts
+++ b/tools/pr-metrics/tests/report.test.ts
@@ -1,0 +1,224 @@
+import { expect, test } from "bun:test";
+
+import type { Card } from "../index";
+import {
+  briefs,
+  type CardRow,
+  costByComplexity,
+  coverage,
+  exploration,
+  formatTable,
+  merged,
+  toRow,
+  waste,
+} from "../report";
+
+function card(overrides: Partial<Card["pr"]> & Record<string, unknown> = {}): Card {
+  const pr = {
+    number: 1,
+    branch: "feat/x",
+    base_sha: "a",
+    head_sha: "b",
+    generated_at: "2026-09-01T00:00:00.000Z",
+    merged_at: "2026-09-02T00:00:00.000Z",
+    phase: "at-open" as const,
+    ...overrides,
+  };
+
+  return {
+    schema_version: 1,
+    pr,
+    issue: { number: null, type: null, labels: [] },
+    complexity: { declared: 2, method: "confirmed" },
+    window: {
+      sessions: 1,
+      first_ts: null,
+      last_ts: null,
+      span_seconds: 0,
+      active_seconds: 600,
+      compactions: 0,
+    },
+    spend: {
+      usd_equivalent: 50,
+      tokens: {
+        input: 0,
+        output: 1_000,
+        thinking: 0,
+        cache_write_5m: 0,
+        cache_write_1h: 0,
+        cache_read: 9_000,
+      },
+      by_model: {},
+      by_actor: {
+        main: {
+          tokens: {
+            input: 0,
+            output: 0,
+            thinking: 0,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+          },
+          usd_equivalent: 40,
+          messages: 0,
+        },
+        subagent: {
+          tokens: {
+            input: 0,
+            output: 0,
+            thinking: 0,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+          },
+          usd_equivalent: 10,
+          messages: 0,
+        },
+      },
+      effort: {},
+      unpriced_models: [],
+    },
+    diff: {
+      files: { generated: 0, test: 0, docs: 0, config: 0, source: 2 },
+      loc: {
+        generated: { added: 0, deleted: 0 },
+        test: { added: 0, deleted: 0 },
+        docs: { added: 0, deleted: 0 },
+        config: { added: 0, deleted: 0 },
+        source: { added: 30, deleted: 10 },
+      },
+      packages: ["osn/api"],
+      touches_migration: false,
+      commits: 1,
+    },
+    interaction: {
+      user_turns: 4,
+      corrective_turns: 2,
+      tokens_before_first_edit: 2_000,
+      tool_calls: {},
+      edit_churn: { files_edited_3plus: 0, max_edits_one_file: 0 },
+      skills: {},
+      subagents: {},
+    },
+  };
+}
+
+test("toRow computes the shares the SQL views compute", () => {
+  const row = toRow(card());
+
+  expect(row.totalTokens).toBe(10_000);
+  expect(row.cacheReadShare).toBeCloseTo(0.9, 6);
+  expect(row.exploreShare).toBeCloseTo(0.2, 6);
+  expect(row.subagentShare).toBeCloseTo(0.2, 6);
+  expect(row.sourceLoc).toBe(40);
+});
+
+test("toRow divides by zero safely on an empty card", () => {
+  const empty = card();
+  empty.spend.tokens = {
+    input: 0,
+    output: 0,
+    thinking: 0,
+    cache_write_5m: 0,
+    cache_write_1h: 0,
+    cache_read: 0,
+  };
+  empty.spend.usd_equivalent = 0;
+
+  const row = toRow(empty);
+
+  expect(row.cacheReadShare).toBe(0);
+  expect(row.subagentShare).toBe(0);
+});
+
+// The whole reason this filter is merge status and not `phase === "at-merge"`:
+// a remote session's container dies with its transcripts, so its cards stay
+// `at-open` forever. Filtering on phase would drop every remote PR and bias
+// every number toward work done locally.
+test("merged keeps at-open cards that did merge", () => {
+  const rows = [toRow(card({ phase: "at-open" })), toRow(card({ phase: "at-merge" }))];
+
+  expect(merged(rows)).toHaveLength(2);
+});
+
+test("merged drops a card whose PR has not merged", () => {
+  expect(merged([toRow(card({ merged_at: null }))])).toHaveLength(0);
+});
+
+test("waste ranks small, low-rated, expensive PRs by cost", () => {
+  const rows: CardRow[] = [
+    { ...toRow(card({ number: 1 })), usd: 10 },
+    { ...toRow(card({ number: 2 })), usd: 90 },
+  ];
+
+  const table = waste(rows);
+
+  expect(table.rows[0][0]).toBe("#2");
+  expect(table.rows).toHaveLength(2);
+});
+
+// An agent's unreviewed guess about how hard something was is exactly the
+// input that would make "was this worth it?" circular.
+test("waste excludes unconfirmed ratings", () => {
+  const row = { ...toRow(card()), ratingMethod: "unconfirmed" };
+
+  expect(waste([row]).rows).toHaveLength(0);
+});
+
+test("waste excludes a large diff even at a low rating", () => {
+  const row = { ...toRow(card()), sourceLoc: 5_000 };
+
+  expect(waste([row]).rows).toHaveLength(0);
+});
+
+test("exploration needs a minimum sample before ranking a package", () => {
+  const rows = [toRow(card()), toRow(card())];
+
+  expect(exploration(rows).rows).toHaveLength(0);
+  expect(exploration(rows, 2).rows[0]).toEqual(["osn/api", "2", "20%"]);
+});
+
+test("briefs groups by month of merge", () => {
+  const rows = [
+    toRow(card({ merged_at: "2026-08-15T00:00:00.000Z" })),
+    toRow(card({ merged_at: "2026-09-02T00:00:00.000Z" })),
+  ];
+
+  expect(briefs(rows).rows.map((r) => r[0])).toEqual(["2026-08", "2026-09"]);
+});
+
+test("costByComplexity divides cost by the declared rating", () => {
+  const table = costByComplexity([toRow(card())]);
+
+  // $50 at a declared 2.
+  expect(table.rows[0]).toEqual(["2", "1", "$50.00", "$25.00", "10m"]);
+});
+
+test("coverage splits by rating method and phase", () => {
+  const rows = [
+    toRow(card({ phase: "at-open" })),
+    { ...toRow(card({ phase: "at-merge" })), ratingMethod: "unconfirmed" },
+  ];
+
+  const table = coverage(rows);
+
+  expect(table.rows).toHaveLength(2);
+  expect(table.rows.map((r) => r[1]).sort()).toEqual(["at-merge", "at-open"]);
+});
+
+test("formatTable says so rather than printing an empty frame", () => {
+  const rendered = formatTable({ title: "T", headers: ["a"], rows: [] });
+
+  expect(rendered).toContain("(no rows)");
+});
+
+test("formatTable pads columns to the widest cell", () => {
+  const rendered = formatTable({
+    title: "T",
+    headers: ["package", "PRs"],
+    rows: [["osn/api", "3"]],
+  });
+
+  expect(rendered).toContain("package  PRs");
+  expect(rendered).toContain("osn/api  3");
+});

--- a/tools/pr-metrics/tests/report.test.ts
+++ b/tools/pr-metrics/tests/report.test.ts
@@ -8,6 +8,7 @@ import {
   coverage,
   exploration,
   formatTable,
+  median,
   merged,
   toRow,
   waste,
@@ -95,6 +96,7 @@ function card(overrides: Partial<Card["pr"]> & Record<string, unknown> = {}): Ca
       user_turns: 4,
       corrective_turns: 2,
       tokens_before_first_edit: 2_000,
+      sessions_with_observed_edit: 1,
       tool_calls: {},
       edit_churn: { files_edited_3plus: 0, max_edits_one_file: 0 },
       skills: {},
@@ -221,4 +223,37 @@ test("formatTable pads columns to the widest cell", () => {
 
   expect(rendered).toContain("package  PRs");
   expect(rendered).toContain("osn/api  3");
+});
+
+// --- median, not mean -------------------------------------------------------
+
+// The distributions here are severely right-skewed — across the first 34 cards
+// the median was 3.6M tokens, the mean 15.4M, the maximum 92.7M. A mean over
+// that describes the three largest pull requests and invents month-over-month
+// growth that is not in the data.
+test("median resists the outlier a mean would follow", () => {
+  expect(median([1, 2, 3, 4, 100])).toBe(3);
+  expect(median([1, 2, 3, 4])).toBe(2.5);
+  expect(median([])).toBe(0);
+});
+
+test("toRow reports an unknown explore share as null, not as 100%", () => {
+  const c = card();
+  c.interaction.tokens_before_first_edit = null;
+  c.interaction.sessions_with_observed_edit = 0;
+
+  expect(toRow(c).exploreShare).toBeNull();
+});
+
+// Ranking packages by a share that silently means "no edit was seen" sorted
+// the table by which branches avoided the Edit tool.
+test("exploration excludes cards whose boundary was never observed", () => {
+  const unknown = { ...toRow(card()), exploreShare: null };
+  const known = toRow(card());
+
+  const table = exploration([unknown, unknown, unknown], 1);
+  expect(table.rows).toHaveLength(0);
+  expect(table.note).toContain("3 card(s) excluded");
+
+  expect(exploration([known, known], 2).rows).toHaveLength(1);
 });

--- a/tools/pr-metrics/tsconfig.json
+++ b/tools/pr-metrics/tsconfig.json
@@ -9,5 +9,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["index.ts", "tests"]
+  "include": ["index.ts", "backfill.ts", "tests"]
 }

--- a/tools/pr-metrics/tsconfig.json
+++ b/tools/pr-metrics/tsconfig.json
@@ -9,5 +9,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["index.ts", "backfill.ts", "tests"]
+  "include": ["index.ts", "backfill.ts", "report.ts", "tests"]
 }

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -152,7 +152,8 @@ warning below.
 | `diff.packages` | Workspace directories touched |
 | `interaction.user_turns` | Real human instructions |
 | `interaction.corrective_turns` | Human turns arriving *after* the agent started work |
-| `interaction.tokens_before_first_edit` | Exploration cost, summed per session |
+| `interaction.tokens_before_first_edit` | Exploration cost, summed per session. **`null` when no edit was observed** — see below |
+| `interaction.sessions_with_observed_edit` | How many sessions contributed to that figure, so a partial reading reads as partial |
 | `interaction.edit_churn` | `files_edited_3plus`, `max_edits_one_file` |
 | `interaction.skills`, `interaction.subagents`, `interaction.tool_calls` | Histograms |
 
@@ -230,10 +231,25 @@ Most of the card describes cost. Two fields point at what to *do*, one per
 lever:
 
 **`tokens_before_first_edit` → a missing skill or wiki page.** Everything spent
-before the first `Edit` or `Write` is the agent working out where the code
-lives. It is summed per session, so a second session re-orienting from scratch
-is charged again rather than hidden behind the first session's answer.
-Repeatedly high in one area means that area has no usable map.
+before the first edit is the agent working out where the code lives. It is
+summed per session, so a second session re-orienting from scratch is charged
+again rather than hidden behind the first session's answer. Repeatedly high in
+one area means that area has no usable map.
+
+> [!warning] An edit is not only an `Edit` call, and an unseen edit is `null`.
+> This repository's agent instructions tell agents to change files "with sed,
+> heredocs, or short scripts, rather than using the dedicated Edit tool", so
+> counting only `Edit`/`Write` missed most of them. In the first 34 cards, 15
+> pull requests changed real source with zero `Edit` calls, and each reported
+> that **100%** of its tokens went on exploration. The per-package ranking was
+> then sorted by which branches happened to avoid the Edit tool: `cire/host`
+> appeared worst in the repository at 62%, and reads 5% once fixed.
+>
+> Two rules follow. Shell writes count as edits (`sed -i`, heredoc redirects,
+> `tee`, `mv`) — conservatively, since a false positive moves the boundary too
+> early. And a session that never shows an edit banks **nothing**: the card
+> reports `null`, and every ranking drops it. "We did not see the boundary" and
+> "all of it was exploration" are different claims, and only one is true.
 
 **`corrective_turns` → an unclear brief.** Human turns that arrive after the
 agent has already picked up tools: course corrections rather than the task. One
@@ -305,6 +321,12 @@ packages need a skill or a wiki page; whether briefs are getting clearer;
 whether the context surface is bloating; cost per unit of declared difficulty;
 whether delegation is paying off; and — run this one first — how much of the
 history can be trusted at all.
+
+Every per-pull-request distribution is summarised with a **median, never a
+mean**. These are severely right-skewed: across the first 34 cards the median
+was 3.6M tokens, the mean 15.4M and the maximum 92.7M. The mean described the
+three largest pull requests and showed 8.5× month-over-month growth where the
+median showed about 2×.
 
 The raw view, if you want to start from nothing:
 

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -109,6 +109,26 @@ Two traps the collector handles and any reimplementation must:
 on the machine that did the work. Once written it is committed, which is what
 makes the history durable.
 
+### Remote sessions
+
+Nothing extra is needed. Every session — local, cloud, another machine — has its
+own transcripts, cards its own branch, and commits the JSON with the branch. The
+repository is the aggregation point, so a central service would only duplicate
+what the repository already does for a few hundred rows a year.
+
+One thing does need care: a remote container is destroyed when the session ends
+and takes its transcripts with it, and a card that was never written is gone for
+good. So a **`SessionEnd` hook in `.claude/settings.json`** writes the card at
+the end of every session, in every environment, whether or not anyone reached
+`prep-pr`. It is idempotent — it rewrites the same file — it already refuses
+`main`, and it ends in `|| true` so it can never fail a session. The settings
+file is committed, so remote sessions pick it up with no per-machine setup.
+
+The consequence to remember: **a remote card can never be refreshed past
+`at-open`**, because the container that held its transcripts is gone. That is
+why the `merged` view filters on merge status rather than on `phase` — see the
+warning below.
+
 ## Schema
 
 `schema_version` is `1`. Bump it when a field changes meaning or leaves.
@@ -153,9 +173,13 @@ which you are looking at:
 - `at-open` — written by `prep-pr`, covers work up to the pull request.
 - `at-merge` — written after merge, includes review fixes.
 
-Filter on `phase` in any query that compares totals, or a merged PR and an open
-one will not be measuring the same thing. `queries.sql` does this for you: its
-`merged` view is `at-merge` only.
+> [!caution] Do not filter a query on `phase = 'at-merge'`.
+> It looks like caution and behaves like bias. A remote session's cards stay
+> `at-open` forever, so that filter silently drops every pull request not worked
+> on a machine you still own — and every trend then describes your laptop rather
+> than the fleet. Both `merged` views (SQL and `report`) filter on **merge
+> status**, and keep `phase` as a visible column instead. Query 7 reports the
+> split so an `at-open`-heavy corpus is obvious rather than invisible.
 
 > [!warning] The `at-merge` refresh cannot run in CI, and this is not a gap
 > that can be closed.
@@ -251,12 +275,29 @@ still a true record, and it warns on stderr rather than exiting non-zero.
 The committed files *are* the datalake. DuckDB reads them where they sit, so
 there is no service to run and no free-tier cap to watch:
 
-**`tools/pr-metrics/queries.sql` holds the seven that matter** — run it and the
-views plus every query below are already defined:
+**`bun run --cwd tools/pr-metrics report` is the normal way in.** It computes
+the seven analyses over the same cards, in TypeScript, and needs nothing
+installed:
 
 ```bash
-duckdb -init tools/pr-metrics/queries.sql
+bun run --cwd tools/pr-metrics report               # all seven
+bun run --cwd tools/pr-metrics report -- --waste    # just one
 ```
+
+That matters because **DuckDB does not exist in a remote session.** None of the
+`duckdb` npm packages ship a binary — they are all libraries — so `bunx` is no
+help and there is no `brew` in a cloud container. A report that only runs on one
+laptop cannot tell you how the fleet is doing.
+
+`queries.sql` is the same seven in SQL, and it is the better tool for a question
+nobody anticipated. It is the optional local power tool, not the interface:
+
+```bash
+duckdb -init tools/pr-metrics/queries.sql     # local only; brew install duckdb
+```
+
+The two carry the same ratio definitions, duplicated on purpose. Change one,
+change the other.
 
 It defines `cards` (everything), `merged` (`at-merge` only) and `metrics` (the
 shared ratios), then answers: where agents cost too much for the job; which

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -151,10 +151,54 @@ A card written when the PR opens cannot see review-cycle cost. `phase` says
 which you are looking at:
 
 - `at-open` — written by `prep-pr`, covers work up to the pull request.
-- `at-merge` — rewritten after merge, includes review fixes.
+- `at-merge` — written after merge, includes review fixes.
 
 Filter on `phase` in any query that compares totals, or a merged PR and an open
-one will not be measuring the same thing.
+one will not be measuring the same thing. `queries.sql` does this for you: its
+`merged` view is `at-merge` only.
+
+> [!warning] The `at-merge` refresh cannot run in CI, and this is not a gap
+> that can be closed.
+> `~/.claude/projects` is local and unversioned. A GitHub Actions runner has no
+> transcripts, so a workflow can update `merged_at` and the final diff but not
+> a single token of spend — and a card that silently kept `at-open` spend under
+> an `at-merge` label would be worse than no card at all, because no query
+> could tell it from a complete one.
+>
+> The refresh is therefore a **local** command, run on the machine that did the
+> work:
+>
+> ```bash
+> bun run --cwd tools/pr-metrics card -- \
+>   --branch feat/x --phase at-merge --merged-at "$(date -u +%FT%TZ)"
+> ```
+>
+> In practice the backfill below is the easier path: it rewrites every merged
+> pull request it has transcripts for in one pass, so the `at-merge` set can be
+> brought up to date periodically instead of per-merge.
+
+## Backfilling
+
+`bun run --cwd tools/pr-metrics backfill` writes cards for pull requests that
+merged before cards existed.
+
+```bash
+bun run --cwd tools/pr-metrics backfill -- --dry-run     # list what it would write
+bun run --cwd tools/pr-metrics backfill -- --limit 200
+```
+
+A merged branch is usually deleted, so the file list comes from the GitHub API
+(`repos/:owner/:repo/pulls/:n/files`) rather than a local `git diff`. Spend
+still comes from local transcripts, so a backfill reaches only as far back as
+this machine's logs and only for branches this machine worked on.
+
+**A pull request with no local transcript is skipped, not written as zero.** A
+zero-cost card is indistinguishable from a genuinely cheap one once it is in
+the datalake, and it would drag every average it touches toward nothing.
+
+Ratings are transcribed, never invented: a backfilled card carries whatever the
+issue's `complexity:` label says, and `rate-complexity`'s backfill mode marks
+anything it adds `complexity:unconfirmed`.
 
 ## The two fields that name a cause
 
@@ -206,6 +250,22 @@ still a true record, and it warns on stderr rather than exiting non-zero.
 
 The committed files *are* the datalake. DuckDB reads them where they sit, so
 there is no service to run and no free-tier cap to watch:
+
+**`tools/pr-metrics/queries.sql` holds the seven that matter** — run it and the
+views plus every query below are already defined:
+
+```bash
+duckdb -init tools/pr-metrics/queries.sql
+```
+
+It defines `cards` (everything), `merged` (`at-merge` only) and `metrics` (the
+shared ratios), then answers: where agents cost too much for the job; which
+packages need a skill or a wiki page; whether briefs are getting clearer;
+whether the context surface is bloating; cost per unit of declared difficulty;
+whether delegation is paying off; and — run this one first — how much of the
+history can be trusted at all.
+
+The raw view, if you want to start from nothing:
 
 ```sql
 CREATE VIEW cards AS


### PR DESCRIPTION
## Summary

Stacked on #918. Makes the cards usable — and specifically usable **from a remote session**, which turned out to be the constraint that reshaped this PR.

**In the pull request.** `--format markdown` renders a card as a collapsed `<details>` block, and `prep-pr` appends one after `## Test plan`. A block rather than a section because that skill permits exactly five `##` headings and counts them — a metrics section would fail a body that is otherwise correct.

**Backwards.** `backfill` writes cards for pull requests that merged before cards existed, reading the file list from the GitHub API since a merged branch is usually deleted. Over the last 40 merged PRs it writes 34 and skips 6.

**Afterwards.** `bun run --cwd tools/pr-metrics report` computes seven analyses over the cards in TypeScript, needing nothing installed. `queries.sql` is the same seven in SQL — the optional local tool for a question nobody anticipated.

**In every environment.** A `SessionEnd` hook writes the card at the end of every session, so a remote container that is destroyed before anyone reaches `prep-pr` does not take its spend with it.

**And honestly.** The first run over real cards produced a confident, wrong finding, and the last commit fixes the three defects behind it — see Issues.

Run against 34 real backfilled cards, after the fixes:

```
2. Which packages need a skill or a wiki page
  package     PRs  explore share
  pulse/web     4  19%
  osn/db        4  18%
  cire/host     5   5%
  ...18 card(s) excluded: no edit observed, so the boundary is unknown.

4. Is the context surface bloating?
  month    PRs  cache-read share  median tokens
  2026-08    4  84%               1.7M
  2026-09   30  96%               3.6M
```

Before the fixes the same data claimed `cire/host` spent **62%** of its tokens before the first edit — worst in the repository — and 8.5x month-over-month token growth. Both were artefacts.

## Workspaces affected

- `@tools/pr-metrics` — `renderDetails` + `compactTokens`/`humanDuration`, `--format markdown`, `backfill.ts`, `report.ts`, `queries.sql`, and `tools` added to the workspace roots `diff.packages` recognises (without it the package could not see its own diff).

Also touched: `.claude/settings.json` (the `SessionEnd` hook), `.claude/skills/prep-pr/SKILL.md`, `wiki/observability/session-metrics.md`.

## Issues

None filed. Two things worth a reviewer's attention:

**DuckDB does not exist in a remote session, and cannot.** None of the `duckdb` npm packages ship a binary — `duckdb`, `@duckdb/node-api` and `@duckdb/duckdb-wasm` are all libraries — so `bunx` is no help, and a cloud container has no `brew`. A report that only ran under `queries.sql` could describe one laptop and nothing else. That is why `report.ts` exists. The two carry the same ratio definitions, duplicated deliberately: generating one from the other would cost more than it saves at this size, and the duplication is noted in both files.

**Three metric defects, found by running the thing on real data and fixed in `d0f6c37`.** They are worth reading as a group, because each one produced a confident number that was wrong:

1. **An edit is not only an `Edit` call.** This repository tells agents to change files "with sed, heredocs, or short scripts, rather than using the dedicated Read, Edit, or Write tools". Counting only the tools meant 15 of 34 pull requests changed real source with zero observed edits. Shell writes now count, matched conservatively.
2. **An unobserved boundary is `null`, not 100%.** A session that never shows an edit now banks nothing and drops out of every ranking, with `sessions_with_observed_edit` making a partial reading legible. The old behaviour sorted the per-package table by which branches happened to avoid the Edit tool: `cire/host` read 62% and reads 5% correctly.
3. **Median, never mean.** These distributions are severely right-skewed — median 3.6M tokens, mean 15.4M, maximum 92.7M. The mean described the three largest pull requests.

**A planned CI job was dropped rather than built.** There is no workflow refreshing cards to `phase: at-merge`. `~/.claude/projects` is local and unversioned, so a runner has no transcripts; such a job could update `merged_at` and the diff but not one token of spend, and a card carrying `at-open` spend under an `at-merge` label is worse than no card because no query could tell it from a complete one. The refresh is a local command, and the backfill is the bulk path to it.

## Decisions

### The `merged` view filters on merge status, not `phase`

Both views — SQL and `report` — filter on `pr.merged_at IS NOT NULL`. Filtering on `phase = 'at-merge'` looks like caution and behaves like bias: a remote container is destroyed with its transcripts, so a remotely-produced card can **never** be refreshed past `at-open`, and that filter would silently drop every pull request not worked on a machine still in hand. Every trend would then describe one laptop rather than the fleet. `phase` is a visible column instead, and the coverage query reports the split.

### A `SessionEnd` hook, not a `prep-pr` step alone

Until now the card was written by `prep-pr`, so a session that did the work but never reached that step lost its spend permanently — a live risk for remote containers. The hook is idempotent, already refuses `main`, and ends in `|| true` so it can never fail a session. `.claude/settings.json` is committed, so remote sessions pick it up with no per-machine setup.

### No central sink

A Worker plus D1 that sessions POST cards to would buy querying without a checkout, at the cost of auth, infrastructure and a second source of truth — for a few hundred rows a year that the repository already versions. Cards are committed files and every session cards its own branch, so the repository is already the aggregation point.

### A pull request with no local transcript is skipped, not written as zero

Once a zero-cost card is in the corpus nothing distinguishes it from a genuinely cheap pull request, and it drags every average toward nothing. Skipped numbers are reported instead.

## Test plan

- `bun test tools/pr-metrics` — **71 tests, all passing** (up from 43). Seven new cover the metric fixes: the shell forms that write files, the read-only redirects that must not count (`2>&1`, `>/dev/null`), a shell write moving the first-edit boundary, `null` when no edit was ever seen, median against an outlier, and a ranking that excludes unknown boundaries. One existing test changed its expectation rather than its code — a session that greps but never edits used to contribute all its tokens as exploration and now contributes none, which is the point of the change. Eight over the `<details>` renderer, including that it contributes **no** `##` heading, the property `prep-pr`'s shape check depends on; thirteen over the report, including that `merged` keeps an `at-open` card that did merge and drops an unmerged one.
- `bun run --cwd tools/pr-metrics check` — clean.
- `bun run lint` — no errors from the package.
- `bun run fmt:check` — clean across 1451 files.
- `bash scripts/validate-changesets.sh` — passes.
- `.claude/settings.json` parses as JSON.
- **Exercised against real data, twice:** backfilled 34 real merged PRs and ran the full report before and after the metric fixes, which is how the three defects were found. Rendered the `<details>` block from a real branch.
- Rebased onto current `main` after #919 (the Effect 3.22 → 4.0.0-rc.112 migration) landed; the lockfile conflict was resolved by regenerating, and tests and typecheck pass on the new base.
- Not exercised: `queries.sql` end to end, which needs DuckDB installed locally. Its seven queries mirror the `report` functions that **are** covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kRJ2QVtZ8N9wHGZtZJDTE
