### PR TITLE
fix(cire): stop rebuilding the dev D1 from zero on every merge

### DIFF
--- a/.changeset/cire-dev-d1-cost.md
+++ b/.changeset/cire-dev-d1-cost.md
@@ -1,0 +1,20 @@
+---
+"@cire/db": patch
+---
+
+The cire dev deploy no longer rebuilds `cire-db-dev` from zero on every merge.
+It dropped every table, replayed all 57 migrations from `0001` and re-seeded —
+8,007 D1 rows written and about 22,630 read a time, against a free-tier ceiling
+of 100,000 written a day shared by every database on the account. Thirteen
+merges on 2026-09-09 spent 104,091 and went over it. Almost none of that was the
+seed: SQLite rebuilds the whole table for every `ALTER TABLE ... DROP COLUMN`,
+and D1 bills that schema churn even against empty tables.
+
+`deploy-cire-api-dev` now applies migrations forward, exactly as production
+does, and supersedes queued runs. The full reset → migrate → seed moved to
+`.github/workflows/cire-dev-db-rebuild.yml`, nightly and on demand. The chain is
+still proved from zero on every pull request by the in-memory T-S1 lockstep
+test, and once a night against real D1.
+
+Docs only for this package — the `db:reset:dev` and `db:seed:dev` rows in
+`cire/db/README.md` now say when they run. xchromo/osn#979, #980.

