### PR TITLE
chore(tools): backfill 73 session-metrics cards, and price dated model ids

### DIFF
--- a/.changeset/witty-pears-shave.md
+++ b/.changeset/witty-pears-shave.md
@@ -1,0 +1,8 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Price a model id that carries its snapshot date. Transcripts name Haiku as
+`claude-haiku-4-5-20251001` while the rate table is keyed bare, so the lookup
+missed and every Haiku session costed zero. The date now comes off before the
+table is read.

--- a/.claude/metrics/chore-astro-bundle-guards.json
+++ b/.claude/metrics/chore-astro-bundle-guards.json
@@ -5,7 +5,7 @@
     "branch": "chore/astro-bundle-guards",
     "base_sha": "0fbe9a2b7098c414b16bbbb8acd5e3302f1016d1",
     "head_sha": "40126c22a89a4383441130552bf38c70fc900a56",
-    "generated_at": "2026-09-07T07:41:41.701Z",
+    "generated_at": "2026-09-09T06:24:29.021Z",
     "merged_at": "2026-09-06T15:01:52Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 27.54766679999997,
+    "usd_equivalent": 15.584483900000004,
     "tokens": {
-      "input": 812,
-      "output": 299622,
-      "thinking": 104702,
-      "cache_write_5m": 430882,
-      "cache_write_1h": 633828,
-      "cache_read": 91305218
+      "input": 477,
+      "output": 159832,
+      "thinking": 50035,
+      "cache_write_5m": 165828,
+      "cache_write_1h": 358937,
+      "cache_read": 55222201
     },
     "by_model": {
       "claude-sonnet-5": {
         "tokens": {
-          "input": 718,
-          "output": 259073,
-          "thinking": 104702,
+          "input": 434,
+          "output": 144997,
+          "thinking": 50035,
           "cache_write_5m": 0,
-          "cache_write_1h": 633828,
-          "cache_read": 89798759
+          "cache_write_1h": 358937,
+          "cache_read": 54402392
         },
-        "usd_equivalent": 23.087229799999985,
-        "messages": 359
+        "usd_equivalent": 13.7670644,
+        "messages": 217
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 94,
-          "output": 40549,
+          "input": 43,
+          "output": 14835,
           "thinking": 0,
-          "cache_write_5m": 430882,
+          "cache_write_5m": 165828,
           "cache_write_1h": 0,
-          "cache_read": 1506459
+          "cache_read": 819809
         },
-        "usd_equivalent": 4.460436999999999,
-        "messages": 44
+        "usd_equivalent": 1.8174194999999997,
+        "messages": 23
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 812,
-          "output": 299622,
-          "thinking": 104702,
-          "cache_write_5m": 430882,
-          "cache_write_1h": 633828,
-          "cache_read": 91305218
+          "input": 477,
+          "output": 159832,
+          "thinking": 50035,
+          "cache_write_5m": 165828,
+          "cache_write_1h": 358937,
+          "cache_read": 55222201
         },
-        "usd_equivalent": 27.54766679999997,
-        "messages": 403
+        "usd_equivalent": 15.584483900000004,
+        "messages": 240
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 359
+      "high": 217
     },
     "unpriced_models": []
   },
@@ -137,19 +137,18 @@
   "interaction": {
     "user_turns": 7,
     "corrective_turns": 2,
-    "tokens_before_first_edit": 4829223,
+    "tokens_before_first_edit": 2623796,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 112,
-      "Edit": 53,
-      "Read": 48,
-      "Write": 11,
-      "Grep": 5,
-      "StructuredOutput": 4
+      "Edit": 38,
+      "Read": 25,
+      "Bash": 14,
+      "Write": 3,
+      "Grep": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 8,
-      "max_edits_one_file": 10
+      "files_edited_3plus": 4,
+      "max_edits_one_file": 8
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-backfill-metrics-cards.json
+++ b/.claude/metrics/chore-backfill-metrics-cards.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 973,
+    "branch": "chore/backfill-metrics-cards",
+    "base_sha": "495ac60d479588f0aca2c38612c7880d45ae3f2f",
+    "head_sha": "2537ddc6f915b3a5d8f447bc16924b31a5c21760",
+    "generated_at": "2026-09-09T06:31:54.591Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-09-09T06:25:11.310Z",
+    "last_ts": "2026-09-09T06:31:49.691Z",
+    "span_seconds": 398,
+    "active_seconds": 154,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.6090574999999998,
+    "tokens": {
+      "input": 36,
+      "output": 8408,
+      "thinking": 0,
+      "cache_write_5m": 179434,
+      "cache_write_1h": 0,
+      "cache_read": 554430
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 36,
+          "output": 8408,
+          "thinking": 0,
+          "cache_write_5m": 179434,
+          "cache_write_1h": 0,
+          "cache_read": 554430
+        },
+        "usd_equivalent": 1.6090574999999998,
+        "messages": 16
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 36,
+          "output": 8408,
+          "thinking": 0,
+          "cache_write_5m": 179434,
+          "cache_write_1h": 0,
+          "cache_read": 554430
+        },
+        "usd_equivalent": 1.6090574999999998,
+        "messages": 16
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 0,
+      "config": 73,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 8,
+        "deleted": 0
+      },
+      "test": {
+        "added": 17,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 6076,
+        "deleted": 1157
+      },
+      "source": {
+        "added": 19,
+        "deleted": 4
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 3,
+      "Bash": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-cire-api-test-typecheck.json
+++ b/.claude/metrics/chore-cire-api-test-typecheck.json
@@ -1,0 +1,162 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 823,
+    "branch": "chore/cire-api-test-typecheck",
+    "base_sha": "b84c78188446243df33cd34a38e23fe858489af1",
+    "head_sha": "b0721738a1220e98e1c4a8440f27d1b39f388a27",
+    "generated_at": "2026-09-09T06:24:29.042Z",
+    "merged_at": "2026-08-30T02:40:26Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 769,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-25T03:21:30.473Z",
+    "last_ts": "2026-08-25T09:37:50.268Z",
+    "span_seconds": 22580,
+    "active_seconds": 8419,
+    "compactions": 32
+  },
+  "spend": {
+    "usd_equivalent": 24.238248000000013,
+    "tokens": {
+      "input": 1109,
+      "output": 238619,
+      "thinking": 118711,
+      "cache_write_5m": 77920,
+      "cache_write_1h": 2463934,
+      "cache_read": 56501792
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 13,
+          "output": 3356,
+          "thinking": 0,
+          "cache_write_5m": 77920,
+          "cache_write_1h": 0,
+          "cache_read": 521222
+        },
+        "usd_equivalent": 0.831576,
+        "messages": 8
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 1096,
+          "output": 235263,
+          "thinking": 118711,
+          "cache_write_5m": 0,
+          "cache_write_1h": 2463934,
+          "cache_read": 55980570
+        },
+        "usd_equivalent": 23.406672000000004,
+        "messages": 548
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 2
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 1109,
+          "output": 238619,
+          "thinking": 118711,
+          "cache_write_5m": 77920,
+          "cache_write_1h": 2463934,
+          "cache_read": 56501792
+        },
+        "usd_equivalent": 24.238248000000013,
+        "messages": 558
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 548
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 46,
+      "docs": 0,
+      "config": 1,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 31,
+        "deleted": 0
+      },
+      "test": {
+        "added": 835,
+        "deleted": 560
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 2,
+        "deleted": 1
+      },
+      "source": {
+        "added": 40,
+        "deleted": 1
+      }
+    },
+    "packages": [
+      "cire/api"
+    ],
+    "touches_migration": false,
+    "commits": 4
+  },
+  "interaction": {
+    "user_turns": 40,
+    "corrective_turns": 38,
+    "tokens_before_first_edit": 4349948,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Edit": 68,
+      "Bash": 31,
+      "Read": 22,
+      "Grep": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 9,
+      "max_edits_one_file": 6
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-cire-api-typecheck-gate.json
+++ b/.claude/metrics/chore-cire-api-typecheck-gate.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 786,
+    "branch": "chore/cire-api-typecheck-gate",
+    "base_sha": "861635605f93bc17180d1bf8dc16b22966d420a8",
+    "head_sha": "36efb3df7e59c6021cddeeb84172e0cb704083d7",
+    "generated_at": "2026-09-09T06:24:29.046Z",
+    "merged_at": "2026-08-25T04:09:44Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 5,
+    "first_ts": "2026-08-24T11:12:49.400Z",
+    "last_ts": "2026-08-25T03:00:47.914Z",
+    "span_seconds": 56879,
+    "active_seconds": 692,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 5.27898975,
+    "tokens": {
+      "input": 109,
+      "output": 40028,
+      "thinking": 0,
+      "cache_write_5m": 257627,
+      "cache_write_1h": 0,
+      "cache_read": 5335152
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 109,
+          "output": 40028,
+          "thinking": 0,
+          "cache_write_5m": 257627,
+          "cache_write_1h": 0,
+          "cache_read": 5335152
+        },
+        "usd_equivalent": 5.27898975,
+        "messages": 84
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 109,
+          "output": 40028,
+          "thinking": 0,
+          "cache_write_5m": 257627,
+          "cache_write_1h": 0,
+          "cache_read": 5335152
+        },
+        "usd_equivalent": 5.27898975,
+        "messages": 84
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 0,
+      "docs": 0,
+      "config": 0,
+      "source": 17
+    },
+    "loc": {
+      "generated": {
+        "added": 33,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 594,
+        "deleted": 572
+      }
+    },
+    "packages": [
+      "cire/api",
+      "shared/crypto"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 5,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 18,
+      "Bash": 13,
+      "Glob": 6,
+      "Grep": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-dep-guard-gaps.json
+++ b/.claude/metrics/chore-dep-guard-gaps.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 835,
+    "branch": "chore/dep-guard-gaps",
+    "base_sha": "8101ce475f5993f0f3523459484d24d8248fc2da",
+    "head_sha": "9ad77b79e4dd4ff9244a29d0bf630ed7c8f602c1",
+    "generated_at": "2026-09-09T06:24:29.040Z",
+    "merged_at": "2026-08-30T12:42:19Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 495,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-30T05:15:07.124Z",
+    "last_ts": "2026-08-30T10:45:12.617Z",
+    "span_seconds": 19805,
+    "active_seconds": 112,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.6187095000000001,
+    "tokens": {
+      "input": 19,
+      "output": 7077,
+      "thinking": 0,
+      "cache_write_5m": 52570,
+      "cache_write_1h": 0,
+      "cache_read": 226254
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 19,
+          "output": 7077,
+          "thinking": 0,
+          "cache_write_5m": 52570,
+          "cache_write_1h": 0,
+          "cache_read": 226254
+        },
+        "usd_equivalent": 0.6187095000000001,
+        "messages": 9
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 1
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 19,
+          "output": 7077,
+          "thinking": 0,
+          "cache_write_5m": 52570,
+          "cache_write_1h": 0,
+          "cache_read": 226254
+        },
+        "usd_equivalent": 0.6187095000000001,
+        "messages": 10
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 2,
+      "docs": 3,
+      "config": 3,
+      "source": 3
+    },
+    "loc": {
+      "generated": {
+        "added": 12,
+        "deleted": 1
+      },
+      "test": {
+        "added": 96,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 63,
+        "deleted": 5
+      },
+      "config": {
+        "added": 77,
+        "deleted": 11
+      },
+      "source": {
+        "added": 301,
+        "deleted": 28
+      }
+    },
+    "packages": [
+      "tools/oxlint"
+    ],
+    "touches_migration": false,
+    "commits": 3
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 4
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-deps-advisory-refresh.json
+++ b/.claude/metrics/chore-deps-advisory-refresh.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-advisory-refresh",
     "base_sha": "eee06ccf60ec4583b78fb994d13d299572e1b68f",
     "head_sha": "e9eec1c47da2f4ac48e986baece70fa99e8011e0",
-    "generated_at": "2026-09-07T07:41:52.605Z",
+    "generated_at": "2026-09-09T06:24:29.025Z",
     "merged_at": "2026-09-06T05:02:17Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 41.70225225000001,
+    "usd_equivalent": 23.94187425,
     "tokens": {
-      "input": 593,
-      "output": 183842,
-      "thinking": 58974,
-      "cache_write_5m": 349861,
-      "cache_write_1h": 219681,
-      "cache_read": 65439592
+      "input": 341,
+      "output": 85410,
+      "thinking": 22305,
+      "cache_write_5m": 134003,
+      "cache_write_1h": 128911,
+      "cache_read": 39356581
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 109,
-          "output": 31027,
+          "input": 51,
+          "output": 11295,
           "thinking": 0,
-          "cache_write_5m": 349861,
+          "cache_write_5m": 134003,
           "cache_write_1h": 0,
-          "cache_read": 1220601
+          "cache_read": 689110
         },
-        "usd_equivalent": 3.5731517499999987,
-        "messages": 49
+        "usd_equivalent": 1.46470375,
+        "messages": 26
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 484,
-          "output": 152815,
-          "thinking": 58974,
+          "input": 290,
+          "output": 74115,
+          "thinking": 22305,
           "cache_write_5m": 0,
-          "cache_write_1h": 219681,
-          "cache_read": 64218991
+          "cache_write_1h": 128911,
+          "cache_read": 38667471
         },
-        "usd_equivalent": 38.12910050000001,
-        "messages": 242
+        "usd_equivalent": 22.477170500000007,
+        "messages": 145
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 593,
-          "output": 183842,
-          "thinking": 58974,
-          "cache_write_5m": 349861,
-          "cache_write_1h": 219681,
-          "cache_read": 65439592
+          "input": 341,
+          "output": 85410,
+          "thinking": 22305,
+          "cache_write_5m": 134003,
+          "cache_write_1h": 128911,
+          "cache_read": 39356581
         },
-        "usd_equivalent": 41.70225225000001,
-        "messages": 291
+        "usd_equivalent": 23.94187425,
+        "messages": 171
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 242
+      "high": 145
     },
     "unpriced_models": []
   },
@@ -152,14 +152,12 @@
   "interaction": {
     "user_turns": 6,
     "corrective_turns": 1,
-    "tokens_before_first_edit": 818997,
+    "tokens_before_first_edit": 9516686,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 123,
-      "Write": 20,
-      "Read": 12,
-      "StructuredOutput": 6,
-      "Grep": 4
+      "Bash": 67,
+      "Write": 9,
+      "Read": 5
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-better-sqlite3-13.json
+++ b/.claude/metrics/chore-deps-better-sqlite3-13.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-better-sqlite3-13",
     "base_sha": "fca74814cbbdf0fe9646250dcfbef3fcb003bf5c",
     "head_sha": "71b25c1ddf796a4bb42f43bc5cfc1ec6e1f4b655",
-    "generated_at": "2026-09-07T07:42:00.958Z",
+    "generated_at": "2026-09-09T06:24:29.029Z",
     "merged_at": "2026-09-06T05:02:13Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 5.04507725,
+    "usd_equivalent": 2.935829,
     "tokens": {
-      "input": 85,
-      "output": 17101,
-      "thinking": 3618,
-      "cache_write_5m": 38389,
-      "cache_write_1h": 18519,
-      "cache_read": 8384012
+      "input": 44,
+      "output": 8599,
+      "thinking": 1222,
+      "cache_write_5m": 12966,
+      "cache_write_1h": 12501,
+      "cache_read": 5029173
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 56,
-          "output": 11782,
-          "thinking": 3618,
+          "input": 34,
+          "output": 6770,
+          "thinking": 1222,
           "cache_write_5m": 0,
-          "cache_write_1h": 18519,
-          "cache_read": 8024295
+          "cache_write_1h": 12501,
+          "cache_read": 4897411
         },
-        "usd_equivalent": 4.492167499999998,
-        "messages": 28
+        "usd_equivalent": 2.7431355,
+        "messages": 17
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 29,
-          "output": 5319,
+          "input": 10,
+          "output": 1829,
           "thinking": 0,
-          "cache_write_5m": 38389,
+          "cache_write_5m": 12966,
           "cache_write_1h": 0,
-          "cache_read": 359717
+          "cache_read": 131762
         },
-        "usd_equivalent": 0.5529097500000001,
-        "messages": 14
+        "usd_equivalent": 0.19269349999999996,
+        "messages": 5
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 85,
-          "output": 17101,
-          "thinking": 3618,
-          "cache_write_5m": 38389,
-          "cache_write_1h": 18519,
-          "cache_read": 8384012
+          "input": 44,
+          "output": 8599,
+          "thinking": 1222,
+          "cache_write_5m": 12966,
+          "cache_write_1h": 12501,
+          "cache_read": 5029173
         },
-        "usd_equivalent": 5.04507725,
-        "messages": 42
+        "usd_equivalent": 2.935829,
+        "messages": 22
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 28
+      "high": 17
     },
     "unpriced_models": []
   },
@@ -134,14 +134,12 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 6263264,
+    "tokens_before_first_edit": 3417998,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 15,
-      "Read": 5,
-      "Grep": 3,
+      "Bash": 8,
       "Write": 2,
-      "StructuredOutput": 1
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-changesets-cli-3.json
+++ b/.claude/metrics/chore-deps-changesets-cli-3.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-changesets-cli-3",
     "base_sha": "8058ef3d260f6c1e850e07f423f2d43557879743",
     "head_sha": "19090b4b4e04220bb5a041ff513c6f8e2ff2ad8b",
-    "generated_at": "2026-09-07T07:41:55.991Z",
+    "generated_at": "2026-09-09T06:24:29.027Z",
     "merged_at": "2026-09-06T05:02:15Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 9.406627250000003,
+    "usd_equivalent": 6.093830250000001,
     "tokens": {
-      "input": 109,
-      "output": 21243,
-      "thinking": 4774,
-      "cache_write_5m": 83803,
-      "cache_write_1h": 29547,
-      "cache_read": 16111537
+      "input": 66,
+      "output": 12647,
+      "thinking": 1711,
+      "cache_write_5m": 28095,
+      "cache_write_1h": 20744,
+      "cache_read": 10788583
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 23,
-          "output": 2888,
+          "input": 8,
+          "output": 1026,
           "thinking": 0,
-          "cache_write_5m": 83803,
+          "cache_write_5m": 28095,
           "cache_write_1h": 0,
-          "cache_read": 129326
+          "cache_read": 51634
         },
-        "usd_equivalent": 0.6607467499999998,
-        "messages": 8
+        "usd_equivalent": 0.22710075,
+        "messages": 3
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 86,
-          "output": 18355,
-          "thinking": 4774,
+          "input": 58,
+          "output": 11621,
+          "thinking": 1711,
           "cache_write_5m": 0,
-          "cache_write_1h": 29547,
-          "cache_read": 15982211
+          "cache_write_1h": 20744,
+          "cache_read": 10736949
         },
-        "usd_equivalent": 8.7458805,
-        "messages": 43
+        "usd_equivalent": 5.866729500000001,
+        "messages": 29
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 109,
-          "output": 21243,
-          "thinking": 4774,
-          "cache_write_5m": 83803,
-          "cache_write_1h": 29547,
-          "cache_read": 16111537
+          "input": 66,
+          "output": 12647,
+          "thinking": 1711,
+          "cache_write_5m": 28095,
+          "cache_write_1h": 20744,
+          "cache_read": 10788583
         },
-        "usd_equivalent": 9.406627250000003,
-        "messages": 51
+        "usd_equivalent": 6.093830250000001,
+        "messages": 32
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 43
+      "high": 29
     },
     "unpriced_models": []
   },
@@ -130,18 +130,17 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1071573,
+    "tokens_before_first_edit": 1430183,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 22,
+      "Bash": 14,
       "Write": 4,
-      "Read": 4,
-      "Edit": 3,
-      "StructuredOutput": 1
+      "Edit": 2,
+      "Read": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 3
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 2
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-deps-in-range-sweep.json
+++ b/.claude/metrics/chore-deps-in-range-sweep.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-in-range-sweep",
     "base_sha": "b485f54e96e6d30fde9c442e1ffc0ec666a0fa07",
     "head_sha": "5de432275d22a9731ab36a6b2d6aa644125464ac",
-    "generated_at": "2026-09-07T07:42:08.113Z",
+    "generated_at": "2026-09-09T06:24:29.030Z",
     "merged_at": "2026-09-06T05:02:10Z",
     "phase": "at-merge"
   },
@@ -23,57 +23,57 @@
     "first_ts": "2026-09-02T06:36:49.185Z",
     "last_ts": "2026-09-06T03:37:21.888Z",
     "span_seconds": 334833,
-    "active_seconds": 896,
+    "active_seconds": 894,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 5.116096749999998,
+    "usd_equivalent": 3.4756912499999992,
     "tokens": {
-      "input": 98,
-      "output": 19174,
-      "thinking": 2080,
-      "cache_write_5m": 109841,
-      "cache_write_1h": 42993,
-      "cache_read": 7039641
+      "input": 60,
+      "output": 11927,
+      "thinking": 1040,
+      "cache_write_5m": 38083,
+      "cache_write_1h": 28315,
+      "cache_read": 5312095
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 38,
-          "output": 6731,
+          "input": 14,
+          "output": 2427,
           "thinking": 0,
-          "cache_write_5m": 109841,
+          "cache_write_5m": 38083,
           "cache_write_1h": 0,
-          "cache_read": 179395
+          "cache_read": 107637
         },
-        "usd_equivalent": 0.94466875,
-        "messages": 8
+        "usd_equivalent": 0.35258225000000004,
+        "messages": 4
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 60,
-          "output": 12443,
-          "thinking": 2080,
+          "input": 46,
+          "output": 9500,
+          "thinking": 1040,
           "cache_write_5m": 0,
-          "cache_write_1h": 42993,
-          "cache_read": 6860246
+          "cache_write_1h": 28315,
+          "cache_read": 5204458
         },
-        "usd_equivalent": 4.171427999999999,
-        "messages": 30
+        "usd_equivalent": 3.1231089999999995,
+        "messages": 23
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 98,
-          "output": 19174,
-          "thinking": 2080,
-          "cache_write_5m": 109841,
-          "cache_write_1h": 42993,
-          "cache_read": 7039641
+          "input": 60,
+          "output": 11927,
+          "thinking": 1040,
+          "cache_write_5m": 38083,
+          "cache_write_1h": 28315,
+          "cache_read": 5312095
         },
-        "usd_equivalent": 5.116096749999998,
-        "messages": 38
+        "usd_equivalent": 3.4756912499999992,
+        "messages": 27
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 30
+      "high": 23
     },
     "unpriced_models": []
   },
@@ -169,9 +169,8 @@
     "tokens_before_first_edit": 218270,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 19,
