### PR TITLE
fix(ops): make the Cloudflare dev-token fallback visible, and fix the runbook that told you to break it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,8 @@ name: Deploy
 # a separate Cloudflare account; tracked as `S-M` in xchromo/osn-tracker (#190).
 #
 # The dev tier is fully isolated — own Workers, own D1, own R2, own OSN identity
-# origin — and its database is wiped and re-seeded on every deploy. See
+# origin. Its database takes migrations forward on each deploy and is wiped and
+# re-seeded once a night by cire-dev-db-rebuild.yml, not on every merge. See
 # [[wiki/runbooks/dev-environment]].
 on:
   push:
@@ -207,6 +208,37 @@ jobs:
       # Serial: concurrent Miniflare workerd instances contend.
       - name: D1 integration tests
         run: bun run test:d1
+
+  # ═══ Which credential the dev jobs got ═════════════════════════════════════
+  #
+  # Every dev job resolves its Cloudflare token as
+  # `secrets.CLOUDFLARE_API_TOKEN_DEV || secrets.CLOUDFLARE_API_TOKEN`, and a
+  # `||` cannot tell a missing secret from a deliberate one. Unset, the fallback
+  # is taken in silence and a dev job runs on whatever the second name resolves
+  # to. This job prints which of the two the run got, so the placement is a line
+  # in the log rather than something to infer.
+  #
+  # It prints a NAME, never a value: `secrets.X && 'a' || 'b'` yields a literal,
+  # and the secret itself never reaches the step. Nothing depends on this job —
+  # no `needs:` edge — so it cannot delay or fail a deploy. It exists to be read
+  # on the day the dev credential appears, or the day it goes missing again.
+  # See [[wiki/runbooks/dev-environment]] §Two Environments, two tokens for the
+  # ordered move and why deleting the repository-scope secret early breaks
+  # every deploy in the repository.
+  credential-scope:
+    name: Cloudflare credential scope
+    needs: [changes]
+    # Only when a job that actually holds the credential is going to run. A
+    # docs-only push deploys nothing, so there is nothing to report on.
+    if: needs.changes.outputs.cire_api == 'true' || needs.changes.outputs.osn_api == 'true'
+    runs-on: ubuntu-latest
+    environment: dev
+    timeout-minutes: 2
+    steps:
+      - name: Report which Cloudflare credential the dev jobs hold
+        env:
+          SOURCE: ${{ secrets.CLOUDFLARE_API_TOKEN_DEV && 'CLOUDFLARE_API_TOKEN_DEV (dev Environment)' || 'CLOUDFLARE_API_TOKEN (fallback — the dev-only credential is unset)' }}
+        run: echo "Dev jobs in this run hold $SOURCE"
 
   # ═══ cire API + D1 ═════════════════════════════════════════════════════════
   #

--- a/wiki/runbooks/dev-environment.md
+++ b/wiki/runbooks/dev-environment.md
@@ -9,7 +9,7 @@ related:
   - "[[cire-auth]]"
   - "[[oidc-provider]]"
   - "[[devloop-urls]]"
-last-reviewed: 2026-09-09
+last-reviewed: 2026-09-10
 ---
 
 # Dev environment (cire + OSN identity)
@@ -129,18 +129,48 @@ See [[musubi-identity-migration]] for why RP IDs behave this way.
 | `dev` | `CLOUDFLARE_API_TOKEN_DEV` | none |
 | `production` | `CLOUDFLARE_API_TOKEN` | required |
 
-The two secrets are deliberately named differently. A job that lands in the wrong
-Environment then fails on an empty token instead of quietly deploying with the
-other tier's rights. This is what closed the tracked finding **S-M
+The two secrets are deliberately named differently, so that a job landing in the
+wrong Environment fails on an empty token instead of quietly deploying with the
+other tier's rights. That is what closed the tracked finding **S-M
 (preview-ci-prod-token)**: no push-triggered job can reach a prod-scoped
 credential any more.
 
