### PR TITLE
docs: move the Effect v4 API reference out of CLAUDE.md

### DIFF
--- a/.claude/metrics/docs-effect-out-of-claude-md.json
+++ b/.claude/metrics/docs-effect-out-of-claude-md.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 941,
+    "branch": "docs/effect-out-of-claude-md",
+    "base_sha": "6ac29559475594b4ab7545f8495af5b95adc2a5b",
+    "head_sha": "6387058804d8a0c6ee721218f26a473e13814b77",
+    "generated_at": "2026-09-08T11:26:34.236Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 0,
+    "first_ts": null,
+    "last_ts": null,
+    "span_seconds": 0,
+    "active_seconds": 0,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0,
+    "tokens": {
+      "input": 0,
+      "output": 0,
+      "thinking": 0,
+      "cache_write_5m": 0,
+      "cache_write_1h": 0,
+      "cache_read": 0
+    },
+    "by_model": {},
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 4,
+      "config": 0,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 144,
+        "deleted": 112
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {},
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ One label is orthogonal to all of that: **`needs:decision`**, on both repos. It 
 | Understand DB environments (local bun:sqlite vs dev/staging/prod D1) | `[[wiki/systems/database-environments]]` |
 | Cut D1 latency with read replicas (the Sessions API, `first-primary`, one session per invocation, turning replication on) | `[[wiki/systems/d1-read-replication]]` |
 | Write new Effect service or Elysia route | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]` |
-| Write Effect code (v4 — see §Effect v4 below for the API shapes that changed) | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]`, `[[wiki/conventions/testing-patterns]]` |
+| Write Effect code (v4 — the v3 forms that no longer compile, and what to write instead) | `[[wiki/architecture/effect-v4-api]]`, then `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]`, `[[wiki/conventions/testing-patterns]]` |
 | Understand accounts, profiles, orgs | `[[wiki/systems/identity-model]]` |
 | Add or verify ARC S2S tokens | `[[wiki/systems/arc-tokens]]` |
 | Let another app sign a user in with their OSN account (OIDC, PKCE, consent, pairwise `sub`) | `[[wiki/systems/oidc-provider]]` |
@@ -218,119 +218,12 @@ One-line summaries — open wiki page for full contract, API surface, finding hi
 | Component Library | Zaidan-style (shadcn for SolidJS) on Kobalte. Component defaults use `base:`-prefixed classes written directly in source; two class utils cover the rest: `clsx()` conditional joins, `cn()` only for arbitrary conflicts. | `[[wiki/architecture/component-library]]` |
 | Share-source attribution | Closed `ShareSource` enum (`instagram | facebook | tiktok | x | whatsapp | copy_link | other`) drives the share picker, `?source=` URL injection, RSVP attribution columns (`share_source_first` sticky, `share_source_last` overwriting), and four bounded-cardinality counters. Single source of truth in `pulse/api/src/lib/shareSource.ts`; metric attribute type via `import type`. Lightweight `checkEventVisibility` (3 cols) gates the high-frequency share / exposure endpoints instead of the full `loadVisibleEvent`. Organiser self-RSVPs / self-views excluded. | `[[wiki/systems/event-access]]` |
 
