### PR TITLE
feat(ops): guard the D1 cost of a from-zero migration rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,28 @@ jobs:
       - name: Check release-age excludes are marked and bounded
         run: bun run check:release-age-excludes
 
+      # The same split as the step above, for the same reason. The tests in the
+      # step further up feed the guard synthetic migration chains and prove it
+      # measures and fails correctly; this runs it against the chain the repo
+      # really ships, which is the thing a pull request changes.
+      #
+      # What it guards: a from-zero rebuild of the cire D1 costs rows in
+      # proportion to the number of schema statements in the chain, not to the
+      # amount of data, and that number only grows. Thirteen merges spent
+      # 104,091 rows written on 2026-09-09 against a free-tier ceiling of
+      # 100,000 a day account-wide, with no commit doing anything wrong
+      # (xchromo/osn#979). The budget is a row in
+      # scripts/d1-migration-cost-budgets.txt, not an argument here.
+      #
+      # It needs no install: the script imports bun:sqlite and Node built-ins
+      # and nothing else, which is why it belongs in this job rather than in
+      # build-test. Invoked by path, like guard-bundle-size.sh, rather than
+      # through a root package.json script — root package.json is off the
+      # changeset allowlist on purpose, and this change ships nothing any
+      # versioned package would name.
+      - name: Guard the D1 cost of the migration chains
+        run: bun run scripts/guard-d1-migration-cost.ts --all
+
   openapi-freshness:
     name: OpenAPI Freshness
     runs-on: ubuntu-latest

--- a/scripts/d1-migration-cost-budgets.txt
+++ b/scripts/d1-migration-cost-budgets.txt
@@ -4,10 +4,13 @@
 #
 #   <migrations-dir>  <budget, in estimated D1 rows written to replay it from zero>
 #
-# The guard replays the chain into an in-memory SQLite, counts schema writes,
-# and prices them at 27 D1 rows each. The script's own header carries the two
-# remote measurements that constant is calibrated against and how tight the fit
-# is.
+# The guard replays the chain into an in-memory SQLite and counts schema
+# writes, which is exact. It then PRICES them at 27 D1 rows each, which is not:
+# the evidence puts that constant somewhere around 22 to 27, and the script's
+# own header carries both anchors and why the band is that wide. So read the
+# row figures here as indicative, and pessimistic by up to about a fifth rather
+# than optimistic. The guard also prints the same line in schema writes, which
+# is the form to trust.
 #
 # RE-BASELINING. Run `bun run scripts/guard-d1-migration-cost.ts --all`, read
 # the printed cost, and edit the row here. Two rules, from
@@ -17,17 +20,20 @@
 # bundle guard does not — squashing the chain into a fresh baseline puts the
 # cost back down instead of moving the line up. Reach for that first.
 
-# 3700 is twice the 1836 rows the squashed baseline costs today. The mistake
-# this guard exists to catch is not one bad migration — nothing in the chain
-# that went over the ceiling was wrong — it is the chain regrowing until a
-# day's rebuilds no longer fit. So the line is drawn where the bill has
-# doubled: at 3700 a replay is 3.7% of the day's 100,000 rows written and 27
-# replays a day still fit, against the 13 merges that went over on 2026-09-09.
+# 3700 is twice what the squashed baseline prices at today. The mistake this
+# guard exists to catch is not one bad migration — nothing in the chain that
+# went over the ceiling was wrong — it is the chain regrowing until a day's
+# rebuilds no longer fit. So the line is drawn where the bill has doubled: 68
+# schema writes now, tripping at 137.
 #
-# That is 1864 rows of headroom, which is MORE than any single migration in the
-# 57-file chain this replaced would add — the heaviest, 0006_multi_tenant, is
-# 28 schema writes and 756 rows. Deliberate: a budget tight enough to trip on
-# one ordinary feature migration (0057_registry was 405 rows on its own) would
-# be raised on sight every few pull requests, which is the failure the second
-# rule names.
+# In rows, priced at 27: 1836 today, 3700 at the line, so a replay goes from
+# 1.8% to 3.7% of the day's 100,000 rows written and from roughly 54 replays a
+# day to 27, against the 13 merges that went over the ceiling on 2026-09-09.
+# Those row figures move with the constant; the 68-against-137 does not.
+#
+# The headroom is 69 schema writes, which is MORE than any single migration in
+# the 57-file chain this replaced would add — the heaviest, 0006_multi_tenant,
+# is 28. Deliberate: a budget tight enough to trip on one ordinary feature
+# migration (0057_registry was 15 schema writes on its own) would be raised on
+# sight every few pull requests, which is the failure the second rule names.
 cire/db/migrations 3700

--- a/scripts/d1-migration-cost-budgets.txt
+++ b/scripts/d1-migration-cost-budgets.txt
@@ -1,0 +1,33 @@
+# D1 migration-cost budgets — read by scripts/guard-d1-migration-cost.ts, and
+# by nothing else. This file, not the script and not a workflow step, is where
+# the number lives.
+#
+#   <migrations-dir>  <budget, in estimated D1 rows written to replay it from zero>
+#
+# The guard replays the chain into an in-memory SQLite, counts schema writes,
+# and prices them at 27 D1 rows each. The script's own header carries the two
+# remote measurements that constant is calibrated against and how tight the fit
+# is.
+#
+# RE-BASELINING. Run `bun run scripts/guard-d1-migration-cost.ts --all`, read
+# the printed cost, and edit the row here. Two rules, from
+# wiki/conventions/bundle-size-guards.md:
+# a budget is a number somebody chose, with the reason in the commit; and a
+# guard that only ever gets raised is not a guard. This one has a remedy the
+# bundle guard does not — squashing the chain into a fresh baseline puts the
+# cost back down instead of moving the line up. Reach for that first.
+
+# 3700 is twice the 1836 rows the squashed baseline costs today. The mistake
+# this guard exists to catch is not one bad migration — nothing in the chain
+# that went over the ceiling was wrong — it is the chain regrowing until a
+# day's rebuilds no longer fit. So the line is drawn where the bill has
+# doubled: at 3700 a replay is 3.7% of the day's 100,000 rows written and 27
+# replays a day still fit, against the 13 merges that went over on 2026-09-09.
+#
+# That is 1864 rows of headroom, which is MORE than any single migration in the
+# 57-file chain this replaced would add — the heaviest, 0006_multi_tenant, is
+# 28 schema writes and 756 rows. Deliberate: a budget tight enough to trip on
+# one ordinary feature migration (0057_registry was 405 rows on its own) would
+# be raised on sight every few pull requests, which is the failure the second
+# rule names.
+cire/db/migrations 3700

--- a/scripts/guard-d1-migration-cost.ts
+++ b/scripts/guard-d1-migration-cost.ts
@@ -29,45 +29,63 @@
  * SQLite's own `changes`.
  *
  * WHY THAT CORRELATES WITH D1's BILL. A from-zero rebuild runs against empty
- * tables, so the bill is almost all schema churn — of the 200 heaviest queries
- * on `cire-db-dev` in the week to 2026-09-10, schema statements were 89% of
- * rows written and the seed's inserts were 11%. SQLite rebuilds the whole
- * table for every dropped column and D1 bills that against no data at all, so
- * each schema statement costs a roughly fixed number of rows whatever the
- * table holds. Two remote measurements fix the constant, and one constant fits
- * both:
+ * tables, so nearly all of what it spends is schema churn: SQLite rebuilds the
+ * whole table for every dropped column, and D1 bills that against no data at
+ * all. Each schema statement therefore costs a roughly fixed number of rows
+ * whatever the table holds, which is the claim the constant rests on.
  *
- *   - one `ALTER TABLE ... DROP COLUMN` on `wedding_invite_customisations`,
- *     against a table with no rows in it, cost 54 rows written — two schema
- *     writes at 27 apiece, exactly;
- *   - the 57-file chain squashed by xchromo/osn#984 measures 269 schema
- *     writes here, which at 27 apiece predicts 7,265 rows. The rebuild that
- *     replayed it cost 8,007 rows written in total, of which the 89% schema
- *     share is 7,126. The prediction is 2.0% high.
+ * ONE HARD ANCHOR fixes it. One `ALTER TABLE ... DROP COLUMN` on
+ * `wedding_invite_customisations`, against a table with no rows in it, cost 54
+ * D1 rows written — two schema writes at 27 apiece.
+ *   measured 2026-09-10:
+ *   bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes --limit=200
  *
- * High is the safe side, and the two together also reproduce the figure the
- * incident was reported with: 7,265 for the chain plus the seed's share is
- * 8,007, and 100,000 / 8,007 is the 12 full rebuilds a day that chain afforded.
+ * ONE SOFT ANCHOR agrees within about 20%, and no better than that. The 57-file
+ * chain squashed by xchromo/osn#984 measures 269 schema writes here. Its
+ * rebuild cost 8,007 D1 rows written in total (unverified here — taken from
+ * wiki/runbooks/free-tier-limits.md and the xchromo/osn#979 investigation, and
+ * not re-derived by this branch), but that total covers drop, replay AND seed,
+ * so it only bounds the chain once the seed is subtracted, and the seed's cost
+ * is what is not known precisely:
  *
