### PR TITLE
test(tools): give backfill.ts its first tests, and fix what they found

### DIFF
--- a/.changeset/pr-metrics-backfill-tests.md
+++ b/.changeset/pr-metrics-backfill-tests.md
@@ -1,0 +1,8 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Give `backfill.ts` its first tests, and make it name cards with `branchSlug`
+rather than a partial copy of it — a branch name ending in a character outside
+the slug's class made `backfill` and `card` write two different files for the
+same branch.

--- a/.claude/metrics/test-pr-metrics-backfill.json
+++ b/.claude/metrics/test-pr-metrics-backfill.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": null,
+    "branch": "test/pr-metrics-backfill",
+    "base_sha": "5667074a2ffd3b62aae424c5c3fd33fc162f32d4",
+    "head_sha": "4bcdd66a73adb9a4ec225bc9558306aa325e1dac",
+    "generated_at": "2026-09-08T14:37:45.709Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": 944,
+    "type": "Task",
+    "labels": [
+      "product:shared",
+      "area:ops",
+      "complexity:2"
+    ]
+  },
+  "complexity": {
+    "declared": 2,
+    "method": "confirmed"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-08T13:47:11.088Z",
+    "last_ts": "2026-09-08T14:32:16.485Z",
+    "span_seconds": 2705,
+    "active_seconds": 1818,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 11.63010975,
+    "tokens": {
+      "input": 650,
+      "output": 10440,
+      "thinking": 0,
+      "cache_write_5m": 486260,
+      "cache_write_1h": 0,
+      "cache_read": 13615803
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 232,
+          "output": 9815,
+          "thinking": 0,
+          "cache_write_5m": 354997,
+          "cache_write_1h": 0,
+          "cache_read": 12254354
+        },
+        "usd_equivalent": 8.592443249999997,
+        "messages": 116
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 418,
+          "output": 625,
+          "thinking": 0,
+          "cache_write_5m": 131263,
+          "cache_write_1h": 0,
+          "cache_read": 1361449
+        },
+        "usd_equivalent": 3.0376665000000003,
+        "messages": 14
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 650,
+          "output": 10440,
+          "thinking": 0,
+          "cache_write_5m": 486260,
+          "cache_write_1h": 0,
+          "cache_read": 13615803
+        },
+        "usd_equivalent": 11.63010975,
+        "messages": 130
+      }
+    },
+    "effort": {
+      "high": 130
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 1,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 8,
+        "deleted": 0
+      },
+      "test": {
+        "added": 487,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 3,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 51,
+        "deleted": 4
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 5
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 19,
+      "Edit": 17,
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 12
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/tools/pr-metrics/README.md
+++ b/tools/pr-metrics/README.md
@@ -71,6 +71,9 @@ right-skewed — median 3.6M tokens against a mean of 15.4M and a maximum of
 | `tests/render.test.ts`         | The `<details>` block — including that it contributes no `##` heading                         |
 | `tests/pr-metrics.test.ts`     | The pure functions, against synthetic records                                                 |
 | `tests/pr-metrics.cli.test.ts` | The real script as a subprocess, against a throwaway git repo and a fake `~/.claude/projects` |
+| `tests/dispatch-branch.test.ts` | `TASK-BRANCH:` marker resolution, the readers that consult it, and the dedupe |
+| `tests/backfill.test.ts`       | `backfill.ts` as a subprocess, against a stubbed `gh` on `PATH` |
+| `tests/report.test.ts`         | The `report` subcommand's analyses |
 
 The CLI test earns its keep: subagent spend lives in a
 `<session-id>/subagents/*.jsonl` sibling of the main transcript, and a collector

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -24,6 +24,8 @@
  * worse than no card, because a query cannot tell it from a cheap one.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+
 import {
   branchSlug,
   buildCard,
@@ -71,6 +73,17 @@ function flag(name: string): string | null {
  * --numstat` lines `parseNumstat` already understands. */
 export function numstatFromApi(files: ChangedFile[]): string {
   return files.map((f) => `${f.additions}\t${f.deletions}\t${f.filename}`).join("\n");
+}
+
+/** The branch a card on disk was written for, or `null` if it cannot be read. */
+function readCardBranch(path: string): string | null {
+  try {
+    const card = JSON.parse(readFileSync(path, "utf8") as string) as { pr?: { branch?: string } };
+
+    return card.pr?.branch ?? null;
+  } catch {
+    return null;
+  }
 }
 
 if (import.meta.main) {
@@ -158,6 +171,20 @@ if (import.meta.main) {
     // outside the class made `backfill` and `card` write two different files
     // for the same branch, and nothing downstream keys on the filename.
     const path = `${outDir}/${branchSlug(pull.headRefName)}.json`;
+
+    // `branchSlug` is not injective — `feat/x-`, `feat-x` and `feat/x` all slug
+    // to `feat-x` — and this loop writes many cards in one pass. `card` writes
+    // one per run and cannot see a clash; here it is visible, and a silently
+    // overwritten card is indistinguishable from a pull request that was never
+    // backfilled at all.
+    const existing = written > 0 && existsSync(path) ? readCardBranch(path) : null;
+    if (existing !== null && existing !== pull.headRefName) {
+      console.warn(
+        `  ⚠️  slug collision on ${branchSlug(pull.headRefName)}.json: \`${existing}\` and \`${pull.headRefName}\` — keeping the first, skipping #${pull.number}.`,
+      );
+      skipped.push(pull.number);
+      continue;
+    }
 
     if (dryRun) {
       console.log(

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  branchSlug,
   buildCard,
   declaredFromLabels,
   defaultMetricsDir,
@@ -43,7 +44,7 @@ interface PullRequest {
   closingIssuesReferences: { number: number }[];
 }
 
-interface ChangedFile {
+export interface ChangedFile {
   filename: string;
   additions: number;
   deletions: number;
@@ -68,7 +69,7 @@ function flag(name: string): string | null {
 
 /** GitHub's per-file additions and deletions, reshaped into the `git diff
  * --numstat` lines `parseNumstat` already understands. */
-function numstatFromApi(files: ChangedFile[]): string {
+export function numstatFromApi(files: ChangedFile[]): string {
   return files.map((f) => `${f.additions}\t${f.deletions}\t${f.filename}`).join("\n");
 }
 
@@ -152,7 +153,11 @@ if (import.meta.main) {
       generatedAt: new Date().toISOString(),
     });
 
-    const path = `${outDir}/${pull.headRefName.replace(/[^a-zA-Z0-9._-]/g, "-")}.json`;
+    // `branchSlug`, not a copy of its first step: the inline version omitted
+    // the trailing `^-+|-+$` strip, so a branch name ending in a character
+    // outside the class made `backfill` and `card` write two different files
+    // for the same branch, and nothing downstream keys on the filename.
+    const path = `${outDir}/${branchSlug(pull.headRefName)}.json`;
 
     if (dryRun) {
       console.log(

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -72,7 +72,22 @@ function flag(name: string): string | null {
 /** GitHub's per-file additions and deletions, reshaped into the `git diff
  * --numstat` lines `parseNumstat` already understands. */
 export function numstatFromApi(files: ChangedFile[]): string {
-  return files.map((f) => `${f.additions}\t${f.deletions}\t${f.filename}`).join("\n");
+  return files
+    .filter((f) => {
+      // Git permits tabs and newlines in a path and the files API returns it
+      // verbatim, so such a name would inject an extra record into the numstat
+      // that `parseNumstat` counts as a real file. Dropping it loses one row of
+      // a diff summary; keeping it corrupts the whole card.
+      if (typeof f.filename !== "string" || /[\t\n\r]/.test(f.filename)) {
+        console.warn(`  ⚠️  skipping a changed file whose name carries a tab or newline.`);
+
+        return false;
+      }
+
+      return true;
+    })
+    .map((f) => `${f.additions}\t${f.deletions}\t${f.filename}`)
+    .join("\n");
 }
 
 /** The branch a card on disk was written for, or `null` if it cannot be read. */

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -11,7 +11,7 @@
 // silently vanishes.
 
 import { expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -163,6 +163,10 @@ esac
   );
   await chmod(join(binDir, "gh"), 0o755);
 
+  // Assert the mode rather than trusting the `chmod` above. A comment saying
+  // why something is safe is intent; this is the control.
+  expect((await stat(join(binDir, "gh"))).mode & 0o111).toBeGreaterThan(0);
+
   return { dir, sessions, binDir, log, git };
 }
 
@@ -174,7 +178,22 @@ async function runBackfill(f: Awaited<ReturnType<typeof fixture>>, extra: string
       stdout: "pipe",
       stderr: "pipe",
       // Prepend, never replace: `git` and `sh` are still needed.
-      env: { ...process.env, PATH: `${f.binDir}:${process.env.PATH}` },
+      //
+      // The tokens are blanked as a SECOND line of defence. Shadowing on PATH
+      // is the happy path, but it fails on any exec error — a `noexec` TMPDIR,
+      // a filesystem that drops the execute bit, an MDM policy — and the real
+      // `gh` then resolves further down. With no credentials that fall-through
+      // exits non-zero and the test fails loudly offline, instead of quietly
+      // going online with the developer's account.
+      env: {
+        ...process.env,
+        PATH: `${f.binDir}:${process.env.PATH}`,
+        GH_TOKEN: "",
+        GITHUB_TOKEN: "",
+        GH_ENTERPRISE_TOKEN: "",
+        GH_CONFIG_DIR: join(f.dir, "gh-config"),
+        GH_NO_UPDATE_NOTIFIER: "1",
+      },
     },
   );
   const [stdout, stderr] = await Promise.all([
@@ -252,6 +271,11 @@ test("a merged PR with no local transcript is skipped, not written as a zero car
     expect(stdout).toContain("wrote 0 card(s)");
     expect(stdout).toContain(String(PR));
 
+    // Every test that spawns backfill proves the stub answered, not the real
+    // `gh` — otherwise this one would fail on the assertions above only after
+    // an authenticated call had already gone out.
+    expect(await readFile(f.log, "utf8")).toContain("pr list");
+
     // `mkdirSync` sits inside the write branch, so on a skip the directory is
     // never created — assert absence, not emptiness.
     expect(await Bun.file(join(f.dir, "cards", `${SLUG}.json`)).exists()).toBe(false);
@@ -276,6 +300,55 @@ test("--dry-run reports what it would write and writes nothing", async () => {
     const calls = await readFile(f.log, "utf8");
     expect(calls).toContain("pr list");
     expect(calls).toContain("--jq .commits");
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// `branchSlug` is not injective: `feat/x-`, `feat-x` and `feat/x` all slug to
+// `feat-x`. `card` writes one file per run so it cannot notice; `backfill`
+// writes many in one pass and can. A silently overwritten card is
+// indistinguishable from a PR that was never backfilled, which is the same
+// failure the file already refuses for zero-cost cards.
+test("backfill warns rather than silently overwriting when two branches share a slug", async () => {
+  const f = await fixture({ withTranscript: true });
+  try {
+    // A second merged PR whose different branch name slugs to the same file.
+    await writeFile(
+      join(f.binDir, "gh"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >> ${JSON.stringify(f.log)}
+case "$*" in
+  *"pr list"*)
+    printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]},{"number":9999,"headRefName":"${SLUG}","mergedAt":"2026-09-09T13:00:00Z","baseRefOid":"ccc","headRefOid":"ddd","labels":[],"closingIssuesReferences":[]}]' ;;
+  *"/files"*)
+    printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
+  *)
+    printf '%s' '3' ;;
+esac
+`,
+    );
+    await chmod(join(f.binDir, "gh"), 0o755);
+
+    // Both branches need transcripts, or the second is skipped before the
+    // collision can happen.
+    const project = join(f.sessions, await projectDirFor(f.dir));
+    await writeFile(
+      join(project, "sess-2.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-2",
+        gitBranch: SLUG,
+        requestId: "req-other",
+        timestamp: "2026-09-09T11:00:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 50 } },
+      })}\n`,
+    );
+
+    const { stdout, stderr } = await runBackfill(f);
+
+    expect(stdout + stderr).toContain("collision");
+    expect(stdout + stderr).toContain(SLUG);
   } finally {
     await rm(f.dir, { recursive: true, force: true });
   }

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -141,6 +141,49 @@ async function fixture(options: { withTranscript: boolean }) {
     );
   }
 
+  // A SECOND project directory, with a name this repository does not own,
+  // carrying the same marker for the same branch. `repoPaths` is what stops
+  // another checkout's transcript — MCP server names, private skill names —
+  // being attributed to a card this repo commits publicly, and a positive-only
+  // fixture cannot tell a working scope check from one that admits everything.
+  // Its 9999 tokens must not appear in any assertion below.
+  const foreign = join(sessions, "-Users-ac--work-otherproj-main", "sess-1", "subagents");
+  await mkdir(foreign, { recursive: true });
+  await writeFile(
+    join(sessions, "-Users-ac--work-otherproj-main", "sess-1.jsonl"),
+    `${JSON.stringify({
+      type: "assistant",
+      sessionId: "other-1",
+      gitBranch: "main",
+      message: {
+        model: "claude-opus-5",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_foreign",
+            name: "Agent",
+            input: { prompt: `TASK-BRANCH: ${BRANCH}\n\nSomeone else's work.` },
+          },
+        ],
+      },
+    })}\n`,
+  );
+  await writeFile(
+    join(foreign, "agent-other.meta.json"),
+    JSON.stringify({ toolUseId: "toolu_foreign", spawnDepth: 1 }),
+  );
+  await writeFile(
+    join(foreign, "agent-other.jsonl"),
+    `${JSON.stringify({
+      type: "assistant",
+      sessionId: "other-1",
+      gitBranch: "main",
+      isSidechain: true,
+      requestId: "req-foreign",
+      message: { model: "claude-opus-5", usage: { output_tokens: 9999 } },
+    })}\n`,
+  );
+
   // The stub. Executable with a shebang, or Bun skips it and silently resolves
   // the REAL `gh` further down PATH — verified on Bun 1.4.0 — which would send
   // the test to the network with the developer's credentials.
@@ -200,15 +243,17 @@ async function runBackfill(f: Awaited<ReturnType<typeof fixture>>, extra: string
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ]);
-  await proc.exited;
+  const exitCode = await proc.exited;
 
-  return { stdout, stderr };
+  return { stdout, stderr, exitCode };
 }
 
 test("backfill cards a marked subagent, and agrees with `card` on both figure and filename", async () => {
   const f = await fixture({ withTranscript: true });
   try {
-    await runBackfill(f);
+    const run = await runBackfill(f);
+
+    expect(run.exitCode).toBe(0);
 
     // The stub was actually reached — without this the test passes just as well
     // against the real `gh` failing on a PR number no repository has.
@@ -226,6 +271,8 @@ test("backfill cards a marked subagent, and agrees with `card` on both figure an
     // Assert the marker path FIRST. Equality alone can pass vacuously: if
     // ownership were broken for both tools they would agree on a number that
     // never included the subagent at all.
+    // 1000, never 10999: the foreign project's marked transcript names this
+    // same branch and must be rejected on ownership alone.
     expect(backfilled.spend.by_actor.subagent?.tokens.output).toBe(1000);
     expect(backfilled.spend.by_actor.main?.tokens.output).toBe(0);
 
@@ -349,6 +396,42 @@ esac
 
     expect(stdout + stderr).toContain("collision");
     expect(stdout + stderr).toContain(SLUG);
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// `backfill.ts` guards `gh pr list` failing and exits 1 with a message naming
+// authentication. The stub always exited 0, so that path had never run — and it
+// is the path a developer hits first, on the day their `gh` token expires.
+test("a failing `gh pr list` exits non-zero and says so, rather than carding nothing quietly", async () => {
+  const f = await fixture({ withTranscript: true });
+  try {
+    await writeFile(
+      join(f.binDir, "gh"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >> ${JSON.stringify(f.log)}
+echo "gh: could not authenticate" >&2
+exit 1
+`,
+    );
+    await chmod(join(f.binDir, "gh"), 0o755);
+
+    const { stderr, exitCode } = await runBackfill(f);
+
+    expect(exitCode).toBe(1);
+
+    // The FIRST line, not a substring of the whole stream. Bun prints a source
+    // excerpt when a script throws, and that excerpt quotes the very
+    // `console.error` line this asserts on — so `toContain` over all of stderr
+    // passes just as happily on a crash as on the handled path, which is the
+    // opposite of what this test is for. A crash's first line is the excerpt's
+    // `110 | …`; the handled path's is the message itself.
+    const firstLine = stderr.trim().split("\n")[0] ?? "";
+
+    expect(firstLine).toContain("pr-metrics backfill:");
+    expect(firstLine).toContain("authenticated");
+    expect(await Bun.file(join(f.dir, "cards", `${SLUG}.json`)).exists()).toBe(false);
   } finally {
     await rm(f.dir, { recursive: true, force: true });
   }

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -69,25 +69,42 @@ async function projectDirFor(repo: string): Promise<string> {
  * `ownedByRepo` then answers `true` for everything — the test would pass
  * without ever exercising ownership.
  */
-async function fixture(options: { withTranscript: boolean }) {
+async function fixture(options: { withTranscript: boolean; withBranch?: boolean }) {
   const dir = await mkdtemp(join(tmpdir(), "pr-metrics-backfill-"));
+  // Identity through the environment and signing through `-c` rather than three
+  // `git config` spawns: `fixture()` is the largest line item in this file's
+  // runtime and every spawn here is paid five times.
   const git = async (...args: string[]) => {
-    const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Test",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "Test",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+    });
     await proc.exited;
   };
 
   await git("init", "-q", "-b", "main");
-  await git("config", "user.email", "test@example.com");
-  await git("config", "user.name", "Test");
-  await git("config", "commit.gpgsign", "false");
   await writeFile(join(dir, "seed.txt"), "seed\n");
   await git("add", ".");
   await git("commit", "-qm", "seed");
-  await git("checkout", "-qb", BRANCH);
-  await mkdir(join(dir, "osn", "api", "src"), { recursive: true });
-  await writeFile(join(dir, "osn", "api", "src", "svc.ts"), "export const a = 1;\n");
-  await git("add", ".");
-  await git("commit", "-qm", "work");
+
+  // Only the test that also runs `card` needs a real branch: `index.ts` resolves
+  // `git diff --numstat main...HEAD` against it, while `backfill.ts` takes every
+  // branch name from the stubbed `gh` JSON and never touches a local ref.
+  if (options.withBranch) {
+    await git("checkout", "-qb", BRANCH);
+    await mkdir(join(dir, "osn", "api", "src"), { recursive: true });
+    await writeFile(join(dir, "osn", "api", "src", "svc.ts"), "export const a = 1;\n");
+    await git("add", ".");
+    await git("commit", "-qm", "work");
+  }
 
   const sessions = join(dir, "sessions");
   const project = join(sessions, await projectDirFor(dir));
@@ -249,7 +266,7 @@ async function runBackfill(f: Awaited<ReturnType<typeof fixture>>, extra: string
 }
 
 test("backfill cards a marked subagent, and agrees with `card` on both figure and filename", async () => {
-  const f = await fixture({ withTranscript: true });
+  const f = await fixture({ withTranscript: true, withBranch: true });
   try {
     const run = await runBackfill(f);
 

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -1,0 +1,282 @@
+// `backfill.ts` recards merged pull requests in bulk and had no test at all.
+// It is the tool nobody watches: a wrong argv or a renamed `--json` field only
+// surfaces when someone runs it over hundreds of PRs and gets numbers that
+// cannot be checked by hand.
+//
+// The seam is a stubbed `gh` on `PATH`. `sh()` spawns a bare `"gh"` with no
+// `env`, so the child inherits the backfill process's environment and a
+// directory PREPENDED to `PATH` resolves the stub. Prepended, never replaced:
+// `repoProjectPaths()` and `repoRoot()` spawn `git`, and `transcriptFiles`
+// spawns `sh -c ls`, so a replaced `PATH` loses them and every transcript
+// silently vanishes.
+
+import { expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { type ChangedFile, numstatFromApi } from "../backfill";
+import { parseNumstat } from "../index";
+
+test("numstatFromApi reshapes the GitHub API's file list into numstat lines", () => {
+  const files: ChangedFile[] = [
+    { filename: "osn/api/src/auth.ts", additions: 10, deletions: 3 },
+    { filename: "wiki/notes.md", additions: 5, deletions: 0 },
+    { filename: "bun.lock", additions: 1, deletions: 1 },
+  ];
+
+  expect(numstatFromApi(files)).toBe(
+    "10\t3\tosn/api/src/auth.ts\n5\t0\twiki/notes.md\n1\t1\tbun.lock",
+  );
+
+  // The lines exist to be understood by `parseNumstat`, so assert that rather
+  // than only the string: a tab swapped for a space would still look right.
+  const diff = parseNumstat(numstatFromApi(files), 2);
+
+  expect(diff.commits).toBe(2);
+  expect(diff.loc.source).toEqual({ added: 10, deleted: 3 });
+  expect(diff.loc.docs).toEqual({ added: 5, deleted: 0 });
+});
+
+const BACKFILL = new URL("../backfill.ts", import.meta.url).pathname;
+const CARD = new URL("../index.ts", import.meta.url).pathname;
+
+/** The branch carries a trailing dash on purpose: it is legal in git
+ * (`git check-ref-format --branch 'feat/foo-'` passes) and it is exactly where
+ * `backfill`'s inline slug used to diverge from `branchSlug`. */
+const BRANCH = "feat/backfill-fixture-";
+const SLUG = "feat-backfill-fixture";
+const PR = 4242;
+
+/** Claude Code names a project directory after the session's cwd with `/` and
+ * `.` flattened to `-`, and the collector trusts a `TASK-BRANCH:` marker only
+ * from a directory this repository owns. `git` resolves symlinks, so the name
+ * has to come from git rather than from `mkdtemp`. */
+async function projectDirFor(repo: string): Promise<string> {
+  const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], { cwd: repo, stdout: "pipe" });
+  const top = (await new Response(proc.stdout).text()).trim();
+  await proc.exited;
+
+  return top.replaceAll(/[/.]/g, "-");
+}
+
+/**
+ * A throwaway git repository, a sessions tree whose project directory this
+ * repo owns, and a stubbed `gh`.
+ *
+ * A git repository and not a plain temp dir, deliberately: from a non-git
+ * directory both `git` calls in `repoProjectPaths()` fail, it returns `[]`, and
+ * `ownedByRepo` then answers `true` for everything — the test would pass
+ * without ever exercising ownership.
+ */
+async function fixture(options: { withTranscript: boolean }) {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-backfill-"));
+  const git = async (...args: string[]) => {
+    const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    await proc.exited;
+  };
+
+  await git("init", "-q", "-b", "main");
+  await git("config", "user.email", "test@example.com");
+  await git("config", "user.name", "Test");
+  await git("config", "commit.gpgsign", "false");
+  await writeFile(join(dir, "seed.txt"), "seed\n");
+  await git("add", ".");
+  await git("commit", "-qm", "seed");
+  await git("checkout", "-qb", BRANCH);
+  await mkdir(join(dir, "osn", "api", "src"), { recursive: true });
+  await writeFile(join(dir, "osn", "api", "src", "svc.ts"), "export const a = 1;\n");
+  await git("add", ".");
+  await git("commit", "-qm", "work");
+
+  const sessions = join(dir, "sessions");
+  const project = join(sessions, await projectDirFor(dir));
+  const subagents = join(project, "sess-1", "subagents");
+  await mkdir(subagents, { recursive: true });
+
+  if (options.withTranscript) {
+    // The orchestrator session runs on `main` and dispatches with the marker.
+    await writeFile(
+      join(project, "sess-1.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-1",
+        gitBranch: "main",
+        timestamp: "2026-09-09T10:00:00.000Z",
+        requestId: "req-parent",
+        message: {
+          model: "claude-opus-5",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_dispatch",
+              name: "Agent",
+              input: { prompt: `TASK-BRANCH: ${BRANCH}\n\nImplement it.` },
+            },
+          ],
+        },
+      })}\n`,
+    );
+    await writeFile(
+      join(subagents, "agent-worker.meta.json"),
+      JSON.stringify({ agentType: "implementer", toolUseId: "toolu_dispatch", spawnDepth: 1 }),
+    );
+    // Stamped `main` — inherited from the parent session, wrong by construction.
+    await writeFile(
+      join(subagents, "agent-worker.jsonl"),
+      [400, 600]
+        .map((output, i) =>
+          JSON.stringify({
+            type: "assistant",
+            sessionId: "sess-1",
+            gitBranch: "main",
+            isSidechain: true,
+            effort: "high",
+            requestId: `req-w${i}`,
+            timestamp: `2026-09-09T10:0${i + 1}:00.000Z`,
+            message: { model: "claude-opus-5", usage: { output_tokens: output } },
+          }),
+        )
+        .join("\n"),
+    );
+  }
+
+  // The stub. Executable with a shebang, or Bun skips it and silently resolves
+  // the REAL `gh` further down PATH — verified on Bun 1.4.0 — which would send
+  // the test to the network with the developer's credentials.
+  const binDir = join(dir, "bin");
+  await mkdir(binDir, { recursive: true });
+  const log = join(dir, "gh-calls.log");
+  await writeFile(
+    join(binDir, "gh"),
+    `#!/bin/sh
+printf '%s\\n' "$*" >> ${JSON.stringify(log)}
+case "$*" in
+  *"pr list"*)
+    printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]}]' ;;
+  *"/files"*)
+    printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
+  *)
+    printf '%s' '3' ;;
+esac
+`,
+  );
+  await chmod(join(binDir, "gh"), 0o755);
+
+  return { dir, sessions, binDir, log, git };
+}
+
+async function runBackfill(f: Awaited<ReturnType<typeof fixture>>, extra: string[] = []) {
+  const proc = Bun.spawn(
+    ["bun", BACKFILL, "--sessions-dir", f.sessions, "--out-dir", join(f.dir, "cards"), ...extra],
+    {
+      cwd: f.dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      // Prepend, never replace: `git` and `sh` are still needed.
+      env: { ...process.env, PATH: `${f.binDir}:${process.env.PATH}` },
+    },
+  );
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+
+  return { stdout, stderr };
+}
+
+test("backfill cards a marked subagent, and agrees with `card` on both figure and filename", async () => {
+  const f = await fixture({ withTranscript: true });
+  try {
+    await runBackfill(f);
+
+    // The stub was actually reached — without this the test passes just as well
+    // against the real `gh` failing on a PR number no repository has.
+    const calls = await readFile(f.log, "utf8");
+    expect(calls).toContain("pr list");
+    expect(calls).toContain(`repos/xchromo/osn/pulls/${PR}/files`);
+    expect(calls).toContain("--jq .commits");
+
+    // The filename `branchSlug` would produce, not the inline slug: a trailing
+    // dash is where the two used to differ.
+    const backfilled = JSON.parse(await readFile(join(f.dir, "cards", `${SLUG}.json`), "utf8")) as {
+      spend: { usd_equivalent: number; by_actor: Record<string, { tokens: { output: number } }> };
+    };
+
+    // Assert the marker path FIRST. Equality alone can pass vacuously: if
+    // ownership were broken for both tools they would agree on a number that
+    // never included the subagent at all.
+    expect(backfilled.spend.by_actor.subagent?.tokens.output).toBe(1000);
+    expect(backfilled.spend.by_actor.main?.tokens.output).toBe(0);
+
+    // Now the agreement the doc comment has only ever asserted in prose. Read
+    // the JSON: both tools print `toFixed(2)`, so comparing stdout compares
+    // two-decimal roundings.
+    const live = Bun.spawn(
+      [
+        "bun",
+        CARD,
+        "--branch",
+        BRANCH,
+        "--base",
+        "main",
+        "--sessions-dir",
+        f.sessions,
+        "--out-dir",
+        join(f.dir, "live"),
+      ],
+      { cwd: f.dir, stdout: "pipe", stderr: "pipe" },
+    );
+    await live.exited;
+
+    const liveCard = JSON.parse(await readFile(join(f.dir, "live", `${SLUG}.json`), "utf8")) as {
+      spend: { usd_equivalent: number };
+    };
+
+    expect(backfilled.spend.usd_equivalent).toBeGreaterThan(0);
+    expect(backfilled.spend.usd_equivalent).toBe(liveCard.spend.usd_equivalent);
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// `wiki/observability/session-metrics.md` §Backfilling states this rule and
+// nothing tested it: a zero-cost card is indistinguishable from a genuinely
+// cheap one once it is in the datalake, and it drags every average it touches.
+test("a merged PR with no local transcript is skipped, not written as a zero card", async () => {
+  const f = await fixture({ withTranscript: false });
+  try {
+    const { stdout } = await runBackfill(f);
+
+    expect(stdout).toContain("wrote 0 card(s)");
+    expect(stdout).toContain(String(PR));
+
+    // `mkdirSync` sits inside the write branch, so on a skip the directory is
+    // never created — assert absence, not emptiness.
+    expect(await Bun.file(join(f.dir, "cards", `${SLUG}.json`)).exists()).toBe(false);
+    const dir = Bun.spawnSync(["test", "-d", join(f.dir, "cards")]);
+    expect(dir.exitCode).not.toBe(0);
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+test("--dry-run reports what it would write and writes nothing", async () => {
+  const f = await fixture({ withTranscript: true });
+  try {
+    const { stdout } = await runBackfill(f, ["--dry-run"]);
+
+    expect(stdout).toContain("would write");
+    expect(stdout).toContain(`#${PR}`);
+    expect(await Bun.file(join(f.dir, "cards", `${SLUG}.json`)).exists()).toBe(false);
+
+    // The three `gh` calls run BEFORE the dry-run branch, so the stub is still
+    // exercised — a dry run is not an offline run.
+    const calls = await readFile(f.log, "utf8");
+    expect(calls).toContain("pr list");
+    expect(calls).toContain("--jq .commits");
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -10,7 +10,7 @@
 // spawns `sh -c ls`, so a replaced `PATH` loses them and every transcript
 // silently vanishes.
 
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +36,32 @@ test("numstatFromApi reshapes the GitHub API's file list into numstat lines", ()
   expect(diff.commits).toBe(2);
   expect(diff.loc.source).toEqual({ added: 10, deleted: 3 });
   expect(diff.loc.docs).toEqual({ added: 5, deleted: 0 });
+});
+
+// Git permits tabs and newlines in path names and the files API returns the
+// path verbatim, so a merged PR adding such a file could inject an extra record
+// into the numstat that `parseNumstat` then counts as a real file — its own
+// bucket, its own counts, its own entry in `card.diff.packages`.
+test("numstatFromApi drops a filename carrying the delimiters it formats with", () => {
+  const files: ChangedFile[] = [
+    { filename: "osn/api/src/real.ts", additions: 1, deletions: 0 },
+    { filename: "evil\n999\t999\tfake/injected.ts", additions: 1, deletions: 0 },
+    { filename: "also\tevil.ts", additions: 1, deletions: 0 },
+  ];
+
+  const lines = numstatFromApi(files).split("\n").filter(Boolean);
+
+  expect(lines).toEqual(["1\t0\tosn/api/src/real.ts"]);
+  expect(parseNumstat(numstatFromApi(files), 1).files.source).toBe(1);
+});
+
+/** Every temp directory this file makes, removed even when a fixture throws
+ * partway through — `fixture()` does ~20 awaits after `mkdtemp` and each one
+ * can reject, leaving a directory behind with an executable `gh` in it. */
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
 });
 
 const BACKFILL = new URL("../backfill.ts", import.meta.url).pathname;
