### PR TITLE
feat(ops): alert on Cloudflare free-tier ceilings instead of listing them in a runbook

### DIFF
--- a/.github/workflows/free-tier-ceiling-alert.yml
+++ b/.github/workflows/free-tier-ceiling-alert.yml
@@ -1,0 +1,76 @@
+# Watch the Cloudflare free-tier counters and file one issue when a day gets
+# near a ceiling.
+#
+# `wiki/runbooks/free-tier-limits.md` listed the ceilings and said to watch
+# them, which meant a person opening a dashboard. Nobody did, so the D1
+# rows-written ceiling was crossed on 2026-08-30 and again on 2026-09-09 and was
+# only found by hand on 2026-09-10 (#979). Three other days in between ran at
+# 56-64% of the ceiling and looked like ordinary days.
+#
+# All the logic is in `scripts/check-free-tier-ceilings.ts`, tested in
+# `scripts/tests/check-free-tier-ceilings.test.ts`. This job is the caller.
+#
+# Read-only against Cloudflare. It runs two GET/POST analytics queries and
+# writes nothing to any account resource.
+name: Free-tier ceiling alert
+
+on:
+  schedule:
+    # 22:00 UTC. The daily counters reset at UTC midnight, so this reads the day
+    # with two hours left in it — late enough that the figure is close to final,
+    # early enough to still be a warning. It is also 08:00 in Australia/Sydney,
+    # so the result is waiting at the start of the day rather than overnight.
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+    inputs:
+      end:
+        description: "Last UTC day to check (YYYY-MM-DD). Defaults to today."
+        required: false
+        type: string
+      days:
+        description: "How many UTC days back to check, ending with that day."
+        required: false
+        default: "2"
+        type: string
+
+permissions:
+  contents: read
+  # The job opens, reopens and edits one issue in this repository.
+  issues: write
+
+# One run at a time, so a hand-started run and the nightly one cannot both
+# decide whether the issue exists and both create it.
+concurrency:
+  group: free-tier-ceiling-alert
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check the daily counters
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      # No `bun install`. The script imports only Bun built-ins and `fetch`,
+      # the same rule every other file under scripts/ follows.
+      #
+      # The script exits non-zero on any bad response — a non-2xx, a GraphQL
+      # error, an account the token cannot read, a total that is not a number.
+      # That fails this job, which is the point: a watcher that reports
+      # all-clear while it is broken is worse than no watcher.
+      - name: Read the counters and file or update the issue
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GH_TOKEN: ${{ github.token }}
+          END: ${{ inputs.end }}
+          DAYS: ${{ inputs.days || '2' }}
+        run: |
+          ARGS=(--repo "$GITHUB_REPOSITORY" --days "$DAYS")
+          if [ -n "$END" ]; then ARGS+=(--end "$END"); fi
+          bun run scripts/check-free-tier-ceilings.ts "${ARGS[@]}"

--- a/.github/workflows/free-tier-ceiling-alert.yml
+++ b/.github/workflows/free-tier-ceiling-alert.yml
@@ -63,6 +63,24 @@ jobs:
       # error, an account the token cannot read, a total that is not a number.
       # That fails this job, which is the point: a watcher that reports
       # all-clear while it is broken is worse than no watcher.
