### PR TITLE
feat(shared): RFC 6238 TOTP primitives on a @shared/crypto/totp subpath

### DIFF
--- a/.changeset/shared-crypto-totp.md
+++ b/.changeset/shared-crypto-totp.md
@@ -1,0 +1,33 @@
+---
+"@shared/crypto": minor
+---
+
+RFC 6238 TOTP primitives on a new `@shared/crypto/totp` subpath: secret
+generation, RFC 4648 base32 both ways, the `otpauth://` URI an authenticator
+app scans, code derivation and verification. No new dependency — base32 is
+forty lines and HMAC-SHA-1 is in WebCrypto, which Bun, Node and workerd all
+carry.
+
+The subpath is the point. `src/index.ts` does not re-export any of it, because
+the barrel reaches `@osn/db` and `drizzle-orm` through the ARC helpers, and a
+caller deriving six digits should not load a database driver to do it. The
+module imports `./timing-safe` and nothing else, and a test resolves
+`@shared/crypto/totp` through the package's own `exports` map so a typo in that
+map fails the suite rather than the first consumer.
+
+Correctness rests on published vectors rather than on ones we chose: RFC 4226
+Appendix D counters 0 to 9, all six SHA-1 rows of RFC 6238 Appendix B, and the
+RFC 4648 §10 base32 strings in both directions. The base32 vectors earn their
+place — a codec that is self-consistent but wrong, bits regrouped the wrong way
+or the alphabet permuted, passes every round-trip test and is first noticed by
+an authenticator app at enrolment.
+
+`verifyTotpCode` derives every candidate in the drift window and compares all
+of them with `timingSafeEqualString`, with no early return, so a valid and an
+invalid six-digit code do the same work. It never throws: a malformed code, a
+secret under RFC 4226's 128-bit floor, and an unusable date are all `false`,
+and the drift window is clamped at both ends so a caller cannot choose how much
+CPU one verification spends. `base32Decode` validates before it case-folds —
+uppercasing maps `ß` to `SS` and `ſ` to `S`, so the other order would admit
+characters that are not in the alphabet — and its error message names no part
+of its input, which is a secret.

--- a/.changeset/shared-crypto-totp.md
+++ b/.changeset/shared-crypto-totp.md
@@ -3,10 +3,10 @@
 ---
 
 RFC 6238 TOTP primitives on a new `@shared/crypto/totp` subpath: secret
-generation, RFC 4648 base32 both ways, the `otpauth://` URI an authenticator
-app scans, code derivation and verification. No new dependency — base32 is
-forty lines and HMAC-SHA-1 is in WebCrypto, which Bun, Node and workerd all
-carry.
+generation, RFC 4648 base32 both ways, `parseTotpSecret` for the base32 a user
+types back, the `otpauth://` URI an authenticator app scans, code derivation
+and verification. No new dependency — base32 is forty lines and HMAC-SHA-1 is
+in WebCrypto, which Bun, Node and workerd all carry.
 
 The subpath is the point. `src/index.ts` does not re-export any of it, because
 the barrel reaches `@osn/db` and `drizzle-orm` through the ARC helpers, and a
@@ -27,7 +27,20 @@ of them with `timingSafeEqualString`, with no early return, so a valid and an
 invalid six-digit code do the same work. It never throws: a malformed code, a
 secret under RFC 4226's 128-bit floor, and an unusable date are all `false`,
 and the drift window is clamped at both ends so a caller cannot choose how much
-CPU one verification spends. `base32Decode` validates before it case-folds —
-uppercasing maps `ß` to `SS` and `ſ` to `S`, so the other order would admit
-characters that are not in the alphabet — and its error message names no part
-of its input, which is a secret.
+CPU one verification spends. A secret under the floor is run against a fixed
+dummy secret rather than returned on, so `false` costs the same whether the
+account has TOTP enrolled or not — "not enrolled" is an absent or empty secret
+in every schema shape this sits behind, and the fast path would have answered
+that question to anyone who could reach the route.
+
+`base32Decode` validates before it case-folds — uppercasing maps `ß` to `SS`
+and `ſ` to `S`, so the other order would admit characters that are not in the
+alphabet — and its error message names no part of its input, which is a secret.
+It refuses input over 512 characters before scanning it, since the length is an
+unauthenticated caller's choice and decoding is linear in it. It stays a
+general codec, returning whatever bytes the input carries: the 128-bit floor
+lives in `parseTotpSecret`, which is what an enrolment route wants, because a
+one-character input decodes to zero bytes without error. `totpUri` enforces the
+same floor rather than committing an unusable secret to a QR code, and its
+return value is documented as secret material — the shape most likely to be
+logged carries the whole secret.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ One label is orthogonal to all of that: **`needs:decision`**, on both repos. It 
 | Write new Effect service or Elysia route | `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]` |
 | Write Effect code (v4 — the v3 forms that no longer compile, and what to write instead) | `[[wiki/architecture/effect-v4-api]]`, then `[[wiki/architecture/backend-patterns]]`, `[[wiki/architecture/schema-layers]]`, `[[wiki/conventions/testing-patterns]]` |
 | Understand accounts, profiles, orgs | `[[wiki/systems/identity-model]]` |
+| Get a locked-out account back in (TOTP, email-verified recovery, the restricted `osn-recovery` session, the provenance cooldown) | `[[wiki/architecture/account-recovery-factors]]` |
 | Add or verify ARC S2S tokens | `[[wiki/systems/arc-tokens]]` |
 | Let another app sign a user in with their OSN account (OIDC, PKCE, consent, pairwise `sub`) | `[[wiki/systems/oidc-provider]]` |
 | Add a handle/name search (query normalisation, LIKE escaping, index-friendly prefix ranges — use `@shared/db-utils/search`, never a hand-rolled `LIKE 'q%'`) | `[[wiki/systems/social-graph]]` §Search |