- * HOW TIGHT THAT IS, HONESTLY. Two anchor points, both from one database in
- * one week, fitted with one constant. It is not a regression and it does not
- * model D1's accounting; it asserts that a schema statement has a roughly
- * fixed price, which those two points and the 89/11 split support and nothing
- * here proves. Treat the printed row count as an estimate good to about ±10%
- * and the schema-write count as the exact thing being guarded. The estimate
- * also folds in the per-file `d1_migrations` ledger insert that
- * `wrangler d1 migrations apply` makes, since the calibration chain paid for
- * 57 of those — which over-charges a short chain slightly, again on the safe
- * side.
+ *   - `cire/db/seed/dev-seed.sql` inserts 2,063 tuples, and D1 bills index
+ *     entries as rows written too, so the seed cost AT LEAST that. The chain
+ *     is then at most 8,007 - 2,063 = 5,944, or 22.1 rows per schema write.
+ *     measured 2026-09-10: replay cire/db/migrations/0001_initial.sql then
+ *     cire/db/seed/dev-seed.sql into bun:sqlite and sum SQLite's `changes`.
+ *   - The often-quoted "89% schema, 11% seed" split does NOT settle it. That
+ *     is the split within the 200 HEAVIEST queries — 56,852 rows written
+ *     across those 200, against roughly 409,000 on the database over the
+ *     week's rebuild days — not a share of one rebuild. The seed cost it
+ *     implies, 881 rows, is below the seed's own floor of 2,063, which is the
+ *     tell that the sample over-represents schema statements. Neither of those
+ *     two sampling figures was re-derived on this branch.
+ *
+ * So the constant sits somewhere around 22 to 27, and this guard uses 27: the
+ * top of the band, the only directly measured point, and the safe side, since
+ * over-stating what a rebuild costs is the error that does not lose a day's
+ * quota.
+ *
+ * WHAT THAT UNCERTAINTY DOES AND DOES NOT TOUCH. The schema-write count is
+ * exact — it is counted, not modelled — and it is what a reader should trust.
+ * Every ROW figure the guard prints, and every "replays a day" derived from
+ * one, carries the 22-27 band: read them as indicative, and as pessimistic by
+ * up to about a fifth rather than optimistic. The line the guard enforces is
+ * printed in schema writes beside the budget for exactly that reason, so the
+ * threshold can be read without trusting the constant at all.
  *
  * WHAT IS NOT IN THE NUMBER. The seed. This guard prices the chain, because
  * the chain is what a pull request changes; a full dev rebuild drops, replays
- * and then seeds, and the seed is a further tenth or so on top.
+ * and then seeds, and the seed's 2,063 tuples come on top. The per-file
+ * `d1_migrations` ledger insert that `wrangler d1 migrations apply` makes is
+ * inside the constant rather than modelled, since the calibration chain paid
+ * for 57 of them — which over-charges a short chain slightly, again on the
+ * safe side.
  *
  * The read ceiling is not guarded either. It is 5,000,000 a day against
- * 100,000 written, and the same rebuild that spent 8% of the write allowance
- * spent 0.5% of the read one, so writes are the binding constraint and a
- * second threshold would only be a second number to keep true.
+ * 100,000 written, and the rebuild that spent 8% of the write allowance spent
+ * 0.5% of the read one, so writes are the binding constraint and a second
+ * threshold would only be a second number to keep true.
  *
  * Usage:
  *   guard-d1-migration-cost.ts --all              every row in the budgets
@@ -85,10 +103,11 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 /**
- * Rows written on D1 per schema write, calibrated against the two remote
- * measurements in this file's header. Changing it changes every printed
- * estimate and every headroom figure, so it is a re-baseline of the same
- * weight as a budget row.
+ * Rows written on D1 per schema write. The evidence puts it somewhere around
+ * 22 to 27 — see this file's header for both anchors and why the band is that
+ * wide — and 27 is the top of it, which is the safe side. Changing it changes
+ * every printed row figure and every headroom figure, so it is a re-baseline
+ * of the same weight as a budget row.
  */
 export const ROWS_WRITTEN_PER_SCHEMA_WRITE = 27;
 
@@ -382,6 +401,15 @@ function percentOfCeiling(rows: number): string {
   return `${((rows / DAILY_ROWS_WRITTEN_CEILING) * 100).toFixed(1)}%`;
 }
 
