### PR TITLE
fix(tools): count skills invoked as slash commands

### DIFF
--- a/.changeset/olive-hounds-count.md
+++ b/.changeset/olive-hounds-count.md
@@ -1,0 +1,11 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Count skills invoked as slash commands, not only through the `Skill` tool.
+
+A skill run as `/name` produces no `Skill` tool call. It arrives as a user record opening with `<command-name>`, which `humanTurnText` rejects as machinery — correctly, since the record is an envelope rather than a typed instruction — so the invocation was never counted. `skillCommandsIn` reads the envelope, behind a deny-list of the CLI's own commands: `/compact` alone outnumbers every skill invocation in these transcripts combined, and it already means something as `window.compactions`.
+
+Both routes are real invocations, so a skill used each way counts twice. That is the opposite of the queued-prompt case, where two records are one instruction and get collapsed.
+
+Worth stating because it was the reason for the change: this closes an undercount, it does not overturn the finding. Re-running the backfill over 34 merged pull requests moves the total from 5 recorded invocations to 6. Skill usage really is as low as the cards said.

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -349,6 +349,70 @@ export function isCompactionCommand(record: SessionRecord): boolean {
   return typeof content === "string" && content.includes("<command-name>/compact</command-name>");
 }
 
+/**
+ * Commands built into the CLI rather than skills this repository wrote.
+ *
+ * They dominate the `<command-name>` records — `/compact` alone outnumbers
+ * every skill invocation in the transcripts combined — so counting them as
+ * skills would bury the signal under session housekeeping. `/compact` is
+ * already counted separately as `window.compactions`, where it means something.
+ */
+const BUILTIN_COMMANDS = new Set([
+  "add-dir",
+  "agents",
+  "clear",
+  "compact",
+  "config",
+  "context",
+  "cost",
+  "doctor",
+  "exit",
+  "export",
+  "help",
+  "init",
+  "login",
+  "logout",
+  "mcp",
+  "memory",
+  "model",
+  "plugin",
+  "pr-comments",
+  "release-notes",
+  "resume",
+  "review",
+  "status",
+  "terminal-setup",
+  "vim",
+]);
+
+const COMMAND_NAME = /<command-name>\/?([^<]+)<\/command-name>/g;
+
+/**
+ * Skills invoked as `/name` rather than through the `Skill` tool.
+ *
+ * Both routes are real invocations and both belong in the histogram, so a
+ * skill used once each way counts twice — unlike a queued prompt echoed as a
+ * user record, which is one instruction seen twice and is collapsed.
+ *
+ * Worth knowing before reading the output: this fixes an undercount, not the
+ * headline. Across every transcript in this repository the `<command-name>`
+ * records are overwhelmingly built-ins — `/compact` fifteen times, `/config`
+ * and `/clear` five each — and `/prep-pr` never appears among them at all.
+ * Skill usage really is as low as the cards said it was.
+ */
+export function skillCommandsIn(record: SessionRecord): string[] {
+  const content = record.message?.content;
+  if (typeof content !== "string") return [];
+
+  const found: string[] = [];
+  for (const match of content.matchAll(COMMAND_NAME)) {
+    const name = match[1].trim();
+    if (name && !BUILTIN_COMMANDS.has(name)) found.push(name);
+  }
+
+  return found;
+}
+
 export interface SpendSummary {
   usd_equivalent: number;
   tokens: TokenTotals;
@@ -551,6 +615,13 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
       // agent mid-flight rather than opening the task.
       if (sessionsWithWork.has(session)) correctiveTurns += 1;
       continue;
+    }
+
+    // A slash-invoked skill lands here rather than above: the record opens with
+    // `<command-name>`, so `humanTurnText` rejects it as machinery. It is both
+    // — an envelope, and evidence that a skill ran.
+    for (const name of skillCommandsIn(record)) {
+      skills[name] = (skills[name] ?? 0) + 1;
     }
 
     if (record.type !== "assistant") continue;

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -15,6 +15,7 @@ import {
   parseNumstat,
   readUsage,
   type SessionRecord,
+  skillCommandsIn,
 } from "../index";
 
 function assistant(overrides: Partial<SessionRecord> = {}): SessionRecord {
@@ -542,4 +543,88 @@ test("aggregateInteraction reports null when no edit was ever observed", () => {
 
   expect(interaction.tokens_before_first_edit).toBeNull();
   expect(interaction.sessions_with_observed_edit).toBe(0);
+});
+
+// --- skills invoked as slash commands ---------------------------------------
+
+// A skill invoked as `/name` never produces a `Skill` tool call, so the
+// histogram missed it. The record opens with `<command-name>`, which
+// `humanTurnText` rejects as machinery — correctly, since it is an envelope
+// rather than a typed instruction — so the count has to come from the envelope
+// itself.
+test("skillCommandsIn reads a slash-invoked skill", () => {
+  const record: SessionRecord = {
+    type: "user",
+    message: { content: "<command-name>/prep-pr</command-name>\n<command-args></command-args>" },
+  };
+
+  expect(skillCommandsIn(record)).toEqual(["prep-pr"]);
+});
+
+// `/compact` outnumbers every skill invocation in these transcripts combined.
+// Counting the built-ins as skills would bury the signal under housekeeping —
+// and `/compact` already means something as `window.compactions`.
+test("skillCommandsIn ignores the CLI's own commands", () => {
+  for (const name of ["/compact", "/clear", "/config", "/exit", "/login", "/model"]) {
+    expect(
+      skillCommandsIn({
+        type: "user",
+        message: { content: `<command-name>${name}</command-name>` },
+      }),
+    ).toEqual([]);
+  }
+});
+
+test("skillCommandsIn tolerates a name written without the slash", () => {
+  expect(
+    skillCommandsIn({
+      type: "user",
+      message: { content: "<command-name>review-deps</command-name>" },
+    }),
+  ).toEqual(["review-deps"]);
+});
+
+test("skillCommandsIn returns nothing for an ordinary turn", () => {
+  expect(skillCommandsIn({ type: "user", message: { content: "fix the auth bug" } })).toEqual([]);
+  expect(
+    skillCommandsIn({ type: "user", message: { content: [{ type: "tool_result" }] } }),
+  ).toEqual([]);
+});
+
+// Both routes are real invocations, so a skill used each way ran twice. This is
+// the opposite of the queued-prompt case, where two records are one instruction
+// and get collapsed.
+test("aggregateInteraction counts both invocation routes", () => {
+  const interaction = aggregateInteraction([
+    {
+      type: "user",
+      sessionId: "s1",
+      timestamp: "…01",
+      message: { content: "<command-name>/prep-pr</command-name>" },
+    },
+    assistant({
+      timestamp: "…02",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Skill", { skill: "prep-pr" })],
+        usage: usage({}),
+      },
+    }),
+  ]);
+
+  expect(interaction.skills).toEqual({ "prep-pr": 2 });
+});
+
+test("aggregateInteraction does not count a slash command as a turn", () => {
+  const interaction = aggregateInteraction([
+    {
+      type: "user",
+      sessionId: "s1",
+      timestamp: "…01",
+      message: { content: "<command-name>/review-deps</command-name>" },
+    },
+  ]);
+
+  expect(interaction.user_turns).toBe(0);
+  expect(interaction.skills).toEqual({ "review-deps": 1 });
 });