--- a/docs/superpowers/specs/2026-09-09-account-recovery-factors-design.md
+++ b/docs/superpowers/specs/2026-09-09-account-recovery-factors-design.md
@@ -1,0 +1,250 @@
+# Design — additional account-access factors (TOTP + email-verified recovery)
+
+Status: **amended after stress-plan**. Author: orchestrate run 2026-09-09.
+Revision 2 — every finding from the attack pass is closed below, in the text.
+
+## Problem
+
+An OSN account is reachable by exactly two things: a WebAuthn credential, or
+one of ten recovery codes. Both live on objects a person can lose in one
+event. A user whose only phone is lost or wiped, and who never printed the
+recovery codes, is locked out permanently. There is no support-side reset and
+no second independent factor.
+
+## Non-goals, and the decision they preserve
+
+`wiki/systems/passkey-primary.md` records that OTP and magic-link **primary
+login were removed on purpose**. Nothing here reinstates them. No new factor
+mints an ordinary session, and no new factor becomes a login factor. Phishing
+resistance of the sign-in path is unchanged.
+
+Out of scope: SMS, support-operated resets, trusted-contact recovery, and any
+change to cire or pulse (they inherit through OIDC).
+
+## What is added
+
+### A. TOTP (RFC 6238), enrolled from an authenticator app
+
+Independent of both the mailbox and the passkey device, and usable offline.
+Two roles, and the second is what makes it worth building:
+
+1. **A step-up factor** — at named purposes only, see §D.
+2. **A recovery factor** — `POST /login/recovery/totp/complete` mints the same
+   restricted recovery session §B describes. This is settled, not optional: a
+   step-up-only TOTP would do nothing for the problem statement, since it is
+   reachable only by someone already signed in.
+
+TOTP is not a login factor.
+
+### B. Recovery ends in a restricted session, enforced by audience
+
+`POST /login/recovery/email/begin` takes an **email identifier only** (not a
+handle — a handle is public and this endpoint sends mail) and always returns
+the same 202. Where it resolves, a code goes to the address on file.
+
+`POST /login/recovery/email/complete` and `POST /login/recovery/totp/complete`
+exchange the factor for a **restricted recovery session**.
+
+The restriction is a **distinct token audience**, not a flag:
+
+- The access token is minted with `aud: "osn-recovery"`, and `osn-recovery` is
+  added to the reserved OIDC client-id deny-list.
+- Every existing verifier already pins `aud === "osn-access"` — the four
+  osn-api entry points and the three downstream services verifying over JWKS
+  (`pulse/api`, `zap/api`, `cire/api` through `@shared/osn-auth-client`). All
+  seven therefore reject it with **no change to any of them**. This is the
+  whole reason for the audience: a boolean claim on an `osn-access` token
+  would be fail-open at every verifier not individually updated, three of
+  which deploy on someone else's cadence.
+- `resolvePasskeyEnrollPrincipal` is the **only** resolver taught to accept the
+  new audience.
+- `sessions.restrictedUntil` exists as the source of truth for **rotation**:
+  `refreshTokens` copies it forward and re-mints with the recovery audience
+  while it is set. `completePasskeyRegistration` clears it. Without this the
+  restriction would expire on the first silent refresh, five minutes in.
+- The restricted session gets a **short absolute `expiresAt` (15 minutes) and
+  no sliding extension**. A credential with exactly one purpose must not
+  outlive the window in which that purpose is plausible, and a 30-day sliding
+  session that can do nothing is a dead end that also consumes a slot against
+  `MAX_SESSIONS_PER_ACCOUNT`.
+- `/login/recovery/email/complete` sets the session cookie exactly as
+  `/login/recovery/complete` does, or `completePasskeyRegistration`'s
+  other-session sweep cannot resolve the caller and returns `session_stale`.
+
+**The enrolment gate.** `beginPasskeyRegistration` refuses without a
+`passkey_register` step-up whenever the account has ≥1 passkey — which is the
+*common* recovery case, since losing a phone does not delete its passkey row.
+A recovery-audience token therefore **bypasses that step-up**: the email OTP or
+TOTP code that minted the session already was a ceremony, at an AMR strength
+`passkeyRegisterAllowedAmr` accepts today. The alternative — letting a
+restricted session mint step-up tokens — would let it reach
+`/recovery/generate`, `DELETE /account`, `GET /account/export` and
+`/account/email/complete`, i.e. everything the restriction claims to prevent.
+
+### C. Recovery is loud — most of which already exists
+
+`consumeRecoveryCode` **already** deletes every session on the account, writes
+a `recovery_code_consume` security event and detaches a `recovery-consumed`
+notice. That is not new scope. What is new:
+
+- Email and TOTP recovery must **match** that existing behaviour.
+- A **provenance-aware cooldown**, added to all three recovery paths.
+
+### D. The cooldown, by provenance — not a global lock
+
+A global 72-hour lock on `passkey_delete` and `email_change` after any recovery
+protects the wrong party. Trace it: an attacker with the mailbox recovers,
+every other session is revoked, they enrol their own passkey (satisfying the
+`passkey_register` step-up with an OTP to the mailbox they now own). The owner
+signs in with their real passkey, sees the notice — and cannot delete the
+attacker's credential or move off the compromised mailbox for three days. The
+attacker moved first, so a symmetric lock hands them the window. The
+lost-device case fails the same way: the owner cannot revoke the passkey on the
+stolen phone.
+
+So the cooldown is asymmetric:
+
+- A step-up token whose AMR came from a credential that **predates** the
+  recovery may delete any passkey and change the email **immediately**. That is
+  the owner acting, and a pre-recovery passkey is exactly the proof of
+  ownership that should unlock action.
+- A step-up minted from the **recovery-enrolled** credential, or from OTP, may
+  not delete pre-recovery passkeys or change the email for 72 hours.
+- **One recovery per 72 hours per account**, so the mailbox holder cannot
+  simply re-run it.
+- The `recovery-used` notice carries a **"this wasn't me"** path that revokes
+  the recovery-enrolled credential and the recovery session family. Without
+  this the owner has a warning and no lever.
+
+`wiki/runbooks/musubi-identity-migration.md` step 8 walks an operator through
+recovery-login → OTP step-up → enrol passkey → delete the old passkeys. Under a
+global lock that runbook breaks; under the asymmetric rule it still works,
+because the operator's step-up comes from the pre-recovery credential. The
+runbook is re-checked and updated in the same PR as the cooldown.
+
+## Shape of the change
+
+| Area | Change |
+|---|---|
+| `@shared/crypto` | New `totp.ts` on its **own subpath export** (`./totp`, like `./timing-safe`) so it does not drag `@osn/db` in through the barrel. Base32 gen/encode/decode, RFC 6238 over WebCrypto HMAC-SHA1, ±1 step drift, constant-time compare. No new npm dependency, so no 3-day soak. |
+| `@osn/db` | `totpCredentials` (`secretCiphertext`, `iv`, `keyVersion`, `confirmedAt`, `lastUsedAt`). `sessions.restrictedUntil`. `passkeys.enrolledViaRecoveryAt`. `accounts.lastRecoveredAt`. Migrations number sequentially from `0007_`. |
+| `@osn/api` | TOTP service + step-up-gated routes; the `osn-recovery` audience and its rotation carry-forward; email + TOTP recovery routes; provenance cooldown; new limiters; new security-event kinds. |
+| `@shared/email` | `totp-enrolled`, `totp-disabled`, `otp-recovery`, `recovery-used`. |
+| `@osn/client` | `TotpClient`; `RecoveryClient.emailRecoveryBegin/Complete`, `totpRecoveryComplete`. Ships **with its API phase**, not in a trailing PR. |
+| `@osn/ui` / `@osn/social` | `<TotpView>` in Settings → Security; TOTP factor in `<StepUpDialog>`; "email me a code" on `<RecoveryLoginForm>`. |
+
+### TOTP secrets at rest
+
+"Store only what verification needs" is not available — RFC 6238 verification
+needs the raw HMAC key. Plaintext in D1 is not acceptable either: it would be
+the weakest secret in a schema where recovery codes are hashed, session tokens
+are hashed and IPs are HMAC-peppered, and a dump would yield a working step-up
+factor for every enrolled account.
+
+So: a new Worker secret `OSN_TOTP_ENCRYPTION_KEY` (32 random bytes, base64),
+per environment, imported once in `build-deps.ts` as an AES-GCM `CryptoKey` and
+carried on `AuthConfig` — exactly the shape `OSN_SESSION_IP_PEPPER` already
+uses, including **failing closed at boot** in non-local tiers when absent. The
+Worker's secrets and its database are separate trust domains. The pending,
+not-yet-confirmed secret during enrolment lives in a `CeremonyStores` entry
+with a Redis variant, never in D1.
+
+### Which step-up allow-lists admit `totp`
+
+There is no single gate; there are three allow-lists, and one is deliberately
+WebAuthn-only. Naming them is not optional.
+
+| Allow-list | Admits `totp`? |
+|---|---|
+| `passkeyRegisterAllowedAmr` | **Yes** |
+| `recoveryGenerateAllowedAmr` | **Yes** |
+| `passkeyDeleteAllowedAmr` | **No — stays `["webauthn"]`** |
+
+`passkeyDelete` gates both `DELETE` and `PATCH /passkeys/:id`. Its existing
+rationale holds with TOTP present: the caller necessarily holds a passkey, so
+requiring one costs nothing. Admitting TOTP there would make a stolen access
+token plus a cloud-synced authenticator seed enough to delete the victim's real
+passkeys — which the cooldown would then stop the victim undoing.
+
+Three knock-on edits an implementer will otherwise miss:
+
+- The AMR arrays are typed `readonly ("webauthn" | "otp")[]` at three sites in
+  `config.ts`. Adding `totp` is a type widening, not a one-line join.
+- `issueStepUpToken` maps factor to AMR with a **two-branch ternary** whose
+  else-arm is `"recovery"`. A `totp` factor added to `StepUpFactor` without
+  touching that line mints `amr: ["recovery"]`, which no allow-list admits.
+- `<StepUpDialog>`'s `passkeyOnly` prop needs a defined meaning with a third
+  factor present.
+
+TOTP **enrolment and disable are themselves step-up gated**, for the same
+reason passkey registration is: a stolen access token must not silently bind an
+attacker's seed.
+
+### Enumeration, timing and flood control on `/login/recovery/email/begin`
+
+A uniform 202 is not sufficient here. Every existing OTP send *awaits* the
+provider call, and a Resend round-trip is hundreds of milliseconds against a
+sub-millisecond probe — the send itself is the oracle. And the recipient is the
+account's own address, so an unthrottled endpoint floods the victim's inbox.
+
+- Dispatch the send **detached with a timeout**, the pattern `notifyRecovery`
+  already uses, so both branches return at probe cost.
+- Add a **per-resolved-account cap** (3 per 24 h) through the existing
+  `AccountCapLimiter` family, keyed on `accountId` — never on the submitted
+  identifier — and still answering 202 when exceeded. Per-IP limits alone are
+  defeated by a rotating fleet, which this issuer already sees.
+- Extend the turnstile endpoint literal union and gate `begin`.
+- Complete side: 6-digit code, existing `MAX_OTP_ATTEMPTS` per entry, per-account
+  lockout reusing the `recovery-lockout-store.ts` shape.
+
+## Sequencing — six issues, strictly in order
+
+They share far more than four files. The full overlap set, which is also the
+reason nothing here runs concurrently:
+
+- `shared/observability/src/metrics/attrs.ts` — `StepUpFactor`,
+  `AuthRateLimitedEndpoint`, `SecurityEventKind`, `AuthMethod`, `StepUpPurpose`.
+- **All three rate-limiter builders** — `routes/auth/limiters.ts`,
+  `lib/redis-rate-limiters.ts`, `lib/native-rate-limiters.ts`. A new slot
+  missing from any one makes `createAuthRouteContext` throw
+  `must have a check() method` **at boot**. This is the omission that ships a
+  Worker which fails on first request.
+- `osn/api/src/services/auth/{index,context,config,stores,step-up,helpers,tokens}.ts`,
+  `lib/redis-ceremony-stores.ts`, `lib/auth-derive.ts`,
+  `routes/auth/{index,step-up,context,response-schemas}.ts` (two hard-coded
+  purpose unions in `step-up.ts`), `metrics.ts`, `build-deps.ts`, `index.ts`
+  (`Env`), `wrangler.toml`.
+- `osn/db/src/schema/index.ts` and `osn/db/drizzle/` — sequential numbering.
+- `osn/client/src/step-up.ts` mirrors `StepUpPurpose` **by hand**.
+- `wiki/systems/{step-up,passkey-primary,recovery-codes,email,identity-model}.md`.
+
+| # | Issue | Complexity |
+|---|---|---|
+| 1 | `@shared/crypto` TOTP primitives on a `./totp` subpath | 2 |
+| 2 | osn-api TOTP enrol / verify / disable, named step-up allow-lists, `TotpClient` | 5 |
+| 3 | The `osn-recovery` audience: minting, rotation carry-forward, enrolment acceptance, 15-min absolute TTL. **No public route.** | 5 |
+| 4 | `/login/recovery/{email,totp}/*`, caps, detached send, notices, client methods | 5 |
+| 5 | Provenance-aware cooldown across all three recovery paths, "this wasn't me" revoke, runbook update | 5 |
+| 6 | `@osn/ui` + `@osn/social` surfaces for TOTP and email recovery | 3 |
+
+Issue 3 exists separately because the audience primitive reaches `tokens.ts`,
+`helpers.ts`, `auth-derive.ts`, `passkeys.ts`, `context.ts` and the refresh
+path, and needs its own tests against **every** verifier entry point. Reviewed
+in one diff alongside a new unauthenticated mail-sending endpoint, no security
+pass holds it all at once.
+
+## Global constraints for every phase
+
+- **Fail closed** on every limiter, store and boot-time secret check.
+- A new limiter slot goes into **all three** builders in the same commit.
+- No secret in a log line, a metric attribute or an error body. Bounded metric
+  attributes only; no `console.*`; no raw OTel constructors.
+- Constant-time compare for every code check.
+- Enumeration-safe: uniform response **and** comparable latency, which for a
+  mail-sending branch means detaching the send.
+- Every new unauthenticated endpoint is rate limited per IP **and** capped per
+  resolved account.
+- Tests: `it.effect` + `createTestLayer()`; route tests via
+  `createXxxRoutes(createTestLayer())`. TDD for anything with logic.
+- Wiki updated in the same PR as the code it describes, `last-reviewed` bumped.
+- A changeset in every PR, package names matching the workspace `name` exactly.

--- a/shared/crypto/package.json
+++ b/shared/crypto/package.json
@@ -8,7 +8,8 @@
     "./jwk": "./src/jwk.ts",
     "./testing": "./src/testing.ts",
     "./timing-safe": "./src/timing-safe.ts",