+/**
+ * The budget restated in the unit the guard counts exactly: the largest whole
+ * number of schema writes that still fits, once the chain's real data rows are
+ * taken off the top.
+ */
+function budgetInSchemaWrites(budget: number, dataRows: number): number {
+  return Math.max(0, Math.floor((budget - dataRows) / ROWS_WRITTEN_PER_SCHEMA_WRITE));
+}
+
 /** Runs one record. Returns true when the chain is inside its budget. */
 export function runGuard(chain: string, dir: string, budget: number, budgetsPath: string): boolean {
   const cost = measureChain(dir);
@@ -396,20 +424,30 @@ export function runGuard(chain: string, dir: string, budget: number, budgetsPath
     `  replaying the chain from zero costs about ${rows} D1 rows written ` +
       `(${percentOfCeiling(rows)} of the ${DAILY_ROWS_WRITTEN_CEILING}/day free-tier ceiling)`,
   );
-  console.log(`  that affords ${affordable} replay(s) a day, before the seed a full rebuild adds`);
+  console.log(
+    `  that affords roughly ${affordable} replay(s) a day, before the seed a full rebuild adds`,
+  );
   console.log(
     `  budget ${budget} rows written (${rebuildsPerDay(budget)} a day), ` +
       `${budget - rows} rows of headroom`,
   );
+  // Every row figure above is priced by a constant the evidence only pins to
+  // about 22-27 (see the file header). This line is the same threshold in the
+  // unit the guard counts exactly, so it can be read without that constant.
+  console.log(
+    `  exactly: ${cost.schemaWrites} schema writes against a line at ` +
+      `${budgetInSchemaWrites(budget, cost.dataRows)}`,
+  );
 
   if (rows > budget) {
     console.error(
-      `::error::${chain} costs about ${rows} D1 rows written to replay from zero, over the ` +
-        `${budget} row budget in ${budgetsPath}. That affords ${affordable} replays a day ` +
-        `against the ${DAILY_ROWS_WRITTEN_CEILING} rows/day free-tier ceiling, down from ` +
-        `${rebuildsPerDay(budget)} at the budget. The chain has grown, which is what this guard ` +
-        `watches: squash it into a fresh baseline the way xchromo/osn#984 did, or raise the ` +
-        `budget deliberately with the reason in the commit.`,
+      `::error::${chain} is ${cost.schemaWrites} schema writes, over the line at ` +
+        `${budgetInSchemaWrites(budget, cost.dataRows)}. That is about ${rows} D1 rows written to ` +
+        `replay from zero, over the ${budget} row budget in ${budgetsPath}, and affords roughly ` +
+        `${affordable} replays a day against the ${DAILY_ROWS_WRITTEN_CEILING} rows/day ` +
+        `free-tier ceiling, down from ${rebuildsPerDay(budget)} at the budget. The chain has ` +
+        `grown, which is what this guard watches: squash it into a fresh baseline the way ` +
+        `xchromo/osn#984 did, or raise the budget deliberately with the reason in the commit.`,
     );
     return false;
   }

--- a/scripts/guard-d1-migration-cost.ts
+++ b/scripts/guard-d1-migration-cost.ts
@@ -1,0 +1,508 @@
+/**
+ * Guard the D1 cost of building a database from its migration chain.
+ *
+ * WHAT THIS IS FOR. The cire dev deploy crossed a hard free-tier ceiling by
+ * growing, not by breaking. Every `ALTER TABLE ... DROP COLUMN` added to the
+ * chain made each from-zero rebuild a little more expensive, and on 2026-09-09
+ * thirteen merges spent 104,091 D1 rows written against a limit of 100,000 a
+ * day across the whole account (xchromo/osn#979). No commit was wrong and no
+ * test failed. This guard puts a committed number in front of that growth, the
+ * way `scripts/guard-bundle-size.sh` puts one in front of a bundle.
+ *
+ * THE TWO RULES, from wiki/conventions/bundle-size-guards.md, unchanged:
+ *
+ *   1. A budget is a number somebody chose, re-baselined deliberately, with
+ *      the reason in the commit. It lives in one committed file the guard
+ *      reads — scripts/d1-migration-cost-budgets.txt — never as an argument at
+ *      a call site.
+ *   2. A guard that only ever gets raised is not a guard. Raising it is a
+ *      decision with a paragraph attached, not a lockfile refresh. This guard
+ *      has a second answer the bundle one does not: squashing the chain into a
+ *      fresh baseline puts the number back DOWN, which is what
+ *      xchromo/osn#984 did. Reach for that first.
+ *
+ * HOW IT MEASURES. Offline, with no D1 call: it replays every `.sql` file in
+ * the chain into an in-memory `bun:sqlite` database and counts SCHEMA WRITES.
+ * One per statement that changes the schema; two for a statement that makes
+ * SQLite rebuild a whole table (`ALTER TABLE ... DROP COLUMN`). Rows that a
+ * data statement in a migration actually writes are counted exactly, from
+ * SQLite's own `changes`.
+ *
+ * WHY THAT CORRELATES WITH D1's BILL. A from-zero rebuild runs against empty
+ * tables, so the bill is almost all schema churn — of the 200 heaviest queries
+ * on `cire-db-dev` in the week to 2026-09-10, schema statements were 89% of
+ * rows written and the seed's inserts were 11%. SQLite rebuilds the whole
+ * table for every dropped column and D1 bills that against no data at all, so
+ * each schema statement costs a roughly fixed number of rows whatever the
+ * table holds. Two remote measurements fix the constant, and one constant fits
+ * both:
+ *
+ *   - one `ALTER TABLE ... DROP COLUMN` on `wedding_invite_customisations`,
+ *     against a table with no rows in it, cost 54 rows written — two schema
+ *     writes at 27 apiece, exactly;
+ *   - the 57-file chain squashed by xchromo/osn#984 measures 269 schema
+ *     writes here, which at 27 apiece predicts 7,265 rows. The rebuild that
+ *     replayed it cost 8,007 rows written in total, of which the 89% schema
+ *     share is 7,126. The prediction is 2.0% high.
+ *
+ * High is the safe side, and the two together also reproduce the figure the
+ * incident was reported with: 7,265 for the chain plus the seed's share is
+ * 8,007, and 100,000 / 8,007 is the 12 full rebuilds a day that chain afforded.
+ *
+ * HOW TIGHT THAT IS, HONESTLY. Two anchor points, both from one database in
+ * one week, fitted with one constant. It is not a regression and it does not
+ * model D1's accounting; it asserts that a schema statement has a roughly
+ * fixed price, which those two points and the 89/11 split support and nothing
+ * here proves. Treat the printed row count as an estimate good to about ±10%
+ * and the schema-write count as the exact thing being guarded. The estimate
+ * also folds in the per-file `d1_migrations` ledger insert that
+ * `wrangler d1 migrations apply` makes, since the calibration chain paid for
+ * 57 of those — which over-charges a short chain slightly, again on the safe
+ * side.
+ *
+ * WHAT IS NOT IN THE NUMBER. The seed. This guard prices the chain, because
+ * the chain is what a pull request changes; a full dev rebuild drops, replays
+ * and then seeds, and the seed is a further tenth or so on top.
+ *
+ * The read ceiling is not guarded either. It is 5,000,000 a day against
+ * 100,000 written, and the same rebuild that spent 8% of the write allowance
+ * spent 0.5% of the read one, so writes are the binding constraint and a
+ * second threshold would only be a second number to keep true.
+ *
+ * Usage:
+ *   guard-d1-migration-cost.ts --all              every row in the budgets
+ *                                                 file. What ci.yml calls.
+ *   guard-d1-migration-cost.ts <migrations-dir>   one chain, matched to its
+ *                                                 row by repo-relative path.
+ *
+ * D1_MIGRATION_COST_BUDGETS_FILE overrides the budgets file path, and
+ * D1_MIGRATION_COST_BUDGETS_ROOT the root each row's path resolves against
+ * (the repo root in real use; a fixture tree in the tests).
+ */
+
+import { Database } from "bun:sqlite";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * Rows written on D1 per schema write, calibrated against the two remote
+ * measurements in this file's header. Changing it changes every printed
+ * estimate and every headroom figure, so it is a re-baseline of the same
+ * weight as a budget row.
+ */
+export const ROWS_WRITTEN_PER_SCHEMA_WRITE = 27;
+
+/**
+ * Cloudflare D1 Free, rows written per day, shared across every database on
+ * the account. wiki/runbooks/free-tier-limits.md is the source and says to
+ * re-verify it against Cloudflare's own pricing page before acting on it.
+ */
+export const DAILY_ROWS_WRITTEN_CEILING = 100_000;
+
+const SCRIPT_DIR = new URL(".", import.meta.url).pathname;
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+export type ChainCost = {
+  readonly files: number;
+  readonly statements: number;
+  /** Schema statements, with a table-rebuilding one counted twice. */
+  readonly schemaWrites: number;
+  /** Statements that rebuild a table, for the reader — not a separate charge. */
+  readonly tableRebuilds: number;
+  /** Rows a data statement in a migration really wrote, from SQLite. */
+  readonly dataRows: number;
+  readonly estimatedRowsWritten: number;
+};
+
+export type BudgetRecord = {
+  readonly chain: string;
+  readonly budget: number;
+};
+
+/**
+ * Split a Drizzle migration file into single statements.
+ *
+ * Drizzle writes `--> statement-breakpoint` between statements, but not
+ * between every pair of them — the archived cire chain held 283 statements
+ * behind 222 breakpoints — so `;` has to be a separator too. Splitting on a
+ * bare `;` would cut a statement in half the moment a column default or a
+ * `CHECK` held one, so this walks the text: single-quoted strings (with `''`
+ * escapes), the three identifier quotings SQLite accepts, line comments,
+ * block comments, and a trigger's `BEGIN ... END;` body all swallow their
+ * semicolons.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = "";
+  let index = 0;
+  let triggerDepth = 0;
+
+  const flush = () => {
+    const trimmed = stripComments(current).trim();
+    if (trimmed.length > 0) statements.push(trimmed);
+    current = "";
+  };
+
+  /** Whether what has accumulated so far opens a body ended by `END`. */
+  const opensTriggerBody = () =>
+    /\bCREATE\s+(?:TEMP\s+|TEMPORARY\s+)?TRIGGER\b/i.test(stripComments(current));
+
+  while (index < sql.length) {
+    const char = sql[index]!;
+    const rest = sql.slice(index);
+
+    if (char === "'" || char === '"' || char === "`") {
+      const end = closingQuote(sql, index, char);
+      current += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (char === "[") {
+      const end = sql.indexOf("]", index + 1);
+      const stop = end === -1 ? sql.length : end + 1;
+      current += sql.slice(index, stop);
+      index = stop;
+      continue;
+    }
+    if (rest.startsWith("--")) {
+      const lineEnd = sql.indexOf("\n", index);
+      const stop = lineEnd === -1 ? sql.length : lineEnd;
+      const comment = sql.slice(index, stop);
+      // The breakpoint marker is written as a comment, so it has to be
+      // recognised here rather than after comments are stripped.
+      if (/^-->\s*statement-breakpoint/.test(comment)) {
+        flush();
+        triggerDepth = 0;
+      } else {
+        current += comment;
+      }
+      index = stop;
+      continue;
+    }
+    if (rest.startsWith("/*")) {
+      const end = sql.indexOf("*/", index + 2);
+      const stop = end === -1 ? sql.length : end + 2;
+      current += sql.slice(index, stop);
+      index = stop;
+      continue;
+    }
+    if (/^BEGIN\b/i.test(rest) && (triggerDepth > 0 || opensTriggerBody())) {
+      triggerDepth += 1;
+      current += rest.slice(0, 5);
+      index += 5;
+      continue;
+    }
+    if (triggerDepth > 0 && /^END\b/i.test(rest)) {
+      triggerDepth -= 1;
+      current += rest.slice(0, 3);
+      index += 3;
+      continue;
+    }
+    if (char === ";" && triggerDepth === 0) {
+      flush();
+      index += 1;
+      continue;
+    }
+
+    current += char;
+    index += 1;
+  }
+
+  flush();
+  return statements;
+}
+
+/** Index just past the closing quote of the run starting at `open`. */
+function closingQuote(sql: string, open: number, quote: string): number {
+  let index = open + 1;
+  while (index < sql.length) {
+    if (sql[index] === quote) {
+      // A doubled quote is an escaped one and the run continues.
+      if (sql[index + 1] === quote) {
+        index += 2;
+        continue;
+      }
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function stripComments(sql: string): string {
+  return sql
+    .replaceAll(/\/\*[\s\S]*?\*\//g, " ")
+    .split("\n")
+    .map((line) => {
+      const at = indexOfUnquoted(line, "--");
+      return at === -1 ? line : line.slice(0, at);
+    })
+    .join("\n");
+}
+
+/** Where `needle` first sits outside any quoted run of `line`. */
+function indexOfUnquoted(line: string, needle: string): number {
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index]!;
+    if (char === "'" || char === '"' || char === "`") {
+      index = closingQuote(line, index, char);
+      continue;
+    }
+    if (line.startsWith(needle, index)) return index;
+    index += 1;
+  }
+  return -1;
+}
+
+const SCHEMA_STATEMENT = /^(?:CREATE|DROP|ALTER)\b/i;
+/**
+ * `ALTER TABLE <name> DROP [COLUMN] <name>`. SQLite implements this by
+ * rebuilding the table, which is the statement D1 bills at about twice an
+ * ordinary schema write. Anchored on the two names either side of `DROP` so a
+ * column default that merely contains the word does not match.
+ */
+const TABLE_REBUILD = /^ALTER\s+TABLE\s+\S+\s+DROP\s+(?:COLUMN\s+)?\S/i;
+/**
+ * Drizzle's other table rebuild: copy into `__new_x`, drop `x`, rename. Each
+ * of its statements already costs a schema write of its own, so this only
+ * counts them for the reader.
+ */
+const REBUILD_SCRATCH_TABLE = /\b__(?:new|keep)_/i;
+
+/** One statement's contribution, ready to sum. */
+type Charge = {
+  readonly schemaWrites: number;
+  readonly rebuild: boolean;
+};
+
+function chargeFor(statement: string): Charge {
+  const normalised = statement.replaceAll(/\s+/g, " ").trim();
+  if (!SCHEMA_STATEMENT.test(normalised)) return { schemaWrites: 0, rebuild: false };
+  if (TABLE_REBUILD.test(normalised)) return { schemaWrites: 2, rebuild: true };
+  return { schemaWrites: 1, rebuild: REBUILD_SCRATCH_TABLE.test(normalised) };
+}
+
+/**
+ * Replay a chain into an in-memory database and total what a from-zero
+ * rebuild of it costs. Throws when a statement does not apply: a chain that
+ * cannot build is a failure, not a cheap chain.
+ */
+export function measureChain(dir: string): ChainCost {
+  const files = readdirSync(dir)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  if (files.length === 0) {
+    throw new Error(`${dir} holds no .sql migrations — nothing was measured, which is not a pass.`);
+  }
+
+  const db = new Database(":memory:");
+  try {
+    // Off for the same reason `wrangler d1 migrations apply` gets away with
+    // the rebuild idiom: a chain that drops and recreates a parent table
+    // would otherwise fail on its children mid-replay.
+    db.run("PRAGMA foreign_keys=OFF");
+
+    let statements = 0;
+    let schemaWrites = 0;
+    let tableRebuilds = 0;
+    let dataRows = 0;
+
+    for (const file of files) {
+      const sql = readFileSync(join(dir, file), "utf8");
+      for (const statement of splitSqlStatements(sql)) {
+        let changes = 0;
+        try {
+          changes = Number(db.run(statement).changes ?? 0);
+        } catch (cause) {
+          throw new Error(
+            `${file} failed to apply: ${String(cause)}\n  statement: ${statement.slice(0, 200)}`,
+            { cause },
+          );
+        }
+        statements += 1;
+        const charge = chargeFor(statement);
+        schemaWrites += charge.schemaWrites;
+        if (charge.rebuild) tableRebuilds += 1;
+        if (charge.schemaWrites === 0) dataRows += changes;
+      }
+    }
+
+    return {
+      files: files.length,
+      statements,
+      schemaWrites,
+      tableRebuilds,
+      dataRows,
+      estimatedRowsWritten: schemaWrites * ROWS_WRITTEN_PER_SCHEMA_WRITE + dataRows,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/** How many from-zero rebuilds of this cost fit in one day's allowance. */
+export function rebuildsPerDay(rowsWritten: number): number {
+  if (rowsWritten <= 0) return DAILY_ROWS_WRITTEN_CEILING;
+  return Math.floor(DAILY_ROWS_WRITTEN_CEILING / rowsWritten);
+}
+
+/**
+ * Parse the budgets file. Fails closed on any malformed row rather than
+ * skipping it — one bad edit should not quietly stop guarding every chain
+ * after it.
+ */
+export function parseBudgets(contents: string, label: string): readonly BudgetRecord[] {
+  const records: BudgetRecord[] = [];
+  const lines = contents.split("\n");
+
+  for (const [offset, line] of lines.entries()) {
+    const stripped = line.split("#")[0]!.trim();
+    if (stripped.length === 0) continue;
+    const fields = stripped.split(/\s+/);
+    const [chain, budget, ...extra] = fields;
+    if (chain === undefined || budget === undefined || extra.length > 0) {
+      throw new Error(
+        `${label}:${offset + 1}: expected '<migrations-dir> <budget-rows-written>', got '${stripped}'`,
+      );
+    }
+    if (!/^\d+$/.test(budget)) {
+      throw new Error(`${label}:${offset + 1}: budget must be a positive integer, got '${budget}'`);
+    }
+    records.push({ chain, budget: Number(budget) });
+  }
+
+  if (records.length === 0) {
+    throw new Error(`${label} has no records — nothing to guard, which is a broken config.`);
+  }
+  return records;
+}
+
+function percentOfCeiling(rows: number): string {
+  return `${((rows / DAILY_ROWS_WRITTEN_CEILING) * 100).toFixed(1)}%`;
+}
+
+/** Runs one record. Returns true when the chain is inside its budget. */
+export function runGuard(chain: string, dir: string, budget: number, budgetsPath: string): boolean {
+  const cost = measureChain(dir);
+  const rows = cost.estimatedRowsWritten;
+  const affordable = rebuildsPerDay(rows);
+
+  console.log(
+    `${chain}: ${cost.files} migration file(s), ${cost.statements} statements, ` +
+      `${cost.schemaWrites} schema writes, ${cost.tableRebuilds} table-rebuild statement(s)`,
+  );
+  console.log(
+    `  replaying the chain from zero costs about ${rows} D1 rows written ` +
+      `(${percentOfCeiling(rows)} of the ${DAILY_ROWS_WRITTEN_CEILING}/day free-tier ceiling)`,
+  );
+  console.log(`  that affords ${affordable} replay(s) a day, before the seed a full rebuild adds`);
+  console.log(
+    `  budget ${budget} rows written (${rebuildsPerDay(budget)} a day), ` +
+      `${budget - rows} rows of headroom`,
+  );
+
+  if (rows > budget) {
+    console.error(
+      `::error::${chain} costs about ${rows} D1 rows written to replay from zero, over the ` +
+        `${budget} row budget in ${budgetsPath}. That affords ${affordable} replays a day ` +
+        `against the ${DAILY_ROWS_WRITTEN_CEILING} rows/day free-tier ceiling, down from ` +
+        `${rebuildsPerDay(budget)} at the budget. The chain has grown, which is what this guard ` +
+        `watches: squash it into a fresh baseline the way xchromo/osn#984 did, or raise the ` +
+        `budget deliberately with the reason in the commit.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+type LoadedBudgets = {
+  readonly path: string;
+  readonly records: readonly BudgetRecord[];
+};
+
+function resolveBudgetsPath(): string {
+  return (
+    process.env.D1_MIGRATION_COST_BUDGETS_FILE ?? join(SCRIPT_DIR, "d1-migration-cost-budgets.txt")
+  );
+}
+
+function budgetsRoot(): string {
+  return process.env.D1_MIGRATION_COST_BUDGETS_ROOT ?? REPO_ROOT;
+}
+
+function loadBudgets(): LoadedBudgets {
+  const path = resolveBudgetsPath();
+  let contents: string;
+  try {
+    contents = readFileSync(path, "utf8");
+  } catch (cause) {
+    throw new Error(`budgets file not found: ${path}`, { cause });
+  }
+  return { path, records: parseBudgets(contents, path) };
+}
+
+function main(argv: readonly string[]): number {
+  if (argv.length !== 1) {
+    console.error(
+      "::error::usage: guard-d1-migration-cost.ts --all | guard-d1-migration-cost.ts <migrations-dir>",
+    );
+    return 1;
+  }
+
+  let path: string;
+  let records: readonly BudgetRecord[];
+  try {
+    ({ path, records } = loadBudgets());
+  } catch (cause) {
+    console.error(
+      `::error::guard-d1-migration-cost.ts: ${String(cause instanceof Error ? cause.message : cause)}`,
+    );
+    return 1;
+  }
+
+  const root = budgetsRoot();
+  const target = argv[0]!;
+  const selected =
+    target === "--all"
+      ? records
+      : records.filter((record) => resolve(root, record.chain) === resolve(target));
+
+  if (selected.length === 0) {
+    console.error(
+      `::error::guard-d1-migration-cost.ts: no budget recorded for '${target}' in ${path} — ` +
+        `add a row before wiring this chain to the guard.`,
+    );
+    return 1;
+  }
+
+  // Every record runs even after one fails, so a run reports every chain over
+  // budget in one pass instead of stopping at the first.
+  let failed = false;
+  for (const record of selected) {
+    const dir = resolve(root, record.chain);
+    try {
+      if (!statSync(dir).isDirectory()) throw new Error("not a directory");
+    } catch {
+      console.error(
+        `::error::guard-d1-migration-cost.ts: migrations directory '${dir}' does not exist.`,
+      );
+      failed = true;
+      continue;
+    }
+    try {
+      if (!runGuard(record.chain, dir, record.budget, path)) failed = true;
+    } catch (cause) {
+      console.error(
+        `::error::${record.chain}: ${String(cause instanceof Error ? cause.message : cause)}`,
+      );
+      failed = true;
+    }
+  }
+
+  return failed ? 1 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/tests/guard-d1-migration-cost.cli.test.ts
+++ b/scripts/tests/guard-d1-migration-cost.cli.test.ts
@@ -1,0 +1,189 @@
+// The CLI half of the D1 migration-cost guard. The tests beside this file
+// import the measurement functions directly and never reach the
+// `import.meta.main` block, so they say nothing about exit codes, the budgets
+// lookup, or the message a failing run prints — which is the whole of what CI
+// and a reviewer actually see. These run the real, unmodified script as a
+// subprocess against fixture chains, pointing its two environment overrides at
+// a throwaway tree instead of this repo's own.
+
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REAL_SCRIPT = new URL("../guard-d1-migration-cost.ts", import.meta.url).pathname;
+
+type Run = { readonly exitCode: number; readonly stdout: string; readonly stderr: string };
+
+/**
+ * Build a fixture tree — a budgets file plus one directory per chain — and run
+ * the real script against it.
+ */
+async function runCli(
+  budgets: string,
+  chains: Readonly<Record<string, Readonly<Record<string, string>>>>,
+  argument = "--all",
+): Promise<Run> {
+  const root = await mkdtemp(join(tmpdir(), "d1-migration-cost-cli-"));
+
+  try {
+    const budgetsFile = join(root, "budgets.txt");
+    await writeFile(budgetsFile, budgets);
+
+    for (const [chain, files] of Object.entries(chains)) {
+      const dir = join(root, chain);
+      await mkdir(dir, { recursive: true });
+      for (const [name, contents] of Object.entries(files)) {
+        await writeFile(join(dir, name), contents);
+      }
+    }
+
+    const proc = Bun.spawn(["bun", "run", REAL_SCRIPT, argument.replace("<root>", root)], {
+      cwd: root,
+      env: {
+        ...process.env,
+        D1_MIGRATION_COST_BUDGETS_FILE: budgetsFile,
+        D1_MIGRATION_COST_BUDGETS_ROOT: root,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    return { exitCode, stdout, stderr };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const ONE_TABLE = {
+  "0001_initial.sql":
+    "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL, `spare` text);\n" +
+    "--> statement-breakpoint\nCREATE INDEX `a_idx` ON `a` (`spare`);",
+};
+
+test("a chain inside its budget exits 0 and prints the cost, the ceiling and the headroom", async () => {
+  const { exitCode, stdout, stderr } = await runCli("db/migrations 1000\n", {
+    "db/migrations": ONE_TABLE,
+  });
+
+  expect(stderr).toBe("");
+  // Two schema writes at 27 rows apiece.
+  expect(stdout).toContain("2 schema writes");
+  expect(stdout).toContain("about 54 D1 rows written");
+  expect(stdout).toContain("100000/day free-tier ceiling");
+  expect(stdout).toContain("946 rows of headroom");
+  expect(exitCode).toBe(0);
+});
+
+test("the printed affordability is the daily ceiling divided by the cost", async () => {
+  const { stdout } = await runCli("db/migrations 1000\n", { "db/migrations": ONE_TABLE });
+  // 100,000 / 54.
+  expect(stdout).toContain("that affords 1851 replay(s) a day");
+});
+
+test("a chain over its budget exits non-zero and names the figure and the ceiling", async () => {
+  const { exitCode, stdout, stderr } = await runCli("db/migrations 100\n", {
+    "db/migrations": {
+      ...ONE_TABLE,
+      // Eight dropped columns, the shape that made the pre-squash chain
+      // expensive: eight table rebuilds at two schema writes each.
+      "0002_drop.sql": Array.from(
+        { length: 8 },
+        (_, index) => `ALTER TABLE \`a\` ADD \`c${index}\` text;`,
+      )
+        .concat(
+          Array.from({ length: 8 }, (_, index) => `ALTER TABLE \`a\` DROP COLUMN \`c${index}\`;`),
+        )
+        .join("\n--> statement-breakpoint\n"),
+    },
+  });
+
+  expect(exitCode).toBe(1);
+  expect(stdout).toContain("8 table-rebuild statement(s)");
+  expect(stderr).toContain("::error::");
+  expect(stderr).toContain("over the 100 row budget");
+  expect(stderr).toContain("100000 rows/day free-tier ceiling");
+  expect(stderr).toContain("squash it into a fresh baseline");
+});
+
+test("every chain is reported before the run fails, not just the first", async () => {
+  const { exitCode, stdout, stderr } = await runCli("db/one 1\ndb/two 1\n", {
+    "db/one": ONE_TABLE,
+    "db/two": ONE_TABLE,
+  });
+
+  expect(exitCode).toBe(1);
+  expect(stdout).toContain("db/one:");
+  expect(stdout).toContain("db/two:");
+  expect(stderr.match(/::error::/g)).toHaveLength(2);
+});
+
+test("a chain with no row in the budgets file is an error, not a silent skip", async () => {
+  const { exitCode, stderr } = await runCli(
+    "db/migrations 1000\n",
+    { "db/migrations": ONE_TABLE, "db/other": ONE_TABLE },
+    "<root>/db/other",
+  );
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("no budget recorded for");
+});
+
+test("a single chain can be named by path, and only that one runs", async () => {
+  const { exitCode, stdout } = await runCli(
+    "db/one 1000\ndb/two 1\n",
+    { "db/one": ONE_TABLE, "db/two": ONE_TABLE },
+    "<root>/db/one",
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("db/one:");
+  expect(stdout).not.toContain("db/two:");
+});
+
+test("a chain whose directory is missing is an error", async () => {
+  const { exitCode, stderr } = await runCli("db/gone 1000\n", {});
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("does not exist");
+});
+
+test("a chain directory holding no .sql files is an error, not a pass", async () => {
+  const { exitCode, stderr } = await runCli("db/migrations 1000\n", {
+    "db/migrations": { "README.md": "nothing here" },
+  });
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("holds no .sql migrations");
+});
+
+test("a chain that does not apply fails rather than measuring cheap", async () => {
+  const { exitCode, stderr } = await runCli("db/migrations 1000\n", {
+    "db/migrations": { "0001_initial.sql": "CREATE INDEX `i` ON `nope` (`id`);" },
+  });
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("failed to apply");
+});
+
+test("a malformed budgets row stops the run rather than being skipped", async () => {
+  const { exitCode, stderr } = await runCli("db/migrations\n", { "db/migrations": ONE_TABLE });
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("expected '<migrations-dir> <budget-rows-written>'");
+});
+
+test("an empty budgets file is a broken config, not a pass", async () => {
+  const { exitCode, stderr } = await runCli("# nothing\n", {});
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("has no records");
+});
+
+test("calling it with no argument is a usage error", async () => {
+  const proc = Bun.spawn(["bun", "run", REAL_SCRIPT], { stdout: "pipe", stderr: "pipe" });
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("usage:");
+});

--- a/scripts/tests/guard-d1-migration-cost.cli.test.ts
+++ b/scripts/tests/guard-d1-migration-cost.cli.test.ts
@@ -83,8 +83,31 @@ test("a chain inside its budget exits 0 and prints the cost, the ceiling and the
 
 test("the printed affordability is the daily ceiling divided by the cost", async () => {
   const { stdout } = await runCli("db/migrations 1000\n", { "db/migrations": ONE_TABLE });
-  // 100,000 / 54.
-  expect(stdout).toContain("that affords 1851 replay(s) a day");
+  // 100,000 / 54, hedged because the price per schema write is only pinned to
+  // a band.
+  expect(stdout).toContain("that affords roughly 1851 replay(s) a day");
+});
+
+// Every row figure the guard prints is priced by a constant the evidence pins
+// only to about 22-27, so the guard also states its line in the unit it counts
+// exactly. 1000 rows of budget is 37 schema writes at 27 apiece.
+test("the line is also printed in schema writes, which needs no constant", async () => {
+  const { stdout } = await runCli("db/migrations 1000\n", { "db/migrations": ONE_TABLE });
+  expect(stdout).toContain("exactly: 2 schema writes against a line at 37");
+});
+
+test("the schema-write line takes real data rows off the top first", async () => {
+  const { stdout } = await runCli("db/migrations 1000\n", {
+    "db/migrations": {
+      ...ONE_TABLE,
+      // Ten real rows, so 990 of the 1000 is left to spend on schema writes.
+      "0002_backfill.sql": `INSERT INTO \`a\` (\`id\`) VALUES ${Array.from(
+        { length: 10 },
+        (_, index) => `('r${index}')`,
+      ).join(", ")};`,
+    },
+  });
+  expect(stdout).toContain("exactly: 2 schema writes against a line at 36");
 });
 
 test("a chain over its budget exits non-zero and names the figure and the ceiling", async () => {
@@ -107,6 +130,8 @@ test("a chain over its budget exits non-zero and names the figure and the ceilin
   expect(exitCode).toBe(1);
   expect(stdout).toContain("8 table-rebuild statement(s)");
   expect(stderr).toContain("::error::");
+  // The exact count and line first, then the priced figures.
+  expect(stderr).toContain("26 schema writes, over the line at 3");
   expect(stderr).toContain("over the 100 row budget");
   expect(stderr).toContain("100000 rows/day free-tier ceiling");
   expect(stderr).toContain("squash it into a fresh baseline");

--- a/scripts/tests/guard-d1-migration-cost.test.ts
+++ b/scripts/tests/guard-d1-migration-cost.test.ts
@@ -1,0 +1,250 @@
+// The pure half of the D1 migration-cost guard: the statement splitter, the
+// replay-and-count measurement, and the budgets-file parser. The CLI half —
+// exit codes, the budgets lookup, the error text — is in the .cli.test.ts
+// beside this file.
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DAILY_ROWS_WRITTEN_CEILING,
+  measureChain,
+  parseBudgets,
+  rebuildsPerDay,
+  ROWS_WRITTEN_PER_SCHEMA_WRITE,
+  splitSqlStatements,
+} from "../guard-d1-migration-cost";
+
+async function withChain<T>(
+  files: Readonly<Record<string, string>>,
+  run: (dir: string) => T,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "d1-migration-cost-"));
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      await writeFile(join(dir, name), contents);
+    }
+    return run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("splits on Drizzle's statement-breakpoint marker", () => {
+  const statements = splitSqlStatements(
+    "CREATE TABLE `a` (`id` text);\n--> statement-breakpoint\nCREATE TABLE `b` (`id` text);",
+  );
+  expect(statements).toHaveLength(2);
+  expect(statements[0]).toContain("`a`");
+  expect(statements[1]).toContain("`b`");
+});
+
+test("splits on bare semicolons too, since Drizzle does not breakpoint every pair", () => {
+  const statements = splitSqlStatements("DROP TABLE `a`; DROP TABLE `b`; DROP TABLE `c`;");
+  expect(statements).toHaveLength(3);
+});
+
+test("a semicolon inside a string default does not split the statement", () => {
+  const statements = splitSqlStatements(
+    "CREATE TABLE `a` (`note` text DEFAULT 'one; two' NOT NULL);",
+  );
+  expect(statements).toHaveLength(1);
+  expect(statements[0]).toContain("one; two");
+});
+
+test("a doubled quote inside a string default does not end the string", () => {
+  const statements = splitSqlStatements(
+    "CREATE TABLE `a` (`note` text DEFAULT 'it''s; fine' NOT NULL);",
+  );
+  expect(statements).toHaveLength(1);
+});
+
+test("a semicolon inside a quoted identifier does not split the statement", () => {
+  const statements = splitSqlStatements('CREATE TABLE "od;d" ("id" text);');
+  expect(statements).toHaveLength(1);
+});
+
+test("a semicolon inside a comment does not split the statement", () => {
+  const statements = splitSqlStatements(
+    "-- a note; with a semicolon\nCREATE TABLE `a` (`id` text);\n/* another; one */\nCREATE TABLE `b` (`id` text);",
+  );
+  expect(statements).toHaveLength(2);
+});
+
+test("a trigger body's semicolons stay inside one statement", () => {
+  const statements = splitSqlStatements(
+    "CREATE TRIGGER `t` AFTER INSERT ON `a` BEGIN UPDATE `a` SET `id` = 'x'; DELETE FROM `a`; END;\n" +
+      "--> statement-breakpoint\nCREATE TABLE `b` (`id` text);",
+  );
+  expect(statements).toHaveLength(2);
+  expect(statements[0]).toContain("DELETE FROM");
+});
+
+test("comment-only files contribute no statements", () => {
+  expect(splitSqlStatements("-- nothing here\n\n/* nor here */\n")).toEqual([]);
+});
+
+test("each schema statement is one schema write", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql":
+        "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL, `spare` text);\n" +
+        "--> statement-breakpoint\nCREATE INDEX `a_idx` ON `a` (`spare`);",
+    },
+    measureChain,
+  );
+  expect(cost.files).toBe(1);
+  expect(cost.statements).toBe(2);
+  expect(cost.schemaWrites).toBe(2);
+  expect(cost.tableRebuilds).toBe(0);
+  expect(cost.estimatedRowsWritten).toBe(2 * ROWS_WRITTEN_PER_SCHEMA_WRITE);
+});
+
+test("a dropped column is charged twice, because SQLite rebuilds the table", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL, `spare` text);",
+      "0002_drop.sql": "ALTER TABLE `a` DROP COLUMN `spare`;",
+    },
+    measureChain,
+  );
+  expect(cost.statements).toBe(2);
+  expect(cost.schemaWrites).toBe(3);
+  expect(cost.tableRebuilds).toBe(1);
+});
+
+test("the bare `DROP <column>` spelling is charged the same as `DROP COLUMN`", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL, `spare` text);",
+      "0002_drop.sql": "ALTER TABLE `a` DROP `spare`;",
+    },
+    measureChain,
+  );
+  expect(cost.schemaWrites).toBe(3);
+  expect(cost.tableRebuilds).toBe(1);
+});
+
+test("a column default containing the word DROP is not mistaken for a rebuild", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL);",
+      "0002_add.sql": "ALTER TABLE `a` ADD `state` text DEFAULT 'DROP' NOT NULL;",
+    },
+    measureChain,
+  );
+  expect(cost.schemaWrites).toBe(2);
+  expect(cost.tableRebuilds).toBe(0);
+});
+
+test("the __new_/__keep_ rebuild idiom is reported, and each of its statements charged once", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL, `spare` text);",
+      "0002_rebuild.sql":
+        "CREATE TABLE `__new_a` (`id` text PRIMARY KEY NOT NULL);\n" +
+        "--> statement-breakpoint\nINSERT INTO `__new_a` (`id`) SELECT `id` FROM `a`;\n" +
+        "--> statement-breakpoint\nDROP TABLE `a`;\n" +
+        "--> statement-breakpoint\nALTER TABLE `__new_a` RENAME TO `a`;",
+    },
+    measureChain,
+  );
+  expect(cost.statements).toBe(5);
+  // The INSERT is a data statement: no schema write, and no rows to copy.
+  expect(cost.schemaWrites).toBe(4);
+  // The two schema statements naming the scratch table. The plain
+  // `DROP TABLE a` beside them is an ordinary schema write.
+  expect(cost.tableRebuilds).toBe(2);
+  expect(cost.dataRows).toBe(0);
+});
+
+test("rows a migration really writes are counted from SQLite, not estimated", async () => {
+  const cost = await withChain(
+    {
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL);",
+      "0002_backfill.sql": "INSERT INTO `a` (`id`) VALUES ('x'), ('y'), ('z');",
+    },
+    measureChain,
+  );
+  expect(cost.schemaWrites).toBe(1);
+  expect(cost.dataRows).toBe(3);
+  expect(cost.estimatedRowsWritten).toBe(ROWS_WRITTEN_PER_SCHEMA_WRITE + 3);
+});
+
+// `measureChain` is synchronous, so these assert on the call itself rather
+// than on a rejected promise — the temp directory is the only async part.
+test("a chain that does not apply throws rather than measuring cheap", async () => {
+  await withChain({ "0001_init.sql": "CREATE INDEX `i` ON `nope` (`id`);" }, (dir) => {
+    expect(() => measureChain(dir)).toThrow("0001_init.sql failed to apply");
+  });
+});
+
+test("a directory with no migrations throws rather than passing", async () => {
+  await withChain({ "README.md": "not a migration" }, (dir) => {
+    expect(() => measureChain(dir)).toThrow("holds no .sql migrations");
+  });
+});
+
+test("files are replayed in filename order", async () => {
+  // 0002 depends on 0001 having run, so a chain measured out of order fails.
+  const cost = await withChain(
+    {
+      "0002_add.sql": "ALTER TABLE `a` ADD `spare` text;",
+      "0001_init.sql": "CREATE TABLE `a` (`id` text PRIMARY KEY NOT NULL);",
+    },
+    measureChain,
+  );
+  expect(cost.schemaWrites).toBe(2);
+});
+
+test("rebuildsPerDay divides the daily ceiling and rounds down", () => {
+  expect(rebuildsPerDay(1000)).toBe(100);
+  expect(rebuildsPerDay(7265)).toBe(13);
+  expect(rebuildsPerDay(DAILY_ROWS_WRITTEN_CEILING + 1)).toBe(0);
+});
+
+test("parseBudgets reads a row and ignores comments and blank lines", () => {
+  const records = parseBudgets(
+    "# a note\n\ncire/db/migrations 3700 # measured 1836\n",
+    "budgets.txt",
+  );
+  expect(records).toEqual([{ chain: "cire/db/migrations", budget: 3700 }]);
+});
+
+test("parseBudgets rejects a row with a missing field", () => {
+  expect(() => parseBudgets("cire/db/migrations\n", "budgets.txt")).toThrow("budgets.txt:1");
+});
+
+test("parseBudgets rejects a row with an extra field", () => {
+  expect(() => parseBudgets("cire/db/migrations 3700 extra\n", "budgets.txt")).toThrow(
+    "budgets.txt:1",
+  );
+});
+
+test("parseBudgets rejects a non-numeric budget", () => {
+  expect(() => parseBudgets("cire/db/migrations lots\n", "budgets.txt")).toThrow(
+    "budget must be a positive integer",
+  );
+});
+
+test("parseBudgets rejects a file with no records at all", () => {
+  expect(() => parseBudgets("# only a comment\n", "budgets.txt")).toThrow("has no records");
+});
+
+// The fixtures above prove the guard works. This one proves the tree it guards
+// still passes it, so a migration that busts the budget fails `bun run
+// test:scripts` as well as the workflow step.
+test("every committed chain is inside its committed budget", () => {
+  const root = new URL("../../", import.meta.url).pathname;
+  const budgetsFile = join(root, "scripts/d1-migration-cost-budgets.txt");
+  const records = parseBudgets(readFileSync(budgetsFile, "utf8"), budgetsFile);
+
+  expect(records.length).toBeGreaterThan(0);
+  for (const record of records) {
+    const cost = measureChain(join(root, record.chain));
+    expect(cost.estimatedRowsWritten).toBeLessThanOrEqual(record.budget);
+  }
+});

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -225,24 +225,51 @@ chain that no longer applies fails the guard instead of measuring cheap.
 
 `bun:sqlite` cannot report D1's rows-read/rows-written accounting, so the row
 figure is a **proxy priced by one constant**: 27 D1 rows written per schema
