### PR TITLE
Report comment-line delta in prep-pr; close out xchromo/osn#925

### DIFF
--- a/.changeset/comment-cleanup-residue-cire.md
+++ b/.changeset/comment-cleanup-residue-cire.md
@@ -1,0 +1,19 @@
+---
+"@cire/invites": patch
+"@cire/host": patch
+---
+
+State four comment constraints directly instead of citing a tracker finding.
+
+`rsvp-saved.ts` keeps every load-bearing sentence about the RSVP dwell — the
+knee/floor arithmetic, the VoiceOver and WCAG 2.2 SC 4.1.3 reasoning, and "the
+way to get it back is NOT to lower it" — while losing the `C-L1` citation to
+the private tracker and three blocks of before/after narration. It also fixes
+an internal contradiction: one block said "five sequential D1 round-trips"
+where another twelve lines down says six serialised.
+
+`registry-store.ts` keeps the seven-file sibling-cache list intact, and the
+consent registry's rule about `<head>` resources is now stated as a rule rather
+than as the history of one vendor.
+
+No behavior changes; every edit is comment text.

--- a/.changeset/comment-cleanup-residue-versioned.md
+++ b/.changeset/comment-cleanup-residue-versioned.md
@@ -1,0 +1,17 @@
+---
+"@osn/api": patch
+"@pulse/api": patch
+"@shared/observability": patch
+---
+
+State four comment constraints directly instead of citing a tracker finding.
+
+`recommendations.ts` carried D1's 100-bound-parameter cap as a tracker citation
+three times over; each now states the constraint, and a claim the old text made
+about the query binding `profileId` "once" is corrected — it binds a fixed
+number of times, which is what the file's own measurement a few hundred lines
+down already said. `d1ParamCounts.test.ts` loses five tracker numbers that its
+own six-site index already covers, and `redact.ts` loses a finding tag from its
+fast-path note. The deny-list's three-part admission test is untouched.
+
+No behavior changes; every edit is comment text.

--- a/.claude/skills/prep-pr/SKILL.md
+++ b/.claude/skills/prep-pr/SKILL.md
@@ -213,6 +213,38 @@ the concern to the user and let them decide whether to split. With no user,
 record the observation under `## Decisions` and continue. The wording is in
 `references/workflow-steps.md`.
 
+### Comment-line delta
+
+Print how many comment lines the branch adds and removes:
+
+```bash
+bun run scripts/comment-delta.ts "$BASE"
+```
+
+Report the net figure in the PR body's test-plan table. **This is a number to
+look at, not a gate** — there is no threshold to pass, and no cleanup is
+required to come out negative. `#929` legitimately rewrapped 334 comment lines
+to move 64 misattached doc blocks; a merge-and-rewrap nets near zero and that
+is correct.
+
+It exists because a comment-cleanup branch that *grows* comment volume is worth
+a second look before a human opens the diff, and nobody had been measuring it.
+The failure it catches is real and was measured: a batch instructed to "rewrite
+each reference to the constraint it stood for" turned single-line
+parentheticals into paragraphs and added 66 comment lines net while reporting
+itself as a cleanup.
+
+Two traps in reading the number:
+
+- **Diff it against the branch point, not a moved base.** If the base branch has
+  been force-pushed since the branch was cut, `git merge-base` falls back to an
+  older ancestor and sweeps the base's own commits into the count. That produced
+  a reported `+85` for a branch actually running `-40`. Step 0 resolves `$BASE`;
+  use it, and if the number looks surprising, check `git log "$BASE"..HEAD`
+  contains only your commits.
+- **It is trivially gamed** by joining wrapped lines, which is why it is not a
+  gate. A branch that halves its comment lines by rewrapping has done nothing.
+
 ## Step 6 — Parallel reviews
 
 **Unless the task says these reviews have already run** — then record what it says they found, note it under `## Decisions`, and go to Step 7.