-Store both **only** on their Environment. A repository-level `CLOUDFLARE_API_TOKEN`
-is visible to every job in every workflow, gate or no gate — which hands the
-unattended dev job the production credential and undoes the split. Check with
-`gh secret list` (repo scope) and `gh secret list --env production`; if the token
-appears at repo scope, delete it there (`gh secret delete CLOUDFLARE_API_TOKEN`)
-after confirming the `production` Environment holds it.
+**That protection is worth exactly as much as the secrets' placement, so read
+the placement before trusting it.** Every dev job in `deploy.yml` reads
+
+```yaml
+CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_DEV || secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+and a `||` cannot tell a missing secret from a deliberate one. With
+`CLOUDFLARE_API_TOKEN_DEV` unset the fallback is taken silently, and a dev job
+runs on whatever `CLOUDFLARE_API_TOKEN` resolves to — including a
+repository-scope copy, which is visible to every job in every workflow, gate or
+no gate. The `Cloudflare credential scope` job in `deploy.yml` prints which of
+the two each run got; read its line rather than assuming.
+
+**Moving the token to its Environment is an ordered operation, and the order is
+the whole of it.** Do not start at step 3.
+
+1. `gh secret list --env production` and `gh secret list --env dev`. Note what
+   is actually there. An Environment with no rows is the state to fix, not a
+   formatting quirk.
+2. Put `CLOUDFLARE_API_TOKEN` on `production` and a real `CLOUDFLARE_API_TOKEN_DEV`
+   on `dev`. Both must exist before anything is removed.
+3. Re-run step 1 and confirm both. Then deploy once to each tier and confirm the
+   `Cloudflare credential scope` line names the Environment, not the fallback.
+4. Only now `gh secret delete CLOUDFLARE_API_TOKEN` at repository scope.
+5. Before you do, find every workflow that reads a `CLOUDFLARE_*` secret without
+   declaring an `environment:` — `grep -l CLOUDFLARE .github/workflows/*.yml` and
+   check each one. `free-tier-ceiling-alert.yml` is one by design: it is a
+   scheduled watcher, it cannot take `environment: production` because that gate
+   waits on a human and nobody approves a cron at 22:00 UTC, and it needs only
+   `d1 (read)` and `account (read)`. Give it a read-only credential of its own at
+   that point rather than a share of a deploy token.
+
+Deleting the repository-scope secret before step 3 breaks **every** deploy in the
+repository, dev and production alike, because that is the value the `||` has been
+resolving to.
 
 **What the split does not buy.** `Workers Scripts:Edit` and `D1:Edit` are
 account-level permissions — Cloudflare offers no per-script or per-database


### PR DESCRIPTION
Partly addresses a tracker finding. Does **not** close it — the remaining step needs a credential only the repository owner can mint.

## The reader-facing bug

`wiki/runbooks/dev-environment.md` §"Two Environments, two tokens" described the two-token split as done, then gave the cleanup step for it:

> if the token appears at repo scope, delete it there (`gh secret delete CLOUDFLARE_API_TOKEN`) after confirming the `production` Environment holds it.

Anyone who read that page, ran `gh secret list`, saw the token at repository scope and followed the instruction would break **every deploy in the repository** — dev and production alike — because that value is what every job's `||` resolves to. The page named one precondition, not both, and said nothing about the workflows that read a Cloudflare secret without declaring an `environment:`.

It is now an ordered five-step move that says which step cannot be skipped and what breaks if it is:

1. List what each Environment actually holds.
2. Put a token on **both** Environments.
3. Re-list, then deploy once to each tier and read the credential-scope line.
4. Only now delete the repository-scope secret.
5. Before that, `grep -l CLOUDFLARE .github/workflows/*.yml` and check every workflow with no `environment:`. `free-tier-ceiling-alert.yml` is one by design — a scheduled watcher cannot take `environment: production`, because that gate waits on a human and nobody approves a cron at 22:00 UTC. It needs only `d1 (read)` and `account (read)`, so that is the moment to give it a read-only credential of its own.

## Making the silent half visible

Every dev job resolves:

```yaml
CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_DEV || secrets.CLOUDFLARE_API_TOKEN }}
```

A `||` cannot tell a missing secret from a deliberate one, so which credential a dev job holds is currently something a reader infers. A new `Cloudflare credential scope` job prints it:

```
Dev jobs in this run hold CLOUDFLARE_API_TOKEN (fallback — the dev-only credential is unset)
```

- It prints a **name, never a value**. `secrets.X && 'a' || 'b'` yields a literal; the secret never reaches the step.
- **No `needs:` edge points at it**, so it cannot delay or fail a deploy.
- It runs only when a job that holds the credential is going to run, so a docs-only push reports nothing.

It exists to be read on the day the dev credential appears — or the day it goes missing again.

## Also

`deploy.yml`'s header still said the dev database "is wiped and re-seeded on every deploy". Not since #982: it takes migrations forward per deploy and is rebuilt once a night by `cire-dev-db-rebuild.yml`.

## What this does not do

It does not create the missing credential. Minting a Cloudflare token and setting an Environment secret needs the dashboard and the token's value, neither of which is reachable from here. The tracker row stays open with the ordered steps.

## Verified

- `bun run lint` — exit 0
- `bun run fmt:check` — exit 0
- `bun run test:scripts` — 253 pass, 0 fail
- `deploy.yml` parses
- `changeset-required.sh` — `skip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