-write. A from-zero rebuild runs against empty tables, so its bill is nearly all
-schema churn — of the 200 heaviest queries on `cire-db-dev` in the week to
-2026-09-10, schema statements were 89% of rows written and the seed's inserts
-11% — and D1 bills a table rebuild whatever the table holds. Two remote
-measurements fix the constant, and one value fits both:
+write. A from-zero rebuild runs against empty tables, so nearly all of what it
+spends is schema churn — D1 bills a table rebuild whatever the table holds — and
+the constant asserts that each schema statement therefore has a roughly fixed
+price. One measurement fixes it; a second only bounds it.
 
-| Anchor | Measured on D1 | Guard's estimate |
-|---|---:|---:|
-| One `ALTER TABLE ... DROP COLUMN` on an empty `wedding_invite_customisations` | 54 rows written | 2 schema writes → **54** |
-| The 57-file chain squashed by xchromo/osn#984 (269 schema writes) | 8,007 rows written for the whole rebuild, of which the 89% schema share is 7,126 | **7,265**, 2.0% high |
+**The hard anchor.** One `ALTER TABLE ... DROP COLUMN` on
+`wedding_invite_customisations`, against a table with no rows in it, cost **54
+D1 rows written** — two schema writes at 27 apiece.
+<!-- measured 2026-09-10: bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes --limit=200 -->
 
