### PR TITLE
perf(tools): batch backfill's GitHub calls instead of two per PR

### DIFF
--- a/.changeset/backfill-batched-gh.md
+++ b/.changeset/backfill-batched-gh.md
@@ -1,0 +1,8 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Batch `backfill`'s GitHub calls: commit counts come from one GraphQL document
+per 50 pull requests instead of a REST call each, and the changed-file lists are
+fetched eight at a time rather than serially. A `--limit 25` dry run goes from
+14.87s to 3.75s with identical output.

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -101,6 +101,113 @@ function readCardBranch(path: string): string | null {
   }
 }
 
+/** `gh`, asynchronously, so several calls can be in flight at once. `sh` stays
+ * for the one call that has to finish before anything else can start. */
+async function ghAsync(command: string[]): Promise<CommandResult> {
+  const proc = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+  const [out] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+
+  return { ok: proc.exitCode === 0, out };
+}
+
+/** How many `gh api` calls are allowed in flight. Enough to hide the round-trip
+ * latency that dominates here, low enough not to look like a burst to the API. */
+const FILE_FETCH_CONCURRENCY = 8;
+
+/** How many pull requests one GraphQL document asks about.
+ *
+ * Not `--limit`: GitHub costs a query by the nodes it could return, and
+ * `gh pr list --json commits` — which fetches every listing field per node —
+ * fails that limit outright at 50. One aliased `commits{totalCount}` per pull
+ * request is far cheaper than that, but the ceiling is real and undocumented,
+ * so the document is chunked rather than assumed to fit.
+ */
+const COMMIT_QUERY_CHUNK = 50;
+
+/**
+ * The commit count of every given pull request, in one GraphQL document per
+ * chunk rather than one REST call each.
+ *
+ * `gh api repos/…/pulls/:n --jq .commits` costs a round trip per pull request —
+ * measured 7.41 s for ten — and the numbers are independent of everything else
+ * the loop does, so there is no reason to fetch them one at a time.
+ */
+async function commitCounts(repo: string, numbers: number[]): Promise<Map<number, number>> {
+  const [owner, name] = repo.split("/");
+  const counts = new Map<number, number>();
+
+  for (let i = 0; i < numbers.length; i += COMMIT_QUERY_CHUNK) {
+    const chunk = numbers.slice(i, i + COMMIT_QUERY_CHUNK);
+    const fields = chunk
+      .map((n) => `p${n}: pullRequest(number: ${n}) { commits { totalCount } }`)
+      .join("\n      ");
+
+    const result = await ghAsync([
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=query { repository(owner: "${owner}", name: "${name}") { ${fields} } }`,
+    ]);
+
+    if (!result.ok) continue;
+
+    let parsed: { data?: { repository?: Record<string, { commits?: { totalCount?: number } }> } };
+    try {
+      parsed = JSON.parse(result.out) as typeof parsed;
+    } catch {
+      continue;
+    }
+
+    for (const n of chunk) {
+      const total = parsed.data?.repository?.[`p${n}`]?.commits?.totalCount;
+      if (typeof total === "number") counts.set(n, total);
+    }
+  }
+
+  return counts;
+}
+
+/** The changed-file list of every given pull request, a bounded number of
+ * requests at a time. The list has to stay on the paginated REST endpoint:
+ * `gh pr list --json files` silently truncates at 100 files, and this
+ * repository already has a pull request with 289. */
+async function fileLists(repo: string, numbers: number[]): Promise<Map<number, ChangedFile[]>> {
+  const lists = new Map<number, ChangedFile[]>();
+  const queue = [...numbers];
+
+  const worker = async () => {
+    for (let n = queue.shift(); n !== undefined; n = queue.shift()) {
+      const result = await ghAsync([
+        "gh",
+        "api",
+        "--paginate",
+        `repos/${repo}/pulls/${n}/files`,
+        "--jq",
+        ".[] | {filename, additions, deletions}",
+      ]);
+
+      lists.set(
+        n,
+        result.out
+          .split("\n")
+          .filter(Boolean)
+          .flatMap((line) => {
+            try {
+              return [JSON.parse(line) as ChangedFile];
+            } catch {
+              return [];
+            }
+          }),
+      );
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(FILE_FETCH_CONCURRENCY, queue.length) }, worker));
+
+  return lists;
+}
+
 if (import.meta.main) {
   const repo = flag("repo") ?? "xchromo/osn";
   const limit = flag("limit") ?? "100";
@@ -137,49 +244,48 @@ if (import.meta.main) {
   const skipped: number[] = [];
   let written = 0;
 
+  // No transcript means the work happened on another machine, or before this
+  // machine's logs begin. Writing a zero-cost card would put a row in the
+  // datalake that reads exactly like a genuinely cheap pull request — so those
+  // are dropped here, before anything is fetched for them.
+  const carded = pulls.filter((pull) => (byBranch.get(pull.headRefName)?.length ?? 0) > 0);
   for (const pull of pulls) {
-    const records = byBranch.get(pull.headRefName);
+    if (!carded.includes(pull)) skipped.push(pull.number);
+  }
 
-    // No transcript means the work happened on another machine, or before this
-    // machine's logs begin. Writing a zero-cost card would put a row in the
-    // datalake that reads exactly like a genuinely cheap pull request.
-    if (!records || records.length === 0) {
-      skipped.push(pull.number);
-      continue;
-    }
+  // Both fetches happen up front rather than twice per iteration. Neither
+  // depends on the other's result, and the loop's own work is local.
+  const numbers = carded.map((pull) => pull.number);
+  const [counts, files] = await Promise.all([
+    commitCounts(repo, numbers),
+    fileLists(repo, numbers),
+  ]);
 
-    const filesResult = sh([
-      "gh",
-      "api",
-      "--paginate",
-      `repos/${repo}/pulls/${pull.number}/files`,
-      "--jq",
-      ".[] | {filename, additions, deletions}",
-    ]);
-
-    const files = filesResult.out
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as ChangedFile);
+  for (const pull of carded) {
+    const records = byBranch.get(pull.headRefName) ?? [];
 
     const labels = pull.labels.map((label) => label.name);
     const complexity = declaredFromLabels(labels);
-    const commits = sh(["gh", "api", `repos/${repo}/pulls/${pull.number}`, "--jq", ".commits"]);
+    const changed = files.get(pull.number) ?? [];
 
-    const card = buildCard(records, parseNumstat(numstatFromApi(files), Number(commits.out) || 0), {
-      branch: pull.headRefName,
-      prNumber: pull.number,
-      issueNumber: pull.closingIssuesReferences[0]?.number ?? null,
-      issueType: null,
-      issueLabels: labels,
-      declaredComplexity: complexity.declared,
-      complexityMethod: complexity.method,
-      baseSha: pull.baseRefOid,
-      headSha: pull.headRefOid,
-      mergedAt: pull.mergedAt,
-      phase: "at-merge",
-      generatedAt: new Date().toISOString(),
-    });
+    const card = buildCard(
+      records,
+      parseNumstat(numstatFromApi(changed), counts.get(pull.number) ?? 0),
+      {
+        branch: pull.headRefName,
+        prNumber: pull.number,
+        issueNumber: pull.closingIssuesReferences[0]?.number ?? null,
+        issueType: null,
+        issueLabels: labels,
+        declaredComplexity: complexity.declared,
+        complexityMethod: complexity.method,
+        baseSha: pull.baseRefOid,
+        headSha: pull.headRefOid,
+        mergedAt: pull.mergedAt,
+        phase: "at-merge",
+        generatedAt: new Date().toISOString(),
+      },
+    );
 
     // `branchSlug`, not a copy of its first step: the inline version omitted
     // the trailing `^-+|-+$` strip, so a branch name ending in a character

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -241,6 +241,8 @@ printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 case "$*" in
   *"pr list"*)
     printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]}]' ;;
+  *"api graphql"*)
+    printf '%s' '{"data":{"repository":{"p${PR}":{"commits":{"totalCount":3}}}}}' ;;
   *"/files"*)
     printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
   *)
@@ -309,7 +311,9 @@ test("backfill cards a marked subagent, and agrees with `card` on both figure an
     const calls = await readFile(f.log, "utf8");
     expect(calls).toContain("pr list");
     expect(calls).toContain(`repos/xchromo/osn/pulls/${PR}/files`);
-    expect(calls).toContain("--jq .commits");
+    // One batched GraphQL document, not a REST call per pull request.
+    expect(calls).toContain("api graphql");
+    expect(calls).not.toContain("--jq .commits");
 
     // The filename `branchSlug` would produce, not the inline slug: a trailing
     // dash is where the two used to differ.
@@ -395,7 +399,7 @@ test("--dry-run reports what it would write and writes nothing", async () => {
     // exercised — a dry run is not an offline run.
     const calls = await readFile(f.log, "utf8");
     expect(calls).toContain("pr list");
-    expect(calls).toContain("--jq .commits");
+    expect(calls).toContain("api graphql");
   } finally {
     await rm(f.dir, { recursive: true, force: true });
   }
@@ -417,6 +421,8 @@ printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 case "$*" in
   *"pr list"*)
     printf '%s' '[{"number":${PR},"headRefName":"${BRANCH}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","labels":[],"closingIssuesReferences":[]},{"number":9999,"headRefName":"${SLUG}","mergedAt":"2026-09-09T13:00:00Z","baseRefOid":"ccc","headRefOid":"ddd","labels":[],"closingIssuesReferences":[]}]' ;;
+  *"api graphql"*)
+    printf '%s' '{"data":{"repository":{"p${PR}":{"commits":{"totalCount":3}},"p9999":{"commits":{"totalCount":1}}}}}' ;;
   *"/files"*)
     printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
   *)
@@ -481,6 +487,26 @@ exit 1
     expect(firstLine).toContain("pr-metrics backfill:");
     expect(firstLine).toContain("authenticated");
     expect(await Bun.file(join(f.dir, "cards", `${SLUG}.json`)).exists()).toBe(false);
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// The whole point of the batching: `gh` invocations must grow with the number of
+// pull requests once, not twice. Before this, a `--limit 100` run made 201 calls
+// and took about 150 s; the count is what stops that returning unnoticed.
+test("one gh call per carded PR for files, plus one batched query, and no per-PR commits call", async () => {
+  const f = await fixture({ withTranscript: true });
+  try {
+    await runBackfill(f);
+
+    const calls = (await readFile(f.log, "utf8")).split("\n").filter(Boolean);
+
+    // `pr list`, one `api graphql`, one `/files` for the single carded PR.
+    expect(calls).toHaveLength(3);
+    expect(calls.filter((c) => c.includes("api graphql"))).toHaveLength(1);
+    expect(calls.filter((c) => c.includes("/files"))).toHaveLength(1);
+    expect(calls.filter((c) => c.includes("--jq .commits"))).toHaveLength(0);
   } finally {
     await rm(f.dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

`backfill.ts` made two blocking `gh` round trips per pull request, one after the
other, and neither call's key came from the other's result. At the shipped
`--limit 100` that is about 201 `gh` invocations and roughly 150 s of waiting.

Commit counts now come from one `gh api graphql` document per 50 pull requests —
an aliased `commits{totalCount}` each — and the changed-file lists are fetched
eight at a time. Both prefetches run once, before the loop.

- A pull request with no local transcript now costs **no request at all**. It was
  already skipped, but only after both calls had been made for it.
- Measured `--dry-run --limit 25` against the real API: **14.87 s → 3.75 s**,
  byte-identical output including all eight dollar figures.

## Workspaces affected

`@tools/pr-metrics`. One changeset, `patch`, naming that package alone;
`scripts/changeset-required.sh` returns `required` for this branch's file list
and `validate-changesets.sh` passes.

## Issues

**Closes**

| Issue | What |
|---|---|
| #956 | Cut backfill's two serial `gh` round trips per PR to one batched query (P-W1) |

Closes #956

**Opened**

| Issue | What |
|---|---|
| — | None |

## Decisions

### Why a hand-written GraphQL document and not a `--json` field — `P-W1`

- **Issue** — the obvious fold is to add the commit count to the `gh pr list`
  call that already runs, or to take the file list from it too.
- **Why** — both fail, and quietly enough to be worth recording rather than
  rediscovering.
- **Solution** — `gh pr list --json commits` fails GitHub's GraphQL node limit
  outright at `--limit 50`, so the count cannot join the listing. And
  `gh pr list --json files` **silently truncates at 100 files** — this
  repository already has a pull request with 289 — so the file list has to stay
  on the paginated REST endpoint. What remains is one hand-written
  `gh api graphql` document for the counts, plus concurrency for the files.
- **Rationale** — the truncation is the dangerous one: it returns a plausible
  answer, so a card built on it would under-report a large diff with nothing to
  show anything went wrong. Both are noted in the code at the point someone
  would try them.

### The document is chunked at 50, and that number is not `--limit` — `approach`

- **Issue** — a single document asking about every pull request would be
  simpler.
- **Why** — GitHub costs a query by the nodes it could return, and the ceiling
  is real but undocumented for this shape.
- **Solution** — chunk at 50 aliases per document.
- **Rationale** — one `commits{totalCount}` per alias is far cheaper than the
  full listing node that fails at 50, so 50 is conservative rather than
  measured-to-the-edge. Chunking also means a larger `--limit` degrades into
  more documents rather than one failure.

### Concurrency is bounded, and the output order is not — `approach`

- **Issue** — an unbounded `Promise.all` over `--limit` entries would burst the
  API.
- **Solution** — eight workers pulling from a shared queue; results land in a
  `Map` keyed by pull-request number, and the card loop still walks the original
  listing order.
- **Rationale** — the per-pull-request console output and the order cards are
  written in are both unchanged, which is what makes the before/after outputs
  comparable byte for byte.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Tests | `bun run --cwd tools/pr-metrics test` | `109 pass, 0 fail`, 6 files |
| Type check | `bun run --cwd tools/pr-metrics check` | `tsc --noEmit`, no diagnostics |
| Lint | `bun run lint` | 0 errors in `tools/pr-metrics` |
| Format | `bun run fmt:check` | clean, 1471 files |
| Changeset | `scripts/changeset-required.sh` over the branch's file list | `required`; `validate-changesets.sh` passes |

Exercised against the real GitHub API, not only the stub:

- **Correctness of the replacement**: the GraphQL `commits{totalCount}` was
  compared against the `gh api …/pulls/:n --jq .commits` scalar it replaces
  across 12 real merged pull requests — **0 mismatches**.
- **End to end**: `--dry-run --limit 25` run under both the parent branch's code
  and this one, same machine, same input — 14.87 s against 3.75 s, and the eight
  `would write` lines match exactly, dollar figures included.
- A test pins the call count: one `pr list`, one `api graphql`, one `/files` per
  carded pull request, and zero per-PR commits calls. That count is what stops
  the serial version returning unnoticed.

Not verified: no run has been made at the full `--limit 100`, so the 150 s → 24 s
figure from the review is extrapolated from the 25-PR measurement above rather
than observed. The chunking boundary at 50 aliases has likewise not been crossed
by a real run — 25 pull requests fit in one document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3oFqUaGv1KNeC2X6ZBnrL