-    "./tokens": "./src/tokens.ts"
+    "./tokens": "./src/tokens.ts",
+    "./totp": "./src/totp.ts"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/shared/crypto/src/totp.ts
+++ b/shared/crypto/src/totp.ts
@@ -3,12 +3,12 @@
  * the shared secret to an authenticator app.
  *
  * The scheme: a 20-byte secret is generated once, shown to the user as a QR
- * code (`totpUri`) or as base32 text they can type, and thereafter both sides
- * derive the same six digits from it and the current 30-second step. The
- * server keeps the secret because HMAC verification needs the raw key —
- * unlike recovery codes and session tokens in this package, a TOTP secret
- * cannot be stored as a hash. Encrypting it at rest is the caller's job, not
- * this module's.
+ * code (`totpUri`) or as base32 text they can type back (`parseTotpSecret`),
+ * and thereafter both sides derive the same six digits from it and the current
+ * 30-second step. The server keeps the secret because HMAC verification needs
+ * the raw key — unlike recovery codes and session tokens in this package, a
+ * TOTP secret cannot be stored as a hash. Encrypting it at rest is the
+ * caller's job, not this module's.
  *
  * Deliberately its own module importing nothing but `./timing-safe`:
  * `@shared/crypto`'s index pulls in `@osn/db` and `drizzle-orm`, which a
@@ -35,6 +35,26 @@ const TOTP_SECRET_BYTES = 20;
 /** RFC 4226 §4 R6 — the shared secret must be at least 128 bits. */
 const TOTP_MIN_SECRET_BYTES = 16;
 
+/**
+ * The floor is enforced at four entry points and thrown at three of them —
+ * `verifyTotpCode` answers `false` instead — so the wording lives in one place
+ * and reads the same wherever a caller meets it.
+ */
+function secretFloorError(functionName: string): TypeError {
+  return new TypeError(`${functionName}: secret must be at least ${TOTP_MIN_SECRET_BYTES} bytes`);
+}
+
+/**
+ * Ceiling on what `base32Decode` will look at, so the work one call performs is
+ * bounded whatever the caller passes — the same principle `TOTP_MAX_WINDOW`
+ * applies to verification. The input is a string an unauthenticated caller
+ * chose the length of, and decoding is linear in it: eight million characters
+ * measure in tens of milliseconds against a Workers CPU budget of ten. A
+ * 20-byte secret is 32 characters, so 512 leaves room for spacing and padding
+ * many times over.
+ */
+const BASE32_MAX_INPUT_LENGTH = 512;
+
 const TOTP_DIGITS = 6;
 
 /** RFC 6238's default time step X. */
@@ -52,6 +72,18 @@ const TOTP_MAX_WINDOW = 10;
 
 /** Six ASCII digits. `\d` would do — without `u` it is ASCII-only — but say it. */
 const SIX_ASCII_DIGITS = /^[0-9]{6}$/;