-> [!warning] Two anchors, one constant — not a regression
-> Both readings come from one database in one week. The model asserts that a
-> schema statement has a roughly fixed price; it does not reconstruct D1's
-> accounting, and nothing here proves it. Treat the printed row figure as good
-> to about ±10% and the schema-write count as the exact thing being guarded.
+**The soft anchor**, which agrees within about a fifth and no better. The
+57-file chain squashed by xchromo/osn#984 measures 269 schema writes here, and
+its rebuild cost **8,007 D1 rows written** in total — but that total covers
+drop, replay *and* seed, so it bounds the chain only once the seed is taken off,
+and the seed's cost is the part not known precisely.
+<!-- 8,007 is unverified here: taken from [[free-tier-limits]] and the xchromo/osn#979 investigation, not re-derived -->
+
+| Bound on the constant | Where it comes from |
+|---:|---|
+| **≤ 22.1** rows per schema write | `cire/db/seed/dev-seed.sql` inserts **2,063 tuples**, and D1 bills index entries as rows written too, so the seed cost at least that. The chain is then at most 8,007 − 2,063 = 5,944.<br><!-- measured 2026-09-10: replay cire/db/migrations/0001_initial.sql then cire/db/seed/dev-seed.sql into bun:sqlite and sum SQLite's `changes` --> |
+| **27** rows per schema write | The hard anchor above — the only figure measured directly. |
+
+> [!warning] The "89% schema, 11% seed" split does not settle this
+> That split is taken from the **200 heaviest queries** — 56,852 rows written
+> across those 200, against roughly 409,000 on the database over the week's
+> rebuild days — so it is a share of a sample, not a share of a rebuild.
+> Multiplying 8,007 by 0.89 is not sound: the seed cost it implies, 881 rows,
+> is below the seed's own floor of 2,063, which is the tell that the sample
+> over-represents schema statements. Neither sampling figure was re-derived
+> when this section was written.
+
+So the constant sits somewhere around **22 to 27**, and the guard uses 27: the
+top of the band, the only directly measured point, and the safe side, since
+over-stating a rebuild is the error that does not lose a day's quota.
+
+> [!important] What the uncertainty touches
+> The **schema-write count is exact** — counted, not modelled — and it is what
+> to trust. Every **row** figure on this page or in the guard's output, and
+> every "replays a day" derived from one, carries the 22–27 band: read them as
+> indicative, and as pessimistic by up to about a fifth rather than optimistic.
+> The guard prints its line in schema writes beside the row budget for that
+> reason, so the threshold can be read without the constant.
+>
 > Three things sit outside the number on purpose: the **seed** a full dev