-      "Write": 4,
-      "StructuredOutput": 2
+      "Bash": 13,
+      "Write": 3
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-ioredis-6.json
+++ b/.claude/metrics/chore-deps-ioredis-6.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-ioredis-6",
     "base_sha": "19090b4b4e04220bb5a041ff513c6f8e2ff2ad8b",
     "head_sha": "eee06ccf60ec4583b78fb994d13d299572e1b68f",
-    "generated_at": "2026-09-07T07:41:54.235Z",
+    "generated_at": "2026-09-09T06:24:29.026Z",
     "merged_at": "2026-09-06T05:02:16Z",
     "phase": "at-merge"
   },
@@ -27,39 +27,39 @@
     "compactions": 2
   },
   "spend": {
-    "usd_equivalent": 55.42687475000001,
+    "usd_equivalent": 30.32216124999997,
     "tokens": {
-      "input": 1208,
-      "output": 147753,
-      "thinking": 64796,
-      "cache_write_5m": 1314391,
-      "cache_write_1h": 372826,
-      "cache_read": 79567612
+      "input": 657,
+      "output": 64765,
+      "thinking": 22881,
+      "cache_write_5m": 545883,
+      "cache_write_1h": 185976,
+      "cache_read": 46856445
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 98,
-          "output": 12630,
+          "input": 43,
+          "output": 4954,
           "thinking": 0,
-          "cache_write_5m": 238910,
+          "cache_write_5m": 95120,
           "cache_write_1h": 0,
-          "cache_read": 828718
+          "cache_read": 408473
         },
-        "usd_equivalent": 2.2237864999999992,
-        "messages": 38
+        "usd_equivalent": 0.9228014999999999,
+        "messages": 18
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 1110,
-          "output": 135123,
-          "thinking": 64796,
-          "cache_write_5m": 1075481,
-          "cache_write_1h": 372826,
-          "cache_read": 78738894
+          "input": 614,
+          "output": 59811,
+          "thinking": 22881,
+          "cache_write_5m": 450763,
+          "cache_write_1h": 185976,
+          "cache_read": 46447972
         },
-        "usd_equivalent": 53.20308824999997,
-        "messages": 555
+        "usd_equivalent": 29.399359749999963,
+        "messages": 307
       },
       "<synthetic>": {
         "tokens": {
@@ -77,31 +77,31 @@
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 474,
-          "output": 126537,
-          "thinking": 56549,
-          "cache_write_5m": 238910,
-          "cache_write_1h": 372826,
-          "cache_read": 39161242
+          "input": 257,
+          "output": 60185,
+          "thinking": 22881,
+          "cache_write_5m": 95120,
+          "cache_write_1h": 185976,
+          "cache_read": 23988327
         },
-        "usd_equivalent": 27.967863500000007,
-        "messages": 227
+        "usd_equivalent": 15.954333499999988,
+        "messages": 126
       },
       "subagent": {
         "tokens": {
-          "input": 734,
-          "output": 21216,
-          "thinking": 8247,
-          "cache_write_5m": 1075481,
+          "input": 400,
+          "output": 4580,
+          "thinking": 0,
+          "cache_write_5m": 450763,
           "cache_write_1h": 0,
-          "cache_read": 40406370
+          "cache_read": 22868118
         },
-        "usd_equivalent": 27.459011250000014,
-        "messages": 367
+        "usd_equivalent": 14.367827749999996,
+        "messages": 200
       }
     },
     "effort": {
-      "high": 555
+      "high": 307
     },
     "unpriced_models": []
   },
@@ -144,27 +144,20 @@
   "interaction": {
     "user_turns": 5,
     "corrective_turns": 3,
-    "tokens_before_first_edit": 5344836,
+    "tokens_before_first_edit": 3826471,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 299,
-      "Write": 22,
-      "Read": 15,
-      "Edit": 9,
-      "StructuredOutput": 4,
-      "Agent": 3,
-      "Glob": 3,
-      "Skill": 1
+      "Bash": 106,
+      "Write": 8,
+      "Read": 5,
+      "Edit": 1,
+      "Glob": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
     },
-    "skills": {
-      "review-deps": 1
-    },
-    "subagents": {
-      "general-purpose": 3
-    }
+    "skills": {},
+    "subagents": {}
   }
 }

--- a/.claude/metrics/chore-deps-jest-dom-7.json
+++ b/.claude/metrics/chore-deps-jest-dom-7.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-jest-dom-7",
     "base_sha": "5e6fdf4de54d344106bb09b0af379b0bda6621a2",
     "head_sha": "044f902c0402e536b7401d246ddfe2b35b2d7afe",
-    "generated_at": "2026-09-07T07:42:05.143Z",
+    "generated_at": "2026-09-09T06:24:29.030Z",
     "merged_at": "2026-09-06T05:02:11Z",
     "phase": "at-merge"
   },
@@ -23,57 +23,57 @@
     "first_ts": "2026-09-02T06:42:48.248Z",
     "last_ts": "2026-09-02T06:59:45.136Z",
     "span_seconds": 1017,
-    "active_seconds": 404,
+    "active_seconds": 402,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 2.3049904999999997,
+    "usd_equivalent": 1.67715525,
     "tokens": {
-      "input": 43,
-      "output": 6347,
-      "thinking": 593,
-      "cache_write_5m": 14582,
-      "cache_write_1h": 12641,
-      "cache_read": 3857106
+      "input": 29,
+      "output": 4688,
+      "thinking": 213,
+      "cache_write_5m": 7389,
+      "cache_write_1h": 8781,
+      "cache_read": 2851638
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 30,
-          "output": 5865,
-          "thinking": 593,
+          "input": 22,
+          "output": 4376,
+          "thinking": 213,
           "cache_write_5m": 0,
-          "cache_write_1h": 12641,
-          "cache_read": 3794704
+          "cache_write_1h": 8781,
+          "cache_read": 2807639
         },
-        "usd_equivalent": 2.170537,
-        "messages": 15
+        "usd_equivalent": 1.6011395,
+        "messages": 11
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 13,
-          "output": 482,
+          "input": 7,
+          "output": 312,
           "thinking": 0,
-          "cache_write_5m": 14582,
+          "cache_write_5m": 7389,
           "cache_write_1h": 0,
-          "cache_read": 62402
+          "cache_read": 43999
         },
-        "usd_equivalent": 0.1344535,
-        "messages": 3
+        "usd_equivalent": 0.07601574999999999,
+        "messages": 2
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 43,
-          "output": 6347,
-          "thinking": 593,
-          "cache_write_5m": 14582,
-          "cache_write_1h": 12641,
-          "cache_read": 3857106
+          "input": 29,
+          "output": 4688,
+          "thinking": 213,
+          "cache_write_5m": 7389,
+          "cache_write_1h": 8781,
+          "cache_read": 2851638
         },
-        "usd_equivalent": 2.3049904999999997,
-        "messages": 18
+        "usd_equivalent": 1.67715525,
+        "messages": 13
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 15
+      "high": 11
     },
     "unpriced_models": []
   },
@@ -134,12 +134,11 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1973487,
+    "tokens_before_first_edit": 1482268,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 8,
-      "Write": 3,
-      "StructuredOutput": 1
+      "Bash": 6,
+      "Write": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-jsdom-30.json
+++ b/.claude/metrics/chore-deps-jsdom-30.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-jsdom-30",
     "base_sha": "71b25c1ddf796a4bb42f43bc5cfc1ec6e1f4b655",
     "head_sha": "72aaf7458bd38fcd1de04d51639936aa6d5779e9",
-    "generated_at": "2026-09-07T07:41:59.344Z",
+    "generated_at": "2026-09-09T06:24:29.028Z",
     "merged_at": "2026-09-06T05:02:14Z",
     "phase": "at-merge"
   },
@@ -21,59 +21,59 @@
   "window": {
     "sessions": 2,
     "first_ts": "2026-09-02T06:52:26.288Z",
-    "last_ts": "2026-09-02T06:53:56.770Z",
-    "span_seconds": 90,
-    "active_seconds": 103,
+    "last_ts": "2026-09-02T06:53:55.565Z",
+    "span_seconds": 89,
+    "active_seconds": 101,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.9663149999999998,
+    "usd_equivalent": 1.4115247499999999,
     "tokens": {
-      "input": 35,
-      "output": 5640,
-      "thinking": 795,
-      "cache_write_5m": 15348,
-      "cache_write_1h": 7633,
-      "cache_read": 3305770
+      "input": 23,
+      "output": 3931,
+      "thinking": 265,
+      "cache_write_5m": 7811,
+      "cache_write_1h": 6272,
+      "cache_read": 2403192
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 22,
-          "output": 4933,
-          "thinking": 795,
+          "input": 16,
+          "output": 3472,
+          "thinking": 265,
           "cache_write_5m": 0,
-          "cache_write_1h": 7633,
-          "cache_read": 3243024
+          "cache_write_1h": 6272,
+          "cache_read": 2358849
         },
-        "usd_equivalent": 1.8212769999999998,
-        "messages": 11
+        "usd_equivalent": 1.3290244999999998,
+        "messages": 8
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 13,
-          "output": 707,
+          "input": 7,
+          "output": 459,
           "thinking": 0,
-          "cache_write_5m": 15348,
+          "cache_write_5m": 7811,
           "cache_write_1h": 0,
-          "cache_read": 62746
+          "cache_read": 44343
         },
-        "usd_equivalent": 0.145038,
-        "messages": 3
+        "usd_equivalent": 0.08250025,
+        "messages": 2
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 35,
-          "output": 5640,
-          "thinking": 795,
-          "cache_write_5m": 15348,
-          "cache_write_1h": 7633,
-          "cache_read": 3305770
+          "input": 23,
+          "output": 3931,
+          "thinking": 265,
+          "cache_write_5m": 7811,
+          "cache_write_1h": 6272,
+          "cache_read": 2403192
         },
-        "usd_equivalent": 1.9663149999999998,
-        "messages": 14
+        "usd_equivalent": 1.4115247499999999,
+        "messages": 10
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 11
+      "high": 8
     },
     "unpriced_models": []
   },
@@ -135,12 +135,11 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1469919,
+    "tokens_before_first_edit": 881873,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 5,
-      "Write": 3,
-      "StructuredOutput": 1
+      "Bash": 3,
+      "Write": 3
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-motion-13.json
+++ b/.claude/metrics/chore-deps-motion-13.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-motion-13",
     "base_sha": "044f902c0402e536b7401d246ddfe2b35b2d7afe",
     "head_sha": "650bb8b8dc6015c443f513a16c43981126a3ecfb",
-    "generated_at": "2026-09-07T07:42:03.732Z",
+    "generated_at": "2026-09-09T06:24:29.029Z",
     "merged_at": "2026-09-06T05:02:12Z",
     "phase": "at-merge"
   },
@@ -23,57 +23,57 @@
     "first_ts": "2026-09-02T06:44:28.972Z",
     "last_ts": "2026-09-02T06:46:50.457Z",
     "span_seconds": 141,
-    "active_seconds": 173,
+    "active_seconds": 172,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 2.9727399999999995,
+    "usd_equivalent": 1.8416525,
     "tokens": {
-      "input": 67,
-      "output": 9861,
-      "thinking": 1258,
-      "cache_write_5m": 38040,
-      "cache_write_1h": 12621,
-      "cache_read": 4723840
+      "input": 31,
+      "output": 5637,
+      "thinking": 538,
+      "cache_write_5m": 8256,
+      "cache_write_1h": 9071,
+      "cache_read": 3116525
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 36,
-          "output": 7304,
-          "thinking": 1258,
+          "input": 24,
+          "output": 5048,
+          "thinking": 538,
           "cache_write_5m": 0,
-          "cache_write_1h": 12621,
-          "cache_read": 4605976
+          "cache_write_1h": 9071,
+          "cache_read": 3072273
         },
-        "usd_equivalent": 2.6119779999999997,
-        "messages": 18
+        "usd_equivalent": 1.7531665,
+        "messages": 12
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 31,
-          "output": 2557,
+          "input": 7,
+          "output": 589,
           "thinking": 0,
-          "cache_write_5m": 38040,
+          "cache_write_5m": 8256,
           "cache_write_1h": 0,
-          "cache_read": 117864
+          "cache_read": 44252
         },
-        "usd_equivalent": 0.360762,
-        "messages": 6
+        "usd_equivalent": 0.08848600000000001,
+        "messages": 2
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 67,
-          "output": 9861,
-          "thinking": 1258,
-          "cache_write_5m": 38040,
-          "cache_write_1h": 12621,
-          "cache_read": 4723840
+          "input": 31,
+          "output": 5637,
+          "thinking": 538,
+          "cache_write_5m": 8256,
+          "cache_write_1h": 9071,
+          "cache_read": 3116525
         },
-        "usd_equivalent": 2.9727399999999995,
-        "messages": 24
+        "usd_equivalent": 1.8416525,
+        "messages": 14
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 18
+      "high": 12
     },
     "unpriced_models": []
   },
@@ -135,12 +135,11 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 3064000,
+    "tokens_before_first_edit": 2043787,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 10,
-      "Read": 4,
-      "Write": 3
+      "Bash": 6,
+      "Write": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-oxlint-oxfmt.json
+++ b/.claude/metrics/chore-deps-oxlint-oxfmt.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-oxlint-oxfmt",
     "base_sha": "72aaf7458bd38fcd1de04d51639936aa6d5779e9",
     "head_sha": "8058ef3d260f6c1e850e07f423f2d43557879743",
-    "generated_at": "2026-09-07T07:41:57.409Z",
+    "generated_at": "2026-09-09T06:24:29.028Z",
     "merged_at": "2026-09-06T05:02:14Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 19.128516499999996,
+    "usd_equivalent": 12.923985000000002,
     "tokens": {
-      "input": 245,
-      "output": 53190,
-      "thinking": 17931,
-      "cache_write_5m": 28604,
-      "cache_write_1h": 66469,
-      "cache_read": 33908153
+      "input": 159,
+      "output": 30722,
+      "thinking": 6415,
+      "cache_write_5m": 10662,
+      "cache_write_1h": 47074,
+      "cache_read": 23235525
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 37,
-          "output": 4301,
+          "input": 17,
+          "output": 1940,
           "thinking": 0,
-          "cache_write_5m": 28604,
+          "cache_write_5m": 10662,
           "cache_write_1h": 0,
-          "cache_read": 295714
+          "cache_read": 178818
         },
-        "usd_equivalent": 0.434342,
-        "messages": 12
+        "usd_equivalent": 0.20463150000000002,
+        "messages": 7
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 208,
-          "output": 48889,
-          "thinking": 17931,
+          "input": 142,
+          "output": 28782,
+          "thinking": 6415,
           "cache_write_5m": 0,
-          "cache_write_1h": 66469,
-          "cache_read": 33612439
+          "cache_write_1h": 47074,
+          "cache_read": 23056707
         },
-        "usd_equivalent": 18.6941745,
-        "messages": 104
+        "usd_equivalent": 12.7193535,
+        "messages": 71
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 245,
-          "output": 53190,
-          "thinking": 17931,
-          "cache_write_5m": 28604,
-          "cache_write_1h": 66469,
-          "cache_read": 33908153
+          "input": 159,
+          "output": 30722,
+          "thinking": 6415,
+          "cache_write_5m": 10662,
+          "cache_write_1h": 47074,
+          "cache_read": 23235525
         },
-        "usd_equivalent": 19.128516499999996,
-        "messages": 116
+        "usd_equivalent": 12.923985000000002,
+        "messages": 78
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 104
+      "high": 71
     },
     "unpriced_models": []
   },
@@ -135,18 +135,17 @@
   "interaction": {
     "user_turns": 3,
     "corrective_turns": 1,
-    "tokens_before_first_edit": 2101420,
+    "tokens_before_first_edit": 1201068,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 54,
-      "Write": 9,
-      "Edit": 6,
-      "StructuredOutput": 2,
-      "Read": 2
+      "Bash": 34,
+      "Write": 7,
+      "Edit": 4,
+      "Read": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 3
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 2
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-deps-solid-router-1.json
+++ b/.claude/metrics/chore-deps-solid-router-1.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-solid-router-1",
     "base_sha": "5de432275d22a9731ab36a6b2d6aa644125464ac",
     "head_sha": "5e6fdf4de54d344106bb09b0af379b0bda6621a2",
-    "generated_at": "2026-09-07T07:42:06.624Z",
+    "generated_at": "2026-09-09T06:24:29.030Z",
     "merged_at": "2026-09-06T05:02:10Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 2.9078287499999997,
+    "usd_equivalent": 1.91753375,
     "tokens": {
-      "input": 68,
-      "output": 10627,
-      "thinking": 968,
-      "cache_write_5m": 36401,
-      "cache_write_1h": 11370,
-      "cache_read": 4601215
+      "input": 36,
+      "output": 5984,
+      "thinking": 406,
+      "cache_write_5m": 10343,
+      "cache_write_1h": 8616,
+      "cache_read": 3233900
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 36,
-          "output": 6284,
-          "thinking": 968,
+          "input": 26,
+          "output": 4571,
+          "thinking": 406,
           "cache_write_5m": 0,
-          "cache_write_1h": 11370,
-          "cache_read": 4315755
+          "cache_write_1h": 8616,
+          "cache_read": 3108678
         },
-        "usd_equivalent": 2.4288575000000003,
-        "messages": 18
+        "usd_equivalent": 1.754904,
+        "messages": 13
       },
       "claude-opus-4-7": {
         "tokens": {
-          "input": 32,
-          "output": 4343,
+          "input": 10,
+          "output": 1413,
           "thinking": 0,
-          "cache_write_5m": 36401,
+          "cache_write_5m": 10343,
           "cache_write_1h": 0,
-          "cache_read": 285460
+          "cache_read": 125222
         },
-        "usd_equivalent": 0.47897124999999996,
-        "messages": 12
+        "usd_equivalent": 0.16262975000000002,
+        "messages": 5
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 68,
-          "output": 10627,
-          "thinking": 968,
-          "cache_write_5m": 36401,
-          "cache_write_1h": 11370,
-          "cache_read": 4601215
+          "input": 36,
+          "output": 5984,
+          "thinking": 406,
+          "cache_write_5m": 10343,
+          "cache_write_1h": 8616,
+          "cache_read": 3233900
         },
-        "usd_equivalent": 2.9078287499999997,
-        "messages": 30
+        "usd_equivalent": 1.91753375,
+        "messages": 18
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 18
+      "high": 13
     },
     "unpriced_models": []
   },
@@ -133,14 +133,13 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1661843,
+    "tokens_before_first_edit": 1424132,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 11,
-      "Read": 4,
+      "Bash": 7,
       "Write": 2,
-      "Glob": 2,
-      "StructuredOutput": 1
+      "Glob": 1,
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-workers-types-5.json
+++ b/.claude/metrics/chore-deps-workers-types-5.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-workers-types-5",
     "base_sha": "650bb8b8dc6015c443f513a16c43981126a3ecfb",
     "head_sha": "fca74814cbbdf0fe9646250dcfbef3fcb003bf5c",
-    "generated_at": "2026-09-07T07:42:02.347Z",
+    "generated_at": "2026-09-09T06:24:29.029Z",
     "merged_at": "2026-09-06T05:02:12Z",
     "phase": "at-merge"
   },
@@ -21,59 +21,59 @@
   "window": {
     "sessions": 3,
     "first_ts": "2026-09-02T06:46:48.386Z",
-    "last_ts": "2026-09-02T06:49:45.244Z",
-    "span_seconds": 177,
-    "active_seconds": 233,
+    "last_ts": "2026-09-02T06:49:43.395Z",
+    "span_seconds": 175,
+    "active_seconds": 231,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 5.366101249999999,
+    "usd_equivalent": 3.4740269999999995,
     "tokens": {
-      "input": 88,
-      "output": 17122,
-      "thinking": 2022,
-      "cache_write_5m": 43089,
-      "cache_write_1h": 29307,
-      "cache_read": 8750470
+      "input": 55,
+      "output": 9295,
+      "thinking": 710,
+      "cache_write_5m": 18608,
+      "cache_write_1h": 18801,
+      "cache_read": 5874134
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 26,
-          "output": 6273,
+          "input": 13,
+          "output": 2322,
           "thinking": 0,
-          "cache_write_5m": 43089,
+          "cache_write_5m": 18608,
           "cache_write_1h": 0,
-          "cache_read": 424825
+          "cache_read": 216901
         },
-        "usd_equivalent": 0.63867375,
-        "messages": 16
+        "usd_equivalent": 0.2828655,
+        "messages": 8
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 62,
-          "output": 10849,
-          "thinking": 2022,
+          "input": 42,
+          "output": 6973,
+          "thinking": 710,
           "cache_write_5m": 0,
-          "cache_write_1h": 29307,
-          "cache_read": 8325645
+          "cache_write_1h": 18801,
+          "cache_read": 5657233
         },
-        "usd_equivalent": 4.727427500000001,
-        "messages": 31
+        "usd_equivalent": 3.1911614999999998,
+        "messages": 21
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 88,
-          "output": 17122,
-          "thinking": 2022,
-          "cache_write_5m": 43089,
-          "cache_write_1h": 29307,
-          "cache_read": 8750470
+          "input": 55,
+          "output": 9295,
+          "thinking": 710,
+          "cache_write_5m": 18608,
+          "cache_write_1h": 18801,
+          "cache_read": 5874134
         },
-        "usd_equivalent": 5.366101249999999,
-        "messages": 47
+        "usd_equivalent": 3.4740269999999995,
+        "messages": 29
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 31
+      "high": 21
     },
     "unpriced_models": []
   },
