### PR TITLE
fix(tools): keep node:fs out of the metrics dashboard's module graph

### DIFF
--- a/.changeset/metrics-node-fs-import.md
+++ b/.changeset/metrics-node-fs-import.md
@@ -1,0 +1,10 @@
+---
+"@tools/metrics": patch
+---
+
+Fix the blank dashboard. `Dashboard.tsx` value-imported `compactTokens` from
+`tools/pr-metrics/index.ts`, which reads `node:fs` at module scope; Vite's
+browser stub throws on first property access, so the app died during module
+evaluation and left an empty page with nothing but a console error. It now
+imports from the new `tools/pr-metrics/format.ts`, and a test guards both the
+import and that file's no-imports contract.

--- a/.changeset/pr-metrics-format-split.md
+++ b/.changeset/pr-metrics-format-split.md
@@ -1,0 +1,7 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Move `compactTokens` and `humanDuration` into `format.ts`, which imports
+nothing, so a browser can use them without pulling in the CLI's `node:fs`.
+Both are re-exported from `index.ts`, so no caller changes.

--- a/.claude/metrics/fix-metrics-node-fs-import.json
+++ b/.claude/metrics/fix-metrics-node-fs-import.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 966,
+    "branch": "fix/metrics-node-fs-import",
+    "base_sha": "3447d5bac261d89a6e13a9e8d813468481c504c1",
+    "head_sha": "2142aad1410843701f942ee5eb0b39812afba93c",
+    "generated_at": "2026-09-09T01:54:08.702Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": 959,
+    "type": null,
+    "labels": [
+      "product:shared",
+      "area:ops",
+      "complexity:2"
+    ]
+  },
+  "complexity": {
+    "declared": 2,
+    "method": "confirmed"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-09-08T14:48:20.058Z",
+    "last_ts": "2026-09-09T01:54:04.661Z",
+    "span_seconds": 39945,
+    "active_seconds": 3838,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 37.23965714999997,
+    "tokens": {
+      "input": 830,
+      "output": 109637,
+      "thinking": 23197,
+      "cache_write_5m": 742968,
+      "cache_write_1h": 307714,
+      "cache_read": 64453025
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 32,
+          "output": 6400,
+          "thinking": 0,
+          "cache_write_5m": 124293,
+          "cache_write_1h": 0,
+          "cache_read": 495392
+        },
+        "usd_equivalent": 1.1846872499999999,
+        "messages": 17
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 466,
+          "output": 98102,
+          "thinking": 23181,
+          "cache_write_5m": 0,
+          "cache_write_1h": 307714,
+          "cache_read": 51259806
+        },
+        "usd_equivalent": 31.161922999999994,
+        "messages": 233
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 1
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 266,
+          "output": 5123,
+          "thinking": 16,
+          "cache_write_5m": 552951,
+          "cache_write_1h": 0,
+          "cache_read": 12577162
+        },
+        "usd_equivalent": 3.949571899999999,
+        "messages": 133
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 66,
+          "output": 12,
+          "thinking": 0,
+          "cache_write_5m": 65724,
+          "cache_write_1h": 0,
+          "cache_read": 120665
+        },
+        "usd_equivalent": 0.943475,
+        "messages": 3
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 498,
+          "output": 104502,
+          "thinking": 23181,
+          "cache_write_5m": 124293,
+          "cache_write_1h": 307714,
+          "cache_read": 51755198
+        },
+        "usd_equivalent": 32.34661024999999,
+        "messages": 251
+      },
+      "subagent": {
+        "tokens": {
+          "input": 332,
+          "output": 5135,
+          "thinking": 16,
+          "cache_write_5m": 618675,
+          "cache_write_1h": 0,
+          "cache_read": 12697827
+        },
+        "usd_equivalent": 4.893046899999999,
+        "messages": 136
+      }
+    },
+    "effort": {
+      "high": 369
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 3,
+      "docs": 1,
+      "config": 0,
+      "source": 4
+    },
+    "loc": {
+      "generated": {
+        "added": 17,
+        "deleted": 0
+      },
+      "test": {
+        "added": 329,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 2,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 44,
+        "deleted": 19
+      }
+    },
+    "packages": [
+      "tools/metrics",
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 6,
+    "corrective_turns": 3,
+    "tokens_before_first_edit": 231096,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 93,
+      "Edit": 28,
+      "Read": 8,
+      "Write": 6,
+      "mcp__claude-in-chrome__read_console_messages": 6,
+      "mcp__claude-in-chrome__navigate": 4,
+      "mcp__claude-in-chrome__read_network_requests": 2,
+      "Agent": 2,
+      "EnterWorktree": 1,
+      "Skill": 1,
+      "TaskStop": 1,
+      "mcp__claude-in-chrome__read_page": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 4,
+      "max_edits_one_file": 9
+    },
+    "skills": {
+      "stress-plan": 1
+    },
+    "subagents": {
+      "general-purpose": 2
+    }
+  }
+}