-> rebuild runs after the replay (a further tenth or so), the per-file
+> rebuild runs after the replay (2,063 tuples, on top), the per-file
 > `d1_migrations` ledger insert (folded into the constant, which over-charges a
 > short chain slightly), and **rows read**, whose ceiling is 5,000,000 a day
 > against 100,000 written and has never been the binding one.
@@ -252,13 +279,21 @@ measurements fix the constant, and one value fits both:
 **This table is documentation, not enforcement.** The `.txt` file is what the
 guard reads; if the two disagree, it is right and this page is stale.
 
-| Chain | Measured (2026-09-10) | Budget | Replays a day |
-|---|---:|---:|---:|
-| `cire/db/migrations` | 1,836 rows (68 schema writes) | 3,700 rows | 54 now, 27 at the budget |
+| Chain | Schema writes now | Line | Priced at 27 | Replays a day (indicative) |
+|---|---:|---:|---:|---:|
+| `cire/db/migrations` | **68** | **137** | 1,836 → 3,700 rows | ~54 now, ~27 at the line |
 
-The pre-squash chain, for scale: 269 schema writes, ~7,265 rows, 13 replays a
-day. Point the guard at `cire/db/migrations-archive` and it goes red, which is
-the fastest way to see it fail.
+The left two columns are exact; the right two move with the constant. The
+pre-squash chain, for scale: 269 schema writes, about 7,265 rows, roughly 13
+replays a day. Point the guard at `cire/db/migrations-archive` and it goes red,
+which is the fastest way to see it fail.
+<!-- measured 2026-09-10: bun run scripts/guard-d1-migration-cost.ts --all -->
+
+**Note the arithmetic on the pre-squash chain does not reproduce 8,007.** At 27
+it prices at 7,265 and the seed floor is 2,063, which sums past the reported
+total — which is another way of saying the true constant is nearer the bottom
+of the band than the top, and that the guard is deliberately charging more than
+a rebuild probably costs.
 
 ### Why the headroom is a doubling, not a hair
 