@@ -139,18 +139,17 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 2911998,
+    "tokens_before_first_edit": 1590099,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 16,
-      "Read": 6,
-      "Edit": 3,
-      "Write": 3,
-      "StructuredOutput": 2
+      "Bash": 12,
+      "Read": 2,
+      "Write": 2,
+      "Edit": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 3
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-hasown-map-guard-polish.json
+++ b/.claude/metrics/chore-hasown-map-guard-polish.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 826,
+    "branch": "chore/hasown-map-guard-polish",
+    "base_sha": "b84c78188446243df33cd34a38e23fe858489af1",
+    "head_sha": "38d3afc953c3eb6aa55ccc096c6fe11a130b5db8",
+    "generated_at": "2026-09-09T06:24:29.041Z",
+    "merged_at": "2026-08-30T02:36:41Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 491,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-28T01:54:10.023Z",
+    "last_ts": "2026-08-28T02:11:47.939Z",
+    "span_seconds": 1058,
+    "active_seconds": 865,
+    "compactions": 1
+  },
+  "spend": {
+    "usd_equivalent": 1.8589590999999999,
+    "tokens": {
+      "input": 92,
+      "output": 16868,
+      "thinking": 7724,
+      "cache_write_5m": 18608,
+      "cache_write_1h": 179754,
+      "cache_read": 3833410
+    },
+    "by_model": {
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 74,
+          "output": 14942,
+          "thinking": 7724,
+          "cache_write_5m": 0,
+          "cache_write_1h": 179754,
+          "cache_read": 3636233
+        },
+        "usd_equivalent": 1.5958306,
+        "messages": 37
+      },
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 18,
+          "output": 1926,
+          "thinking": 0,
+          "cache_write_5m": 18608,
+          "cache_write_1h": 0,
+          "cache_read": 197177
+        },
+        "usd_equivalent": 0.2631285,
+        "messages": 8
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 92,
+          "output": 16868,
+          "thinking": 7724,
+          "cache_write_5m": 18608,
+          "cache_write_1h": 179754,
+          "cache_read": 3833410
+        },
+        "usd_equivalent": 1.8589590999999999,
+        "messages": 45
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 37
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 0,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 13,
+        "deleted": 0
+      },
+      "test": {
+        "added": 14,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 2,
+        "deleted": 1
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/social"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 5,
+    "corrective_turns": 2,
+    "tokens_before_first_edit": 675782,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 6,
+      "Read": 3,
+      "Edit": 1,
+      "Write": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-house-rule-non-subscribing-read.json
+++ b/.claude/metrics/chore-house-rule-non-subscribing-read.json
@@ -5,7 +5,7 @@
     "branch": "chore/house-rule-non-subscribing-read",
     "base_sha": "bb5b11a229842de7193e5656dd0ec9349eb457e0",
     "head_sha": "14a3d50a122d0b82bd2246ef87fac70002cd5e58",
-    "generated_at": "2026-09-07T07:41:46.338Z",
+    "generated_at": "2026-09-09T06:24:29.023Z",
     "merged_at": "2026-09-06T09:12:08Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.9787312500000003,
+    "usd_equivalent": 1.1956515,
     "tokens": {
-      "input": 32,
-      "output": 17852,
+      "input": 20,
+      "output": 9501,
       "thinking": 0,
-      "cache_write_5m": 128829,
+      "cache_write_5m": 75100,
       "cache_write_1h": 0,
-      "cache_read": 1454180
+      "cache_read": 977303
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 32,
-          "output": 17852,
+          "input": 20,
+          "output": 9501,
           "thinking": 0,
-          "cache_write_5m": 128829,
+          "cache_write_5m": 75100,
           "cache_write_1h": 0,
-          "cache_read": 1454180
+          "cache_read": 977303
         },
-        "usd_equivalent": 1.9787312500000003,
-        "messages": 22
+        "usd_equivalent": 1.1956515,
+        "messages": 15
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 32,
-          "output": 17852,
+          "input": 20,
+          "output": 9501,
           "thinking": 0,
-          "cache_write_5m": 128829,
+          "cache_write_5m": 75100,
           "cache_write_1h": 0,
-          "cache_read": 1454180
+          "cache_read": 977303
         },
-        "usd_equivalent": 1.9787312500000003,
-        "messages": 22
+        "usd_equivalent": 1.1956515,
+        "messages": 15
       },
       "subagent": {
         "tokens": {
@@ -121,8 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 11,
-      "Bash": 3,
+      "Read": 6,
+      "Bash": 1,
       "Grep": 1
     },
     "edit_churn": {

--- a/.claude/metrics/chore-jest-dom-marker-cache-and-deps.json
+++ b/.claude/metrics/chore-jest-dom-marker-cache-and-deps.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 827,
+    "branch": "chore/jest-dom-marker-cache-and-deps",
+    "base_sha": "97e620962708fd9eb9289259cca79275425e1678",
+    "head_sha": "8f06afeb51e2e2712b6e5217040072e7e141c2e4",
+    "generated_at": "2026-09-09T06:24:29.041Z",
+    "merged_at": "2026-08-30T02:42:20Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 504,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-28T02:38:22.386Z",
+    "last_ts": "2026-08-28T02:39:46.915Z",
+    "span_seconds": 85,
+    "active_seconds": 99,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.5525924999999999,
+    "tokens": {
+      "input": 23,
+      "output": 5136,
+      "thinking": 0,
+      "cache_write_5m": 37870,
+      "cache_write_1h": 0,
+      "cache_read": 374780
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 23,
+          "output": 5136,
+          "thinking": 0,
+          "cache_write_5m": 37870,
+          "cache_write_1h": 0,
+          "cache_read": 374780
+        },
+        "usd_equivalent": 0.5525924999999999,
+        "messages": 13
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 23,
+          "output": 5136,
+          "thinking": 0,
+          "cache_write_5m": 37870,
+          "cache_write_1h": 0,
+          "cache_read": 374780
+        },
+        "usd_equivalent": 0.5525924999999999,
+        "messages": 13
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 3,
+      "test": 1,
+      "docs": 2,
+      "config": 13,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 18,
+        "deleted": 10
+      },
+      "test": {
+        "added": 89,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 11,
+        "deleted": 6
+      },
+      "config": {
+        "added": 14,
+        "deleted": 10
+      },
+      "source": {
+        "added": 40,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "cire/invites",
+      "cire/landing",
+      "osn/client",
+      "osn/landing",
+      "osn/social",
+      "osn/ui",
+      "pulse/landing",
+      "shared/rp-auth",
+      "shared/sortable",
+      "shared/toast"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 4,
+      "Glob": 2,
+      "Bash": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-needs-decision-label.json
+++ b/.claude/metrics/chore-needs-decision-label.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 847,
+    "branch": "chore/needs-decision-label",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "cd521e65d3355f56a558b835c8fa2a55e02a6d81",
+    "generated_at": "2026-09-09T06:24:29.037Z",
+    "merged_at": "2026-08-31T04:33:47Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-31T03:56:33.745Z",
+    "last_ts": "2026-08-31T03:56:48.237Z",
+    "span_seconds": 14,
+    "active_seconds": 14,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.22364825,
+    "tokens": {
+      "input": 9,
+      "output": 666,
+      "thinking": 0,
+      "cache_write_5m": 26933,
+      "cache_write_1h": 0,
+      "cache_read": 77244
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 9,
+          "output": 666,
+          "thinking": 0,
+          "cache_write_5m": 26933,
+          "cache_write_1h": 0,
+          "cache_read": 77244
+        },
+        "usd_equivalent": 0.22364825,
+        "messages": 4
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 9,
+          "output": 666,
+          "thinking": 0,
+          "cache_write_5m": 26933,
+          "cache_write_1h": 0,
+          "cache_read": 77244
+        },
+        "usd_equivalent": 0.22364825,
+        "messages": 4
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 4,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 50,
+        "deleted": 11
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 7,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-osn-client-polish.json
+++ b/.claude/metrics/chore-osn-client-polish.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 789,
+    "branch": "chore/osn-client-polish",
+    "base_sha": "861635605f93bc17180d1bf8dc16b22966d420a8",
+    "head_sha": "ecbe80dd13951f7c44b40428efce969c5487e888",
+    "generated_at": "2026-09-09T06:24:29.045Z",
+    "merged_at": "2026-08-25T04:14:23Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 505,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-08-25T03:47:05.572Z",
+    "last_ts": "2026-08-25T04:04:42.644Z",
+    "span_seconds": 1057,
+    "active_seconds": 892,
+    "compactions": 3
+  },
+  "spend": {
+    "usd_equivalent": 3.7870828000000007,
+    "tokens": {
+      "input": 153,
+      "output": 35538,
+      "thinking": 4439,
+      "cache_write_5m": 80190,
+      "cache_write_1h": 292742,
+      "cache_read": 6555283
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 43,
+          "output": 9640,
+          "thinking": 0,
+          "cache_write_5m": 80190,
+          "cache_write_1h": 0,
+          "cache_read": 1011519
+        },
+        "usd_equivalent": 1.2481619999999998,
+        "messages": 28
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 110,
+          "output": 25898,
+          "thinking": 4439,
+          "cache_write_5m": 0,
+          "cache_write_1h": 292742,
+          "cache_read": 5543764
+        },
+        "usd_equivalent": 2.5389208000000005,
+        "messages": 55
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 153,
+          "output": 35538,
+          "thinking": 4439,
+          "cache_write_5m": 80190,
+          "cache_write_1h": 292742,
+          "cache_read": 6555283
+        },
+        "usd_equivalent": 3.7870828000000007,
+        "messages": 83
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 55
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 0,
+      "config": 1,
+      "source": 3
+    },
+    "loc": {
+      "generated": {
+        "added": 5,
+        "deleted": 0
+      },
+      "test": {
+        "added": 226,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 1,
+        "deleted": 0
+      },
+      "source": {
+        "added": 39,
+        "deleted": 37
+      }
+    },
+    "packages": [
+      "osn/client"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 7,
+    "corrective_turns": 3,
+    "tokens_before_first_edit": 687347,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Edit": 8,
+      "Read": 7,
+      "Bash": 3,
+      "Grep": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 4
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-session-discipline.json
+++ b/.claude/metrics/chore-session-discipline.json
@@ -5,7 +5,7 @@
     "branch": "chore/session-discipline",
     "base_sha": "dc7bcaff1340a8d551100cdda8952b2488b9e62c",
     "head_sha": "186da7f067f9772488ba827112314d65cc7c4b25",
-    "generated_at": "2026-09-07T07:41:36.601Z",
+    "generated_at": "2026-09-09T06:24:29.016Z",
     "merged_at": "2026-09-07T03:52:44Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 0.522848,
+    "usd_equivalent": 0.2533955,
     "tokens": {
-      "input": 20,
-      "output": 4722,
+      "input": 10,
+      "output": 2086,
       "thinking": 0,
-      "cache_write_5m": 50130,
+      "cache_write_5m": 24834,
       "cache_write_1h": 0,
-      "cache_read": 182771
+      "cache_read": 91966
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 20,
-          "output": 4722,
+          "input": 10,
+          "output": 2086,
           "thinking": 0,
-          "cache_write_5m": 50130,
+          "cache_write_5m": 24834,
           "cache_write_1h": 0,
-          "cache_read": 182771
+          "cache_read": 91966
         },
-        "usd_equivalent": 0.522848,
-        "messages": 10
+        "usd_equivalent": 0.2533955,
+        "messages": 5
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 20,
-          "output": 4722,
+          "input": 10,
+          "output": 2086,
           "thinking": 0,
-          "cache_write_5m": 50130,
+          "cache_write_5m": 24834,
           "cache_write_1h": 0,
-          "cache_read": 182771
+          "cache_read": 91966
         },
-        "usd_equivalent": 0.522848,
-        "messages": 10
+        "usd_equivalent": 0.2533955,
+        "messages": 5
       },
       "subagent": {
         "tokens": {
@@ -119,9 +119,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 3,
-      "Glob": 1,
-      "StructuredOutput": 1
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-svgo-advisory.json
+++ b/.claude/metrics/chore-svgo-advisory.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 961,
+    "branch": "chore/svgo-advisory",
+    "base_sha": "2eb9393ca64639068c42d5a614e3df8ab68c6e61",
+    "head_sha": "9d19c6885a48edb24aff2e429496fc5d53f97bb2",
+    "generated_at": "2026-09-09T06:24:29.014Z",
+    "merged_at": "2026-09-09T01:40:51Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 960,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-09T01:37:24.548Z",
+    "last_ts": "2026-09-09T01:40:45.369Z",
+    "span_seconds": 201,
+    "active_seconds": 201,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0,
+    "tokens": {
+      "input": 126,
+      "output": 30,
+      "thinking": 0,
+      "cache_write_5m": 55916,
+      "cache_write_1h": 0,
+      "cache_read": 682587
+    },
+    "by_model": {
+      "claude-haiku-4-5-20251001": {
+        "tokens": {
+          "input": 126,
+          "output": 30,
+          "thinking": 0,
+          "cache_write_5m": 55916,
+          "cache_write_1h": 0,
+          "cache_read": 682587
+        },
+        "usd_equivalent": 0,
+        "messages": 15
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 126,
+          "output": 30,
+          "thinking": 0,
+          "cache_write_5m": 55916,
+          "cache_write_1h": 0,
+          "cache_read": 682587
+        },
+        "usd_equivalent": 0,
+        "messages": 15
+      }
+    },
+    "effort": {},
+    "unpriced_models": [
+      "claude-haiku-4-5-20251001"
+    ]
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 0,
+      "docs": 0,
+      "config": 1,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 41,
+        "deleted": 29
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 1,
+        "deleted": 1
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {},
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-svgo-advisory.json
+++ b/.claude/metrics/chore-svgo-advisory.json
@@ -5,7 +5,7 @@
     "branch": "chore/svgo-advisory",
     "base_sha": "2eb9393ca64639068c42d5a614e3df8ab68c6e61",
     "head_sha": "9d19c6885a48edb24aff2e429496fc5d53f97bb2",
-    "generated_at": "2026-09-09T06:24:29.014Z",
+    "generated_at": "2026-09-09T06:29:32.626Z",
     "merged_at": "2026-09-09T01:40:51Z",
     "phase": "at-merge"
   },
@@ -27,7 +27,7 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 0,
+    "usd_equivalent": 0.1384297,
     "tokens": {
       "input": 126,
       "output": 30,
@@ -46,7 +46,7 @@
           "cache_write_1h": 0,
           "cache_read": 682587
         },
-        "usd_equivalent": 0,
+        "usd_equivalent": 0.1384297,
         "messages": 15
       }
     },
@@ -72,14 +72,12 @@
           "cache_write_1h": 0,
           "cache_read": 682587
         },
-        "usd_equivalent": 0,
+        "usd_equivalent": 0.1384297,
         "messages": 15
       }
     },
     "effort": {},
-    "unpriced_models": [
-      "claude-haiku-4-5-20251001"
-    ]
+    "unpriced_models": []
   },
   "diff": {
     "files": {

--- a/.claude/metrics/chore-vendored-integrity-gate.json
+++ b/.claude/metrics/chore-vendored-integrity-gate.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 788,
+    "branch": "chore/vendored-integrity-gate",
+    "base_sha": "861635605f93bc17180d1bf8dc16b22966d420a8",
+    "head_sha": "7c57d378192b3b37179cfd4cc18d6bc614350b25",
+    "generated_at": "2026-09-09T06:24:29.046Z",
+    "merged_at": "2026-08-25T04:21:11Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 489,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 5,
+    "first_ts": "2026-08-25T03:35:23.097Z",
+    "last_ts": "2026-08-25T03:43:13.193Z",
+    "span_seconds": 470,
+    "active_seconds": 583,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 2.7333024499999987,
+    "tokens": {
+      "input": 93,
+      "output": 39278,
+      "thinking": 561,
+      "cache_write_5m": 97239,
+      "cache_write_1h": 76251,
+      "cache_read": 2933976
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 57,
+          "output": 32329,
+          "thinking": 0,
+          "cache_write_5m": 97239,
+          "cache_write_1h": 0,
+          "cache_read": 1185625
+        },
+        "usd_equivalent": 2.009066249999999,
+        "messages": 37
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 36,
+          "output": 6949,
+          "thinking": 561,
+          "cache_write_5m": 0,
+          "cache_write_1h": 76251,
+          "cache_read": 1748351
+        },
+        "usd_equivalent": 0.7242362,
+        "messages": 18
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 93,
+          "output": 39278,
+          "thinking": 561,
+          "cache_write_5m": 97239,
+          "cache_write_1h": 76251,
+          "cache_read": 2933976
+        },
+        "usd_equivalent": 2.7333024499999987,
+        "messages": 55
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 18
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 0,
+      "docs": 0,
+      "config": 2,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 4,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 26,
+        "deleted": 16
+      },
+      "source": {
+        "added": 23,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 5,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 10,
+      "Bash": 6,
+      "Glob": 1,
+      "Grep": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/chore-vendored-tree-modes.json
+++ b/.claude/metrics/chore-vendored-tree-modes.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 840,
+    "branch": "chore/vendored-tree-modes",
+    "base_sha": "273e4ba82e35358c1ef08ab4ae2e38f7692ac855",
+    "head_sha": "268c616841441db40ca129c7affba09371e290f6",
+    "generated_at": "2026-09-09T06:24:29.039Z",
+    "merged_at": "2026-08-30T14:13:29Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 562,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-30T13:12:39.308Z",
+    "last_ts": "2026-08-30T13:13:34.999Z",
+    "span_seconds": 56,
+    "active_seconds": 56,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.29891474999999995,
+    "tokens": {
+      "input": 11,
+      "output": 3266,
+      "thinking": 0,
+      "cache_write_5m": 20907,
+      "cache_write_1h": 0,
+      "cache_read": 173082
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 11,
+          "output": 3266,
+          "thinking": 0,
+          "cache_write_5m": 20907,
+          "cache_write_1h": 0,
+          "cache_read": 173082
+        },
+        "usd_equivalent": 0.29891474999999995,
+        "messages": 6
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 11,
+          "output": 3266,
+          "thinking": 0,
+          "cache_write_5m": 20907,
+          "cache_write_1h": 0,
+          "cache_read": 173082
+        },
+        "usd_equivalent": 0.29891474999999995,
+        "messages": 6
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 0,
+      "docs": 2,
+      "config": 0,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 10,
+        "deleted": 1
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 26,
+        "deleted": 12
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 31,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "tools/oxlint"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/docs-claude-md-refresh.json
+++ b/.claude/metrics/docs-claude-md-refresh.json
@@ -5,7 +5,7 @@
     "branch": "docs/claude-md-refresh",
     "base_sha": "7a77cbdc373417e2a7e36def286d3266aa81c9b7",
     "head_sha": "dabb55686d12fae7d5a41057ee037c52bcfd1f61",
-    "generated_at": "2026-09-07T07:41:39.935Z",
+    "generated_at": "2026-09-09T06:24:29.021Z",
     "merged_at": "2026-09-07T02:45:17Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 0.8630182499999999,
+    "usd_equivalent": 0.41775625,
     "tokens": {
-      "input": 36,
-      "output": 2739,
+      "input": 20,
+      "output": 1389,
       "thinking": 0,
-      "cache_write_5m": 97263,
+      "cache_write_5m": 41675,
       "cache_write_1h": 0,
-      "cache_read": 372939
+      "cache_read": 244925
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 36,
-          "output": 2739,
+          "input": 20,
+          "output": 1389,
           "thinking": 0,
-          "cache_write_5m": 97263,
+          "cache_write_5m": 41675,
           "cache_write_1h": 0,
-          "cache_read": 372939
+          "cache_read": 244925
         },
-        "usd_equivalent": 0.8630182499999999,
-        "messages": 16
+        "usd_equivalent": 0.41775625,
+        "messages": 10
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 36,
-          "output": 2739,
+          "input": 20,
+          "output": 1389,
           "thinking": 0,
-          "cache_write_5m": 97263,
+          "cache_write_5m": 41675,
           "cache_write_1h": 0,
-          "cache_read": 372939
+          "cache_read": 244925
         },
-        "usd_equivalent": 0.8630182499999999,
-        "messages": 16
+        "usd_equivalent": 0.41775625,
+        "messages": 10
       },
       "subagent": {
         "tokens": {
@@ -119,9 +119,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 4,
       "Glob": 2,
-      "StructuredOutput": 2
+      "Read": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/docs-test-layout-drift.json
+++ b/.claude/metrics/docs-test-layout-drift.json
@@ -5,7 +5,7 @@
     "branch": "docs/test-layout-drift",
     "base_sha": "804e8d42a9ee3c3571c905cafc61b2fd075523f3",
     "head_sha": "64a02029b5cc54967053669e22a0fadf5fbb4699",
-    "generated_at": "2026-09-07T07:41:49.544Z",
+    "generated_at": "2026-09-09T06:24:29.024Z",
     "merged_at": "2026-09-06T16:11:34Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.52969225,
+    "usd_equivalent": 0.7689817500000001,
     "tokens": {
-      "input": 17,
-      "output": 14682,
+      "input": 9,
+      "output": 6463,
       "thinking": 0,
-      "cache_write_5m": 156555,
+      "cache_write_5m": 79505,
       "cache_write_1h": 0,
-      "cache_read": 368177
+      "cache_read": 220911
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 17,
-          "output": 14682,
+          "input": 9,
+          "output": 6463,
           "thinking": 0,
-          "cache_write_5m": 156555,
+          "cache_write_5m": 79505,
           "cache_write_1h": 0,
-          "cache_read": 368177
+          "cache_read": 220911
         },
-        "usd_equivalent": 1.52969225,
-        "messages": 7
+        "usd_equivalent": 0.7689817500000001,
+        "messages": 4
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 17,
-          "output": 14682,
+          "input": 9,
+          "output": 6463,
           "thinking": 0,
-          "cache_write_5m": 156555,
+          "cache_write_5m": 79505,
           "cache_write_1h": 0,
-          "cache_read": 368177
+          "cache_read": 220911
         },
-        "usd_equivalent": 1.52969225,
-        "messages": 7
+        "usd_equivalent": 0.7689817500000001,
+        "messages": 4
       },
       "subagent": {
         "tokens": {
@@ -121,8 +121,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2,
-      "StructuredOutput": 1
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/docs-visual-verification-notes.json
+++ b/.claude/metrics/docs-visual-verification-notes.json
@@ -5,7 +5,7 @@
     "branch": "docs/visual-verification-notes",
     "base_sha": "3abce2e30862a1156039092bd08e6cf5f18af237",
     "head_sha": "2a7dcc777fe44c2c0c93061cf1cefc5cadbb306c",
-    "generated_at": "2026-09-07T07:41:38.177Z",
+    "generated_at": "2026-09-09T06:24:29.020Z",
     "merged_at": "2026-09-07T03:04:47Z",
     "phase": "at-merge"
   },
@@ -27,57 +27,57 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 13.497305999999993,
+    "usd_equivalent": 8.719838999999997,
     "tokens": {
-      "input": 258,
-      "output": 46124,
-      "thinking": 15060,
-      "cache_write_5m": 254454,
-      "cache_write_1h": 92067,
-      "cache_read": 19663817
+      "input": 170,
+      "output": 25315,
+      "thinking": 4484,
+      "cache_write_5m": 102478,
+      "cache_write_1h": 60128,
+      "cache_read": 13688693
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 258,
-          "output": 46124,
-          "thinking": 15060,
-          "cache_write_5m": 254454,
-          "cache_write_1h": 92067,
-          "cache_read": 19663817
+          "input": 170,
+          "output": 25315,
+          "thinking": 4484,
+          "cache_write_5m": 102478,
+          "cache_write_1h": 60128,
+          "cache_read": 13688693
         },
-        "usd_equivalent": 13.497305999999993,
-        "messages": 129
+        "usd_equivalent": 8.719838999999997,
+        "messages": 85
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 134,
-          "output": 35804,
-          "thinking": 8968,
+          "input": 98,
+          "output": 24200,
+          "thinking": 4484,
           "cache_write_5m": 0,
-          "cache_write_1h": 92067,
-          "cache_read": 14629810
+          "cache_write_1h": 60128,
+          "cache_read": 10723557
         },