-## Effect v4
-
-The repo moved off Effect v3 on 2026-09-06 and is pinned at the exact
-`4.0.0-rc.112` (pre-GA, so exact rather than caret). Everything below is a v3
-form that will not compile, and the v4 form to write instead. Most of the
-surface is unchanged — `Effect.gen`, `provide`, `runPromise`, `tryPromise`,
-`fail`, `flip`, `withSpan`, `catchTag`, `provideService`, `annotateLogs`,
-`Layer.effect`/`succeed`/`merge`, `Option.*`, `Exit.*`, `it.effect`, `it.layer`,
-and **`Data.TaggedError`**, which is this repo's whole error vocabulary and
-needed zero edits.
-
-### Renames
-
-| v3 | v4 |
-| --- | --- |
-| `Effect.catchAll` / `catchAllDefect` / `catchAllCause` | `Effect.catch` / `catchDefect` / `catchCause` |
-| `Effect.either` | `Effect.result` |
-| `Effect.zipRight` / `forkDaemon` / `dieMessage` | `Effect.andThen` / `forkDetach` / `die(new Error(…))` |
-| `Effect.yieldNow()` | `Effect.yieldNow` — a value, not a call |
-| `Layer.scoped` | `Layer.effect` — it supplies and excludes the `Scope` |
-| `Either` module | `Result` — tags are `"Success"`/`"Failure"` |
-| `Cause.failureOption` | `Cause.findErrorOption` |
-| `Context.Tag(id)<Self, Shape>()` | `Context.Service<Self, Shape>()(id)` — argument order flips; `Context.Tag<I, S>` in **type** position is `Context.Key<I, S>` |
-
-Service **identifier strings** are runtime lookup keys. Preserve them exactly
-through any such rewrite — a typo is a service-not-found at request time, not a
-compile error.
-
-### Errors, `Cause` and `Runtime`
-
-`FiberFailure` is gone. `runPromise` rejects with `Cause.squash(cause)`, which
-for a typed failure is the tagged error itself — so a `catch` that checks
-`_tag` now matches. The catch: where v3's `Cause.failureOption` returned `None`
-for a **defect**, `squash` hands you the defect object, which can carry an
-internal message. Gate on the tag before showing a rejection to anyone.
-
-`Cause` is a flat list of reasons, so there is no `Fail` node:
-
-```ts
-// v3: exit.cause._tag === "Fail" && exit.cause.error instanceof NotFound
-Option.getOrUndefined(Cause.findErrorOption(exit.cause)) instanceof NotFound
-```
-
-`ManagedRuntime` no longer extends `Effect`; `runtimeEffect`/`runtime` are
-`contextEffect`/`context`, and `Runtime<R>` is replaced by `Context<R>`.
-
-### Schema
-
-`Schema.decodeUnknown` is `decodeUnknownEffect`, and its failure is tagged
-**`SchemaError`**, not `ParseError` — that is what `catchTag` takes. Constraint
-combinators are *checks*, applied with a schema's `.check(…)`:
-
-```ts
-Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(64))
-Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 0, maximum: 99 }))
-Schema.String.check(Schema.isPattern(/^\d{4}$/))
-Schema.String.check(Schema.makeFilter((s) => ok(s) ? undefined : "why not"))
-```
-
-`isMinLength`/`isMaxLength` cover collections too (v3's `minItems`/`maxItems`).
-A `makeFilter` returns `undefined`/`true` for success and **a string as the
-failure message**; a check's `message` annotation is a plain string, not a
-thunk. `.check(a, b)` short-circuits on the first failure, so ordering a cheap
-bound before an expensive lookup still works.
-
-Four more, and the first two fail quietly:
-
-- **`Schema.Literal` takes one literal, `Schema.Union` takes one array.** Pass
-  the v3 variadic shape and the extra members are dropped rather than rejected;
-  the mistake surfaces later as `{}` where a real type was expected, or as a
-  union that has stopped rejecting one of its cases. Use
-  `Schema.Literals([…])` and `Schema.Union([…])`.
-- **Decode messages no longer echo the input.** v4 renders a reason line plus
-  an `at ["path"]` line where v3 wrote `Expected number, actual "x"`. A test
-  pinned to the old text passes vacuously if it only checks something threw.
-- `Schema.optionalWith(S, { default: () => v })` →
-  `S.pipe(Schema.withDecodingDefaultType(Effect.succeed(v)))`.
-- `Schema.transform(from, to, {decode, encode})` →
-  `from.pipe(Schema.decodeTo(to, SchemaTransformation.transform({ decode, encode })))`.
-  Often unnecessary: `Schema.Trim.check(…)` covers "trim then bound", and
-  `Schema.DateFromString` now rejects a string that parses to an Invalid Date,
-  which is what three hand-rolled transforms here existed for.
-  `Schema.parseJson(S)` is `Schema.fromJsonString(S)`; `DateFromSelf` is `Date`;
-  `Schema.Record({key, value})` is positional, `Schema.Record(key, value)`.
-
-### Logging
-
-`Logger.layer([…])` **replaces the whole active set**, so
-`Logger.tracerLogger` must be listed explicitly or log-to-span correlation
-disappears with no error and no failing type-check. Levels are string literals
-(`"Warn"`, not v3's `"Warning"`), the minimum level is
-`References.MinimumLogLevel` rather than `Logger.withMinimumLogLevel`,
-annotations live on the fiber rather than the logger's `Options`, and **the
-JSON severity field is `level`, not `logLevel`** — a Grafana query on the old
-name matches nothing. `@shared/observability` owns all of this; see
-`[[wiki/observability/logging]]`.
-
-### Layer memoization
-
-The `MemoMap` is shared across `Effect.provide` calls **within one run**, not
-across separate `runPromise` roots. A per-request `Effect.provide(scopedLayer)`
-is a new root every time, so it still **builds and tears the layer down on
-every request** — measured, 5 provides → 5 acquires and 5 releases, against a
-`ManagedRuntime`'s 1 acquire and 0 releases. So the v3 rebuild-cost argument
-for a shared runtime is not weakened at all where it matters; if anything the
-§Conventions "Effect runtime" rule is understated.
-
 ## Conventions
 
 | Area | Rule |
 |---|---|
 | Native apps (iOS) | Swift. One local SPM package at `shared/swift/OSNShared` with four library products — `OSNKit`, `OSNAuth`, `OSNUI`, `OSNTesting`; consumers depend on `.product(name: "OSNKit", package: "OSNShared")`. App targets are thin: all code lives in packages, `*.xcodeproj` is generated by XcodeGen from a committed `project.yml` and is gitignored. **Every target must compile against the macOS SDK too** — `platforms:` is package-level (SPM has no per-target platform) and `swift test` builds every target on the host, so a bare `import UIKit` anywhere in `OSNShared` fails CI. SwiftUI and Liquid Glass exist on macOS 26; genuinely UIKit-only code goes behind `#if canImport(UIKit)` or into the app target |
-| Functional core | **Effect.ts is the backend, settled — not a trial.** Every backend (`osn/api`, `cire/api`, `pulse/api`, `zap/api`), the shared packages and `@osn/client` are built on it, and the 2026-09-06 v4 migration was carried out on that basis. `effect` and `@effect/vitest` are pinned at the exact `4.0.0-rc.112` across 13 packages — exact rather than caret because it is pre-GA. Nothing is left on v3. The API shapes that moved are in §Effect v4. **The frontends use Effect nowhere**, and that stays an open question rather than a rule: it gets evaluated when the Solid apps move to Solid v2, not before |
+| Functional core | **Effect.ts is the backend, settled — not a trial.** Every backend (`osn/api`, `cire/api`, `pulse/api`, `zap/api`), the shared packages and `@osn/client` are built on it, and the 2026-09-06 v4 migration was carried out on that basis. `effect` and `@effect/vitest` are pinned **exact rather than caret**, because the release is pre-GA and a range would move the whole monorepo on someone else's schedule; `bun.lock` and the manifests are where the version is, not this file. Nothing is left on v3, and the v3 forms that no longer compile are in `[[wiki/architecture/effect-v4-api]]`. **The frontends use Effect nowhere**, and that stays an open question rather than a rule: it gets evaluated when the Solid apps move to Solid v2, not before |
 | Effect runtime | Build the layer graph **once** (shared `ManagedRuntime` at boot), never `Effect.provide(DbLive/observability)` inside a per-request `runPromise`. The reason is lifecycle ownership — one OTel SDK and one DB connection per process, owned by something that can close them. The rebuild-cost reason still holds too: v4's shared `MemoMap` spans one run, not separate `runPromise` roots, so a per-request `Effect.provide` of a scoped layer acquires AND releases it every request (measured: 5 provides → 5 acquires, 5 releases; a `ManagedRuntime` → 1 and 0). `@osn/api` threads one runtime through route factories via `makeAppRunner`. See `[[wiki/architecture/backend-patterns]]` |
 | Messaging | `@zap/api` shared backend — Pulse consumes for event chats; users don't need Zap install |
 | Privacy | E2E encryption everywhere; all personalisation data user-accessible + resettable |
@@ -348,7 +241,7 @@ for a shared runtime is not weakened at all where it matters; if anything the
 | Versioning | Automatic — changesets consumed + committed by CI on merge to main |
 | Dependency soak | `bunfig.toml` sets `minimumReleaseAge = 259200` (3 days) so a fresh publish cannot install straight away. An entry in `minimumReleaseAgeExcludes` is a hole in that, so it must carry a `# DROP AFTER <name> <YYYY-MM-DD>` marker comment in the same file, dated no more than 30 days out. `scripts/check-release-age-excludes.ts` (CI step in the `script-tests` job, `bun run check:release-age-excludes` locally) fails on a missing, invalid, expired or over-long marker, and on `minimumReleaseAge` itself dropping below 259200 |
 | Vendored trees | `tools/oxlint` holds two plugins and they are not the same kind of thing. `tools/oxlint/house` is ours: a real workspace (`@tools/oxlint-house`), formatted, linted, typechecked and tested like any other package, and where a rule this repo needs but nobody publishes belongs. `tools/oxlint/anti-slop` is a verbatim upstream copy — excluded from oxfmt and oxlint, MIT licence vendored beside it. Its `SHA256SUMS` covers every tracked file and CI checks both the checksums and the file set, so a re-vendor must regenerate it with the recipe in that directory's `README.md`. `.github/CODEOWNERS` puts the tree under a human owner, along with `scripts/`, `.github/`, `bunfig.toml` and the files that decide a guard runs at all (`package.json`, `oxlintrc.json`, `lefthook.yml`) |
-| Agent skills and their evals | A procedure an agent follows lives in `.claude/skills/<name>/SKILL.md`, and nowhere else. **Every skill here is ours.** No third-party skill is installed, so there is no `.agents/` tree and no `skills-lock.json`, and neither path is in `.github/CODEOWNERS` or the changeset allowlist any more — an allowlist entry for a path nothing writes is a hole nobody is watching. The two `Effect-TS/skills` ones went with the v4 migration, since a migration skill has no second use and what it taught is in §Effect v4. To install one again, use `npx skills add <owner>/<repo>` rather than copying the text in (so `npx skills update` can move the pin) — it lands in `.agents/skills/<name>/` with a `.claude/skills/<name>` symlink and a content-hashing `skills-lock.json`, and **the same commit must restore the CODEOWNERS and allowlist entries for both paths**: that tree is someone else's instructions running with full agent permissions. Claude Code invokes a skill as `/<name>`, so a wrapper in `.claude/commands/` buys nothing and only splits the procedure across two files that drift; the older commands still in that directory are the ones not yet converted. Skills are also what makes a procedure measurable: `.claude/` is a Tessl plugin (`.tessl-plugin/plugin.json`), and each scenario under `.claude/evals/<scenario>/` runs an agent with and without the skill and scores the gap. A scenario pins a real commit of this repo and builds its branch in `setup.sh`, and that commit ships whatever `.claude/` held at the time, so `setup.sh` deletes it — `exclude` in `scenario.json` does not. Every merged fix PR is a free labelled scenario — pin its parent SHA, one checklist item per finding it fixed. `.claude/settings.json` is committed, so its hooks travel to the remote environment — that is what makes a standing rule hold in a session that never reads a local config. Personal hooks and permissions belong in `.claude/settings.local.json`, which is gitignored; a personal untracked `settings.json` will block the pull that first brings the tracked one down. See `.claude/evals/README.md` |
+| Agent skills and their evals | A procedure an agent follows lives in `.claude/skills/<name>/SKILL.md`, and nowhere else. **Every skill here is ours.** No third-party skill is installed, so there is no `.agents/` tree and no `skills-lock.json`, and neither path is in `.github/CODEOWNERS` or the changeset allowlist any more — an allowlist entry for a path nothing writes is a hole nobody is watching. The two `Effect-TS/skills` ones went with the v4 migration, since a migration skill has no second use and what it taught is in `[[wiki/architecture/effect-v4-api]]`. To install one again, use `npx skills add <owner>/<repo>` rather than copying the text in (so `npx skills update` can move the pin) — it lands in `.agents/skills/<name>/` with a `.claude/skills/<name>` symlink and a content-hashing `skills-lock.json`, and **the same commit must restore the CODEOWNERS and allowlist entries for both paths**: that tree is someone else's instructions running with full agent permissions. Claude Code invokes a skill as `/<name>`, so a wrapper in `.claude/commands/` buys nothing and only splits the procedure across two files that drift; the older commands still in that directory are the ones not yet converted. Skills are also what makes a procedure measurable: `.claude/` is a Tessl plugin (`.tessl-plugin/plugin.json`), and each scenario under `.claude/evals/<scenario>/` runs an agent with and without the skill and scores the gap. A scenario pins a real commit of this repo and builds its branch in `setup.sh`, and that commit ships whatever `.claude/` held at the time, so `setup.sh` deletes it — `exclude` in `scenario.json` does not. Every merged fix PR is a free labelled scenario — pin its parent SHA, one checklist item per finding it fixed. `.claude/settings.json` is committed, so its hooks travel to the remote environment — that is what makes a standing rule hold in a session that never reads a local config. Personal hooks and permissions belong in `.claude/settings.local.json`, which is gitignored; a personal untracked `settings.json` will block the pull that first brings the tracked one down. See `.claude/evals/README.md` |
 
 ## Commands
 

--- a/wiki/architecture/backend-patterns.md
+++ b/wiki/architecture/backend-patterns.md
@@ -11,6 +11,7 @@ tags:
   - effect
 status: current
 related:
+  - "[[effect-v4-api]]"
   - "[[d1-limits]]"
   - "[[schema-layers]]"
   - "[[testing-patterns]]"
@@ -21,7 +22,7 @@ packages:
   - "@osn/api"
   - "@zap/api"
   - "@cire/api"
-last-reviewed: 2026-09-06
+last-reviewed: 2026-09-08
 ---
 
 # Backend Code Patterns

--- a/wiki/architecture/effect-v4-api.md
+++ b/wiki/architecture/effect-v4-api.md
@@ -1,0 +1,137 @@
+---
+title: Effect v4 API Shapes
+aliases:
+  - effect v4
+  - effect v3 to v4
+  - effect renames
+tags:
+  - architecture
+  - effect
+  - migration
+status: current
+related:
+  - "[[backend-patterns]]"
+  - "[[schema-layers]]"
+  - "[[testing-patterns]]"
+packages:
+  - "@osn/api"
+  - "@pulse/api"
+  - "@zap/api"
+  - "@cire/api"
+last-reviewed: 2026-09-08
+---
+
+# Effect v4 API Shapes
+
+Every v3 form below will not compile, and the v4 form beside it is what to
+write instead. This page exists because the v3 shapes are still what a model
+reaches for from memory and what every pre-2026-09 example on the internet
+shows — knowing that a rename happened is not enough to write the new name.
+
+The repo moved off Effect v3 on 2026-09-06. Which packages are on it, and why
+the pin is exact rather than caret, is in `CLAUDE.md` under Conventions —
+kept there rather than repeated here so there is one place for it to be right.
+
+Most of the surface is unchanged. `Effect.gen`, `provide`, `runPromise`,
+`tryPromise`, `fail`, `flip`, `withSpan`, `catchTag`, `provideService`,
+`annotateLogs`, `Layer.effect`/`succeed`/`merge`, `Option.*`, `Exit.*`,
+`it.effect`, `it.layer`, and **`Data.TaggedError`** — this repo's whole error
+vocabulary — all needed zero edits.
+
+## Renames
+
+| v3 | v4 |
+| --- | --- |
+| `Effect.catchAll` / `catchAllDefect` / `catchAllCause` | `Effect.catch` / `catchDefect` / `catchCause` |
+| `Effect.either` | `Effect.result` |
+| `Effect.zipRight` / `forkDaemon` / `dieMessage` | `Effect.andThen` / `forkDetach` / `die(new Error(…))` |
+| `Effect.yieldNow()` | `Effect.yieldNow` — a value, not a call |
+| `Layer.scoped` | `Layer.effect` — it supplies and excludes the `Scope` |
+| `Either` module | `Result` — tags are `"Success"`/`"Failure"` |
+| `Cause.failureOption` | `Cause.findErrorOption` |
+| `Context.Tag(id)<Self, Shape>()` | `Context.Service<Self, Shape>()(id)` — argument order flips; `Context.Tag<I, S>` in **type** position is `Context.Key<I, S>` |
+
+Service **identifier strings** are runtime lookup keys. Preserve them exactly
+through any such rewrite — a typo is a service-not-found at request time, not a
+compile error.
+
+## Errors, `Cause` and `Runtime`
+
+`FiberFailure` is gone. `runPromise` rejects with `Cause.squash(cause)`, which
+for a typed failure is the tagged error itself — so a `catch` that checks
+`_tag` now matches. The catch: where v3's `Cause.failureOption` returned `None`
+for a **defect**, `squash` hands you the defect object, which can carry an
+internal message. Gate on the tag before showing a rejection to anyone.
+
+`Cause` is a flat list of reasons, so there is no `Fail` node:
+
+```ts
+// v3: exit.cause._tag === "Fail" && exit.cause.error instanceof NotFound
+Option.getOrUndefined(Cause.findErrorOption(exit.cause)) instanceof NotFound
+```
+
+`ManagedRuntime` no longer extends `Effect`; `runtimeEffect`/`runtime` are
+`contextEffect`/`context`, and `Runtime<R>` is replaced by `Context<R>`.
+
+## Schema
+
+`Schema.decodeUnknown` is `decodeUnknownEffect`, and its failure is tagged
+**`SchemaError`**, not `ParseError` — that is what `catchTag` takes. Constraint
+combinators are *checks*, applied with a schema's `.check(…)`:
+
+```ts
+Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(64))
+Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 0, maximum: 99 }))
+Schema.String.check(Schema.isPattern(/^\d{4}$/))
+Schema.String.check(Schema.makeFilter((s) => ok(s) ? undefined : "why not"))
+```
+
+`isMinLength`/`isMaxLength` cover collections too (v3's `minItems`/`maxItems`).
+A `makeFilter` returns `undefined`/`true` for success and **a string as the
+failure message**; a check's `message` annotation is a plain string, not a
+thunk. `.check(a, b)` short-circuits on the first failure, so ordering a cheap
+bound before an expensive lookup still works.
+
+Four more, and the first two fail quietly:
+
+- **`Schema.Literal` takes one literal, `Schema.Union` takes one array.** Pass
+  the v3 variadic shape and the extra members are dropped rather than rejected;
+  the mistake surfaces later as `{}` where a real type was expected, or as a
+  union that has stopped rejecting one of its cases. Use
+  `Schema.Literals([…])` and `Schema.Union([…])`.
+- **Decode messages no longer echo the input.** v4 renders a reason line plus
+  an `at ["path"]` line where v3 wrote `Expected number, actual "x"`. A test
+  pinned to the old text passes vacuously if it only checks something threw.
+- `Schema.optionalWith(S, { default: () => v })` →
+  `S.pipe(Schema.withDecodingDefaultType(Effect.succeed(v)))`.
+- `Schema.transform(from, to, {decode, encode})` →
+  `from.pipe(Schema.decodeTo(to, SchemaTransformation.transform({ decode, encode })))`.
+  Often unnecessary: `Schema.Trim.check(…)` covers "trim then bound", and
+  `Schema.DateFromString` now rejects a string that parses to an Invalid Date,
+  which is what three hand-rolled transforms here existed for.
+  `Schema.parseJson(S)` is `Schema.fromJsonString(S)`; `DateFromSelf` is `Date`;
+  `Schema.Record({key, value})` is positional, `Schema.Record(key, value)`.
+
+## Logging
+
+`Logger.layer([…])` **replaces the whole active set**, so
+`Logger.tracerLogger` must be listed explicitly or log-to-span correlation
+disappears with no error and no failing type-check. Levels are string literals
+(`"Warn"`, not v3's `"Warning"`), the minimum level is
+`References.MinimumLogLevel` rather than `Logger.withMinimumLogLevel`,
+annotations live on the fiber rather than the logger's `Options`, and **the
+JSON severity field is `level`, not `logLevel`** — a Grafana query on the old
+name matches nothing. `@shared/observability` owns all of this; see
+`[[wiki/observability/logging]]`.
+
+## Layer memoization
+
+The `MemoMap` is shared across `Effect.provide` calls **within one run**, not
+across separate `runPromise` roots. A per-request `Effect.provide(scopedLayer)`
+is a new root every time, so it still **builds and tears the layer down on
+every request** — measured, 5 provides → 5 acquires and 5 releases, against a
+`ManagedRuntime`'s 1 acquire and 0 releases. So the v3 rebuild-cost argument
+for a shared runtime is not weakened at all where it matters; if anything the
+"Effect runtime" rule in `CLAUDE.md`'s Conventions table is understated. The
+pattern itself is in [[backend-patterns]].
+

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -7,7 +7,7 @@ related:
   - "[[deferred-decisions]]"
   - "[[monorepo-structure]]"
   - "[[compliance/index]]"
-last-reviewed: 2026-09-06
+last-reviewed: 2026-09-08
 ---
 
 # OSN Wiki
@@ -25,6 +25,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[monorepo-structure]] — workspace layout, domain prefixes, directory tree
 - [[backend-patterns]] — Elysia route factories, Effect pipelines, service layer
 - [[schema-layers]] — Elysia TypeBox (HTTP) vs Effect Schema (domain)
+- [[effect-v4-api]] — the v3 forms that no longer compile, and the v4 form to write instead
 - [[s2s-patterns]] — graphBridge, cross-package calls, ARC token flow
 - [[frontend-patterns]] — SolidJS, shared UI tokens, lazy loading
 - [[component-library]] — Zaidan/shadcn-style components, Kobalte primitives, CVA variants


### PR DESCRIPTION
## Summary

`CLAUDE.md` is loaded in full at the start of every session, so what sits in it
is paid for on every task. It carried 107 lines of Effect v3-to-v4 rename
tables — a reference consulted when writing Effect code, not on every task —
and a pinned version string that had already drifted: the row claimed 13
packages where 14 declare `effect`.

- The reference moves verbatim to `wiki/architecture/effect-v4-api.md`. All ten
  table rows and four code blocks are byte-identical; the one edited sentence is
  the closing cross-reference, which named a `CLAUDE.md` section by `§` number
  and now names it by title and links `[[backend-patterns]]`.
- The Conventions row keeps the rule and drops the number. The pin is exact
  rather than caret because the release is pre-GA; the manifests and `bun.lock`
  are where the version lives. One place for it to be right, instead of two
  places to disagree.
- Linked from the nav table, `wiki/index` and `backend-patterns`, with
  `last-reviewed` bumped on both pages this branch touches.

## Workspaces affected

None. `wiki/`, `docs/` and top-level prose are on the changeset allowlist, so
`scripts/changeset-required.sh` prints `skip` and no changeset is needed.

## Issues

**Closes**

This branch closes no issue.

**Opened**

| Issue | What |
|---|---|
| — | None |

## Decisions

### A version number in prose is a second source of truth — `approach`

- **Issue** — the Conventions row pinned `4.0.0-rc.112` and counted the packages
  carrying it. The count was wrong by one.
- **Why** — a manifest bump does not touch `CLAUDE.md`, so prose that restates a
  version is wrong from the next bump onward, and it is wrong in the one file
  every session reads as authoritative.
- **Solution** — keep the durable half (exact rather than caret, because pre-GA,
  and nothing is left on v3) and point at the manifests and `bun.lock` for the
  number.
- **Rationale** — correcting 13 to 14 would have been true for exactly as long
  as it took someone to bump the pin. The rule is what a reader needs; the
  number is what a command answers.

### The rename tables are reference, not context — `approach`

- **Issue** — 107 of `CLAUDE.md`'s lines were v3 forms and their v4
  replacements.
- **Why** — it is real and worth keeping: the v3 shapes are still what a model
  reaches for from memory, and every pre-2026-09 example online shows them. But
  it is consulted while writing Effect code, which is a fraction of the tasks
  that load this file.
- **Solution** — a wiki page with its own frontmatter, reachable from the nav
  table row an agent already follows to write Effect code.
- **Rationale** — the repo's own convention says a new reference gets a wiki
  page linked from the nav table and `wiki/index`. Moving it verbatim rather
  than rewriting keeps the diff reviewable: the content check below is a `diff`,
  not a reading.

### The card below reads zero — `approach`

- **Issue** — the session-metrics card records `$0.00` and `0 session(s)`.
- **Why** — `gitBranch` is captured once at session start, not per unit of work.
  This session started in the `main` worktree, so every record is stamped
  `gitBranch: "main"` and the collector matches none of them. The `+0/-0 source`
  is separately correct: this branch changes no source file.
- **Solution** — commit the card as it stands, zero visible.
- **Rationale** — a card is a record; an invented number makes it a worse one.
  Known collector limitation, not a property of this branch.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Format | `bun run fmt:check` | `All matched files use the correct format` (1456 files) |
| Changeset | `bash scripts/changeset-required.sh` | `skip` |
| Content preserved | `diff` of the removed lines against the new page | only the two intended edits — the relocated intro sentence and the rewritten closing cross-reference |
| Tables and code blocks | `grep -c` on both | 10 table rows and 4 code fences before and after |
| Dangling references | `grep -rn '§Effect v4'` across all markdown | no matches remain |
| Wikilink targets | `find` for each linked page | `effect-v4-api`, `backend-patterns`, `schema-layers`, `testing-patterns` all resolve |

No code changed, so no build, type check or test run applies to this branch and
none was run. The claims the moved page makes about v4 API shapes were not
re-verified against the Effect source — they are carried over unaltered from
`CLAUDE.md`, where they were written during the 2026-09-06 migration.

<details><summary>Session metrics — $0.00 · 0 tok · complexity unrated · +0/-0 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $0.00 |
| Tokens | 0 — out 0 · cache-w 0 · cache-r 0 (0%) |
| Models | — |
| Active time | 0s over 0 session(s) |
| Declared complexity | unrated |
| Source diff | +0/-0 across 0 file(s), 0 package(s) |
| Turns | 0 (0 corrective) |
| Before first edit | not observed (no edit seen in the transcript) |
| Subagents | none |

<sub>Card: `.claude/metrics/docs-effect-out-of-claude-md.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3oFqUaGv1KNeC2X6ZBnrL