--- a/tools/metrics/src/Dashboard.tsx
+++ b/tools/metrics/src/Dashboard.tsx
@@ -2,7 +2,7 @@ import * as Plot from "@observablehq/plot";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@osn/ui/ui/card";
 import { For, Show, type JSX } from "solid-js";
 
-import { compactTokens } from "../../pr-metrics/index.ts";
+import { compactTokens } from "../../pr-metrics/format.ts";
 import { cards } from "./cards.ts";
 import { Chart, type ChartTheme } from "./Chart.tsx";
 import {

--- a/tools/metrics/tests/browser-safe.test.ts
+++ b/tools/metrics/tests/browser-safe.test.ts
@@ -129,15 +129,13 @@ function sourceFiles(dir: string): string[] {
 }
 
 describe("the dashboard's module graph stays browser-safe", () => {
-  it("never reaches the pr-metrics CLI entry point", () => {
-    const { files } = walk(sourceFiles(SRC));
+  const { files, builtins } = walk(sourceFiles(SRC));
 
+  it("never reaches the pr-metrics CLI entry point", () => {
     expect([...files].filter((file) => file === CLI)).toEqual([]);
   });
 
   it("statically imports no Node builtin", () => {
-    const { builtins } = walk(sourceFiles(SRC));
-
     expect([...builtins].map(([file, specifier]) => `${file} → ${specifier}`)).toEqual([]);
   });
 
@@ -145,8 +143,6 @@ describe("the dashboard's module graph stays browser-safe", () => {
     // Without this the first two assertions could pass by seeing almost
     // nothing. `@osn/ui` is the dashboard's one workspace dependency, and its
     // files must be inside the graph for their imports to have been checked.
-    const { files } = walk(sourceFiles(SRC));
-
     expect([...files].some((file) => file.includes("/osn/ui/src/"))).toBe(true);
   });
 });

--- a/tools/metrics/tests/browser-safe.test.ts
+++ b/tools/metrics/tests/browser-safe.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The dashboard must not reach a Node builtin.
+ *
+ * This test reads source text rather than importing anything, which is unusual
+ * and deliberate: the property under test belongs to the module graph as Vite
+ * builds it for a browser, and no runtime available here can observe it. Vitest
+ * runs on node (`tools/metrics/vitest.config.ts`), where `import "node:fs"`
+ * simply succeeds — so a test that imported `Dashboard.tsx` and asserted it
+ * rendered would have passed against the very bug this guards.
+ *
+ * What actually happens in the browser: Vite replaces `node:fs` with a stub
+ * that throws on first property access, the throw lands during module
+ * evaluation before `render()` is reached, and the page stays blank with no
+ * failure reported anywhere but the console.
+ *
+ * It follows imports rather than listing files, because the leak that prompted
+ * it was one hop past anything the dashboard names: `shape.ts` imports
+ * `report.ts`, and `report.ts` statically imported `index.ts`. A guard that
+ * only checked the file in the stack trace would have stayed green.
+ *
+ * Only *static* imports are walked, and that is the point rather than a gap:
+ * they are exactly the set evaluated when a module loads. `require()` and
+ * dynamic `import()` are the escape hatch — `report.ts` reaches `node:fs` and
+ * `index.ts` through both, on purpose, inside the functions that need them.
+ */
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = new URL("../src/", import.meta.url).pathname;
+const ROOT = new URL("../../../", import.meta.url).pathname;
+const CLI = new URL("../../pr-metrics/index.ts", import.meta.url).pathname;
+
+/**
+ * Every module a file statically imports.
+ *
+ * Two forms, because a check that knows only the first lets the second through
+ * unseen: `… from "x"`, which also covers `export … from`, and the side-effect
+ * `import "x"`, which has no `from` at all. Type-only imports and exports come
+ * out first — TypeScript erases those, so they pull nothing into the browser.
+ */
+function staticImports(source: string): string[] {
+  const runtime = source.replaceAll(/^\s*(?:import|export)\s+type\s[^;]*;/gm, "");
+
+  return [
+    ...runtime.matchAll(/\bfrom\s*["']([^"']+)["']/g),
+    ...runtime.matchAll(/^\s*import\s+["']([^"']+)["']/gm),
+  ].map((match) => match[1] as string);
+}
+
+/** A specifier written without its extension, or pointing at a directory,
+ * still names a real module. Try what the bundler would try. */
+function resolveFile(base: string): string | null {
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ];
+
+  return candidates.find((path) => existsSync(path) && statSync(path).isFile()) ?? null;
+}
+
+/**
+ * Where a specifier's file lives, or `null` for a third-party package.
+ *
+ * Workspace packages are resolved as well as relative paths. `@osn/ui` is one,
+ * and leaving bare specifiers unwalked would put every component the dashboard
+ * renders outside this test — which is precisely the shape of hop that hid the
+ * original defect.
+ */
+function locate(specifier: string, importer: string): string | null {
+  if (specifier.startsWith(".")) return resolveFile(resolve(dirname(importer), specifier));
+  if (specifier.startsWith("node:") || !specifier.startsWith("@")) return null;
+
+  const [scope, name, ...subpath] = specifier.split("/");
+
+  // Bun links a workspace dependency into the *consuming* package's
+  // `node_modules`, not the root's, so this walks up from the importer the way
+  // resolution actually does. Looking only in the root finds nothing.
+  let search = dirname(importer);
+  let linked = join(search, "node_modules", `${scope}/${name}`);
+  while (!existsSync(linked) && search.startsWith(ROOT) && search !== ROOT) {
+    search = dirname(search);
+    linked = join(search, "node_modules", `${scope}/${name}`);
+  }
+  if (!existsSync(linked)) return null;
+
+  const dir = realpathSync(linked);
+  const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+    exports?: Record<string, string>;
+  };
+  const target = manifest.exports?.[subpath.length > 0 ? `./${subpath.join("/")}` : "."];
+
+  return target === undefined ? null : resolveFile(resolve(dir, target));
+}
+
+/** Every file reachable from `entries` by static import, and the builtins they name. */
+function walk(entries: string[]): { files: Set<string>; builtins: Map<string, string> } {
+  const files = new Set<string>();
+  const builtins = new Map<string, string>();
+  const queue = [...entries];
+
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (files.has(file)) continue;
+    files.add(file);
+
+    for (const specifier of staticImports(readFileSync(file, "utf8"))) {
+      if (specifier.startsWith("node:")) builtins.set(file, specifier);
+
+      const next = locate(specifier, file);
+      if (next !== null) queue.push(next);
+    }
+  }
+
+  return { files, builtins };
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+describe("the dashboard's module graph stays browser-safe", () => {
+  it("never reaches the pr-metrics CLI entry point", () => {
+    const { files } = walk(sourceFiles(SRC));
+
+    expect([...files].filter((file) => file === CLI)).toEqual([]);
+  });
+
+  it("statically imports no Node builtin", () => {
+    const { builtins } = walk(sourceFiles(SRC));
+
+    expect([...builtins].map(([file, specifier]) => `${file} → ${specifier}`)).toEqual([]);
+  });
+
+  it("walks past a workspace package rather than stopping at it", () => {
+    // Without this the first two assertions could pass by seeing almost
+    // nothing. `@osn/ui` is the dashboard's one workspace dependency, and its
+    // files must be inside the graph for their imports to have been checked.
+    const { files } = walk(sourceFiles(SRC));
+
+    expect([...files].some((file) => file.includes("/osn/ui/src/"))).toBe(true);
+  });
+});

--- a/tools/pr-metrics/README.md
+++ b/tools/pr-metrics/README.md
@@ -66,6 +66,8 @@ right-skewed — median 3.6M tokens against a mean of 15.4M and a maximum of
 | Path                           | What                                                                                          |
 | ------------------------------ | --------------------------------------------------------------------------------------------- |
 | `index.ts`                     | Pure aggregation functions, the `<details>` renderer, and the CLI under `import.meta.main`    |
+| `format.ts`                    | `compactTokens` and `humanDuration`. Imports nothing, so a browser can reach it — `index.ts` cannot be imported from one, because its `node:fs` throws under Vite |
+| `report.ts`                    | The `report` subcommand's analyses. Reaches no Node builtin at module scope, so a browser can import it: `node:fs` and the one value it needs from `index.ts` are both `require`d lazily, inside the functions that use them |
 | `backfill.ts`                  | Cards for pull requests that merged before cards existed                                      |
 | `queries.sql`                  | The seven DuckDB queries worth having                                                         |
 | `tests/render.test.ts`         | The `<details>` block — including that it contributes no `##` heading                         |

--- a/tools/pr-metrics/format.ts
+++ b/tools/pr-metrics/format.ts
@@ -1,0 +1,31 @@
+/**
+ * Number formatting shared by the `<details>` renderer and the dashboard.
+ *
+ * This file imports nothing, and that is its contract rather than an accident
+ * of how small it is. `index.ts` is the CLI: it reads `node:fs` at module scope,
+ * which Vite replaces with a stub that throws on first property access, so a
+ * browser module that imports anything from it dies during evaluation — before
+ * it renders, and with an empty page as the only symptom. `@tools/metrics` is a
+ * browser app and needs these two functions, so they live where it can reach
+ * them. `report.ts` is import-free for the same reason.
+ *
+ * `tools/metrics/tests/browser-safe.test.ts` asserts the no-imports property.
+ */
+
+/** 66_000_000 → "66.0M". Cards run to tens of millions of tokens and a raw
+ * digit string at that size is unreadable in a table. */
+export function compactTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+
+  return String(value);
+}
+
+export function humanDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+
+  const hours = Math.floor(seconds / 3600);
+
+  return `${hours}h ${Math.round((seconds % 3600) / 60)}m`;
+}

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -40,6 +40,8 @@
 
 import { closeSync, openSync, readdirSync, readFileSync, readSync } from "node:fs";
 