-        "usd_equivalent": 9.131344999999998,
-        "messages": 67
+        "usd_equivalent": 6.5685485,
+        "messages": 49
       },
       "subagent": {
         "tokens": {
-          "input": 124,
-          "output": 10320,
-          "thinking": 6092,
-          "cache_write_5m": 254454,
+          "input": 72,
+          "output": 1115,
+          "thinking": 0,
+          "cache_write_5m": 102478,
           "cache_write_1h": 0,
-          "cache_read": 5034007
+          "cache_read": 2965136
         },
-        "usd_equivalent": 4.365961000000002,
-        "messages": 62
+        "usd_equivalent": 2.1512904999999996,
+        "messages": 36
       }
     },
     "effort": {
-      "high": 129
+      "high": 85
     },
     "unpriced_models": []
   },
@@ -118,23 +118,20 @@
   "interaction": {
     "user_turns": 0,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1725006,
+    "tokens_before_first_edit": 1932001,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 66,
-      "Edit": 12,
-      "Skill": 2,
-      "Agent": 1,
-      "Read": 1,
-      "Write": 1
+      "Bash": 31,
+      "Edit": 7,
+      "Skill": 1,
+      "Agent": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 3,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 3
     },
     "skills": {
-      "obsidian:obsidian-markdown": 1,
-      "prep-pr": 1
+      "obsidian:obsidian-markdown": 1
     },
     "subagents": {
       "general-purpose": 1

--- a/.claude/metrics/feat-map-guard-lint-rule.json
+++ b/.claude/metrics/feat-map-guard-lint-rule.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 832,
+    "branch": "feat/map-guard-lint-rule",
+    "base_sha": "8c017e096b4151e053acb7f081730178b9e3268d",
+    "head_sha": "f0479e66265938c7fa02fa173f94cf820ab4bdc2",
+    "generated_at": "2026-09-09T06:24:29.040Z",
+    "merged_at": "2026-08-30T03:48:05Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 493,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-30T02:45:16.696Z",
+    "last_ts": "2026-08-30T02:51:00.778Z",
+    "span_seconds": 344,
+    "active_seconds": 59,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.47466699999999995,
+    "tokens": {
+      "input": 17,
+      "output": 3385,
+      "thinking": 0,
+      "cache_write_5m": 48408,
+      "cache_write_1h": 0,
+      "cache_read": 174814
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 17,
+          "output": 3385,
+          "thinking": 0,
+          "cache_write_5m": 48408,
+          "cache_write_1h": 0,
+          "cache_read": 174814
+        },
+        "usd_equivalent": 0.47466699999999995,
+        "messages": 7
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 17,
+          "output": 3385,
+          "thinking": 0,
+          "cache_write_5m": 48408,
+          "cache_write_1h": 0,
+          "cache_read": 174814
+        },
+        "usd_equivalent": 0.47466699999999995,
+        "messages": 7
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 1,
+      "docs": 3,
+      "config": 4,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 22,
+        "deleted": 0
+      },
+      "test": {
+        "added": 136,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 60,
+        "deleted": 7
+      },
+      "config": {
+        "added": 47,
+        "deleted": 5
+      },
+      "source": {
+        "added": 75,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "tools/oxlint"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 1,
+      "StructuredOutput": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-osn-totp-api.json
+++ b/.claude/metrics/feat-osn-totp-api.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 969,
+    "branch": "feat/osn-totp-api",
+    "base_sha": "a621c6c6059ae34bff3a8b92c1086d34249b6153",
+    "head_sha": "c536459c6ec92b740740b16a30d496fc50024dfc",
+    "generated_at": "2026-09-09T06:24:28.993Z",
+    "merged_at": "2026-09-09T05:15:20Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 949,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-09T01:47:06.882Z",
+    "last_ts": "2026-09-09T03:12:36.544Z",
+    "span_seconds": 5130,
+    "active_seconds": 5130,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 60.401499249999986,
+    "tokens": {
+      "input": 1038,
+      "output": 38995,
+      "thinking": 0,
+      "cache_write_5m": 1564019,
+      "cache_write_1h": 0,
+      "cache_read": 93113959
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 652,
+          "output": 38304,
+          "thinking": 0,
+          "cache_write_5m": 1268153,
+          "cache_write_1h": 0,
+          "cache_read": 90672022
+        },
+        "usd_equivalent": 54.22282724999999,
+        "messages": 326
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 386,
+          "output": 691,
+          "thinking": 0,
+          "cache_write_5m": 295866,
+          "cache_write_1h": 0,
+          "cache_read": 2441937
+        },
+        "usd_equivalent": 6.178672,
+        "messages": 13
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 1038,
+          "output": 38995,
+          "thinking": 0,
+          "cache_write_5m": 1564019,
+          "cache_write_1h": 0,
+          "cache_read": 93113959
+        },
+        "usd_equivalent": 60.401499249999986,
+        "messages": 339
+      }
+    },
+    "effort": {
+      "xhigh": 326,
+      "high": 13
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 4,
+      "test": 18,
+      "docs": 10,
+      "config": 3,
+      "source": 36
+    },
+    "loc": {
+      "generated": {
+        "added": 1842,
+        "deleted": 0
+      },
+      "test": {
+        "added": 1478,
+        "deleted": 26
+      },
+      "docs": {
+        "added": 380,
+        "deleted": 13
+      },
+      "config": {
+        "added": 902,
+        "deleted": 14
+      },
+      "source": {
+        "added": 1753,
+        "deleted": 55
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/client",
+      "osn/db",
+      "shared/crypto",
+      "shared/email",
+      "shared/observability",
+      "shared/openapi",
+      "shared/redis"
+    ],
+    "touches_migration": true,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 73,
+      "Edit": 25,
+      "Read": 4,
+      "Write": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 5
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-pr-metrics-complexity.json
+++ b/.claude/metrics/feat-pr-metrics-complexity.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 918,
+    "branch": "feat/pr-metrics-complexity",
+    "base_sha": "f73db88583845b1ada743c0283079fd0ba15079c",
+    "head_sha": "3e722e57dd0d8b3ad660d9fd5dc9b3719fe90440",
+    "generated_at": "2026-09-09T06:24:29.018Z",
+    "merged_at": "2026-09-07T07:51:47Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 6,
+    "first_ts": "2026-09-07T03:04:02.891Z",
+    "last_ts": "2026-09-07T04:29:45.817Z",
+    "span_seconds": 5143,
+    "active_seconds": 1366,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 8.476037999999999,
+    "tokens": {
+      "input": 141,
+      "output": 35614,
+      "thinking": 3398,
+      "cache_write_5m": 72418,
+      "cache_write_1h": 42328,
+      "cache_read": 13418181
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 80,
+          "output": 20450,
+          "thinking": 3398,
+          "cache_write_5m": 0,
+          "cache_write_1h": 42328,
+          "cache_read": 11631667
+        },
+        "usd_equivalent": 6.7507635,
+        "messages": 40
+      },
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 61,
+          "output": 15164,
+          "thinking": 0,
+          "cache_write_5m": 72418,
+          "cache_write_1h": 0,
+          "cache_read": 1786514
+        },
+        "usd_equivalent": 1.7252744999999998,
+        "messages": 36
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 141,
+          "output": 35614,
+          "thinking": 3398,
+          "cache_write_5m": 72418,
+          "cache_write_1h": 42328,
+          "cache_read": 13418181
+        },
+        "usd_equivalent": 8.476037999999999,
+        "messages": 76
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 40
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 5,
+      "config": 0,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 9,
+        "deleted": 0
+      },
+      "test": {
+        "added": 68,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 153,
+        "deleted": 4
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 68,
+        "deleted": 4
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 5,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": 3807031,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 25,
+      "Read": 7,
+      "EnterWorktree": 3,
+      "Edit": 3,
+      "Grep": 3,
+      "Glob": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-pr-metrics-pipeline.json
+++ b/.claude/metrics/feat-pr-metrics-pipeline.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 920,
+    "branch": "feat/pr-metrics-pipeline",
+    "base_sha": "3e722e57dd0d8b3ad660d9fd5dc9b3719fe90440",
+    "head_sha": "d0f6c37428d32ebb46450b78fa74ac1c93b2c651",
+    "generated_at": "2026-09-09T06:24:29.016Z",
+    "merged_at": "2026-09-07T07:51:48Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 7,
+    "first_ts": "2026-09-07T03:10:01.388Z",
+    "last_ts": "2026-09-07T11:32:45.585Z",
+    "span_seconds": 30164,
+    "active_seconds": 6786,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 47.58785725000001,
+    "tokens": {
+      "input": 424,
+      "output": 167779,
+      "thinking": 32840,
+      "cache_write_5m": 365449,
+      "cache_write_1h": 1040392,
+      "cache_read": 61406572
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 354,
+          "output": 133409,
+          "thinking": 32840,
+          "cache_write_5m": 137069,
+          "cache_write_1h": 1040392,
+          "cache_read": 59644861
+        },
+        "usd_equivalent": 44.420026750000005,
+        "messages": 177
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 2
+      },
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 70,
+          "output": 34370,
+          "thinking": 0,
+          "cache_write_5m": 228380,
+          "cache_write_1h": 0,
+          "cache_read": 1761711
+        },
+        "usd_equivalent": 3.1678304999999995,
+        "messages": 40
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 370,
+          "output": 167637,
+          "thinking": 32840,
+          "cache_write_5m": 228380,
+          "cache_write_1h": 1040392,
+          "cache_read": 60111652
+        },
+        "usd_equivalent": 46.07989600000002,
+        "messages": 192
+      },
+      "subagent": {
+        "tokens": {
+          "input": 54,
+          "output": 142,
+          "thinking": 0,
+          "cache_write_5m": 137069,
+          "cache_write_1h": 0,
+          "cache_read": 1294920
+        },
+        "usd_equivalent": 1.50796125,
+        "messages": 27
+      }
+    },
+    "effort": {
+      "high": 177
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 3,
+      "test": 3,
+      "docs": 3,
+      "config": 3,
+      "source": 4
+    },
+    "loc": {
+      "generated": {
+        "added": 33,
+        "deleted": 0
+      },
+      "test": {
+        "added": 445,
+        "deleted": 3
+      },
+      "docs": {
+        "added": 190,
+        "deleted": 10
+      },
+      "config": {
+        "added": 16,
+        "deleted": 2
+      },
+      "source": {
+        "added": 957,
+        "deleted": 8
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 3
+  },
+  "interaction": {
+    "user_turns": 18,
+    "corrective_turns": 12,
+    "tokens_before_first_edit": 2009541,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 64,
+      "Edit": 11,
+      "Read": 11,
+      "Write": 4,
+      "EnterWorktree": 3,
+      "ToolSearch": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 7
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-pr-session-metrics.json
+++ b/.claude/metrics/feat-pr-session-metrics.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 917,
+    "branch": "feat/pr-session-metrics",
+    "base_sha": "8aa5cdc8463d7c156628902cfe414176dbd9a7a0",
+    "head_sha": "f73db88583845b1ada743c0283079fd0ba15079c",
+    "generated_at": "2026-09-09T06:24:29.019Z",
+    "merged_at": "2026-09-07T07:51:46Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 7,
+    "first_ts": "2026-09-07T02:49:14.370Z",
+    "last_ts": "2026-09-07T04:29:19.281Z",
+    "span_seconds": 6005,
+    "active_seconds": 2523,
+    "compactions": 4
+  },
+  "spend": {
+    "usd_equivalent": 13.805316749999998,
+    "tokens": {
+      "input": 203,
+      "output": 95405,
+      "thinking": 12431,
+      "cache_write_5m": 262659,
+      "cache_write_1h": 98244,
+      "cache_read": 17590236
+    },
+    "by_model": {
+      "claude-opus-5": {
+        "tokens": {
+          "input": 144,
+          "output": 62669,
+          "thinking": 12431,
+          "cache_write_5m": 0,
+          "cache_write_1h": 98244,
+          "cache_read": 15879568
+        },
+        "usd_equivalent": 10.489669,
+        "messages": 72
+      },
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 59,
+          "output": 32736,
+          "thinking": 0,
+          "cache_write_5m": 262659,
+          "cache_write_1h": 0,
+          "cache_read": 1710668
+        },
+        "usd_equivalent": 3.3156477500000006,
+        "messages": 34
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 203,
+          "output": 95405,
+          "thinking": 12431,
+          "cache_write_5m": 262659,
+          "cache_write_1h": 98244,
+          "cache_read": 17590236
+        },
+        "usd_equivalent": 13.805316749999998,
+        "messages": 106
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 72
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 2,
+      "docs": 4,
+      "config": 3,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 39,
+        "deleted": 21
+      },
+      "test": {
+        "added": 710,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 296,
+        "deleted": 0
+      },
+      "config": {
+        "added": 32,
+        "deleted": 3
+      },
+      "source": {
+        "added": 849,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "tools/pr-metrics"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 8,
+    "corrective_turns": 2,
+    "tokens_before_first_edit": 1974421,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 28,
+      "Edit": 7,
+      "Read": 7,
+      "Grep": 3,
+      "EnterWorktree": 2,
+      "Write": 2,
+      "ExitWorktree": 1,
+      "Glob": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 4
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-shared-crypto-totp.json
+++ b/.claude/metrics/feat-shared-crypto-totp.json
@@ -5,7 +5,7 @@
     "branch": "feat/shared-crypto-totp",
     "base_sha": "be06e53fb322237baf274b4091a777d7a1cad08f",
     "head_sha": "da51b21a83f31123722841649f4ef193118a0a4c",
-    "generated_at": "2026-09-09T06:24:29.012Z",
+    "generated_at": "2026-09-09T06:29:32.625Z",
     "merged_at": "2026-09-09T01:46:00Z",
     "phase": "at-merge"
   },
@@ -27,7 +27,7 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 21.198507000000003,
+    "usd_equivalent": 21.297085950000003,
     "tokens": {
       "input": 760,
       "output": 28062,
@@ -70,7 +70,7 @@
           "cache_write_1h": 0,
           "cache_read": 580957
         },
-        "usd_equivalent": 0,
+        "usd_equivalent": 0.09857895000000001,
         "messages": 13
       }
     },
@@ -96,7 +96,7 @@
           "cache_write_1h": 0,
           "cache_read": 28924624
         },
-        "usd_equivalent": 21.198507000000003,
+        "usd_equivalent": 21.297085950000003,
         "messages": 217
       }
     },
@@ -104,9 +104,7 @@
       "high": 9,
       "xhigh": 195
     },
-    "unpriced_models": [
-      "claude-haiku-4-5-20251001"
-    ]
+    "unpriced_models": []
   },
   "diff": {
     "files": {

--- a/.claude/metrics/feat-shared-crypto-totp.json
+++ b/.claude/metrics/feat-shared-crypto-totp.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 962,
+    "branch": "feat/shared-crypto-totp",
+    "base_sha": "be06e53fb322237baf274b4091a777d7a1cad08f",
+    "head_sha": "da51b21a83f31123722841649f4ef193118a0a4c",
+    "generated_at": "2026-09-09T06:24:29.012Z",
+    "merged_at": "2026-09-09T01:46:00Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 948,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-08T14:21:42.291Z",
+    "last_ts": "2026-09-09T01:45:50.305Z",
+    "span_seconds": 41048,
+    "active_seconds": 4403,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 21.198507000000003,
+    "tokens": {
+      "input": 760,
+      "output": 28062,
+      "thinking": 0,
+      "cache_write_5m": 846443,
+      "cache_write_1h": 0,
+      "cache_read": 28924624
+    },
+    "by_model": {
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 258,
+          "output": 1045,
+          "thinking": 0,
+          "cache_write_5m": 128986,
+          "cache_write_1h": 0,
+          "cache_read": 799787
+        },
+        "usd_equivalent": 2.466942,
+        "messages": 9
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 390,
+          "output": 26994,
+          "thinking": 0,
+          "cache_write_5m": 685252,
+          "cache_write_1h": 0,
+          "cache_read": 27543880
+        },
+        "usd_equivalent": 18.731565000000003,
+        "messages": 195
+      },
+      "claude-haiku-4-5-20251001": {
+        "tokens": {
+          "input": 112,
+          "output": 23,
+          "thinking": 0,
+          "cache_write_5m": 32205,
+          "cache_write_1h": 0,
+          "cache_read": 580957
+        },
+        "usd_equivalent": 0,
+        "messages": 13
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      },
+      "subagent": {
+        "tokens": {
+          "input": 760,
+          "output": 28062,
+          "thinking": 0,
+          "cache_write_5m": 846443,
+          "cache_write_1h": 0,
+          "cache_read": 28924624
+        },
+        "usd_equivalent": 21.198507000000003,
+        "messages": 217
+      }
+    },
+    "effort": {
+      "high": 9,
+      "xhigh": 195
+    },
+    "unpriced_models": [
+      "claude-haiku-4-5-20251001"
+    ]
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 4,
+      "config": 1,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 46,
+        "deleted": 0
+      },
+      "test": {
+        "added": 523,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 290,
+        "deleted": 3
+      },
+      "config": {
+        "added": 2,
+        "deleted": 1
+      },
+      "source": {
+        "added": 329,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "shared/crypto"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 0,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 43,
+      "Edit": 34,
+      "Read": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 6,
+      "max_edits_one_file": 7
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-subagent-branch-attribution.json
+++ b/.claude/metrics/feat-subagent-branch-attribution.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "pr": {
-    "number": null,
+    "number": 946,
     "branch": "feat/subagent-branch-attribution",
-    "base_sha": "9d62e4f9acc33d85c033c0b3c848569d8c540299",
-    "head_sha": "253d6e92fdbc9ca778c60a7c1d7126ad361b6308",
-    "generated_at": "2026-09-08T12:51:00.097Z",
-    "merged_at": null,
-    "phase": "at-open"
+    "base_sha": "a020dc6fe429b21c26399470519d79ef8e3793c1",
+    "head_sha": "e93bea3b62fbd34ab573cf2867efbd2dfa7ff25d",
+    "generated_at": "2026-09-09T06:24:29.015Z",
+    "merged_at": "2026-09-08T13:33:50Z",
+    "phase": "at-merge"
   },
   "issue": {
     "number": 942,
-    "type": "Feature",
+    "type": null,
     "labels": []
   },
   "complexity": {
@@ -98,7 +98,7 @@
       "generated": 1,
       "test": 2,
       "docs": 2,
-      "config": 0,
+      "config": 1,
       "source": 2
     },
     "loc": {
@@ -115,7 +115,7 @@
         "deleted": 4
       },
       "config": {
-        "added": 0,
+        "added": 149,
         "deleted": 0
       },
       "source": {
@@ -127,7 +127,7 @@
       "tools/pr-metrics"
     ],
     "touches_migration": false,
-    "commits": 4
+    "commits": 5
   },
   "interaction": {
     "user_turns": 0,

--- a/.claude/metrics/fix-antislop-guard-gitdir.json
+++ b/.claude/metrics/fix-antislop-guard-gitdir.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 822,
+    "branch": "fix/antislop-guard-gitdir",
+    "base_sha": "b84c78188446243df33cd34a38e23fe858489af1",
+    "head_sha": "135fde5408246fff24d969d82746b23172df861f",
+    "generated_at": "2026-09-09T06:24:29.045Z",
+    "merged_at": "2026-08-30T03:29:25Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 820,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-28T01:22:42.360Z",
+    "last_ts": "2026-08-28T01:23:40.579Z",
+    "span_seconds": 58,
+    "active_seconds": 58,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.2805995,
+    "tokens": {
+      "input": 9,
+      "output": 3804,
+      "thinking": 0,
+      "cache_write_5m": 20864,
+      "cache_write_1h": 0,
+      "cache_read": 110109
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 9,
+          "output": 3804,
+          "thinking": 0,
+          "cache_write_5m": 20864,
+          "cache_write_1h": 0,
+          "cache_read": 110109
+        },
+        "usd_equivalent": 0.2805995,
+        "messages": 4
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 9,
+          "output": 3804,
+          "thinking": 0,
+          "cache_write_5m": 20864,
+          "cache_write_1h": 0,
+          "cache_read": 110109
+        },
+        "usd_equivalent": 0.2805995,
+        "messages": 4
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 0,
+      "config": 1,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 8,
+        "deleted": 0
+      },
+      "source": {
+        "added": 103,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-browserslist-advisories.json
+++ b/.claude/metrics/fix-browserslist-advisories.json
@@ -5,7 +5,7 @@
     "branch": "fix/browserslist-advisories",
     "base_sha": "a6c9eb6de6ea076c07b228dc21089ce79171cded",
     "head_sha": "5d14ee9f62b8c15a5a33931c8b680af25a27fb59",
-    "generated_at": "2026-09-07T07:42:09.532Z",
+    "generated_at": "2026-09-09T06:24:29.031Z",
     "merged_at": "2026-09-02T02:08:09Z",
     "phase": "at-merge"
   },
@@ -27,39 +27,39 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 27.22232775,
+    "usd_equivalent": 13.141533,
     "tokens": {
-      "input": 490,
-      "output": 127759,
-      "thinking": 50253,
-      "cache_write_5m": 592077,
-      "cache_write_1h": 706755,
-      "cache_read": 26515743
+      "input": 268,
+      "output": 55015,
+      "thinking": 17061,
+      "cache_write_5m": 229902,
+      "cache_write_1h": 275521,
+      "cache_read": 15145441
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 30,
-          "output": 1910,
+          "input": 16,
+          "output": 988,
           "thinking": 0,
-          "cache_write_5m": 108875,
+          "cache_write_5m": 53964,
           "cache_write_1h": 0,
-          "cache_read": 155214
+          "cache_read": 104202
         },
-        "usd_equivalent": 0.80597575,
-        "messages": 10
+        "usd_equivalent": 0.414156,
+        "messages": 6
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 460,
-          "output": 125849,
-          "thinking": 50253,
-          "cache_write_5m": 483202,
-          "cache_write_1h": 706755,
-          "cache_read": 26360529
+          "input": 252,
+          "output": 54027,
+          "thinking": 17061,
+          "cache_write_5m": 175938,
+          "cache_write_1h": 275521,
+          "cache_read": 15041239
         },