--- a/cire/host/src/lib/registry-store.ts
+++ b/cire/host/src/lib/registry-store.ts
@@ -59,7 +59,7 @@ export interface RegistryItem {
  * shows the as-given figure as the headline with the primary line underneath.
  *
  * `note`, `displayName` and `familyName` are GUEST-AUTHORED. Every renderer must
- * put them in a text node (S-L3).
+ * put them in a text node — never `innerHTML`.
  */
 export interface GiftLogEntry {
   kind: "claim" | "contribution";
@@ -141,13 +141,12 @@ export function peekCachedRegistry(weddingId: string): RegistrySnapshot | null {
  *
  * Deleting the map entry would mint a fresh signal on the next `entryFor`, and
  * every view that captured the old accessor at mount would then read a signal
- * nothing writes to again — a dead view with stale content. This was the
- * repo-wide `P-W2` finding; every sibling cache (`vendors-store`,
- * `budget-store`, `tasks-store`, `enquiries-store`, `events-store`,
- * `guests-store`, `households-store`) still notifies the same way. What
- * changed since is the VALUE: nulling it out here used to hide the gift list
- * and log behind a loading flash on every organiser edit, so the snapshot is
- * left in place and the wedding is marked `stale` instead. `hasCachedRegistry`
+ * nothing writes to again — a dead view with stale content. Every sibling
+ * cache (`vendors-store`, `budget-store`, `tasks-store`, `enquiries-store`,
+ * `events-store`, `guests-store`, `households-store`) notifies the same way.
+ * The VALUE is kept as well: nulling it would flash the gift list and log
+ * through a loading state on every organiser edit, so the snapshot stays and
+ * the wedding is marked `stale` instead. `hasCachedRegistry`
  * treats a stale id as a miss, which is what makes the next
  * `ensureRegistryLoaded` actually refetch rather than short-circuiting on the
  * (still-present) cached value.

--- a/cire/invites/src/components/rsvp-saved.ts
+++ b/cire/invites/src/components/rsvp-saved.ts
@@ -3,35 +3,27 @@
  *
  * ## Why a guest needs this at all
  *
- * A successful RSVP used to be invisible. `handleSubmit` called `onSubmitted`
- * and `onClose` back to back, so the sheet vanished the instant the POST
- * returned and the only evidence anything had happened was a sheet that was
- * no longer there — indistinguishable, to a guest, from a mis-tap that
- * dismissed it. The reply had been recorded and nothing said so.
+ * The sheet must not vanish the instant the POST returns. A sheet that is
+ * simply gone is indistinguishable, to a guest, from a mis-tap that dismissed
+ * it — the reply is recorded and nothing says so.
  *
- * ## Where the confirmation itself lives now
+ * ## Where the confirmation lives
  *
- * The Save button used to carry the confirmation — a gold sweep and a drawn
- * tick — but that button is gone the moment the sheet closes over it, which
- * is exactly when a guest would otherwise have time to register it. The
- * animated confirmation moved to the events section's Respond button, which
- * stays on screen after the sheet closes; see `rsvp-responded.ts` for that
- * choreography. What is left here is just the dwell: the Save button swaps
- * its label to "Saved", locks the sheet's controls, and holds briefly before
+ * The animated confirmation lives on the events section's Respond button, not
+ * on Save — Save is gone the moment the sheet closes over it, which is exactly
+ * when a guest would otherwise have time to register it. The Respond button
+ * stays on screen after the close; see `rsvp-responded.ts` for that
+ * choreography. What is left here is just the dwell: the Save button swaps its
+ * label to "Saved", locks the sheet's controls, and holds briefly before
  * closing itself — long enough that the sheet still doesn't just vanish.
  *
  * ## Why the dwell is a BUDGET, not a fixed hold
  *
- * The dwell used to be a flat 900ms started when the server's 200 landed, so
- * what a guest actually waited through was `round-trip + 900ms`. Those two add
- * up: the POST is five sequential D1 round-trips behind a Worker, so a real
- * save routinely spent half a second on "Saving…" and then another nine tenths
- * of a second on a sheet that had already finished its job. Reported as "quite
- * a delay for the form to close after you click save", and it was.
- *
- * The fix is to stop treating the network wait as free. `savedDwellMs` spends a
- * total time-on-screen budget measured from the CLICK, so a slow reply eats
- * into the dwell rather than stacking on top of it.
+ * The dwell is a budget spent from the CLICK, not a hold started when the reply
+ * lands — do not reintroduce a fixed hold. It stacks on the round-trip, and the
+ * POST is six serialised D1 round-trips behind a Worker: half a second of
+ * "Saving…" before the hold begins, which guests read as "quite a delay for the
+ * form to close after you click save". A slow reply eats the budget instead.
  *
  * Be precise about how far that goes, because the floor below bounds it. Up to
  * the KNEE — a reply of `SAVED_DWELL_MS - SAVED_DWELL_MIN_MS` — the budget is
@@ -70,11 +62,10 @@
  *
  * So this number is an accessibility floor wearing a timing constant's clothes,
  * and the ~100ms it costs a fast save is the price of the announcement being
- * heard. The way to get it back is NOT to lower it: it is to stop the
- * announcement's lifetime depending on the dwell at all, by hoisting the live
- * region to the page root beside the `<Toaster>` (which was relocated there for
- * a structurally identical reason). Filed as C-L1 in `xchromo/osn-tracker`;
- * once that lands the floor answers only to the label swap and can drop.
+ * heard. The way to get it back is NOT to lower it: it is to hoist the live
+ * region to the page root beside the `<Toaster>` (relocated there for a
+ * structurally identical reason), so the announcement's lifetime stops
+ * depending on the dwell.
  *
  * Nothing downstream is timed against these numbers: the Respond-button
  * celebration is measured from the moment the sheet uncovers that button (see

--- a/cire/invites/src/lib/consent/categories.ts
+++ b/cire/invites/src/lib/consent/categories.ts
@@ -4,8 +4,8 @@
  * The site-wide consent flow is category-based, not vendor-based: a guest
  * toggles "third-party embeds", not "Pinterest" and "Google Maps" separately.
  * Vendors declare which category they belong to (see `vendors.ts`), so adding a
- * third party is a registry entry rather than a new gate, a new storage key and
- * a new prompt — which is exactly what the bespoke Pinterest gate used to be.
+ * third party is a registry entry — never a new gate, a new storage key and a
+ * new prompt of its own.
  *
  * WHY THESE FOUR (and not the usual six-category cookie-banner boilerplate):
  * every category here maps to something the guest site genuinely does. We

--- a/cire/invites/src/lib/consent/vendors.ts
+++ b/cire/invites/src/lib/consent/vendors.ts
@@ -28,12 +28,10 @@ import type { ConsentCategory } from "./categories";
  *  - `"always"` — loads on every visit regardless of the guest's choice. Used
  *    for first-party necessities (the session cookie, the consent record
  *    itself) and Turnstile, which the claim form cannot function without.
- *    Google Fonts used to be the one third party in this bucket — its `<link>`
- *    lived in the `<head>` of the server-rendered document, so gating it would
- *    have either swapped the typeface mid-visit or left the prerendered legal
- *    pages inconsistent with the SSR'd invite. Self-hosting the two woff2
- *    families (tracker #98) removed the vendor from this table entirely rather
- *    than gating it.
+ *    A third party whose resource sits in the server-rendered `<head>` cannot
+ *    be gated at all: a client-side gate would swap the typeface mid-visit or
+ *    leave the prerendered legal pages inconsistent with the SSR'd invite.
+ *    Self-host it instead of adding it here.
  *
  * The preferences dialog surfaces this distinction rather than hiding it: an
  * `"always"` vendor is listed with a plain "loads on every visit" note instead

--- a/osn/api/src/services/recommendations.ts
+++ b/osn/api/src/services/recommendations.ts
@@ -40,21 +40,17 @@ export class DatabaseError extends Data.TaggedError("DatabaseError")<{
 /**
  * Caller's connection list is capped before we expand to friends-of-friends.
  * Prevents a hub user with thousands of connections from producing an
- * unbounded FOF fan-out (P-C1). Tuned for the "enough candidates to produce
+ * unbounded FOF fan-out. Tuned for the "enough candidates to produce
  * a good top-N list" sweet spot.
  *
  * Bounds two things that must stay in lockstep: the size of `myConnectionIds`
  * below (which step 3 uses to tell "one of my connections" from "a
- * candidate") and the seed subquery the FOF query correlates against (see
- * that query for why it no longer binds `myConnectionIds` itself). Until
- * osn-tracker#589 this constant also stood in, unintentionally, as the only
- * thing stopping the FOF query from binding more parameters than D1 allows
- * — 500 ids bound into two `inArray` calls is 1,000 binds, D1's documented
- * cap is 100 per query, and nobody had checked the second number against
- * the first. 51 accepted connections was already over it, so every caller
- * past that point got a 500 in production. The query now binds `profileId`
- * once regardless of how large this constant is, so raising it is a
- * decision about read cost and recall, never one that can reopen that bug.
+ * candidate") and the seed subquery the FOF query correlates against — see
+ * that query for the subquery form it uses, which binds `profileId` once and
+ * never binds `myConnectionIds` itself. Raising this constant is therefore
+ * purely a decision about read cost and recall; it cannot overflow D1's
+ * 100-bound-parameter-per-query cap, because the bind count does not grow
+ * with it.
  */
 const MAX_MY_CONNECTIONS_FOR_FOF = 500;
 
@@ -82,22 +78,22 @@ const MAX_FOF_FANOUT_ROWS = 10_000;
  * defence as MAX_FOF_FANOUT_ROWS: membership of one very large organisation
  * must not turn a suggestion request into an unbounded read.
  *
- * This used to be a budget for the whole fan-out, filled by one query ordered
- * `(organisation_id, profile_id)` — so a caller in one large organisation
- * filled the budget from that organisation alone and never saw a co-member
- * from any other, and a caller in fifty organisations of 250 members each saw
- * co-members from about eight of them, every time, because organisation ids
- * are random and the draw is fixed per caller (osn-tracker#574). It is now
- * split evenly across the caller's organisations — see the query that reads
- * it, below — so this constant is the *total* budget and each organisation's
- * actual share is `MAX_ORG_COMEMBER_ROWS / (number of the caller's
- * organisations)`.
+ * This is the *total* budget across all of the caller's organisations, split
+ * evenly — see the query that reads it, below — so each organisation's actual
+ * share is `MAX_ORG_COMEMBER_ROWS / (number of the caller's organisations)`.
+ *
+ * A single query ordered `(organisation_id, profile_id)` and capped at this
+ * total would starve every organisation but the lowest-id one: a caller in one
+ * large organisation would fill the budget from that organisation alone, and a
+ * caller in fifty organisations of 250 members each would see co-members from
+ * about eight of them, every time, because organisation ids are random and the
+ * draw is fixed per caller. The per-organisation split below exists to prevent
+ * exactly that.
  */
 const MAX_ORG_COMEMBER_ROWS = 2_000;
 
 /**
- * Arms per `UNION ALL` batch in the co-member fan-out query, below
- * (osn-tracker#589, P-C1).
+ * Arms per `UNION ALL` batch in the co-member fan-out query, below.
  *
  * D1 does not run on `bun:sqlite`, which is what this repo's local/test
  * engine uses and where a compound `SELECT` may carry up to SQLite's own
@@ -359,8 +355,8 @@ const LEXICAL_SCORE = {
  * signal Facebook's own ranking uses. Nothing in OSN exposes another profile's
  * connection list, so a mutual-connection boost would make result *ordering* an
  * oracle for "is this arbitrary handle a friend-of-a-friend?" — the same
- * disclosure that keeps `mutualCount` out of the search payload (see
- * `S-L4` in `xchromo/osn-tracker`). Ordering leaks as readily as a field does.
+ * disclosure risk that keeps `mutualCount` out of the search payload
+ * entirely. Ordering leaks as readily as a field does.
  *
  * [fb]: https://engineering.fb.com/2010/05/17/web/the-life-of-a-typeahead-query/
  */
@@ -531,8 +527,8 @@ export function createRecommendationService() {
       // runs later than this read, in its own D1 round trip, so it can see
       // a connection accepted for the caller *after* this snapshot was
       // taken — a temporal gap this slice cannot close no matter how it is
-      // capped. See the fresh re-check before hydration, below (S-H1),
-      // which is what actually closes that one.
+      // capped. See the fresh re-check before hydration, below, which is
+      // what actually closes that one.
       const myConnectionIds = myEdgeRows
         .filter((r) => r.status === "accepted")
         .map(counterpartOf)
@@ -543,7 +539,7 @@ export function createRecommendationService() {
       );
       const myOrgIds = myOrgRows.map((r) => r.organisationId);
 
-      // Set for O(1) membership lookup in the aggregation loop (P-W2).
+      // Set for O(1) membership lookup in the aggregation loop.
       const myConnectionIdSet = new Set(myConnectionIds);
       const excludeIds = new Set<string>([
         profileId,
@@ -565,9 +561,9 @@ export function createRecommendationService() {
                   // calls — once per edge direction — so the bind count grew
                   // with the caller's connection count and D1's 100-bound-
                   // parameter cap turned into a production 500 past 50
-                  // accepted connections (osn-tracker#589). This binds only
-                  // `profileId`, a fixed number of times, however large
-                  // `myConnectionIds` is.
+                  // accepted connections. This binds only `profileId`, a
+                  // fixed number of times, however large `myConnectionIds`
+                  // is.
                   //
                   // `IN (<subquery>)` rather than `IN (<literal list>)`: the
                   // subquery re-reads the caller's own accepted edges inside
@@ -577,8 +573,7 @@ export function createRecommendationService() {
                   // MAX_MY_CONNECTIONS_FOR_FOF — not to stay under any bind
                   // cap, since none applies here.
                   //
-                  // A correlated `EXISTS` (the shape osn-tracker#589
-                  // proposed) was measured and rejected: on real
+                  // A correlated `EXISTS` was measured and rejected: on real
                   // (Miniflare/workerd) D1, `EXPLAIN QUERY PLAN` showed it as
                   // `SCAN c` with a `CORRELATED SCALAR SUBQUERY` run once per
                   // row of the outer table — a full scan of every accepted
@@ -643,13 +638,12 @@ export function createRecommendationService() {
                 // Batched `UNION ALL`: one statement per group of up to
                 // MAX_ORG_COMEMBER_ARMS_PER_QUERY (5) of the caller's
                 // organisations, the batches run concurrently and merged here
-                // in application code (osn-tracker#574, reopened as
-                // osn-tracker#589 / P-C1 — see that constant's comment for why
-                // 5, not the 50 this originally unioned in one statement). The
-                // query both versions replaced gave the whole budget to one
-                // global `ORDER BY (organisation_id, profile_id) LIMIT
-                // MAX_ORG_COMEMBER_ROWS` — see the note on that constant for
-                // why that starved every organisation but the lowest-id one.
+                // in application code — see `MAX_ORG_COMEMBER_ARMS_PER_QUERY`'s
+                // comment for why 5, not the 50 this originally unioned in one
+                // statement. The query both versions replaced gave the whole
+                // budget to one global `ORDER BY (organisation_id, profile_id)
+                // LIMIT MAX_ORG_COMEMBER_ROWS` — see the note on that constant
+                // for why that starved every organisation but the lowest-id one.
                 // Splitting the budget per organisation, with its own `ORDER
                 // BY profile_id LIMIT <share>`, is what fixes it: every
                 // organisation the caller belongs to contributes candidates,
@@ -830,7 +824,7 @@ export function createRecommendationService() {
         )
         .slice(0, safeLimit);
 
-      // Step 4.5: fresh re-check (osn-tracker#589 follow-up, S-H1).
+      // Step 4.5: fresh re-check.
       //
       // Steps 1 and 2 are two separate, un-transacted D1 round trips — no
       // `db.batch`/`db.transaction` joins them. Step 1 snapshots the

--- a/osn/api/src/services/recommendations.ts
+++ b/osn/api/src/services/recommendations.ts
@@ -45,12 +45,12 @@ export class DatabaseError extends Data.TaggedError("DatabaseError")<{
  *
  * Bounds two things that must stay in lockstep: the size of `myConnectionIds`
  * below (which step 3 uses to tell "one of my connections" from "a
- * candidate") and the seed subquery the FOF query correlates against — see
- * that query for the subquery form it uses, which binds `profileId` once and
- * never binds `myConnectionIds` itself. Raising this constant is therefore
- * purely a decision about read cost and recall; it cannot overflow D1's
- * 100-bound-parameter-per-query cap, because the bind count does not grow
- * with it.
+ * candidate") and the seed subquery the FOF query filters against — see that
+ * query for the subquery form it uses, which binds `profileId` a fixed number
+ * of times and never binds `myConnectionIds` itself. Raising this constant is
+ * therefore purely a decision about read cost and recall; it cannot overflow
+ * D1's 100-bound-parameter-per-query cap, because the bind count does not
+ * grow with it.
  */
 const MAX_MY_CONNECTIONS_FOR_FOF = 500;
 
@@ -82,13 +82,11 @@ const MAX_FOF_FANOUT_ROWS = 10_000;
  * evenly — see the query that reads it, below — so each organisation's actual
  * share is `MAX_ORG_COMEMBER_ROWS / (number of the caller's organisations)`.
  *
- * A single query ordered `(organisation_id, profile_id)` and capped at this
- * total would starve every organisation but the lowest-id one: a caller in one
- * large organisation would fill the budget from that organisation alone, and a
- * caller in fifty organisations of 250 members each would see co-members from
- * about eight of them, every time, because organisation ids are random and the
- * draw is fixed per caller. The per-organisation split below exists to prevent
- * exactly that.
+ * The split is per-organisation on purpose: one global `ORDER BY
+ * (organisation_id, profile_id) LIMIT` spends the whole budget on the
+ * lowest-id organisations the caller belongs to, and organisation ids are
+ * random and fixed per caller, so the same few win every request. Do not
+ * revert it.
  */
 const MAX_ORG_COMEMBER_ROWS = 2_000;
 
@@ -642,8 +640,7 @@ export function createRecommendationService() {
                 // comment for why 5, not the 50 this originally unioned in one
                 // statement. The query both versions replaced gave the whole
                 // budget to one global `ORDER BY (organisation_id, profile_id)
-                // LIMIT MAX_ORG_COMEMBER_ROWS` — see the note on that constant
-                // for why that starved every organisation but the lowest-id one.
+                // LIMIT MAX_ORG_COMEMBER_ROWS`.
                 // Splitting the budget per organisation, with its own `ORDER
                 // BY profile_id LIMIT <share>`, is what fixes it: every
                 // organisation the caller belongs to contributes candidates,
@@ -672,7 +669,7 @@ export function createRecommendationService() {
                 // `LIMIT`.
                 //
                 // Measured on real (Miniflare/workerd) D1, three organisations
-                // of 600/300/100 members, cap 150, share 50: the pre-#574
+                // of 600/300/100 members, cap 150, share 50: the single
                 // global query read 151 rows for 150 results, and the window
                 // function read 2,860 for the same 150. Both the single-
                 // statement `UNION ALL` this batching replaces and the
@@ -846,10 +843,10 @@ export function createRecommendationService() {
       //
       // Fixed by re-reading, fresh, immediately before hydration, for just
       // the ids that survived ranking — at most `safeLimit` (≤ 50), so this
-      // cannot reopen #589's 100-bound cap. That safety is measured, not
+      // cannot reopen the 100-bound cap. That safety is measured, not
       // asserted: naively filtering with `or(inArray(requesterId, ids),
       // inArray(addresseeId, ids))` binds the id list TWICE, the same
-      // mistake #589 fixed, and at safeLimit's ceiling of 50 that is 102
+      // mistake this shape exists to avoid, and at safeLimit's ceiling of 50 that is 102
       // params (`bun run` against `.toSQL()` — 2 profileId equality binds +
       // 2 × 50-id `inArray`s — over D1's 100-per-statement cap). Each query
       // below instead runs the id filter once, against a subquery that

--- a/pulse/api/tests/services/d1ParamCounts.test.ts
+++ b/pulse/api/tests/services/d1ParamCounts.test.ts
@@ -6,7 +6,7 @@
  * running past 100 params and watching it throw. What they DO prove,
  * cheaply and on every test run: the real service functions — not a
  * reconstruction of their queries — emit the SQL this fix promises,
- * exercised well past the OLD per-site cliff each site used to break at.
+ * exercised well past each site's own bind-count cliff.
  *
  * The capture mechanism is drizzle's own `logger` hook, which fires with
  * the exact SQL text and bound-parameter array the driver is about to
@@ -17,7 +17,7 @@
  * a plain `inArray(col, ids)` or `.values(rows)`, the captured parameter
  * count jumps from O(1) to O(n) and the relevant assertion below fails.
  *
- * Six sites, in the order the brief lists them:
+ * Six sites:
  *   1. series.ts        materializeInstances  — INSERT, 31 cols/row
  *   2. accountErasure.ts purgeAccount         — 4 hostedEventIds DELETEs
  *   3. closeFriends.ts  getCloseFriendsOfBatch

--- a/pulse/api/tests/services/d1ParamCounts.test.ts
+++ b/pulse/api/tests/services/d1ParamCounts.test.ts
@@ -1,7 +1,6 @@
 /**
- * osn-tracker #590, #591, #592, #594, #595 + events.ts:296 — regression
- * guard for the "bound one SQL parameter per array element / per column
- * per row" defect class. D1 caps a query at 100 bound parameters
+ * Regression guard for the "bound one SQL parameter per array element / per
+ * column per row" defect class. D1 caps a query at 100 bound parameters
  * (developers.cloudflare.com/d1/platform/limits/); bun:sqlite enforces no
  * such cap, so these tests can't reproduce the production failure by
  * running past 100 params and watching it throw. What they DO prove,
@@ -87,10 +86,10 @@ function findStatement(captured: Captured[], ...needles: string[]): Captured {
 }
 
 // ---------------------------------------------------------------------------
-// 1. series.ts materializeInstances — osn-tracker#594
+// 1. series.ts materializeInstances
 // ---------------------------------------------------------------------------
 
-describe("series.ts materializeInstances (osn-tracker#594)", () => {
+describe("series.ts materializeInstances", () => {
   it("inserts 200 instances (31 cols/row — 6200 params the old way) with 1 bound param", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const now = new Date();
@@ -147,10 +146,10 @@ describe("series.ts materializeInstances (osn-tracker#594)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. accountErasure.ts purgeAccount — osn-tracker#595 (GDPR)
+// 2. accountErasure.ts purgeAccount (GDPR erasure)
 // ---------------------------------------------------------------------------
 
-describe("accountErasure.ts purgeAccount (osn-tracker#595)", () => {
+describe("accountErasure.ts purgeAccount", () => {
   it("purges an account with 150 hosted events (past the old 100-id cliff) via 1-param deletes", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const HOST = "usr_host";
@@ -190,10 +189,10 @@ describe("accountErasure.ts purgeAccount (osn-tracker#595)", () => {
 
 // ---------------------------------------------------------------------------
 // 3. closeFriends.ts getCloseFriendsOfBatch + pulseUsers.ts
-//    getAttendanceVisibilityBatch — osn-tracker#591
+//    getAttendanceVisibilityBatch
 // ---------------------------------------------------------------------------
 
-describe("closeFriends.ts getCloseFriendsOfBatch (osn-tracker#591)", () => {
+describe("closeFriends.ts getCloseFriendsOfBatch", () => {
   it("looks up 150 attendees (past the old 100-id cliff, and past the old 1000-id truncation risk) with 1 bound param", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const attendeeIds = Array.from({ length: 150 }, (_, i) => `usr_${i}`);
@@ -208,7 +207,7 @@ describe("closeFriends.ts getCloseFriendsOfBatch (osn-tracker#591)", () => {
   });
 });
 
-describe("pulseUsers.ts getAttendanceVisibilityBatch (osn-tracker#591)", () => {
+describe("pulseUsers.ts getAttendanceVisibilityBatch", () => {
   it("looks up 150 attendees with 1 bound param instead of 1-per-id", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const attendeeIds = Array.from({ length: 150 }, (_, i) => `usr_${i}`);
@@ -224,10 +223,10 @@ describe("pulseUsers.ts getAttendanceVisibilityBatch (osn-tracker#591)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. rsvps.ts inviteGuests — osn-tracker#590 (both the SELECT and the INSERT)
+// 4. rsvps.ts inviteGuests (both the SELECT and the INSERT)
 // ---------------------------------------------------------------------------
 
-describe("rsvps.ts inviteGuests (osn-tracker#590)", () => {
+describe("rsvps.ts inviteGuests", () => {
   it("invites 150 guests (past the old ~17-row insert cliff) with 1 bound param each on the SELECT and the INSERT", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const event = await Effect.runPromise(
@@ -254,10 +253,10 @@ describe("rsvps.ts inviteGuests (osn-tracker#590)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. discovery.ts discoverEvents(friendsOnly) — osn-tracker#592
+// 5. discovery.ts discoverEvents(friendsOnly)
 // ---------------------------------------------------------------------------
 
-describe("discovery.ts discoverEvents friendsOnly (osn-tracker#592)", () => {
+describe("discovery.ts discoverEvents friendsOnly", () => {
   it("filters by 150 connections (past the old ~50-connection cliff), the set bound twice at 1 param each", async () => {
     const { layer, captured } = createCapturingTestLayer();
     const connectionIds = Array.from({ length: 150 }, (_, i) => `usr_conn_${i}`);

--- a/scripts/comment-delta.ts
+++ b/scripts/comment-delta.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+/**
+ * Report how many comment lines a branch adds and removes against a base.
+ *
+ * A number to look at, never a gate. There is no threshold: a cleanup that
+ * rewraps a block nets near zero, and joining wrapped lines would game any
+ * threshold anyway. What it catches is a branch that calls itself a comment
+ * cleanup while growing comment volume, which is otherwise invisible until a
+ * human opens the diff and counts by eye.
+ *
+ * Pass the base explicitly. Resolving it here with `git merge-base` would be
+ * wrong whenever the base branch has been force-pushed since this branch was
+ * cut: the merge-base then falls back to an older ancestor and the base's own
+ * commits land in the count, which is how a branch running -40 once got
+ * reported as +85.
+ */
+
+const base = process.argv[2];
+if (!base) {
+  console.error("usage: bun run scripts/comment-delta.ts <base-ref>");
+  process.exit(2);
+}
+
+const EXTENSIONS = ["*.ts", "*.tsx", "*.mjs", "*.js"];
+
+const diff = new TextDecoder().decode(
+  Bun.spawnSync({
+    cmd: ["git", "diff", `${base}...HEAD`, "--", ...EXTENSIONS],
+    stdout: "pipe",
+  }).stdout,
+);
+
+/**
+ * Whether a diffed source line is comment text.
+ *
+ * Line-oriented and therefore approximate: a string literal whose continuation
+ * line starts with `*` counts, and a commented-out block of code counts as
+ * comment. Both are rare enough not to move the figure, and the alternative —
+ * parsing every revision of every file — buys precision this does not need.
+ */
+function isComment(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("//") || t.startsWith("/*") || t.startsWith("*");
+}
+
+let added = 0;
+let removed = 0;
+let addedComments = 0;
+let removedComments = 0;
+
+for (const line of diff.split("\n")) {
+  if (line.startsWith("+++") || line.startsWith("---")) continue;
+  if (line.startsWith("+")) {
+    added++;
+    if (isComment(line.slice(1))) addedComments++;
+  } else if (line.startsWith("-")) {
+    removed++;
+    if (isComment(line.slice(1))) removedComments++;
+  }
+}
+
+const net = addedComments - removedComments;
+const sign = net > 0 ? "+" : "";
+
+console.log(`comment lines: +${addedComments} -${removedComments} (net ${sign}${net})`);
+console.log(
+  `all lines:     +${added} -${removed} (net ${added - removed >= 0 ? "+" : ""}${added - removed})`,
+);
+if (net > 0) {
+  console.log(
+    `\nThis branch adds ${net} comment lines. That is not a failure — but if it\n` +
+      `is a cleanup branch, check the diff for parentheticals that became paragraphs.`,
+  );
+}

--- a/scripts/comment-delta.ts
+++ b/scripts/comment-delta.ts
@@ -8,27 +8,20 @@
  * cleanup while growing comment volume, which is otherwise invisible until a
  * human opens the diff and counts by eye.
  *
- * Pass the base explicitly. Resolving it here with `git merge-base` would be
- * wrong whenever the base branch has been force-pushed since this branch was
- * cut: the merge-base then falls back to an older ancestor and the base's own
- * commits land in the count, which is how a branch running -40 once got
- * reported as +85.
+ * The base is passed in rather than resolved here. Resolving it with
+ * `git merge-base` is wrong whenever the base branch has been force-pushed
+ * since the branch was cut: the merge-base falls back to an older ancestor and
+ * the base's own commits land in the count, turning a branch that removes 40
+ * comment lines into one that appears to add 85.
  */
 
-const base = process.argv[2];
-if (!base) {
-  console.error("usage: bun run scripts/comment-delta.ts <base-ref>");
-  process.exit(2);
+export interface CommentDelta {
+  readonly added: number;
+  readonly removed: number;
+  readonly addedComments: number;
+  readonly removedComments: number;
+  readonly netComments: number;
 }
-
-const EXTENSIONS = ["*.ts", "*.tsx", "*.mjs", "*.js"];
-
-const diff = new TextDecoder().decode(
-  Bun.spawnSync({
-    cmd: ["git", "diff", `${base}...HEAD`, "--", ...EXTENSIONS],
-    stdout: "pipe",
-  }).stdout,
-);
 
 /**
  * Whether a diffed source line is comment text.
@@ -38,37 +31,68 @@ const diff = new TextDecoder().decode(
  * comment. Both are rare enough not to move the figure, and the alternative —
  * parsing every revision of every file — buys precision this does not need.
  */
-function isComment(line: string): boolean {
+export function isCommentLine(line: string): boolean {
   const t = line.trim();
   return t.startsWith("//") || t.startsWith("/*") || t.startsWith("*");
 }
 
-let added = 0;
-let removed = 0;
-let addedComments = 0;
-let removedComments = 0;
+/** Count added/removed lines in a unified diff, and how many of them are comments. */
+export function countCommentDelta(diff: string): CommentDelta {
+  let added = 0;
+  let removed = 0;
+  let addedComments = 0;
+  let removedComments = 0;
 
-for (const line of diff.split("\n")) {
-  if (line.startsWith("+++") || line.startsWith("---")) continue;
-  if (line.startsWith("+")) {
-    added++;
-    if (isComment(line.slice(1))) addedComments++;
-  } else if (line.startsWith("-")) {
-    removed++;
-    if (isComment(line.slice(1))) removedComments++;
+  for (const line of diff.split("\n")) {
+    // `+++`/`---` are file headers, not content, and would otherwise be counted
+    // as an added and a removed line in every file the diff touches.
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) {
+      added++;
+      if (isCommentLine(line.slice(1))) addedComments++;
+    } else if (line.startsWith("-")) {
+      removed++;
+      if (isCommentLine(line.slice(1))) removedComments++;
+    }
   }
+
+  return {
+    added,
+    removed,
+    addedComments,
+    removedComments,
+    netComments: addedComments - removedComments,
+  };
 }
 
-const net = addedComments - removedComments;
-const sign = net > 0 ? "+" : "";
+const EXTENSIONS = ["*.ts", "*.tsx", "*.mjs", "*.js"];
 
-console.log(`comment lines: +${addedComments} -${removedComments} (net ${sign}${net})`);
-console.log(
-  `all lines:     +${added} -${removed} (net ${added - removed >= 0 ? "+" : ""}${added - removed})`,
-);
-if (net > 0) {
-  console.log(
-    `\nThis branch adds ${net} comment lines. That is not a failure — but if it\n` +
-      `is a cleanup branch, check the diff for parentheticals that became paragraphs.`,
+function gitDiff(base: string): string {
+  return new TextDecoder().decode(
+    Bun.spawnSync({ cmd: ["git", "diff", `${base}...HEAD`, "--", ...EXTENSIONS], stdout: "pipe" })
+      .stdout,
   );
+}
+
+function signed(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+if (import.meta.main) {
+  const base = process.argv[2];
+  if (!base) {
+    console.error("usage: bun run scripts/comment-delta.ts <base-ref>");
+    process.exit(2);
+  }
+  const d = countCommentDelta(gitDiff(base));
+  console.log(
+    `comment lines: +${d.addedComments} -${d.removedComments} (net ${signed(d.netComments)})`,
+  );
+  console.log(`all lines:     +${d.added} -${d.removed} (net ${signed(d.added - d.removed)})`);
+  if (d.netComments > 0) {
+    console.log(
+      `\nThis branch adds ${d.netComments} comment lines. Not a failure — but on a\n` +
+        `cleanup branch, check the diff for parentheticals that became paragraphs.`,
+    );
+  }
 }

--- a/scripts/tests/comment-delta.test.ts
+++ b/scripts/tests/comment-delta.test.ts
@@ -1,0 +1,64 @@
+// The counting half of scripts/comment-delta.ts, exercised against literal
+// diff text so no repository state is involved. The CLI half is a `git diff`
+// and two `console.log`s, which is why only the counter is exported.
+//
+// No `bun install`: this imports `bun:test` and the script under test, matching
+// every other file under scripts/.
+
+import { expect, test } from "bun:test";
+
+import { countCommentDelta, isCommentLine } from "../comment-delta";
+
+test("classifies the three comment openers and nothing else", () => {
+  expect(isCommentLine("// a line comment")).toBe(true);
+  expect(isCommentLine("  /* block open */")).toBe(true);
+  expect(isCommentLine(" * continuation")).toBe(true);
+  expect(isCommentLine("const x = 1;")).toBe(false);
+  expect(isCommentLine("")).toBe(false);
+  // `*` as a bare operator or a glob in a string is not comment text, but a
+  // line-oriented check cannot tell — documented as accepted imprecision.
+  expect(isCommentLine("  * 2;")).toBe(true);
+});
+
+test("ignores the +++/--- file headers", () => {
+  const diff = ["--- a/x.ts", "+++ b/x.ts", "+// added", "-// removed"].join("\n");
+  const d = countCommentDelta(diff);
+  expect(d.added).toBe(1);
+  expect(d.removed).toBe(1);
+  expect(d.netComments).toBe(0);
+});
+
+test("nets negative when a parenthetical is stripped in place", () => {
+  const diff = [
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "-// Bound checked at the edge (S-M1).",
+    "-// A second line of the same block.",
+    "+// Bound checked at the edge.",
+  ].join("\n");
+  expect(countCommentDelta(diff).netComments).toBe(-1);
+});
+
+test("nets positive when a one-liner becomes a paragraph — the case this exists to catch", () => {
+  const diff = [
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "-// Never cached or stored (tracker#468).",
+    "+// The response is never cached or stored. A per-user list in a shared",
+    "+// cache would serve one caller's suggestions to another, so the header",
+    "+// is set on every response rather than inferred from the route.",
+  ].join("\n");
+  expect(countCommentDelta(diff).netComments).toBe(2);
+});
+
+test("separates comment lines from code lines in the same diff", () => {
+  const diff = [
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "+// a comment",
+    "+const added = 1;",
+    "-const removed = 2;",
+  ].join("\n");
+  const d = countCommentDelta(diff);
+  expect(d).toMatchObject({ added: 2, removed: 1, addedComments: 1, removedComments: 0 });
+});

--- a/shared/observability/src/logger/redact.ts
+++ b/shared/observability/src/logger/redact.ts
@@ -329,16 +329,14 @@ const asScalar = (value: unknown): RedactedValue => {
  * Primitives and non-object values pass through unchanged.
  *
  * Does not follow cycles: a value already on the path down is replaced with
- * {@link CIRCULAR_PLACEHOLDER} rather than walked again. It used to throw
- * instead, on the grounds that a cyclic log entry is a bug — true, but this
- * function runs *inside the logger*, where a throw kills the fiber that was
- * only trying to log. Marking the cycle reports the same bug without the
- * outage.
+ * {@link CIRCULAR_PLACEHOLDER} rather than walked again. It does not throw —
+ * a cyclic log entry is a bug, but this function runs *inside the logger*,
+ * where a throw kills the fiber that was only trying to log. Marking the
+ * cycle reports the same bug without the outage.
  *
- * Fast path (P-I1): primitives return immediately without allocating
- * a new WeakSet or walking anything. Hot log paths (per-request,
- * per-metric) stay allocation-free for the common case of scalar
- * messages and annotations.
+ * Fast path: a primitive returns immediately, allocating no WeakSet and
+ * walking nothing, so the hot per-request and per-metric log paths stay
+ * allocation-free for scalar messages and annotations.
  */
 export const redact = (value: unknown): RedactedValue => {
   // Primitive fast path — no allocation, no walk.


### PR DESCRIPTION
## Summary

What survives from #925, which is now closed as not planned.

The comment-cleanup effort was measured and the measurement was unflattering: #930 added **66 comment lines net** while describing itself as a cleanup, because its instruction — "rewrite each reference to the constraint it stood for" — turns a single-line parenthetical into a paragraph. Nobody was counting, so it took a human reading the PRs to notice.

Two things come out of that:

- **`/prep-pr` now prints a branch's net comment-line delta**, backed by `scripts/comment-delta.ts`. Deliberately a number to look at, not a gate.
- **The four high-risk comment files already cleared** on this branch ship, since the work is done, verified, and removes a real private-tracker citation from a public file. The remaining ~155 files do not — see #925 for why.

#925's own closing comment carries the full argument. The short version: `src` has 40,049 comment lines, 16,997 of them in blocks of ten lines or more, and #925 explicitly forbade touching those blocks. Its scope was 711 tokens on lines that overwhelmingly stay, so it could not reduce comment volume even executed perfectly. The seven-file trial run bought −24 lines and surfaced three defects *in the cleanup itself*, including a rewrite that came out longer than the original and a factual claim that contradicted the code.

## Workspaces affected

Versioned (patch, one changeset): `@osn/api`, `@pulse/api`, `@shared/observability`. Ignored/version-less (patch, separate changeset per convention): `@cire/invites`, `@cire/host`. `scripts/` and `.claude/` are on the changeset allowlist. No behavior changes anywhere — every source edit is comment text.

## Issues

**Closes**

This PR closes no issue. #925 is closed as `not planned` with its reasoning recorded there; this branch is the part of it worth keeping.

**Opened**

None.

## Decisions

### Report the delta, do not gate on it — `convention`

- **Issue** — A comment cleanup that grows comment volume is invisible until a human opens the diff and counts by eye, which is exactly how #930's +66 went unnoticed through an adversarial review pass that only ever asked "was anything lost?".
- **Why** — A hard `net ≤ 0` CI check is the obvious move and the wrong one. It is trivially gamed by joining wrapped lines, and it punishes legitimate work: #929 rewrapped 334 comment lines to relocate 64 misattached doc blocks and nets ≈0 correctly.
- **Solution** — `/prep-pr` prints the figure and reports it in the PR body's test-plan table. No threshold.
- **Rationale** — The number is diagnostic, not normative. A cleanup at +66 is worth a second look; it is not automatically wrong, and no automation can tell the difference.

### Pass the base in rather than resolving it — `bugfix`

- **Issue** — My own first measurement of this reported `+85` comment lines for #937, which was wrong; the real figure is `−40`. I reported that wrong number to the repo owner as evidence against the work.
- **Why** — The base branch had been force-pushed. `git merge-base` then falls back to an older common ancestor, and the base branch's own commits — here #927's rule, its tests and the wiki convention page — land inside the measured diff.
- **Solution** — The script takes the base as an argument and does not resolve it. `/prep-pr` already resolves `$BASE` in Step 0, and the skill now warns that a surprising figure means checking `git log "$BASE"..HEAD` holds only your commits.
- **Rationale** — The failure is silent and directional: it inflates. A measurement tool that quietly overstates the thing it measures is worse than no tool.

**Out of scope** — The ~155 files #925 leaves behind. They are `warn`-level and safe to fix opportunistically; roughly 500 of the 711 diagnostics are plain parenthetical or leading-label strips.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Comment-delta counter | `bun test scripts/tests/comment-delta.test.ts` | 5 pass, 0 fail |
| Script suite | `bun run test:scripts` | 148 pass, 1 skip, 1 fail — the failure is a pre-existing Bun-version TOML assertion in `cire-dev-db-guard.cli.test.ts`, identical on the unmodified branch, and green in CI |
| Self-check on a known figure | `bun run scripts/comment-delta.ts 14c8f9d` on `fix/mechanical-token-cleanup` | reproduces `-40`, matching the hand count |
| `@osn/api` tests | `bun run --cwd osn/api test:run` | 1153 pass, 0 fail |
| `@cire/invites` tests | `bun run --cwd cire/invites test` | 999 pass, 0 fail |
| `@cire/host` tests | `bun run --cwd cire/host test:run` | 1223 pass, 0 fail |
| `@shared/observability` tests | `bun run --cwd shared/observability test:run` | 113 pass, 0 fail |
| `@pulse/api` (`d1ParamCounts`) | `bun run --cwd pulse/api test:run` | 7 pass, 0 fail |
| Rule diagnostics on the four files | `bunx --bun oxlint -c oxlintrc.json --format=json <file>` | 0 |
| Type check | `bun run check` | 38/38 workspaces pass |
| Format | `bun run fmt:check` | passes |
| Changesets | `bash scripts/validate-changesets.sh` | passes |

The four source files were checked against the code rather than against their own prose. Two internal contradictions were fixed on the way: `recommendations.ts` claimed the FOF query binds `profileId` "once" where it binds a fixed number of times (the same file measures three binds a few hundred lines below), and `rsvp-saved.ts` said "five sequential D1 round-trips" twelve lines above another block saying "six serialised".

`redact.ts`'s three-part deny-list admission test, `registry-store.ts`'s seven-file sibling-cache list, and `rsvp-saved.ts`'s "the way to get it back is NOT to lower it" are preserved verbatim — each is the sentence its file exists to protect.

This PR is stacked on #927 (base: `claude/verbose-comments-analysis-8rm8r2`), which must merge first. It is independent of #929, #930 and #937.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQDjMy2vkipJQiCc9fxRgS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQDjMy2vkipJQiCc9fxRgS)_