+      # This job declares no `environment:`, so both Cloudflare secrets resolve
+      # at REPOSITORY scope. That is where `CLOUDFLARE_API_TOKEN` lives today —
+      # `gh secret list --env production` is empty, so every deploy job reads
+      # the repository copy too.
+      #
+      # `wiki/runbooks/dev-environment.md` §"Two Environments, two tokens" wants
+      # that scope emptied: put the token on the `production` Environment and
+      # `gh secret delete CLOUDFLARE_API_TOKEN` at repo scope. The day that
+      # happens this job loses its credential, and it cannot simply take
+      # `environment: production` in exchange — that Environment gates on a human
+      # approving, and a watcher nobody approves at 22:00 UTC watches nothing.
+      # It needs a token at a scope an unattended job can read. Read-only is
+      # enough: `d1 (read)` and `account (read)`, no write rights of any kind.
+      #
+      # The break would be loud — a 401 exits the script non-zero and fails this
+      # job, which is the behaviour to keep. Do not paper over it with a
+      # `continue-on-error` or an empty-token skip; a watcher that goes quiet
+      # when its credential is gone is worse than no watcher.
       - name: Read the counters and file or update the issue
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/check-free-tier-ceilings.ts
+++ b/scripts/check-free-tier-ceilings.ts
@@ -1,0 +1,645 @@
+#!/usr/bin/env bun
+/**
+ * Watch the Cloudflare free-tier counters and file one issue when a day gets
+ * near a ceiling.
+ *
+ * `wiki/runbooks/free-tier-limits.md` used to list these ceilings and say to
+ * watch them, which meant a person opening a dashboard. Nobody did, so the D1
+ * rows-written ceiling was crossed on 2026-08-30 and again on 2026-09-09 and
+ * was only found by hand on 2026-09-10 (xchromo/osn#979).
+ *
+ * Read-only. It asks Cloudflare's GraphQL analytics API for per-day, per-
+ * database and per-script totals, compares each day against its ceiling, and
+ * writes the result into one GitHub issue that it reopens and edits rather
+ * than filing again. A week spent near the line is one thread.
+ *
+ * Everything above the CLI block is pure: feed it a parsed API response and a
+ * database-name map, get back the breaches and the issue body. The CLI block
+ * is the only part that makes a network call, shells out to `gh`, or sets an
+ * exit code.
+ *
+ * Fails loudly. Any bad response — a non-2xx, a GraphQL error, an account the
+ * token cannot see, a field that is not a number — throws. A watcher that
+ * reports all-clear when it is broken is worse than no watcher.
+ */
+
+// The Cloudflare free-tier ceilings. Every one is account-wide, across every
+// Worker and every database on the account; the three daily ones reset at UTC
+// midnight and storage is a running total.
+//
+// These are the documented limits as of 2026-09-10 and they WILL drift.
+// Re-read Cloudflare's own pages before acting on a figure here —
+// https://developers.cloudflare.com/workers/platform/pricing/ and
+// https://developers.cloudflare.com/d1/platform/pricing/. The same numbers are
+// in `wiki/runbooks/free-tier-limits.md` and have to move with these.
+//
+// Storage uses a decimal gigabyte, which is how Cloudflare prices it. Were it
+// binary the true ceiling would be larger, so this errs toward warning early.
+export const CEILINGS = {
+  d1RowsWritten: 100_000,
+  d1RowsRead: 5_000_000,
+  workersRequests: 100_000,
+  d1StorageBytes: 5_000_000_000,
+} as const;
+
+/** Report a counter once it reaches this share of its ceiling. */
+export const WARN_FRACTION = 0.8;
+
+/**
+ * The title the issue is found by. Stable, because it is the key: change it
+ * and the next run opens a second issue beside the one already open.
+ */
+export const ISSUE_TITLE = "Cloudflare free tier: a daily counter is near its ceiling";
+
+/**
+ * Labels for the issue when this opens it. Every one exists in `xchromo/osn`
+ * today — `gh issue create` fails on a label that does not, which is the
+ * failure we want rather than an unlabelled issue.
+ */
+export const ISSUE_LABELS = [
+  "area:ops",
+  "product:shared",
+  "complexity:2",
+  "complexity:unconfirmed",
+];
+
+/** The org issue type. Acting on a ceiling is work to schedule, not a defect. */
+export const ISSUE_TYPE = "Task";
+
+/** One `d1AnalyticsAdaptiveGroups` group, grouped by database and day. */
+export interface D1Group {
+  readonly dimensions: { readonly databaseId: string; readonly date: string };
+  readonly sum: {
+    readonly rowsRead: number;
+    readonly rowsWritten: number;
+    readonly readQueries: number;
+    readonly writeQueries: number;
+  };
+}
+
+/** One `workersInvocationsAdaptive` group, grouped by script and day. */
+export interface WorkerGroup {
+  readonly dimensions: { readonly scriptName: string; readonly date: string };
+  readonly sum: { readonly requests: number };
+}
+
+/** One `d1StorageAdaptiveGroups` group — the day's high-water size per database. */
+export interface StorageGroup {
+  readonly dimensions: { readonly databaseId: string; readonly date: string };
+  readonly max: { readonly databaseSizeBytes: number };
+}
+
+/** The three datasets one query returns, already narrowed to the account. */
+export interface Usage {
+  readonly d1: readonly D1Group[];
+  readonly workers: readonly WorkerGroup[];
+  readonly storage: readonly StorageGroup[];
+}
+
+/** A named part of one day's total — a database, or a Worker script. */
+export interface Contributor {
+  readonly name: string;
+  readonly amount: number;
+  /** A second figure printed beside the amount, where the dataset has one. */
+  readonly note?: string;
+}
+
+/** One counter, on one day, at or above the warning share of its ceiling. */
+export interface Breach {
+  readonly counter: string;
+  readonly day: string;
+  readonly used: number;
+  readonly ceiling: number;
+  /** How the amounts are written — rows, requests or bytes. */
+  readonly unit: "count" | "bytes";
+  /** What made up the total, largest first. Empty only if the API returned none. */
+  readonly contributors: readonly Contributor[];
+  /** Heading for the contributors' `note` column, where they carry one. */
+  readonly noteHeader?: string;
+}
+
+/** The share of its ceiling a breach has used, as a fraction. */
+export function fraction(breach: Breach): number {
+  return breach.used / breach.ceiling;
+}
+
+function percent(breach: Breach): string {
+  return `${Math.round(fraction(breach) * 100)}%`;
+}
+
+/**
+ * A database's name, falling back to its id.
+ *
+ * The fallback is a display concern only — a run whose name lookup failed
+ * outright never reaches here, because `listDatabases` throws. This covers the
+ * narrower case of a database created between the two calls.
+ */
+function databaseName(id: string, names: ReadonlyMap<string, string>): string {
+  return names.get(id) ?? id;
+}
+
+function byAmountDescending(a: Contributor, b: Contributor): number {
+  return b.amount - a.amount;
+}
+
+/** Group daily totals by day, keeping each contributor's share of the day. */
+function accumulate(
+  rows: readonly { day: string; name: string; amount: number; note?: string }[],
+): Map<string, Contributor[]> {
+  const days = new Map<string, Contributor[]>();
+  for (const row of rows) {
+    const day = days.get(row.day) ?? [];
+    day.push({ name: row.name, amount: row.amount, note: row.note });
+    days.set(row.day, day);
+  }
+  return days;
+}
+
+function breachesFor(
+  counter: string,
+  ceiling: number,
+  unit: "count" | "bytes",
+  days: ReadonlyMap<string, Contributor[]>,
+  noteHeader?: string,
+): Breach[] {
+  const found: Breach[] = [];
+  for (const [day, contributors] of days) {
+    const used = contributors.reduce((total, c) => total + c.amount, 0);
+    if (used < ceiling * WARN_FRACTION) continue;
+    found.push({
+      counter,
+      day,
+      used,
+      ceiling,
+      unit,
+      contributors: contributors.toSorted(byAmountDescending),
+      noteHeader,
+    });
+  }
+  return found;
+}
+
+/**
+ * The latest day the storage dataset reports. Storage is a running total, not
+ * a daily one, so only the newest reading says anything about the ceiling.
+ */
+function latestDay(groups: readonly StorageGroup[]): string | undefined {
+  let latest: string | undefined;
+  for (const group of groups) {
+    if (latest === undefined || group.dimensions.date > latest) latest = group.dimensions.date;
+  }
+  return latest;
+}
+
+/**
+ * Every counter at or above the warning share of its ceiling, worst first.
+ *
+ * Each daily counter is account-wide, so the total it compares is the sum
+ * across every database or script for that day; the contributors are what
+ * makes the figure actionable.
+ */
+export function findBreaches(usage: Usage, names: ReadonlyMap<string, string>): readonly Breach[] {
+  const written = accumulate(
+    usage.d1.map((g) => ({
+      day: g.dimensions.date,
+      name: databaseName(g.dimensions.databaseId, names),
+      amount: g.sum.rowsWritten,
+      note: g.sum.writeQueries.toLocaleString("en-US"),
+    })),
+  );
+  const read = accumulate(
+    usage.d1.map((g) => ({
+      day: g.dimensions.date,
+      name: databaseName(g.dimensions.databaseId, names),
+      amount: g.sum.rowsRead,
+      note: g.sum.readQueries.toLocaleString("en-US"),
+    })),
+  );
+  const requests = accumulate(
+    usage.workers.map((g) => ({
+      day: g.dimensions.date,
+      name: g.dimensions.scriptName,
+      amount: g.sum.requests,
+    })),
+  );
+
+  const newest = latestDay(usage.storage);
+  const storage = accumulate(
+    usage.storage
+      .filter((g) => g.dimensions.date === newest)
+      .map((g) => ({
+        day: g.dimensions.date,
+        name: databaseName(g.dimensions.databaseId, names),
+        amount: g.max.databaseSizeBytes,
+      })),
+  );
+
+  return [
+    ...breachesFor("D1 rows written", CEILINGS.d1RowsWritten, "count", written, "Write queries"),
+    ...breachesFor("D1 rows read", CEILINGS.d1RowsRead, "count", read, "Read queries"),
+    ...breachesFor("Workers requests", CEILINGS.workersRequests, "count", requests),
+    ...breachesFor("D1 storage", CEILINGS.d1StorageBytes, "bytes", storage),
+    // Worst first, and the newer day first where two are equally bad — which
+    // is what two runs of the same over-budget job in a week look like.
+  ].toSorted((a, b) => fraction(b) - fraction(a) || b.day.localeCompare(a.day));
+}
+
+function megabytes(bytes: number): string {
+  return `${(bytes / 1_000_000).toFixed(1)} MB`;
+}
+
+function amount(value: number, unit: "count" | "bytes"): string {
+  return unit === "bytes" ? megabytes(value) : value.toLocaleString("en-US");
+}
+
+/** The window a run covered, for the reader who wants to reproduce it. */
+export interface Window {
+  readonly start: string;
+  readonly end: string;
+}
+
+/**
+ * The issue body. Names the counter, the day, the figure and the databases or
+ * scripts that spent it, because "the account is at 82%" tells nobody what to
+ * change.
+ */
+export function renderIssueBody(breaches: readonly Breach[], window: Window, now: string): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `${breaches.length} Cloudflare free-tier ${breaches.length === 1 ? "counter is" : "counters are"} at or above ${Math.round(WARN_FRACTION * 100)}% of a ceiling.`,
+    "",
+    `Window ${window.start} to ${window.end} (UTC). Read at ${now}.`,
+    "",
+  );
+
+  for (const breach of breaches) {
+    const spenders = breach.contributors.filter((c) => c.amount > 0);
+    const noteHeader = breach.noteHeader;
+    lines.push(
+      `## ${breach.counter} — ${breach.day}`,
+      "",
+      `${amount(breach.used, breach.unit)} of ${amount(breach.ceiling, breach.unit)} (${percent(breach)}).`,
+      "",
+      noteHeader
+        ? `| Database or script | Amount | ${noteHeader} |`
+        : "| Database or script | Amount |",
+      noteHeader ? "|---|---:|---:|" : "|---|---:|",
+    );
+    for (const c of spenders) {
+      const row = `| \`${c.name}\` | ${amount(c.amount, breach.unit)} |`;
+      lines.push(noteHeader ? `${row} ${c.note ?? ""} |` : row);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "Every ceiling here is account-wide, across every Worker and every database.",
+    "The three daily ones reset at UTC midnight; storage is a running total.",
+    "Past a daily ceiling, D1 queries error and Workers return 429 from the edge,",
+    "so both APIs go to 503 or 429 for the rest of the day.",
+    "",
+    "What to do: find which job or route spent the rows, and either cut it or move",
+    "to Workers Paid. For D1, `bunx wrangler d1 insights <db> --time-period=7d",
+    "--sort-by=writes --limit=20 --json` names the query. The ceilings, what breaks",
+    "at each, and the upgrade costs are in `wiki/runbooks/free-tier-limits.md`.",
+    "",
+    "Filed by `.github/workflows/free-tier-ceiling-alert.yml`, which runs",
+    "`scripts/check-free-tier-ceilings.ts` once a day and edits this issue in",
+    "place. Close it when the numbers are back under the line; a later day over",
+    "the line reopens it.",
+  );
+
+  return lines.join("\n");
+}
+
+const GRAPHQL_ENDPOINT = "https://api.cloudflare.com/client/v4/graphql";
+
+/**
+ * One query for all three datasets.
+ *
+ * `d1AnalyticsAdaptiveGroups` is the shape the 2026-09-10 investigation used.
+ * `workersInvocationsAdaptive` and `d1StorageAdaptiveGroups` were read off the
+ * API's own schema — `sum { requests }` and `max { databaseSizeBytes }` are
+ * the fields it declares, not guesses.
+ *
+ * Asking for `date` alone as the time dimension collapses the hours the filter
+ * selects into one row per day per database or script, which is the figure the
+ * ceilings are stated in.
+ */
+const USAGE_QUERY = `query($acct: String!, $start: Time!, $end: Time!) {
+  viewer {
+    accounts(filter: { accountTag: $acct }) {
+      d1: d1AnalyticsAdaptiveGroups(
+        limit: 2000
+        filter: { datetimeHour_geq: $start, datetimeHour_leq: $end }
+        orderBy: [date_ASC]
+      ) {
+        dimensions { databaseId date }
+        sum { readQueries writeQueries rowsRead rowsWritten }
+      }
+      workers: workersInvocationsAdaptive(
+        limit: 2000
+        filter: { datetimeHour_geq: $start, datetimeHour_leq: $end }
+      ) {
+        dimensions { scriptName date }
+        sum { requests }
+      }
+      storage: d1StorageAdaptiveGroups(
+        limit: 2000
+        filter: { datetimeHour_geq: $start, datetimeHour_leq: $end }
+        orderBy: [date_ASC]
+      ) {
+        dimensions { databaseId date }
+        max { databaseSizeBytes }
+      }
+    }
+  }
+}`;
+
+/**
+ * Narrow a GraphQL response to `Usage`, or throw saying what was wrong.
+ *
+ * Separate from the fetch so the error paths are testable without a network,
+ * and so a malformed payload can never be read as an empty one — an empty
+ * `Usage` is indistinguishable from a quiet day, and would report all-clear.
+ */
+export function parseUsage(payload: unknown): Usage {
+  if (typeof payload !== "object" || payload === null) {
+    throw new TypeError("Cloudflare GraphQL returned a non-object body");
+  }
+
+  const body = payload as {
+    errors?: readonly { message?: string }[] | null;
+    data?: { viewer?: { accounts?: readonly Usage[] } | null } | null;
+  };
+
+  if (body.errors && body.errors.length > 0) {
+    const messages = body.errors.map((e) => e.message ?? "(no message)").join("; ");
+    throw new Error(`Cloudflare GraphQL errors: ${messages}`);
+  }
+
+  const accounts = body.data?.viewer?.accounts;
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    throw new Error(
+      "Cloudflare GraphQL returned no account. Check CLOUDFLARE_ACCOUNT_ID and that the token can read it.",
+    );
+  }
+
+  const account = accounts[0];
+  // Each dataset must come back as an array, even an empty one. Defaulting a
+  // missing key to `[]` would turn a renamed field into a quiet day and report
+  // all-clear on a counter nobody is reading any more.
+  for (const dataset of ["d1", "workers", "storage"] as const) {
+    if (!Array.isArray(account?.[dataset])) {
+      throw new TypeError(`Cloudflare GraphQL returned no '${dataset}' array`);
+    }
+  }
+  const usage: Usage = { d1: account.d1, workers: account.workers, storage: account.storage };
+
+  for (const group of usage.d1) {
+    assertNumbers("d1AnalyticsAdaptiveGroups", [
+      group.sum?.rowsRead,
+      group.sum?.rowsWritten,
+      group.sum?.readQueries,
+      group.sum?.writeQueries,
+    ]);
+  }
+  for (const group of usage.workers) {
+    assertNumbers("workersInvocationsAdaptive", [group.sum?.requests]);
+  }
+  for (const group of usage.storage) {
+    assertNumbers("d1StorageAdaptiveGroups", [group.max?.databaseSizeBytes]);
+  }
+
+  return usage;
+}
+
+function assertNumbers(dataset: string, values: readonly unknown[]): void {
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new TypeError(`${dataset} returned a non-numeric total (${String(value)})`);
+    }
+  }
+}
+
+/** The UTC day `offset` days back from `now`, as `YYYY-MM-DD`. */
+export function utcDay(now: Date, offset: number): string {
+  const day = new Date(now.getTime());
+  day.setUTCDate(day.getUTCDate() - offset);
+  return day.toISOString().slice(0, 10);
+}
+
+/**
+ * The query window for a run: whole UTC days, ending with `end`.
+ *
+ * `days` is 2 by default — yesterday, which is complete, and today, which
+ * catches an overrun on the day it happens rather than the morning after.
+ */
+export function windowFor(end: string, days: number): Window {
+  const endDate = new Date(`${end}T00:00:00Z`);
+  if (Number.isNaN(endDate.getTime())) throw new Error(`Not a date: ${end}`);
+  return { start: utcDay(endDate, days - 1), end };
+}
+
+async function fetchUsage(token: string, account: string, window: Window): Promise<Usage> {
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      query: USAGE_QUERY,
+      variables: {
+        acct: account,
+        start: `${window.start}T00:00:00Z`,
+        end: `${window.end}T23:00:00Z`,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Cloudflare GraphQL returned HTTP ${response.status}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
+
+  return parseUsage(await response.json());
+}
+
+/** Database id to name, so the issue body can say `cire-db-dev` and not a uuid. */
+async function listDatabases(token: string, account: string): Promise<ReadonlyMap<string, string>> {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/d1/database?per_page=100`,
+    { headers: { authorization: `Bearer ${token}` } },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Cloudflare D1 list returned HTTP ${response.status}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    success?: boolean;
+    result?: readonly { uuid?: string; name?: string }[] | null;
+  };
+  if (body.success !== true || !Array.isArray(body.result)) {
+    throw new Error("Cloudflare D1 list did not succeed");
+  }
+
+  const names = new Map<string, string>();
+  for (const database of body.result) {
+    if (database.uuid && database.name) names.set(database.uuid, database.name);
+  }
+  return names;
+}
+
+type Run = (args: readonly string[]) => Promise<string>;
+
+const gh: Run = async (args) => {
+  const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`gh ${args[0]} failed (${exitCode}): ${stderr.trim()}`);
+  return stdout;
+};
+
+/** What the run should do with the issue, given what the search found. */
+export type IssueAction =
+  | { readonly kind: "create" }
+  | { readonly kind: "edit"; readonly number: number }
+  | { readonly kind: "reopen"; readonly number: number };
+
+/** The issue the search matched, if any. */
+export interface ExistingIssue {
+  readonly number: number;
+  readonly state: string;
+}
+
+/**
+ * Pick the action. An open issue is edited in place so a week near the line
+ * stays one thread; a closed one is reopened, which is the signal that the
+ * counter went back over after someone had dealt with it.
+ */
+export function planIssueAction(existing: ExistingIssue | undefined): IssueAction {
+  if (!existing) return { kind: "create" };
+  return existing.state.toUpperCase() === "OPEN"
+    ? { kind: "edit", number: existing.number }
+    : { kind: "reopen", number: existing.number };
+}
+
+/** The one issue whose title matches exactly, newest first, or undefined. */
+export function matchIssue(listJson: string, title: string): ExistingIssue | undefined {
+  const issues = JSON.parse(listJson) as readonly {
+    number: number;
+    title: string;
+    state: string;
+  }[];
+  return issues.find((issue) => issue.title === title);
+}
+
+async function syncIssue(run: Run, repo: string, body: string): Promise<string> {
+  const listed = await run([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--limit",
+    "100",
+    "--search",
+    `${ISSUE_TITLE} in:title`,
+    "--json",
+    "number,title,state",
+  ]);
+  const action = planIssueAction(matchIssue(listed, ISSUE_TITLE));
+
+  const bodyFile = `${process.env.RUNNER_TEMP ?? "."}/free-tier-ceiling-body.md`;
+  await Bun.write(bodyFile, body);
+
+  if (action.kind === "create") {
+    const url = await run([
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      ISSUE_TITLE,
+      "--type",
+      ISSUE_TYPE,
+      "--label",
+      ISSUE_LABELS.join(","),
+      "--body-file",
+      bodyFile,
+    ]);
+    return `opened ${url.trim()}`;
+  }
+
+  const number = String(action.number);
+  if (action.kind === "reopen") {
+    await run([
+      "issue",
+      "reopen",
+      number,
+      "--repo",
+      repo,
+      "--comment",
+      "A counter is over the line again. The body below has the current figures.",
+    ]);
+  }
+  await run(["issue", "edit", number, "--repo", repo, "--body-file", bodyFile]);
+  return `${action.kind === "reopen" ? "reopened and updated" : "updated"} ${repo}#${number}`;
+}
+
+function flag(name: string, fallback: string): string {
+  const index = Bun.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : (Bun.argv[index + 1] ?? fallback);
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+if (import.meta.main) {
+  const now = new Date();
+  const end = flag("end", utcDay(now, 0));
+  const days = Number(flag("days", "2"));
+  if (!Number.isInteger(days) || days < 1) throw new Error(`--days must be a positive integer`);
+  const window = windowFor(end, days);
+
+  const token = required("CLOUDFLARE_API_TOKEN");
+  const account = required("CLOUDFLARE_ACCOUNT_ID");
+
+  const [usage, names] = await Promise.all([
+    fetchUsage(token, account, window),
+    listDatabases(token, account),
+  ]);
+  const breaches = findBreaches(usage, names);
+
+  if (breaches.length === 0) {
+    console.log(
+      `free-tier ceilings: clear for ${window.start} to ${window.end} — nothing at ${Math.round(WARN_FRACTION * 100)}% of a ceiling.`,
+    );
+    process.exit(0);
+  }
+
+  const body = renderIssueBody(breaches, window, `${now.toISOString().slice(0, 19)}Z`);
+
+  for (const breach of breaches) {
+    console.log(
+      `free-tier ceilings: ${breach.counter} on ${breach.day} at ${percent(breach)} of its ceiling.`,
+    );
+  }
+
+  if (Bun.argv.includes("--dry-run")) {
+    console.log(`\n--- ${ISSUE_TITLE} ---\n${body}`);
+    process.exit(0);
+  }
+
+  console.log(await syncIssue(gh, flag("repo", "xchromo/osn"), body));
+}

--- a/scripts/check-free-tier-ceilings.ts
+++ b/scripts/check-free-tier-ceilings.ts
@@ -23,23 +23,30 @@
  * reports all-clear when it is broken is worse than no watcher.
  */
 
-// The Cloudflare free-tier ceilings. Every one is account-wide, across every
-// Worker and every database on the account; the three daily ones reset at UTC
-// midnight and storage is a running total.
+// The Cloudflare free-tier ceilings. The first three are daily and reset at UTC
+// midnight; the last two are running totals. Four are account-wide, across every
+// Worker and every database. `d1DatabaseBytes` is the exception — it binds one
+// database on its own, and it is the storage ceiling that arrives first: at
+// 480 MB a database has stopped taking writes while the account total is still
+// a tenth of its 5 GB.
 //
 // These are the documented limits as of 2026-09-10 and they WILL drift.
 // Re-read Cloudflare's own pages before acting on a figure here —
-// https://developers.cloudflare.com/workers/platform/pricing/ and
-// https://developers.cloudflare.com/d1/platform/pricing/. The same numbers are
-// in `wiki/runbooks/free-tier-limits.md` and have to move with these.
+// https://developers.cloudflare.com/workers/platform/pricing/,
+// https://developers.cloudflare.com/d1/platform/pricing/ and
+// https://developers.cloudflare.com/d1/platform/limits/ (which is where the
+// two storage figures live). The same numbers are in
+// `wiki/runbooks/free-tier-limits.md` and have to move with these.
 //
-// Storage uses a decimal gigabyte, which is how Cloudflare prices it. Were it
-// binary the true ceiling would be larger, so this errs toward warning early.
+// Storage uses decimal megabytes and gigabytes, which is how Cloudflare prices
+// it. Were they binary the true ceilings would be larger, so this errs toward
+// warning early.
 export const CEILINGS = {
   d1RowsWritten: 100_000,
   d1RowsRead: 5_000_000,
   workersRequests: 100_000,
   d1StorageBytes: 5_000_000_000,
+  d1DatabaseBytes: 500_000_000,
 } as const;
 
 /** Report a counter once it reaches this share of its ceiling. */
@@ -194,9 +201,10 @@ function latestDay(groups: readonly StorageGroup[]): string | undefined {
 /**
  * Every counter at or above the warning share of its ceiling, worst first.
  *
- * Each daily counter is account-wide, so the total it compares is the sum
- * across every database or script for that day; the contributors are what
- * makes the figure actionable.
+ * All but one are account-wide, so the total compared is the sum across every
+ * database or script for that day, and the contributors are what makes the
+ * figure actionable. The exception is a single database's size, which binds
+ * each database on its own and so is checked once per database.
  */
 export function findBreaches(usage: Usage, names: ReadonlyMap<string, string>): readonly Breach[] {
   const written = accumulate(
@@ -224,14 +232,25 @@ export function findBreaches(usage: Usage, names: ReadonlyMap<string, string>): 
   );
 
   const newest = latestDay(usage.storage);
-  const storage = accumulate(
-    usage.storage
-      .filter((g) => g.dimensions.date === newest)
-      .map((g) => ({
-        day: g.dimensions.date,
-        name: databaseName(g.dimensions.databaseId, names),
-        amount: g.max.databaseSizeBytes,
-      })),
+  const sizes = usage.storage
+    .filter((g) => g.dimensions.date === newest)
+    .map((g) => ({
+      day: g.dimensions.date,
+      name: databaseName(g.dimensions.databaseId, names),
+      amount: g.max.databaseSizeBytes,
+    }));
+
+  // Two ceilings over the same rows. The account one sums them; the per-database
+  // one weighs each alone, so its counter carries the database's name — the
+  // heading has to say which database, not that one of seven is full.
+  const storage = accumulate(sizes);
+  const perDatabase = sizes.flatMap((size) =>
+    breachesFor(
+      `D1 database size: ${size.name}`,
+      CEILINGS.d1DatabaseBytes,
+      "bytes",
+      accumulate([size]),
+    ),
   );
 
   return [
@@ -239,6 +258,7 @@ export function findBreaches(usage: Usage, names: ReadonlyMap<string, string>): 
     ...breachesFor("D1 rows read", CEILINGS.d1RowsRead, "count", read, "Read queries"),
     ...breachesFor("Workers requests", CEILINGS.workersRequests, "count", requests),
     ...breachesFor("D1 storage", CEILINGS.d1StorageBytes, "bytes", storage),
+    ...perDatabase,
     // Worst first, and the newer day first where two are equally bad — which
     // is what two runs of the same over-budget job in a week look like.
   ].toSorted((a, b) => fraction(b) - fraction(a) || b.day.localeCompare(a.day));
@@ -294,10 +314,12 @@ export function renderIssueBody(breaches: readonly Breach[], window: Window, now
   }
 
   lines.push(
-    "Every ceiling here is account-wide, across every Worker and every database.",
-    "The three daily ones reset at UTC midnight; storage is a running total.",
+    "The row and request ceilings are daily and account-wide, across every Worker",
+    "and every database; they reset at UTC midnight. Storage is a running total,",
+    "and has two lines — 5 GB across the account, and 500 MB for any one database.",
     "Past a daily ceiling, D1 queries error and Workers return 429 from the edge,",
-    "so both APIs go to 503 or 429 for the rest of the day.",
+    "so both APIs go to 503 or 429 for the rest of the day. A full database stops",
+    "taking writes on its own, whatever the account total says.",
     "",
     "What to do: find which job or route spent the rows, and either cut it or move",
     "to Workers Paid. For D1, `bunx wrangler d1 insights <db> --time-period=7d",

--- a/scripts/tests/check-free-tier-ceilings.test.ts
+++ b/scripts/tests/check-free-tier-ceilings.test.ts
@@ -1,0 +1,284 @@
+// The pure half of scripts/check-free-tier-ceilings.ts: threshold arithmetic,
+// the issue body, response narrowing and the create/edit/reopen choice. The
+// network half is two `fetch` calls and a `gh` spawn, which is why the parsing
+// is a separate exported function from the fetching.
+//
+// No `bun install`: this imports `bun:test` and the script under test, matching
+// every other file under scripts/.
+
+import { expect, test } from "bun:test";
+
+import {
+  CEILINGS,
+  type D1Group,
+  findBreaches,
+  fraction,
+  ISSUE_TITLE,
+  matchIssue,
+  parseUsage,
+  planIssueAction,
+  renderIssueBody,
+  type StorageGroup,
+  type Usage,
+  utcDay,
+  WARN_FRACTION,
+  windowFor,
+  type WorkerGroup,
+} from "../check-free-tier-ceilings";
+
+const NAMES = new Map([
+  ["bf0510eb", "cire-db-dev"],
+  ["6e835474", "cire-db"],
+  ["1c1425e1", "osn-db-dev"],
+]);
+
+function d1(databaseId: string, date: string, rowsWritten: number, rowsRead = 0): D1Group {
+  return {
+    dimensions: { databaseId, date },
+    sum: { rowsWritten, rowsRead, writeQueries: 1, readQueries: 1 },
+  };
+}
+
+function worker(scriptName: string, date: string, requests: number): WorkerGroup {
+  return { dimensions: { scriptName, date }, sum: { requests } };
+}
+
+function storage(databaseId: string, date: string, databaseSizeBytes: number): StorageGroup {
+  return { dimensions: { databaseId, date }, max: { databaseSizeBytes } };
+}
+
+const EMPTY: Usage = { d1: [], workers: [], storage: [] };
+
+test("the day the ceiling was crossed fires, with the database named", () => {
+  // The real 2026-08-30 figures, the first of the two overruns nobody saw.
+  const usage: Usage = {
+    ...EMPTY,
+    d1: [d1("bf0510eb", "2026-08-30", 104_091), d1("6e835474", "2026-08-30", 657)],
+  };
+
+  const breaches = findBreaches(usage, NAMES);
+
+  expect(breaches).toHaveLength(1);
+  expect(breaches[0]!.counter).toBe("D1 rows written");
+  expect(breaches[0]!.day).toBe("2026-08-30");
+  expect(breaches[0]!.used).toBe(104_748);
+  expect(breaches[0]!.contributors[0]).toMatchObject({ name: "cire-db-dev", amount: 104_091 });
+});
+
+test("a day at 64% of the ceiling reads as normal", () => {
+  const usage: Usage = { ...EMPTY, d1: [d1("bf0510eb", "2026-09-08", 64_056)] };
+  expect(findBreaches(usage, NAMES)).toHaveLength(0);
+});
+
+test("the warning line is inclusive, and one row below it is not", () => {
+  const line = CEILINGS.d1RowsWritten * WARN_FRACTION;
+  expect(findBreaches({ ...EMPTY, d1: [d1("bf0510eb", "2026-09-08", line)] }, NAMES)).toHaveLength(
+    1,
+  );
+  expect(
+    findBreaches({ ...EMPTY, d1: [d1("bf0510eb", "2026-09-08", line - 1)] }, NAMES),
+  ).toHaveLength(0);
+});
+
+test("the total is account-wide, so databases under the line together cross it", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    d1: [
+      d1("bf0510eb", "2026-09-09", 45_000),
+      d1("6e835474", "2026-09-09", 45_000),
+      d1("1c1425e1", "2026-09-09", 10_000),
+    ],
+  };
+
+  const breaches = findBreaches(usage, NAMES);
+
+  expect(breaches).toHaveLength(1);
+  expect(breaches[0]!.used).toBe(100_000);
+  expect(breaches[0]!.contributors.map((c) => c.name)).toEqual([
+    "cire-db-dev",
+    "cire-db",
+    "osn-db-dev",
+  ]);
+});
+
+test("each day is judged on its own", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    d1: [d1("bf0510eb", "2026-08-30", 104_091), d1("bf0510eb", "2026-09-09", 104_091)],
+  };
+  expect(findBreaches(usage, NAMES).map((b) => b.day)).toEqual(["2026-09-09", "2026-08-30"]);
+});
+
+test("rows read has its own, much higher ceiling", () => {
+  const under: Usage = { ...EMPTY, d1: [d1("bf0510eb", "2026-09-09", 0, 294_202)] };
+  expect(findBreaches(under, NAMES)).toHaveLength(0);
+
+  const over: Usage = { ...EMPTY, d1: [d1("bf0510eb", "2026-09-09", 0, 4_500_000)] };
+  expect(findBreaches(over, NAMES)[0]!.counter).toBe("D1 rows read");
+});
+
+test("Workers requests are counted account-wide and broken down by script", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    workers: [worker("cire-api", "2026-09-09", 70_000), worker("osn-api", "2026-09-09", 15_000)],
+  };
+
+  const breaches = findBreaches(usage, NAMES);
+
+  expect(breaches).toHaveLength(1);
+  expect(breaches[0]!.counter).toBe("Workers requests");
+  expect(breaches[0]!.contributors[0]!.name).toBe("cire-api");
+});
+
+test("storage reads the newest day only, so yesterday's size is not added to today's", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    storage: [
+      storage("bf0510eb", "2026-09-09", 3_000_000_000),
+      storage("bf0510eb", "2026-09-10", 3_000_000_000),
+      storage("6e835474", "2026-09-10", 1_100_000_000),
+    ],
+  };
+
+  const breaches = findBreaches(usage, NAMES);
+
+  expect(breaches).toHaveLength(1);
+  expect(breaches[0]!.counter).toBe("D1 storage");
+  expect(breaches[0]!.day).toBe("2026-09-10");
+  expect(breaches[0]!.used).toBe(4_100_000_000);
+});
+
+test("worst counter first", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    d1: [d1("bf0510eb", "2026-09-09", 85_000)],
+    workers: [worker("cire-api", "2026-09-09", 99_000)],
+  };
+  expect(findBreaches(usage, NAMES).map((b) => b.counter)).toEqual([
+    "Workers requests",
+    "D1 rows written",
+  ]);
+  expect(fraction(findBreaches(usage, NAMES)[0]!)).toBeCloseTo(0.99);
+});
+
+test("a database the name lookup does not know is shown by its id", () => {
+  const usage: Usage = { ...EMPTY, d1: [d1("00000000", "2026-09-09", 90_000)] };
+  expect(findBreaches(usage, NAMES)[0]!.contributors[0]!.name).toBe("00000000");
+});
+
+test("the body names the counter, the day, the figure and the database", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    d1: [d1("bf0510eb", "2026-09-09", 104_091), d1("6e835474", "2026-09-09", 0)],
+  };
+
+  const body = renderIssueBody(
+    findBreaches(usage, NAMES),
+    { start: "2026-09-09", end: "2026-09-10" },
+    "2026-09-10T08:00:00Z",
+  );
+
+  expect(body).toContain("D1 rows written — 2026-09-09");
+  expect(body).toContain("104,091 of 100,000 (104%)");
+  expect(body).toContain("`cire-db-dev`");
+  expect(body).toContain("wiki/runbooks/free-tier-limits.md");
+  // A database that spent nothing that day is not worth a row.
+  expect(body).not.toContain("`cire-db`");
+});
+
+test("the body prints storage in megabytes, not raw bytes", () => {
+  const usage: Usage = { ...EMPTY, storage: [storage("bf0510eb", "2026-09-10", 4_100_000_000)] };
+  const body = renderIssueBody(
+    findBreaches(usage, NAMES),
+    { start: "2026-09-10", end: "2026-09-10" },
+    "2026-09-10T08:00:00Z",
+  );
+  expect(body).toContain("4100.0 MB of 5000.0 MB (82%)");
+});
+
+test("parseUsage narrows a well-formed response", () => {
+  const payload = {
+    errors: null,
+    data: {
+      viewer: { accounts: [{ d1: [d1("bf0510eb", "2026-09-09", 5)], workers: [], storage: [] }] },
+    },
+  };
+  expect(parseUsage(payload).d1).toHaveLength(1);
+});
+
+test("parseUsage throws on a GraphQL error rather than reporting a quiet day", () => {
+  const payload = { errors: [{ message: "authentication error" }], data: null };
+  expect(() => parseUsage(payload)).toThrow(/authentication error/);
+});
+
+test("parseUsage throws when the account is missing", () => {
+  expect(() => parseUsage({ errors: null, data: { viewer: { accounts: [] } } })).toThrow(
+    /no account/,
+  );
+});
+
+test("parseUsage throws when a dataset is not an array", () => {
+  const payload = { data: { viewer: { accounts: [{ d1: [], workers: [], storage: null }] } } };
+  expect(() => parseUsage(payload)).toThrow(/no 'storage' array/);
+});
+
+test("parseUsage throws when a total is not a number", () => {
+  const payload = {
+    data: {
+      viewer: {
+        accounts: [
+          {
+            d1: [
+              {
+                dimensions: { databaseId: "bf0510eb", date: "2026-09-09" },
+                sum: { rowsWritten: null, rowsRead: 0, writeQueries: 0, readQueries: 0 },
+              },
+            ],
+            workers: [],
+            storage: [],
+          },
+        ],
+      },
+    },
+  };
+  expect(() => parseUsage(payload)).toThrow(/non-numeric/);
+});
+
+test("parseUsage throws on a body that is not an object", () => {
+  expect(() => parseUsage("gateway timeout")).toThrow(/non-object/);
+});
+
+test("the window is whole UTC days ending with the day given", () => {
+  expect(windowFor("2026-09-10", 2)).toEqual({ start: "2026-09-09", end: "2026-09-10" });
+  expect(windowFor("2026-09-10", 1)).toEqual({ start: "2026-09-10", end: "2026-09-10" });
+  // Across a month boundary, which is where hand-rolled date arithmetic fails.
+  expect(windowFor("2026-09-01", 3)).toEqual({ start: "2026-08-30", end: "2026-09-01" });
+});
+
+test("utcDay steps back in UTC, not in the runner's zone", () => {
+  expect(utcDay(new Date("2026-03-01T00:30:00Z"), 1)).toBe("2026-02-28");
+});
+
+test("windowFor rejects a date it cannot read", () => {
+  expect(() => windowFor("yesterday", 2)).toThrow(/Not a date/);
+});
+
+test("no match opens a new issue; an open one is edited; a closed one is reopened", () => {
+  const listed = JSON.stringify([
+    { number: 12, title: "Something else", state: "OPEN" },
+    { number: 34, title: ISSUE_TITLE, state: "CLOSED" },
+  ]);
+
+  expect(planIssueAction(matchIssue("[]", ISSUE_TITLE))).toEqual({ kind: "create" });
+  expect(planIssueAction(matchIssue(listed, ISSUE_TITLE))).toEqual({ kind: "reopen", number: 34 });
+  expect(
+    planIssueAction(
+      matchIssue(JSON.stringify([{ number: 7, title: ISSUE_TITLE, state: "OPEN" }]), ISSUE_TITLE),
+    ),
+  ).toEqual({ kind: "edit", number: 7 });
+});
+
+test("a title that only contains the search text is not the issue", () => {
+  const listed = JSON.stringify([{ number: 9, title: `${ISSUE_TITLE} (again)`, state: "OPEN" }]);
+  expect(matchIssue(listed, ISSUE_TITLE)).toBeUndefined();
+});