-        "usd_equivalent": 26.416351999999993,
-        "messages": 230
+        "usd_equivalent": 12.727377000000002,
+        "messages": 126
       },
       "<synthetic>": {
         "tokens": {
@@ -77,31 +77,31 @@
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 286,
-          "output": 116538,
-          "thinking": 43645,
-          "cache_write_5m": 108875,
-          "cache_write_1h": 706755,
-          "cache_read": 18337815
+          "input": 166,
+          "output": 53788,
+          "thinking": 17061,
+          "cache_write_5m": 53964,
+          "cache_write_1h": 275521,
+          "cache_read": 10905665
         },
-        "usd_equivalent": 19.83180625,
-        "messages": 139
+        "usd_equivalent": 9.8908475,
+        "messages": 82
       },
       "subagent": {
         "tokens": {
-          "input": 204,
-          "output": 11221,
-          "thinking": 6608,
-          "cache_write_5m": 483202,
+          "input": 102,
+          "output": 1227,
+          "thinking": 0,
+          "cache_write_5m": 175938,
           "cache_write_1h": 0,
-          "cache_read": 8177928
+          "cache_read": 4239776
         },
-        "usd_equivalent": 7.390521499999999,
-        "messages": 102
+        "usd_equivalent": 3.250685500000001,
+        "messages": 51
       }
     },
     "effort": {
-      "high": 230
+      "high": 126
     },
     "unpriced_models": []
   },
@@ -149,26 +149,19 @@
   "interaction": {
     "user_turns": 4,
     "corrective_turns": 2,
-    "tokens_before_first_edit": 982586,
+    "tokens_before_first_edit": 2197258,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 125,
-      "Read": 4,
-      "StructuredOutput": 2,
-      "Agent": 2,
-      "Write": 2,
-      "Skill": 1,
-      "Workflow": 1
+      "Bash": 40,
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,
-      "max_edits_one_file": 1
+      "max_edits_one_file": 0
     },
     "skills": {
-      "prep-pr": 1
+      "workflow-authoring": 1
     },
-    "subagents": {
-      "general-purpose": 2
-    }
+    "subagents": {}
   }
 }

--- a/.claude/metrics/fix-ci-playwright-workspace-version.json
+++ b/.claude/metrics/fix-ci-playwright-workspace-version.json
@@ -5,7 +5,7 @@
     "branch": "fix/ci-playwright-workspace-version",
     "base_sha": "42178e92200ef4a2e3dd2ec2d134641ca2282ab6",
     "head_sha": "b485f54e96e6d30fde9c442e1ffc0ec666a0fa07",
-    "generated_at": "2026-09-07T07:41:51.053Z",
+    "generated_at": "2026-09-09T06:24:29.024Z",
     "merged_at": "2026-09-06T05:02:09Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 0.5110915,
+    "usd_equivalent": 0.338594,
     "tokens": {
-      "input": 6,
-      "output": 958,
-      "thinking": 592,
+      "input": 4,
+      "output": 555,
+      "thinking": 296,
       "cache_write_5m": 0,
-      "cache_write_1h": 988,
-      "cache_read": 954463
+      "cache_write_1h": 660,
+      "cache_read": 636198
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 6,
-          "output": 958,
-          "thinking": 592,
+          "input": 4,
+          "output": 555,
+          "thinking": 296,
           "cache_write_5m": 0,
-          "cache_write_1h": 988,
-          "cache_read": 954463
+          "cache_write_1h": 660,
+          "cache_read": 636198
         },
-        "usd_equivalent": 0.5110915,
-        "messages": 3
+        "usd_equivalent": 0.338594,
+        "messages": 2
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 6,
-          "output": 958,
-          "thinking": 592,
+          "input": 4,
+          "output": 555,
+          "thinking": 296,
           "cache_write_5m": 0,
-          "cache_write_1h": 988,
-          "cache_read": 954463
+          "cache_write_1h": 660,
+          "cache_read": 636198
         },
-        "usd_equivalent": 0.5110915,
-        "messages": 3
+        "usd_equivalent": 0.338594,
+        "messages": 2
       },
       "subagent": {
         "tokens": {
@@ -77,7 +77,7 @@
       }
     },
     "effort": {
-      "high": 3
+      "high": 2
     },
     "unpriced_models": []
   },
@@ -121,7 +121,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 2
+      "Bash": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-consent-cookie-prefix.json
+++ b/.claude/metrics/fix-cire-consent-cookie-prefix.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-consent-cookie-prefix",
     "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
     "head_sha": "2ea7944b2511c5c3d2018d6dcc9f0cbf4580f3db",
-    "generated_at": "2026-09-07T07:42:28.163Z",
+    "generated_at": "2026-09-09T06:24:29.037Z",
     "merged_at": "2026-08-31T06:43:13Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 4.829325750000001,
+    "usd_equivalent": 2.227305500000001,
     "tokens": {
-      "input": 100,
-      "output": 70704,
+      "input": 49,
+      "output": 26777,
       "thinking": 0,
-      "cache_write_5m": 317955,
+      "cache_write_5m": 159032,
       "cache_write_1h": 0,
-      "cache_read": 2148014
+      "cache_read": 1127371
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 100,
-          "output": 70704,
+          "input": 49,
+          "output": 26777,
           "thinking": 0,
-          "cache_write_5m": 317955,
+          "cache_write_5m": 159032,
           "cache_write_1h": 0,
-          "cache_read": 2148014
+          "cache_read": 1127371
         },
-        "usd_equivalent": 4.829325750000001,
-        "messages": 55
+        "usd_equivalent": 2.227305500000001,
+        "messages": 29
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 100,
-          "output": 70704,
+          "input": 49,
+          "output": 26777,
           "thinking": 0,
-          "cache_write_5m": 317955,
+          "cache_write_5m": 159032,
           "cache_write_1h": 0,
-          "cache_read": 2148014
+          "cache_read": 1127371
         },
-        "usd_equivalent": 4.829325750000001,
-        "messages": 55
+        "usd_equivalent": 2.227305500000001,
+        "messages": 29
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 23,
-      "Grep": 5,
-      "StructuredOutput": 3
+      "Read": 9,
+      "Grep": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-desired-state-seed-reland.json
+++ b/.claude/metrics/fix-cire-desired-state-seed-reland.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-desired-state-seed-reland",
     "base_sha": "bb5b11a229842de7193e5656dd0ec9349eb457e0",
     "head_sha": "367c7be91f24c9f540042c159c60f1df080ecf2a",
-    "generated_at": "2026-09-07T07:41:44.852Z",
+    "generated_at": "2026-09-09T06:24:29.023Z",
     "merged_at": "2026-09-06T09:10:39Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.4363032500000001,
+    "usd_equivalent": 0.6191525,
     "tokens": {
-      "input": 27,
-      "output": 11867,
+      "input": 11,
+      "output": 4243,
       "thinking": 0,
-      "cache_write_5m": 151413,
+      "cache_write_5m": 64884,
       "cache_write_1h": 0,
-      "cache_read": 386324
+      "cache_read": 214995
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 27,
-          "output": 11867,
+          "input": 11,
+          "output": 4243,
           "thinking": 0,
-          "cache_write_5m": 151413,
+          "cache_write_5m": 64884,
           "cache_write_1h": 0,
-          "cache_read": 386324
+          "cache_read": 214995
         },
-        "usd_equivalent": 1.4363032500000001,
-        "messages": 12
+        "usd_equivalent": 0.6191525,
+        "messages": 6
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 27,
-          "output": 11867,
+          "input": 11,
+          "output": 4243,
           "thinking": 0,
-          "cache_write_5m": 151413,
+          "cache_write_5m": 64884,
           "cache_write_1h": 0,
-          "cache_read": 386324
+          "cache_read": 214995
         },
-        "usd_equivalent": 1.4363032500000001,
-        "messages": 12
+        "usd_equivalent": 0.6191525,
+        "messages": 6
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 5,
-      "Glob": 2,
-      "StructuredOutput": 1
+      "Read": 2,
+      "Glob": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-desired-state-seed.json
+++ b/.claude/metrics/fix-cire-desired-state-seed.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-desired-state-seed",
     "base_sha": "ce3e26dd8704b7a23d774f1db4603a2399cc14cd",
     "head_sha": "c7c52be571002b14ca4c4bb66b2e6770d9e147e6",
-    "generated_at": "2026-09-07T07:41:47.802Z",
+    "generated_at": "2026-09-09T06:24:29.024Z",
     "merged_at": "2026-09-06T07:51:46Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 3.3134810000000012,
+    "usd_equivalent": 1.528494,
     "tokens": {
-      "input": 90,
-      "output": 24288,
+      "input": 44,
+      "output": 9478,
       "thinking": 0,
-      "cache_write_5m": 339356,
+      "cache_write_5m": 146794,
       "cache_write_1h": 0,
-      "cache_read": 1169712
+      "cache_read": 747723
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 90,
-          "output": 24288,
+          "input": 44,
+          "output": 9478,
           "thinking": 0,
-          "cache_write_5m": 339356,
+          "cache_write_5m": 146794,
           "cache_write_1h": 0,
-          "cache_read": 1169712
+          "cache_read": 747723
         },
-        "usd_equivalent": 3.3134810000000012,
-        "messages": 40
+        "usd_equivalent": 1.528494,
+        "messages": 24
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 90,
-          "output": 24288,
+          "input": 44,
+          "output": 9478,
           "thinking": 0,
-          "cache_write_5m": 339356,
+          "cache_write_5m": 146794,
           "cache_write_1h": 0,
-          "cache_read": 1169712
+          "cache_read": 747723
         },
-        "usd_equivalent": 3.3134810000000012,
-        "messages": 40
+        "usd_equivalent": 1.528494,
+        "messages": 24
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 10,
-      "Bash": 4,
-      "StructuredOutput": 4,
+      "Bash": 3,
+      "Read": 3,
       "Glob": 3
     },
     "edit_churn": {

--- a/.claude/metrics/fix-cire-dev-db-guard-toml.json
+++ b/.claude/metrics/fix-cire-dev-db-guard-toml.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-dev-db-guard-toml",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "f872171fc9896acba792ae38c44fbc8dc91987b8",
-    "generated_at": "2026-09-07T07:42:15.636Z",
+    "generated_at": "2026-09-09T06:24:29.033Z",
     "merged_at": "2026-09-06T07:51:26Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.6148995000000002,
+    "usd_equivalent": 0.8036560000000001,
     "tokens": {
-      "input": 68,
-      "output": 8783,
+      "input": 36,
+      "output": 3909,
       "thinking": 0,
-      "cache_write_5m": 173360,
+      "cache_write_5m": 83326,
       "cache_write_1h": 0,
-      "cache_read": 622969
+      "cache_read": 369927
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 68,
-          "output": 8783,
+          "input": 36,
+          "output": 3909,
           "thinking": 0,
-          "cache_write_5m": 173360,
+          "cache_write_5m": 83326,
           "cache_write_1h": 0,
-          "cache_read": 622969
+          "cache_read": 369927
         },
-        "usd_equivalent": 1.6148995000000002,
-        "messages": 28
+        "usd_equivalent": 0.8036560000000001,
+        "messages": 16
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 68,
-          "output": 8783,
+          "input": 36,
+          "output": 3909,
           "thinking": 0,
-          "cache_write_5m": 173360,
+          "cache_write_5m": 83326,
           "cache_write_1h": 0,
-          "cache_read": 622969
+          "cache_read": 369927
         },
-        "usd_equivalent": 1.6148995000000002,
-        "messages": 28
+        "usd_equivalent": 0.8036560000000001,
+        "messages": 16
       },
       "subagent": {
         "tokens": {
@@ -119,8 +119,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 8,
-      "StructuredOutput": 4
+      "Read": 4
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-r2-followups.json
+++ b/.claude/metrics/fix-cire-r2-followups.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 829,
+    "branch": "fix/cire-r2-followups",
+    "base_sha": "b0721738a1220e98e1c4a8440f27d1b39f388a27",
+    "head_sha": "0c6dc02358a053e56de0e1b2a799bb60c47bb620",
+    "generated_at": "2026-09-09T06:24:29.040Z",
+    "merged_at": "2026-08-30T02:40:27Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 475,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-28T01:54:13.450Z",
+    "last_ts": "2026-08-28T07:03:42.537Z",
+    "span_seconds": 18569,
+    "active_seconds": 1544,
+    "compactions": 4
+  },
+  "spend": {
+    "usd_equivalent": 5.289412049999999,
+    "tokens": {
+      "input": 187,
+      "output": 49456,
+      "thinking": 17551,
+      "cache_write_5m": 138287,
+      "cache_write_1h": 387045,
+      "cache_read": 9052724
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 33,
+          "output": 12949,
+          "thinking": 0,
+          "cache_write_5m": 138287,
+          "cache_write_1h": 0,
+          "cache_read": 1257085
+        },
+        "usd_equivalent": 1.8167262500000008,
+        "messages": 23
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 154,
+          "output": 36507,
+          "thinking": 17551,
+          "cache_write_5m": 0,
+          "cache_write_1h": 387045,
+          "cache_read": 7795639
+        },
+        "usd_equivalent": 3.4726858,
+        "messages": 77
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 187,
+          "output": 49456,
+          "thinking": 17551,
+          "cache_write_5m": 138287,
+          "cache_write_1h": 387045,
+          "cache_read": 9052724
+        },
+        "usd_equivalent": 5.289412049999999,
+        "messages": 100
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 77
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 4,
+      "docs": 0,
+      "config": 0,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 9,
+        "deleted": 0
+      },
+      "test": {
+        "added": 147,
+        "deleted": 4
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 22,
+        "deleted": 10
+      }
+    },
+    "packages": [
+      "cire/api"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 7,
+    "corrective_turns": 3,
+    "tokens_before_first_edit": 2327471,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Read": 7,
+      "Bash": 4,
+      "Edit": 3,
+      "Grep": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-cire-store-notifying-invalidate.json
+++ b/.claude/metrics/fix-cire-store-notifying-invalidate.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-store-notifying-invalidate",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "66c9950197ee25bfc25f86664de7ac607504d843",
-    "generated_at": "2026-09-07T07:42:17.114Z",
+    "generated_at": "2026-09-09T06:24:29.033Z",
     "merged_at": "2026-09-06T07:50:35Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 0.5311485,
+    "usd_equivalent": 0.20187249999999998,
     "tokens": {
-      "input": 38,
-      "output": 2338,
+      "input": 14,
+      "output": 878,
       "thinking": 0,
-      "cache_write_5m": 62186,
+      "cache_write_5m": 21250,
       "cache_write_1h": 0,
-      "cache_read": 167692
+      "cache_read": 94080
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 38,
-          "output": 2338,
+          "input": 14,
+          "output": 878,
           "thinking": 0,
-          "cache_write_5m": 62186,
+          "cache_write_5m": 21250,
           "cache_write_1h": 0,
-          "cache_read": 167692
+          "cache_read": 94080
         },
-        "usd_equivalent": 0.5311485,
-        "messages": 8
+        "usd_equivalent": 0.20187249999999998,
+        "messages": 4
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 38,
-          "output": 2338,
+          "input": 14,
+          "output": 878,
           "thinking": 0,
-          "cache_write_5m": 62186,
+          "cache_write_5m": 21250,
           "cache_write_1h": 0,
-          "cache_read": 167692
+          "cache_read": 94080
         },
-        "usd_equivalent": 0.5311485,
-        "messages": 8
+        "usd_equivalent": 0.20187249999999998,
+        "messages": 4
       },
       "subagent": {
         "tokens": {
@@ -120,9 +120,7 @@
     "corrective_turns": 0,
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
-    "tool_calls": {
-      "StructuredOutput": 2
-    },
+    "tool_calls": {},
     "edit_churn": {
       "files_edited_3plus": 0,
       "max_edits_one_file": 0

--- a/.claude/metrics/fix-email-change-conflict-branch.json
+++ b/.claude/metrics/fix-email-change-conflict-branch.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 833,
+    "branch": "fix/email-change-conflict-branch",
+    "base_sha": "e0f19b6e36296cecb36cf20c7a30eaa0e331ee7f",
+    "head_sha": "7a1ad043fdb635acb8a64deb928a79a1f911ffab",
+    "generated_at": "2026-09-09T06:24:29.040Z",
+    "merged_at": "2026-08-30T14:17:27Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 481,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-30T04:21:22.563Z",
+    "last_ts": "2026-08-30T04:33:29.063Z",
+    "span_seconds": 727,
+    "active_seconds": 306,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 2.5746047499999998,
+    "tokens": {
+      "input": 41,
+      "output": 19563,
+      "thinking": 0,
+      "cache_write_5m": 178411,
+      "cache_write_1h": 0,
+      "cache_read": 1940512
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 41,
+          "output": 19563,
+          "thinking": 0,
+          "cache_write_5m": 178411,
+          "cache_write_1h": 0,
+          "cache_read": 1940512
+        },
+        "usd_equivalent": 2.5746047499999998,
+        "messages": 31
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 41,
+          "output": 19563,
+          "thinking": 0,
+          "cache_write_5m": 178411,
+          "cache_write_1h": 0,
+          "cache_read": 1940512
+        },
+        "usd_equivalent": 2.5746047499999998,
+        "messages": 31
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 1,
+      "config": 1,
+      "source": 5
+    },
+    "loc": {
+      "generated": {
+        "added": 20,
+        "deleted": 0
+      },
+      "test": {
+        "added": 345,
+        "deleted": 3
+      },
+      "docs": {
+        "added": 29,
+        "deleted": 2
+      },
+      "config": {
+        "added": 2,
+        "deleted": 2
+      },
+      "source": {
+        "added": 92,
+        "deleted": 16
+      }
+    },
+    "packages": [
+      "osn/api",
+      "shared/observability"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 12,
+      "Grep": 4
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-metrics-node-fs-import.json
+++ b/.claude/metrics/fix-metrics-node-fs-import.json
@@ -5,7 +5,7 @@
     "branch": "fix/metrics-node-fs-import",
     "base_sha": "10e490c9aa8581cf5b4cf2f739e1f689370a0083",
     "head_sha": "c05ea4e4123ab69028dd1efb3347c506b5027105",
-    "generated_at": "2026-09-09T06:24:29.009Z",
+    "generated_at": "2026-09-09T06:29:32.622Z",
     "merged_at": "2026-09-09T02:54:03Z",
     "phase": "at-merge"
   },
@@ -27,7 +27,7 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 39.42625564999997,
+    "usd_equivalent": 39.50281149999998,
     "tokens": {
       "input": 904,
       "output": 114279,
@@ -94,7 +94,7 @@
           "cache_write_1h": 0,
           "cache_read": 179151
         },
-        "usd_equivalent": 0,
+        "usd_equivalent": 0.07655585000000001,
         "messages": 5
       },
       "claude-fable-5-1": {
@@ -132,16 +132,14 @@
           "cache_write_1h": 0,
           "cache_read": 12876978
         },
-        "usd_equivalent": 4.893046899999999,
+        "usd_equivalent": 4.969602749999999,
         "messages": 141
       }
     },
     "effort": {
       "high": 380
     },
