### PR TITLE
fix(scripts): skip the eval run when a skill has no scenario

### DIFF
--- a/.claude/metrics/fix-skill-evals-skip-when-none.json
+++ b/.claude/metrics/fix-skill-evals-skip-when-none.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 940,
+    "branch": "fix/skill-evals-skip-when-none",
+    "base_sha": "6ac29559475594b4ab7545f8495af5b95adc2a5b",
+    "head_sha": "458ee0409ae6eaf3a3f1c0f33d5c6bfb200fe73d",
+    "generated_at": "2026-09-08T09:08:45.801Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 0,
+    "first_ts": null,
+    "last_ts": null,
+    "span_seconds": 0,
+    "active_seconds": 0,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0,
+    "tokens": {
+      "input": 0,
+      "output": 0,
+      "thinking": 0,
+      "cache_write_5m": 0,
+      "cache_write_1h": 0,
+      "cache_read": 0
+    },
+    "by_model": {},
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 1,
+      "docs": 0,
+      "config": 1,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 52,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 24,
+        "deleted": 8
+      },
+      "source": {
+        "added": 25,
+        "deleted": 1
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {},
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -213,16 +213,32 @@ jobs:
         if: steps.skills.outputs.list != ''
         run: bun run scripts/skill-evals.ts check-names
 
-      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
-        if: steps.skills.outputs.list != ''
-        with:
-          token: ${{ secrets.TESSL_TOKEN }}
-
+      # Most skills have no scenario, so a branch can change one and leave
+      # nothing to run. `subset` prints a name per scenario and exits 0 either
+      # way; an empty stdout is the signal to skip the rest of the job rather
+      # than to fail it. This runs before `setup-tessl` so that the skip costs
+      # nothing.
       - name: Narrow the run to those skills' scenarios
+        id: subset
         if: steps.skills.outputs.list != ''
         env:
           SKILLS: ${{ steps.skills.outputs.list }}
-        run: bun run scripts/skill-evals.ts subset --skills "$SKILLS" --out "$RUNNER_TEMP/scenarios"
+        run: |
+          # Not a pipe into `grep -c`: `|| true` on that pipeline would swallow
+          # a real `subset` failure — an unknown skill name — as a count of 0.
+          bun run scripts/skill-evals.ts subset \
+            --skills "$SKILLS" --out "$RUNNER_TEMP/scenarios" > "$RUNNER_TEMP/picked.txt"
+          COUNT=$(grep -c . "$RUNNER_TEMP/picked.txt" || true)
+          echo "Scenarios to run: $COUNT"
+          if [ "$COUNT" = "0" ]; then
+            echo "::notice::No eval scenario covers ${SKILLS}; skipping the run."
+          fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        if: steps.subset.outputs.count != '' && steps.subset.outputs.count != '0'
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
 
       # `--skip-baseline` because the baseline cannot move when only a skill
       # changed, and it is half the solves. `-n 1` because this is the inner
@@ -241,7 +257,7 @@ jobs:
       - name: Start the eval run
         id: run
         continue-on-error: true
-        if: steps.skills.outputs.list != ''
+        if: steps.subset.outputs.count != '' && steps.subset.outputs.count != '0'
         env:
           TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -266,7 +282,7 @@ jobs:
       # goes into a sticky comment, and `skill-eval-collect.yml` picks it up on
       # its next sweep and edits the table in.
       - name: Leave the run id for the collector
-        if: steps.skills.outputs.list != '' && steps.run.outcome == 'success'
+        if: steps.subset.outputs.count != '' && steps.subset.outputs.count != '0' && steps.run.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/scripts/skill-evals.ts
+++ b/scripts/skill-evals.ts
@@ -335,6 +335,18 @@ function cmdChanged() {
   for (const skill of skills) console.log(skill);
 }
 
+/** A skill with no scenario is the normal state, not an error.
+ *
+ * Most skills have never had one written — `orchestrate`, `stress-plan`,
+ * `rate-complexity`, `setup-osn` and `review-deps` among them — so a branch
+ * that edits one has nothing to narrow a run to. Failing there reddens the
+ * check on a pull request that has done nothing wrong, and a red check nobody
+ * can act on is a check people learn to ignore. So an empty pick writes no
+ * scenario, prints nothing on stdout and exits 0; the caller reads the empty
+ * stdout and skips the run.
+ *
+ * A name that is not a skill at all still fails. That one is a typo, and the
+ * whole point of the exit code is to catch the case a human can fix. */
 function cmdSubset() {
   const out = readArg("--out") ?? fail("subset needs --out <dir>");
   const wanted = (readArg("--skills") ?? "")
@@ -344,13 +356,25 @@ function cmdSubset() {
   if (wanted.length === 0) fail("subset needs --skills a,b");
 
   const skills = listSkills();
+  const unknown = wanted.filter((s) => !skills.includes(s));
+  if (unknown.length > 0) {
+    fail(
+      `not a skill in ${SKILLS_DIR}/: ${unknown.join(", ")}\n` +
+        `Known skills: ${skills.join(", ")}`,
+    );
+  }
+
   const picked = listScenarios().filter((s) => {
     const owner = skillOf(s, skills);
     return owner !== null && wanted.includes(owner);
   });
-  if (picked.length === 0) fail(`no scenarios for: ${wanted.join(", ")}`);
 
   mkdirSync(out, { recursive: true });
+  if (picked.length === 0) {
+    console.error(`No scenarios cover: ${wanted.join(", ")}. Nothing to run.`);
+    return;
+  }
+
   for (const scenario of picked)
     cpSync(join(EVALS_DIR, scenario), join(out, scenario), { recursive: true });
   for (const scenario of picked) console.log(scenario);

--- a/scripts/tests/skill-evals.cli.test.ts
+++ b/scripts/tests/skill-evals.cli.test.ts
@@ -76,7 +76,7 @@ test("a scenario belongs to the longest matching skill name", async () => {
   try {
     const out = join(dir, "out");
     const wrong = await run(dir, "subset", "--skills", "review", "--out", out);
-    expect(wrong.exitCode).toBe(1);
+    expect(wrong.stdout.trim()).toBe("");
     const right = await run(
       dir,
       "subset",
@@ -86,6 +86,57 @@ test("a scenario belongs to the longest matching skill name", async () => {
       join(dir, "out2"),
     );
     expect(right.stdout.trim()).toBe("review-security-two");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Most skills have never had a scenario written for them, so a branch that
+// edits one narrows a run to nothing. That is the ordinary case and must not
+// redden the check.
+test("subset skips, rather than fails, when a skill has no scenario", async () => {
+  const dir = await makeTree(["prep-pr", "orchestrate"], ["prep-pr-one"]);
+  try {
+    const out = join(dir, "out");
+    const result = await run(dir, "subset", "--skills", "orchestrate", "--out", out);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("");
+    expect(result.stderr).toContain("orchestrate");
+    expect(await Bun.file(join(out, "prep-pr-one/task.md")).exists()).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// A skill that has scenarios and one that has none, named together: the ones
+// that exist still run.
+test("subset keeps the scenarios that do exist alongside a skill with none", async () => {
+  const dir = await makeTree(["prep-pr", "orchestrate"], ["prep-pr-one"]);
+  try {
+    const out = join(dir, "out");
+    const result = await run(dir, "subset", "--skills", "orchestrate,prep-pr", "--out", out);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("prep-pr-one");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// The exit code still has a job: a name that is not a skill at all is a typo,
+// and silently running nothing would hide it.
+test("subset fails on a name that is not a skill", async () => {
+  const dir = await makeTree(["prep-pr"], ["prep-pr-one"]);
+  try {
+    const result = await run(
+      dir,
+      "subset",
+      "--skills",
+      "prep-pr,prep-prr",
+      "--out",
+      join(dir, "out"),
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("prep-prr");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

The `Scenario eval` check went red on any pull request where **none** of the
skills it changed had an eval scenario. `subset` takes the union, so a branch
touching one covered skill and three uncovered ones was fine; a branch touching
only uncovered ones failed. Most skills are uncovered — `orchestrate`,
`stress-plan`, `rate-complexity`, `setup-osn` and `review-deps` have never had a
scenario written — so that was the common case for a skill edit: a failing check
that said nothing about the change. A red check nobody can act on is one people
learn to ignore, and that is the whole gate lost, not just this one.

- `subset` now exits 0 and writes no scenario when its pick is empty, with a
  line on stderr naming the skills it covered.
- A `--skills` name that is not a skill at all still exits 1. That case is a
  typo, and the exit code is the only thing that catches it.
- The workflow counts the scenarios `subset` printed and gates the rest of the
  job on that count, so nothing downstream runs on an empty set.
- `subset` moved ahead of `setup-tessl` in the job, so a skip costs no setup.

## Workspaces affected

None. `scripts/` and `.github/` are not workspaces and ship in no package, so
`scripts/changeset-required.sh` prints `skip` for this branch and no changeset
is needed.

## Issues

**Closes**

This branch closes no issue.

**Opened**

| Issue | What |
|---|---|
| — | None |

## Decisions

### An empty scenario set is the ordinary case, not an error — `approach`

- **Issue** — `cmdSubset` called `fail()` when no scenario matched the changed
  skills, exiting 1 and failing the workflow step.
- **Why** — eleven skills live in `.claude/skills/` and six scenarios exist
  across four of them. A branch editing any of the other seven hit this. The
  eval job's own contract, written at the top of `skill-eval.yml`, is that it
  never fails the check; this path broke that contract.
- **Solution** — an empty pick prints a note on stderr, writes nothing to
  stdout, creates the (empty) output directory and returns 0. The workflow
  counts stdout lines and gates `setup-tessl`, the run, and the sticky comment
  on that count being non-zero.
- **Rationale** — the count has to come from the script rather than from a
  second `git diff` in YAML, because `subset` already owns the skill-to-scenario
  mapping and a second implementation would drift. Making the step
  `continue-on-error: true` was rejected: it would have hidden a genuine
  `subset` failure just as thoroughly as it hid this one.

### A skill name that does not exist still fails — `approach`

- **Issue** — with the change above, a typo in `--skills` would produce the same
  quiet zero-scenario skip as a real skill with no scenario.
- **Why** — the two are opposite situations. One is expected and needs no
  action; the other is a mistake that silently stops the eval running for a
  skill someone believed they were testing.
- **Solution** — `subset` validates every requested name against `listSkills()`
  first and fails with the unknown names and the known list.
- **Rationale** — this keeps the exit code meaningful. It also means the
  existing longest-prefix test ("`review` must not claim
  `review-security-two`") still exercises a real branch: with `review` a
  declared skill in that fixture, the assertion moved from exit code 1 to an
  empty stdout, which is the thing that test was always about.

### The scenario count is read from a file, not a pipe — `approach`

- **Issue** — the obvious shell for this is
  `COUNT=$(… subset … | grep -c . || true)`.
- **Why** — GitHub Actions runs `run:` steps under `set -eo pipefail`, but the
  trailing `|| true` applies to the whole pipeline. A `subset` exit of 1 (the
  typo case above) would be swallowed and read as a count of zero — the exact
  failure this branch exists to stop being invisible.
- **Solution** — `subset` writes stdout to `$RUNNER_TEMP/picked.txt` and
  `grep -c` counts that file, so `set -e` still sees the script's own exit code.
- **Rationale** — `grep -c` returns 1 on zero matches, so `|| true` is still
  needed on that line; it now guards only the count, not the script.

### The card for this branch reads zero spend — `approach`

- **Issue** — the session-metrics card below records `$0.00` and `0 session(s)`
  despite a real session having produced the branch.
- **Why** — `gitBranch` in a transcript record is a property of the *session*,
  captured once at its start, not of the work. This session started in the
  `main` worktree and did the work in `fix-eval-skip`, so every record is
  stamped `gitBranch: "main"` and the collector matches none of them.
- **Solution** — the card is committed as it stands, with the zero left visible.
  The diff, file and package counts in it are real and come from git.
- **Rationale** — a card is a record, and an invented number would make it a
  worse one than an honest zero. This is a known limitation of the collector,
  not of this branch; the fix belongs with the collector.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Script tests | `bun run test:scripts` | `148 pass, 0 fail` across 13 files |
| Type check (repo) | `bun run check` | `38 successful, 38 total` — no workspace covers `scripts/`, so this gate does not read the changed files |
| Type check (changed files) | `tsc --noEmit --ignoreConfig --strict …` on both changed `.ts` files | exit 0 |
| Lint | `bun run lint` | no errors; pre-existing `no-console` / `no-array-sort` warnings only, none introduced by this branch |
| Format | `bun run fmt:check` | `All matched files use the correct format` |
| Changeset | `bash scripts/changeset-required.sh` | `skip` |

Three new tests cover the behaviour directly: a skill with no scenario skips at
exit 0, a mixed request still copies the scenarios that do exist, and an unknown
name still exits 1.

Exercised by hand in this worktree against the real `.claude/` tree:

- `subset --skills orchestrate` — printed `No scenarios cover: orchestrate.
  Nothing to run.` on stderr, nothing on stdout, exit 0.
- `subset --skills prep-pr` — printed both `prep-pr-*` scenarios, exit 0.
- `subset --skills orchestraate` — exit 1, naming the unknown skill and listing
  the eleven real ones.

Not verified: the workflow YAML itself has not run. The change to
`skill-eval.yml` is three `if:` conditions and one rewritten `run:` block, and
the first pull request to touch a skill after this merges is what proves it.

<details><summary>Session metrics — $0.00 · 0 tok · complexity unrated · +25/-1 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $0.00 |
| Tokens | 0 — out 0 · cache-w 0 · cache-r 0 (0%) |
| Models | — |
| Active time | 0s over 0 session(s) |
| Declared complexity | unrated |
| Source diff | +25/-1 across 1 file(s), 0 package(s) |
| Turns | 0 (0 corrective) |
| Before first edit | not observed (no edit seen in the transcript) |
| Subagents | none |

<sub>Card: `.claude/metrics/fix-skill-evals-skip-when-none.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3oFqUaGv1KNeC2X6ZBnrL