--- a/.github/workflows/cire-dev-db-rebuild.yml
+++ b/.github/workflows/cire-dev-db-rebuild.yml
@@ -1,0 +1,91 @@
+# Rebuild the DEV cire D1 from zero: reset (drop every table incl. the migration
+# ledger) -> replay all migrations from 0001 -> seed.
+#
+# This used to run on every merge, inside deploy-cire-api-dev. At 8,007 D1 rows
+# written and ~22,630 read per run against a free-tier ceiling of 100,000
+# written per day account-wide, 13 merges in a day went over it (#979). The
+# per-merge job now applies migrations incrementally, exactly as production
+# does, and the from-zero replay lives here instead — once a night, plus
+# on demand.
+#
+# What the replay is FOR: proving the migration chain still builds a working
+# database from nothing, so a migration that only works as an increment fails
+# on dev rather than in production months later. Most of that proof is already
+# free — cire/api/tests/db/ddl-lockstep.test.ts (T-S1) applies the full chain to
+# an in-memory SQLite on every `bun test`, so on every PR. What only a REMOTE
+# replay catches is DDL that bun:sqlite accepts and D1 rejects. That is what
+# this job is here for.
+#
+# DESTRUCTIVE, and unattended. Both destructive steps route through scripts/
+# guards that re-derive the target from cire/api/wrangler.toml and refuse
+# anything but `cire-db-dev`. There is no flag anywhere in this path that
+# points at production.
+name: Rebuild cire dev D1
+
+on:
+  schedule:
+    # 14:00 UTC — 01:00 in Australia/Sydney, when nobody is merging. The D1
+    # daily counters reset at UTC midnight, so this lands mid-day with plenty
+    # of headroom either side.
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    name: Reset, replay and seed cire-db-dev
+    runs-on: ubuntu-latest
+    environment: dev
+    # Shares the dev deploy's group so a rebuild and a deploy never touch
+    # cire-db-dev at once. `cancel-in-progress: false` means a rebuild queued
+    # behind a deploy waits for it. The reverse — a merge landing mid-rebuild —
+    # cancels this job, because the deploy side sets `cancel-in-progress: true`;
+    # that leaves dev with its tables dropped and its ledger gone, so the next
+    # `migrations apply` replays the whole chain and puts it right. Dev is 503
+    # in between. Disposable tier, self-healing, and one merge's worth of rows.
+    concurrency:
+      group: deploy-dev-cire-api
+      cancel-in-progress: false
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_DEV || secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Guard against placeholder D1 database_id
+        run: bun run scripts/check-d1-database-id.ts
+
+      - name: Reset the dev D1 (drops every table)
+        run: bun run --cwd cire/db db:reset:dev
+
+      - name: Replay cire D1 migrations from zero (dev)
+        run: bun run --cwd cire/db db:migrate:dev
+
+      # CIRE_DEV_OWNER_PROFILE_ID repoints the seeded wedding at a real dev
+      # account. The seed owns it as `usr_dev_bootstrap_owner`, an id no account
+      # holds, so without this the sample wedding — its guests, its events and
+      # its comped entitlements (registry, vendors, AI) — is invisible to
+      # everyone signing in to test. It is a VARIABLE, not a secret: an OSN
+      # profile id is not a credential, and a masked value would only make the
+      # seed log unreadable. Unset, the seed says so and carries on.
+      - name: Seed the dev D1
+        run: bun run --cwd cire/db db:seed:dev
+        env:
+          CIRE_DEV_OWNER_PROFILE_ID: ${{ vars.CIRE_DEV_OWNER_PROFILE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,15 +211,31 @@ jobs:
   # ═══ cire API + D1 ═════════════════════════════════════════════════════════
   #
   # ── dev ────────────────────────────────────────────────────────────────────
-  # The dev database is DISPOSABLE and is rebuilt from scratch here:
-  # reset (drop every table incl. the migration ledger) -> migrate (replay all
-  # migrations from 0001 against an empty DB) -> seed -> deploy. Two things fall
-  # out of that order: dev data never drifts, and every merge re-tests the whole
-  # migration chain, so a migration that only works as an increment fails here
-  # rather than in production months later.
+  # Migrations are applied INCREMENTALLY here, exactly as production applies
+  # them, then the Worker is deployed. No reset, no reseed.
   #
-  # Both destructive steps route through scripts/ guards that re-derive the
-  # target from cire/api/wrangler.toml and refuse anything but `cire-db-dev`.
+  # It used to reset (drop every table incl. the migration ledger) -> migrate
+  # (replay all 57 migrations from 0001 against an empty DB) -> seed on every
+  # merge. That cost 8,007 D1 rows written and ~22,630 read per run, against a
+  # free-tier ceiling of 100,000 written per day ACROSS THE WHOLE ACCOUNT: 13
+  # merges on 2026-09-09 spent 104,091 and went over. Almost none of it was the
+  # seed — SQLite rebuilds the whole table for every `ALTER TABLE ... DROP
+  # COLUMN`, and D1 bills that schema churn even against empty tables. See #979.
+  #
+  # The property that bought was: every merge re-tests the whole migration chain
+  # from zero, so a migration that only works as an increment fails on dev
+  # rather than in production months later. We keep it, twice over and for free:
+  #
+  #   - cire/api/tests/db/ddl-lockstep.test.ts (T-S1) applies the full chain to
+  #     an in-memory DB on every `bun test` — so every PR, not just merges to
+  #     main — and diffs it against the DDL mirror and the Drizzle schema.
+  #   - cire-dev-db-rebuild.yml does the real reset -> replay -> seed against
+  #     remote cire-db-dev nightly and on workflow_dispatch, which is what
+  #     catches the DDL that bun:sqlite accepts and D1 rejects.
+  #
+  # Dev data is still disposable; it just gets its clean floor once a day
+  # instead of once a merge. A wedding a tester made by hand now survives until
+  # the next nightly rather than dying on the next merge.
   deploy-cire-api-dev:
     name: Deploy cire/api — dev
     needs: [build, changes]
@@ -228,7 +244,13 @@ jobs:
     environment: dev
     concurrency:
       group: deploy-dev-cire-api
-      cancel-in-progress: false
+      # Supersede queued dev deploys — a burst of merges otherwise runs this
+      # job once per merge, and each run only rebuilds dev to the same shape
+      # the last one would (#980). Cancelling mid-flight can leave dev's DB one
+      # migration ahead of its Worker; both self-heal on the next merge, and
+      # the dev tier is disposable by design. Production has its own group and
+      # is deliberately NOT cancellable.
+      cancel-in-progress: true
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_DEV || secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -253,25 +275,8 @@ jobs:
       - name: Guard against placeholder D1 database_id
         run: bun run scripts/check-d1-database-id.ts
 
-      - name: Reset the dev D1 (drops every table)
-        run: bun run --cwd cire/db db:reset:dev
-
-      - name: Replay cire D1 migrations from zero (dev)
+      - name: Apply cire D1 migrations (remote dev)
         run: bun run --cwd cire/db db:migrate:dev
-
-      # CIRE_DEV_OWNER_PROFILE_ID repoints the seeded wedding at a real dev
-      # account. The seed owns it as `usr_dev_bootstrap_owner`, an id no account
-      # holds, so without this the sample wedding — its guests, its events and
-      # its comped entitlements (registry, vendors, AI) — is invisible to
-      # everyone signing in to test, and this job resets the tier on every
-      # cire_api change, wiping any wedding a tester made by hand. It is a
-      # VARIABLE, not a secret: an OSN profile id is not a credential, and a
-      # masked value would only make the seed log unreadable. Unset, the seed
-      # says so and carries on.
-      - name: Seed the dev D1
-        run: bun run --cwd cire/db db:seed:dev
-        env:
-          CIRE_DEV_OWNER_PROFILE_ID: ${{ vars.CIRE_DEV_OWNER_PROFILE_ID }}
 
       - name: Deploy cire/api Worker (dev)
         run: bunx wrangler deploy --env dev

--- a/cire/db/README.md
+++ b/cire/db/README.md
@@ -38,9 +38,9 @@ Run from the repo root with `bun run --cwd cire/db <script>`. Wrangler reads
 | `db:migrate:dev`   | Apply pending migrations to the **dev** D1 (`cire-db-dev`, `--env dev`). CI runs this every merge |
 | `db:migrate:prod`  | Apply pending migrations to the **production** D1 (`--env production`). Coordinate with deploys.  |
 | `db:seed`          | Apply `seed/dev-seed.sql` to the local D1 (idempotent — uses `INSERT OR IGNORE`)                  |
-| `db:seed:dev`      | Same seed against `cire-db-dev`. Guarded — refuses any other remote database.                     |
+| `db:seed:dev`      | Same seed against `cire-db-dev`. Guarded — refuses any other remote database. Nightly, with the reset above |
 | `db:reset`         | Wipe local D1 state, re-run migrations + seed. Destructive — local only.                          |
-| `db:reset:dev`     | Drop every table in `cire-db-dev` incl. `d1_migrations`. Destructive — dev only, no prod flag.    |
+| `db:reset:dev`     | Drop every table in `cire-db-dev` incl. `d1_migrations`. Destructive — dev only, no prod flag. Run nightly by `cire-dev-db-rebuild.yml`, not on merge |
 | `db:studio`        | Launch Drizzle Studio for browsing the schema / writing one-off queries                           |
 | `seed:generate`    | Regenerate `seed/dev-seed.sql` and `seed/dev-reset.sql` from `seed/data/` + `src/schema.ts`       |
 | `test`             | Run the seed sync tests (`bun test`) — fail if either generated `.sql` is out of sync             |

--- a/scripts/cire-db-reset.sh
+++ b/scripts/cire-db-reset.sh
@@ -5,9 +5,14 @@
 #
 #   bun run --cwd cire/db db:reset:dev      # scripts/cire-db-reset.sh --dev
 #
-# This is what makes the dev tier's data disposable: the deploy pipeline runs
-# reset -> migrate -> seed on every merge to main, so dev never accumulates state
-# and every deploy re-tests the migrations from 0001.
+# This is what makes the dev tier's data disposable: .github/workflows/
+# cire-dev-db-rebuild.yml runs reset -> migrate -> seed nightly (and on
+# workflow_dispatch), so dev never accumulates state for long and the migration
+# chain is re-tested from 0001 against real D1 once a day.
+#
+# It ran on every merge until 2026-09-10. At 8,007 D1 rows written a time
+# against a 100,000/day free-tier ceiling shared by every database on the
+# account, a 13-merge day went over it. See xchromo/osn#979.
 #
 # DESTRUCTIVE, and unattended in CI. The only accepted target is `cire-db-dev`;
 # the shared guard re-checks that against cire/api/wrangler.toml rather than

--- a/scripts/cire-db-seed.sh
+++ b/scripts/cire-db-seed.sh
@@ -59,10 +59,10 @@ fi
 # profile id is committed here).
 #
 # It is not a nicety on dev. The seed owns the wedding as usr_dev_bootstrap_owner,
-# an id no account holds, and every cire_api deploy resets and reseeds the tier —
+# an id no account holds, and the nightly rebuild resets and reseeds the tier —
 # so without the override the seeded wedding, its 494 guests and its comped
 # entitlements (registry, vendors, AI) are invisible to whoever signs in to test
-# them, and any wedding a tester makes by hand is wiped on the next deploy.
+# them, and any wedding a tester makes by hand is wiped on the next rebuild.
 if [ -n "${CIRE_DEV_OWNER_PROFILE_ID:-}" ]; then
   # The value is interpolated into a SQL string literal below. It comes from
   # cire/db/.env, the workflow, or the ambient environment — trusted-ish, but a

--- a/wiki/runbooks/dev-environment.md
+++ b/wiki/runbooks/dev-environment.md
@@ -159,16 +159,46 @@ deploy would queue behind that click. Each job takes a group named for its own
 surface **and** tier (`deploy-dev-cire-api`, `deploy-production-cire-api`), so two
 runs never deploy the same thing at once while unrelated surfaces stay parallel.
 
-### The dev database is rebuilt every deploy
+The dev cire job also sets **`cancel-in-progress: true`**. A burst of merges
+otherwise queues one dev deploy per merge, and each one only brings dev to the
+shape the last one would; superseding them is free. Cancelling mid-flight can
+leave dev's database one migration ahead of its Worker, which the next merge
+puts right — the tier is disposable, and the alternative was multiplying the D1
+bill by the size of the burst (xchromo/osn#980). **Production stays
+`cancel-in-progress: false`**: a half-deployed live wedding is not a trade worth
+making.
 
-`deploy-cire-api-dev` runs **reset → migrate → seed → deploy**:
+### The dev database is rebuilt nightly, not every deploy
+
+`deploy-cire-api-dev` runs **migrate → deploy**, applying migrations forward
+exactly as production does:
+
+```
+bun run --cwd cire/db db:migrate:dev  # apply anything not in d1_migrations yet
+bunx wrangler deploy --env dev        # from cire/api
+```
+
+The full rebuild — **reset → migrate → seed** — moved to its own workflow,
+`.github/workflows/cire-dev-db-rebuild.yml`, on a nightly schedule (14:00 UTC,
+01:00 in Sydney) and `workflow_dispatch`:
 
 ```
 bun run --cwd cire/db db:reset:dev    # drop every table INCLUDING d1_migrations
 bun run --cwd cire/db db:migrate:dev  # replay 0001.. against an empty database
 bun run --cwd cire/db db:seed:dev     # the sample wedding, at production scale
-bunx wrangler deploy --env dev        # from cire/api
 ```
+
+**Why it moved.** A rebuild costs **8,007 D1 rows written and about 22,630
+read**, and the free tier allows 100,000 written a day across every database on
+the account. Thirteen merges on 2026-09-09 spent 104,091 and went over the
+ceiling. Almost none of that is the seed: SQLite rebuilds the whole table for
+every `ALTER TABLE ... DROP COLUMN`, and D1 bills the schema churn even against
+empty tables. Of the 200 heaviest queries on `cire-db-dev` in a week, DDL
+accounted for 89% of rows written and 99.7% of rows read; the seed's `INSERT`s
+were 11% and 0.3%. See xchromo/osn#979.
+
+The rebuild also shares the deploy's `deploy-dev-cire-api` concurrency group, so
+a rebuild and a deploy never touch `cire-db-dev` at once.
 
 The seeded wedding matches a real live one in shape and size — 5 events, 199
 households, 494 guests, 1131 invitations, 168 replies, 3 co-hosts, all 4
@@ -194,10 +224,17 @@ are generated gradients, not photographs: the bucket is `cire-assets-dev`, pinne
 in `seed/assets.ts`, and no couple's photo is ever copied onto a tier this many
 people can reach. Re-run only after recreating the bucket.
 
-Two things fall out of that order. Dev data never drifts from the seed, and
-**every merge re-tests the whole migration chain** — a migration that only works
-as an increment from the current prod shape fails here, on a disposable database,
-instead of in production months later.
+**What still re-tests the migration chain.** The nightly rebuild replays it from
+zero against real D1, and that is the only place DDL which `bun:sqlite` accepts
+but D1 rejects gets caught. Most of the proof is cheaper and more frequent than
+that: `cire/api/tests/db/ddl-lockstep.test.ts` (T-S1) applies the whole chain to
+an in-memory database on every `bun test`, so on every pull request, and diffs a
+normalised snapshot of it against the DDL mirror in `cire/api/src/db/setup.ts`
+and the Drizzle schema. A migration that only works as an increment fails there
+first.
+
+Dev data now gets its clean floor once a night rather than once a merge, so a
+wedding a tester made by hand survives the working day.
 
 Both destructive steps route through `scripts/cire-dev-db-guard.ts`, which
 re-derives the target from `cire/api/wrangler.toml` at run time and aborts unless
@@ -621,7 +658,8 @@ ceremony spans two requests, so it is what catches Redis being misconfigured.
    `id.dev.musubi.social/.well-known/openid-configuration` still returns **200**.
    A 302 on either API host means Access was put on the wrong destination — pull
    it off before anything else.
-7. Re-run the dev deploy and confirm the reset replayed migrations from zero.
+7. Run the **Rebuild cire dev D1** workflow by hand (`workflow_dispatch`) and
+   confirm the reset replayed migrations from zero.
 
 ---
 

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -12,7 +12,7 @@ related:
   - "[[observability-setup]]"
   - "[[cire-auth]]"
   - "[[dev-environment]]"
-last-reviewed: 2026-09-09
+last-reviewed: 2026-09-10
 ---
 
 # Free-Tier Limits & Unavailability Runbook
@@ -193,14 +193,37 @@ DB-touching route** — i.e. effectively the whole app, since auth, claims, RSVP
 graph all read D1. Note the daily counters are **shared across every DB on the
 one account** (5 GB storage and the day's read/write counts are account-wide).
 
-**Dev's share.** The account holds **7 of 10** databases: `cire-db`,
-`osn-db-prod`, `zap-db-prod`, `cire-db-dev`, `osn-db-dev`, plus the unused
-`osn-db-staging` and `osn-db`. The two unused ones are the obvious reclaim if a
-new tier ever needs a slot. The dev tier's write cost is not zero: every merge
-that touches cire drops and re-seeds `cire-db-dev`, so it spends rows-written
-from the same **100K/day** budget production draws on. A seed is on the order of
-tens of rows, so this only matters if deploys ever run in a tight loop.
+**Dev's share — and the 2026-09 overrun.** The account holds **7 of 10**
+databases: `cire-db`, `osn-db-prod`, `zap-db-prod`, `cire-db-dev`, `osn-db-dev`,
+plus the unused `osn-db-staging` and `osn-db`. The two unused ones are the
+obvious reclaim if a new tier ever needs a slot.
+
+**Dev, not production, is what nearly all D1 usage on this account has been.**
+Until 2026-09-10 every merge touching cire dropped `cire-db-dev`, replayed all
+57 migrations from `0001` and re-seeded it. That is **8,007 rows written and
+about 22,630 read per deploy** — so 13 merges on 2026-09-09 spent 104,091 rows
+written and went over the 100K/day ceiling, as did 2026-08-30. Production wrote
+between 3 and 116 rows a day over the same window.
+
+An earlier version of this page said a seed was "on the order of tens of rows".
+That was wrong by three orders of magnitude, and it blamed the wrong step. The
+seed is about 2,060 rows; the cost is the **migration replay**. SQLite rebuilds
+the whole table for every `ALTER TABLE ... DROP COLUMN`, and D1 bills that
+schema churn even when the table is empty — one such statement on
+`wedding_invite_customisations` costs 54 rows written and 421 read against no
+data at all. Of the 200 heaviest queries on `cire-db-dev` in the week to
+2026-09-10, DDL was 89% of rows written and 99.7% of rows read.
+
+Fixed in xchromo/osn#979 and #980: the per-merge dev deploy now applies
+migrations forward like production, the full rebuild runs nightly in
+`.github/workflows/cire-dev-db-rebuild.yml`, and the dev job supersedes queued
+runs. Budget after: one rebuild a day, 8% of the write ceiling.
 [[dev-environment]]
+
+**The number to watch is per-deploy, not per-day.** Any job that rebuilds a
+database from zero costs rows in proportion to the *number of migrations*, not
+the amount of data, and that number only grows. Before adding one, work out its
+cost against 100K/day.
 
 **User-visible symptom:** 503 / "service unavailable" across the app until the
 daily counter resets at **UTC midnight**, or storage is freed.
@@ -208,6 +231,16 @@ daily counter resets at **UTC midnight**, or storage is freed.
 **How to detect:** CF dashboard → Workers & Pages → D1 → database → metrics
 (rows read/written vs the daily line, storage vs 5 GB); Workers Logs error
 lines from the D1 query path.
+
+For per-day, per-database numbers without the dashboard, query the GraphQL
+analytics API — `d1AnalyticsAdaptiveGroups`, dimensions `databaseId` and `date`,
+sum `rowsRead`/`rowsWritten`/`readQueries`/`writeQueries`. To find *which query*
+is spending them:
+
+```bash
+bunx wrangler d1 insights <db> --time-period=7d --sort-by=writes --limit=20 --json
+bunx wrangler d1 insights <db> --time-period=7d --sort-by=reads  --limit=20 --json
+```
 
 **Upgrade path:** **Workers Paid** unlocks the D1 paid tier — 25B rows
 read/mo + 50M rows written/mo included, 10 GB max DB size, 50K databases, 1 TB


### PR DESCRIPTION
Closes #979. Closes #980.

## The problem

`deploy-cire-api-dev` dropped every table in `cire-db-dev`, replayed all 57 migrations from `0001` and re-seeded, on every merge touching `cire/api`. That is **8,007 D1 rows written and about 22,630 read per deploy**, against a free-tier ceiling of **100,000 written a day across every database on the account**.

| Day | Account rows written | `cire-db-dev` | cire/api dev deploys |
|---|---|---|---|
| 2026-08-30 | 104,831 | 104,091 | 13 |
| 2026-08-31 | 56,159 | 56,049 | 7 |
| 2026-09-02 | 40,095 | 40,035 | 5 |
| 2026-09-06 | 64,184 | 64,089 | 8 |
| 2026-09-07 | 40,055 | 40,035 | 5 |
| 2026-09-08 | 64,200 | 64,056 | 8 |
| 2026-09-09 | 104,115 | 104,091 | 13 |

Every figure is an exact multiple of 8,007, and the deploy counts match. Two days went over the ceiling. Production wrote between 3 and 116 rows a day over the same window.

The cost is schema churn, not data. SQLite rebuilds the whole table for each `ALTER TABLE ... DROP COLUMN`, and D1 bills it even against empty tables — one such statement on `wedding_invite_customisations` costs 54 rows written and 421 read with nothing in the table. Across the 200 heaviest queries on `cire-db-dev` in a week, DDL was 89% of rows written and 99.7% of rows read; the seed's `INSERT`s were 11% and 0.3%.

## The change

- `deploy-cire-api-dev` applies migrations **forward**, exactly as production does. No reset, no reseed.
- It sets **`cancel-in-progress: true`**, so a burst of merges collapses to the last one instead of running the job once per merge. Production keeps `cancel-in-progress: false`.
- The full **reset → migrate → seed** moved to a new workflow, `.github/workflows/cire-dev-db-rebuild.yml`: nightly at 14:00 UTC (01:00 in Sydney) and on `workflow_dispatch`. It shares the deploy's concurrency group so the two never touch the database at once.

## What still tests the migration chain from zero

Both of these already existed or are free; neither costs remote D1:

- **`cire/api/tests/db/ddl-lockstep.test.ts` (T-S1)** applies all 57 migrations to an in-memory SQLite on every `bun test` — every pull request, not just merges — and diffs a normalised structural snapshot against the DDL mirror in `cire/api/src/db/setup.ts` and the Drizzle schema. 58 tests, passing.
- **The nightly rebuild** does the same against real D1, which is the only place DDL that `bun:sqlite` accepts and D1 rejects gets caught.

So the chain is now proved *more* often than before, not less.

## Budget after

One rebuild a day: 8,007 rows written, 8% of the ceiling. Merges cost a handful of rows each.

## Docs

- `wiki/runbooks/free-tier-limits.md` — the D1 section said a seed was "on the order of tens of rows" and blamed the seed rather than the replay. Wrong by three orders of magnitude, corrected, with the `wrangler d1 insights` commands for finding the next one.
- `wiki/runbooks/dev-environment.md` — rebuild cadence, the concurrency change and what proves the chain.
- `cire/db/README.md`, `scripts/cire-db-reset.sh`, `scripts/cire-db-seed.sh` — when the reset and seed actually run now.

## Risks

- **A merge landing mid-rebuild cancels the rebuild**, because the deploy side sets `cancel-in-progress: true`. That leaves dev with its tables dropped and its ledger gone; the next `migrations apply` replays the whole chain and puts it right, at one merge's worth of rows. Dev returns 503 in between. Disposable tier, self-healing, and documented on both jobs.
- **Dev data now persists between nightlies.** That is the intended trade — a wedding a tester made by hand survives the working day instead of dying on the next merge.
- **The first merge after this lands** applies nothing, because the last rebuild left `cire-db-dev` with all 57 migrations in its ledger.

## Verification

- `bun test cire/api/tests/db/` — 126 pass
- `bun test --cwd cire/db` — 5 pass
- `bun run test:scripts` — 153 pass
- `bash scripts/validate-changesets.sh` — clean
- Both workflow files parse

Evidence for every number: Cloudflare GraphQL `d1AnalyticsAdaptiveGroups`, `wrangler d1 insights`, and `gh run list` deploy-job counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