-    "unpriced_models": [
-      "claude-haiku-4-5-20251001"
-    ]
+    "unpriced_models": []
   },
   "diff": {
     "files": {

--- a/.claude/metrics/fix-metrics-node-fs-import.json
+++ b/.claude/metrics/fix-metrics-node-fs-import.json
@@ -3,67 +3,63 @@
   "pr": {
     "number": 966,
     "branch": "fix/metrics-node-fs-import",
-    "base_sha": "3447d5bac261d89a6e13a9e8d813468481c504c1",
-    "head_sha": "2142aad1410843701f942ee5eb0b39812afba93c",
-    "generated_at": "2026-09-09T01:54:08.702Z",
-    "merged_at": null,
-    "phase": "at-open"
+    "base_sha": "10e490c9aa8581cf5b4cf2f739e1f689370a0083",
+    "head_sha": "c05ea4e4123ab69028dd1efb3347c506b5027105",
+    "generated_at": "2026-09-09T06:24:29.009Z",
+    "merged_at": "2026-09-09T02:54:03Z",
+    "phase": "at-merge"
   },
   "issue": {
     "number": 959,
     "type": null,
-    "labels": [
-      "product:shared",
-      "area:ops",
-      "complexity:2"
-    ]
+    "labels": []
   },
   "complexity": {
-    "declared": 2,
-    "method": "confirmed"
+    "declared": null,
+    "method": "none"
   },
   "window": {
-    "sessions": 4,
+    "sessions": 5,
     "first_ts": "2026-09-08T14:48:20.058Z",
-    "last_ts": "2026-09-09T01:54:04.661Z",
-    "span_seconds": 39945,
-    "active_seconds": 3838,
+    "last_ts": "2026-09-09T01:57:40.229Z",
+    "span_seconds": 40160,
+    "active_seconds": 4073,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 37.23965714999997,
+    "usd_equivalent": 39.42625564999997,
     "tokens": {
-      "input": 830,
-      "output": 109637,
-      "thinking": 23197,
-      "cache_write_5m": 742968,
-      "cache_write_1h": 307714,
-      "cache_read": 64453025
+      "input": 904,
+      "output": 114279,
+      "thinking": 23512,
+      "cache_write_5m": 799351,
+      "cache_write_1h": 318398,
+      "cache_read": 68440473
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 32,
-          "output": 6400,
+          "input": 42,
+          "output": 7339,
           "thinking": 0,
-          "cache_write_5m": 124293,
+          "cache_write_5m": 133829,
           "cache_write_1h": 0,
-          "cache_read": 495392
+          "cache_read": 615339
         },
-        "usd_equivalent": 1.1846872499999999,
-        "messages": 17
+        "usd_equivalent": 1.3277857499999997,
+        "messages": 22
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 466,
-          "output": 98102,
-          "thinking": 23181,
+          "input": 488,
+          "output": 101797,
+          "thinking": 23496,
           "cache_write_5m": 0,
-          "cache_write_1h": 307714,
-          "cache_read": 51259806
+          "cache_write_1h": 318398,
+          "cache_read": 54948156
         },
-        "usd_equivalent": 31.161922999999994,
-        "messages": 233
+        "usd_equivalent": 33.205423,
+        "messages": 244
       },
       "<synthetic>": {
         "tokens": {
@@ -89,6 +85,18 @@
         "usd_equivalent": 3.949571899999999,
         "messages": 133
       },
+      "claude-haiku-4-5-20251001": {
+        "tokens": {
+          "input": 42,
+          "output": 8,
+          "thinking": 0,
+          "cache_write_5m": 46847,
+          "cache_write_1h": 0,
+          "cache_read": 179151
+        },
+        "usd_equivalent": 0,
+        "messages": 5
+      },
       "claude-fable-5-1": {
         "tokens": {
           "input": 66,
@@ -105,40 +113,42 @@
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 498,
-          "output": 104502,
-          "thinking": 23181,
-          "cache_write_5m": 124293,
-          "cache_write_1h": 307714,
-          "cache_read": 51755198
+          "input": 530,
+          "output": 109136,
+          "thinking": 23496,
+          "cache_write_5m": 133829,
+          "cache_write_1h": 318398,
+          "cache_read": 55563495
         },
-        "usd_equivalent": 32.34661024999999,
-        "messages": 251
+        "usd_equivalent": 34.53320874999999,
+        "messages": 267
       },
       "subagent": {
         "tokens": {
-          "input": 332,
-          "output": 5135,
+          "input": 374,
+          "output": 5143,
           "thinking": 16,
-          "cache_write_5m": 618675,
+          "cache_write_5m": 665522,
           "cache_write_1h": 0,
-          "cache_read": 12697827
+          "cache_read": 12876978
         },
         "usd_equivalent": 4.893046899999999,
-        "messages": 136
+        "messages": 141
       }
     },
     "effort": {
-      "high": 369
+      "high": 380
     },
-    "unpriced_models": []
+    "unpriced_models": [
+      "claude-haiku-4-5-20251001"
+    ]
   },
   "diff": {
     "files": {
       "generated": 2,
       "test": 3,
       "docs": 1,
-      "config": 0,
+      "config": 1,
       "source": 4
     },
     "loc": {
@@ -155,7 +165,7 @@
         "deleted": 0
       },
       "config": {
-        "added": 0,
+        "added": 203,
         "deleted": 0
       },
       "source": {
@@ -168,15 +178,15 @@
       "tools/pr-metrics"
     ],
     "touches_migration": false,
-    "commits": 2
+    "commits": 3
   },
   "interaction": {
-    "user_turns": 6,
+    "user_turns": 7,
     "corrective_turns": 3,
     "tokens_before_first_edit": 231096,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 93,
+      "Bash": 100,
       "Edit": 28,
       "Read": 8,
       "Write": 6,

--- a/.claude/metrics/fix-osn-email-change-hardening.json
+++ b/.claude/metrics/fix-osn-email-change-hardening.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 844,
+    "branch": "fix/osn-email-change-hardening",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "eef98274e29c36bf658c2316542f56c5238e2788",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-31T04:33:06Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 557,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-30T15:30:25.597Z",
+    "last_ts": "2026-08-30T15:33:21.441Z",
+    "span_seconds": 176,
+    "active_seconds": 176,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.03410575,
+    "tokens": {
+      "input": 16,
+      "output": 7423,
+      "thinking": 0,
+      "cache_write_5m": 82049,
+      "cache_write_1h": 0,
+      "cache_read": 671289
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 16,
+          "output": 7423,
+          "thinking": 0,
+          "cache_write_5m": 82049,
+          "cache_write_1h": 0,
+          "cache_read": 671289
+        },
+        "usd_equivalent": 1.03410575,
+        "messages": 11
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 16,
+          "output": 7423,
+          "thinking": 0,
+          "cache_write_5m": 82049,
+          "cache_write_1h": 0,
+          "cache_read": 671289
+        },
+        "usd_equivalent": 1.03410575,
+        "messages": 11
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 4,
+      "test": 4,
+      "docs": 0,
+      "config": 0,
+      "source": 4
+    },
+    "loc": {
+      "generated": {
+        "added": 1679,
+        "deleted": 0
+      },
+      "test": {
+        "added": 171,
+        "deleted": 29
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 69,
+        "deleted": 40
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/db"
+    ],
+    "touches_migration": true,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 3,
+      "Grep": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-osn-fof-bind-cap.json
+++ b/.claude/metrics/fix-osn-fof-bind-cap.json
@@ -5,7 +5,7 @@
     "branch": "fix/osn-fof-bind-cap",
     "base_sha": "e7c6f0f170f01a937c8e3fa06ff9db2bf4b0cdb9",
     "head_sha": "e189c0eb5e18726ff593766ce4aecfee816d3c43",
-    "generated_at": "2026-09-07T07:42:23.374Z",
+    "generated_at": "2026-09-09T06:24:29.036Z",
     "merged_at": "2026-08-31T15:41:16Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 5.636750000000005,
+    "usd_equivalent": 2.7609844999999997,
     "tokens": {
-      "input": 99,
-      "output": 57885,
+      "input": 55,
+      "output": 24144,
       "thinking": 0,
-      "cache_write_5m": 460112,
+      "cache_write_5m": 225202,
       "cache_write_1h": 0,
-      "cache_read": 2626860
+      "cache_read": 1499194
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 99,
-          "output": 57885,
+          "input": 55,
+          "output": 24144,
           "thinking": 0,
-          "cache_write_5m": 460112,
+          "cache_write_5m": 225202,
           "cache_write_1h": 0,
-          "cache_read": 2626860
+          "cache_read": 1499194
         },
-        "usd_equivalent": 5.636750000000005,
-        "messages": 59
+        "usd_equivalent": 2.7609844999999997,
+        "messages": 35
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 99,
-          "output": 57885,
+          "input": 55,
+          "output": 24144,
           "thinking": 0,
-          "cache_write_5m": 460112,
+          "cache_write_5m": 225202,
           "cache_write_1h": 0,
-          "cache_read": 2626860
+          "cache_read": 1499194
         },
-        "usd_equivalent": 5.636750000000005,
-        "messages": 59
+        "usd_equivalent": 2.7609844999999997,
+        "messages": 35
       },
       "subagent": {
         "tokens": {
@@ -121,11 +121,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 16,
-      "Grep": 6,
-      "StructuredOutput": 4,
+      "Read": 8,
       "Glob": 3,
-      "Bash": 2
+      "Bash": 2,
+      "Grep": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-osn-recs-fanout.json
+++ b/.claude/metrics/fix-osn-recs-fanout.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 838,
+    "branch": "fix/osn-recs-fanout",
+    "base_sha": "1ca185d1876826e037897b868ad6ecdc61c99143",
+    "head_sha": "45fe898507e73b489e4b3d3b0cd08faaa059132c",
+    "generated_at": "2026-09-09T06:24:29.039Z",
+    "merged_at": "2026-08-30T12:44:05Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 285,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-30T12:10:25.314Z",
+    "last_ts": "2026-08-30T12:26:10.795Z",
+    "span_seconds": 945,
+    "active_seconds": 158,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.39810775,
+    "tokens": {
+      "input": 31,
+      "output": 9104,
+      "thinking": 0,
+      "cache_write_5m": 141401,
+      "cache_write_1h": 0,
+      "cache_read": 573193
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 31,
+          "output": 9104,
+          "thinking": 0,
+          "cache_write_5m": 141401,
+          "cache_write_1h": 0,
+          "cache_read": 573193
+        },
+        "usd_equivalent": 1.39810775,
+        "messages": 16
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 31,
+          "output": 9104,
+          "thinking": 0,
+          "cache_write_5m": 141401,
+          "cache_write_1h": 0,
+          "cache_read": 573193
+        },
+        "usd_equivalent": 1.39810775,
+        "messages": 16
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 0,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 11,
+        "deleted": 0
+      },
+      "test": {
+        "added": 148,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 125,
+        "deleted": 36
+      }
+    },
+    "packages": [
+      "osn/api"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 3,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 4,
+      "Grep": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-osn-token-issuer.json
+++ b/.claude/metrics/fix-osn-token-issuer.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 839,
+    "branch": "fix/osn-token-issuer",
+    "base_sha": "273e4ba82e35358c1ef08ab4ae2e38f7692ac855",
+    "head_sha": "20646b9fc881878a0309d94bffab795790cc021d",
+    "generated_at": "2026-09-09T06:24:29.039Z",
+    "merged_at": "2026-08-30T14:12:38Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 177,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-30T12:39:48.240Z",
+    "last_ts": "2026-08-30T12:55:39.164Z",
+    "span_seconds": 951,
+    "active_seconds": 316,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 2.66057025,
+    "tokens": {
+      "input": 38,
+      "output": 21349,
+      "thinking": 0,
+      "cache_write_5m": 191637,
+      "cache_write_1h": 0,
+      "cache_read": 1857848
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 38,
+          "output": 21349,
+          "thinking": 0,
+          "cache_write_5m": 191637,
+          "cache_write_1h": 0,
+          "cache_read": 1857848
+        },
+        "usd_equivalent": 2.66057025,
+        "messages": 28
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 38,
+          "output": 21349,
+          "thinking": 0,
+          "cache_write_5m": 191637,
+          "cache_write_1h": 0,
+          "cache_read": 1857848
+        },
+        "usd_equivalent": 2.66057025,
+        "messages": 28
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 20,
+      "docs": 1,
+      "config": 3,
+      "source": 24
+    },
+    "loc": {
+      "generated": {
+        "added": 17,
+        "deleted": 0
+      },
+      "test": {
+        "added": 359,
+        "deleted": 58
+      },
+      "docs": {
+        "added": 27,
+        "deleted": 2
+      },
+      "config": {
+        "added": 50,
+        "deleted": 11
+      },
+      "source": {
+        "added": 283,
+        "deleted": 65
+      }
+    },
+    "packages": [
+      "cire/api",
+      "osn/api",
+      "pulse/api",
+      "shared/crypto",
+      "shared/dev-urls",
+      "shared/osn-auth-client",
+      "zap/api"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 5
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-pulse-d1-bind-cap.json
+++ b/.claude/metrics/fix-pulse-d1-bind-cap.json
@@ -5,7 +5,7 @@
     "branch": "fix/pulse-d1-bind-cap",
     "base_sha": "15e404061d22adc354aeebda036351cf728ce450",
     "head_sha": "caf24cd736bf28fdf1d7ca62a2d7c1c4bf88af9b",
-    "generated_at": "2026-09-07T07:42:21.696Z",
+    "generated_at": "2026-09-09T06:24:29.036Z",
     "merged_at": "2026-09-06T09:25:51Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 5.028939749999999,
+    "usd_equivalent": 1.9149035,
     "tokens": {
-      "input": 84,
-      "output": 65025,
+      "input": 33,
+      "output": 22269,
       "thinking": 0,
-      "cache_write_5m": 374445,
+      "cache_write_5m": 146796,
       "cache_write_1h": 0,
-      "cache_read": 2125227
+      "cache_read": 881077
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 84,
-          "output": 65025,
+          "input": 33,
+          "output": 22269,
           "thinking": 0,
-          "cache_write_5m": 374445,
+          "cache_write_5m": 146796,
           "cache_write_1h": 0,
-          "cache_read": 2125227
+          "cache_read": 881077
         },
-        "usd_equivalent": 5.028939749999999,
-        "messages": 44
+        "usd_equivalent": 1.9149035,
+        "messages": 18
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 84,
-          "output": 65025,
+          "input": 33,
+          "output": 22269,
           "thinking": 0,
-          "cache_write_5m": 374445,
+          "cache_write_5m": 146796,
           "cache_write_1h": 0,
-          "cache_read": 2125227
+          "cache_read": 881077
         },
-        "usd_equivalent": 5.028939749999999,
-        "messages": 44
+        "usd_equivalent": 1.9149035,
+        "messages": 18
       },
       "subagent": {
         "tokens": {
@@ -122,9 +122,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 16,
-      "Grep": 5,
-      "StructuredOutput": 3
+      "Read": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-redis-reply-boundary.json
+++ b/.claude/metrics/fix-redis-reply-boundary.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 846,
+    "branch": "fix/redis-reply-boundary",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "972d2be097a8148570897352b6744db208dfb14c",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-31T04:34:02Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 472,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-08-31T00:23:04.405Z",
+    "last_ts": "2026-08-31T00:33:37.572Z",
+    "span_seconds": 633,
+    "active_seconds": 316,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.9860367499999998,
+    "tokens": {
+      "input": 58,
+      "output": 19240,
+      "thinking": 0,
+      "cache_write_5m": 127535,
+      "cache_write_1h": 0,
+      "cache_read": 1415306
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 58,
+          "output": 19240,
+          "thinking": 0,
+          "cache_write_5m": 127535,
+          "cache_write_1h": 0,
+          "cache_read": 1415306
+        },
+        "usd_equivalent": 1.9860367499999998,
+        "messages": 38
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 58,
+          "output": 19240,
+          "thinking": 0,
+          "cache_write_5m": 127535,
+          "cache_write_1h": 0,
+          "cache_read": 1415306
+        },
+        "usd_equivalent": 1.9860367499999998,
+        "messages": 38
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 0,
+      "config": 1,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 5,
+        "deleted": 0
+      },
+      "test": {
+        "added": 167,
+        "deleted": 19
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 1,
+        "deleted": 1
+      },
+      "source": {
+        "added": 162,
+        "deleted": 24
+      }
+    },
+    "packages": [
+      "shared/redis"
+    ],
+    "touches_migration": false,
+    "commits": 4
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 8,
+      "Grep": 1,
+      "Bash": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-sqlite-foreign-keys.json
+++ b/.claude/metrics/fix-sqlite-foreign-keys.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 842,
+    "branch": "fix/sqlite-foreign-keys",
+    "base_sha": "1789a19df627206d8bcbff0ff2d02a54f667370b",
+    "head_sha": "7dd2a0d7c529ed55edcf40f587313f29cca541bf",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-30T14:20:51Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 575,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-30T14:15:40.885Z",
+    "last_ts": "2026-08-30T14:18:23.937Z",
+    "span_seconds": 163,
+    "active_seconds": 163,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.6091135,
+    "tokens": {
+      "input": 23,
+      "output": 9655,
+      "thinking": 0,
+      "cache_write_5m": 104468,
+      "cache_write_1h": 0,
+      "cache_read": 1429397
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 23,
+          "output": 9655,
+          "thinking": 0,
+          "cache_write_5m": 104468,
+          "cache_write_1h": 0,
+          "cache_read": 1429397
+        },
+        "usd_equivalent": 1.6091135,
+        "messages": 18
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 23,
+          "output": 9655,
+          "thinking": 0,
+          "cache_write_5m": 104468,
+          "cache_write_1h": 0,
+          "cache_read": 1429397
+        },
+        "usd_equivalent": 1.6091135,
+        "messages": 18
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 4,
+      "test": 1,
+      "docs": 0,
+      "config": 0,
+      "source": 7
+    },
+    "loc": {
+      "generated": {
+        "added": 1714,
+        "deleted": 0
+      },
+      "test": {
+        "added": 27,
+        "deleted": 7
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 81,
+        "deleted": 17
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/db",
+      "pulse/db",
+      "shared/db-utils",
+      "zap/db"
+    ],
+    "touches_migration": true,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 5,
+      "Grep": 4
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-swift-retrying-transport.json
+++ b/.claude/metrics/fix-swift-retrying-transport.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 836,
+    "branch": "fix/swift-retrying-transport",
+    "base_sha": "8101ce475f5993f0f3523459484d24d8248fc2da",
+    "head_sha": "17633f4f6c2806169045ddb33e3073d351dd2c98",
+    "generated_at": "2026-09-09T06:24:29.039Z",
+    "merged_at": "2026-08-30T11:58:45Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 532,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-30T10:12:58.977Z",
+    "last_ts": "2026-08-30T10:32:28.463Z",
+    "span_seconds": 1169,
+    "active_seconds": 345,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 2.177551250000001,
+    "tokens": {
+      "input": 32,
+      "output": 24564,
+      "thinking": 0,
+      "cache_write_5m": 186831,
+      "cache_write_1h": 0,
+      "cache_read": 791195
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 32,
+          "output": 24564,
+          "thinking": 0,
+          "cache_write_5m": 186831,
+          "cache_write_1h": 0,
+          "cache_read": 791195
+        },
+        "usd_equivalent": 2.177551250000001,
+        "messages": 17
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 32,
+          "output": 24564,
+          "thinking": 0,
+          "cache_write_5m": 186831,
+          "cache_write_1h": 0,
+          "cache_read": 791195
+        },
+        "usd_equivalent": 2.177551250000001,
+        "messages": 17
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 1,
+      "config": 0,
+      "source": 14
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 10,
+        "deleted": 1
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 1149,
+        "deleted": 159
+      }
+    },
+    "packages": [
+      "shared/swift"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 3,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 5
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-zap-c2b-perf.json
+++ b/.claude/metrics/fix-zap-c2b-perf.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 837,
+    "branch": "fix/zap-c2b-perf",
+    "base_sha": "8101ce475f5993f0f3523459484d24d8248fc2da",
+    "head_sha": "ea992d4112c50a682420500bc3cfe6d2d7413c5e",
+    "generated_at": "2026-09-09T06:24:29.039Z",
+    "merged_at": "2026-08-30T12:03:59Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 291,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-30T10:37:47.847Z",
+    "last_ts": "2026-08-30T10:53:03.372Z",
+    "span_seconds": 916,
+    "active_seconds": 318,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 2.2298482500000003,
+    "tokens": {
+      "input": 46,
+      "output": 19591,
+      "thinking": 0,
+      "cache_write_5m": 166351,
+      "cache_write_1h": 0,
+      "cache_read": 1400299
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 46,
+          "output": 19591,
+          "thinking": 0,
+          "cache_write_5m": 166351,
+          "cache_write_1h": 0,
+          "cache_read": 1400299
+        },
+        "usd_equivalent": 2.2298482500000003,
+        "messages": 31
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 46,
+          "output": 19591,
+          "thinking": 0,
+          "cache_write_5m": 166351,
+          "cache_write_1h": 0,
+          "cache_read": 1400299
+        },
+        "usd_equivalent": 2.2298482500000003,
+        "messages": 31
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 6,
+      "test": 5,
+      "docs": 0,
+      "config": 0,
+      "source": 6
+    },
+    "loc": {
+      "generated": {
+        "added": 616,
+        "deleted": 0
+      },
+      "test": {
+        "added": 288,
+        "deleted": 57
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 146,
+        "deleted": 71
+      }
+    },
+    "packages": [
+      "zap/api",
+      "zap/db"
+    ],
+    "touches_migration": true,
+    "commits": 3
+  },
+  "interaction": {
+    "user_turns": 3,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 10,
+      "Grep": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-zap-class-guard.json
+++ b/.claude/metrics/fix-zap-class-guard.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 841,
+    "branch": "fix/zap-class-guard",
+    "base_sha": "273e4ba82e35358c1ef08ab4ae2e38f7692ac855",
+    "head_sha": "50b30905dc82292d0e3478b6b394e9eabc0bafea",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-30T14:14:43Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 567,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-08-30T13:09:25.558Z",
+    "last_ts": "2026-08-30T13:46:18.674Z",
+    "span_seconds": 2213,
+    "active_seconds": 468,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 3.1999039999999996,
+    "tokens": {
+      "input": 55,
+      "output": 31470,
+      "thinking": 0,
+      "cache_write_5m": 257168,
+      "cache_write_1h": 0,
+      "cache_read": 1611158
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 55,
+          "output": 31470,
+          "thinking": 0,
+          "cache_write_5m": 257168,
+          "cache_write_1h": 0,
+          "cache_read": 1611158
+        },
+        "usd_equivalent": 3.1999039999999996,
+        "messages": 35
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 55,
+          "output": 31470,
+          "thinking": 0,
+          "cache_write_5m": 257168,
+          "cache_write_1h": 0,
+          "cache_read": 1611158
+        },
+        "usd_equivalent": 3.1999039999999996,
+        "messages": 35
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 4,
+      "docs": 0,
+      "config": 0,
+      "source": 5
+    },
+    "loc": {
+      "generated": {
+        "added": 12,
+        "deleted": 0
+      },
+      "test": {
+        "added": 379,
+        "deleted": 2
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 187,
+        "deleted": 25
+      }
+    },
+    "packages": [
+      "zap/api",
+      "zap/db"
+    ],
+    "touches_migration": false,
+    "commits": 3
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 11,
+      "StructuredOutput": 1,
+      "Bash": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/perf-cire-d1-sessions.json
+++ b/.claude/metrics/perf-cire-d1-sessions.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-d1-sessions",
     "base_sha": "f3bef1bf425835270c41cc7387c5289086e66018",
     "head_sha": "4deb5734ac742957ceee569a64cd09b0cb5ff86f",
-    "generated_at": "2026-09-07T07:42:20.255Z",
+    "generated_at": "2026-09-09T06:24:29.034Z",
     "merged_at": "2026-09-06T09:35:37Z",
     "phase": "at-merge"
   },
@@ -27,69 +27,69 @@
     "compactions": 11
   },
   "spend": {
-    "usd_equivalent": 52.011302499999964,
+    "usd_equivalent": 27.776247500000014,
     "tokens": {
-      "input": 1044,
-      "output": 236188,
-      "thinking": 69227,
-      "cache_write_5m": 1497766,
-      "cache_write_1h": 1373637,
-      "cache_read": 46007950
+      "input": 596,
+      "output": 116029,
+      "thinking": 31519,
+      "cache_write_5m": 538740,
+      "cache_write_1h": 772866,
+      "cache_read": 27553515
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 72,
-          "output": 40897,
+          "input": 32,
+          "output": 13696,
           "thinking": 0,
-          "cache_write_5m": 332571,
+          "cache_write_5m": 119187,
           "cache_write_1h": 0,
-          "cache_read": 1049798
+          "cache_read": 606240
         },
-        "usd_equivalent": 3.626252749999999,
-        "messages": 32
+        "usd_equivalent": 1.3905987499999999,
+        "messages": 17
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 972,
-          "output": 195291,
-          "thinking": 69227,
-          "cache_write_5m": 1165195,
-          "cache_write_1h": 1373637,
-          "cache_read": 44958152
+          "input": 564,
+          "output": 102333,
+          "thinking": 31519,
+          "cache_write_5m": 419553,
+          "cache_write_1h": 772866,
+          "cache_read": 26947275
         },
-        "usd_equivalent": 48.385049749999986,
-        "messages": 486
+        "usd_equivalent": 26.385648750000023,
+        "messages": 282
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 722,
-          "output": 233493,
-          "thinking": 68336,
-          "cache_write_5m": 332571,
-          "cache_write_1h": 1373637,
-          "cache_read": 33278371
+          "input": 440,
+          "output": 115308,
+          "thinking": 31519,
+          "cache_write_5m": 119187,
+          "cache_write_1h": 772866,
+          "cache_read": 21053607
         },
