### PR TITLE
docs: mark a measured figure with the command that produced it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,28 @@ So: tables and mermaid for anything a reader might hit through GitHub; the Obsid
 - **Use `[[wiki links]]`** between wiki pages; never relative markdown links. `wiki/` is the only vault — the second one at `cire/wiki/` folded into it on 2026-08-21, and every cire page is now a plain wikilink (`[[cire-vendors]]`, `[[cire-platform-plan]]`, `[[cire-invite-builder]]`). Cire pages carry a `cire-` prefix where a bare name would collide.
 - **Security/performance findings** are issues in `xchromo/osn-tracker`, and the body names the affected wiki page by path (e.g. `wiki/systems/rate-limiting.md`) — a wikilink does not resolve on GitHub.
 - **Update `last-reviewed`** in frontmatter of any wiki page you touch.
+- **Two kinds of number, written differently.** A **documented ceiling** is a provider's
+  published limit: leave it in prose and name the pricing page — the page's own drift
+  warning covers it. A **measured figure is ours**, and nobody can check it without
+  running something, so it carries the command and the date on the line under it:
+
+  ```markdown
+  A full dev rebuild costs **8,007 D1 rows written**.
+
+  *Measured 2026-09-10 — `bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes`*
+  ```
+
+  The marker is **visible, not an HTML comment**: pages render in Obsidian and on GitHub,
+  a comment shows in neither, and the reader it is written for would never see it. Where
+  no one command produces the figure, name the method instead (*Measured 2026-08-31 —
+  latency probe from a Sydney client, n=25*). Where either the method or the date is
+  missing, mark it `*Unverified — …*`, say what you do know, and leave the figure
+  itself alone. An invented command is worse than none — that is the mistake this rule
+  exists to stop.
+- **`last-reviewed` is not a warranty on the numbers.** It says someone read the page.
+  `free-tier-limits.md` was read the day before its D1 write ceiling was crossed and
+  still said a seed cost "tens of rows" against a real 8,007 — reading a number cannot
+  tell you it is false. The measured marker is what a reader re-runs instead.
 
 ## Current State (summary)
 

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -7,7 +7,7 @@ related:
   - "[[frontend-patterns]]"
   - "[[testing-patterns]]"
   - "[[review-findings]]"
-last-reviewed: 2026-09-09
+last-reviewed: 2026-09-10
 ---
 
 # Astro bundle-size guards
@@ -44,6 +44,11 @@ the minified build the same library costs 21261 bytes, so a fresh dependency of
 exactly the class the guard was written for would have landed under the line
 and deployed. The fix was to re-measure against the build as it is now and set
 the headroom to ~11.7 KB, roughly half the mistake.
+
+*Unverified — the method is on record, the date is not. Gzip
+`cire/invites/dist/client/_astro/animate.*.js` from a clean build, or rebuild
+with `stubMotionForSsr()` removed and diff the total. Written into this page
+2026-09-07.*
 
 The corollary is a check, not a rule: **you have not verified a guard until you
 have seen it fail.** Break the input, watch the non-zero exit. A guard that
@@ -106,6 +111,10 @@ touching a threshold. In short:
 > (parse the HTML too, or force `inlineStylesheets: "never"` so everything
 > lands in `dist/_astro` where the guard already looks); this is a product
 > decision, not something fixed in this script.
+>
+> *Unverified — no command on record. Written into this page 2026-09-07;
+> recount the inline `<style>`/`<script>` blocks in
+> `musubi/landing/dist/index.html` before acting on the 3116.*
 
 ### Where it runs, and why twice
 
@@ -149,6 +158,11 @@ the guard regardless of how large or small the app's own baseline is:
 | cire/landing | static | 177641 B | 189324 B |
 | musubi/landing | static | 15182 B | 26865 B |
 | pulse/landing | static | 16683 B | 28366 B |
+
+*Measured 2026-09-06 — clean `bun run build` at the worktree root with no
+`PUBLIC_*` vars set, then `scripts/guard-bundle-size.sh --all`, which prints
+each app's gzip total. `scripts/bundle-size-budgets.txt` is still the file the
+guard reads; this table only mirrors it.*
 
 `cire/landing` ships a Three.js scene by design (the wax-seal hero) — its
 JS number is dominated by one intentional dependency, which is exactly why

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -14,7 +14,7 @@ related:
   - "[[observability/metrics]]"
   - "[[conventions/review-findings]]"
   - "[[conventions/stacked-prs]]"
-last-reviewed: 2026-09-08
+last-reviewed: 2026-09-10
 ---
 
 # Session Metrics
@@ -111,6 +111,11 @@ Three traps the collector handles and any reimplementation must:
   are never collapsed, because a person who types "continue" twice steered
   twice.
 