### PR DESCRIPTION
## Summary

Based on #920. A skill run as `/name` produces no `Skill` tool call — it arrives as a user record opening with `<command-name>`, which `humanTurnText` rejects as machinery. Correctly so: the record is an envelope, not a typed instruction. But it is also evidence that a skill ran, and that evidence was being thrown away.

`skillCommandsIn` reads the envelope, behind a deny-list of the CLI's own commands. The deny-list matters more than it looks: `/compact` alone outnumbers every skill invocation in these transcripts combined, so counting built-ins as skills would bury the signal under session housekeeping — and `/compact` already means something as `window.compactions`.

**This closes an undercount; it does not overturn the finding it came from.** I originally offered the gap as the explanation for skills appearing in only 2 of 34 pull requests. Checking the transcripts first would have shown that `<command-name>` records are overwhelmingly built-ins — `/compact` ×15, `/config` ×5, `/clear` ×5 — and that `/prep-pr` never appears among them. Re-running the backfill over the same 34 merged PRs moves the total from **5 recorded invocations to 6**. Skill usage really is as low as the cards said.

## Workspaces affected

- `@tools/pr-metrics` — `skillCommandsIn` plus a `BUILTIN_COMMANDS` deny-list in `index.ts`; `aggregateInteraction` merges both routes into `interaction.skills`.

## Issues

None filed. One thing a reviewer should weigh: the deny-list is a fixed set of 25 built-in command names, so a new CLI command added upstream would be miscounted as a skill until the list is updated. The alternative — an allow-list of this repo's own skills — fails the other way, silently dropping third-party and plugin skills, which are exactly the ones worth noticing. A deny-list that occasionally over-counts is the safer error here, since an unexpected name showing up in the histogram is visible, and a missing one is not.

## Decisions

### Both invocation routes count separately

A skill invoked once via `/name` and once via the `Skill` tool ran twice, and the histogram says 2. This is deliberately the opposite of the queued-prompt rule added in #920, where two records are one instruction and get collapsed. The two cases look alike and want opposite treatment, which is why both now carry a test saying so.

### `/compact` stays out of the skill histogram

It is already counted as `window.compactions`, where it means "this session exhausted its context" — a real signal. Counting it again as a skill would double-count it into meaninglessness.

## Test plan

- `bun test tools/pr-metrics` — **77 tests, all passing** (up from 71). Six new: a slash-invoked skill counts; six built-ins do not; a name written without the leading slash still resolves; an ordinary turn and a tool-result array yield nothing; both routes count separately; and a slash command is not counted as a user turn.
- `bun run --cwd tools/pr-metrics check` — clean.
- `bun run lint` — no errors from the package.
- `bun run fmt:check` — clean across 1456 files.
- `bash scripts/validate-changesets.sh` — passes.
- **Exercised against real data:** re-ran `backfill --limit 40` before and after. Skills went from `{obsidian-markdown: 2, review-deps: 1, prep-pr: 2}` to the same plus `{workflow-authoring: 1}` — one additional invocation recovered, which is the honest size of the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kRJ2QVtZ8N9wHGZtZJDTE