@@ -71,6 +97,7 @@ async function projectDirFor(repo: string): Promise<string> {
  */
 async function fixture(options: { withTranscript: boolean; withBranch?: boolean }) {
   const dir = await mkdtemp(join(tmpdir(), "pr-metrics-backfill-"));
+  tempDirs.push(dir);
   // Identity through the environment and signing through `-c` rather than three
   // `git config` spawns: `fixture()` is the largest line item in this file's
   // runtime and every spawn here is paid five times.
@@ -210,7 +237,7 @@ async function fixture(options: { withTranscript: boolean; withBranch?: boolean 
   await writeFile(
     join(binDir, "gh"),
     `#!/bin/sh
-printf '%s\\n' "$*" >> ${JSON.stringify(log)}
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 case "$*" in
   *"pr list"*)
     printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]}]' ;;
@@ -253,6 +280,11 @@ async function runBackfill(f: Awaited<ReturnType<typeof fixture>>, extra: string
         GH_ENTERPRISE_TOKEN: "",
         GH_CONFIG_DIR: join(f.dir, "gh-config"),
         GH_NO_UPDATE_NOTIFIER: "1",
+        // The stub reads its log path from here rather than having it
+        // interpolated into its own source: `JSON.stringify` escapes `"` and
+        // `\` but leaves `$` and backticks live inside a double-quoted shell
+        // word, and this path descends from `TMPDIR`.
+        GH_CALL_LOG: f.log,
       },
     },
   );
@@ -381,7 +413,7 @@ test("backfill warns rather than silently overwriting when two branches share a 
     await writeFile(
       join(f.binDir, "gh"),
       `#!/bin/sh
-printf '%s\\n' "$*" >> ${JSON.stringify(f.log)}
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 case "$*" in
   *"pr list"*)
     printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]},{"number":9999,"headRefName":"${SLUG}","mergedAt":"2026-09-09T13:00:00Z","baseRefOid":"ccc","headRefOid":"ddd","labels":[],"closingIssuesReferences":[]}]' ;;
@@ -427,7 +459,7 @@ test("a failing `gh pr list` exits non-zero and says so, rather than carding not
     await writeFile(
       join(f.binDir, "gh"),
       `#!/bin/sh
-printf '%s\\n' "$*" >> ${JSON.stringify(f.log)}
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 echo "gh: could not authenticate" >&2
 exit 1
 `,


### PR DESCRIPTION
## Summary

`tools/pr-metrics/backfill.ts` recards merged pull requests in bulk and had no
test at all, so a renamed flag or a reshaped `--json` field would have surfaced
only as numbers nobody could check by hand across hundreds of cards. It now has
seven, and they found two real defects in the tool along the way.

The seam needs no production change: `sh()` spawns a bare `"gh"` with no `env`,
so a stub prepended to `PATH` answers all three calls and the tests exercise the
real argv the tool builds.

- **A latent slug divergence.** `backfill` named cards with a partial copy of
  `branchSlug`, missing its trailing `^-+|-+$` strip, so a branch name ending
  outside the slug's class made `backfill` and `card` write two different files
  for the same branch. Never fired: none of the 37 existing cards or 585 remote
  branches differs under the two slugs.
- **And the collision that fix bought.** `branchSlug` is not injective —
  `feat/x-`, `feat-x` and `feat/x` all slug to `feat-x` — and `backfill` writes
  up to `--limit` cards in one pass, so a clash silently overwrote the earlier
  card. It now warns with both branch names and skips.

## Workspaces affected

`@tools/pr-metrics`. One changeset, `patch`, naming that package alone.
`scripts/changeset-required.sh` returns `required` for this file list and
`validate-changesets.sh` passes. Note the class: `tools/pr-metrics/package.json`
carries no `version` field, so changesets treats it as version-less like
`@cire/*` — it must never share a changeset with a versioned package.

## Issues

**Closes**

| Issue | What |
|---|---|
| #944 | Add a test file for `tools/pr-metrics/backfill.ts` (T-M1) |

Closes #944

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#956 | Cut backfill's two serial `gh` round trips per PR (P-W1) — fixed by #957, stacked on this branch |

## Decisions

### The seam is a stubbed `gh` on `PATH`, and the stub is a control — `S-M1`

- **Issue** — the test spread `process.env` into the spawned backfill, so
  `GH_TOKEN` and `GH_CONFIG_DIR` reached it, and the only thing keeping the real
  `gh` from running was the stub being executable.
- **Why** — that fall-through happens on any exec failure, not just a bad mode:
  a `noexec` TMPDIR, a filesystem that drops the execute bit, an MDM policy.
  The suite would then go online with the developer's credentials and fail
  slowly for the wrong reason. The branch's own comment described the hazard,
  which is the author's intent, not a control.
- **Solution** — the tokens are blanked in the child environment, the
  executable bit is asserted before any spawn, and every test that spawns
  backfill reads the argv log.
- **Rationale** — the two halves fail independently: shadowing is the happy
  path, and blanked tokens mean a fall-through hits an unauthenticated `gh`,
  exits non-zero and fails the test offline instead of quietly online.

### Fixing the slug divergence bought a collision — `S-L4`

- **Issue** — moving the card filename onto `branchSlug` made `backfill` and
  `card` agree, but `branchSlug` is not injective.
- **Why** — `backfill` writes many cards in one pass where `card` writes one, so
  a clash silently overwrote the earlier card. That is indistinguishable from a
  pull request never backfilled — the same failure the file already refuses for
  zero-cost cards.
- **Solution** — read the card already at the path; when it names a different
  branch, warn with both names and skip.
- **Rationale** — `branchSlug` cannot be made injective without changing
  `card`'s filenames too, and agreement between the two tools is the point of
  the change. The check belongs at the write, where `backfill` alone can see the
  clash.

### The ownership gate was tested only where it admits — `T-E1`

- **Issue** — dropping `repoPaths` from backfill's `recordsByBranch` call left
  the whole suite green.
- **Why** — that option is what stops another checkout's transcript, MCP server
  and private skill names included, being attributed to a card this repository
  commits publicly. A positive-only fixture cannot tell a working scope check
  from one that admits everything. The package's one existing rejection test
  covers `readRecordsForBranch`, which backfill does not use.
- **Solution** — the fixture carries a second project directory this repo does
  not own, holding the same marker for the same branch and 9999 tokens. The
  assertion is 1000, never 10999.
- **Rationale** — deleting the option now fails two tests, which is the only
  thing that makes the git-repository apparatus in the fixture load-bearing
  rather than incidental.

### A test that passed against its own mutant — `T-E2`

- **Issue** — the new failing-`gh` test passed with the `!listed.ok` guard
  deleted.
- **Why** — Bun prints a source excerpt when a script throws, and that excerpt
  quotes the very `console.error` line the test matched on, so `toContain` over
  the whole stream cannot tell the handled path from a crash.
- **Solution** — read the first line of stderr only.
- **Rationale** — worth recording rather than quietly fixing: it is a false
  pass that no amount of reading the test would have revealed, and mutation is
  what found it.

### Filenames carrying the delimiters they are formatted with — `S-L3`

- **Issue** — `numstatFromApi` formatted GitHub's filenames into a tab- and
  newline-delimited record with no escaping, over an unchecked cast.
- **Why** — git permits both characters in a path and the files API returns it
  verbatim, so a merged PR adding such a file injected an extra record that
  `parseNumstat` counted as a real file: its own bucket, counts and package
  entry.
- **Solution** — drop such names with a warning.
- **Rationale** — losing one row of a diff summary beats corrupting the card,
  and the alternative (escaping) would need `parseNumstat` to learn to unescape.

### P-W1 goes to a linked follow-up, not this branch — `P-W1`

- **Issue** — `backfill.ts` makes two blocking `gh` round trips per pull
  request, serially: measured 1.51 s per PR, so roughly 150 s and 201 `gh`
  invocations at its shipped `--limit 100`.
- **Why** — it is `high`, so the review rules forbid filing it and continuing.
  It is also pre-existing and a different concern from adding a test file, and
  folding a performance rewrite of the tool into a test-focused branch is what
  Step 5 exists to catch.
- **Solution** — **#957**, opened immediately and stacked on this branch. It is
  measured end to end: `--dry-run --limit 25` against the real API goes 14.87 s
  to 3.75 s with byte-identical output, and the GraphQL counts match the REST
  scalar they replace across 12 real pull requests.
- **Rationale** — the measured fix is a hand-written `gh api graphql` query
  folding in `commits{totalCount}` plus concurrent `/files` calls, taking the
  run to about 24 s. Two naive folds were tried and rejected on measurement:
  `gh pr list --json commits` fails outright on GitHub's GraphQL node limit at
  `--limit 50`, and `gh pr list --json files` silently truncates at 100 files.
  That is enough design to deserve its own stress-test rather than riding along
  here.

### Sharing the fixture was considered and rejected — `P-I1`

- **Issue** — the `withTranscript: true` fixture is built four times
  identically, about 426 ms of duplication.
- **Why** — sharing looks like an obvious saving.
- **Solution** — not shared. P-W2's cheaper fixture was taken instead: identity
  through `GIT_AUTHOR_*` rather than three `git config` spawns, and the branch
  half made opt-in since only one test runs `card`. The file went from 1085 ms
  to about 750 ms.
- **Rationale** — the out-dir, the `gh` call log and the in-place `bin/gh`
  rewrites are all per-test, so a shared fixture would make the dry-run
  assertions vacuous and couple the file to its declaration order. A saving that
  makes assertions vacuous is not a saving.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Tests | `bun run --cwd tools/pr-metrics test` | `108 pass, 0 fail`, 6 files |
| Type check | `bun run --cwd tools/pr-metrics check` | `tsc --noEmit`, no diagnostics |
| Lint | `bun run lint` | 0 errors in `tools/pr-metrics` |
| Format | `bun run fmt:check` | clean, 1471 files |
| Changeset | `scripts/changeset-required.sh` over the branch's file list | `required`; `validate-changesets.sh` passes |
| Comment delta | `bun run scripts/comment-delta.ts origin/main` | +126 lines — a new test file and its reasoning; no existing comment was rewritten |
| Build | — | the package has no `build` script; it runs as source and `check` stands in |

Every guard this branch adds was verified by mutation rather than by reading:

- reverting the slug fix fails 1 test;
- removing the skip-when-no-transcript rule fails 1;
- deleting `repoPaths` from backfill's reader fails 2, on `1000` vs `10999`;
- bypassing the `!listed.ok` guard fails 1 — and did **not**, in the first
  version of that test, which is why the assertion reads only the first line of
  stderr.

Not verified: the `gh` stub is exercised only where the real `gh` is absent from
the spawned process's resolution order. The blanked tokens mean a fall-through
fails offline rather than going online, but no test forces that fall-through —
proving it would mean making the stub unexecutable on purpose, which is a
platform-dependent thing to assert.
<details><summary>Session metrics — $11.63 · 14.1M tok · complexity 2 · +51/-4 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $11.63 |
| Tokens | 14.1M — out 10.4K · cache-w 486.3K · cache-r 13.6M (96%) |
| Models | claude-opus-5 (74%), claude-fable-5-1 (26%) |
| Active time | 30m over 1 session(s) |
| Declared complexity | 2 |
| Source diff | +51/-4 across 1 file(s), 1 package(s) |
| Turns | 0 (0 corrective) |
| Before first edit | not observed (no edit seen in the transcript) |
| Subagents | none |

<sub>Card: `.claude/metrics/test-pr-metrics-backfill.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3oFqUaGv1KNeC2X6ZBnrL