+*Measured 2026-09-08 — a one-off scan of `~/.claude/projects/**/*.jsonl` on the
+machine that did the work. No script was kept, and that directory is local and
+unversioned, so the counts describe one machine on one day and nobody else can
+reproduce them. They size the traps; they are not a repository statistic.*
+
 ## Attributing subagent spend
 
 `gitBranch` is a property of the **session**, captured once when it starts and
@@ -129,6 +134,10 @@ The scale, measured over 904 transcript files and 9.03e9 tokens:
 Subagent transcripts are 27.0% of all spend, and **85.8% of that is stamped
 `HEAD`** against 7.4% on a real branch. A branch whose work was delegated saw
 almost none of its own cost.
+
+*Measured 2026-09-08 — the same one-off scan of `~/.claude/projects` as above,
+904 transcript files, and the depth-2 counts below come from it too. One
+machine, one day, no script kept.*
 
 So `orchestrate` puts a marker on its own line at the top of every dispatch
 prompt:
@@ -323,6 +332,10 @@ one area means that area has no usable map.
 > early. And a session that never shows an edit banks **nothing**: the card
 > reports `null`, and every ranking drops it. "We did not see the boundary" and
 > "all of it was exploration" are different claims, and only one is true.
+>
+> *Measured 2026-09-07 over the 34 cards that existed then. Re-derive the
+> per-package share over today's corpus with
+> `bun run --cwd tools/pr-metrics report -- --exploration`.*
 
 **`corrective_turns` → an unclear brief.** Human turns that arrive after the
 agent has already picked up tools: course corrections rather than the task. One
@@ -409,6 +422,10 @@ mean**. These are severely right-skewed: across the first 34 cards the median
 was 3.6M tokens, the mean 15.4M and the maximum 92.7M. The mean described the
 three largest pull requests and showed 8.5× month-over-month growth where the
 median showed about 2×.
+
+*Measured 2026-09-07 over the 34 cards that existed then. The mean and maximum
+came from an ad-hoc pass, not a committed query; the median re-derives over
+today's corpus with `bun run --cwd tools/pr-metrics report -- --context`.*
 
 The raw view, if you want to start from nothing:
 

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -28,6 +28,11 @@ last-reviewed: 2026-09-10
 > **All numbers below are the documented limits as of `last-reviewed` and
 > WILL drift — re-verify against the provider's own pricing page before
 > acting on a quota decision.** Each section links its source page.
+>
+> That covers the ceilings. A figure of **ours** — one only a command here can
+> produce — carries that command and the date it was run, in italics under it.
+> Re-run it rather than trusting `last-reviewed`, which says someone read the
+> page and nothing about whether its numbers are still true.
 
 ## Dependency → service map (who depends on what)
 
@@ -205,6 +210,10 @@ about 22,630 read per deploy** — so 13 merges on 2026-09-09 spent 104,091 rows
 written and went over the 100K/day ceiling, as did 2026-08-30. Production wrote
 between 3 and 116 rows a day over the same window.
 
+*Measured 2026-09-10 — per-day, per-database totals from the Cloudflare GraphQL
+`d1AnalyticsAdaptiveGroups` dataset, dimensions `databaseId` and `date`, summing
+`rowsRead` and `rowsWritten`.*
+
 An earlier version of this page said a seed was "on the order of tens of rows".
 That was wrong by three orders of magnitude, and it blamed the wrong step. The
 seed is about 2,060 rows; the cost is the **migration replay**. SQLite rebuilds
@@ -213,6 +222,8 @@ schema churn even when the table is empty — one such statement on
 `wedding_invite_customisations` costs 54 rows written and 421 read against no
 data at all. Of the 200 heaviest queries on `cire-db-dev` in the week to
 2026-09-10, DDL was 89% of rows written and 99.7% of rows read.
+
+*Measured 2026-09-10 — `bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes`, and the same with `--sort-by=reads`.*
 
 Fixed in xchromo/osn#979 and #980: the per-merge dev deploy now applies
 migrations forward like production, the full rebuild runs nightly in

--- a/wiki/systems/d1-read-replication.md
+++ b/wiki/systems/d1-read-replication.md
@@ -19,7 +19,7 @@ related:
   - "[[free-tier-limits]]"
 packages:
   - "@cire/api"
-last-reviewed: 2026-09-01
+last-reviewed: 2026-09-10
 ---
 
 # D1 Read Replication and the Sessions API
@@ -33,14 +33,17 @@ is how a Worker actually uses them without giving up read-your-writes.
 
 ## The cost being paid
 
-Measured 2026-08-31 from a Sydney client against the OC-primary `cire-db`, by
-diffing a route that runs one extra `SELECT` against a route that runs none:
+What one query costs against the OC-primary `cire-db`:
 
 | Measure | Value |
 |---|---|
 | Control (no D1 query) | 15.0 ms |
 | One extra `SELECT` | 50.7 ms |
 | **Cost of one query** | **35.7 ms** (p10 33.0, p90 39.3, n=25) |
