### PR TITLE
docs: critical and high findings are not deferrable

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -162,7 +162,7 @@ Two rules for anything you dispatch into a worktree:
   reaches for `git checkout <ref> -- <path>`, and putting it back discards
   whatever you had uncommitted in that tree.
 
-Run the `prep-pr` skill on the branch. Its own steps validate the changeset, build and test, run `review-tests`, and run the performance and security reviews in parallel. This skill's contract is stronger: **after the reviews, dispatch fix subagents to add the missing tests and fix every security and performance finding** — Critical, High and Medium at minimum, Low and Info when cheap — then re-verify. A finding deliberately deferred is carried into the PR body as a tracked follow-up. Scale review depth to the change: a docs or config PR does not need three review agents; an auth, route or binding change does. Then the five-section PR body, push, and open the PR.
+Run the `prep-pr` skill on the branch. Its own steps validate the changeset, build and test, run `review-tests`, and run the performance and security reviews in parallel. This skill's contract is stronger: **after the reviews, dispatch fix subagents to add the missing tests and fix every security and performance finding** — Critical, High and Medium at minimum, Low and Info when cheap — then re-verify. **Critical and High are not deferrable at all**: fix them here, or open the follow-up pull request immediately and link it before either merges — see `wiki/conventions/review-findings.md`. A Medium deliberately deferred is carried into the PR body as a tracked follow-up. Scale review depth to the change: a docs or config PR does not need three review agents; an auth, route or binding change does. Then the five-section PR body, push, and open the PR.
 
 ### Step 5 — Watch, merge, tear down
 

--- a/.claude/skills/prep-pr/SKILL.md
+++ b/.claude/skills/prep-pr/SKILL.md
@@ -227,7 +227,11 @@ Invoke the `review-security` skill (`.claude/skills/review-security/SKILL.md`) a
 
 Wait for both agents to complete. Present both reports to the user in full, using the finding IDs from each review (e.g. S-H1, P-W2) so they can be referenced in the PR description.
 
-Ask the user: "Do you want to address any findings before pushing?" If yes, pause and let the user make changes, then re-run steps 3 and 4 before continuing. With no user, list the findings under `## Decisions` with what you would fix and what you would defer, and continue.
+**A `critical` or `high` finding is not deferrable.** Fix it on this branch, or open the follow-up pull request immediately and link it from this one before either merges. That is the whole option set — filing it and continuing is not in it, and neither is "out of scope for this branch". A filed-and-open `high` is a live unpatched defect whose location is now written down; the issue is an attack map with a timer on it. `medium` and below may be filed and scheduled.
+
+Severity comes from the tier letter in the finding ID, assigned by the review before anyone knows what fixing it costs. Re-rating it afterwards to make it deferrable is the failure mode this rule exists to prevent — the same contamination as re-rating an issue's complexity once its token cost is on screen.
+
+Ask the user: "Do you want to address any findings before pushing?" If yes, pause and let the user make changes, then re-run steps 3 and 4 before continuing. With no user, fix every `critical` and `high` on the branch and re-run steps 3 and 4; list what you fixed and what you deferred under `## Decisions`, and continue. A run that cannot fix them — no tooling, no network — says so plainly and names them as blocking rather than reporting the branch ready.
 
 ---
 

--- a/wiki/conventions/review-findings.md
+++ b/wiki/conventions/review-findings.md
@@ -5,7 +5,7 @@ tags: [convention, review]
 related:
   - "[[contributing]]"
   - "[[stacked-prs]]"
-last-reviewed: 2026-08-31
+last-reviewed: 2026-09-08
 ---
 
 # Review Finding IDs
@@ -53,6 +53,37 @@ Each finding uses a four-field format:
 | **Why** | Why this matters (risk, impact) |
 | **Solution** | Concrete fix or mitigation |
 | **Rationale** | Why this solution is the right approach |