@@ -266,11 +301,13 @@ The rule further up this page — headroom smaller than the smallest mistake —
 assumes a baseline that is not supposed to move. A migration chain is supposed
 to grow, and the mistake here is not one bad migration: nothing in the chain
 that went over the ceiling was wrong. So the line is drawn at a **doubling** of
-the per-rebuild bill, which is the smallest step that materially changes the
-answer to "how many rebuilds a day can we afford". A budget tight enough to
-trip on one ordinary feature migration — `0057_registry` was 405 rows on its own
-— would be raised on sight every few pull requests, which is the failure the
-second rule names.
+the chain — 68 schema writes now, tripping at 137 — which is the smallest step
+that materially changes the answer to "how many rebuilds a day can we afford".
+A budget tight enough to trip on one ordinary feature migration —
+`0057_registry` was 15 schema writes on its own — would be raised on sight every
+few pull requests, which is the failure the second rule names. The doubling is
+in the exact unit, so it holds wherever in the 22–27 band the constant really
+sits.
 
 The other half of that: **this guard has a remedy the bundle guards do not.**
 Squashing the chain into a fresh baseline puts the number back down instead of

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -233,7 +233,7 @@ price. One measurement fixes it; a second only bounds it.
 **The hard anchor.** One `ALTER TABLE ... DROP COLUMN` on
 `wedding_invite_customisations`, against a table with no rows in it, cost **54
 D1 rows written** — two schema writes at 27 apiece.
-<!-- measured 2026-09-10: bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes --limit=200 -->
+*Measured 2026-09-10 — `bunx wrangler d1 insights cire-db-dev --time-period=7d --sort-by=writes --limit=200`. The `--limit` is the point: it returns the 200 heaviest queries, not the week.*
 
 **The soft anchor**, which agrees within about a fifth and no better. The
 57-file chain squashed by xchromo/osn#984 measures 269 schema writes here, and
@@ -244,7 +244,7 @@ and the seed's cost is the part not known precisely.
 
 | Bound on the constant | Where it comes from |
 |---:|---|
-| **≤ 22.1** rows per schema write | `cire/db/seed/dev-seed.sql` inserts **2,063 tuples**, and D1 bills index entries as rows written too, so the seed cost at least that. The chain is then at most 8,007 − 2,063 = 5,944.<br><!-- measured 2026-09-10: replay cire/db/migrations/0001_initial.sql then cire/db/seed/dev-seed.sql into bun:sqlite and sum SQLite's `changes` --> |
+| **≤ 22.1** rows per schema write | `cire/db/seed/dev-seed.sql` inserts **2,063 tuples**, and D1 bills index entries as rows written too, so the seed cost at least that. The chain is then at most 8,007 − 2,063 = 5,944.<br>*Measured 2026-09-10 — replay `cire/db/migrations/0001_initial.sql` then `cire/db/seed/dev-seed.sql` into `bun:sqlite` and sum SQLite's `changes`.* |
 | **27** rows per schema write | The hard anchor above — the only figure measured directly. |
 
 > [!warning] The "89% schema, 11% seed" split does not settle this
@@ -287,7 +287,7 @@ The left two columns are exact; the right two move with the constant. The
 pre-squash chain, for scale: 269 schema writes, about 7,265 rows, roughly 13
 replays a day. Point the guard at `cire/db/migrations-archive` and it goes red,
 which is the fastest way to see it fail.
-<!-- measured 2026-09-10: bun run scripts/guard-d1-migration-cost.ts --all -->
+*Measured 2026-09-10 — `bun run scripts/guard-d1-migration-cost.ts --all`.*
 
 **Note the arithmetic on the pre-squash chain does not reproduce 8,007.** At 27
 it prices at 7,265 and the seed floor is 2,063, which sums past the reported

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -1,16 +1,18 @@
 ---
-title: Astro bundle-size guards
-description: scripts/guard-bundle-size.sh — measuring and gating each Astro app's deployed bundle, and the src/pages test-route check beside it
-tags: [convention, build, astro, performance]
+title: Guards that gate on a number
+description: The two rules any committed threshold obeys, and the guards that hold them — scripts/guard-bundle-size.sh over each Astro app's deployed bundle, the src/pages test-route check beside it, and scripts/guard-d1-migration-cost.ts over what a from-zero D1 rebuild spends against the free-tier ceiling
+tags: [convention, build, astro, performance, ops, d1]
 related:
   - "[[cire-development]]"
   - "[[frontend-patterns]]"
   - "[[testing-patterns]]"
   - "[[review-findings]]"
+  - "[[free-tier-limits]]"
+  - "[[dev-environment]]"
 last-reviewed: 2026-09-10
 ---
 
-# Astro bundle-size guards
+# Guards that gate on a number
 
 Tracker #287 found cire/invites' SSR Worker bundle at 470 KB gzip, unnoticed,
 from two mistakes: a whole animation library reachable from the server module
@@ -20,6 +22,11 @@ fix cire/invites got: both mistakes can happen in any of the repo's six Astro
 apps, and both are now checked on every one of them.
 
 Two separate scripts, because the two mistakes are different shapes.
+
+A third guard on this page measures nothing to do with bundles. `scripts/guard-d1-migration-cost.ts`
+gates what a from-zero D1 rebuild spends against a free-tier quota, and it is
+here because it obeys the same two rules and was built from this page. The page
+name still says bundles because the file has not moved.
 
 ## Two rules for any guard that gates on a number
 
@@ -188,8 +195,103 @@ cire/invites picked up 119 KB gzip of vitest. This check walks all six apps'
 It needs no build and no per-app baseline — a plain directory walk — so it runs
 in the fast `lint` job in `ci.yml`, not `build-test`.
 