+
+/**
+ * Stand-in key for a secret `verifyTotpCode` cannot verify against, so that
+ * case does the same HMACs and the same comparisons as a real one instead of
+ * returning in microseconds. "Not enrolled" is an absent or empty secret in
+ * every schema shape this will sit behind, so the fast path would otherwise
+ * answer, to anyone who can reach the route, whether an account has a second
+ * factor. Same move as hashing an incoming password against a dummy hash when
+ * no user matches. Its bytes are never compared against anything, so a
+ * constant serves.
+ */
+const TOTP_DUMMY_SECRET = new Uint8Array(TOTP_SECRET_BYTES);
 
 /** A fresh 160-bit TOTP shared secret. */
 export function generateTotpSecret(): Uint8Array {
@@ -84,11 +116,23 @@ export function base32Encode(bytes: Uint8Array): string {
  * a trailing partial group are discarded, so a truncated string decodes to the
  * whole bytes it does carry rather than failing.
  *
+ * Input longer than 512 characters is refused before anything scans it, so an
+ * unauthenticated caller cannot choose how long one decode runs.
+ *
+ * A general codec, and deliberately not a secret parser: it returns whatever
+ * bytes the input carries, including none at all for a one- or two-character
+ * input whose only bits are the leftover ones. Use `parseTotpSecret` for
+ * anything that has to be a usable secret.
+ *
  * The thrown message names no part of the input. This function's argument is a
  * shared secret a user pasted, and an error message is the one place a
  * fragment of it would reach a log.
  */
 export function base32Decode(input: string): Uint8Array {
+  if (input.length > BASE32_MAX_INPUT_LENGTH) {
+    throw new TypeError(`base32Decode: input is longer than ${BASE32_MAX_INPUT_LENGTH} characters`);
+  }
+
   const compact = input.replace(/[\s=]/g, "");
   if (!BASE32_INPUT.test(compact)) {
     throw new TypeError("base32Decode: input has a character outside the RFC 4648 alphabet");
@@ -112,8 +156,37 @@ export function base32Decode(input: string): Uint8Array {
 }
 
 /**
+ * A shared secret from the base32 a user typed or pasted: `base32Decode`, then
+ * RFC 4226 §4 R6's 128-bit floor.
+ *
+ * The floor is the whole difference from the codec, and it is what an enrolment
+ * route needs. `base32Decode("A")` is not an error and is not a secret: five
+ * bits do not fill a byte, so it decodes to zero bytes, and a zero-length key
+ * is one WebCrypto refuses rather than one it verifies. Anything that becomes
+ * a stored secret comes through here.
+ *
+ * Throws a `TypeError` naming no part of the input, for the reason
+ * `base32Decode` gives.
+ */
+export function parseTotpSecret(input: string): Uint8Array {
+  const secret = base32Decode(input);
+  if (secret.length < TOTP_MIN_SECRET_BYTES) throw secretFloorError("parseTotpSecret");
+  return secret;
+}
+
+/**
  * The `otpauth://` URI an authenticator app scans, per the Key Uri Format the
  * ecosystem settled on.
+ *
+ * **The return value is secret material**: it carries the whole shared secret
+ * in its `secret` parameter, in the shape most likely to be logged. Do not log
+ * it, cache it or persist it, and put it only in a `Cache-Control: no-store`
+ * response, straight to the person enrolling.
+ *
+ * Throws a `TypeError` on a secret below the 128-bit floor, which
+ * `deriveTotpCode` would refuse to derive against: a QR code is the one place
+ * an unusable secret would otherwise be committed to, since the authenticator
+ * keeps it and nothing checks it again until the first code fails.
  *
  * The issuer appears twice, as the label prefix and as the `issuer` parameter,
  * because apps differ in which they read. Both halves of the label are
@@ -124,6 +197,8 @@ export function base32Decode(input: string): Uint8Array {
  * sign to the user.
  */
 export function totpUri(opts: { secret: Uint8Array; accountName: string; issuer: string }): string {
+  if (opts.secret.length < TOTP_MIN_SECRET_BYTES) throw secretFloorError("totpUri");
+
   const label = `${encodeURIComponent(opts.issuer)}:${encodeURIComponent(opts.accountName)}`;
   const params = [
     `secret=${base32Encode(opts.secret)}`,
@@ -150,9 +225,7 @@ export async function deriveTotpCode(secret: Uint8Array, counter: number): Promi
   if (!Number.isSafeInteger(counter) || counter < 0) {
     throw new TypeError("deriveTotpCode: counter must be a non-negative safe integer");
   }
-  if (secret.length < TOTP_MIN_SECRET_BYTES) {
-    throw new TypeError(`deriveTotpCode: secret must be at least ${TOTP_MIN_SECRET_BYTES} bytes`);
-  }
+  if (secret.length < TOTP_MIN_SECRET_BYTES) throw secretFloorError("deriveTotpCode");
 
   // Copied, not passed through: it re-types the array as one backed by a plain
   // ArrayBuffer, which is what WebCrypto's BufferSource accepts, and it stops
@@ -188,6 +261,32 @@ export async function deriveTotpCode(secret: Uint8Array, counter: number): Promi
  * code of the same shape do the same work. A malformed code, an unusable
  * secret or an unusable date is `false`, not an exception — this runs behind
  * routes that take the code from an untrusted request body.
+ *
+ * `false` does not say which of "wrong code" and "no TOTP on this account" it
+ * means, and it costs the same either way: a secret below the 128-bit floor —
+ * the shape an absent credential row takes — is run against a dummy secret so
+ * the answer is not faster. A code that is not six ASCII digits is rejected
+ * before any of that, which reveals nothing: the caller wrote the code.
+ *
+ * # Caller obligations
+ *
+ * Two things a complete implementation needs that a stateless function cannot
+ * do, so the entry point above it must:
+ *
+ * - **Single use.** RFC 6238 §5.2: a code accepted once must be refused for the
+ *   rest of its step, per account. Record the accepted step and reject a
+ *   repeat. A code that mints a session — recovery, rather than step-up —
+ *   makes a replay worth an account takeover rather than a repeated ceremony,
+ *   and one code is valid for a minute and a half at the default window.
+ * - **Attempt throttling.** RFC 4226 §7.3 requires a throttling parameter, and
+ *   the arithmetic is why: six digits over ±1 step is three acceptable codes in
+ *   a million, which is even odds inside a few hundred thousand attempts and
+ *   under an hour of traffic at a hundred a second. A per-IP limit alone does
+ *   not do it against a rotating fleet, so every entry point that reaches here
+ *   needs a per-account lockout too.
+ *
+ * Encrypting the secret at rest is the caller's job in the same way — see the
+ * module docstring.
  */
 export async function verifyTotpCode(opts: {
   secret: Uint8Array;
@@ -198,7 +297,6 @@ export async function verifyTotpCode(opts: {
   const { secret, code, at = new Date(), window = TOTP_DEFAULT_WINDOW } = opts;
 
   if (!SIX_ASCII_DIGITS.test(code)) return false;
-  if (secret.length < TOTP_MIN_SECRET_BYTES) return false;
 
   const counter = Math.floor(at.getTime() / 1000 / TOTP_STEP_SECONDS);
   if (!Number.isSafeInteger(counter) || counter < 0) return false;
@@ -214,7 +312,12 @@ export async function verifyTotpCode(opts: {
   const counters = Array.from({ length: span * 2 + 1 }, (_, index) =>
     Math.max(0, counter - span + index),
   );
-  const candidates = await Promise.all(counters.map((step) => deriveTotpCode(secret, step)));
+
+  // A secret under the floor cannot match anything, but it is answered at full
+  // price rather than returned on: see the dummy secret's own comment.
+  const usable = secret.length >= TOTP_MIN_SECRET_BYTES;
+  const key = usable ? secret : TOTP_DUMMY_SECRET;
+  const candidates = await Promise.all(counters.map((step) => deriveTotpCode(key, step)));
 
   // Bitwise `|`, not `||=` or `.some`: both short-circuit, which would make
   // the number of comparisons depend on whether — and where — the code matched.
@@ -222,5 +325,5 @@ export async function verifyTotpCode(opts: {
     (accumulated, candidate) => accumulated | (timingSafeEqualString(candidate, code) ? 1 : 0),
     0,
   );
-  return matched === 1;
+  return usable && matched === 1;
 }

--- a/shared/crypto/src/totp.ts
+++ b/shared/crypto/src/totp.ts
@@ -1,0 +1,226 @@
+/**
+ * RFC 6238 time-based one-time passwords, and the RFC 4648 base32 that carries
+ * the shared secret to an authenticator app.
+ *
+ * The scheme: a 20-byte secret is generated once, shown to the user as a QR
+ * code (`totpUri`) or as base32 text they can type, and thereafter both sides
+ * derive the same six digits from it and the current 30-second step. The
+ * server keeps the secret because HMAC verification needs the raw key —
+ * unlike recovery codes and session tokens in this package, a TOTP secret
+ * cannot be stored as a hash. Encrypting it at rest is the caller's job, not
+ * this module's.
+ *
+ * Deliberately its own module importing nothing but `./timing-safe`:
+ * `@shared/crypto`'s index pulls in `@osn/db` and `drizzle-orm`, which a
+ * caller deriving six digits has no business loading. Import it as
+ * `@shared/crypto/totp`.
+ */
+
+import { timingSafeEqualString } from "./timing-safe";
+
+/** RFC 4648 §6 alphabet — uppercase letters then the digits 2 to 7. */
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/**
+ * What `base32Decode` accepts once whitespace and `=` padding are stripped.
+ * Tested BEFORE case-folding, never after: Unicode uppercasing maps `ß` to
+ * `SS`, `ı` to `I`, `ſ` to `S` and `ﬀ` to `FF`, so folding first would let all
+ * four through a check against the alphabet.
+ */
+const BASE32_INPUT = /^[A-Za-z2-7]*$/;
+
+/** RFC 4226 §4 recommends 160 bits of shared secret. */
+const TOTP_SECRET_BYTES = 20;
+
+/** RFC 4226 §4 R6 — the shared secret must be at least 128 bits. */
+const TOTP_MIN_SECRET_BYTES = 16;
+
+const TOTP_DIGITS = 6;
+
+/** RFC 6238's default time step X. */
+const TOTP_STEP_SECONDS = 30;
+
+/** One step either side, which is RFC 6238 §5.2's recommendation for drift. */
+const TOTP_DEFAULT_WINDOW = 1;
+
+/**
+ * Hard ceiling on the drift window, so the work one call performs is bounded
+ * whatever the caller passes. Ten steps is ±5 minutes; a window large enough
+ * to matter beyond that is a clock problem, not a drift problem.
+ */
+const TOTP_MAX_WINDOW = 10;
+
+/** Six ASCII digits. `\d` would do — without `u` it is ASCII-only — but say it. */
+const SIX_ASCII_DIGITS = /^[0-9]{6}$/;
+
+/** A fresh 160-bit TOTP shared secret. */
+export function generateTotpSecret(): Uint8Array {
+  const bytes = new Uint8Array(TOTP_SECRET_BYTES);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** Base32 of `bytes`: uppercase, unpadded, RFC 4648 alphabet. */
+export function base32Encode(bytes: Uint8Array): string {
+  let carry = 0;
+  let bits = 0;
+  let out = "";
+  for (const byte of bytes) {
+    carry = (carry << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += BASE32_ALPHABET[(carry >>> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) out += BASE32_ALPHABET[(carry << (5 - bits)) & 0x1f];
+  return out;
+}
+
+/**
+ * Bytes from base32. Tolerant of what a person retypes — lowercase, spaces
+ * between groups, and the `=` padding some apps display — and strict about
+ * everything else: any other character throws a `TypeError`. Bits left over in
+ * a trailing partial group are discarded, so a truncated string decodes to the
+ * whole bytes it does carry rather than failing.
+ *
+ * The thrown message names no part of the input. This function's argument is a
+ * shared secret a user pasted, and an error message is the one place a
+ * fragment of it would reach a log.
+ */
+export function base32Decode(input: string): Uint8Array {
+  const compact = input.replace(/[\s=]/g, "");
+  if (!BASE32_INPUT.test(compact)) {
+    throw new TypeError("base32Decode: input has a character outside the RFC 4648 alphabet");
+  }
+
+  const symbols = compact.toUpperCase();
+  const out = new Uint8Array(Math.floor((symbols.length * 5) / 8));
+  let carry = 0;
+  let bits = 0;
+  let index = 0;
+  for (const symbol of symbols) {
+    carry = (carry << 5) | BASE32_ALPHABET.indexOf(symbol);
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out[index] = (carry >>> bits) & 0xff;
+      index += 1;
+    }
+  }
+  return out;
+}
+
+/**
+ * The `otpauth://` URI an authenticator app scans, per the Key Uri Format the
+ * ecosystem settled on.
+ *
+ * The issuer appears twice, as the label prefix and as the `issuer` parameter,
+ * because apps differ in which they read. Both halves of the label are
+ * percent-encoded and joined with a literal colon, so a colon inside either
+ * field arrives as `%3A` and cannot be mistaken for the separator. The
+ * parameters are assembled by hand rather than through `URLSearchParams`,
+ * which form-encodes a space as `+` — an authenticator would show that plus
+ * sign to the user.
+ */
+export function totpUri(opts: { secret: Uint8Array; accountName: string; issuer: string }): string {
+  const label = `${encodeURIComponent(opts.issuer)}:${encodeURIComponent(opts.accountName)}`;
+  const params = [
+    `secret=${base32Encode(opts.secret)}`,
+    `issuer=${encodeURIComponent(opts.issuer)}`,
+    "algorithm=SHA1",
+    `digits=${TOTP_DIGITS}`,
+    `period=${TOTP_STEP_SECONDS}`,
+  ].join("&");
+  return `otpauth://totp/${label}?${params}`;
+}
+
+/**
+ * The six-digit code for one counter value: HMAC-SHA-1 over the counter as an
+ * 8-byte big-endian integer, RFC 4226 §5.3 dynamic truncation, then modulo a
+ * million and zero-padded.
+ *
+ * Throws a `TypeError` on a counter that is not a non-negative safe integer,
+ * or a secret below the 128-bit floor. Both would otherwise fail quietly:
+ * `setBigUint64` wraps a negative counter modulo 2^64 and returns a plausible
+ * wrong code, and WebCrypto refuses a zero-length HMAC key with a `DataError`
+ * that says nothing about which argument was wrong.
+ */
+export async function deriveTotpCode(secret: Uint8Array, counter: number): Promise<string> {
+  if (!Number.isSafeInteger(counter) || counter < 0) {
+    throw new TypeError("deriveTotpCode: counter must be a non-negative safe integer");
+  }
+  if (secret.length < TOTP_MIN_SECRET_BYTES) {
+    throw new TypeError(`deriveTotpCode: secret must be at least ${TOTP_MIN_SECRET_BYTES} bytes`);
+  }
+
+  // Copied, not passed through: it re-types the array as one backed by a plain
+  // ArrayBuffer, which is what WebCrypto's BufferSource accepts, and it stops
+  // the caller's buffer from being the live HMAC key.
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(secret),
+    { name: "HMAC", hash: "SHA-1" },
+    false,
+    ["sign"],
+  );
+
+  const message = new ArrayBuffer(8);
+  new DataView(message).setBigUint64(0, BigInt(counter), false);
+  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", key, message));
+
+  const offset = mac[mac.length - 1] & 0x0f;
+  const truncated =
+    ((mac[offset] & 0x7f) << 24) |
+    (mac[offset + 1] << 16) |
+    (mac[offset + 2] << 8) |
+    mac[offset + 3];
+
+  return (truncated % 10 ** TOTP_DIGITS).toString().padStart(TOTP_DIGITS, "0");
+}
+
+/**
+ * Whether `code` is valid for `secret` at `at`, allowing `window` steps of
+ * clock drift either side.
+ *
+ * Never throws and never returns early on a match: every candidate in the
+ * window is derived and every one is compared, so a valid code and an invalid
+ * code of the same shape do the same work. A malformed code, an unusable
+ * secret or an unusable date is `false`, not an exception — this runs behind
+ * routes that take the code from an untrusted request body.
+ */
+export async function verifyTotpCode(opts: {
+  secret: Uint8Array;
+  code: string;
+  at?: Date;
+  window?: number;
+}): Promise<boolean> {
+  const { secret, code, at = new Date(), window = TOTP_DEFAULT_WINDOW } = opts;
+
+  if (!SIX_ASCII_DIGITS.test(code)) return false;
+  if (secret.length < TOTP_MIN_SECRET_BYTES) return false;
+
+  const counter = Math.floor(at.getTime() / 1000 / TOTP_STEP_SECONDS);
+  if (!Number.isSafeInteger(counter) || counter < 0) return false;
+
+  // Clamped at both ends. The lower bound keeps a nonsensical window from
+  // disabling verification silently; the upper bound keeps `window` from
+  // choosing how much CPU one request spends. A NaN window collapses to the
+  // current step alone rather than falling through Math.max unnoticed.
+  const span = Number.isFinite(window)
+    ? Math.min(TOTP_MAX_WINDOW, Math.max(0, Math.trunc(window)))
+    : 0;
+
+  const counters = Array.from({ length: span * 2 + 1 }, (_, index) =>
+    Math.max(0, counter - span + index),
+  );
+  const candidates = await Promise.all(counters.map((step) => deriveTotpCode(secret, step)));
+
+  // Bitwise `|`, not `||=` or `.some`: both short-circuit, which would make
+  // the number of comparisons depend on whether — and where — the code matched.
+  const matched = candidates.reduce(
+    (accumulated, candidate) => accumulated | (timingSafeEqualString(candidate, code) ? 1 : 0),
+    0,
+  );
+  return matched === 1;
+}

--- a/shared/crypto/tests/totp.test.ts
+++ b/shared/crypto/tests/totp.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  base32Decode,
+  base32Encode,
+  deriveTotpCode,
+  generateTotpSecret,
+  totpUri,
+  verifyTotpCode,
+} from "../src/totp";
+
+/**
+ * The seed both RFC 4226 Appendix D and RFC 6238 Appendix B publish their
+ * vectors against: the ASCII string "12345678901234567890", 20 bytes.
+ */
+const RFC_SEED = new TextEncoder().encode("12345678901234567890");
+
+/** RFC 4226 Appendix D, HOTP counters 0 through 9. Six digits, as published. */
+const HOTP_VECTORS = [
+  "755224",
+  "287082",
+  "359152",
+  "969429",
+  "338314",
+  "254676",
+  "287922",
+  "162583",
+  "399871",
+  "520489",
+];
+
+/**
+ * RFC 6238 Appendix B, the SHA-1 rows. The RFC publishes eight digits; this
+ * module derives six, and the low six of the published value is exactly that
+ * — dynamic truncation yields a 31-bit integer and the code is
+ * `truncated % 10**digits`, so `(x % 10**8) % 10**6 === x % 10**6` because
+ * 10**6 divides 10**8.
+ */
+const TOTP_VECTORS = [
+  { seconds: 59, eightDigit: "94287082" },
+  { seconds: 1_111_111_109, eightDigit: "07081804" },
+  { seconds: 1_111_111_111, eightDigit: "14050471" },
+  { seconds: 1_234_567_890, eightDigit: "89005924" },
+  { seconds: 2_000_000_000, eightDigit: "69279037" },
+  { seconds: 20_000_000_000, eightDigit: "65353130" },
+];
+
+/** RFC 4648 §10, base32 column. Encoding here is unpadded. */
+const BASE32_VECTORS = [
+  { plain: "", encoded: "", padded: "" },
+  { plain: "f", encoded: "MY", padded: "MY======" },
+  { plain: "fo", encoded: "MZXQ", padded: "MZXQ====" },
+  { plain: "foo", encoded: "MZXW6", padded: "MZXW6===" },
+  { plain: "foob", encoded: "MZXW6YQ", padded: "MZXW6YQ=" },
+  { plain: "fooba", encoded: "MZXW6YTB", padded: "MZXW6YTB" },
+  { plain: "foobar", encoded: "MZXW6YTBOI", padded: "MZXW6YTBOI======" },
+];
+
+/** The RFC seed, base32-encoded — the string an authenticator app receives. */
+const RFC_SEED_BASE32 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+const TOTP_STEP_SECONDS = 30;
+
+function counterAt(seconds: number): number {
+  return Math.floor(seconds / TOTP_STEP_SECONDS);
+}
+
+describe("deriveTotpCode — RFC 4226 Appendix D", () => {
+  it.each(HOTP_VECTORS.map((code, counter) => ({ counter, code })))(
+    "counter $counter derives $code",
+    async ({ counter, code }) => {
+      expect(await deriveTotpCode(RFC_SEED, counter)).toBe(code);
+    },
+  );
+});
+
+describe("deriveTotpCode — RFC 6238 Appendix B", () => {
+  it.each(TOTP_VECTORS)("t=$seconds derives the low six of $eightDigit", async (vector) => {
+    expect(await deriveTotpCode(RFC_SEED, counterAt(vector.seconds))).toBe(
+      vector.eightDigit.slice(-6),
+    );
+  });
+});
+
+describe("deriveTotpCode — rejected inputs", () => {
+  it("rejects a negative counter rather than wrapping it", async () => {
+    await expect(deriveTotpCode(RFC_SEED, -1)).rejects.toThrow(TypeError);
+  });
+
+  it("rejects a non-integer counter", async () => {
+    await expect(deriveTotpCode(RFC_SEED, 1.5)).rejects.toThrow(TypeError);
+  });
+
+  it("rejects a secret below the 128-bit floor", async () => {
+    await expect(deriveTotpCode(new Uint8Array(15), 1)).rejects.toThrow(TypeError);
+  });
+
+  it("rejects an empty secret", async () => {
+    await expect(deriveTotpCode(new Uint8Array(0), 1)).rejects.toThrow(TypeError);
+  });
+});
+
+describe("base32Encode — RFC 4648 §10", () => {
+  it.each(BASE32_VECTORS)('encodes "$plain" as $encoded', ({ plain, encoded }) => {
+    expect(base32Encode(new TextEncoder().encode(plain))).toBe(encoded);
+  });
+
+  it("emits only uppercase alphabet characters and no padding", () => {
+    for (let length = 0; length <= 40; length++) {
+      const bytes = new Uint8Array(length);
+      crypto.getRandomValues(bytes);
+      expect(base32Encode(bytes)).toMatch(/^[A-Z2-7]*$/);
+    }
+  });
+});
+
+describe("base32Decode — RFC 4648 §10", () => {
+  it.each(BASE32_VECTORS)('decodes $encoded to "$plain"', ({ plain, encoded }) => {
+    expect(new TextDecoder().decode(base32Decode(encoded))).toBe(plain);
+  });
+
+  it.each(BASE32_VECTORS)('decodes the padded form $padded to "$plain"', ({ plain, padded }) => {
+    expect(new TextDecoder().decode(base32Decode(padded))).toBe(plain);
+  });
+
+  it("round-trips every byte length from 0 to 40", () => {
+    for (let length = 0; length <= 40; length++) {
+      const bytes = new Uint8Array(length);
+      crypto.getRandomValues(bytes);
+      expect([...base32Decode(base32Encode(bytes))]).toStrictEqual([...bytes]);
+    }
+  });
+
+  it("accepts lowercase, spaced and padded spellings of the same secret", () => {
+    const canonical = [...base32Decode(RFC_SEED_BASE32)];
+    expect([...base32Decode(RFC_SEED_BASE32.toLowerCase())]).toStrictEqual(canonical);
+    expect([...base32Decode("GEZD GNBV GY3T QOJQ GEZD GNBV GY3T QOJQ")]).toStrictEqual(canonical);
+    expect([...base32Decode(`${RFC_SEED_BASE32}======`)]).toStrictEqual(canonical);
+  });
+
+  it.each(["0", "1", "8", "9", "-", "!", "@", "ß", "ſ", "ı"])(
+    "rejects %s, which is outside the alphabet",
+    (character) => {
+      expect(() => base32Decode(`MZXW6YTB${character}`)).toThrow(TypeError);
+    },
+  );
+
+  it("keeps the rejected input out of the error message", () => {
+    let message = "";
+    try {
+      base32Decode("MZXW6YTB!");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toBe("");
+    expect(message).not.toContain("MZXW6YTB");
+    expect(message).not.toContain("!");
+  });
+
+  it.each([1, 3, 6])("drops the leftover bits of a %s-character input", (length) => {
+    const truncated = RFC_SEED_BASE32.slice(0, length);
+    expect(base32Decode(truncated)).toHaveLength(Math.floor((length * 5) / 8));
+  });
+});
+
+describe("base32 and the code derivation agree", () => {
+  it("decodes the published seed encoding back into the Appendix B seed", async () => {
+    const decoded = base32Decode(RFC_SEED_BASE32);
+    expect([...decoded]).toStrictEqual([...RFC_SEED]);
+    expect(await deriveTotpCode(decoded, 1)).toBe("287082");
+  });
+});
+
+describe("verifyTotpCode — RFC 6238 Appendix B", () => {
+  it.each(TOTP_VECTORS)("accepts the published code at t=$seconds", async (vector) => {
+    const accepted = await verifyTotpCode({
+      secret: RFC_SEED,
+      code: vector.eightDigit.slice(-6),
+      at: new Date(vector.seconds * 1000),
+    });
+    expect(accepted).toBe(true);
+  });
+});
+
+describe("verifyTotpCode — drift window", () => {
+  const at = new Date(1_111_111_111 * 1000);
+  const counter = counterAt(1_111_111_111);
+
+  it("accepts the previous, current and next step at window 1", async () => {
+    for (const offset of [-1, 0, 1]) {
+      const code = await deriveTotpCode(RFC_SEED, counter + offset);
+      expect(await verifyTotpCode({ secret: RFC_SEED, code, at })).toBe(true);
+    }
+  });
+
+  it("rejects the steps either side of that window", async () => {
+    for (const offset of [-2, 2]) {
+      const code = await deriveTotpCode(RFC_SEED, counter + offset);
+      expect(await verifyTotpCode({ secret: RFC_SEED, code, at })).toBe(false);
+    }
+  });
+
+  it("accepts only the current step at window 0", async () => {
+    const current = await deriveTotpCode(RFC_SEED, counter);
+    const next = await deriveTotpCode(RFC_SEED, counter + 1);
+    expect(await verifyTotpCode({ secret: RFC_SEED, code: current, at, window: 0 })).toBe(true);
+    expect(await verifyTotpCode({ secret: RFC_SEED, code: next, at, window: 0 })).toBe(false);
+  });
+
+  it("clamps a large window rather than deriving unbounded candidates", async () => {
+    const inside = await deriveTotpCode(RFC_SEED, counter + 10);
+    const outside = await deriveTotpCode(RFC_SEED, counter + 11);
+    expect(await verifyTotpCode({ secret: RFC_SEED, code: inside, at, window: 100 })).toBe(true);
+    expect(await verifyTotpCode({ secret: RFC_SEED, code: outside, at, window: 100 })).toBe(false);
+  });
+});
+
+describe("verifyTotpCode — malformed input", () => {
+  const at = new Date(1_111_111_111 * 1000);
+
+  it.each(["12345", "1234567", "12a456", "", "12 456", "12345 ", "123456\n", "１２３４５６"])(
+    "rejects %j without throwing",
+    async (code) => {
+      expect(await verifyTotpCode({ secret: RFC_SEED, code, at })).toBe(false);
+    },
+  );
+
+  it("returns false for an invalid date rather than throwing", async () => {
+    const code = await deriveTotpCode(RFC_SEED, counterAt(1_111_111_111));
+    expect(await verifyTotpCode({ secret: RFC_SEED, code, at: new Date("not a date") })).toBe(
+      false,
+    );
+  });
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])("survives a window of %s", async (window) => {
+    const code = await deriveTotpCode(RFC_SEED, counterAt(1_111_111_111));
+    const accepted = await verifyTotpCode({ secret: RFC_SEED, code, at, window });
+    expect(typeof accepted).toBe("boolean");
+  });
+
+  it("returns false for a secret below the 128-bit floor rather than throwing", async () => {
+    expect(await verifyTotpCode({ secret: new Uint8Array(15), code: "123456", at })).toBe(false);
+  });
+
+  it("returns false for an empty secret rather than throwing", async () => {
+    expect(await verifyTotpCode({ secret: new Uint8Array(0), code: "123456", at })).toBe(false);
+  });
+});
+
+describe("generateTotpSecret", () => {
+  it("produces 20 bytes", () => {
+    expect(generateTotpSecret()).toHaveLength(20);
+  });
+
+  it("produces a fresh secret on each call", () => {
+    const seen = new Set(Array.from({ length: 100 }, () => base32Encode(generateTotpSecret())));
+    expect(seen.size).toBe(100);
+  });
+});
+
+describe("totpUri", () => {
+  it("carries the secret, the issuer and the algorithm parameters", () => {
+    const uri = new URL(totpUri({ secret: RFC_SEED, accountName: "ada", issuer: "OSN" }));
+    expect(uri.protocol).toBe("otpauth:");
+    expect(uri.pathname).toBe("/OSN:ada");
+    expect(uri.searchParams.get("secret")).toBe(RFC_SEED_BASE32);
+    expect(uri.searchParams.get("issuer")).toBe("OSN");
+    expect(uri.searchParams.get("algorithm")).toBe("SHA1");
+    expect(uri.searchParams.get("digits")).toBe("6");
+    expect(uri.searchParams.get("period")).toBe("30");
+  });
+
+  it("percent-encodes a space, a colon and a non-ASCII character in both fields", () => {
+    const raw = totpUri({
+      secret: RFC_SEED,
+      accountName: "adá lovelace:1",
+      issuer: "Musubi Social: ID",
+    });
+
+    expect(raw).toContain("otpauth://totp/Musubi%20Social%3A%20ID:ad%C3%A1%20lovelace%3A1?");
+    expect(raw).toContain("issuer=Musubi%20Social%3A%20ID");
+
+    const uri = new URL(raw);
+    expect(uri.searchParams.get("issuer")).toBe("Musubi Social: ID");
+    expect(decodeURIComponent(uri.pathname.slice(1))).toBe("Musubi Social: ID:adá lovelace:1");
+  });
+
+  it("emits a secret an authenticator can decode back to the seed", () => {
+    const secret = generateTotpSecret();
+    const uri = new URL(totpUri({ secret, accountName: "ada", issuer: "OSN" }));
+    expect([...base32Decode(uri.searchParams.get("secret") ?? "")]).toStrictEqual([...secret]);
+  });
+});
+
+describe("the ./totp subpath", () => {
+  it("resolves through the package's own exports map", async () => {
+    const viaSubpath = await import("@shared/crypto/totp");
+    expect(viaSubpath.verifyTotpCode).toBe(verifyTotpCode);
+    expect(viaSubpath.deriveTotpCode).toBe(deriveTotpCode);
+    expect(viaSubpath.base32Decode).toBe(base32Decode);
+  });
+});

--- a/shared/crypto/tests/totp.test.ts
+++ b/shared/crypto/tests/totp.test.ts
@@ -1,13 +1,30 @@
-import { describe, expect, it } from "vitest";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { timingSafeEqualString } from "../src/timing-safe";
 import {
   base32Decode,
   base32Encode,
   deriveTotpCode,
   generateTotpSecret,
+  parseTotpSecret,
   totpUri,
   verifyTotpCode,
 } from "../src/totp";
+
+/**
+ * The comparison is wrapped, not replaced: every test still compares for real,
+ * and the wrapper only counts. Counting is how "no early return" is asserted
+ * at all — the property is about how many comparisons happen, and a timing
+ * measurement would decide it differently on a loaded CI machine than on a
+ * quiet one.
+ */
+vi.mock("../src/timing-safe", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/timing-safe")>();
+  return { timingSafeEqualString: vi.fn(actual.timingSafeEqualString) };
+});
+
+const comparisons = vi.mocked(timingSafeEqualString);
 
 /**
  * The seed both RFC 4226 Appendix D and RFC 6238 Appendix B publish their
@@ -65,6 +82,27 @@ function counterAt(seconds: number): number {
   return Math.floor(seconds / TOTP_STEP_SECONDS);
 }
 
+/**
+ * A six-digit code no candidate in the window can equal, chosen rather than
+ * assumed: of the ten repeated-digit codes at most three are in any window, so
+ * one of them is always free and the test never turns on a one-in-a-million
+ * collision.
+ */
+async function unmatchableCode(secret: Uint8Array, counter: number, span: number): Promise<string> {
+  const accepted = new Set(
+    await Promise.all(
+      Array.from({ length: span * 2 + 1 }, (_, index) =>
+        deriveTotpCode(secret, counter - span + index),
+      ),
+    ),
+  );
+  const free = Array.from({ length: 10 }, (_, digit) => String(digit).repeat(6)).find(
+    (candidate) => !accepted.has(candidate),
+  );
+  if (free === undefined) throw new Error("every repeated-digit code was in the window");
+  return free;
+}
+
 describe("deriveTotpCode — RFC 4226 Appendix D", () => {
   it.each(HOTP_VECTORS.map((code, counter) => ({ counter, code })))(
     "counter $counter derives $code",
@@ -97,6 +135,10 @@ describe("deriveTotpCode — rejected inputs", () => {
 
   it("rejects an empty secret", async () => {
     await expect(deriveTotpCode(new Uint8Array(0), 1)).rejects.toThrow(TypeError);
+  });
+
+  it("accepts a secret of exactly the 128-bit floor", async () => {
+    await expect(deriveTotpCode(new Uint8Array(16), 1)).resolves.toMatch(/^[0-9]{6}$/);
   });
 });
 
@@ -163,6 +205,71 @@ describe("base32Decode — RFC 4648 §10", () => {
   });
 });
 
+describe("base32Decode — bounded work", () => {
+  it("decodes an input at the 512-character ceiling", () => {
+    expect(base32Decode("A".repeat(512))).toHaveLength(320);
+  });
+
+  it("rejects an input above the ceiling rather than decoding it", () => {
+    expect(() => base32Decode("A".repeat(513))).toThrow(TypeError);
+  });
+
+  it("rejects on the length it was given, before whitespace is stripped", () => {
+    expect(() => base32Decode(`${RFC_SEED_BASE32}${" ".repeat(600)}`)).toThrow(TypeError);
+  });
+
+  it("keeps the rejected input out of the error message", () => {
+    let message = "";
+    try {
+      base32Decode("MZXW6YTB".repeat(100));
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toBe("");
+    expect(message).not.toContain("MZXW6YTB");
+  });
+});
+
+describe("parseTotpSecret", () => {
+  it("decodes the published seed encoding into the Appendix B seed", () => {
+    expect([...parseTotpSecret(RFC_SEED_BASE32)]).toStrictEqual([...RFC_SEED]);
+  });
+
+  it("accepts the spellings the codec accepts", () => {
+    expect([...parseTotpSecret("gezd gnbv gy3t qojq gezd gnbv gy3t qojq")]).toStrictEqual([
+      ...RFC_SEED,
+    ]);
+    expect([...parseTotpSecret(`${RFC_SEED_BASE32}======`)]).toStrictEqual([...RFC_SEED]);
+  });
+
+  it("accepts a secret of exactly the 128-bit floor", () => {
+    expect(parseTotpSecret(base32Encode(RFC_SEED.slice(0, 16)))).toHaveLength(16);
+  });
+
+  it("rejects a secret one byte below the floor", () => {
+    expect(() => parseTotpSecret(base32Encode(RFC_SEED.slice(0, 15)))).toThrow(TypeError);
+  });
+
+  it.each(["A", "AB", ""])("rejects %j, which carries no whole byte at all", (input) => {
+    expect(() => parseTotpSecret(input)).toThrow(TypeError);
+  });
+
+  it("rejects a character outside the alphabet, as the codec does", () => {
+    expect(() => parseTotpSecret(`${RFC_SEED_BASE32}!`)).toThrow(TypeError);
+  });
+
+  it("keeps the rejected input out of the error message", () => {
+    let message = "";
+    try {
+      parseTotpSecret("MZXW6YTB");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toBe("");
+    expect(message).not.toContain("MZXW6YTB");
+  });
+});
+
 describe("base32 and the code derivation agree", () => {
   it("decodes the published seed encoding back into the Appendix B seed", async () => {
     const decoded = base32Decode(RFC_SEED_BASE32);
@@ -213,6 +320,98 @@ describe("verifyTotpCode — drift window", () => {
     expect(await verifyTotpCode({ secret: RFC_SEED, code: inside, at, window: 100 })).toBe(true);
     expect(await verifyTotpCode({ secret: RFC_SEED, code: outside, at, window: 100 })).toBe(false);
   });
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 0.4])(
+    "collapses a window of %s to the current step, and still accepts it",
+    async (window) => {
+      const current = await deriveTotpCode(RFC_SEED, counter);
+      const next = await deriveTotpCode(RFC_SEED, counter + 1);
+      expect(await verifyTotpCode({ secret: RFC_SEED, code: current, at, window })).toBe(true);
+      expect(await verifyTotpCode({ secret: RFC_SEED, code: next, at, window })).toBe(false);
+    },
+  );
+});
+
+describe("verifyTotpCode — the same work wherever the match is", () => {
+  const at = new Date(1_111_111_111 * 1000);
+  const counter = counterAt(1_111_111_111);
+  const WINDOW = 1;
+  const CANDIDATES = WINDOW * 2 + 1;
+
+  let signatures: MockInstance<SubtleCrypto["sign"]>;
+
+  beforeEach(() => {
+    signatures = vi.spyOn(crypto.subtle, "sign");
+  });
+
+  afterEach(() => {
+    signatures.mockRestore();
+  });
+
+  it.each([
+    { where: "the first candidate", offset: -1 },
+    { where: "the middle candidate", offset: 0 },
+    { where: "the last candidate", offset: 1 },
+  ])("derives and compares every candidate when the code matches $where", async ({ offset }) => {
+    const code = await deriveTotpCode(RFC_SEED, counter + offset);
+    comparisons.mockClear();
+    signatures.mockClear();
+
+    expect(await verifyTotpCode({ secret: RFC_SEED, code, at, window: WINDOW })).toBe(true);
+
+    expect(comparisons).toHaveBeenCalledTimes(CANDIDATES);
+    expect(signatures).toHaveBeenCalledTimes(CANDIDATES);
+  });
+
+  it("derives and compares every candidate when the code matches none of them", async () => {
+    const code = await unmatchableCode(RFC_SEED, counter, WINDOW);
+    comparisons.mockClear();
+    signatures.mockClear();
+
+    expect(await verifyTotpCode({ secret: RFC_SEED, code, at, window: WINDOW })).toBe(false);
+
+    expect(comparisons).toHaveBeenCalledTimes(CANDIDATES);
+    expect(signatures).toHaveBeenCalledTimes(CANDIDATES);
+  });
+
+  it.each([0, 15])(
+    "does the same work for a %s-byte secret it cannot verify against",
+    async (length) => {
+      comparisons.mockClear();
+      signatures.mockClear();
+
+      expect(
+        await verifyTotpCode({
+          secret: new Uint8Array(length),
+          code: "123456",
+          at,
+          window: WINDOW,
+        }),
+      ).toBe(false);
+
+      expect(comparisons).toHaveBeenCalledTimes(CANDIDATES);
+      expect(signatures).toHaveBeenCalledTimes(CANDIDATES);
+    },
+  );
+});
+
+describe("verifyTotpCode — the code guard runs before any HMAC", () => {
+  const at = new Date(1_111_111_111 * 1000);
+
+  let signatures: MockInstance<SubtleCrypto["sign"]>;
+
+  beforeEach(() => {
+    signatures = vi.spyOn(crypto.subtle, "sign");
+  });
+
+  afterEach(() => {
+    signatures.mockRestore();
+  });
+
+  it.each(["1234567", "12345", "12a456", ""])("derives nothing for %j", async (code) => {
+    expect(await verifyTotpCode({ secret: RFC_SEED, code, at })).toBe(false);
+    expect(signatures).not.toHaveBeenCalled();
+  });
 });
 
 describe("verifyTotpCode — malformed input", () => {
@@ -232,10 +431,12 @@ describe("verifyTotpCode — malformed input", () => {
     );
   });
 
-  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])("survives a window of %s", async (window) => {
-    const code = await deriveTotpCode(RFC_SEED, counterAt(1_111_111_111));
-    const accepted = await verifyTotpCode({ secret: RFC_SEED, code, at, window });
-    expect(typeof accepted).toBe("boolean");
+  it("returns false for a pre-1970 date, whose step counter is negative", async () => {
+    // The code for counter 0 — what a negative counter clamps to if it is not
+    // refused first, and so the code such a date would wrongly accept.
+    expect(
+      await verifyTotpCode({ secret: RFC_SEED, code: HOTP_VECTORS[0], at: new Date(-1000) }),
+    ).toBe(false);
   });
 
   it("returns false for a secret below the 128-bit floor rather than throwing", async () => {
@@ -244,6 +445,12 @@ describe("verifyTotpCode — malformed input", () => {
 
   it("returns false for an empty secret rather than throwing", async () => {
     expect(await verifyTotpCode({ secret: new Uint8Array(0), code: "123456", at })).toBe(false);
+  });
+
+  it("verifies against a secret of exactly the 128-bit floor", async () => {
+    const secret = RFC_SEED.slice(0, 16);
+    const code = await deriveTotpCode(secret, counterAt(1_111_111_111));
+    expect(await verifyTotpCode({ secret, code, at })).toBe(true);
   });
 });
 
@@ -290,6 +497,19 @@ describe("totpUri", () => {
     const uri = new URL(totpUri({ secret, accountName: "ada", issuer: "OSN" }));
     expect([...base32Decode(uri.searchParams.get("secret") ?? "")]).toStrictEqual([...secret]);
   });
+
+  it.each([0, 4, 15])("refuses to encode a %s-byte secret into a QR code", (length) => {
+    expect(() =>
+      totpUri({ secret: new Uint8Array(length), accountName: "ada", issuer: "OSN" }),
+    ).toThrow(TypeError);
+  });
+
+  it("encodes a secret of exactly the 128-bit floor", () => {
+    const uri = new URL(
+      totpUri({ secret: RFC_SEED.slice(0, 16), accountName: "ada", issuer: "OSN" }),
+    );
+    expect(base32Decode(uri.searchParams.get("secret") ?? "")).toHaveLength(16);
+  });
 });
 
 describe("the ./totp subpath", () => {
@@ -298,5 +518,6 @@ describe("the ./totp subpath", () => {
     expect(viaSubpath.verifyTotpCode).toBe(verifyTotpCode);
     expect(viaSubpath.deriveTotpCode).toBe(deriveTotpCode);
     expect(viaSubpath.base32Decode).toBe(base32Decode);
+    expect(viaSubpath.parseTotpSecret).toBe(parseTotpSecret);
   });
 });

--- a/wiki/architecture/account-recovery-factors.md
+++ b/wiki/architecture/account-recovery-factors.md
@@ -1,7 +1,21 @@
-# Design — additional account-access factors (TOTP + email-verified recovery)
+---
+title: Account recovery factors — TOTP and email-verified recovery
+tags: [architecture, auth, security, recovery, totp]
+related:
+  - "[[passkey-primary]]"
+  - "[[recovery-codes]]"
+  - "[[step-up]]"
+  - "[[sessions]]"
+  - "[[identity-model]]"
+last-reviewed: 2026-09-09
+---
 
-Status: **amended after stress-plan**. Author: orchestrate run 2026-09-09.
-Revision 2 — every finding from the attack pass is closed below, in the text.
+# Account recovery factors — TOTP and email-verified recovery
+
+The design for two new ways back into an OSN account, and the six issues it
+splits into. Written 2026-09-09 and amended after a stress-plan pass; every
+finding from that pass is closed below, in the text. Actionable work lives in
+GitHub Issues — this page holds the decisions those issues are built from.
 
 ## Problem
 
@@ -13,8 +27,8 @@ no second independent factor.
 
 ## Non-goals, and the decision they preserve
 
-`wiki/systems/passkey-primary.md` records that OTP and magic-link **primary
-login were removed on purpose**. Nothing here reinstates them. No new factor
+[[passkey-primary]] records that OTP and magic-link **primary login were
+removed on purpose**. Nothing here reinstates them. No new factor
 mints an ordinary session, and no new factor becomes a login factor. Phishing
 resistance of the sign-in path is unchanged.
 
@@ -116,7 +130,7 @@ So the cooldown is asymmetric:
   the recovery-enrolled credential and the recovery session family. Without
   this the owner has a warning and no lever.
 
-`wiki/runbooks/musubi-identity-migration.md` step 8 walks an operator through
+[[musubi-identity-migration]] step 8 walks an operator through
 recovery-login → OTP step-up → enrol passkey → delete the old passkeys. Under a
 global lock that runbook breaks; under the asymmetric rule it still works,
 because the operator's step-up comes from the pre-recovery credential. The
@@ -216,7 +230,8 @@ reason nothing here runs concurrently:
   (`Env`), `wrangler.toml`.
 - `osn/db/src/schema/index.ts` and `osn/db/drizzle/` — sequential numbering.
 - `osn/client/src/step-up.ts` mirrors `StepUpPurpose` **by hand**.
-- `wiki/systems/{step-up,passkey-primary,recovery-codes,email,identity-model}.md`.
+- The wiki pages every phase makes stale: [[step-up]], [[passkey-primary]],
+  [[recovery-codes]], [[email]], [[identity-model]].
 
 | # | Issue | Complexity |
 |---|---|---|
@@ -240,6 +255,19 @@ pass holds it all at once.
 - No secret in a log line, a metric attribute or an error body. Bounded metric
   attributes only; no `console.*`; no raw OTel constructors.
 - Constant-time compare for every code check.
+- **Every accepted code is single use**, TOTP included. RFC 6238 §5.2 requires
+  it and `verifyTotpCode` cannot: it is stateless, so the entry point records
+  the accepted step against the account and refuses a repeat for the rest of
+  that step. A TOTP code mints a session at
+  `POST /login/recovery/totp/complete`, so a code replayed off the wire is an
+  account takeover rather than a repeated ceremony.
+- **Both TOTP entry points are throttled per account**, not only per IP — the
+  step-up verify and `POST /login/recovery/totp/complete`. RFC 4226 §7.3
+  requires a throttling parameter, and the arithmetic says why: six digits over
+  ±1 step is three acceptable codes in a million, even odds inside a few
+  hundred thousand attempts, which a rotating fleet reaches in under an hour
+  against a per-IP limit alone. `osn/api/src/lib/recovery-lockout-store.ts` is
+  the existing shape to reuse.
 - Enumeration-safe: uniform response **and** comparable latency, which for a
   mail-sending branch means detaching the send.
 - Every new unauthenticated endpoint is rate limited per IP **and** capped per
@@ -247,4 +275,11 @@ pass holds it all at once.
 - Tests: `it.effect` + `createTestLayer()`; route tests via
   `createXxxRoutes(createTestLayer())`. TDD for anything with logic.
 - Wiki updated in the same PR as the code it describes, `last-reviewed` bumped.
+- The compliance pages count as wiki: a TOTP secret is an authentication
+  credential bound to a person, and `lastUsedAt` sits on the same footing as
+  `passkeys.last_used_at`, which already has a row in both. The phase that adds
+  a column adds its row to [[compliance/data-map]] (`wiki/compliance/data-map.md`
+  — purpose, lawful basis, retention, who can read it) and to
+  [[compliance/retention]] (`wiki/compliance/retention.md` — how long, and what
+  deletes it).
 - A changeset in every PR, package names matching the workspace `name` exactly.

--- a/wiki/architecture/monorepo-structure.md
+++ b/wiki/architecture/monorepo-structure.md
@@ -49,7 +49,7 @@ packages:
   - "@shared/toast"
   - "@shared/turnstile"
   - "@shared/typescript-config"
-last-reviewed: 2026-08-21
+last-reviewed: 2026-09-09
 ---
 
 # Monorepo Structure
@@ -95,7 +95,7 @@ cire/
   theme/               # @cire/theme — zero-dep shared theming validators (CSS-colour allow-list, IB-S-L1)
   landing/             # @cire/landing — Astro + Solid marketing site for the apex (port 4323; prod cireweddings.com)
 shared/
-  crypto/              # @shared/crypto — ARC tokens (S2S), recovery codes; Signal Protocol pending
+  crypto/              # @shared/crypto — ARC tokens (S2S), recovery codes, RFC 6238 TOTP; Signal Protocol pending
   db-utils/            # @shared/db-utils — createDrizzleClient, makeDbLive, commitBatch, rowsChanged
   email/               # @shared/email — EmailService Tag: Resend / Cloudflare / Log / Noop transports
   feature-flags/       # @shared/feature-flags — key-optional, fail-safe GrowthBook flag client

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -7,7 +7,7 @@ related:
   - "[[deferred-decisions]]"
   - "[[monorepo-structure]]"
   - "[[compliance/index]]"
-last-reviewed: 2026-09-08
+last-reviewed: 2026-09-09
 ---
 
 # OSN Wiki
@@ -30,6 +30,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[frontend-patterns]] — SolidJS, shared UI tokens, lazy loading
 - [[component-library]] — Zaidan/shadcn-style components, Kobalte primitives, CVA variants
 - [[drag-and-drop]] — `@shared/sortable` for drag-to-reorder, multi-container lists, and the keyboard + announcement path it owns
+- [[account-recovery-factors]] — TOTP and email-verified recovery: the restricted `osn-recovery` session, the step-up allow-lists, the provenance cooldown, and the six issues they split into
 - [[cire-platform-plan]] — cire's build plan from digital invite to wedding-management platform
 - [[cire-invite-builder]] — organiser-editable invite images + copy (slots, storage, API, guest rendering)
 - [[cire-guest-event-editor]] — the interactive events + guests editor alongside the CSV schema


### PR DESCRIPTION
## Summary

Adds RFC 6238 time-based one-time password primitives to `@shared/crypto`, on a new `./totp` subpath. This is phase 1 of #947 — everything it exports is consumed by the osn-api TOTP work in #949, and nothing in this branch is reachable from a route yet.

It also lands the architecture document the rest of that epic is built from, at `wiki/architecture/account-recovery-factors.md`.

- No new npm dependency. Base32 is forty lines and HMAC-SHA-1 is in WebCrypto, which Bun, Node and workerd all provide. A new package would also have to wait out the three-day `minimumReleaseAge` in `bunfig.toml`.
- Not re-exported from `src/index.ts`. The barrel pulls in `@osn/db` and `drizzle-orm`, and a caller deriving six digits should not load a database driver. Import it as `@shared/crypto/totp`.
- The correctness argument is the published vectors, not the tests: RFC 6238 Appendix B and RFC 4648 §10, checked against the RFCs rather than against each other.

## Workspaces affected

`@shared/crypto` — minor bump, named exactly in `.changeset/shared-crypto-totp.md`. `scripts/validate-changesets.sh` passes. No other workspace imports the new subpath yet; `grep -rn "crypto/totp"` finds hits only inside `shared/crypto`.

## Issues

**Closes**

| Issue | What |
|---|---|
| #948 | `@shared/crypto`: RFC 6238 TOTP primitives on a `./totp` subpath |

Closes #948

**Opened**

None. Every finding from this branch's own security and test review was fixed in it rather than deferred.

## Decisions

### The tests could not fail on the module's headline claim — `T-E1`

- **Issue** — `verifyTotpCode` documents that it never returns early on a match, so a valid and an invalid code do the same work. 173 tests, and none of them asserted it. Replacing the `|` accumulation with `candidates.some(...)`, or `Promise.all` with a sequential loop that breaks on first match, left every test green while destroying the property.
- **Why** — both mutations are exactly what a future contributor reaches for on noticing the function derives three HMACs to check one code, and the sequential form makes work proportional to *which* candidate matched — a timing oracle on the code itself. A comment warning against it is a claim, not a control, and that PR's reviewer would have had a green suite telling them nothing broke.
- **Solution** — two deterministic spies: one wrapping `timingSafeEqualString`, one on `crypto.subtle.sign`, each asserting a call count of exactly `2 * window + 1` across four cases — match on the first candidate, the middle, the last, and no match.
- **Rationale** — call counts are exact and reproducible in CI; a timing measurement is neither. The four-position sweep is what separates "no early return" from "no early return on the inputs we tried". The `sign` spy is not redundant: it catches lazy derivation, which the comparison spy alone misses.

### A test that asserted only its own return type — `T-U1`

- **Issue** — the nonsense-window case asserted `expect(typeof accepted).toBe("boolean")`, which cannot fail for any input that does not throw. Deleting `Math.max(0, …)` from the span clamp left all tests green.
- **Why** — that mutation is verification silently switched off: at `window: -1` a span of `-1` makes `Array.from({ length: -1 })` empty, so no candidate is derived and every code fails for every user. The clamp's own comment says the lower bound exists so a nonsensical window does not disable verification silently; the test named after that behaviour asserted everything except it.
- **Solution** — replaced, not supplemented: for `-1`, `NaN`, `Infinity` and `0.4`, a correct current-step code returns `true` and a correct next-step code returns `false`, pinning the collapse to the current step rather than to no steps.
- **Rationale** — the intended behaviour is specific and stated, so the assertion can be too. An assertion that cannot go red is worse than no assertion, because it reads as coverage.

### The 128-bit secret floor held on both verification paths and neither enrolment path — `S-L1`

- **Issue** — `deriveTotpCode` and `verifyTotpCode` enforced `TOTP_MIN_SECRET_BYTES`. `totpUri` checked nothing and would encode a 4-byte or 0-byte secret into a QR code, and `base32Decode` returns a zero-length array for a 1- or 2-character input with no error, because the output length floors to zero bytes. Those two are the enrolment path.
- **Why** — an enrolment flow trusting either could bind an account to a secret below RFC 4226 §4 R6's floor, or an empty one. It fails closed, so the consequence is a silently unusable second factor and a lockout at the moment it is needed — not a bypass, but an absent control on the one path where the secret's strength is decided.
- **Solution** — `totpUri` now enforces the floor, and a new `parseTotpSecret` decodes and then enforces it, leaving `base32Decode` a general codec.
- **Rationale** — the floor is the module's own stated invariant. Enforcing it at two of four entry points means it holds only where the code happens to reach it.

### Obligations this module cannot enforce are now written where the caller will read them — `S-M1`, `S-M2`

- **Issue** — RFC 6238 §5.2 requires single-use consumption and RFC 4226 §7.3 requires a throttle. `verifyTotpCode` cannot enforce either alone and correctly does not try, but neither its docstring nor the architecture document stated them as caller obligations.
- **Why** — the docstring names encrypting the secret at rest as "the caller's job", so its list of obligations reads as complete. TOTP is a recovery factor in this design, so a replayed code is worth an account takeover rather than a step-up; and six digits at `window: 1` gives three acceptable codes in 10⁶, which is even odds at roughly 231,000 attempts.
- **Solution** — both stated on `verifyTotpCode`, and both added to the architecture document's global constraints along with the two compliance pages a new credential column owes a row to.
- **Rationale** — #949 is where these get wired, and the two places its implementer will actually read are the function they call and the design they are working from.

### Smaller hardening — `S-L2`, `S-L3`, `S-L4`

- `totpUri` now says on the function that its return value is secret material — it is the one function returning a whole secret, in the shape most likely to be logged.
- `base32Decode` caps input at 512 characters before doing any work. It is the one function taking attacker-controlled input of attacker-chosen length and it will sit behind the enrolment route; an 8,000,000-character input measured 64–79 ms against a 10 ms Workers CPU budget. 20 bytes is 32 characters, so the cap leaves ample room for spacing and padding.
- An unusable secret now runs the same comparisons against a fixed dummy before returning false. The previous fast path was measurably faster than a real verification, which for a caller whose "not enrolled" state is an absent secret is an observable signal for whether an account has a second factor.

### Three things deliberately left alone — approach

- `hash: "SHA-1"` is correct. HMAC-SHA-1 rests on the compression function's pseudorandomness, not collision resistance; RFC 6238 §1.2 makes it the required default and `algorithm=SHA1` is what every authenticator reads.
- The `% 10**6` modulo bias (0.047%) is inherent to RFC 4226 §5.3 and identical in every conforming implementation. Rejection sampling would break interop.
- Non-canonical base32 is accepted — `"MY"` and `"MZ"` both decode to `0x66`. RFC 4648 §3.5 permits it; §12 cautions only where the encoded form is compared as an identity, which it is not here.

### The design document moved out of a scratch path — approach

- **Issue** — it was committed to `docs/superpowers/specs/`, with none of the frontmatter `CLAUDE.md` requires.
- **Why** — it holds the sequencing, the step-up allow-list decisions and the threat reasoning that five later issues are built from. That is a durable architecture decision, and `wiki/architecture/` is where someone will look for it.
- **Solution** — `git mv` to `wiki/architecture/account-recovery-factors.md` with `title`, `tags`, `related` and `last-reviewed`, linked from `wiki/index.md` and the navigation table in `CLAUDE.md`.
- **Rationale** — repo convention, and the rename is recorded so the history follows.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Tests | `bun run --cwd shared/crypto test:run` | 204 pass, 6 files, 0 fail |
| Type check | `bun run check` | 39 successful, 39 total |
| Type check, uncached | `bunx --bun tsc --noEmit` in `shared/crypto` | exit 0, 0 errors |
| Lint | `bun run lint` | 0 errors; the 1020 warnings are pre-existing in `scripts/` and `cire/api` and none names a file this branch touches |
| Format | `bun run fmt:check` | All matched files use the correct format (1473 files) |
| Changesets | `bash scripts/validate-changesets.sh` | All changeset package references are valid |

**Mutation testing.** The point of this branch's second commit is that a green suite was not proving anything, so the suite was checked against deliberate breakage rather than trusted. Thirteen mutations were applied during review and six survived; all six are now killed. I re-verified the most important one myself on the committed tree — replacing the `|` accumulation with `.some()` fails 2 tests.

| Mutation | Killed by |
|---|---|
| `.some()` in place of the `reduce`/`\|` | comparison-count assertions at two match positions |
| `Promise.all` → sequential loop breaking on match | all four match-position cases, plus both unusable-secret cases |
| `Math.max(0, …)` deleted from the span clamp | the `window: -1` current-step case |
| Secret floor `<` → `<=` | the exactly-16-byte boundary cases, derive and verify |
| `counter < 0` guard dropped | the pre-1970 date case |
| `$` anchor dropped from the six-digit regex | `crypto.subtle.sign` spy, 0 → 3 calls for `"1234567"` |

**Not run:** `bun run test` across the whole monorepo, `test:d1` and `test:browser`. No other workspace imports this subpath yet, there is no D1 lane and no DOM surface. CI covers the full suite.

**Nothing to exercise by hand.** There is no route, no UI and no binding in this branch.