-        "usd_equivalent": 38.295059249999994,
-        "messages": 357
+        "usd_equivalent": 21.885282249999996,
+        "messages": 221
       },
       "subagent": {
         "tokens": {
-          "input": 322,
-          "output": 2695,
-          "thinking": 891,
-          "cache_write_5m": 1165195,
+          "input": 156,
+          "output": 721,
+          "thinking": 0,
+          "cache_write_5m": 419553,
           "cache_write_1h": 0,
-          "cache_read": 12729579
+          "cache_read": 6499908
         },
-        "usd_equivalent": 13.716243250000005,
-        "messages": 161
+        "usd_equivalent": 5.89096525,
+        "messages": 78
       }
     },
     "effort": {
-      "high": 486
+      "high": 282
     },
     "unpriced_models": []
   },
@@ -132,31 +132,23 @@
   "interaction": {
     "user_turns": 15,
     "corrective_turns": 12,
-    "tokens_before_first_edit": 3113289,
+    "tokens_before_first_edit": 2137073,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 258,
-      "Edit": 24,
-      "Read": 17,
-      "Write": 12,
-      "Agent": 3,
-      "StructuredOutput": 3,
-      "Grep": 2,
+      "Bash": 98,
+      "Edit": 10,
+      "Read": 6,
+      "Write": 5,
       "EnterWorktree": 1,
-      "Skill": 1,
-      "ToolSearch": 1,
+      "Grep": 1,
       "WebFetch": 1,
       "Glob": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 5,
-      "max_edits_one_file": 6
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 5
     },
-    "skills": {
-      "obsidian:obsidian-markdown": 1
-    },
-    "subagents": {
-      "general-purpose": 3
-    }
+    "skills": {},
+    "subagents": {}
   }
 }

--- a/.claude/metrics/perf-cire-entitlement-reads.json
+++ b/.claude/metrics/perf-cire-entitlement-reads.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-entitlement-reads",
     "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
     "head_sha": "16d786d2fc27a381037f8b64b391856bb1d819fc",
-    "generated_at": "2026-09-07T07:42:26.611Z",
+    "generated_at": "2026-09-09T06:24:29.037Z",
     "merged_at": "2026-08-31T06:44:15Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.4136684999999993,
+    "usd_equivalent": 0.5943322499999999,
     "tokens": {
-      "input": 47,
-      "output": 14703,
+      "input": 20,
+      "output": 5500,
       "thinking": 0,
-      "cache_write_5m": 102596,
+      "cache_write_5m": 43931,
       "cache_write_1h": 0,
-      "cache_read": 809267
+      "cache_read": 364327
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 47,
-          "output": 14703,
+          "input": 20,
+          "output": 5500,
           "thinking": 0,
-          "cache_write_5m": 102596,
+          "cache_write_5m": 43931,
           "cache_write_1h": 0,
-          "cache_read": 809267
+          "cache_read": 364327
         },
-        "usd_equivalent": 1.4136684999999993,
-        "messages": 22
+        "usd_equivalent": 0.5943322499999999,
+        "messages": 10
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 47,
-          "output": 14703,
+          "input": 20,
+          "output": 5500,
           "thinking": 0,
-          "cache_write_5m": 102596,
+          "cache_write_5m": 43931,
           "cache_write_1h": 0,
-          "cache_read": 809267
+          "cache_read": 364327
         },
-        "usd_equivalent": 1.4136684999999993,
-        "messages": 22
+        "usd_equivalent": 0.5943322499999999,
+        "messages": 10
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 7,
-      "Grep": 3,
-      "StructuredOutput": 2
+      "Read": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-cire-events-editor-scope.json
+++ b/.claude/metrics/perf-cire-events-editor-scope.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-events-editor-scope",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "a9dfce45a733bd60ae28ccfdf758584fe029f8b3",
-    "generated_at": "2026-09-07T07:42:18.762Z",
+    "generated_at": "2026-09-09T06:24:29.033Z",
     "merged_at": "2026-09-06T07:49:41Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 4.706009000000001,
+    "usd_equivalent": 2.3964135000000004,
     "tokens": {
-      "input": 115,
-      "output": 41822,
+      "input": 61,
+      "output": 16241,
       "thinking": 0,
-      "cache_write_5m": 370434,
+      "cache_write_5m": 189006,
       "cache_write_1h": 0,
-      "cache_read": 2689343
+      "cache_read": 1617592
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 115,
-          "output": 41822,
+          "input": 61,
+          "output": 16241,
           "thinking": 0,
-          "cache_write_5m": 370434,
+          "cache_write_5m": 189006,
           "cache_write_1h": 0,
-          "cache_read": 2689343
+          "cache_read": 1617592
         },
-        "usd_equivalent": 4.706009000000001,
-        "messages": 60
+        "usd_equivalent": 2.3964135000000004,
+        "messages": 36
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 115,
-          "output": 41822,
+          "input": 61,
+          "output": 16241,
           "thinking": 0,
-          "cache_write_5m": 370434,
+          "cache_write_5m": 189006,
           "cache_write_1h": 0,
-          "cache_read": 2689343
+          "cache_read": 1617592
         },
-        "usd_equivalent": 4.706009000000001,
-        "messages": 60
+        "usd_equivalent": 2.3964135000000004,
+        "messages": 36
       },
       "subagent": {
         "tokens": {
@@ -122,10 +122,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 21,
-      "Bash": 6,
-      "StructuredOutput": 5,
-      "Grep": 2,
+      "Read": 11,
+      "Bash": 4,
       "Glob": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-cire-font-build-guard.json
+++ b/.claude/metrics/perf-cire-font-build-guard.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 850,
+    "branch": "perf/cire-font-build-guard",
+    "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
+    "head_sha": "f214eab18a664d314561822e78b0bdcb009733c4",
+    "generated_at": "2026-09-09T06:24:29.037Z",
+    "merged_at": "2026-08-31T06:42:12Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 128,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-31T05:42:30.146Z",
+    "last_ts": "2026-08-31T05:43:22.560Z",
+    "span_seconds": 52,
+    "active_seconds": 52,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.30964825,
+    "tokens": {
+      "input": 10,
+      "output": 3134,
+      "thinking": 0,
+      "cache_write_5m": 24311,
+      "cache_write_1h": 0,
+      "cache_read": 158609
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 10,
+          "output": 3134,
+          "thinking": 0,
+          "cache_write_5m": 24311,
+          "cache_write_1h": 0,
+          "cache_read": 158609
+        },
+        "usd_equivalent": 0.30964825,
+        "messages": 5
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 10,
+          "output": 3134,
+          "thinking": 0,
+          "cache_write_5m": 24311,
+          "cache_write_1h": 0,
+          "cache_read": 158609
+        },
+        "usd_equivalent": 0.30964825,
+        "messages": 5
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 2,
+      "docs": 1,
+      "config": 5,
+      "source": 16
+    },
+    "loc": {
+      "generated": {
+        "added": 31,
+        "deleted": 0
+      },
+      "test": {
+        "added": 355,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 26,
+        "deleted": 1
+      },
+      "config": {
+        "added": 117,
+        "deleted": 3
+      },
+      "source": {
+        "added": 398,
+        "deleted": 27
+      }
+    },
+    "packages": [
+      "cire/host",
+      "cire/landing",
+      "cire/vendor"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/perf-cire-invites-ssr-bundle.json
+++ b/.claude/metrics/perf-cire-invites-ssr-bundle.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-invites-ssr-bundle",
     "base_sha": "851df71756b28cbe60cc72bac4f82de072179237",
     "head_sha": "0fbe9a2b7098c414b16bbbb8acd5e3302f1016d1",
-    "generated_at": "2026-09-07T07:41:43.205Z",
+    "generated_at": "2026-09-09T06:24:29.022Z",
     "merged_at": "2026-09-06T15:01:51Z",
     "phase": "at-merge"
   },
@@ -27,53 +27,53 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 8.053326199999999,
+    "usd_equivalent": 3.8940299,
     "tokens": {
-      "input": 343,
-      "output": 72984,
-      "thinking": 6001,
-      "cache_write_5m": 342404,
-      "cache_write_1h": 232888,
-      "cache_read": 16673976
+      "input": 179,
+      "output": 34361,
+      "thinking": 2681,
+      "cache_write_5m": 127802,
+      "cache_write_1h": 122562,
+      "cache_read": 9344301
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 91,
-          "output": 35672,
+          "input": 37,
+          "output": 13078,
           "thinking": 0,
-          "cache_write_5m": 342404,
+          "cache_write_5m": 127802,
           "cache_write_1h": 0,
-          "cache_read": 1270250
+          "cache_read": 653034
         },
-        "usd_equivalent": 3.667405000000001,
-        "messages": 46
+        "usd_equivalent": 1.4524145000000002,
+        "messages": 22
       },
       "claude-sonnet-5": {
         "tokens": {
-          "input": 252,
-          "output": 37312,
-          "thinking": 6001,
+          "input": 142,
+          "output": 21283,
+          "thinking": 2681,
           "cache_write_5m": 0,
-          "cache_write_1h": 232888,
-          "cache_read": 15403726
+          "cache_write_1h": 122562,
+          "cache_read": 8691267
         },
-        "usd_equivalent": 4.385921199999999,
-        "messages": 126
+        "usd_equivalent": 2.441615400000001,
+        "messages": 71
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 343,
-          "output": 72984,
-          "thinking": 6001,
-          "cache_write_5m": 342404,
-          "cache_write_1h": 232888,
-          "cache_read": 16673976
+          "input": 179,
+          "output": 34361,
+          "thinking": 2681,
+          "cache_write_5m": 127802,
+          "cache_write_1h": 122562,
+          "cache_read": 9344301
         },
-        "usd_equivalent": 8.053326199999999,
-        "messages": 172
+        "usd_equivalent": 3.8940299,
+        "messages": 93
       },
       "subagent": {
         "tokens": {
@@ -89,7 +89,7 @@
       }
     },
     "effort": {
-      "high": 126
+      "high": 71
     },
     "unpriced_models": []
   },
@@ -132,20 +132,18 @@
   "interaction": {
     "user_turns": 4,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1465401,
+    "tokens_before_first_edit": 884171,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 53,
-      "Read": 20,
-      "Edit": 12,
-      "Grep": 6,
-      "StructuredOutput": 3,
-      "Glob": 3,
-      "Write": 2
+      "Bash": 12,
+      "Read": 8,
+      "Edit": 6,
+      "Write": 2,
+      "Glob": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 6
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 3
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/perf-cire-invites-worker-size.json
+++ b/.claude/metrics/perf-cire-invites-worker-size.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-invites-worker-size",
     "base_sha": "7094065879b85fc107c0778a176d3d8002a9cf85",
     "head_sha": "6379aad47887720961d148bc96d0d90a5d2f1b0f",
-    "generated_at": "2026-09-07T07:42:14.028Z",
+    "generated_at": "2026-09-09T06:24:29.032Z",
     "merged_at": "2026-09-02T01:17:53Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 2.8127072499999994,
+    "usd_equivalent": 1.1462695000000003,
     "tokens": {
-      "input": 86,
-      "output": 27510,
+      "input": 36,
+      "output": 10185,
       "thinking": 0,
-      "cache_write_5m": 245963,
+      "cache_write_5m": 91412,
       "cache_write_1h": 0,
-      "cache_read": 1174517
+      "cache_read": 640279
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 86,
-          "output": 27510,
+          "input": 36,
+          "output": 10185,
           "thinking": 0,
-          "cache_write_5m": 245963,
+          "cache_write_5m": 91412,
           "cache_write_1h": 0,
-          "cache_read": 1174517
+          "cache_read": 640279
         },
-        "usd_equivalent": 2.8127072499999994,
-        "messages": 41
+        "usd_equivalent": 1.1462695000000003,
+        "messages": 21
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 86,
-          "output": 27510,
+          "input": 36,
+          "output": 10185,
           "thinking": 0,
-          "cache_write_5m": 245963,
+          "cache_write_5m": 91412,
           "cache_write_1h": 0,
-          "cache_read": 1174517
+          "cache_read": 640279
         },
-        "usd_equivalent": 2.8127072499999994,
-        "messages": 41
+        "usd_equivalent": 1.1462695000000003,
+        "messages": 21
       },
       "subagent": {
         "tokens": {
@@ -121,10 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 18,
-      "Glob": 3,
-      "StructuredOutput": 3,
-      "Bash": 2
+      "Read": 7,
+      "Glob": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-cire-store-reactive-readers.json
+++ b/.claude/metrics/perf-cire-store-reactive-readers.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-store-reactive-readers",
     "base_sha": "07e6b0d68307fb03d356f327b276ebea627e3136",
     "head_sha": "ce3e26dd8704b7a23d774f1db4603a2399cc14cd",
-    "generated_at": "2026-09-07T07:42:11.034Z",
+    "generated_at": "2026-09-09T06:24:29.032Z",
     "merged_at": "2026-09-06T07:50:37Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 3.7209282500000005,
+    "usd_equivalent": 1.48277375,
     "tokens": {
-      "input": 66,
-      "output": 26581,
+      "input": 27,
+      "output": 9715,
       "thinking": 0,
-      "cache_write_5m": 414337,
+      "cache_write_5m": 146143,
       "cache_write_1h": 0,
-      "cache_read": 932934
+      "cache_read": 652740
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 66,
-          "output": 26581,
+          "input": 27,
+          "output": 9715,
           "thinking": 0,
-          "cache_write_5m": 414337,
+          "cache_write_5m": 146143,
           "cache_write_1h": 0,
-          "cache_read": 932934
+          "cache_read": 652740
         },
-        "usd_equivalent": 3.7209282500000005,
-        "messages": 21
+        "usd_equivalent": 1.48277375,
+        "messages": 12
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 66,
-          "output": 26581,
+          "input": 27,
+          "output": 9715,
           "thinking": 0,
-          "cache_write_5m": 414337,
+          "cache_write_5m": 146143,
           "cache_write_1h": 0,
-          "cache_read": 932934
+          "cache_read": 652740
         },
-        "usd_equivalent": 3.7209282500000005,
-        "messages": 21
+        "usd_equivalent": 1.48277375,
+        "messages": 12
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "StructuredOutput": 3,
-      "Read": 3,
-      "Bash": 2,
+      "Read": 2,
+      "Bash": 1,
       "Grep": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-cire-store-stale-while-revalidate.json
+++ b/.claude/metrics/perf-cire-store-stale-while-revalidate.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-store-stale-while-revalidate",
     "base_sha": "66c9950197ee25bfc25f86664de7ac607504d843",
     "head_sha": "07e6b0d68307fb03d356f327b276ebea627e3136",
-    "generated_at": "2026-09-07T07:42:12.541Z",
+    "generated_at": "2026-09-09T06:24:29.032Z",
     "merged_at": "2026-09-06T07:50:36Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 4.038887749999999,
+    "usd_equivalent": 1.4421565000000003,
     "tokens": {
-      "input": 66,
-      "output": 33051,
+      "input": 26,
+      "output": 12192,
       "thinking": 0,
-      "cache_write_5m": 432333,
+      "cache_write_5m": 149664,
       "cache_write_1h": 0,
-      "cache_read": 1020403
+      "cache_read": 403653
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 66,
-          "output": 33051,
+          "input": 26,
+          "output": 12192,
           "thinking": 0,
-          "cache_write_5m": 432333,
+          "cache_write_5m": 149664,
           "cache_write_1h": 0,
-          "cache_read": 1020403
+          "cache_read": 403653
         },
-        "usd_equivalent": 4.038887749999999,
-        "messages": 26
+        "usd_equivalent": 1.4421565000000003,
+        "messages": 11
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 66,
-          "output": 33051,
+          "input": 26,
+          "output": 12192,
           "thinking": 0,
-          "cache_write_5m": 432333,
+          "cache_write_5m": 149664,
           "cache_write_1h": 0,
-          "cache_read": 1020403
+          "cache_read": 403653
         },
-        "usd_equivalent": 4.038887749999999,
-        "messages": 26
+        "usd_equivalent": 1.4421565000000003,
+        "messages": 11
       },
       "subagent": {
         "tokens": {
@@ -121,9 +121,6 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 9,
-      "StructuredOutput": 2,
-      "Grep": 2,
       "Glob": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-error-tag-walk.json
+++ b/.claude/metrics/perf-error-tag-walk.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 825,
+    "branch": "perf/error-tag-walk",
+    "base_sha": "b84c78188446243df33cd34a38e23fe858489af1",
+    "head_sha": "6aec8e39ad74af67555c6843470c52d6b2c956d4",
+    "generated_at": "2026-09-09T06:24:29.041Z",
+    "merged_at": "2026-08-30T03:30:21Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 473,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-08-28T01:54:06.332Z",
+    "last_ts": "2026-08-28T02:08:59.884Z",
+    "span_seconds": 894,
+    "active_seconds": 927,
+    "compactions": 1
+  },
+  "spend": {
+    "usd_equivalent": 2.2951023500000005,
+    "tokens": {
+      "input": 93,
+      "output": 26358,
+      "thinking": 9316,
+      "cache_write_5m": 45599,
+      "cache_write_1h": 183642,
+      "cache_read": 3888816
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 21,
+          "output": 9805,
+          "thinking": 0,
+          "cache_write_5m": 45599,
+          "cache_write_1h": 0,
+          "cache_read": 289578
+        },
+        "usd_equivalent": 0.6750127499999999,
+        "messages": 11
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 72,
+          "output": 16553,
+          "thinking": 9316,
+          "cache_write_5m": 0,
+          "cache_write_1h": 183642,
+          "cache_read": 3599238
+        },
+        "usd_equivalent": 1.6200896000000002,
+        "messages": 36
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 93,
+          "output": 26358,
+          "thinking": 9316,
+          "cache_write_5m": 45599,
+          "cache_write_1h": 183642,
+          "cache_read": 3888816
+        },
+        "usd_equivalent": 2.2951023500000005,
+        "messages": 47
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 36
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 0,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 5,
+        "deleted": 0
+      },
+      "test": {
+        "added": 25,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 6,
+        "deleted": 5
+      }
+    },
+    "packages": [
+      "osn/api"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 5,
+    "corrective_turns": 2,
+    "tokens_before_first_edit": 779276,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 4,
+      "Read": 3,
+      "Write": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/perf-jest-dom-setup.json
+++ b/.claude/metrics/perf-jest-dom-setup.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 792,
+    "branch": "perf/jest-dom-setup",
+    "base_sha": "f7880d4c05b7b21978f27cead66ae6c88bf5b3f5",
+    "head_sha": "97e620962708fd9eb9289259cca79275425e1678",
+    "generated_at": "2026-09-09T06:24:29.045Z",
+    "merged_at": "2026-08-30T02:42:19Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 500,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-08-25T04:33:16.256Z",
+    "last_ts": "2026-08-28T01:47:21.296Z",
+    "span_seconds": 249245,
+    "active_seconds": 2391,
+    "compactions": 5
+  },
+  "spend": {
+    "usd_equivalent": 18.396812000000004,
+    "tokens": {
+      "input": 166,
+      "output": 91225,
+      "thinking": 52879,
+      "cache_write_5m": 63320,
+      "cache_write_1h": 588394,
+      "cache_read": 7069795
+    },
+    "by_model": {
+      "claude-fable-5": {
+        "tokens": {
+          "input": 90,
+          "output": 76789,
+          "thinking": 51694,
+          "cache_write_5m": 0,
+          "cache_write_1h": 436841,
+          "cache_read": 3993861
+        },
+        "usd_equivalent": 16.571030999999998,
+        "messages": 45
+      },
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 16,
+          "output": 1796,
+          "thinking": 0,
+          "cache_write_5m": 63320,
+          "cache_write_1h": 0,
+          "cache_read": 123774
+        },
+        "usd_equivalent": 0.502617,
+        "messages": 6
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 60,
+          "output": 12640,
+          "thinking": 1185,
+          "cache_write_5m": 0,
+          "cache_write_1h": 151553,
+          "cache_read": 2952160
+        },
+        "usd_equivalent": 1.3231639999999998,
+        "messages": 30
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 166,
+          "output": 91225,
+          "thinking": 52879,
+          "cache_write_5m": 63320,
+          "cache_write_1h": 588394,
+          "cache_read": 7069795
+        },
+        "usd_equivalent": 18.396812000000004,
+        "messages": 81
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {
+      "high": 75
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 0,
+      "docs": 0,
+      "config": 0,
+      "source": 43
+    },
+    "loc": {
+      "generated": {
+        "added": 4,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 55,
+        "deleted": 10
+      }
+    },
+    "packages": [
+      "cire/host",
+      "cire/invites",
+      "cire/landing",
+      "cire/vendor",
+      "osn/client",
+      "osn/landing",
+      "osn/social",
+      "osn/ui",
+      "pulse/landing",
+      "pulse/web",
+      "shared/rp-auth",
+      "shared/sortable",
+      "shared/test-config",
+      "shared/toast"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 10,
+    "corrective_turns": 6,
+    "tokens_before_first_edit": 1633466,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 9,
+      "Write": 1,
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 1
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/perf-osn-recommender-fanout.json
+++ b/.claude/metrics/perf-osn-recommender-fanout.json
@@ -5,7 +5,7 @@
     "branch": "perf/osn-recommender-fanout",
     "base_sha": "8b55084abdc82867cb1aeaacb4102ecb1213b146",
     "head_sha": "e7c6f0f170f01a937c8e3fa06ff9db2bf4b0cdb9",
-    "generated_at": "2026-09-07T07:42:25.052Z",
+    "generated_at": "2026-09-09T06:24:29.036Z",
     "merged_at": "2026-08-31T15:41:14Z",
     "phase": "at-merge"
   },
@@ -27,41 +27,41 @@
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.483175,
+    "usd_equivalent": 0.640822,
     "tokens": {
-      "input": 21,
-      "output": 12550,
+      "input": 11,
+      "output": 4492,
       "thinking": 0,
-      "cache_write_5m": 152672,
+      "cache_write_5m": 64920,
       "cache_write_1h": 0,
-      "cache_read": 430240
+      "cache_read": 245434
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 21,
-          "output": 12550,
+          "input": 11,
+          "output": 4492,
           "thinking": 0,
-          "cache_write_5m": 152672,
+          "cache_write_5m": 64920,
           "cache_write_1h": 0,
-          "cache_read": 430240
+          "cache_read": 245434
         },