+import { compactTokens, humanDuration } from "./format.ts";
+
 export const SCHEMA_VERSION = 1;
 
 /**
@@ -909,23 +911,7 @@ export function buildCard(records: SessionRecord[], diff: DiffSummary, context: 
 // Rendering
 // ---------------------------------------------------------------------------
 
-/** 66_000_000 → "66.0M". Cards run to tens of millions of tokens and a raw
- * digit string at that size is unreadable in a table. */
-export function compactTokens(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
-
-  return String(value);
-}
-
-export function humanDuration(seconds: number): string {
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
-
-  const hours = Math.floor(seconds / 3600);
-
-  return `${hours}h ${Math.round((seconds % 3600) / 60)}m`;
-}
+export { compactTokens, humanDuration } from "./format.ts";
 
 function share(part: number, whole: number): string {
   return whole > 0 ? `${Math.round((part / whole) * 100)}%` : "0%";

--- a/tools/pr-metrics/report.ts
+++ b/tools/pr-metrics/report.ts
@@ -19,7 +19,14 @@
  * SQL from TypeScript would cost more than it saves at this size.
  */
 
-import { type Card, compactTokens, defaultMetricsDir } from "./index.ts";
+// Nothing here may statically import a value from `index.ts`: it reads
+// `node:fs` at module scope, and `@tools/metrics` imports this file into a
+// browser, where Vite's stub for that builtin throws on first property access
+// and blanks the page. So `Card` is a type (erased), `compactTokens` comes from
+// the import-free `format.ts`, and the one value the CLI block still needs is
+// required lazily down there — the same way `loadCards` handles `node:fs`.
+import { compactTokens } from "./format.ts";
+import type { Card } from "./index.ts";
 
 export interface CardRow {
   pr: number | null;
@@ -352,6 +359,7 @@ const REPORTS = {
 } as const;
 
 if (import.meta.main) {
+  const { defaultMetricsDir } = require("./index.ts") as typeof import("./index.ts");
   const dirIndex = Bun.argv.indexOf("--dir");
   const dir =
     dirIndex >= 0 && Bun.argv[dirIndex + 1] ? Bun.argv[dirIndex + 1] : defaultMetricsDir();

--- a/tools/pr-metrics/tests/format.test.ts
+++ b/tools/pr-metrics/tests/format.test.ts
@@ -1,0 +1,39 @@
+// The formatters, imported straight from `format.ts` rather than through
+// `index.ts`'s re-export.
+//
+// `render.test.ts` covers the same two functions and would keep passing if
+// `format.ts` vanished and the bodies moved back into `index.ts`, because it
+// imports them from `../index`. This file pins the thing that actually matters
+// about the split: these functions are reachable on their own, from a module a
+// browser can load. `browser-safe.test.ts` asserts the file imports nothing;
+// this asserts it exports what it is supposed to.
+
+import { expect, test } from "bun:test";
+
+import { compactTokens, humanDuration } from "../format";
+
+test("compactTokens keeps large counts readable", () => {
+  expect(compactTokens(66_000_000)).toBe("66.0M");
+  expect(compactTokens(1_500)).toBe("1.5K");
+  expect(compactTokens(42)).toBe("42");
+});
+
+test("compactTokens switches units at the boundaries, not near them", () => {
+  expect(compactTokens(999)).toBe("999");
+  expect(compactTokens(1_000)).toBe("1.0K");
+  expect(compactTokens(999_999)).toBe("1000.0K");
+  expect(compactTokens(1_000_000)).toBe("1.0M");
+});
+
+test("humanDuration reads in the unit that fits", () => {
+  expect(humanDuration(45)).toBe("45s");
+  expect(humanDuration(1_200)).toBe("20m");
+  expect(humanDuration(7_500)).toBe("2h 5m");
+});
+
+test("humanDuration switches units at the boundaries", () => {
+  expect(humanDuration(59)).toBe("59s");
+  expect(humanDuration(60)).toBe("1m");
+  expect(humanDuration(3_599)).toBe("60m");
+  expect(humanDuration(3_600)).toBe("1h 0m");
+});

--- a/tools/pr-metrics/tests/report.cli.test.ts
+++ b/tools/pr-metrics/tests/report.cli.test.ts
@@ -1,0 +1,142 @@
+// `report.ts` as its own entry point, which is the only way to reach the
+// `import.meta.main` block.
+//
+// That block holds the line this file exists for:
+//
+//     const { defaultMetricsDir } = require("./index.ts") as typeof import("./index.ts");
+//
+// `index.ts` reads `node:fs` at module scope, and `@tools/metrics` imports
+// `report.ts` into a browser, so the import had to become lazy. Nothing else
+// tests it: `report.test.ts` imports `report.ts`'s named exports as a library,
+// which never sets `import.meta.main`. A wrong path, a renamed export, or a
+// future edit dropping `defaultMetricsDir` from `index.ts` would type-check and
+// then fail the first time somebody ran the CLI by hand.
+//
+// Subprocess rather than import, for that reason — the same seam
+// `pr-metrics.cli.test.ts` and `backfill.test.ts` use for their own entry
+// points.
+
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Card } from "../index";
+
+function card(number: number): Card {
+  const zero = {
+    input: 0,
+    output: 0,
+    thinking: 0,
+    cache_write_5m: 0,
+    cache_write_1h: 0,
+    cache_read: 0,
+  };
+
+  return {
+    schema_version: 1,
+    pr: {
+      number,
+      branch: `feat/x-${number}`,
+      base_sha: "a",
+      head_sha: "b",
+      generated_at: "2026-09-01T00:00:00.000Z",
+      merged_at: "2026-09-02T00:00:00.000Z",
+      phase: "at-merge",
+    },
+    issue: { number: null, type: null, labels: [] },
+    complexity: { declared: 2, method: "confirmed" },
+    window: {
+      sessions: 1,
+      first_ts: null,
+      last_ts: null,
+      span_seconds: 0,
+      active_seconds: 600,
+      compactions: 0,
+    },
+    spend: {
+      usd_equivalent: 50,
+      tokens: { ...zero, output: 1_000, cache_read: 9_000 },
+      by_model: {},
+      by_actor: {
+        main: { tokens: { ...zero }, usd_equivalent: 40, messages: 0 },
+        subagent: { tokens: { ...zero }, usd_equivalent: 10, messages: 0 },
+      },
+      effort: {},
+      unpriced_models: [],
+    },
+    diff: {
+      files: { generated: 0, test: 0, docs: 0, config: 0, source: 2 },
+      loc: {
+        generated: { added: 0, deleted: 0 },
+        test: { added: 0, deleted: 0 },
+        docs: { added: 0, deleted: 0 },
+        config: { added: 0, deleted: 0 },
+        source: { added: 30, deleted: 10 },
+      },
+      packages: ["osn/api"],
+      touches_migration: false,
+      commits: 1,
+    },
+    interaction: {
+      user_turns: 4,
+      corrective_turns: 2,
+      tokens_before_first_edit: 2_000,
+      sessions_with_observed_edit: 1,
+      tool_calls: {},
+      edit_churn: { files_edited_3plus: 0, max_edits_one_file: 0 },
+      skills: {},
+      subagents: {},
+    },
+  };
+}
+
+async function runReport(args: string[]): Promise<{ code: number; stdout: string }> {
+  const proc = Bun.spawn(["bun", join(import.meta.dir, "..", "report.ts"), ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+
+  return { code: await proc.exited, stdout };
+}
+
+test("the report CLI runs end to end over a directory of cards", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pr-metrics-report-"));
+
+  try {
+    await writeFile(join(dir, "a.json"), JSON.stringify(card(1)));
+    await writeFile(join(dir, "b.json"), JSON.stringify(card(2)));
+
+    const { code, stdout } = await runReport(["--dir", dir, "--coverage", "--json"]);
+
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(stdout) as {
+      cards: number;
+      merged: number;
+      dir: string;
+      tables: Record<string, { title: string; rows: string[][] }>;
+    };
+
+    expect(parsed.cards).toBe(2);
+    expect(parsed.merged).toBe(2);
+    expect(parsed.dir).toBe(dir);
+    expect(parsed.tables.coverage?.rows.length).toBeGreaterThan(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// The `--dir` path above never calls `defaultMetricsDir`, so it would still pass
+// if the lazy require resolved nothing. Omitting `--dir` is what forces the
+// required binding to be called.
+test("the report CLI resolves its default directory through the lazy require", async () => {
+  const { code, stdout } = await runReport(["--coverage", "--json"]);
+
+  expect(code).toBe(0);
+
+  const parsed = JSON.parse(stdout) as { dir: string };
+
+  expect(parsed.dir).toContain(".claude/metrics");
+});


### PR DESCRIPTION
## Summary

The session-metrics dashboard rendered a blank page. `tools/metrics/src/Dashboard.tsx` imported `compactTokens` from `tools/pr-metrics/index.ts`, which reads `node:fs` at module scope; Vite replaces that builtin with a stub that throws on first property access, so the app died during module evaluation before `render()` ran. Nothing about the failure was visible from the server — the page returned HTTP 200 and every module transformed and served correctly — which left a browser console exception as the only evidence.

`compactTokens` and `humanDuration` move into a new `format.ts` that imports nothing, and `index.ts` re-exports both so the CLI and its tests are untouched.

That alone did not fix it, and the second half is the more interesting one. `report.ts` also imported `index.ts` statically, and `shape.ts` imports `report.ts`, so the browser still reached `node:fs` two hops out. `report.ts` was already built to be browser-safe — it pulls `node:fs` in through a lazy `require` inside `loadCards` — so the fix follows the idiom already in that file rather than inventing one.

- New guard test walks the import graph from `tools/metrics/src/` and asserts the CLI entry point is unreachable and that no reachable file statically imports a `node:` builtin.
- `tools/pr-metrics/README.md`'s Layout table gains rows for `format.ts` and `report.ts`, the latter of which was already missing.

## Workspaces affected

`@tools/metrics`, `@tools/pr-metrics`.

Two changesets rather than one, and deliberately so. `tools/metrics/package.json` carries `"version": "0.2.0"`; `tools/pr-metrics/package.json` has no `version` field at all, which is what makes a package ignored by changesets — not `.changeset/config.json`'s `ignore` array, which is empty, and not `privatePackages.version`, which only decides whether an already-versioned private package gets bumped. Naming both in one file is the "mixed ignored and not-ignored" shape that `scripts/validate-changesets.sh` exists to catch, and it aborts `changeset version` on `main` after the merge rather than failing in the PR.

- `.changeset/metrics-node-fs-import.md` — `@tools/metrics`, patch
- `.changeset/pr-metrics-format-split.md` — `@tools/pr-metrics`, patch

## Issues

**Closes**

| Issue | What |
|---|---|
| #959 | Metrics dashboard renders blank: `Dashboard.tsx` pulls `node:fs` in through the pr-metrics CLI |

Closes #959

**Opened**

| Issue | What |
|---|---|
| xchromo/osn#965 | `T-E1` — backfill's batched commit counts fail silently to `commits: 0` |
| xchromo/osn-tracker#643 | `S-L1` |

Both are in code this branch does not touch — `backfill.ts` came in with #957, and the dev-server allow-list predates the branch. Neither is fixed here.

## Decisions

### Move the formatters out rather than making `index.ts` browser-safe — `approach`

- **Issue** — `index.ts` is the CLI entry point and reads `node:fs` at module scope. `Dashboard.tsx` wanted two pure formatting functions from it and got the whole module, including the builtin.
- **Why** — Vite's browser stub for `node:fs` throws on first property access, during module evaluation, before `render()` runs. The page returns HTTP 200 and every module serves correctly, so nothing outside the browser console shows a failure.
- **Solution** — `compactTokens` and `humanDuration` move verbatim into `format.ts`, which imports nothing as its contract. `index.ts` imports them back for `renderDetails` and re-exports both.
- **Rationale** — The alternative was to make `index.ts` itself safe by deferring its `node:fs` import. That would have meant rewriting a 1,600-line CLI to gain nothing the split does not already give, and it would leave the next browser consumer importing a CLI and hoping. A leaf module with a stated no-imports contract can be checked, and is.

### Fix `report.ts` too, which the first fix missed — `approach`

- **Issue** — After `Dashboard.tsx` was pointed at `format.ts` the page was still blank. `report.ts` also imported `index.ts` statically, and `shape.ts` imports `report.ts`, so the browser reached `node:fs` two hops out.
- **Why** — The stack trace named `index.ts` and nothing else, so the obvious reading was that fixing its one named importer was the fix. It was not, and a guard written against that reading would have stayed green while the page stayed blank.
- **Solution** — `Card` becomes a type-only import, `compactTokens` comes from `format.ts`, and `defaultMetricsDir` is required lazily inside the `import.meta.main` block.
- **Rationale** — `report.ts` was already designed to be browser-safe: line 323 pulls `node:fs` in through a lazy `require` inside `loadCards` for exactly this reason. The static import was the single thing defeating that, so the fix follows the idiom the file already uses rather than introducing a second one. The lazy `require` runs only on a direct CLI invocation, where loading `index.ts` is unavoidable anyway.

### Make the guard walk the graph, not check a list — `T-S1`, and the reason the first version was inadequate

- **Issue** — The first guard asserted only that no file under `tools/metrics/src/` value-imports `index.ts`. Every file in `src/` passed it while the dashboard was still broken.
- **Why** — The defect's whole character is that it hides one hop further out than the evidence points. A guard that can only see the file named in the stack trace does not address the class.
- **Solution** — `tools/metrics/tests/browser-safe.test.ts` follows static imports transitively from `tools/metrics/src/`, through relative paths **and** workspace packages, counting side-effect imports and resolving extensionless specifiers. It asserts the CLI entry point is unreachable and that no reachable file statically imports a `node:` builtin. A third assertion checks `@osn/ui` files are actually inside the walked graph, so the other two cannot pass by seeing nothing — that one caught a real bug in the resolver, since Bun links workspace dependencies into the consuming package's `node_modules` rather than the root's.
- **Rationale** — A runtime test cannot catch this class: vitest runs on node, where `import "node:fs"` succeeds, and only Vite's browser build externalizes it. A test that imported `Dashboard.tsx` and asserted it rendered would have passed against the broken code. Reading source text is unusual and the file says why. Only static imports are walked, deliberately — they are exactly the set evaluated on load, and `require`/dynamic `import()` are the escape hatch this fix itself uses.

### Two changesets, not one — `approach`

- **Issue** — The plan called for a single changeset naming both packages.
- **Why** — `@tools/pr-metrics` has no `version` field, which is what makes a package ignored by changesets. Mixing an ignored package with a versioned one aborts `changeset version` on `main` after the merge, not in the PR.
- **Solution** — One changeset per package, and `scripts/validate-changesets.sh` added to the gates.
- **Rationale** — `scripts/changeset-required.sh` was the only script the plan cited, and it answers a different question — whether a changeset is needed, never whether the one written is valid. The evidence that `@tools/pr-metrics` is genuinely ignored: `.changeset/pr-metrics-backfill-tests.md` named it alone in #955, and the release commit bumped `tools/metrics/package.json` while leaving `tools/pr-metrics/package.json` untouched. There is no `tools/pr-metrics/CHANGELOG.md`.

### Hoist the guard's graph walk — `P-I1`

- **Issue** — Each of the three `it` blocks called `walk(sourceFiles(SRC))` independently, re-reading and re-parsing the same 10 files three times.
- **Why** — Immaterial in absolute terms — the suite runs in about 10ms — but it is repeated work in code this branch adds, and the three assertions test three properties of one graph rather than three graphs.
- **Solution** — Compute the walk once at `describe` scope and read `files` and `builtins` from the shared result.
- **Rationale** — No isolation is lost, because nothing about the walk depends on which assertion is running.

### Cover the lazy require and `format.ts` directly — `T-S1`, `T-S2`

- **Issue** — The `require("./index.ts")` line is the exact line this branch adds, and no test reached it: `report.test.ts` imports `report.ts`'s named exports as a library, which never sets `import.meta.main`. Separately, `format.ts` was exercised only through `index.ts`'s re-export.
- **Why** — A wrong path, a renamed export, or a future edit dropping `defaultMetricsDir` from `index.ts` would type-check and then fail the first time somebody ran the CLI by hand. And a test that reaches the formatters through `index.ts` would keep passing if `format.ts` were deleted and the bodies moved back — which is the one regression the split exists to prevent.
- **Solution** — `tests/report.cli.test.ts` spawns `report.ts` as a subprocess, the seam `pr-metrics.cli.test.ts` and `backfill.test.ts` already use. Two cases: one with `--dir`, one without, because only the second actually calls the required binding. `tests/format.test.ts` imports straight from `../format` and pins the unit boundaries.
- **Rationale** — Closes the only line this branch changed that nothing executed.

**Out of scope** — xchromo/osn#965 — `T-E1`. xchromo/osn-tracker#643 — `S-L1`.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Type check | `bun run check` | 39 successful, 39 total |
| Dashboard tests | `bun run --cwd tools/metrics test:run` | 14 pass, 2 files |
| CLI tests | `bun run --cwd tools/pr-metrics test` | 115 pass, 0 fail, 8 files |
| Format | `bun run fmt:check` | all 1473 files correct |
| Lint | `bunx --bun oxlint tools/metrics tools/pr-metrics` | no new warnings; the one at `tools/metrics/src/Chart.tsx:46` predates this branch and is in an untouched file |
| Changeset needed? | `scripts/changeset-required.sh` | `required` — two present |
| Changesets valid? | `scripts/validate-changesets.sh` | pass |
| Dependency audit | `bun audit --audit-level=high` | no vulnerabilities, 862 packages |
| CLI still works | `bun run --cwd tools/pr-metrics report` | 38 cards, all seven tables — exercises the lazy `require` |
| Comment delta | `bun run scripts/comment-delta.ts origin/main` | +100 −2 (net +98) |

**Exercised by hand, and the only gate that could have caught the bug.** `bun run dev:metrics`, then load the page and read the browser console. Before: an empty `#root` and `Error: Module "node:fs" has been externalized for browser compatibility`. After: the dashboard renders — coverage panel, spend-over-time and token charts, axes and real data across 38 cards — with nothing in the console but Vite's two connection lines.

**The guard was watched to fail**, once per evasion it claims to close, since a check that has only ever passed is indistinguishable from one that cannot fail:

| Broken input | Result |
|---|---|
| `Dashboard.tsx` imports `index.ts` again | both assertions red |
| `report.ts` imports `index.ts` statically again — the transitive case | both assertions red |
| `Chart.tsx` gets `import "../../pr-metrics/index"` — side-effect **and** extensionless | both assertions red |
| `node:fs` added to `osn/ui/src/components/ui/card.tsx` — through a workspace package | builtin assertion red, naming the file |

**Not verified.** No automated check runs a browser against this dashboard; the render is confirmed by hand only, and CI would not catch a reintroduction that evaded the static guard.

The comment delta is `+98`, and all of it is in the three test files. Each carries a header explaining why it exists — why the guard reads source text rather than importing anything, why `report.ts` needs a subprocess to reach one line, and why `format.ts` gets a test when `render.test.ts` already covers the same two functions. This is not a cleanup branch, so the growth is expected rather than something to trim, but it is worth knowing where it went.
<details><summary>Session metrics — $37.41 · 65.9M tok · complexity 2 · +44/-19 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $37.41 |
| Tokens | 65.9M — out 109.8K · cache-w 1.1M · cache-r 64.8M (98%) |
| Models | claude-opus-5 (84%), claude-sonnet-5 (11%), claude-opus-4-7 (3%), claude-fable-5-1 (3%), <synthetic> (0%) |
| Active time | 1h 4m over 4 session(s) |
| Declared complexity | 2 |
| Source diff | +44/-19 across 4 file(s), 2 package(s) |
| Turns | 6 (3 corrective) |
| Before first edit | 231.1K (0%) |
| Subagents | 2× general-purpose (13% of spend) |

<sub>Card: `.claude/metrics/fix-metrics-node-fs-import.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>