+
+## Critical and high findings are not deferrable
+
+> [!important] A `critical` or `high` finding is fixed on the branch that found
+> it, or in a pull request opened immediately after and linked before that
+> branch merges. Filing it and moving on is not one of the options.
+
+Everything below this line is about how a finding is *recorded*. This rule is
+about whether it is allowed to stay open, and it comes first because the
+recording convention exists to serve it rather than to substitute for it.
+
+The reasoning is the same one that makes the tracker private. A filed-and-open
+`critical` or `high` is a live, unpatched defect whose location is now written
+down; the issue is an attack map with a timer on it, and every day it stays
+open is a day that map exists for a defect nobody is fixing. A finding fixed in
+the same breath as it is found never becomes that.
+
+`medium` and below may be filed and scheduled. `info` records an observation
+and asks for no fix at all.
+
+Two consequences worth stating, because they are the ones people work around:
+
+- **"Out of scope for this branch" is not a deferral.** If the finding is real
+  and it is `high`, the follow-up pull request is opened now, not added to a
+  backlog. A tracked follow-up that exists as a link in the PR body satisfies
+  this; one that exists as an intention does not.
+- **Downgrading severity to avoid the rule is the failure mode.** Severity
+  comes from the tier letter in the finding ID, which the review assigns
+  before anyone knows what fixing it would cost. Re-rating it afterwards to
+  make it deferrable is the same contamination as re-rating an issue's
+  complexity once its token cost is on screen.
 
 ## Filing a finding
 


### PR DESCRIPTION
## Summary

`prep-pr` offered deferral at every severity — "list the findings under `## Decisions` with what you would fix and what you would defer, and continue". That let a `critical` or `high` be filed and left open, which is the one outcome the tracker being private is meant to prevent.

A filed-and-open `high` is a live unpatched defect whose location is now written down. The issue is an attack map with a timer on it, and every day it stays open is a day that map exists for something nobody is fixing. The rule that removes the problem isn't better secrecy — it's fixing it: on the branch that found it, or in a pull request opened immediately and linked before either merges.

`medium` and below may still be filed and scheduled. `info` asks for no fix at all.

## Workspaces affected

None — no package changes, so no changeset (`scripts/changeset-required.sh` returns `skip`).

Files: `.claude/skills/prep-pr/SKILL.md`, `.claude/skills/orchestrate/SKILL.md`, `wiki/conventions/review-findings.md`.

## Issues

None filed. One thing worth a reviewer's attention: **`orchestrate` was already most of the way here** — it dispatched fix subagents for "Critical, High and Medium at minimum" — but it then allowed "a finding deliberately deferred" without qualifying which severities that covers. The two sentences contradicted each other, and an agent reading the second one had a defensible route to leaving a High open. That is now explicit rather than implied.

## Decisions

### The two escape hatches are named, because they are the ones people reach for

**"Out of scope for this branch" is not a deferral.** If the finding is real and it is `high`, the follow-up PR is opened now, not added to a backlog. A tracked follow-up that exists as a link in the PR body satisfies the rule; one that exists as an intention does not.

**Downgrading severity to avoid the rule is the actual failure mode.** Severity comes from the tier letter the review assigned before anyone knew what fixing it would cost. Re-rating it afterwards is the same contamination as re-rating an issue's `complexity:` once its token cost is on screen — the same argument, applied to a different number.

### The rule goes before the filing convention, not after

In `wiki/conventions/review-findings.md` it now sits above `## Filing a finding`. The recording convention exists to serve the fixing rule rather than to substitute for it, and a reader who finds the filing instructions first will reasonably conclude that filing is the deliverable.

### An unattended run names them as blocking

`prep-pr` with no user now fixes every `critical` and `high` and re-runs the review steps. Where it genuinely cannot — no tooling, no network — it says so and reports the branch **not** ready, rather than listing them under Decisions and calling the run complete.

## Test plan

- `bash scripts/changeset-required.sh` — returns `skip`; `.claude/**` and `wiki/**` are both on the allowlist.
- The three edits were each applied by exact-match assertion, so a silent miss would have failed rather than passed quietly.
- `wiki/conventions/review-findings.md` frontmatter `last-reviewed` bumped to 2026-09-08, per the wiki maintenance rule.
- Not run: `bun run fmt:check` and `bun run lint`. This worktree has no `node_modules` and the change is markdown only — no formatted file types are touched. CI will run both.
- Not exercised: the rule's effect on a real review. The next `prep-pr` run that surfaces a `high` is the test, and it is worth watching the first one to see whether the "fix it here" path is actually taken or quietly reasoned around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kRJ2QVtZ8N9wHGZtZJDTE
