### PR TITLE
feat(tools): attribute subagent spend to the branch it worked on

### DIFF
--- a/.changeset/subagent-branch-attribution.md
+++ b/.changeset/subagent-branch-attribution.md
@@ -1,0 +1,9 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Attribute a subagent's spend to the branch it worked on. `gitBranch` is captured
+once per session and inherited, so delegated work was recorded against the
+orchestrator's branch — 85.8% of subagent spend stamped `HEAD`. The collector now
+reads a `TASK-BRANCH:` marker back out of the dispatch prompt, inherits it down
+nested dispatches, and de-duplicates records that appear in two session files.

--- a/.claude/metrics/feat-subagent-branch-attribution.json
+++ b/.claude/metrics/feat-subagent-branch-attribution.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": null,
+    "branch": "feat/subagent-branch-attribution",
+    "base_sha": "9d62e4f9acc33d85c033c0b3c848569d8c540299",
+    "head_sha": "253d6e92fdbc9ca778c60a7c1d7126ad361b6308",
+    "generated_at": "2026-09-08T12:51:00.097Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": 942,
+    "type": "Feature",
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-08T11:41:46.779Z",
+    "last_ts": "2026-09-08T12:44:09.509Z",
+    "span_seconds": 3743,
+    "active_seconds": 1583,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 11.330775249999997,
+    "tokens": {
+      "input": 974,
+      "output": 9772,
+      "thinking": 0,
+      "cache_write_5m": 471489,
+      "cache_write_1h": 0,
+      "cache_read": 12272868
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 204,
+          "output": 8981,
+          "thinking": 0,
+          "cache_write_5m": 334563,
+          "cache_write_1h": 0,
+          "cache_read": 10034963
+        },
+        "usd_equivalent": 7.334045249999999,
+        "messages": 102
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 770,
+          "output": 791,
+          "thinking": 0,
+          "cache_write_5m": 136926,
+          "cache_write_1h": 0,
+          "cache_read": 2237905
+        },
+        "usd_equivalent": 3.99673,
+        "messages": 25
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 974,
+          "output": 9772,
+          "thinking": 0,
+          "cache_write_5m": 471489,
+          "cache_write_1h": 0,
+          "cache_read": 12272868
+        },
+        "usd_equivalent": 11.330775249999997,
+        "messages": 127
+      }
+    },
+    "effort": {
+      "high": 127
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 2,
+      "config": 0,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 9,
+        "deleted": 0
+      },
+      "test": {
+        "added": 777,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 87,
+        "deleted": 4
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 454,
+        "deleted": 60
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 4
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Edit": 19,
+      "Bash": 18,
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 3,
+      "max_edits_one_file": 11
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -104,6 +104,16 @@ Dispatch **one** `general-purpose` subagent that owns planning and implementatio
 conversation, so anything not in the text does not exist, and anything wrong in it
 gets followed to the letter. Every dispatch carries:
 
+- **The branch, as the first line: `TASK-BRANCH: <branch>`.** On its own line,
+  verbatim, in **every** prompt this skill sends to the `Agent` tool — Step 3's
+  hand-off, Step 4's fix subagents, Step 5's shepherd, and every re-dispatch.
+  A subagent's `gitBranch` is the *orchestrator session's*, captured once at
+  session start and inherited, so without this line its spend is attributed to
+  `main` and lands on no card. It is 85.8% of subagent spend today. The
+  collector reads the marker back out of this prompt
+  (`tools/pr-metrics/index.ts`, `resolveDispatchBranch`); a subagent that
+  dispatches further work does not need to repeat it, because a child with no
+  marker inherits its parent's.
 - **The reader.** Every file the task creates names the file or command that reads
   it. If nothing reads it, the task is not done — "create the file" and "make
   something call it" are separate steps, and an implementer reliably does the

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -29,7 +29,7 @@ import {
   declaredFromLabels,
   defaultMetricsDir,
   parseNumstat,
-  type SessionRecord,
+  recordsByBranch,
 } from "./index.ts";
 
 interface PullRequest {
@@ -63,46 +63,6 @@ function flag(name: string): string | null {
   const index = Bun.argv.indexOf(`--${name}`);
 
   return index >= 0 && Bun.argv[index + 1] ? Bun.argv[index + 1] : null;
-}
-
-/** Every branch that appears in a transcript, with its records. One pass over
- * the logs; a per-PR scan would re-read gigabytes once per pull request. */
-function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[]> {
-  const byBranch = new Map<string, SessionRecord[]>();
-  const patterns = [`${sessionsDir}/*/*.jsonl`, `${sessionsDir}/*/*/subagents/*.jsonl`];
-
-  for (const pattern of patterns) {
-    const found = sh(["sh", "-c", `ls -1 ${pattern} 2>/dev/null || true`]);
-
-    for (const file of found.out.split("\n").filter(Boolean)) {
-      let text: string;
-      try {
-        text = require("node:fs").readFileSync(file, "utf8") as string;
-      } catch {
-        continue;
-      }
-
-      for (const line of text.split("\n")) {
-        if (!line.includes('"gitBranch"')) continue;
-
-        let record: SessionRecord;
-        try {
-          record = JSON.parse(line) as SessionRecord;
-        } catch {
-          continue;
-        }
-
-        const branch = record.gitBranch;
-        if (!branch || branch === "main") continue;
-
-        const existing = byBranch.get(branch);
-        if (existing) existing.push(record);
-        else byBranch.set(branch, [record]);
-      }
-    }
-  }
-
-  return byBranch;
 }
 
 /** GitHub's per-file additions and deletions, reshaped into the `git diff

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -30,6 +30,7 @@ import {
   defaultMetricsDir,
   parseNumstat,
   recordsByBranch,
+  repoProjectPaths,
 } from "./index.ts";
 
 interface PullRequest {
@@ -98,7 +99,7 @@ if (import.meta.main) {
   }
 
   const pulls = JSON.parse(listed.out) as PullRequest[];
-  const byBranch = recordsByBranch(sessionsDir);
+  const byBranch = recordsByBranch(sessionsDir, { repoPaths: repoProjectPaths() });
 
   console.log(
     `pr-metrics backfill: ${pulls.length} merged PR(s), ${byBranch.size} branch(es) with transcripts.`,

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -1146,15 +1146,6 @@ function dedupeKey(record: SessionRecord): string | null {
 }
 
 /**
- * The records belonging to one branch.
- *
- * Two things beyond a `gitBranch` match. A subagent file's branch comes from
- * `resolveDispatchBranch` when the dispatch carried a marker — `gitBranch`
- * there is the *parent session's* and is wrong by construction. And a record
- * present in two session files is returned once; Claude Code sometimes writes
- * one conversation into two files, and both copies are real.
- */
-/**
  * Subagent transcripts that carry no marker and whose own `gitBranch` is not a
  * task branch — so their spend lands on no card at all.
  *
@@ -1242,6 +1233,15 @@ export function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[
   return byBranch;
 }
 
+/**
+ * The records belonging to one branch.
+ *
+ * Two things beyond a `gitBranch` match. A subagent file's branch comes from
+ * `resolveDispatchBranch` when the dispatch carried a marker — `gitBranch`
+ * there is the *parent session's* and is wrong by construction. And a record
+ * present in two session files is returned once; Claude Code sometimes writes
+ * one conversation into two files, and both copies are real.
+ */
 export function readRecordsForBranch(sessionsDir: string, branch: string): SessionRecord[] {
   const records: SessionRecord[] = [];
   const seen = new Set<string>();

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -37,6 +37,9 @@
  * `SCHEMA_VERSION` is bumped whenever a field changes meaning or leaves.
  * Readers key off this.
  */
+
+import { closeSync, openSync, readdirSync, readFileSync, readSync } from "node:fs";
+
 export const SCHEMA_VERSION = 1;
 
 /**
@@ -995,6 +998,29 @@ export function branchSlug(branch: string): string {
  * dispatch may lead with a worktree instruction — only to be alone on its own. */
 const TASK_BRANCH_MARKER = /^TASK-BRANCH:[ \t]*(\S+)[ \t]*$/m;
 
+/** How far into a prompt the marker is honoured.
+ *
+ * A dispatch prompt routinely quotes text this repository did not author —
+ * issue bodies, review comments, fetched pages — and a planted
+ * `TASK-BRANCH: something-else` line would otherwise re-point a subagent's whole
+ * spend onto another branch's card, which is then committed publicly. The skill
+ * asks for the marker on the first line; a small window allows a leading
+ * worktree instruction without honouring anything quoted further down. */
+const MARKER_WINDOW_LINES = 3;
+
+/** A ref this repository could actually have. Rejects `..`, a leading dash and
+ * anything outside the characters a branch name uses, so a malformed or hostile
+ * capture names no card at all rather than an unexpected one. */
+const PLAUSIBLE_REF = /^[A-Za-z0-9][\w.\-/]*$/;
+
+function markerBranch(prompt: string): string | null {
+  const head = prompt.split("\n", MARKER_WINDOW_LINES).join("\n");
+  const captured = TASK_BRANCH_MARKER.exec(head)?.[1];
+  if (!captured || captured.includes("..") || !PLAUSIBLE_REF.test(captured)) return null;
+
+  return captured;
+}
+
 /**
  * The branch a subagent was dispatched to work on, or `null`.
  *
@@ -1008,23 +1034,39 @@ const TASK_BRANCH_MARKER = /^TASK-BRANCH:[ \t]*(\S+)[ \t]*$/m;
  * spawned it, and that id appears in the parent transcript on the `tool_use`
  * block whose `input.prompt` is the dispatch.
  */
+const resolvedBranches = new Map<string, string | null>();
+
 export function resolveDispatchBranch(
   subagentFile: string,
   seen = new Set<string>(),
 ): string | null {
+  // Resolution is a pure function of the tree, and both readers plus the CLI's
+  // warning path resolve the same files; without this the later walks repeat
+  // the first in full.
+  const memo = resolvedBranches.get(subagentFile);
+  if (memo !== undefined) return memo;
+
+  const branch = resolveUncached(subagentFile, seen);
+  resolvedBranches.set(subagentFile, branch);
+
+  return branch;
+}
+
+function resolveUncached(subagentFile: string, seen: Set<string>): string | null {
   // A malformed tree could point a parent back at its child; a chain this long
   // is not a real dispatch either way.
   if (seen.has(subagentFile) || seen.size > 8) return null;
   seen.add(subagentFile);
 
-  const toolUseId = readSubagentMeta(subagentFile.replace(/\.jsonl$/, ".meta.json"))?.toolUseId;
+  const meta = readSubagentMeta(subagentFile.replace(/\.jsonl$/, ".meta.json"));
+  const toolUseId = meta?.toolUseId;
   if (!toolUseId) return null;
 
-  for (const parent of parentCandidates(subagentFile)) {
+  for (const parent of parentCandidates(subagentFile, meta)) {
     const prompt = findDispatchPrompt(parent, toolUseId);
     if (prompt === null) continue;
 
-    const marked = TASK_BRANCH_MARKER.exec(prompt)?.[1];
+    const marked = markerBranch(prompt);
     if (marked) return marked;
 
     // No marker on this dispatch. If another subagent wrote it, that agent was
@@ -1049,7 +1091,7 @@ export interface SubagentMeta {
 
 function readSubagentMeta(file: string): SubagentMeta | null {
   try {
-    return JSON.parse(require("node:fs").readFileSync(file, "utf8") as string) as SubagentMeta;
+    return JSON.parse(readFileSync(file, "utf8") as string) as SubagentMeta;
   } catch {
     return null;
   }
@@ -1063,13 +1105,20 @@ function readSubagentMeta(file: string): SubagentMeta | null {
  * `spawnDepth: 2` — dispatched by another subagent — and every one of those
  * parents is a sibling rather than the session file.
  */
-function parentCandidates(subagentFile: string): string[] {
+function parentCandidates(subagentFile: string, meta: SubagentMeta | null): string[] {
   const subagentsDir = subagentFile.replace(/\/[^/]+$/, "");
   const session = `${subagentFile.replace(/\/subagents\/[^/]+$/, "")}.jsonl`;
 
+  // The sidecar names the dispatching agent outright on every nested subagent —
+  // 79 of 79 depth-2 sidecars on this machine carry `parentAgentId`, and the
+  // file it names exists in all 79 — so the sibling scan is a fallback, not the
+  // mechanism. Scanning first was O(n²): the largest directory here holds 127
+  // subagent transcripts and every nested child re-read all of them.
+  const named = meta?.parentAgentId ? [`${subagentsDir}/agent-${meta.parentAgentId}.jsonl`] : [];
+
   let siblings: string[] = [];
   try {
-    siblings = (require("node:fs").readdirSync(subagentsDir) as string[])
+    siblings = readdirSync(subagentsDir)
       .filter((name) => name.endsWith(".jsonl"))
       .map((name) => `${subagentsDir}/${name}`)
       .filter((file) => file !== subagentFile);
@@ -1077,23 +1126,35 @@ function parentCandidates(subagentFile: string): string[] {
     siblings = [];
   }
 
-  return [session, ...siblings];
+  return [...named, session, ...siblings];
 }
 
-/** The `input.prompt` of the `tool_use` block with this id, or `null`. */
-function findDispatchPrompt(file: string, toolUseId: string): string | null {
+/** Every dispatch prompt in a transcript, by `tool_use` id.
+ *
+ * Built once per parent file. A session file is the parent of many subagents —
+ * one 9.4 MB file here was read 203 times before this cache, and the largest
+ * transcript is 72 MB — so a per-call read was quadratic in subagents per
+ * session, and the `split("\n")` array was re-allocated on each one. */
+const dispatchPrompts = new Map<string, Map<string, string>>();
+
+function promptIndex(file: string): Map<string, string> {
+  const memo = dispatchPrompts.get(file);
+  if (memo !== undefined) return memo;
+
+  const index = new Map<string, string>();
+  dispatchPrompts.set(file, index);
+
   let text: string;
   try {
-    text = require("node:fs").readFileSync(file, "utf8") as string;
+    text = readFileSync(file, "utf8") as string;
   } catch {
-    return null;
+    return index;
   }
 
   for (const line of text.split("\n")) {
-    // The id is on the `tool_use` line and on its `tool_result`; the block
-    // scan below rejects the latter. Transcripts reach tens of megabytes, so
-    // this reject runs before the parse.
-    if (!line.includes(toolUseId)) continue;
+    // Most lines carry no dispatch, and these files reach tens of megabytes, so
+    // reject before the parse.
+    if (!line.includes('"tool_use"')) continue;
 
     let record: SessionRecord;
     try {
@@ -1109,22 +1170,76 @@ function findDispatchPrompt(file: string, toolUseId: string): string | null {
       // `content` holds plain strings as well as blocks, so narrow before
       // reading a field — the same guard `toolUses` uses.
       if (block === null || typeof block !== "object") continue;
-      if (block.type === "tool_use" && block.id === toolUseId) {
-        return typeof block.input?.prompt === "string" ? block.input.prompt : null;
+      if (block.type === "tool_use" && block.id && typeof block.input?.prompt === "string") {
+        index.set(block.id, block.input.prompt);
       }
     }
   }
 
-  return null;
+  return index;
+}
+
+/** The `input.prompt` of the `tool_use` block with this id, or `null`. */
+function findDispatchPrompt(file: string, toolUseId: string): string | null {
+  return promptIndex(file).get(toolUseId) ?? null;
+}
+
+/**
+ * How Claude Code names a project directory: the session's working directory
+ * with `/` and `.` both flattened to `-`.
+ */
+export function encodeProjectDir(path: string): string {
+  return path.replaceAll(/[/.]/g, "-");
+}
+
+/** Every worktree of this repository, plus the common git dir that a
+ * bare-repo-root session records. Used to decide which project directories
+ * under `~/.claude/projects` belong to this checkout. */
+export function repoProjectPaths(): string[] {
+  const paths = new Set<string>();
+
+  const worktrees = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], { stdout: "pipe" });
+  for (const line of worktrees.stdout.toString().split("\n")) {
+    if (line.startsWith("worktree ")) paths.add(line.slice("worktree ".length).trim());
+  }
+
+  const common = Bun.spawnSync(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], {
+    stdout: "pipe",
+  });
+  const dir = common.stdout.toString().trim();
+  // A bare repo's common dir IS the root every worktree hangs off, and an
+  // orchestrator session runs there. A normal clone's is `<root>/.git`.
+  if (dir) paths.add(dir.replace(/\/\.git$/, ""));
+
+  return [...paths].filter(Boolean);
+}
+
+/** Options both readers share. */
+export interface ReadOptions {
+  /** Absolute paths this repository owns. When given, a subagent transcript is
+   * admitted on the strength of its `TASK-BRANCH:` marker only if it sits under
+   * one of them.
+   *
+   * `~/.claude/projects` holds every project on the machine, and a card is
+   * committed to a public repository, carrying `interaction.tool_calls`,
+   * `skills` and `subagents` keyed verbatim from the transcript — MCP server
+   * and private skill names among them. A marker is an attribution hint an
+   * agent wrote, not a proof of provenance, so it is never sufficient on its
+   * own. */
+  repoPaths?: string[];
 }
 
 /** Every transcript file under a `~/.claude/projects`-shaped directory. */
-function transcriptFiles(sessionsDir: string): { file: string; isSubagent: boolean }[] {
+function transcriptFiles(
+  sessionsDir: string,
+  repoPaths?: string[],
+): { file: string; isSubagent: boolean; ownedByRepo: boolean }[] {
   const roots: [string, boolean][] = [
     [`${sessionsDir}/*/*.jsonl`, false],
     [`${sessionsDir}/*/*/subagents/*.jsonl`, true],
   ];
-  const files: { file: string; isSubagent: boolean }[] = [];
+  const files: { file: string; isSubagent: boolean; ownedByRepo: boolean }[] = [];
+  const prefixes = repoPaths?.map(encodeProjectDir);
 
   for (const [pattern, isSubagent] of roots) {
     const found = Bun.spawnSync(["sh", "-c", `ls -1 ${pattern} 2>/dev/null || true`], {
@@ -1132,11 +1247,40 @@ function transcriptFiles(sessionsDir: string): { file: string; isSubagent: boole
     });
 
     for (const file of found.stdout.toString().split("\n").filter(Boolean)) {
-      files.push({ file, isSubagent });
+      files.push({ file, isSubagent, ownedByRepo: ownedByRepo(sessionsDir, file, prefixes) });
     }
   }
 
   return files;
+}
+
+/** The first line of a file, without reading the rest of it. The 366 subagent
+ * transcripts here total 200 MB and only their first line is wanted. */
+function firstLine(file: string): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(file, "r");
+    const buffer = Buffer.alloc(64 * 1024);
+    const read = readSync(fd, buffer, 0, buffer.length, 0);
+    const text = buffer.toString("utf8", 0, read);
+    const newline = text.indexOf("\n");
+
+    return newline === -1 ? text : text.slice(0, newline);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/** Whether a transcript's project directory belongs to this repository. With
+ * no prefixes given, nothing is scoped and every file counts as owned. */
+function ownedByRepo(sessionsDir: string, file: string, prefixes: string[] | undefined): boolean {
+  if (!prefixes || prefixes.length === 0) return true;
+
+  const project = file.slice(sessionsDir.length + 1).split("/")[0] ?? "";
+
+  return prefixes.some((prefix) => project === prefix || project.startsWith(`${prefix}-`));
 }
 
 /** `requestId` where there is one, else the record's own uuid. A record with
@@ -1153,19 +1297,15 @@ function dedupeKey(record: SessionRecord): string | null {
  * write. This is what makes a forgotten one visible on the next card instead
  * of silently reproducing the under-reporting the marker exists to fix.
  */
-export function unattributedSubagentFiles(sessionsDir: string): number {
+export function unattributedSubagentFiles(sessionsDir: string, options: ReadOptions = {}): number {
   let count = 0;
 
-  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
-    if (!isSubagent) continue;
+  for (const { file, isSubagent, ownedByRepo } of transcriptFiles(sessionsDir, options.repoPaths)) {
+    if (!isSubagent || !ownedByRepo) continue;
     if (resolveDispatchBranch(file) !== null) continue;
 
-    let head: string;
-    try {
-      head = (require("node:fs").readFileSync(file, "utf8") as string).split("\n", 1)[0] ?? "";
-    } catch {
-      continue;
-    }
+    const head = firstLine(file);
+    if (head === null) continue;
 
     let record: SessionRecord;
     try {
@@ -1189,16 +1329,19 @@ export function unattributedSubagentFiles(sessionsDir: string): number {
  * dedupe — because two readers with different rules produced a backfilled card
  * and a live card that disagreed about the same branch.
  */
-export function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[]> {
+export function recordsByBranch(
+  sessionsDir: string,
+  options: ReadOptions = {},
+): Map<string, SessionRecord[]> {
   const byBranch = new Map<string, SessionRecord[]>();
   const seen = new Set<string>();
 
-  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
-    const resolved = isSubagent ? resolveDispatchBranch(file) : null;
+  for (const { file, isSubagent, ownedByRepo } of transcriptFiles(sessionsDir, options.repoPaths)) {
+    const resolved = isSubagent && ownedByRepo ? resolveDispatchBranch(file) : null;
 
     let text: string;
     try {
-      text = require("node:fs").readFileSync(file, "utf8") as string;
+      text = readFileSync(file, "utf8") as string;
     } catch {
       continue;
     }
@@ -1242,20 +1385,26 @@ export function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[
  * present in two session files is returned once; Claude Code sometimes writes
  * one conversation into two files, and both copies are real.
  */
-export function readRecordsForBranch(sessionsDir: string, branch: string): SessionRecord[] {
+export function readRecordsForBranch(
+  sessionsDir: string,
+  branch: string,
+  options: ReadOptions = {},
+): SessionRecord[] {
   const records: SessionRecord[] = [];
   const seen = new Set<string>();
 
-  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
+  for (const { file, isSubagent, ownedByRepo } of transcriptFiles(sessionsDir, options.repoPaths)) {
     // One resolve per file, before any line is read. When it answers, it
     // answers for every record in the file — and it also decides whether the
     // per-line reject below can be used at all.
-    const resolved = isSubagent ? resolveDispatchBranch(file) : null;
+    // A marker admits a file only from a project directory this repository
+    // owns; see `ReadOptions.repoPaths`.
+    const resolved = isSubagent && ownedByRepo ? resolveDispatchBranch(file) : null;
     if (resolved !== null && resolved !== branch) continue;
 
     let text: string;
     try {
-      text = require("node:fs").readFileSync(file, "utf8") as string;
+      text = readFileSync(file, "utf8") as string;
     } catch {
       continue;
     }
@@ -1316,7 +1465,7 @@ if (import.meta.main) {
 
   const sessionsDir = flag("sessions-dir") ?? `${process.env.HOME}/.claude/projects`;
   const base = flag("base") ?? "origin/main";
-  const records = readRecordsForBranch(sessionsDir, branch);
+  const records = readRecordsForBranch(sessionsDir, branch, { repoPaths: repoProjectPaths() });
 
   const numstat = git(["diff", "--numstat", `${base}...HEAD`]);
   const commits = git(["rev-list", "--count", `${base}..HEAD`]);
@@ -1369,7 +1518,7 @@ if (import.meta.main) {
     // The usual cause on delegated work: the dispatch carried no
     // `TASK-BRANCH:` marker, so the subagent's spend is stamped with the
     // orchestrator session's branch and belongs to no card.
-    const unattributed = unattributedSubagentFiles(sessionsDir);
+    const unattributed = unattributedSubagentFiles(sessionsDir, { repoPaths: repoProjectPaths() });
     if (unattributed > 0) {
       console.warn(
         `   ${unattributed} subagent transcript(s) carry no TASK-BRANCH marker and sit under a`,

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -127,11 +127,16 @@ export interface ToolUseInput {
   subagent_type?: string;
   file_path?: string;
   command?: string;
+  /** The dispatch prompt. Carries the `TASK-BRANCH:` marker that
+   * `resolveDispatchBranch` reads. */
+  prompt?: string;
 }
 
 export interface ContentBlock {
   type?: string;
   name?: string;
+  /** Present on `tool_use` blocks; pairs with a subagent's `meta.toolUseId`. */
+  id?: string;
   input?: ToolUseInput;
 }
 
@@ -139,6 +144,10 @@ export interface SessionRecord {
   type?: string;
   sessionId?: string;
   gitBranch?: string;
+  /** Stable per API call. The dedupe key: one conversation is sometimes
+   * written into two session files, and both copies carry this. */
+  requestId?: string;
+  uuid?: string;
   timestamp?: string;
   isSidechain?: boolean;
   isCompactSummary?: boolean;
@@ -980,37 +989,300 @@ export function branchSlug(branch: string): string {
 // CLI
 // ---------------------------------------------------------------------------
 
-function readSessionRecords(sessionsDir: string, branch: string): SessionRecord[] {
-  const roots = [`${sessionsDir}/*/*.jsonl`, `${sessionsDir}/*/*/subagents/*.jsonl`];
-  const records: SessionRecord[] = [];
+/** The marker `orchestrate` puts at the top of every dispatch prompt.
+ *
+ * `m` because the marker is not required to be the very first line — a
+ * dispatch may lead with a worktree instruction — only to be alone on its own. */
+const TASK_BRANCH_MARKER = /^TASK-BRANCH:[ \t]*(\S+)[ \t]*$/m;
 
-  for (const pattern of roots) {
+/**
+ * The branch a subagent was dispatched to work on, or `null`.
+ *
+ * `gitBranch` cannot answer this. It is a property of the *session*, captured
+ * once when the session starts and inherited by every subagent, so a subagent
+ * working in a task worktree records the branch its parent started on. Across
+ * this machine's transcripts that is 85.8% of subagent spend stamped `HEAD`.
+ *
+ * The pairing is already on disk: every `agent-<id>.jsonl` has a sibling
+ * `agent-<id>.meta.json` carrying the `toolUseId` of the `Agent` tool call that
+ * spawned it, and that id appears in the parent transcript on the `tool_use`
+ * block whose `input.prompt` is the dispatch.
+ */
+export function resolveDispatchBranch(
+  subagentFile: string,
+  seen = new Set<string>(),
+): string | null {
+  // A malformed tree could point a parent back at its child; a chain this long
+  // is not a real dispatch either way.
+  if (seen.has(subagentFile) || seen.size > 8) return null;
+  seen.add(subagentFile);
+
+  const toolUseId = readSubagentMeta(subagentFile.replace(/\.jsonl$/, ".meta.json"))?.toolUseId;
+  if (!toolUseId) return null;
+
+  for (const parent of parentCandidates(subagentFile)) {
+    const prompt = findDispatchPrompt(parent, toolUseId);
+    if (prompt === null) continue;
+
+    const marked = TASK_BRANCH_MARKER.exec(prompt)?.[1];
+    if (marked) return marked;
+
+    // No marker on this dispatch. If another subagent wrote it, that agent was
+    // itself dispatched to a branch, and this one inherits it: the skills that
+    // dispatch at depth 2 do not emit the marker and cannot all be edited.
+    return parent.includes("/subagents/") ? resolveDispatchBranch(parent, seen) : null;
+  }
+
+  return null;
+}
+
+/** The sidecar Claude Code writes beside every subagent transcript. */
+export interface SubagentMeta {
+  agentType?: string;
+  description?: string;
+  model?: string;
+  parentAgentId?: string;
+  spawnDepth?: number;
+  /** The `Agent` tool call that spawned this subagent. The join to the parent. */
+  toolUseId?: string;
+}
+
+function readSubagentMeta(file: string): SubagentMeta | null {
+  try {
+    return JSON.parse(require("node:fs").readFileSync(file, "utf8") as string) as SubagentMeta;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Where the `tool_use` that spawned this subagent might live: the session
+ * transcript first, then every sibling subagent transcript.
+ *
+ * The siblings are not optional. 79 of this machine's 363 subagent files are
+ * `spawnDepth: 2` — dispatched by another subagent — and every one of those
+ * parents is a sibling rather than the session file.
+ */
+function parentCandidates(subagentFile: string): string[] {
+  const subagentsDir = subagentFile.replace(/\/[^/]+$/, "");
+  const session = `${subagentFile.replace(/\/subagents\/[^/]+$/, "")}.jsonl`;
+
+  let siblings: string[] = [];
+  try {
+    siblings = (require("node:fs").readdirSync(subagentsDir) as string[])
+      .filter((name) => name.endsWith(".jsonl"))
+      .map((name) => `${subagentsDir}/${name}`)
+      .filter((file) => file !== subagentFile);
+  } catch {
+    siblings = [];
+  }
+
+  return [session, ...siblings];
+}
+
+/** The `input.prompt` of the `tool_use` block with this id, or `null`. */
+function findDispatchPrompt(file: string, toolUseId: string): string | null {
+  let text: string;
+  try {
+    text = require("node:fs").readFileSync(file, "utf8") as string;
+  } catch {
+    return null;
+  }
+
+  for (const line of text.split("\n")) {
+    // The id is on the `tool_use` line and on its `tool_result`; the block
+    // scan below rejects the latter. Transcripts reach tens of megabytes, so
+    // this reject runs before the parse.
+    if (!line.includes(toolUseId)) continue;
+
+    let record: SessionRecord;
+    try {
+      record = JSON.parse(line) as SessionRecord;
+    } catch {
+      continue;
+    }
+
+    const content = record.message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      // `content` holds plain strings as well as blocks, so narrow before
+      // reading a field — the same guard `toolUses` uses.
+      if (block === null || typeof block !== "object") continue;
+      if (block.type === "tool_use" && block.id === toolUseId) {
+        return typeof block.input?.prompt === "string" ? block.input.prompt : null;
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Every transcript file under a `~/.claude/projects`-shaped directory. */
+function transcriptFiles(sessionsDir: string): { file: string; isSubagent: boolean }[] {
+  const roots: [string, boolean][] = [
+    [`${sessionsDir}/*/*.jsonl`, false],
+    [`${sessionsDir}/*/*/subagents/*.jsonl`, true],
+  ];
+  const files: { file: string; isSubagent: boolean }[] = [];
+
+  for (const [pattern, isSubagent] of roots) {
     const found = Bun.spawnSync(["sh", "-c", `ls -1 ${pattern} 2>/dev/null || true`], {
       stdout: "pipe",
     });
 
     for (const file of found.stdout.toString().split("\n").filter(Boolean)) {
-      let text: string;
+      files.push({ file, isSubagent });
+    }
+  }
+
+  return files;
+}
+
+/** `requestId` where there is one, else the record's own uuid. A record with
+ * neither is always kept: dropping it would be worse than counting it twice. */
+function dedupeKey(record: SessionRecord): string | null {
+  return record.requestId ?? record.uuid ?? null;
+}
+
+/**
+ * The records belonging to one branch.
+ *
+ * Two things beyond a `gitBranch` match. A subagent file's branch comes from
+ * `resolveDispatchBranch` when the dispatch carried a marker — `gitBranch`
+ * there is the *parent session's* and is wrong by construction. And a record
+ * present in two session files is returned once; Claude Code sometimes writes
+ * one conversation into two files, and both copies are real.
+ */
+/**
+ * Subagent transcripts that carry no marker and whose own `gitBranch` is not a
+ * task branch — so their spend lands on no card at all.
+ *
+ * Nothing enforces the marker; it is a line a skill instructs an agent to
+ * write. This is what makes a forgotten one visible on the next card instead
+ * of silently reproducing the under-reporting the marker exists to fix.
+ */
+export function unattributedSubagentFiles(sessionsDir: string): number {
+  let count = 0;
+
+  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
+    if (!isSubagent) continue;
+    if (resolveDispatchBranch(file) !== null) continue;
+
+    let head: string;
+    try {
+      head = (require("node:fs").readFileSync(file, "utf8") as string).split("\n", 1)[0] ?? "";
+    } catch {
+      continue;
+    }
+
+    let record: SessionRecord;
+    try {
+      record = JSON.parse(head) as SessionRecord;
+    } catch {
+      continue;
+    }
+
+    if (!record.gitBranch || record.gitBranch === "main" || record.gitBranch === "HEAD") count++;
+  }
+
+  return count;
+}
+
+/**
+ * Every task branch a transcript mentions, with its records. One pass, for
+ * `backfill`, which cards many branches at once and would otherwise re-read
+ * hundreds of megabytes per branch.
+ *
+ * Shares `readRecordsForBranch`'s rules — marker resolution and `requestId`
+ * dedupe — because two readers with different rules produced a backfilled card
+ * and a live card that disagreed about the same branch.
+ */
+export function recordsByBranch(sessionsDir: string): Map<string, SessionRecord[]> {
+  const byBranch = new Map<string, SessionRecord[]>();
+  const seen = new Set<string>();
+
+  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
+    const resolved = isSubagent ? resolveDispatchBranch(file) : null;
+
+    let text: string;
+    try {
+      text = require("node:fs").readFileSync(file, "utf8") as string;
+    } catch {
+      continue;
+    }
+
+    for (const line of text.split("\n")) {
+      if (resolved === null && !line.includes('"gitBranch"')) continue;
+
+      let record: SessionRecord;
       try {
-        text = require("node:fs").readFileSync(file, "utf8") as string;
+        record = JSON.parse(line) as SessionRecord;
       } catch {
         continue;
       }
 
-      for (const line of text.split("\n")) {
-        // Cheap reject before the parse: these files run to megabytes and the
-        // overwhelming majority of lines belong to other branches.
-        if (!line.includes(branch)) continue;
+      const branch = resolved ?? record.gitBranch;
+      // `main` and the bare-repo `HEAD` are not task branches, and `card`
+      // refuses both.
+      if (!branch || branch === "main" || branch === "HEAD") continue;
 
-        let record: SessionRecord;
-        try {
-          record = JSON.parse(line) as SessionRecord;
-        } catch {
-          continue;
-        }
-
-        if (record.gitBranch === branch) records.push(record);
+      const key = dedupeKey(record);
+      if (key !== null) {
+        if (seen.has(key)) continue;
+        seen.add(key);
       }
+
+      const existing = byBranch.get(branch);
+      if (existing) existing.push(record);
+      else byBranch.set(branch, [record]);
+    }
+  }
+
+  return byBranch;
+}
+
+export function readRecordsForBranch(sessionsDir: string, branch: string): SessionRecord[] {
+  const records: SessionRecord[] = [];
+  const seen = new Set<string>();
+
+  for (const { file, isSubagent } of transcriptFiles(sessionsDir)) {
+    // One resolve per file, before any line is read. When it answers, it
+    // answers for every record in the file — and it also decides whether the
+    // per-line reject below can be used at all.
+    const resolved = isSubagent ? resolveDispatchBranch(file) : null;
+    if (resolved !== null && resolved !== branch) continue;
+
+    let text: string;
+    try {
+      text = require("node:fs").readFileSync(file, "utf8") as string;
+    } catch {
+      continue;
+    }
+
+    for (const line of text.split("\n")) {
+      // These files run to tens of megabytes and most lines belong to other
+      // branches, so reject before the parse. It cannot be used on a resolved
+      // file: those lines are stamped with the parent's branch and carry the
+      // resolved name nowhere.
+      if (resolved === null && !line.includes(branch)) continue;
+
+      let record: SessionRecord;
+      try {
+        record = JSON.parse(line) as SessionRecord;
+      } catch {
+        continue;
+      }
+
+      if (resolved === null && record.gitBranch !== branch) continue;
+
+      const key = dedupeKey(record);
+      if (key !== null) {
+        if (seen.has(key)) continue;
+        seen.add(key);
+      }
+
+      records.push(record);
     }
   }
 
@@ -1044,7 +1316,7 @@ if (import.meta.main) {
 
   const sessionsDir = flag("sessions-dir") ?? `${process.env.HOME}/.claude/projects`;
   const base = flag("base") ?? "origin/main";
-  const records = readSessionRecords(sessionsDir, branch);
+  const records = readRecordsForBranch(sessionsDir, branch);
 
   const numstat = git(["diff", "--numstat", `${base}...HEAD`]);
   const commits = git(["rev-list", "--count", `${base}..HEAD`]);
@@ -1093,6 +1365,18 @@ if (import.meta.main) {
       `⚠️  pr-metrics: no session records matched branch \`${branch}\` under ${sessionsDir}.`,
     );
     console.warn("   The card still carries the diff; spend and interaction are zero.");
+
+    // The usual cause on delegated work: the dispatch carried no
+    // `TASK-BRANCH:` marker, so the subagent's spend is stamped with the
+    // orchestrator session's branch and belongs to no card.
+    const unattributed = unattributedSubagentFiles(sessionsDir);
+    if (unattributed > 0) {
+      console.warn(
+        `   ${unattributed} subagent transcript(s) carry no TASK-BRANCH marker and sit under a`,
+      );
+      console.warn("   `main`/`HEAD` session, so their spend lands on no card. See");
+      console.warn("   wiki/observability/session-metrics.md §Attributing subagent spend.");
+    }
   }
 
   if (card.spend.unpriced_models.length > 0) {

--- a/tools/pr-metrics/tests/dispatch-branch.test.ts
+++ b/tools/pr-metrics/tests/dispatch-branch.test.ts
@@ -502,3 +502,79 @@ test("the marker is matched on its own line and nowhere else", async () => {
     }
   }
 });
+
+// S-M1. `~/.claude/projects` holds every project on this machine, and the cards
+// this tool writes are committed to a public repository. A marker is an
+// attribution hint an agent wrote, not a provenance claim, so it must not on
+// its own admit a transcript from another checkout — two projects using
+// `fix/flaky-test` in the same week is a collision, not an attack.
+test("a marked transcript from another project is not admitted to this repo's card", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-scope-"));
+  try {
+    for (const project of ["-Users-ac--work-osn-git-mine", "-Users-ac--work-otherproj-main"]) {
+      await mkdir(join(dir, project, "sess-1/subagents"), { recursive: true });
+      await writeFile(
+        join(dir, project, "sess-1.jsonl"),
+        `${dispatch("toolu_1", "TASK-BRANCH: feat/x\n\nGo.")}\n`,
+      );
+      await writeFile(
+        join(dir, project, "sess-1/subagents/agent-a.meta.json"),
+        JSON.stringify({ toolUseId: "toolu_1" }),
+      );
+      await writeFile(
+        join(dir, project, "sess-1/subagents/agent-a.jsonl"),
+        `${JSON.stringify({
+          type: "assistant",
+          gitBranch: "main",
+          isSidechain: true,
+          requestId: `req-${project}`,
+          message: { model: "claude-opus-5", usage: { output_tokens: 1 } },
+        })}\n`,
+      );
+    }
+
+    const scoped = readRecordsForBranch(dir, "feat/x", {
+      repoPaths: ["/Users/ac/.work/osn.git"],
+    });
+
+    expect(scoped.map((r) => r.requestId)).toEqual(["req--Users-ac--work-osn-git-mine"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// S-L2. A dispatch prompt routinely quotes text this repository did not author —
+// issue bodies, review comments, fetched pages. A planted marker further down
+// must not re-point a subagent's whole spend onto another branch's public card.
+test("a marker planted below the window, or naming an implausible ref, is ignored", async () => {
+  const quoted =
+    "TASK-BRANCH: feat/real\n\nThe issue says:\n\n" +
+    "TASK-BRANCH: feat/attacker-controlled\n\nHandle it.";
+
+  const cases: [string, string | null][] = [
+    // The real marker wins; the quoted one is out of the window anyway.
+    [quoted, "feat/real"],
+    // Only a quoted marker, well below the window: nothing is attributed.
+    ["Context follows.\n\n\n\nTASK-BRANCH: feat/planted\n", null],
+    // Implausible refs name no card rather than an unexpected one.
+    ["TASK-BRANCH: ../../etc/passwd", null],
+    ["TASK-BRANCH: -rf", null],
+  ];
+
+  for (const [prompt, expected] of cases) {
+    const dir = await tree();
+    try {
+      await writeFile(join(dir, "proj/sess-1.jsonl"), `${dispatch("toolu_1", prompt)}\n`);
+      await writeFile(
+        join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+        JSON.stringify({ toolUseId: "toolu_1" }),
+      );
+      const file = join(dir, "proj/sess-1/subagents/agent-aaa.jsonl");
+      await writeFile(file, `${JSON.stringify({ type: "assistant", isSidechain: true })}\n`);
+
+      expect(resolveDispatchBranch(file)).toBe(expected as string);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});

--- a/tools/pr-metrics/tests/dispatch-branch.test.ts
+++ b/tools/pr-metrics/tests/dispatch-branch.test.ts
@@ -299,3 +299,206 @@ test("a resolved subagent file is not counted as unattributed", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// T-E1. The exclusion is the only thing keeping one branch's delegated spend
+// off another branch's card, and a positive-only suite cannot see it: with the
+// guard deleted every test above still passed, while every marked transcript
+// would land on every card.
+test("readRecordsForBranch excludes a subagent marked for a different branch", async () => {
+  const dir = await tree();
+  try {
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      [
+        dispatch("toolu_x", "TASK-BRANCH: feat/x\n\nMine."),
+        dispatch("toolu_y", "TASK-BRANCH: feat/y\n\nSomeone else's."),
+      ].join("\n"),
+    );
+
+    for (const [name, tool, out] of [
+      ["agent-x", "toolu_x", 11],
+      ["agent-y", "toolu_y", 22],
+    ] as const) {
+      await writeFile(
+        join(dir, `proj/sess-1/subagents/${name}.meta.json`),
+        JSON.stringify({ toolUseId: tool, spawnDepth: 1 }),
+      );
+      await writeFile(
+        join(dir, `proj/sess-1/subagents/${name}.jsonl`),
+        `${JSON.stringify({
+          type: "assistant",
+          gitBranch: "main",
+          isSidechain: true,
+          requestId: `req-${name}`,
+          message: { model: "claude-opus-5", usage: { output_tokens: out } },
+        })}\n`,
+      );
+    }
+
+    // An equality, not an absence: this fails whether feat/y leaks in or
+    // feat/x drops out.
+    const output = readRecordsForBranch(dir, "feat/x").map(
+      (r) => r.message?.usage?.output_tokens ?? 0,
+    );
+    expect(output).toEqual([11]);
+    expect(readRecordsForBranch(dir, "feat/y").map((r) => r.message?.usage?.output_tokens)).toEqual(
+      [22],
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-E3. The third arm of the warning's condition: an unmarked subagent whose
+// own gitBranch is already a real task branch is fine, and counting it would
+// make the warning cry wolf on a healthy run.
+test("unattributedSubagentFiles ignores an unmarked subagent already on a task branch", async () => {
+  const dir = await tree();
+  try {
+    // No meta file at all, so the resolver returns null.
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-fine.jsonl"),
+      `${JSON.stringify({ type: "assistant", gitBranch: "feat/already-right", isSidechain: true })}\n`,
+    );
+    expect(unattributedSubagentFiles(dir)).toBe(0);
+
+    // A record with no branch at all is the other arm, and does count.
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-nobranch.jsonl"),
+      `${JSON.stringify({ type: "assistant", isSidechain: true })}\n`,
+    );
+    expect(unattributedSubagentFiles(dir)).toBe(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-E4. Both readers call the resolver on every subagent file they see, so one
+// bad sidecar escaping the catch would abort the whole card rather than
+// degrade it.
+test("resolveDispatchBranch survives a missing, empty or unparseable sidecar", async () => {
+  const dir = await tree();
+  try {
+    const base = join(dir, "proj/sess-1/subagents");
+    const record = `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`;
+
+    await writeFile(join(base, "agent-nometa.jsonl"), record);
+
+    await writeFile(join(base, "agent-nokey.jsonl"), record);
+    await writeFile(join(base, "agent-nokey.meta.json"), JSON.stringify({ agentType: "x" }));
+
+    await writeFile(join(base, "agent-garbage.jsonl"), record);
+    await writeFile(join(base, "agent-garbage.meta.json"), "not json at all");
+
+    expect(resolveDispatchBranch(join(base, "agent-nometa.jsonl"))).toBeNull();
+    expect(resolveDispatchBranch(join(base, "agent-nokey.jsonl"))).toBeNull();
+    expect(resolveDispatchBranch(join(base, "agent-garbage.jsonl"))).toBeNull();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-E4, the cycle. `parentCandidates` returns every sibling, so two files each
+// naming the other's tool_use id recurse until the guard stops them. This test
+// fails by hanging or overflowing the stack, not by asserting.
+test("resolveDispatchBranch terminates when two siblings dispatch each other", async () => {
+  const dir = await tree();
+  try {
+    const base = join(dir, "proj/sess-1/subagents");
+    await writeFile(join(dir, "proj/sess-1.jsonl"), "");
+
+    await writeFile(join(base, "agent-a.jsonl"), `${dispatch("toolu_b", "No marker here.")}\n`);
+    await writeFile(join(base, "agent-a.meta.json"), JSON.stringify({ toolUseId: "toolu_a" }));
+    await writeFile(join(base, "agent-b.jsonl"), `${dispatch("toolu_a", "None here either.")}\n`);
+    await writeFile(join(base, "agent-b.meta.json"), JSON.stringify({ toolUseId: "toolu_b" }));
+
+    expect(resolveDispatchBranch(join(base, "agent-a.jsonl"))).toBeNull();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-U1. `requestId` is the assistant side; `uuid` is the fallback for the
+// records `user_turns` and `corrective_turns` are counted from. If it never
+// fires those numbers double on a duplicated conversation.
+test("the uuid fallback dedupes records that carry no requestId", async () => {
+  const dir = await tree();
+  try {
+    const assistant = JSON.stringify({
+      type: "assistant",
+      gitBranch: "feat/x",
+      requestId: "req-dup",
+      message: { model: "claude-opus-5", usage: { output_tokens: 5 } },
+    });
+    const user = JSON.stringify({ type: "user", gitBranch: "feat/x", uuid: "u-dup" });
+    const other = JSON.stringify({ type: "user", gitBranch: "feat/x", uuid: "u-different" });
+
+    await writeFile(join(dir, "proj/sess-1.jsonl"), [assistant, user, other].join("\n"));
+    await writeFile(join(dir, "proj/sess-2.jsonl"), [assistant, user].join("\n"));
+
+    // One assistant, one deduped user, one near-neighbour that must survive —
+    // deduping and dropping look the same from a single length assertion.
+    expect(readRecordsForBranch(dir, "feat/x")).toHaveLength(3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-S1. `backfill` reads through `recordsByBranch`, so an un-deduped pass here
+// is the live-card/backfilled-card disagreement the shared reader exists to end.
+test("recordsByBranch dedupes a record present in two session files", async () => {
+  const dir = await tree();
+  try {
+    const line = JSON.stringify({
+      type: "assistant",
+      gitBranch: "feat/x",
+      requestId: "req-dup",
+      message: { model: "claude-opus-5", usage: { output_tokens: 7 } },
+    });
+    await writeFile(join(dir, "proj/sess-1.jsonl"), `${line}\n`);
+    await writeFile(join(dir, "proj/sess-2.jsonl"), `${line}\n`);
+
+    expect(recordsByBranch(dir).get("feat/x")).toHaveLength(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// T-S2. The producer is `.claude/skills/orchestrate/SKILL.md` and the consumer
+// is this parser; nothing else couples them. The last case reads the marker out
+// of the skill file itself, so the two fail together the day either changes.
+test("the marker is matched on its own line and nowhere else", async () => {
+  const skill = await Bun.file(
+    new URL("../../../.claude/skills/orchestrate/SKILL.md", import.meta.url).pathname,
+  ).text();
+  // The form the skill actually instructs, with a real branch substituted.
+  expect(skill).toContain("TASK-BRANCH: <branch>");
+
+  const cases: [string, string | null][] = [
+    ["TASK-BRANCH: feat/x\n\nGo.", "feat/x"],
+    // Not required to be the first line — a dispatch may lead with a worktree
+    // instruction. This is the `m` flag's whole reason.
+    ["Work only in /tmp/wt.\n\nTASK-BRANCH: feat/x\n\nGo.", "feat/x"],
+    // Quoted mid-sentence: must not card someone else's branch.
+    ["Use TASK-BRANCH: feat/x here.", null],
+    // Trailing note: matches nothing, and the warning then counts the file.
+    ["TASK-BRANCH: feat/x (worktree)", null],
+  ];
+
+  for (const [prompt, expected] of cases) {
+    const dir = await tree();
+    try {
+      await writeFile(join(dir, "proj/sess-1.jsonl"), `${dispatch("toolu_1", prompt)}\n`);
+      await writeFile(
+        join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+        JSON.stringify({ toolUseId: "toolu_1" }),
+      );
+      const file = join(dir, "proj/sess-1/subagents/agent-aaa.jsonl");
+      await writeFile(file, `${JSON.stringify({ type: "assistant", isSidechain: true })}\n`);
+
+      expect(resolveDispatchBranch(file)).toBe(expected as string);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});

--- a/tools/pr-metrics/tests/dispatch-branch.test.ts
+++ b/tools/pr-metrics/tests/dispatch-branch.test.ts
@@ -1,0 +1,301 @@
+// `gitBranch` is a property of the session, captured once when it starts and
+// inherited by every subagent, so a subagent working in a task worktree records
+// the branch its PARENT started on. These tests cover the resolver that reads
+// the branch back out of the dispatch prompt instead.
+//
+// They live in their own file rather than at the end of `pr-metrics.test.ts`
+// because #931 appends there; a separate file has no conflict to resolve.
+
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readRecordsForBranch,
+  recordsByBranch,
+  resolveDispatchBranch,
+  unattributedSubagentFiles,
+} from "../index";
+
+/** A sessions tree shaped like `~/.claude/projects`. Returns the root. */
+async function tree(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-dispatch-"));
+  await mkdir(join(dir, "proj/sess-1/subagents"), { recursive: true });
+  return dir;
+}
+
+/** The parent's assistant record carrying the dispatch. The tool is named
+ * `Agent` in real transcripts — never `Task`. */
+function dispatch(toolUseId: string, prompt: string, gitBranch = "main"): string {
+  return JSON.stringify({
+    type: "assistant",
+    sessionId: "sess-1",
+    gitBranch,
+    timestamp: "2026-09-08T10:00:00.000Z",
+    message: {
+      model: "claude-opus-5",
+      content: [{ type: "tool_use", id: toolUseId, name: "Agent", input: { prompt } }],
+    },
+  });
+}
+
+test("resolves the branch from a TASK-BRANCH marker in the parent's dispatch prompt", async () => {
+  const dir = await tree();
+  try {
+    const subagent = join(dir, "proj/sess-1/subagents/agent-aaa.jsonl");
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "TASK-BRANCH: feat/x\n\nDo the thing.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ agentType: "general-purpose", toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      subagent,
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`,
+    );
+
+    expect(resolveDispatchBranch(subagent)).toBe("feat/x");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// 79 of this machine's 363 subagent transcripts are `spawnDepth: 2`, and every
+// one of their parents is a sibling `subagents/*.jsonl` rather than the session
+// file. Searching only the session file finds nothing for 8.3% of subagent spend.
+test("finds the dispatch in a sibling subagent transcript, not just the session file", async () => {
+  const dir = await tree();
+  try {
+    const child = join(dir, "proj/sess-1/subagents/agent-child.jsonl");
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_parent", "TASK-BRANCH: feat/x\n\nOuter.")}\n`,
+    );
+
+    // The depth-1 agent dispatches the depth-2 one; its transcript holds the
+    // `tool_use`, and it carries a marker of its own.
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-parent.jsonl"),
+      `${dispatch("toolu_child", "TASK-BRANCH: feat/x\n\nInner.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-child.meta.json"),
+      JSON.stringify({ agentType: "general-purpose", toolUseId: "toolu_child", spawnDepth: 2 }),
+    );
+    await writeFile(
+      child,
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`,
+    );
+
+    expect(resolveDispatchBranch(child)).toBe("feat/x");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// The depth-2 prompts are written by `stress-plan`, `prep-pr` and
+// `superpowers:subagent-driven-development` — the last a plugin nobody in this
+// repository can edit — so requiring a marker on every dispatch would lose
+// their spend for good. A child with no marker inherits the branch of whatever
+// dispatched it.
+test("a child with no marker inherits the branch of the transcript that dispatched it", async () => {
+  const dir = await tree();
+  try {
+    const child = join(dir, "proj/sess-1/subagents/agent-child.jsonl");
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_parent", "TASK-BRANCH: feat/x\n\nOuter.")}\n`,
+    );
+
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-parent.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_parent", spawnDepth: 1 }),
+    );
+    // No marker in the inner dispatch — this is the real shape.
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-parent.jsonl"),
+      `${dispatch("toolu_child", "Attack the plan at NEW-FEAT.md. Report findings.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-child.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_child", spawnDepth: 2 }),
+    );
+    await writeFile(
+      child,
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`,
+    );
+
+    expect(resolveDispatchBranch(child)).toBe("feat/x");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("returns null when no marker appears anywhere in the chain", async () => {
+  const dir = await tree();
+  try {
+    const subagent = join(dir, "proj/sess-1/subagents/agent-aaa.jsonl");
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "Just do the thing.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      subagent,
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`,
+    );
+
+    expect(resolveDispatchBranch(subagent)).toBeNull();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// The reader is where the resolver has to actually bite. Two things break it if
+// missed: the cheap `line.includes(branch)` reject drops these lines before the
+// parse (they are stamped `main` and carry `feat/x` nowhere), and the equality
+// test that follows compares the stamped branch rather than the resolved one.
+test("readRecordsForBranch returns subagent records the marker assigns to the branch", async () => {
+  const dir = await tree();
+  try {
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "TASK-BRANCH: feat/x\n\nGo.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-1",
+        gitBranch: "main",
+        isSidechain: true,
+        requestId: "req-1",
+        timestamp: "2026-09-08T10:01:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 1234 } },
+      })}\n`,
+    );
+
+    const records = readRecordsForBranch(dir, "feat/x");
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.message?.usage?.output_tokens).toBe(1234);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Claude Code sometimes writes one conversation into two session files: 615 of
+// this machine's assistant records, 5.2% of session spend, are present twice.
+// The reader has always counted both.
+test("readRecordsForBranch counts a record present in two session files once", async () => {
+  const dir = await tree();
+  try {
+    const line = `${JSON.stringify({
+      type: "assistant",
+      sessionId: "sess-1",
+      gitBranch: "feat/x",
+      isSidechain: false,
+      requestId: "req-dup",
+      timestamp: "2026-09-08T10:02:00.000Z",
+      message: { model: "claude-opus-5", usage: { output_tokens: 500 } },
+    })}\n`;
+    await writeFile(join(dir, "proj/sess-1.jsonl"), line);
+    await writeFile(join(dir, "proj/sess-2.jsonl"), line);
+
+    expect(readRecordsForBranch(dir, "feat/x")).toHaveLength(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// `backfill.ts` had its own reader grouping on `gitBranch`, so a backfilled card
+// and a live card disagreed on the same branch. Both now go through this.
+test("recordsByBranch groups a marker-resolved subagent file under the marked branch", async () => {
+  const dir = await tree();
+  try {
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "TASK-BRANCH: feat/x\n\nGo.")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-1",
+        gitBranch: "main",
+        isSidechain: true,
+        requestId: "req-1",
+        message: { model: "claude-opus-5", usage: { output_tokens: 99 } },
+      })}\n`,
+    );
+
+    const byBranch = recordsByBranch(dir);
+
+    expect(byBranch.get("feat/x")).toHaveLength(1);
+    // `main` is not a task branch and never gets a card.
+    expect(byBranch.has("main")).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Nothing enforces the marker — it is a line a skill tells an agent to write.
+// So a forgotten one has to be visible, or it silently reproduces the bug this
+// whole change exists to fix.
+test("counts subagent files that resolve to nothing under a main or HEAD session", async () => {
+  const dir = await tree();
+  try {
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "No marker here.", "HEAD")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.jsonl"),
+      `${JSON.stringify({ type: "assistant", gitBranch: "HEAD", isSidechain: true, requestId: "r1" })}\n`,
+    );
+
+    expect(unattributedSubagentFiles(dir)).toBe(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a resolved subagent file is not counted as unattributed", async () => {
+  const dir = await tree();
+  try {
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      `${dispatch("toolu_1", "TASK-BRANCH: feat/x\n\nGo.", "HEAD")}\n`,
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.meta.json"),
+      JSON.stringify({ toolUseId: "toolu_1", spawnDepth: 1 }),
+    );
+    await writeFile(
+      join(dir, "proj/sess-1/subagents/agent-aaa.jsonl"),
+      `${JSON.stringify({ type: "assistant", gitBranch: "HEAD", isSidechain: true, requestId: "r1" })}\n`,
+    );
+
+    expect(unattributedSubagentFiles(dir)).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/pr-metrics/tests/pr-metrics.cli.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.cli.test.ts
@@ -483,3 +483,71 @@ test("card attributes a subagent stamped `main` to the branch its dispatch marke
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// The marker is a line a skill asks an agent to write, so nothing enforces it.
+// This warning is the whole enforcement story, and it fires on exactly the run
+// where the operator has no other signal — the card that came back empty. The
+// existing empty-card test points at a directory with no transcripts at all, so
+// the count is always 0 and this block never ran.
+test("the CLI names unmarked subagent transcripts when a card comes back empty", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-warn-"));
+  const branch = "feat/nothing-matched";
+
+  try {
+    const git = async (...args: string[]) => {
+      const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+      await proc.exited;
+    };
+    await git("init", "-q", "-b", "main");
+    await git("config", "user.email", "test@example.com");
+    await git("config", "user.name", "Test");
+    await git("config", "commit.gpgsign", "false");
+    await writeFile(join(dir, "seed.txt"), "seed\n");
+    await git("add", ".");
+    await git("commit", "-qm", "seed");
+    await git("checkout", "-qb", branch);
+
+    // One unmarked subagent under a `main` session: its spend belongs to no card.
+    const subagents = join(dir, "sessions", "-proj", "sess-1", "subagents");
+    await mkdir(subagents, { recursive: true });
+    await writeFile(
+      join(dir, "sessions", "-proj", "sess-1.jsonl"),
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", timestamp: "2026-09-08T10:00:00.000Z" })}\n`,
+    );
+    await writeFile(
+      join(subagents, "agent-orphan.jsonl"),
+      `${JSON.stringify({ type: "assistant", gitBranch: "main", isSidechain: true })}\n`,
+    );
+
+    const proc = Bun.spawn(
+      [
+        "bun",
+        SCRIPT,
+        "--branch",
+        branch,
+        "--base",
+        "main",
+        "--sessions-dir",
+        join(dir, "sessions"),
+        "--out-dir",
+        join(dir, "cards"),
+      ],
+      { cwd: dir, stdout: "pipe", stderr: "pipe" },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+
+    expect(stderr).toContain("no session records matched");
+    expect(stderr).toContain("1 subagent transcript(s) carry no TASK-BRANCH marker");
+    // The pointer the operator is sent to must exist; a rename would otherwise
+    // break it silently.
+    expect(stderr).toContain("wiki/observability/session-metrics.md");
+    expect(
+      await Bun.file(
+        new URL("../../../wiki/observability/session-metrics.md", import.meta.url).pathname,
+      ).text(),
+    ).toContain("## Attributing subagent spend");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/pr-metrics/tests/pr-metrics.cli.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.cli.test.ts
@@ -369,6 +369,19 @@ test("card writes to the repository root even when run with --cwd", async () => 
   }
 });
 
+/** Claude Code names a project directory after the session's cwd, with `/` and
+ * `.` flattened to `-`. The collector only trusts a `TASK-BRANCH:` marker from a
+ * project directory this repository owns, so a fixture has to be named the way
+ * a real one would be. `git` resolves symlinks (`/var` → `/private/var` on
+ * macOS), so the name comes from git rather than from `mkdtemp`. */
+async function projectDirFor(repo: string): Promise<string> {
+  const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], { cwd: repo, stdout: "pipe" });
+  const top = (await new Response(proc.stdout).text()).trim();
+  await proc.exited;
+
+  return top.replaceAll(/[/.]/g, "-");
+}
+
 // The unit tests feed `resolveDispatchBranch` a hand-built tree. This one runs
 // the real script end to end over a subagent transcript stamped with a
 // DIFFERENT branch from the card's — which is the actual shape on disk, and the
@@ -395,7 +408,7 @@ test("card attributes a subagent stamped `main` to the branch its dispatch marke
     await git("add", ".");
     await git("commit", "-qm", "work");
 
-    const project = join(dir, "sessions", "-orchestrator-root");
+    const project = join(dir, "sessions", await projectDirFor(dir));
     const subagents = join(project, "sess-1", "subagents");
     await mkdir(subagents, { recursive: true });
 
@@ -508,10 +521,11 @@ test("the CLI names unmarked subagent transcripts when a card comes back empty",
     await git("checkout", "-qb", branch);
 
     // One unmarked subagent under a `main` session: its spend belongs to no card.
-    const subagents = join(dir, "sessions", "-proj", "sess-1", "subagents");
+    const project = join(dir, "sessions", await projectDirFor(dir));
+    const subagents = join(project, "sess-1", "subagents");
     await mkdir(subagents, { recursive: true });
     await writeFile(
-      join(dir, "sessions", "-proj", "sess-1.jsonl"),
+      join(project, "sess-1.jsonl"),
       `${JSON.stringify({ type: "assistant", gitBranch: "main", timestamp: "2026-09-08T10:00:00.000Z" })}\n`,
     );
     await writeFile(

--- a/tools/pr-metrics/tests/pr-metrics.cli.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.cli.test.ts
@@ -368,3 +368,118 @@ test("card writes to the repository root even when run with --cwd", async () => 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// The unit tests feed `resolveDispatchBranch` a hand-built tree. This one runs
+// the real script end to end over a subagent transcript stamped with a
+// DIFFERENT branch from the card's — which is the actual shape on disk, and the
+// shape the old `gitBranch` match dropped entirely.
+test("card attributes a subagent stamped `main` to the branch its dispatch marked", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-marker-"));
+  const branch = "feat/marker-fixture";
+
+  try {
+    const git = async (...args: string[]) => {
+      const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+      await proc.exited;
+    };
+    await git("init", "-q", "-b", "main");
+    await git("config", "user.email", "test@example.com");
+    await git("config", "user.name", "Test");
+    await git("config", "commit.gpgsign", "false");
+    await writeFile(join(dir, "seed.txt"), "seed\n");
+    await git("add", ".");
+    await git("commit", "-qm", "seed");
+    await git("checkout", "-qb", branch);
+    await mkdir(join(dir, "osn", "api", "src"), { recursive: true });
+    await writeFile(join(dir, "osn", "api", "src", "svc.ts"), "export const a = 1;\n");
+    await git("add", ".");
+    await git("commit", "-qm", "work");
+
+    const project = join(dir, "sessions", "-orchestrator-root");
+    const subagents = join(project, "sess-1", "subagents");
+    await mkdir(subagents, { recursive: true });
+
+    // The orchestrator session runs on `main` and dispatches with the marker.
+    await writeFile(
+      join(project, "sess-1.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-1",
+        gitBranch: "main",
+        timestamp: "2026-09-07T10:00:00.000Z",
+        requestId: "req-parent",
+        message: {
+          model: "claude-opus-5",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_dispatch",
+              name: "Agent",
+              input: { prompt: `TASK-BRANCH: ${branch}\n\nImplement it.` },
+            },
+          ],
+        },
+      })}\n`,
+    );
+
+    await writeFile(
+      join(subagents, "agent-worker.meta.json"),
+      JSON.stringify({ agentType: "implementer", toolUseId: "toolu_dispatch", spawnDepth: 1 }),
+    );
+    // Stamped `main` — inherited from the parent session, wrong by construction.
+    await writeFile(
+      join(subagents, "agent-worker.jsonl"),
+      [
+        JSON.stringify({
+          type: "assistant",
+          sessionId: "sess-1",
+          gitBranch: "main",
+          isSidechain: true,
+          effort: "high",
+          requestId: "req-w1",
+          timestamp: "2026-09-07T10:01:00.000Z",
+          message: { model: "claude-opus-5", usage: { output_tokens: 700 } },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          sessionId: "sess-1",
+          gitBranch: "main",
+          isSidechain: true,
+          effort: "high",
+          requestId: "req-w2",
+          timestamp: "2026-09-07T10:01:30.000Z",
+          message: { model: "claude-opus-5", usage: { output_tokens: 300 } },
+        }),
+      ].join("\n"),
+    );
+
+    const proc = Bun.spawn(
+      [
+        "bun",
+        SCRIPT,
+        "--branch",
+        branch,
+        "--base",
+        "main",
+        "--sessions-dir",
+        join(dir, "sessions"),
+        "--out-dir",
+        join(dir, "cards"),
+      ],
+      { cwd: dir, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+
+    const card = JSON.parse(
+      await Bun.file(join(dir, "cards", "feat-marker-fixture.json")).text(),
+    ) as Card;
+
+    // The exact sum, not merely non-zero: a non-zero assertion cannot tell a
+    // resolved file from a stray record that matched some other way.
+    expect(card.spend.tokens.output).toBe(1000);
+    expect(card.spend.by_actor.subagent.tokens.output).toBe(1000);
+    expect(card.spend.by_actor.main.tokens.output).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -156,6 +156,18 @@ Three things about it worth keeping:
   write, so `card` counts the subagent files that resolve to nothing under a
   `main`/`HEAD` session and warns. A forgotten marker shows up on the next card
   instead of silently under-reporting.
+- **A marker is never sufficient on its own.** `~/.claude/projects` holds every
+  project on the machine, and a card is committed to a public repository
+  carrying `tool_calls`, `skills` and `subagents` keyed verbatim from the
+  transcript — MCP server and private skill names among them. So a marked
+  transcript is admitted only from a project directory this repository owns,
+  derived from `git worktree list` and the common git dir. Two checkouts sharing
+  a branch name is a collision, not an attack, and it must not publish one
+  project's metadata from the other.
+- **The marker is read from the first three lines**, and the value has to look
+  like a ref. Dispatch prompts quote text nobody here wrote — issue bodies,
+  review comments, fetched pages — and a planted `TASK-BRANCH:` line further
+  down would otherwise re-point a subagent's whole spend onto another card.
 
 This is **forward-looking only**. Historical transcripts carry no marker, so the
 85.8% stays where it is; the fix changes what new work records, not what old

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -14,7 +14,7 @@ related:
   - "[[observability/metrics]]"
   - "[[conventions/review-findings]]"
   - "[[conventions/stacked-prs]]"
-last-reviewed: 2026-09-07
+last-reviewed: 2026-09-08
 ---
 
 # Session Metrics
@@ -82,14 +82,20 @@ predate the label.
 
 Claude Code writes a transcript per session under
 `~/.claude/projects/<encoded-cwd>/`, and stamps `gitBranch` on every assistant
-message. That field is the whole join: this repository runs one worktree and one
-branch per task, so a branch name maps to exactly one pull request.
+message. For a session that runs in its own task worktree that field is the
+join: this repository runs one worktree and one branch per task, so a branch
+name maps to exactly one pull request. For delegated work it is not enough —
+see [[#Attributing subagent spend]].
 
-Two traps the collector handles and any reimplementation must:
+Three traps the collector handles and any reimplementation must:
 
 - **Subagent spend is in a sibling directory**, `<session-id>/subagents/*.jsonl`,
   not in the main transcript. Missing it under-reports every delegated task, and
   on orchestrated work that is most of the cost.
+- **One conversation is sometimes written into two session files.** 615 assistant
+  records on this machine — 5.2% of session spend — appear in both, and reading
+  them twice doubles the branch's cost. `readRecordsForBranch` keys on
+  `requestId` and returns each once.
 - **Most `role: "user"` records are machinery** — tool results, hook output,
   system reminders, slash-command envelopes. Counting them destroys `user_turns`
   as a measure of steering.
@@ -104,6 +110,61 @@ Two traps the collector handles and any reimplementation must:
   same text in the same session is collapsed — but two identical `user` turns
   are never collapsed, because a person who types "continue" twice steered
   twice.
+
+## Attributing subagent spend
+
+`gitBranch` is a property of the **session**, captured once when it starts and
+inherited by every subagent. A subagent working in a task worktree therefore
+records the branch its *parent* started on, and `isolation: "worktree"` does not
+help — it pins the subagent's `cwd` and still reports the parent's `gitBranch`.
+
+The scale, measured over 904 transcript files and 9.03e9 tokens:
+
+| Where the spend sits | Share |
+|---|---|
+| Stamped `HEAD` (the bare-repo root) | 62.4% |
+| Stamped `main` | 12.1% |
+| A real branch | 25.5% |
+
+Subagent transcripts are 27.0% of all spend, and **85.8% of that is stamped
+`HEAD`** against 7.4% on a real branch. A branch whose work was delegated saw
+almost none of its own cost.
+
+So `orchestrate` puts a marker on its own line at the top of every dispatch
+prompt:
+
+```
+TASK-BRANCH: feat/example
+```
+
+`resolveDispatchBranch` in `tools/pr-metrics/index.ts` reads it back. Every
+subagent transcript has a sibling `agent-<id>.meta.json` carrying the
+`toolUseId` of the `Agent` call that spawned it; that id appears on the
+`tool_use` block in the parent transcript, whose `input.prompt` is the dispatch.
+The marked branch then replaces `gitBranch` for every record in that file.
+
+Three things about it worth keeping:
+
+- **The parent may be another subagent.** `spawnDepth: 2` is 79 of this
+  machine's 363 subagent files, 8.3% of subagent spend, and every one of those
+  parents is a sibling `subagents/*.jsonl` rather than the session file.
+- **A child with no marker inherits its parent's branch.** Depth-2 prompts are
+  written by `stress-plan`, `prep-pr` and
+  `superpowers:subagent-driven-development` — the last a plugin this repository
+  cannot edit — so requiring a marker everywhere would lose their spend.
+- **Nothing enforces the marker.** It is a line a skill instructs an agent to
+  write, so `card` counts the subagent files that resolve to nothing under a
+  `main`/`HEAD` session and warns. A forgotten marker shows up on the next card
+  instead of silently under-reporting.
+
+This is **forward-looking only**. Historical transcripts carry no marker, so the
+85.8% stays where it is; the fix changes what new work records, not what old
+work recorded.
+
+A wholly delegated card reports zero `user_turns` and "not observed" for first
+edit by construction — those skip sidechain records. The steering for
+orchestrated work lives in the orchestrator's own session, which is deliberately
+not carded: a session that only dispatches is not one task's cost.
 
 `~/.claude/projects/` is local and unversioned, so a card can only be generated
 on the machine that did the work. Once written it is committed, which is what


### PR DESCRIPTION
## Summary

`gitBranch` in a transcript record is a property of the **session**, captured
once when it starts and inherited by every subagent, so a subagent working in a
task worktree recorded the branch its parent started on. `readSessionRecords`
matched strictly on that field, so delegated work landed on the wrong card or on
none. Measured over 904 transcript files and 9.03e9 tokens: subagent transcripts
are 27.0% of all spend and **85.8% of that is stamped `HEAD`**, against 7.4% on
a real branch.

`orchestrate` now puts `TASK-BRANCH: <branch>` at the top of every prompt it
sends to the Agent tool, and the collector reads it back through the sidecar
`toolUseId` that pairs each subagent transcript with the `tool_use` block in its
parent.

- A child with no marker inherits its parent's branch. Depth-2 prompts come from
  `stress-plan`, `prep-pr` and a plugin this repository cannot edit, and are 8.3%
  of subagent spend.
- `backfill.ts` lost its own reader; both tools now share one, so a backfilled
  card and a live card cannot disagree.
- Records that appear in two session files are counted once — 615 of them here,
  5.2% of session spend, double-counted until now.
- **Forward-looking only.** Historical transcripts carry no marker, so the 85.8%
  stays where it is; this changes what new work records.

## Workspaces affected

`@tools/pr-metrics`. One changeset, `patch`, naming that package alone —
`scripts/changeset-required.sh` returns `required` for this file list, and
`scripts/validate-changesets.sh` passes. `.claude/skills/` and `wiki/` belong to
no package.

## Issues

**Closes**

| Issue | What |
|---|---|
| #942 | Attribute subagent token spend to the branch the work happened on |

Closes #942

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#944 | Add a test file for `tools/pr-metrics/backfill.ts` (T-M1) |

## Decisions

### A marker in the dispatch prompt, not a lifecycle hook — `approach`

- **Issue** — nothing on disk names the branch a subagent worked on.
- **Why** — `gitBranch` is the session's, and `isolation: "worktree"` pins a
  subagent's `cwd` while still reporting the parent's `gitBranch`, so neither
  field can answer it.
- **Solution** — `orchestrate` states the branch in the dispatch prompt; the
  collector reads it back via the sidecar's `toolUseId`.
- **Rationale** — the `SubagentStart`/`SubagentStop` hooks exist and carry
  `agent_transcript_path`, so the hook design was buildable. It was rejected
  because none of the hook's inputs names the branch either: its `cwd` is the
  session's, and across the 292 `HEAD`-stamped subagent files here the worktree
  named in the prompt disagrees with it in a large minority. A hook would still
  need the marker, so it buys machinery without buying enforcement. An earlier
  draft of this rationale argued a race over a global "current branch" file;
  that was a strawman — a hook receives `agent_id` and could write one file per
  agent — and the stress review caught it.

### A marker is an attribution hint, never a provenance claim — `S-M1`

- **Issue** — once a marker resolved, the readers dropped the `gitBranch` check,
  and `transcriptFiles` globs all of `~/.claude/projects`, which holds every
  project on this machine. Another checkout using the same branch name was
  folded into this repository's card.
- **Why** — `.claude/metrics/*.json` is tracked and public, and a card keys
  `interaction.tool_calls`, `skills` and `subagents` verbatim from the
  transcript; a tool name is routinely an MCP server identifier. There are three
  other checkouts on this machine, so a branch-name collision is ordinary.
- **Solution** — a marked transcript is admitted only from a project directory
  this repository owns, derived from `git worktree list` plus the common git
  dir. A positive check: the marker alone is never sufficient.
- **Rationale** — it restores the scoping the `gitBranch` match was incidentally
  providing, without giving up the attribution the branch exists for.

### The marker is read from the head of a prompt, and must look like a ref — `S-L2`

- **Issue** — the marker was honoured on any line of a dispatch prompt, first
  match winning, and the captured value was any non-whitespace string.
- **Why** — dispatch prompts quote text this repository did not author: issue
  bodies, review comments, fetched pages. A planted `TASK-BRANCH:` line
  re-pointed a subagent's entire spend onto another branch's public card.
- **Solution** — the first three lines only, and the capture must match a
  plausible ref, rejecting `..` and a leading dash.
- **Rationale** — it keeps the reason the multiline match existed (a dispatch
  may lead with a worktree instruction) while closing the window on quoted text.
  The value never reaches a filesystem path, which is what kept this low.

### Reading each transcript once instead of once per child — `P-C1`, `P-C2`

- **Issue** — carding one branch read 9.27 GB off a 720 MB tree, against 0.66 GB
  before this branch. One 9.4 MB session file was read 203 times, and the
  sibling scan was O(n²) in subagents per session.
- **Why** — every parent transcript was re-read on every child's resolution, and
  the `split("\n")` array of a 72 MB file was re-allocated each time. It grows
  with subagents per session and with session size, both of which grow.
- **Solution** — each parent file is indexed once by `tool_use` id, resolution
  is memoised per file, and the sidecar's `parentAgentId` names the parent
  directly rather than scanning siblings — it is present on 79 of 79 nested
  subagents here.
- **Rationale** — 5.14 s to 1.37 s, peak RSS 1.92 GB to 1.10 GB, and the
  behaviour is identical rather than assumed identical: resolving all 366 real
  subagent transcripts before and after gives 0 mismatches.

### The guards are tested where they must keep things out — `T-E1`

- **Issue** — the suite proved every new gate where it lets something through
  and nowhere it must keep something out.
- **Why** — demonstrated rather than argued: deleting
  `if (resolved !== null && resolved !== branch) continue;` left all 82 tests
  green, while every marked transcript would have been attributed to every
  branch carded — silent, uniform over-reporting on a plausible-looking card.
- **Solution** — seven gaps closed (T-E1 to T-E4, T-U1, T-S1, T-S2), including
  the CLI warning that no test executed and a case that reads the marker out of
  `orchestrate`'s own SKILL.md so producer and parser fail together.
- **Rationale** — verified by mutation, not inspection: removing the branch
  guard now fails one test, removing either dedupe fails three.

### Two low findings accepted rather than fixed — `S-L3`, `P-I2`

- **Issue** — `promptIndex` still reads a whole transcript with no size cap (the
  largest here is 72 MB), and `transcriptFiles` still shells out to `ls` twice
  per call.
- **Why** — both were raised as low-severity throughput concerns.
- **Solution** — not changed.
- **Rationale** — the caches added for P-C1 mean each file is now read at most
  once per run, so the cost is bounded by the size of the operator's own local
  transcript tree, which they already own. Replacing the `ls` subprocesses with
  a directory walk is a refactor of code this branch did not introduce, and
  bundling it here would enlarge the diff without changing a measured number.

**Out of scope** — xchromo/osn#944 — T-M1.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Tests | `bun run --cwd tools/pr-metrics test` | `92 pass, 0 fail`, 200 `expect()` calls, 5 files |
| Type check (package) | `bun run --cwd tools/pr-metrics check` | `tsc --noEmit`, no diagnostics |
| Lint | `bun run lint` | no errors in `tools/pr-metrics`; pre-existing `no-console` / `no-array-sort` warnings only |
| Format | `bun run fmt:check` | `All matched files use the correct format` (1461 files) |
| Changeset | `scripts/changeset-required.sh` over the branch's file list | `required`; `validate-changesets.sh` passes |
| Build | — | `@tools/pr-metrics` has no `build` script; it runs as source, and `check` stands in |

Exercised against the real transcript tree in this worktree, not only fixtures:

- `bun run --cwd tools/pr-metrics card -- --branch feat/subagent-branch-attribution`
  reports `$11.33 · 1 session(s)`, 100% subagent — `$7.33` opus and `$4.00`
  fable, which are this branch's own review and stress-plan agents. The same
  command before the change reported `$0.00 · 0 session(s)`.
- Behaviour equivalence for the performance rewrite: resolving all 366 real
  subagent transcripts with the pre-optimisation and post-optimisation code
  gives **0 mismatches**.
- Timing on the same tree: 5.14 s → 1.37 s, peak RSS 1.92 GB → 1.10 GB.
- Mutation checks: deleting the branch guard fails 1 test; disabling either
  dedupe fails 3; pointing the end-to-end fixture's marker at another branch
  takes its assertion from 1000 to 0.

Not verified: nothing here proves the marker gets written in practice. It is a
line `orchestrate` instructs an agent to emit, and no gate enforces it — the
`card` warning is what surfaces a forgotten one. The first orchestrated run
after this merges is the real test.
<details><summary>Session metrics — $11.33 · 12.8M tok · complexity unrated · +454/-60 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $11.33 |
| Tokens | 12.8M — out 9.8K · cache-w 471.5K · cache-r 12.3M (96%) |
| Models | claude-opus-5 (65%), claude-fable-5-1 (35%) |
| Active time | 26m over 1 session(s) |
| Declared complexity | unrated |
| Source diff | +454/-60 across 2 file(s), 1 package(s) |
| Turns | 0 (0 corrective) |
| Before first edit | not observed (no edit seen in the transcript) |
| Subagents | none |

<sub>Card: `.claude/metrics/feat-subagent-branch-attribution.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3oFqUaGv1KNeC2X6ZBnrL