-        "usd_equivalent": 1.483175,
-        "messages": 11
+        "usd_equivalent": 0.640822,
+        "messages": 6
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 21,
-          "output": 12550,
+          "input": 11,
+          "output": 4492,
           "thinking": 0,
-          "cache_write_5m": 152672,
+          "cache_write_5m": 64920,
           "cache_write_1h": 0,
-          "cache_read": 430240
+          "cache_read": 245434
         },
-        "usd_equivalent": 1.483175,
-        "messages": 11
+        "usd_equivalent": 0.640822,
+        "messages": 6
       },
       "subagent": {
         "tokens": {
@@ -123,9 +123,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 3,
-      "Grep": 1,
-      "StructuredOutput": 1
+      "Read": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-turbo-test-inputs.json
+++ b/.claude/metrics/perf-turbo-test-inputs.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 848,
+    "branch": "perf/turbo-test-inputs",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "b5751a716de151d0e134f638a3354e979a5aa65c",
+    "generated_at": "2026-09-09T06:24:29.037Z",
+    "merged_at": "2026-08-31T04:33:35Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 458,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-31T04:02:00.635Z",
+    "last_ts": "2026-08-31T04:02:52.807Z",
+    "span_seconds": 52,
+    "active_seconds": 68,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.493877,
+    "tokens": {
+      "input": 18,
+      "output": 3951,
+      "thinking": 0,
+      "cache_write_5m": 47636,
+      "cache_write_1h": 0,
+      "cache_read": 194574
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 18,
+          "output": 3951,
+          "thinking": 0,
+          "cache_write_5m": 47636,
+          "cache_write_1h": 0,
+          "cache_read": 194574
+        },
+        "usd_equivalent": 0.493877,
+        "messages": 8
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 18,
+          "output": 3951,
+          "thinking": 0,
+          "cache_write_5m": 47636,
+          "cache_write_1h": 0,
+          "cache_read": 194574
+        },
+        "usd_equivalent": 0.493877,
+        "messages": 8
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 2,
+      "docs": 2,
+      "config": 2,
+      "source": 6
+    },
+    "loc": {
+      "generated": {
+        "added": 15,
+        "deleted": 0
+      },
+      "test": {
+        "added": 91,
+        "deleted": 4
+      },
+      "docs": {
+        "added": 53,
+        "deleted": 14
+      },
+      "config": {
+        "added": 25,
+        "deleted": 0
+      },
+      "source": {
+        "added": 45,
+        "deleted": 15
+      }
+    },
+    "packages": [
+      "tools/lab"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/perf-zap-write-hops.json
+++ b/.claude/metrics/perf-zap-write-hops.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 845,
+    "branch": "perf/zap-write-hops",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "b5f9c7f45fef921b4e354576e72b91aea72ebe69",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-31T04:33:24Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 568,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-30T15:46:54.111Z",
+    "last_ts": "2026-08-30T15:49:52.234Z",
+    "span_seconds": 178,
+    "active_seconds": 192,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.30830925,
+    "tokens": {
+      "input": 25,
+      "output": 13099,
+      "thinking": 0,
+      "cache_write_5m": 99163,
+      "cache_write_1h": 0,
+      "cache_read": 721881
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 25,
+          "output": 13099,
+          "thinking": 0,
+          "cache_write_5m": 99163,
+          "cache_write_1h": 0,
+          "cache_read": 721881
+        },
+        "usd_equivalent": 1.30830925,
+        "messages": 15
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 25,
+          "output": 13099,
+          "thinking": 0,
+          "cache_write_5m": 99163,
+          "cache_write_1h": 0,
+          "cache_read": 721881
+        },
+        "usd_equivalent": 1.30830925,
+        "messages": 15
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 2,
+      "docs": 0,
+      "config": 1,
+      "source": 4
+    },
+    "loc": {
+      "generated": {
+        "added": 53,
+        "deleted": 1
+      },
+      "test": {
+        "added": 277,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 1,
+        "deleted": 1
+      },
+      "source": {
+        "added": 347,
+        "deleted": 166
+      }
+    },
+    "packages": [
+      "zap/api"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 4,
+      "Bash": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/refactor-no-await-in-loop.json
+++ b/.claude/metrics/refactor-no-await-in-loop.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 824,
+    "branch": "refactor/no-await-in-loop",
+    "base_sha": "b84c78188446243df33cd34a38e23fe858489af1",
+    "head_sha": "e0d8df57859f2258739c07e63ff2e264916edb8f",
+    "generated_at": "2026-09-09T06:24:29.042Z",
+    "merged_at": "2026-08-30T02:45:28Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 544,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 2,
+    "first_ts": "2026-08-28T01:50:58.710Z",
+    "last_ts": "2026-08-28T01:52:56.521Z",
+    "span_seconds": 118,
+    "active_seconds": 193,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.2167172499999999,
+    "tokens": {
+      "input": 28,
+      "output": 12319,
+      "thinking": 0,
+      "cache_write_5m": 83543,
+      "cache_write_1h": 0,
+      "cache_read": 772917
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 28,
+          "output": 12319,
+          "thinking": 0,
+          "cache_write_5m": 83543,
+          "cache_write_1h": 0,
+          "cache_read": 772917
+        },
+        "usd_equivalent": 1.2167172499999999,
+        "messages": 18
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 28,
+          "output": 12319,
+          "thinking": 0,
+          "cache_write_5m": 83543,
+          "cache_write_1h": 0,
+          "cache_read": 772917
+        },
+        "usd_equivalent": 1.2167172499999999,
+        "messages": 18
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 2,
+      "test": 0,
+      "docs": 0,
+      "config": 0,
+      "source": 8
+    },
+    "loc": {
+      "generated": {
+        "added": 23,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 149,
+        "deleted": 74
+      }
+    },
+    "packages": [
+      "cire/api",
+      "osn/api",
+      "shared/db-utils"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 4,
+      "Bash": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/refactor-separate-osn-from-musubi.json
+++ b/.claude/metrics/refactor-separate-osn-from-musubi.json
@@ -4,65 +4,62 @@
     "number": 967,
     "branch": "refactor/separate-osn-from-musubi",
     "base_sha": "10e490c9aa8581cf5b4cf2f739e1f689370a0083",
-    "head_sha": "f471052ba21c4367fa253a9aeb12fc0209c727b6",
-    "generated_at": "2026-09-09T02:03:16.093Z",
-    "merged_at": null,
-    "phase": "at-open"
+    "head_sha": "9b33d22a6e4b7520cf96a450e65a09f4434e9b59",
+    "generated_at": "2026-09-09T06:24:29.003Z",
+    "merged_at": "2026-09-09T02:56:45Z",
+    "phase": "at-merge"
   },
   "issue": {
     "number": 954,
     "type": null,
-    "labels": [
-      "complexity:5",
-      "product:musubi"
-    ]
+    "labels": []
   },
   "complexity": {
-    "declared": 5,
-    "method": "confirmed"
+    "declared": null,
+    "method": "none"
   },
   "window": {
-    "sessions": 4,
+    "sessions": 5,
     "first_ts": "2026-09-08T14:34:45.201Z",
-    "last_ts": "2026-09-09T02:03:14.528Z",
-    "span_seconds": 41309,
-    "active_seconds": 4594,
+    "last_ts": "2026-09-09T02:08:33.027Z",
+    "span_seconds": 41628,
+    "active_seconds": 5079,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 34.36269530000002,
+    "usd_equivalent": 37.491811049999995,
     "tokens": {
-      "input": 1670,
-      "output": 112172,
-      "thinking": 29465,
-      "cache_write_5m": 694352,
-      "cache_write_1h": 323767,
-      "cache_read": 55469479
+      "input": 1716,
+      "output": 127296,
+      "thinking": 30203,
+      "cache_write_5m": 760909,
+      "cache_write_1h": 334125,
+      "cache_read": 59931928
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 22,
-          "output": 4564,
+          "input": 44,
+          "output": 15440,
           "thinking": 0,
-          "cache_write_5m": 69208,
+          "cache_write_5m": 135765,
           "cache_write_1h": 0,
-          "cache_read": 426440
+          "cache_read": 992791
         },
-        "usd_equivalent": 0.7599799999999999,
-        "messages": 12
+        "usd_equivalent": 1.7311467500000002,
+        "messages": 24
       },
       "claude-opus-5": {
         "tokens": {
-          "input": 308,
-          "output": 101895,
-          "thinking": 29448,
+          "input": 332,
+          "output": 106143,
+          "thinking": 30186,
           "cache_write_5m": 0,
-          "cache_write_1h": 323767,
-          "cache_read": 35362987
+          "cache_write_1h": 334125,
+          "cache_read": 39259085
         },
-        "usd_equivalent": 23.468078500000008,
-        "messages": 154
+        "usd_equivalent": 25.626027500000006,
+        "messages": 166
       },
       "<synthetic>": {
         "tokens": {
@@ -104,15 +101,15 @@
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 330,
-          "output": 106459,
-          "thinking": 29448,
-          "cache_write_5m": 69208,
-          "cache_write_1h": 323767,
-          "cache_read": 35789427
+          "input": 376,
+          "output": 121583,
+          "thinking": 30186,
+          "cache_write_5m": 135765,
+          "cache_write_1h": 334125,
+          "cache_read": 40251876
         },
-        "usd_equivalent": 24.228058500000007,
-        "messages": 167
+        "usd_equivalent": 27.357174250000003,
+        "messages": 191
       },
       "subagent": {
         "tokens": {
@@ -128,7 +125,7 @@
       }
     },
     "effort": {
-      "high": 344
+      "high": 356
     },
     "unpriced_models": []
   },
@@ -137,7 +134,7 @@
       "generated": 3,
       "test": 27,
       "docs": 47,
-      "config": 11,
+      "config": 12,
       "source": 87
     },
     "loc": {
@@ -154,7 +151,7 @@
         "deleted": 192
       },
       "config": {
-        "added": 31,
+        "added": 235,
         "deleted": 31
       },
       "source": {
@@ -178,19 +175,20 @@
       "zap/api"
     ],
     "touches_migration": false,
-    "commits": 3
+    "commits": 4
   },
   "interaction": {
-    "user_turns": 7,
-    "corrective_turns": 4,
+    "user_turns": 9,
+    "corrective_turns": 5,
     "tokens_before_first_edit": 259301,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 67,
+      "Bash": 71,
       "Edit": 13,
       "Write": 3,
       "Agent": 2,
-      "Read": 1
+      "Read": 2,
+      "Monitor": 1
     },
     "edit_churn": {
       "files_edited_3plus": 3,

--- a/.claude/metrics/test-authorize-error-page-copy.json
+++ b/.claude/metrics/test-authorize-error-page-copy.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 834,
+    "branch": "test/authorize-error-page-copy",
+    "base_sha": "e0f19b6e36296cecb36cf20c7a30eaa0e331ee7f",
+    "head_sha": "647acd22d6c1109cf7a7d1491f7bc2dea3619db3",
+    "generated_at": "2026-09-09T06:24:29.040Z",
+    "merged_at": "2026-08-30T04:46:48Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 464,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-30T04:15:36.068Z",
+    "last_ts": "2026-08-30T04:16:07.428Z",
+    "span_seconds": 31,
+    "active_seconds": 31,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.30879399999999996,
+    "tokens": {
+      "input": 10,
+      "output": 1740,
+      "thinking": 0,
+      "cache_write_5m": 32992,
+      "cache_write_1h": 0,
+      "cache_read": 118088
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 10,
+          "output": 1740,
+          "thinking": 0,
+          "cache_write_5m": 32992,
+          "cache_write_1h": 0,
+          "cache_read": 118088
+        },
+        "usd_equivalent": 0.30879399999999996,
+        "messages": 5
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 10,
+          "output": 1740,
+          "thinking": 0,
+          "cache_write_5m": 32992,
+          "cache_write_1h": 0,
+          "cache_read": 118088
+        },
+        "usd_equivalent": 0.30879399999999996,
+        "messages": 5
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 0,
+      "config": 0,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 14,
+        "deleted": 0
+      },
+      "test": {
+        "added": 72,
+        "deleted": 1
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 1,
+        "deleted": 1
+      }
+    },
+    "packages": [
+      "osn/api"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/test-pr-metrics-backfill.json
+++ b/.claude/metrics/test-pr-metrics-backfill.json
@@ -1,26 +1,22 @@
 {
   "schema_version": 1,
   "pr": {
-    "number": null,
+    "number": 955,
     "branch": "test/pr-metrics-backfill",
     "base_sha": "5667074a2ffd3b62aae424c5c3fd33fc162f32d4",
-    "head_sha": "4bcdd66a73adb9a4ec225bc9558306aa325e1dac",
-    "generated_at": "2026-09-08T14:37:45.709Z",
-    "merged_at": null,
-    "phase": "at-open"
+    "head_sha": "39d45644798c7bdd2df95301e66689e234cc92ea",
+    "generated_at": "2026-09-09T06:24:29.014Z",
+    "merged_at": "2026-09-08T14:48:06Z",
+    "phase": "at-merge"
   },
   "issue": {
     "number": 944,
-    "type": "Task",
-    "labels": [
-      "product:shared",
-      "area:ops",
-      "complexity:2"
-    ]
+    "type": null,
+    "labels": []
   },
   "complexity": {
-    "declared": 2,
-    "method": "confirmed"
+    "declared": null,
+    "method": "none"
   },
   "window": {
     "sessions": 1,
@@ -102,7 +98,7 @@
       "generated": 1,
       "test": 1,
       "docs": 1,
-      "config": 0,
+      "config": 1,
       "source": 1
     },
     "loc": {
@@ -119,7 +115,7 @@
         "deleted": 0
       },
       "config": {
-        "added": 0,
+        "added": 153,
         "deleted": 0
       },
       "source": {
@@ -131,7 +127,7 @@
       "tools/pr-metrics"
     ],
     "touches_migration": false,
-    "commits": 5
+    "commits": 6
   },
   "interaction": {
     "user_turns": 0,

--- a/.claude/metrics/test-pulse-account-cookie.json
+++ b/.claude/metrics/test-pulse-account-cookie.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 843,
+    "branch": "test/pulse-account-cookie",
+    "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
+    "head_sha": "d31fe56e410df2c5033c4602daaa17b73d7093e2",
+    "generated_at": "2026-09-09T06:24:29.038Z",
+    "merged_at": "2026-08-31T04:32:47Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 513,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-08-30T14:20:51.912Z",
+    "last_ts": "2026-08-30T14:21:07.129Z",
+    "span_seconds": 15,
+    "active_seconds": 15,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.11137525000000001,
+    "tokens": {
+      "input": 8,
+      "output": 590,
+      "thinking": 0,
+      "cache_write_5m": 9561,
+      "cache_write_1h": 0,
+      "cache_read": 73658
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 8,
+          "output": 590,
+          "thinking": 0,
+          "cache_write_5m": 9561,
+          "cache_write_1h": 0,
+          "cache_read": 73658
+        },
+        "usd_equivalent": 0.11137525000000001,
+        "messages": 3
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 8,
+          "output": 590,
+          "thinking": 0,
+          "cache_write_5m": 9561,
+          "cache_write_1h": 0,
+          "cache_read": 73658
+        },
+        "usd_equivalent": 0.11137525000000001,
+        "messages": 3
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 1,
+      "docs": 0,
+      "config": 0,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 9,
+        "deleted": 0
+      },
+      "test": {
+        "added": 89,
+        "deleted": 3
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [
+      "pulse/api"
+    ],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "StructuredOutput": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -75,7 +75,14 @@ export const MODEL_RATES = {
 
 export type PricedModel = keyof typeof MODEL_RATES;
 
+/** A transcript names a model either bare (`claude-opus-5`) or with the
+ * snapshot date appended (`claude-haiku-4-5-20251001`). Both are the same model
+ * at the same rates, so the date comes off before the table is consulted. */
+const MODEL_SNAPSHOT_SUFFIX = /-\d{8}$/;
+
 /**
+ * The rate-table key for a model name, or `null` when the table has no entry.
+ *
  * `Object.hasOwn`, never `key in MODEL_RATES` — the house rule in CLAUDE.md,
  * and here it guards a real defect rather than a hypothetical one. Model names
  * arrive from a transcript this script did not write, and `in` walks the
@@ -83,8 +90,14 @@ export type PricedModel = keyof typeof MODEL_RATES;
  * which then destructures to `[undefined, undefined]` and prices the whole card
  * as `NaN`. `hasOwn` sees only the nine real entries.
  */
-export function isPricedModel(model: string): model is PricedModel {
-  return Object.hasOwn(MODEL_RATES, model);
+export function rateKeyFor(model: string): PricedModel | null {
+  const bare = model.replace(MODEL_SNAPSHOT_SUFFIX, "");
+
+  return Object.hasOwn(MODEL_RATES, bare) ? (bare as PricedModel) : null;
+}
+
+export function isPricedModel(model: string): boolean {
+  return rateKeyFor(model) !== null;
 }
 
 const CACHE_WRITE_5M_MULTIPLIER = 1.25;
@@ -229,9 +242,11 @@ export function addTokens(into: TokenTotals, from: TokenTotals): void {
  * one. `unpricedModels` on the card names them so the gap is visible.
  */
 export function costOf(tokens: TokenTotals, model: string): number {
-  if (!isPricedModel(model)) return 0;
+  const key = rateKeyFor(model);
 
-  const [inputRate, outputRate] = MODEL_RATES[model];
+  if (key === null) return 0;
+
+  const [inputRate, outputRate] = MODEL_RATES[key];
 
   return (
     (tokens.input * inputRate +

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -13,6 +13,7 @@ import {
   isFileWritingCommand,
   isHumanTurn,
   parseNumstat,
+  rateKeyFor,
   readUsage,
   type SessionRecord,
   skillCommandsIn,
@@ -113,6 +114,22 @@ test("costOf does not bill thinking tokens on top of output", () => {
 
 test("costOf rates an unknown model at zero rather than guessing", () => {
   expect(costOf({ ...emptyTokens(), output: 5_000_000 }, "claude-nextgen-9")).toBe(0);
+});
+
+// Transcripts name Haiku with its snapshot date appended and the other models
+// without. Keying the table bare and dropping the suffix is what stops a real
+// session costing $0 — three backfilled cards read that way before this.
+test("costOf prices a dated model id at its bare rates", () => {
+  const tokens = { ...emptyTokens(), output: 1_000_000 };
+
+  expect(costOf(tokens, "claude-haiku-4-5-20251001")).toBe(costOf(tokens, "claude-haiku-4-5"));
+  expect(costOf(tokens, "claude-haiku-4-5-20251001")).toBeCloseTo(5, 6);
+});
+
+test("rateKeyFor keeps an unknown model unpriced, dated or not", () => {
+  expect(rateKeyFor("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");
+  expect(rateKeyFor("claude-nextgen-9-20260101")).toBeNull();
+  expect(rateKeyFor("constructor")).toBeNull();
 });
 
 test("aggregateSpend names unpriced models so the gap is visible", () => {


### PR DESCRIPTION
## Summary

Session-performance cards were missing from most pull request bodies. The cause
was not the collector — it runs fine — but that `prep-pr` appends the card as an
optional step nothing enforces, so it gets skipped. This backfills the cards
that were never written and fixes a pricing bug the backfill exposed.

73 cards written: 35 new, 38 rewritten from `at-open` to `at-merge`, which is
the phase that holds the real cost. The corpus goes from 40 cards at $325.65 to
73 merged cards at $520.30.

27 merged pull requests are skipped. No transcript for their branch exists on
this machine — they were worked in remote sessions — and `backfill` refuses to
write a card it cannot cost, because a card reading $0 cannot be told from a
cheap one.

The pricing bug: transcripts name Haiku `claude-haiku-4-5-20251001` while
`MODEL_RATES` is keyed bare, so `Object.hasOwn` missed and every Haiku message
costed zero. #961 recorded 682K cache-read tokens at $0.00. `rateKeyFor` now
drops a trailing `-YYYYMMDD` before the lookup.

## Workspaces affected

| Package | Change |
|---|---|
| `@tools/pr-metrics` | `rateKeyFor` replaces `isPricedModel` as the rate lookup; two tests |
| — | 73 cards under `.claude/metrics/` (not a package) |

## Issues

None. This is the backfill half of the missing-cards problem; no issue was open
for it.

## Decisions

**No gate on the card.** The obvious fix for cards going missing is a CI check
that fails a pull request whose body has no card. The repo owner declined it, so
the miss rate stays. This PR only repairs the record.

**Timestamp-only churn reverted.** Re-running `backfill` after the pricing fix
rewrote all 73 cards, but 70 differed only in `generated_at`. Those were
restored, so the second commit shows the three cards whose cost actually moved:
#961 $0 → $0.14, #962 $21.20 → $21.30, #966 $39.43 → $39.50.

**`unpriced_models` kept.** The fix could have been a wildcard match that prices
anything Haiku-shaped. It is an exact match on the bare id instead: an unknown
model still rates at zero and still names itself in `unpriced_models`, which is
the existing contract for a model released after the table was written.

**Four PRs stay uncosted.** #957, #932, #931 and #933 are among the 27 skipped —
their transcripts live in remote containers, not here. Nothing in this branch
can recover them.

## Test plan

| Gate | Result |
|---|---|
| `bun run --cwd tools/pr-metrics test` | 117 pass, 0 fail |
| `bun run --cwd tools/pr-metrics check` | clean |
| `oxfmt` / `oxlint` (pre-commit) | clean |
| `scripts/changeset-required.sh` | `required` — changeset added |
| `scripts/validate-changesets.sh` | valid |

Two new tests cover the fix: a dated id prices identically to its bare form, and
an unknown model stays unpriced whether or not it carries a date.

**Not run:** the full monorepo suite. This touches one tool workspace that no
package imports.

**By hand:** the card block below is what `--format markdown` emits; it is the
first one on this branch, so it also exercises the append step that has been
getting skipped.

<details><summary>Session metrics — $1.61 · 742.3K tok · complexity unrated · +19/-4 source</summary>

| | |
|---|---|
| Cost (API-equivalent) | $1.61 |
| Tokens | 742.3K — out 8.4K · cache-w 179.4K · cache-r 554.4K (75%) |
| Models | claude-opus-4-7 (100%) |
| Active time | 3m over 4 session(s) |
| Declared complexity | unrated |
| Source diff | +19/-4 across 1 file(s), 1 package(s) |
| Turns | 4 (0 corrective) |
| Before first edit | not observed (no edit seen in the transcript) |
| Subagents | none |

<sub>Card: `.claude/metrics/chore-backfill-metrics-cards.json` · phase `at-open` · [schema](../blob/main/wiki/observability/session-metrics.md)</sub>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