+
+*Measured 2026-08-31 — a hand-run latency probe from a Sydney client, timing a
+route with one extra `SELECT` against one with none, n=25. No script was kept,
+so re-running it means writing the probe again.*
 
 That is the *near* case. The same query from Europe or North America pays the
 transoceanic round trip on top, and a request that reads four tables pays it
@@ -150,6 +153,8 @@ before, inside the noise. That is the expected result and worth keeping: a query
 made outside a session goes to the primary whatever the database is configured
 to do, so enabling replication on its own buys nothing and costs nothing. The
 saving only appears once a Worker that opens sessions is deployed.
+
+*Measured 2026-08-31 — the same hand-run probe as §The cost being paid, n=29.*
 
 A second thing that measurement cannot show from here: the client and the
 primary are both in Oceania, so even with sessions live, a Sydney reader has


### PR DESCRIPTION
Closes #990.

## What

`last-reviewed` certifies that somebody read a page. For a runbook whose job is numbers, that is the wrong guarantee.

`wiki/runbooks/free-tier-limits.md` carried `last-reviewed: 2026-09-09` — the day before its D1 write ceiling was crossed for the second time — and still said a seed cost "on the order of tens of rows" against a real 8,007. It had been read the previous day and the sentence survived, because reading a number cannot tell you it is false.

## The rule

Two kinds of number, written differently.

- A **documented ceiling** is a provider's published limit. It stays in prose, names its pricing page, and the page's existing drift warning covers it.
- A **measured figure is ours**. Nobody can check it without running something, so it carries the command and the date on the line under it:

```markdown
A full dev rebuild costs **8,007 D1 rows written**.

*Measured 2026-09-10 — `bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes`*
```

Where no single command produces the figure, the marker names the method instead. Where the method or the date is missing, it reads `*Unverified — …*`, says what is known, and **leaves the figure alone**. An invented command is worse than none — that is the mistake this rule exists to stop.

## The marker is visible, not an HTML comment

The issue sketched an HTML comment. That was wrong and the agent said so. These pages render in both Obsidian and on GitHub, and a comment shows in neither — so the one reader who needs to know a figure is a month old and machine-local would never see it, which is the failure being fixed. Italics render on both surfaces, cost one line of grey text per load-bearing number, and stay greppable (`*Measured `, `*Unverified `) if a lint is ever wanted.

## Marked

| Page | Figures |
|---|---|
| `free-tier-limits.md` | per-day/per-database D1 totals; the 89% / 99.7% DDL split |
| `bundle-size-guards.md` | the per-app baseline table |
| `d1-read-replication.md` | both latency probes (35.7 ms n=25, 36.7 ms n=29) |
| `session-metrics.md` | the transcript-scan figures; the first-34-cards figures |

Two figures in `bundle-size-guards.md` are marked `*Unverified*` — `motion` at 21261 bytes, and the ~3116-byte inline-HTML blind spot. Neither number was changed; the markers say what to run to re-derive them.

`free-tier-limits.md` gets exactly two inserts in its D1 section and four lines in its opening warning. The **Monitoring** section is untouched — #989 is editing that concurrently.

## Verified

Both cited `pr-metrics` flags were checked by running them, not by reading the source. An earlier draft invented `--explore`; the real flag is `--exploration`, corrected against `report.ts` before commit. `scripts/guard-bundle-size.sh --all` and its `gzip total: N bytes` output confirmed at `scripts/guard-bundle-size.sh:235`.

- `bun run lint` — exit 0, warnings pre-existing and none from these files
- `bun run fmt:check` — exit 0, 1504 files (oxfmt's glob excludes `md`, so it does not cover these either way)
- `scripts/changeset-required.sh` over the five paths — `skip`, no changeset needed
- `scripts/tests/changeset-required.test.sh` — 21 passed

## No enforcement script, deliberately

The issue says start with the convention. A lint that fires on "a `severity: high` page containing a digit" would fire on every ceiling table here and be tuned into uselessness inside a week. If the convention slips, the cheaper first move is the inverse check — flag a `*Measured ` line whose date is older than N months — which needs no guess about which digits matter.

## Pages that qualify and are not touched

Listed so they are not lost: `wiki/systems/d1-limits.md`, `wiki/systems/social-graph.md`, `wiki/architecture/drag-and-drop.md`, `wiki/architecture/backend-patterns.md`, `wiki/architecture/effect-v4-api.md`, `wiki/apps/cire-development.md`. `wiki/conventions/devloop-urls.md` already complies in substance — it carries date, tool and method above its table; only the marker's form differs.

One figure in `CLAUDE.md` itself qualifies — "all 64,491 read `high`" — but sits in a section #988 is editing concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
