### PR TITLE
fix(tools): resolve .claude/metrics against the repo, not the cwd

### DIFF
--- a/.changeset/brave-pandas-resolve.md
+++ b/.changeset/brave-pandas-resolve.md
@@ -1,0 +1,11 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Resolve the default `.claude/metrics` against the repository root rather than the working directory.
+
+Every documented invocation is `bun run --cwd tools/pr-metrics <command>`, and `--cwd` sets the process working directory — so a default of `.claude/metrics` pointed at `tools/pr-metrics/.claude/metrics`, which does not exist. `report` exited 1 on the exact command printed in its own README, and `backfill` and `card` wrote to a stray directory inside the package.
+
+`card` is the one that did real damage. The `SessionEnd` hook runs it and ends in `|| true`, so every card the hook has ever written went into the package and the failure was swallowed. That is why the seeded corpus arrived by a commit rather than from the hook that was supposed to produce it.
+
+A regression test runs the collector from inside a package subdirectory and asserts the card lands at the repository root and not under the package.

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -24,7 +24,13 @@
  * worse than no card, because a query cannot tell it from a cheap one.
  */
 
-import { buildCard, declaredFromLabels, parseNumstat, type SessionRecord } from "./index.ts";
+import {
+  buildCard,
+  declaredFromLabels,
+  defaultMetricsDir,
+  parseNumstat,
+  type SessionRecord,
+} from "./index.ts";
 
 interface PullRequest {
   number: number;
@@ -108,7 +114,7 @@ function numstatFromApi(files: ChangedFile[]): string {
 if (import.meta.main) {
   const repo = flag("repo") ?? "xchromo/osn";
   const limit = flag("limit") ?? "100";
-  const outDir = flag("out-dir") ?? ".claude/metrics";
+  const outDir = flag("out-dir") ?? defaultMetricsDir();
   const sessionsDir = flag("sessions-dir") ?? `${process.env.HOME}/.claude/projects`;
   const dryRun = Bun.argv.includes("--dry-run");
 

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -934,6 +934,36 @@ export function renderDetails(card: Card): string {
 }
 
 /**
+ * The repository root, so `.claude/metrics` means the same directory whichever
+ * way these commands are invoked.
+ *
+ * This is not a nicety. The documented form is
+ * `bun run --cwd tools/pr-metrics report`, and `--cwd` sets the process
+ * working directory — so a default of `.claude/metrics` resolved against the
+ * cwd pointed at `tools/pr-metrics/.claude/metrics`, which never exists.
+ * `report` exited 1 on the exact command in its own README. `card` was worse:
+ * it silently *created* that directory inside the package, and the
+ * `SessionEnd` hook ends in `|| true`, so every card the hook ever wrote went
+ * there and nobody saw it fail.
+ *
+ * Falling back to the cwd keeps the tests working outside a checkout, where
+ * every path is passed explicitly anyway.
+ */
+export function repoRoot(): string {
+  const result = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return result.success ? result.stdout.toString().trim() : ".";
+}
+
+/** Where cards live, resolved against the repository rather than the cwd. */
+export function defaultMetricsDir(): string {
+  return `${repoRoot()}/.claude/metrics`;
+}
+
+/**
  * `feat/pr-session-metrics` → `feat-pr-session-metrics`.
  *
  * One file per branch, never one appended ledger: several branches are open at
@@ -1052,7 +1082,7 @@ if (import.meta.main) {
     process.exit(0);
   }
 
-  const outDir = flag("out-dir") ?? ".claude/metrics";
+  const outDir = flag("out-dir") ?? defaultMetricsDir();
   const outPath = `${outDir}/${branchSlug(branch)}.json`;
   require("node:fs").mkdirSync(outDir, { recursive: true });
   require("node:fs").writeFileSync(outPath, `${JSON.stringify(card, null, 2)}\n`);

--- a/tools/pr-metrics/report.ts
+++ b/tools/pr-metrics/report.ts
@@ -19,7 +19,7 @@
  * SQL from TypeScript would cost more than it saves at this size.
  */
 
-import { type Card, compactTokens } from "./index.ts";
+import { type Card, compactTokens, defaultMetricsDir } from "./index.ts";
 
 export interface CardRow {
   pr: number | null;
@@ -353,7 +353,8 @@ const REPORTS = {
 
 if (import.meta.main) {
   const dirIndex = Bun.argv.indexOf("--dir");
-  const dir = dirIndex >= 0 && Bun.argv[dirIndex + 1] ? Bun.argv[dirIndex + 1] : ".claude/metrics";
+  const dir =
+    dirIndex >= 0 && Bun.argv[dirIndex + 1] ? Bun.argv[dirIndex + 1] : defaultMetricsDir();
   const cards = loadCards(dir);
 
   if (cards.length === 0) {

--- a/tools/pr-metrics/tests/pr-metrics.cli.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.cli.test.ts
@@ -310,3 +310,61 @@ test("the CLI still writes a card when no transcript matches", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// --- default paths resolve against the repository ---------------------------
+
+// The documented invocation is `bun run --cwd tools/pr-metrics <cmd>`, and
+// `--cwd` sets the process working directory. A default of `.claude/metrics`
+// resolved against the cwd therefore pointed at `tools/pr-metrics/.claude/
+// metrics`: `report` exited 1 on the command printed in its own README, and
+// `card` silently created that directory inside the package. The SessionEnd
+// hook ends in `|| true`, so every card it wrote went there unnoticed.
+test("card writes to the repository root even when run with --cwd", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-cwd-"));
+
+  try {
+    const git = async (...args: string[]) => {
+      const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+      await proc.exited;
+    };
+
+    await git("init", "-q", "-b", "main");
+    await git("config", "user.email", "test@example.com");
+    await git("config", "user.name", "Test");
+    await git("config", "commit.gpgsign", "false");
+    await writeFile(join(dir, "seed.txt"), "seed\n");
+    await git("add", ".");
+    await git("commit", "-qm", "seed");
+    await git("checkout", "-qb", "feat/cwd-fixture");
+
+    // A package subdirectory, standing in for `tools/pr-metrics`.
+    await mkdir(join(dir, "tools", "pr-metrics"), { recursive: true });
+
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        SCRIPT,
+        "--branch",
+        "feat/cwd-fixture",
+        "--base",
+        "main",
+        "--sessions-dir",
+        join(dir, "no-sessions"),
+      ],
+      // The point of the test: run from inside the package, as `--cwd` does.
+      { cwd: join(dir, "tools", "pr-metrics"), stdout: "pipe", stderr: "pipe" },
+    );
+
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+
+    // At the repository root, not under the package.
+    expect(await Bun.file(join(dir, ".claude/metrics/feat-cwd-fixture.json")).exists()).toBe(true);
+    expect(
+      await Bun.file(join(dir, "tools/pr-metrics/.claude/metrics/feat-cwd-fixture.json")).exists(),
+    ).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Every documented invocation is `bun run --cwd tools/pr-metrics <command>`, and `--cwd` sets the process working directory — so a default of `.claude/metrics` resolved to `tools/pr-metrics/.claude/metrics`.

`report` exited 1 on the exact command printed in its own README, in the wiki page, and in the `analyse-sessions` skill built around running it:

```
❌ pr-metrics report: no cards under .claude/metrics.
error: script "report" exited with code 1
```

`card` is where it did real damage. It doesn't fail on a missing directory — it *creates* one. The `SessionEnd` hook runs `card` and ends in `|| true`, so **every card that hook has ever written went into a stray directory inside the package**, and the failure was swallowed by design. That explains something that should have been suspicious at the time: the seeded corpus arrived in a commit titled "seed the 34 cards" rather than from the hook whose whole job was to produce it.

`repoRoot()` resolves via `git rev-parse --show-toplevel`, falling back to the cwd outside a checkout.

## Workspaces affected

- `@tools/pr-metrics` — `repoRoot()` and `defaultMetricsDir()` in `index.ts`; the three CLI defaults in `index.ts`, `report.ts` and `backfill.ts` now use it.

## Issues

None filed. Found by a cold review of the skills that sit on top of this, not by any test — which is the part worth dwelling on. **Every existing test passed `--dir` or `--out-dir` explicitly**, so the suite exercised the one code path no real invocation uses. The defaults were the only untested thing in the file and they were the thing that was broken.

The `|| true` on the hook is the second half. It was added so a metrics failure could never break someone's session, which is right — but it also meant the failure had no way to surface. A guard that cannot fail loudly needs something else that can, and there wasn't one.

## Decisions

### Resolve against the repository, not the invocation

`git rev-parse --show-toplevel` rather than walking up for a `.git` directory: it is what git itself considers the root, it works correctly inside a linked worktree (which is how every branch in this repository is checked out), and it costs one subprocess on a command that already shells out repeatedly.

### Fall back to the cwd rather than failing

Outside a checkout there is no root to resolve against, and every such caller — the tests, a fixture directory — passes an explicit path anyway. Failing there would break the tests to guard a case that cannot happen in use.

### The regression test runs from inside a package subdirectory

A test that passes an explicit path cannot catch this, which is exactly why the old suite didn't. The new one creates `tools/pr-metrics/` in a throwaway repo, runs the collector with that as its cwd, and asserts the card lands at the root and **not** under the package.

## Test plan

- `bun test tools/pr-metrics` — **72 tests, all passing** (up from 71).
- `bun run --cwd tools/pr-metrics check` — clean.
- `bun run lint` — no errors from the package.
- `bun run fmt:check` — clean across 1456 files.
- `bash scripts/validate-changesets.sh` — passes.
- **Reproduced and verified by hand.** Before: `report -- --coverage` exits 1; `card` creates `tools/pr-metrics/.claude/metrics/`. After, against a real 34-card corpus: `report` prints the coverage table, `card` writes to `<repo>/.claude/metrics/`, and no stray directory appears in the package.
- Not verified: that the `SessionEnd` hook now writes cards where it should. It fires at session end, so the first real check is the next session that ends after this merges — worth looking for a card that nobody committed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kRJ2QVtZ8N9wHGZtZJDTE