--- a/scripts/tests/check-free-tier-ceilings.test.ts
+++ b/scripts/tests/check-free-tier-ceilings.test.ts
@@ -140,12 +140,55 @@ test("storage reads the newest day only, so yesterday's size is not added to tod
     ],
   };
 
+  const account = findBreaches(usage, NAMES).find((b) => b.counter === "D1 storage");
+
+  expect(account).toBeDefined();
+  expect(account!.day).toBe("2026-09-10");
+  // 3 GB + 1.1 GB from the newest day, not 6 GB + 1.1 GB across both days.
+  expect(account!.used).toBe(4_100_000_000);
+});
+
+test("one database over its own 500 MB line fires while the account total is quiet", () => {
+  const usage: Usage = { ...EMPTY, storage: [storage("6e835474", "2026-09-10", 480_000_000)] };
+
   const breaches = findBreaches(usage, NAMES);
 
+  // 480 MB is 9.6% of the account's 5 GB and 96% of one database's 500 MB.
   expect(breaches).toHaveLength(1);
-  expect(breaches[0]!.counter).toBe("D1 storage");
+  expect(breaches[0]!.counter).toBe("D1 database size: cire-db");
   expect(breaches[0]!.day).toBe("2026-09-10");
-  expect(breaches[0]!.used).toBe(4_100_000_000);
+  expect(breaches[0]!.used).toBe(480_000_000);
+});
+
+test("a database at 79% of its own line is not reported", () => {
+  const usage: Usage = { ...EMPTY, storage: [storage("6e835474", "2026-09-10", 399_000_000)] };
+  expect(findBreaches(usage, NAMES)).toHaveLength(0);
+});
+
+test("each database is weighed on its own, so only the full one is named", () => {
+  const usage: Usage = {
+    ...EMPTY,
+    storage: [
+      storage("bf0510eb", "2026-09-10", 450_000_000),
+      storage("6e835474", "2026-09-10", 1_000_000),
+      storage("1c1425e1", "2026-09-10", 1_000_000),
+    ],
+  };
+
+  const breaches = findBreaches(usage, NAMES);
+
+  expect(breaches.map((b) => b.counter)).toEqual(["D1 database size: cire-db-dev"]);
+});
+
+test("the body names the database in the heading of a per-database breach", () => {
+  const usage: Usage = { ...EMPTY, storage: [storage("bf0510eb", "2026-09-10", 480_000_000)] };
+  const body = renderIssueBody(
+    findBreaches(usage, NAMES),
+    { start: "2026-09-10", end: "2026-09-10" },
+    "2026-09-10T08:00:00Z",
+  );
+  expect(body).toContain("## D1 database size: cire-db-dev — 2026-09-10");
+  expect(body).toContain("480.0 MB of 500.0 MB (96%)");
 });
 
 test("worst counter first", () => {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,10 @@
 {
-  "//": "scripts/ is not a workspace, so `turbo check` never reaches it. Without this, a type error here ships: `skill-evals.ts` read an optional `scenario.path` unguarded, which crashed `ready`, `compare` and `record` on a payload the API really returns, and no gate saw it. The `script-tests` CI job runs `tsc -p scripts/tsconfig.json`, which needs no install because everything under scripts/ imports only bun:test, Bun and Node built-ins, and each other.",
+  "//": "scripts/ is not a workspace, so `turbo check` never reaches it. Without this, a type error here ships: `skill-evals.ts` read an optional `scenario.path` unguarded, which crashed `ready`, `compare` and `record` on a payload the API really returns, and no gate saw it. The `typecheck` CI job runs `tsc -p scripts/tsconfig.json`, which needs no install because everything under scripts/ imports only bun:test, Bun and Node built-ins, and each other.",
   "extends": "../tsconfig.json",
+  "//lib": "The root sets ES2022 because its packages build for workerd and for browsers. Nothing under scripts/ does — every file here runs under the repo's pinned Bun and nowhere else — so the library is raised one year to cover the copying array methods (`toSorted`), which `unicorn/no-array-sort` asks for in place of the mutating `sort`.",
+  "compilerOptions": {
+    "lib": ["ES2023"]
+  },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "**/node_modules"]
 }

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -395,11 +395,16 @@ records persist for **7 days** and are viewable in the CF dashboard.
 `scripts/check-free-tier-ceilings.ts` at 22:00 UTC daily, and on demand through
 `workflow_dispatch` (with `end` and `days` inputs, so a past day can be
 replayed). It reads per-day totals per database and per Worker script from
-Cloudflare's GraphQL analytics API — rows written, rows read, requests, and
-storage against the 5 GB total — and files one issue, titled "Cloudflare free
+Cloudflare's GraphQL analytics API and files one issue, titled "Cloudflare free
 tier: a daily counter is near its ceiling", when any counter reaches **80%** of
 its line. It reopens and edits that one issue rather than opening another, so a
 week near the line is one thread, and the body names the database and the day.
+
+Five ceilings: rows written, rows read and Workers requests per day, plus both
+storage lines — 5 GB across the account and **500 MB for any one database**. The
+per-database line is checked per database, not summed, because it is the storage
+failure that arrives first: a 480 MB database has stopped taking writes while the
+account total is still a tenth of its 5 GB.
 
 Two things to know before trusting it. The ceilings are the `CEILINGS` constant
 at the top of that script, and they have to move whenever the tables above do.

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -390,6 +390,22 @@ records persist for **7 days** and are viewable in the CF dashboard.
   - Recurring `exceededResources` / `exceededCpu` invocation statuses → a heavy
     request path (e.g. spreadsheet import) bumping the Free CPU/subrequest caps.
 
+**The first two of those are watched for you; the rest are read by eye.**
+`.github/workflows/free-tier-ceiling-alert.yml` runs
+`scripts/check-free-tier-ceilings.ts` at 22:00 UTC daily, and on demand through
+`workflow_dispatch` (with `end` and `days` inputs, so a past day can be
+replayed). It reads per-day totals per database and per Worker script from
+Cloudflare's GraphQL analytics API — rows written, rows read, requests, and
+storage against the 5 GB total — and files one issue, titled "Cloudflare free
+tier: a daily counter is near its ceiling", when any counter reaches **80%** of
+its line. It reopens and edits that one issue rather than opening another, so a
+week near the line is one thread, and the body names the database and the day.
+
+Two things to know before trusting it. The ceilings are the `CEILINGS` constant
+at the top of that script, and they have to move whenever the tables above do.
+And it fails loudly: a bad API response exits non-zero and fails the run, rather
+than reporting all-clear.
+
 ---
 
 ## Cloudflare security hardening (free, dashboard) — TODO


### PR DESCRIPTION
Closes #989.

## What

`wiki/runbooks/free-tier-limits.md` listed the ceilings and said to watch them, which meant a person opening a dashboard. Nobody did. The D1 rows-written ceiling was crossed on **2026-08-30 (104,831)** and again on **2026-09-09 (104,115)**, eleven days apart, and was only found by hand on 2026-09-10 (#979). Three days in between ran at 56–64% and looked ordinary.

This reads the counters by API once a day and files one issue when a day passes 80% of a ceiling.

## Counters

All five, each verified against a live query — the Workers dataset was confirmed by `__type` introspection rather than guessed, and `workersOverviewRequestsAdaptiveGroups` ruled out because its `sum` carries only `cpuTimeUs`.

| Counter | Ceiling | Dataset |
|---|---|---|
| D1 rows written | 100,000 / day | `d1AnalyticsAdaptiveGroups` |
| D1 rows read | 5,000,000 / day | same |
| Workers requests | 100,000 / day | `workersInvocationsAdaptive` |
| D1 storage, account | 5 GB | `d1StorageAdaptiveGroups` |
| **D1 size, one database** | **500 MB** | same, per database |

The last one was not in the issue and was added in review. The runbook lists two storage limits, not one, and only the account total was covered — a 480 MB `cire-db` would have passed the account check with room to spare, and a single database filling is the failure that arrives first. Both figures were re-verified against Cloudflare's D1 limits page on 2026-09-10 rather than taken from the runbook.

## Proof it works

Replaying the two days that actually breached:

```
--end 2026-08-30 --days 1  →  D1 rows written at 105% of its ceiling
                              104,831 of 100,000 · cire-db-dev 104,091 / 2,691 write queries
--end 2026-09-09 --days 1  →  104,115 of 100,000 (104%)
```

Both match the figures in #979 exactly. No false positive from the new per-database check — the largest database on the account is `cire-db` at 1,273,856 bytes, 0.25% of 500 MB.

## It fails loudly

A non-2xx, a GraphQL error, an unreadable account or a non-numeric total exits non-zero and reds the job. Verified: a bad token gives `exit=1`, `Cloudflare D1 list returned HTTP 401`. A watcher that reports all-clear while broken is worse than no watcher, and the workflow comment says not to paper over it with `continue-on-error`.

## Shape

- All logic in `scripts/check-free-tier-ceilings.ts`, pure half exported and tested (27 tests); the workflow is a caller.
- One issue, found by a stable title, reopened and edited rather than a new one each day. No auto-close — closing would wipe a thread someone is working; a later breach reopens it with a comment.
- The body names the database or script and the day. "The account is at 82%" tells nobody what to change.
- `workflow_dispatch` takes `end` and `days`, so a past day can be replayed from the Actions tab. That is how the two proofs above were produced.
- Ceilings in one block with a dated comment saying they will drift.

## Two changes outside the obvious

**`scripts/tsconfig.json` raises `lib` to ES2023.** The root pins ES2022 because its packages build for workerd and browsers; nothing under `scripts/` does. `unicorn/no-array-sort` asks for `toSorted`, which is ES2023. Raising it for `scripts/` alone beat switching to the mutating `sort` or touching the root. The stale `script-tests` reference in that file's comment is corrected to `typecheck`, which is the job that actually runs `tsc -p scripts/tsconfig.json` (`ci.yml:122`).

**`wrangler d1 list` is not used** for the id-to-name map — it fails locally with `Authentication error [code: 10000]` and would need a wrangler install in the job. The script calls the REST endpoint wrangler itself calls, `GET /accounts/{id}/d1/database`, with the same token. One credential, one HTTP client, no install step.

## An ops finding came out of this

Checking the token scope turned up something worse than expected: **both GitHub Environments are empty.** `gh secret list --env production` returns nothing, `--env dev` holds only `DEV_LOGIN_SECRET`, and `CLOUDFLARE_API_TOKEN` exists only at repository scope — where `deploy.yml` reads it in all 15 places, including jobs that declare `environment: production`. The two-token split `dev-environment.md` describes is not in place, and following that runbook's delete instruction today would break production deploys, not just this cron. Filed on the tracker; nothing here changes it.

The workflow carries a comment saying which scope it depends on, that it cannot take `environment: production` in exchange (that gate needs a human, and a watcher nobody approves at 22:00 UTC watches nothing), and that it needs only `d1 (read)` and `account (read)` — the moment to give it a separate read-only credential is when the split is actually made.

## Verified

- `bunx --bun tsc -p scripts/tsconfig.json` — exit 0
- `bun run lint` — exit 0, 0 errors
- `bun run fmt:check` — exit 0
- `bun run test:scripts` — 180 pass, 0 fail across 15 files
- `changeset-required.sh` — `skip`

## Not exercised

`gh issue create --type Task` under `GITHUB_TOKEN` — the one step that cannot be run locally without filing the issue for real. Worth one `workflow_dispatch` after merge to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