+## `scripts/guard-d1-migration-cost.ts` — the D1 rebuild-cost guard
+
+Same shape, different number: what a **job** spends against a **quota**, rather
+than how big an artefact is.
+
+The cire dev deploy crossed a hard ceiling by growing. Every
+`ALTER TABLE ... DROP COLUMN` added to the migration chain made each from-zero
+rebuild a little dearer, and on 2026-09-09 thirteen merges spent 104,091 D1 rows
+written against a free-tier limit of 100,000 a day account-wide
+(xchromo/osn#979). No commit was wrong; no version of the job failed a test.
+[[free-tier-limits]] holds the ceiling itself; [[dev-environment]] holds what the
+rebuild now does.
+
+```
+bun run scripts/guard-d1-migration-cost.ts --all              # every chain — what ci.yml calls
+bun run scripts/guard-d1-migration-cost.ts <migrations-dir>   # one chain
+```
+
+### What it counts, and how tight the correlation is
+
+The measurement is local and offline — no D1 call. The guard replays every
+`.sql` file in the chain into an in-memory `bun:sqlite` database and counts
+**schema writes**: one per statement that changes the schema, two for a
+statement that makes SQLite rebuild a whole table (`ALTER TABLE ... DROP
+COLUMN`). Rows that a data statement in a migration really writes are counted
+exactly, from SQLite's own `changes`. Replaying rather than parsing means a
+chain that no longer applies fails the guard instead of measuring cheap.
+
+`bun:sqlite` cannot report D1's rows-read/rows-written accounting, so the row
+figure is a **proxy priced by one constant**: 27 D1 rows written per schema
+write. A from-zero rebuild runs against empty tables, so its bill is nearly all
+schema churn — of the 200 heaviest queries on `cire-db-dev` in the week to
+2026-09-10, schema statements were 89% of rows written and the seed's inserts
+11% — and D1 bills a table rebuild whatever the table holds. Two remote
+measurements fix the constant, and one value fits both:
+
+| Anchor | Measured on D1 | Guard's estimate |
+|---|---:|---:|
+| One `ALTER TABLE ... DROP COLUMN` on an empty `wedding_invite_customisations` | 54 rows written | 2 schema writes → **54** |
+| The 57-file chain squashed by xchromo/osn#984 (269 schema writes) | 8,007 rows written for the whole rebuild, of which the 89% schema share is 7,126 | **7,265**, 2.0% high |
+
+> [!warning] Two anchors, one constant — not a regression
+> Both readings come from one database in one week. The model asserts that a
+> schema statement has a roughly fixed price; it does not reconstruct D1's
+> accounting, and nothing here proves it. Treat the printed row figure as good
+> to about ±10% and the schema-write count as the exact thing being guarded.
+> Three things sit outside the number on purpose: the **seed** a full dev
+> rebuild runs after the replay (a further tenth or so), the per-file
+> `d1_migrations` ledger insert (folded into the constant, which over-charges a
+> short chain slightly), and **rows read**, whose ceiling is 5,000,000 a day
+> against 100,000 written and has never been the binding one.
+
+### The budget — mirrors `scripts/d1-migration-cost-budgets.txt`
+
+**This table is documentation, not enforcement.** The `.txt` file is what the
+guard reads; if the two disagree, it is right and this page is stale.
+
+| Chain | Measured (2026-09-10) | Budget | Replays a day |
+|---|---:|---:|---:|
+| `cire/db/migrations` | 1,836 rows (68 schema writes) | 3,700 rows | 54 now, 27 at the budget |
+
+The pre-squash chain, for scale: 269 schema writes, ~7,265 rows, 13 replays a
+day. Point the guard at `cire/db/migrations-archive` and it goes red, which is
+the fastest way to see it fail.
+
+### Why the headroom is a doubling, not a hair
+
+The rule further up this page — headroom smaller than the smallest mistake —
+assumes a baseline that is not supposed to move. A migration chain is supposed
+to grow, and the mistake here is not one bad migration: nothing in the chain
+that went over the ceiling was wrong. So the line is drawn at a **doubling** of
+the per-rebuild bill, which is the smallest step that materially changes the
+answer to "how many rebuilds a day can we afford". A budget tight enough to
+trip on one ordinary feature migration — `0057_registry` was 405 rows on its own
+— would be raised on sight every few pull requests, which is the failure the
+second rule names.
+
+The other half of that: **this guard has a remedy the bundle guards do not.**
+Squashing the chain into a fresh baseline puts the number back down instead of
+moving the line up, which is exactly what xchromo/osn#984 did — 269 schema
+writes to 68. Reach for that before raising the budget.
+
+### Where it runs
+
+One step in `ci.yml`'s `script-tests` job. That job does no `bun install` on
+purpose, and the script imports `bun:sqlite` and Node built-ins and nothing
+else, so it belongs there rather than in `build-test`. Its own tests
+(`scripts/tests/guard-d1-migration-cost.test.ts` for the measurement,
+`.cli.test.ts` for exit codes and messages) run in the same job under
+`bun run test:scripts`, and one of them re-asserts the committed budget against
+the committed chain — so a migration that busts it fails the tests as well as
+the guard step.
+
 ## Related
 
+- [[free-tier-limits]] — the D1 ceilings this guard is measured against
+- [[dev-environment]] — what the nightly cire dev rebuild does and costs
 - [[cire-development]] — cire/invites' own bundle history (#618 sessions off,
   #616 SSR minification, #617 why `zod` stays)
 - [[frontend-patterns]] — general Astro/Solid patterns

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -244,7 +244,7 @@ about 22–27, so read the row figure as indicative and the schema-write count a
 exact. Method, calibration and how to re-baseline: [[bundle-size-guards]], which
 also sets out why the "89% / 11%" split above cannot be read as a share of one
 rebuild.
-<!-- measured 2026-09-10: bun run scripts/guard-d1-migration-cost.ts --all -->
+*Measured 2026-09-10 — `bun run scripts/guard-d1-migration-cost.ts --all`.*
 
 
 **User-visible symptom:** 503 / "service unavailable" across the app until the

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -234,7 +234,12 @@ runs. Budget after: one rebuild a day, 8% of the write ceiling.
 **The number to watch is per-deploy, not per-day.** Any job that rebuilds a
 database from zero costs rows in proportion to the *number of migrations*, not
 the amount of data, and that number only grows. Before adding one, work out its
-cost against 100K/day.
+cost against 100K/day. `scripts/guard-d1-migration-cost.ts` works the cire chain
+out on every pull request — replaying it offline into an in-memory SQLite and
+failing when the estimate passes the budget in
+`scripts/d1-migration-cost-budgets.txt`. It is 1,836 rows written today, 54
+replays a day. Method, calibration and how to re-baseline:
+[[bundle-size-guards]].
 
 **User-visible symptom:** 503 / "service unavailable" across the app until the
 daily counter resets at **UTC midnight**, or storage is freed.

--- a/wiki/runbooks/free-tier-limits.md
+++ b/wiki/runbooks/free-tier-limits.md
@@ -237,9 +237,15 @@ the amount of data, and that number only grows. Before adding one, work out its
 cost against 100K/day. `scripts/guard-d1-migration-cost.ts` works the cire chain
 out on every pull request — replaying it offline into an in-memory SQLite and
 failing when the estimate passes the budget in
-`scripts/d1-migration-cost-budgets.txt`. It is 1,836 rows written today, 54
-replays a day. Method, calibration and how to re-baseline:
-[[bundle-size-guards]].
+`scripts/d1-migration-cost-budgets.txt`. The chain is **68 schema writes**
+against a line at 137; priced at 27 rows each that is about 1,800 written and
+roughly 54 replays a day, but the price per schema write is only pinned to
+about 22–27, so read the row figure as indicative and the schema-write count as
+exact. Method, calibration and how to re-baseline: [[bundle-size-guards]], which
+also sets out why the "89% / 11%" split above cannot be read as a share of one
+rebuild.
+<!-- measured 2026-09-10: bun run scripts/guard-d1-migration-cost.ts --all -->
+
 
 **User-visible symptom:** 503 / "service unavailable" across the app until the
 daily counter resets at **UTC midnight**, or storage is freed.


### PR DESCRIPTION
Closes #991.

## What

The cire dev deploy crossed a hard free-tier ceiling by **growing, not by breaking**. Every `ALTER TABLE ... DROP COLUMN` added to the chain made each from-zero rebuild slightly dearer, and on 2026-09-09 thirteen merges spent 104,091 D1 rows written against 100,000 a day account-wide (#979). No commit was wrong and no test failed.

This repository already guards a number that creeps — `scripts/guard-bundle-size.sh` fails a build when a bundle passes a committed budget. Nothing did the same for what a job spends against a quota. Now something does.

## How it measures

Offline, no D1 call. It **replays** every `.sql` file into an in-memory `bun:sqlite` database and counts **schema writes** — one per schema-changing statement, two where SQLite rebuilds a whole table. Replaying rather than parsing means a chain that no longer applies fails the guard instead of measuring cheap.

```
cire/db/migrations: 1 migration file(s), 68 statements, 68 schema writes, 0 table-rebuild statement(s)
  replaying the chain from zero costs about 1836 D1 rows written (1.8% of the 100000/day free-tier ceiling)
  that affords roughly 54 replay(s) a day, before the seed a full rebuild adds
  budget 3700 rows written (27 a day), 1864 rows of headroom
  exactly: 68 schema writes against a line at 137
```

## The constant is a band, and the guard says so

`bun:sqlite` cannot report D1's accounting, so rows are a proxy priced at **27 D1 rows per schema write**. Review found the calibration weaker than the first draft claimed, and the correction is the more interesting half of this PR.

- **Anchor one is solid**: one `DROP COLUMN` on an empty `wedding_invite_customisations` cost 54 rows — two schema writes at 27, exactly. Directly measured.
- **Anchor two was not.** It used the "89% schema / 11% seed" split from `wrangler d1 insights`, which returns only the **200 heaviest queries** — 56,852 rows written of roughly 409,000 that week. That is a share of a sample, not of a rebuild.

The agent then did better than restate my correction: it re-derived the seed's floor by replaying `0001_initial.sql` and `dev-seed.sql` and summing `changes` — **2,063 tuples**. The 89/11 split implies 881. A number below its own floor proves the sample over-represents schema statements. That puts the constant at **≤ 22.1** from the seed floor and **27** from the direct measurement, so the honest figure is a **22–27 band**, not a fit.

27 is kept deliberately — over-stating cost is the side that does not lose a day's quota — and the wiki now says outright that at 27 the pre-squash chain prices at 7,265, which with the 2,063 seed floor **sums past the reported 8,007**, so the true constant sits nearer the bottom and the guard charges more than a rebuild probably costs.

**It also corrected me.** I said the trip point does not depend on the constant. With the budget written in rows it does: the line in schema writes is `budget / constant`. So the guard now prints both units — `68 schema writes against a line at 137` — and the budgets file states the doubling as **68 → 137 schema writes**, which holds anywhere in the band.

## The budget: 3,700 rows

Current chain: 1,836 rows, 1.8% of the daily ceiling, roughly 54 replays a day. Pre-squash: 7,265 and 13.

The line is a **doubling**, not "current plus one mistake". The bundle guards' headroom rule assumes a baseline that should not move; a migration chain is meant to grow, and the issue's premise is that no single commit was wrong. So the trip condition is the smallest step that changes the affordability answer — and it has a remedy the bundle guards lack: **squashing puts the number back down** (269 → 68 schema writes), rather than moving the line up. Both the budgets file and the wiki say plainly that one heavy migration will not trip this alone (`0006_multi_tenant` is 756 rows), and why a budget tight enough to trip on an ordinary feature migration would just be raised on sight.

## Proof it fails, re-run independently

```
$ D1_MIGRATION_COST_BUDGETS_FILE=<archive budget> bun run scripts/guard-d1-migration-cost.ts --all
cire/db/migrations-archive: 57 migration file(s), 283 statements, 269 schema writes, 58 table-rebuild statement(s)
  replaying the chain from zero costs about 7265 D1 rows written (7.3% of the 100000/day ceiling)
  ...
::error::cire/db/migrations-archive is 269 schema writes, over the line at 136. ... squash it into a
fresh baseline the way xchromo/osn#984 did, or raise the budget deliberately with the reason in the commit.

red path exit=1 · green path exit=0
```

That 13 replays a day reproduces the figure from the incident. A synthetic `0058` adding and dropping 35 columns on the live chain also goes red, and reds `bun test ./scripts/` with it.

## Two rules, carried over unchanged

From `wiki/conventions/bundle-size-guards.md`: a budget is a number somebody chose with the reason in the commit, and a guard that only ever gets raised is not a guard. Both are in the script header and the budgets file.

## Where the brief was wrong

Issue #991 said "how many rebuilds a day can we afford? Today, one. Before the squash in #984, twelve." **Inverted** — the squash bought the headroom, so today's answer is higher. "One" was the nightly schedule in `cire-dev-db-rebuild.yml`, not a ceiling. The issue body is corrected; the model here does reproduce the twelve (7,265 + seed = 8,007, and 100,000/8,007 = 12).

Also: the root `package.json` is off the changeset allowlist, so a `guard:d1-migration-cost` convenience script would have forced a changeset naming a package that ships nothing. Dropped; CI invokes by path, exactly like `guard-bundle-size.sh`.

## Left out on purpose, each reasoned in the header

Live consumption (#989's territory — the Monitoring section and the new workflow are untouched), a rows-read threshold (5,000,000 a day against 100,000 written, so writes bind), and the seed's own cost.

Also unaddressed and worth passing on: `wiki/runbooks/free-tier-limits.md:210-215` and `wiki/runbooks/dev-environment.md:197` still assert the 89/11 split as fact. Correcting that prose belongs to #990/#992, not here — the pointer added here says the split cannot be read as a share of one rebuild.

## Verified

- `bun run test:scripts` — 191 pass, 0 fail across 16 files. I re-ran the two new files independently: 38 pass.
- `bunx --bun tsc -p scripts/tsconfig.json` — exit 0
- `bun run lint` — exit 0
- `bun run fmt:check` — clean, 1504 files
- `changeset-required.sh` — `skip`
- Guard green and red paths re-run by hand, exit codes above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
