### PR TITLE
fix(osn): give the post-recovery enrolment screen its full fifteen minutes

### DIFF
--- a/.changeset/recovery-token-refresh.md
+++ b/.changeset/recovery-token-refresh.md
@@ -1,0 +1,42 @@
+---
+"@osn/api": patch
+"@osn/client": minor
+"@osn/ui": patch
+---
+
+The post-recovery passkey-enrolment screen now gets the whole fifteen minutes the
+restricted session grants, instead of dying after five.
+
+Two deadlines were in play and only the shorter reached the browser. The session
+row lives `RECOVERY_SESSION_TTL_SEC` (900 s); the access token in the same
+response was signed with `accessTokenTtl` (300 s). `<RecoveryLoginForm>` holds
+that session without adopting it — it must, because `@musubi/social` unmounts the
+flow the moment a session is published, and a `aud: "osn-recovery"` token is one
+every ordinary route rejects. Holding it also puts the flow outside `authFetch`,
+where silent refresh lives. So a user who read the screen for six minutes and
+pressed "Add a passkey" sent a dead bearer and got a 401, with ten minutes of
+their window unspent.
+
+`@osn/client` gains `refreshHeldSession`: a `/token` grant that returns a fresh
+token set **without adopting it**. It reuses the existing single-flight grant, so
+a held-session refresh and a cold-start bootstrap still produce one request —
+two would replay a rotated cookie, which is what revokes a session family.
+`<RecoveryLoginForm>` refreshes 30 s before each token expires.
+
+`@osn/api` caps a restricted session's access token at the life its own row has
+left, at both issuance sites. Rotation carries the absolute deadline forward
+rather than extending it, so without the cap a grant late in the window minted a
+full-length token outliving the row behind it. Nothing was granted by such a
+token — the enrolment bypass tests the row, not the token — but the browser was
+told a deadline the server would not honour, and the screen showed a live button
+that every request refused. Capped, the last token of the window expires exactly
+when the row does, so the timed-out screen and the session's death coincide and
+the client needs no copy of the fifteen minutes. An ordinary session is
+untouched: the cap only ever applies where `restricted_until` is set.
+
+The refresh loop is bounded by the server rather than by a client-side constant:
+once a token arrives with less than the refresh lead on it, that token is the
+deadline and the screen waits it out. A refused grant is retried on a halving
+gap first, because `@osn/client` reports a transient 5xx exactly like a dead
+cookie and giving up on the first refusal would cost the user the window this
+change exists to return.

--- a/.changeset/recovery-token-refresh.md
+++ b/.changeset/recovery-token-refresh.md
@@ -23,6 +23,15 @@ a held-session refresh and a cold-start bootstrap still produce one request —
 two would replay a rotated cookie, which is what revokes a session family.
 `<RecoveryLoginForm>` refreshes 30 s before each token expires.
 
+`refreshHeldSession` resolves to a new exported `HeldSession` — `{ held: true;
+session: Session }` — rather than a bare `Session`. `adoptSession` and
+`setSession` still take a plain `Session`, so a caller cannot write
+`adoptSession(await refreshHeldSession())`: that is precisely the mistake
+holding rather than adopting exists to rule out, and it is now a compile error
+instead of a token minted for the recovery audience getting published as an
+ordinary session. Every caller unwraps `.session` once it has decided to keep
+holding it.
+
 `@osn/api` caps a restricted session's access token at the life its own row has
 left, at both issuance sites. Rotation carries the absolute deadline forward
 rather than extending it, so without the cap a grant late in the window minted a

--- a/osn/api/src/services/auth/tokens.ts
+++ b/osn/api/src/services/auth/tokens.ts
@@ -65,6 +65,9 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
    * `audience` decides what the token can reach. It defaults to
    * {@link ACCESS_TOKEN_AUDIENCE}; the only other value it is ever given is
    * {@link RECOVERY_TOKEN_AUDIENCE}, for a restricted recovery session.
+   *
+   * `ttlSec` shortens the configured lifetime — see {@link sessionBoundTtl},
+   * which is the only thing that ever passes it.
    */
   const issueAccessToken = (
     profileId: string,
@@ -73,6 +76,7 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
     displayName: string | null,
     sessionBinding?: string | null,
     audience: string = ACCESS_TOKEN_AUDIENCE,
+    ttlSec: number = accessTokenTtl,
   ) =>
     Effect.tryPromise({
       try: () => {
@@ -96,16 +100,35 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         // its own session row without a cookie and without leaking either
         // the session id or the account behind the profile.
         if (sessionBinding) payload["osn_sid"] = sessionBinding;
-        return signJwt(
-          payload,
-          config.jwtPrivateKey,
-          config.jwtKid,
-          accessTokenTtl,
-          config.issuerUrl,
-        );
+        return signJwt(payload, config.jwtPrivateKey, config.jwtKid, ttlSec, config.issuerUrl);
       },
       catch: (cause) => new AuthError({ message: String(cause) }),
     });
+
+  /**
+   * The access-token lifetime a session of this kind may hand out.
+   *
+   * For an ordinary session (`restrictedUntil === null`) that is the configured
+   * `accessTokenTtl` and nothing else. For a **restricted recovery session** it
+   * is whatever is smaller: the configured lifetime, or the time the session row
+   * itself has left. A restricted row's deadline is absolute — rotation copies
+   * it forward rather than extending it — so without this cap the last token of
+   * the window outlives the row that authorises it, and the browser is told a
+   * later deadline than the one the server will honour. The screen holding it
+   * then shows a live button that every request refuses.
+   *
+   * The floor of 1 covers the sub-second case where this clock read lands a
+   * second after the one `verifyRefreshToken` admitted the row on.
+   *
+   * This bounds the token, not the session: `verifyJwt` allows 30 s of clock
+   * skew, so a capped token still verifies for a little after its row is gone.
+   * Nothing is granted in that window — the enrolment bypass tests the row's own
+   * deadline (`recoverySessionAdmitsEnrolment`), never the token's.
+   */
+  const sessionBoundTtl = (restrictedUntil: number | null, nowSec: number): number =>
+    restrictedUntil === null
+      ? accessTokenTtl
+      : Math.max(1, Math.min(accessTokenTtl, restrictedUntil - nowSec));
 
   /**
    * Full token issuance: creates a server-side session row and returns an
@@ -140,6 +163,15 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
       // session it was minted from (`osn_sid`).
       const sessionToken = generateSessionToken();
       const sessionId = hashSessionToken(sessionToken);
+      // One clock read, taken before the mint so the token's lifetime and the
+      // row's deadline are computed against the same instant. Every field below
+      // (`createdAt`, `authenticatedAt`, `lastUsedAt`, `expiresAt`) reads it
+      // too, so they move together.
+      const nowSec = Math.floor(Date.now() / 1000);
+      // A restricted session's deadline is absolute: the row's `expiresAt` IS
+      // its `restrictedUntil`, and neither the sliding window in
+      // `verifyRefreshToken` nor rotation in `refreshTokens` moves it.
+      const restrictedUntil = restricted ? nowSec + RECOVERY_SESSION_TTL_SEC : null;
       const accessToken = yield* issueAccessToken(
         profileId,
         email,
@@ -147,13 +179,9 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         displayName,
         deriveSessionBinding(sessionId, profileId),
         restricted ? RECOVERY_TOKEN_AUDIENCE : ACCESS_TOKEN_AUDIENCE,
+        sessionBoundTtl(restrictedUntil, nowSec),
       );
-      const nowSec = Math.floor(Date.now() / 1000);
       const fam = familyId ?? genId("sfam_");
-      // A restricted session's deadline is absolute: the row's `expiresAt` IS
-      // its `restrictedUntil`, and neither the sliding window in
-      // `verifyRefreshToken` nor rotation in `refreshTokens` moves it.
-      const restrictedUntil = restricted ? nowSec + RECOVERY_SESSION_TTL_SEC : null;
 
       const { db } = yield* Db;
 
@@ -198,7 +226,11 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         catch: (cause) => new DatabaseError({ cause }),
       });
 
-      return { accessToken, refreshToken: sessionToken, expiresIn: accessTokenTtl };
+      return {
+        accessToken,
+        refreshToken: sessionToken,
+        expiresIn: sessionBoundTtl(restrictedUntil, nowSec),
+      };
     });
 
   /** Ordinary, unrestricted session issuance. See {@link issueSession}. */
@@ -609,8 +641,16 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
       const newSessionToken = generateSessionToken();
       const newSessionId = hashSessionToken(newSessionToken);
 
+      // One clock read, taken before the mint so the token's lifetime is
+      // measured against the same instant as the row fields below.
+      const nowSec = Math.floor(Date.now() / 1000);
+
       // The restriction rides the SESSION ROW, not the token, so it survives
       // the silent refresh that would otherwise retire it five minutes in.
+      // The row's deadline also caps the token: a restricted session does not
+      // extend on rotation, so a full-length token here would outlive the row
+      // that authorises it and tell the browser a deadline the server will not
+      // honour.
       const accessToken = yield* issueAccessToken(
         profile.id,
         profile.email,
@@ -618,8 +658,8 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
         profile.displayName,
         deriveSessionBinding(newSessionId, profile.id),
         restrictedUntil === null ? ACCESS_TOKEN_AUDIENCE : RECOVERY_TOKEN_AUDIENCE,
+        sessionBoundTtl(restrictedUntil, nowSec),
       );
-      const nowSec = Math.floor(Date.now() / 1000);
 
       const { db } = yield* Db;
       // The old session's metadata (UA label + IP hash + `authenticatedAt`)
@@ -705,7 +745,11 @@ export function createTokensModule(ctx: AuthContext, profiles: ProfilesModule) {
       // Track the rotated-out hash for reuse detection
       yield* trackRotatedSession(oldSessionId, familyId);
 
-      return { accessToken, refreshToken: newSessionToken, expiresIn: accessTokenTtl };
+      return {
+        accessToken,
+        refreshToken: newSessionToken,
+        expiresIn: sessionBoundTtl(restrictedUntil, nowSec),
+      };
     }).pipe(withSessionRotation, withAuthTokenRefresh);
 
   // -------------------------------------------------------------------------

--- a/osn/api/tests/services/recovery-session.test.ts
+++ b/osn/api/tests/services/recovery-session.test.ts
@@ -499,6 +499,94 @@ describe("restricted recovery session — rotation and expiry", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  /**
+   * The row's deadline caps the token, not only the other way round.
+   *
+   * A restricted session does not extend on rotation, so a grant late in the
+   * window would otherwise hand out a full-length access token that outlives
+   * the row authorising it. Nothing is *granted* by such a token — the
+   * enrolment bypass tests the row, not the token — but the browser holding it
+   * is told a deadline the server will not honour, and a screen built on that
+   * promise keeps a live button every request refuses.
+   *
+   * Red without the cap: `expiresIn` and the JWT's lifetime are both 300.
+   */
+  it.effect("a rotation late in the window mints a token that dies with the row", () => {
+    const { layer } = makeHarness();
+    return Effect.gen(function* () {
+      const user = yield* auth.registerProfile("rs-cap@example.com", "rscap");
+      const restricted = yield* auth.issueRecoverySession(
+        user.id,
+        user.accountId,
+        user.email,
+        user.handle,
+        user.displayName,
+        "otp",
+      );
+
+      // Thirty seconds short of the deadline — the last grant the screen makes.
+      const remaining = 30;
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(Date.now() + (RECOVERY_SESSION_TTL_SEC - remaining) * 1000));
+
+      const rotated = yield* auth.refreshTokens(restricted.refreshToken);
+
+      expect(rotated.expiresIn).toBe(remaining);
+      const payload = payloadOf(rotated.accessToken);
+      expect((payload["exp"] as number) - (payload["iat"] as number)).toBe(remaining);
+      // Still restricted: the cap shortens the token, it does not quietly
+      // promote the session.
+      expect(payload["aud"]).toBe(RECOVERY_TOKEN_AUDIENCE);
+    }).pipe(Effect.provide(layer));
+  });
+
+  /**
+   * The same rule at mint, where it bites only if an operator sets
+   * `OSN_ACCESS_TOKEN_TTL` above the recovery window. Both halves matter: the
+   * restricted session is capped to its window, and an ordinary one from the
+   * identical config still gets the full configured lifetime — which is what
+   * separates "the cap works" from "the TTL is broken for everybody".
+   */
+  it.effect(
+    "a configured TTL above the window is capped at mint, and only for the restricted session",
+    () => {
+      const { layer } = makeHarness();
+      return Effect.gen(function* () {
+        const longTtl = RECOVERY_SESSION_TTL_SEC * 2;
+        const generous = createAuthService({ ...config, accessTokenTtl: longTtl });
+
+        const user = yield* generous.registerProfile("rs-capmint@example.com", "rscapmint");
+        const restricted = yield* generous.issueRecoverySession(
+          user.id,
+          user.accountId,
+          user.email,
+          user.handle,
+          user.displayName,
+          "otp",
+        );
+        const ordinary = yield* generous.issueTokens(
+          user.id,
+          user.accountId,
+          user.email,
+          user.handle,
+          user.displayName,
+        );
+
+        const restrictedPayload = payloadOf(restricted.accessToken);
+        expect(restricted.expiresIn).toBe(RECOVERY_SESSION_TTL_SEC);
+        expect((restrictedPayload["exp"] as number) - (restrictedPayload["iat"] as number)).toBe(
+          RECOVERY_SESSION_TTL_SEC,
+        );
+
+        const ordinaryPayload = payloadOf(ordinary.accessToken);
+        expect(ordinary.expiresIn).toBe(longTtl);
+        expect((ordinaryPayload["exp"] as number) - (ordinaryPayload["iat"] as number)).toBe(
+          longTtl,
+        );
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
   it.effect("verifyRefreshToken refuses a restricted session unless asked", () => {
     const { layer } = makeHarness();
     return Effect.gen(function* () {

--- a/osn/api/tests/services/recovery-session.test.ts
+++ b/osn/api/tests/services/recovery-session.test.ts
@@ -541,6 +541,60 @@ describe("restricted recovery session — rotation and expiry", () => {
   });
 
   /**
+   * `sessionBoundTtl` floors at 1 for the sub-second TOCTOU between
+   * `verifyRefreshToken`'s clock read and `refreshTokens`' own later one: a row
+   * that is still alive at the first read can have crossed `restrictedUntil` by
+   * the second. Without the floor, `signJwt` would be called with `ttlSec <= 0`
+   * for a session caught in that race — surfacing only as an intermittent
+   * production failure under load, never in a test that reads the clock once.
+   *
+   * `Date.now` is mocked to move between reads within this single
+   * `refreshTokens` call — the only way to reach the floor without genuinely
+   * racing a clock, since `verifyRefreshToken` already rejects a row that has
+   * really expired by the time its own read happens.
+   *
+   * Red without the floor: `expiresIn` is `0` (or negative, one clock tick
+   * later), and `signJwt` mints a token whose `exp` is at or before its `iat`.
+   */
+  it.effect(
+    "the TOCTOU floor: the clock crosses the deadline between the two reads in one refresh",
+    () => {
+      const { layer, db } = makeHarness();
+      return Effect.gen(function* () {
+        const user = yield* auth.registerProfile("rs-toctou@example.com", "rstoctou");
+        const restricted = yield* auth.issueRecoverySession(
+          user.id,
+          user.accountId,
+          user.email,
+          user.handle,
+          user.displayName,
+          "otp",
+        );
+        const row = yield* sessionRow(db, restricted.refreshToken);
+        const restrictedUntilMs = row!.restrictedUntil! * 1000;
+
+        const dateNowSpy = vi.spyOn(Date, "now");
+        // `verifyRefreshToken`'s own clock read: a second before the deadline,
+        // so the row is still admitted.
+        dateNowSpy.mockReturnValueOnce(restrictedUntilMs - 1000);
+        // Every read after that — including `refreshTokens`' own, later one —
+        // lands exactly ON the deadline: `restrictedUntil - nowSec` is 0.
+        dateNowSpy.mockReturnValue(restrictedUntilMs);
+
+        const rotated = yield* auth.refreshTokens(restricted.refreshToken);
+        dateNowSpy.mockRestore();
+
+        expect(rotated.expiresIn).toBe(1);
+        const payload = payloadOf(rotated.accessToken);
+        expect((payload["exp"] as number) - (payload["iat"] as number)).toBe(1);
+        // Still restricted, and still rotated — the floor changes the TTL it
+        // mints with, not whether the grant succeeds.
+        expect(payload["aud"]).toBe(RECOVERY_TOKEN_AUDIENCE);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  /**
    * The same rule at mint, where it bites only if an operator sets
    * `OSN_ACCESS_TOKEN_TTL` above the recovery window. Both halves matter: the
    * restricted session is capped to its window, and an ordinary one from the

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -16,7 +16,7 @@ import {
   extractJwtSub,
   parseTokenResponse,
 } from "./tokens";
-import type { AccountSession, PublicProfile, Session } from "./tokens";
+import type { AccountSession, HeldSession, PublicProfile, Session } from "./tokens";
 
 const ACCOUNT_SESSION_KEY = "@osn/client:account_session";
 
@@ -143,9 +143,13 @@ export interface OsnAuthService {
    * rotates the session server-side, and a second grant replaying the
    * rotated-out cookie is what reuse detection revokes a family for.
    *
+   * Returns a {@link HeldSession}, not a `Session` — `adoptSession`/
+   * `setSession` don't accept one, so the caller must unwrap `.session`
+   * explicitly rather than being able to hand the result straight to either.
+   *
    * @see wiki/architecture/account-recovery-factors.md — the restricted session.
    */
-  readonly refreshHeldSession: () => Effect.Effect<Session, TokenRefreshError>;
+  readonly refreshHeldSession: () => Effect.Effect<HeldSession, TokenRefreshError>;
 
   readonly logout: () => Effect.Effect<void, StorageError>;
 
@@ -501,8 +505,13 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
       // `restricted_until` is set, and carries that deadline forward rather
       // than extending it — so this can renew the token but can never buy the
       // session more life than it was granted.
+      //
+      // Wrapped as a `HeldSession` rather than returned as a bare `Session`
+      // so `adoptSession`/`setSession` refuse it at compile time — see
+      // `HeldSession` in `./tokens`.
       // -----------------------------------------------------------------------
-      const refreshHeldSession = () => sharedTokenGrant();
+      const refreshHeldSession = (): Effect.Effect<HeldSession, TokenRefreshError> =>
+        Effect.map(sharedTokenGrant(), (session): HeldSession => ({ held: true, session }));
 
       // -----------------------------------------------------------------------
       // Cold-start bootstrap (production login-loop fix).

--- a/osn/client/src/service.ts
+++ b/osn/client/src/service.ts
@@ -125,6 +125,28 @@ export interface OsnAuthService {
 
   readonly refreshSession: () => Effect.Effect<Session, TokenRefreshError | StorageError>;
 
+  /**
+   * Redeems the refresh cookie for a fresh token set and hands it back
+   * **without adopting it** — nothing is written to storage, nothing is
+   * cached, and no session resource is refetched.
+   *
+   * For a flow that HOLDS a session rather than publishing one. Post-recovery
+   * passkey enrolment is the case that needs it: its token carries
+   * `aud: "osn-recovery"`, which every ordinary route rejects, and adopting it
+   * would announce a signed-in user the rest of the app cannot serve. Holding
+   * it also puts the flow outside `authFetch`, so the silent refresh that keeps
+   * every other screen alive is unavailable — this is the replacement.
+   *
+   * Shares the single-flight `/token` grant with `refreshSession` and the
+   * cold-start bootstrap, so a component calling this while the provider is
+   * bootstrapping produces one request, not two. That matters: each grant
+   * rotates the session server-side, and a second grant replaying the
+   * rotated-out cookie is what reuse detection revokes a family for.
+   *
+   * @see wiki/architecture/account-recovery-factors.md — the restricted session.
+   */
+  readonly refreshHeldSession: () => Effect.Effect<Session, TokenRefreshError>;
+
   readonly logout: () => Effect.Effect<void, StorageError>;
 
   /**
@@ -463,6 +485,24 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
           }
           return result.success;
         });
+
+      // -----------------------------------------------------------------------
+      // Held-session refresh.
+      //
+      // The whole implementation: take the shared grant and return what it
+      // gives back. What makes this a distinct method is everything it does
+      // NOT do — no `saveAccountSession`, no `cache` write, no account
+      // reshaping. A held session is one the caller has deliberately kept out
+      // of the app's session state, and refreshing it must not be the thing
+      // that publishes it.
+      //
+      // A restricted recovery session is the caller. On the server the grant
+      // re-mints on the recovery audience for as long as the row's
+      // `restricted_until` is set, and carries that deadline forward rather
+      // than extending it — so this can renew the token but can never buy the
+      // session more life than it was granted.
+      // -----------------------------------------------------------------------
+      const refreshHeldSession = () => sharedTokenGrant();
 
       // -----------------------------------------------------------------------
       // Cold-start bootstrap (production login-loop fix).
@@ -832,6 +872,7 @@ export function createOsnAuthLive(config: OsnAuthConfig): Layer.Layer<OsnAuth, n
         getSession,
         loadSession,
         refreshSession,
+        refreshHeldSession,
         logout,
         setSession,
         listProfiles,

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -12,7 +12,7 @@ import {
 
 import { OsnAuth, createOsnAuthLive, type OsnAuthConfig } from "../service";
 import { Storage, StorageLive } from "../storage";
-import type { PublicProfile, Session } from "../tokens";
+import type { HeldSession, PublicProfile, Session } from "../tokens";
 
 interface AuthContextValue {
   session: Resource<Session | null>;
@@ -34,8 +34,12 @@ interface AuthContextValue {
    * refresh every other screen relies on never runs. Post-recovery passkey
    * enrolment is the caller. Rejects when the issuer refuses the grant, which
    * for a restricted session means its absolute deadline has passed.
+   *
+   * Resolves to a `HeldSession`, not a `Session` — `adoptSession` doesn't
+   * accept one, so `adoptSession(await refreshHeldSession())` is a compile
+   * error rather than a way to publish a restricted `osn-recovery` token.
    */
-  refreshHeldSession: () => Promise<Session>;
+  refreshHeldSession: () => Promise<HeldSession>;
   switchProfile: (profileId: string) => Promise<{ session: Session; profile: PublicProfile }>;
   createProfile: (handle: string, displayName?: string) => Promise<PublicProfile>;
   deleteProfile: (profileId: string) => Promise<void>;

--- a/osn/client/src/solid/context.tsx
+++ b/osn/client/src/solid/context.tsx
@@ -24,6 +24,18 @@ interface AuthContextValue {
    * out-of-band source) and refetches the session resource so the UI updates.
    */
   adoptSession: (session: Session) => Promise<void>;
+  /**
+   * Redeems the refresh cookie for a fresh token set and returns it **without**
+   * adopting it — the session resource is not refetched and nothing is stored.
+   *
+   * The counterpart to {@link AuthContextValue.adoptSession} for a flow that
+   * holds a session rather than publishing one, and the only refresh path such
+   * a flow has: holding the token keeps it outside `authFetch`, so the silent
+   * refresh every other screen relies on never runs. Post-recovery passkey
+   * enrolment is the caller. Rejects when the issuer refuses the grant, which
+   * for a restricted session means its absolute deadline has passed.
+   */
+  refreshHeldSession: () => Promise<Session>;
   switchProfile: (profileId: string) => Promise<{ session: Session; profile: PublicProfile }>;
   createProfile: (handle: string, displayName?: string) => Promise<PublicProfile>;
   deleteProfile: (profileId: string) => Promise<void>;
@@ -107,6 +119,11 @@ export function AuthProvider(props: AuthProviderProps) {
     await refetchProfiles();
   };
 
+  // No `refetchSession`, deliberately: adopting is the caller's decision and
+  // this is the path for the flows that have decided not to.
+  const refreshHeldSession = () =>
+    run(Effect.flatMap(OsnAuth, (auth) => auth.refreshHeldSession()));
+
   const switchProfile = async (profileId: string) => {
     const result = await run(Effect.flatMap(OsnAuth, (auth) => auth.switchProfile(profileId)));
     await refetchSession();
@@ -139,6 +156,7 @@ export function AuthProvider(props: AuthProviderProps) {
         activeProfileId,
         logout,
         adoptSession,
+        refreshHeldSession,
         switchProfile,
         createProfile,
         deleteProfile,

--- a/osn/client/src/tokens.ts
+++ b/osn/client/src/tokens.ts
@@ -33,6 +33,20 @@ export interface Session {
   scopes: string[];
 }
 
+/**
+ * The result of a refresh that must not be adopted — a `Session` wrapped
+ * rather than returned bare. `adoptSession` and `setSession` take a plain
+ * `Session` by name; a `HeldSession` has no `accessToken`/`idToken`/
+ * `expiresAt`/`scopes` at its own top level, so passing one where a `Session`
+ * is expected is a compile error, not a runtime bug that publishes a
+ * restricted token as an ordinary session. A caller unwraps `.session` once
+ * it has decided holding, not adopting, is still the right call.
+ */
+export interface HeldSession {
+  readonly held: true;
+  readonly session: Session;
+}
+
 export function parseTokenResponse(raw: unknown): Session {
   const t = decodeTokenResponse(raw);
   return {

--- a/osn/client/tests/held-session-refresh.test.ts
+++ b/osn/client/tests/held-session-refresh.test.ts
@@ -1,0 +1,168 @@
+import { it, expect } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { vi } from "vitest";
+
+import { OsnAuth, createOsnAuthLive } from "../src/service";
+import { createEphemeralStorage } from "../src/storage";
+
+const config = { issuerUrl: "https://osn.example.com" };
+
+function createTestLayer() {
+  return createOsnAuthLive(config).pipe(Layer.provide(createEphemeralStorage()));
+}
+
+function fakeJwt(sub: string): string {
+  const header = btoa(JSON.stringify({ alg: "ES256", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ sub, aud: "osn-recovery" }));
+  return `${header}.${payload}.fake_signature`;
+}
+
+/** A restricted recovery session's access token, as the issuer would mint it. */
+const RECOVERY_TOKEN = fakeJwt("usr_recovering");
+
+function mockResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Records every call so a test can assert on the `/token` grant specifically.
+ * `sessionFetch` reads the global `fetch` per call, so stubbing the global
+ * reaches the grant.
+ */
+function stubTokenEndpoint(respond: () => Response) {
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
+  const fetchMock = vi
+    .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+    .mockImplementation((input, init) => {
+      const url = typeof input === "string" ? input : ((input as Request).url ?? "");
+      calls.push({ url, init });
+      if (url.endsWith("/token")) return Promise.resolve(respond());
+      return Promise.resolve(mockResponse(404));
+    });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// `refreshHeldSession` — the grant for a flow that holds a session instead of
+// publishing one.
+//
+// Post-recovery passkey enrolment is the caller. Its token carries
+// `aud: "osn-recovery"`, which every ordinary route rejects, so adopting it
+// would announce a signed-in user the app cannot serve — and holding it puts
+// the flow outside `authFetch`, where the silent refresh lives. This method is
+// the replacement, and the two properties below are the whole contract.
+// ---------------------------------------------------------------------------
+
+it.effect("redeems the refresh cookie and returns the new token set", () =>
+  Effect.gen(function* () {
+    const calls = stubTokenEndpoint(() =>
+      mockResponse(200, {
+        access_token: RECOVERY_TOKEN,
+        token_type: "Bearer",
+        expires_in: 90,
+        scope: "openid profile",
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    const session = yield* auth.refreshHeldSession();
+
+    expect(session.accessToken).toBe(RECOVERY_TOKEN);
+    // Receipt-based, so the screen's countdown needs no clock agreement with
+    // the issuer.
+    expect(session.expiresAt).toBeGreaterThan(Date.now());
+    expect(session.expiresAt).toBeLessThanOrEqual(Date.now() + 90_000);
+
+    const grant = calls.find((c) => c.url.endsWith("/token"));
+    expect(grant).toBeDefined();
+    expect(grant?.init?.method).toBe("POST");
+    expect(String(grant?.init?.body)).toContain("grant_type=refresh_token");
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+/**
+ * The refresh token lives only in the HttpOnly cookie, and the issuer is a
+ * different origin from every app that calls it. A cross-origin `fetch` left on
+ * the default `same-origin` credentials mode sends no cookie and silently
+ * discards the `Set-Cookie` that comes back — no error, no warning. Here that
+ * would be worse than a failed refresh: the grant rotates the session, so a
+ * browser that never stored the rotated cookie would replay the old one on the
+ * next grant, and a replayed rotated token is what revokes a whole session
+ * family.
+ */
+it.effect("sends credentials, so the rotated cookie survives the cross-origin hop", () =>
+  Effect.gen(function* () {
+    const calls = stubTokenEndpoint(() =>
+      mockResponse(200, {
+        access_token: RECOVERY_TOKEN,
+        token_type: "Bearer",
+        expires_in: 300,
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    yield* auth.refreshHeldSession();
+
+    const grant = calls.find((c) => c.url.endsWith("/token"));
+    expect(grant?.init?.credentials).toBe("include");
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+/**
+ * The property that separates this from `refreshSession`. `getSession` is the
+ * probe, not `loadSession`: outside a browser there is no `document`, so the
+ * session marker reads as present and `loadSession` would fire a grant of its
+ * own and persist the result — proving nothing.
+ */
+it.effect("does not adopt the session it returns", () =>
+  Effect.gen(function* () {
+    stubTokenEndpoint(() =>
+      mockResponse(200, {
+        access_token: RECOVERY_TOKEN,
+        token_type: "Bearer",
+        expires_in: 300,
+      }),
+    );
+
+    const auth = yield* OsnAuth;
+    const before = yield* auth.getSession();
+    expect(before).toBeNull();
+
+    const session = yield* auth.refreshHeldSession();
+    expect(session.accessToken).not.toBe("");
+
+    // Still nothing stored: the caller holds the token, the client does not.
+    expect(yield* auth.getSession()).toBeNull();
+    expect(yield* auth.getActiveProfile()).toBeNull();
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);
+
+/**
+ * A 4xx is the issuer saying the cookie redeems nothing. For a restricted
+ * recovery session that is its absolute deadline arriving, and the screen turns
+ * it into the timed-out state.
+ */
+it.effect("fails when the issuer refuses the grant", () =>
+  Effect.gen(function* () {
+    stubTokenEndpoint(() => mockResponse(400, { error: "invalid_grant" }));
+
+    const auth = yield* OsnAuth;
+    const result = yield* Effect.result(auth.refreshHeldSession());
+
+    expect(result._tag).toBe("Failure");
+    // And still nothing written on the way out.
+    expect(yield* auth.getSession()).toBeNull();
+
+    vi.unstubAllGlobals();
+  }).pipe(Effect.provide(createTestLayer())),
+);

--- a/osn/client/tests/held-session-refresh.test.ts
+++ b/osn/client/tests/held-session-refresh.test.ts
@@ -69,7 +69,7 @@ it.effect("redeems the refresh cookie and returns the new token set", () =>
     );
 
     const auth = yield* OsnAuth;
-    const session = yield* auth.refreshHeldSession();
+    const { session } = yield* auth.refreshHeldSession();
 
     expect(session.accessToken).toBe(RECOVERY_TOKEN);
     // Receipt-based, so the screen's countdown needs no clock agreement with
@@ -136,7 +136,7 @@ it.effect("does not adopt the session it returns", () =>
     const before = yield* auth.getSession();
     expect(before).toBeNull();
 
-    const session = yield* auth.refreshHeldSession();
+    const { session } = yield* auth.refreshHeldSession();
     expect(session.accessToken).not.toBe("");
 
     // Still nothing stored: the caller holds the token, the client does not.

--- a/osn/ui/src/auth/RecoveryLoginForm.tsx
+++ b/osn/ui/src/auth/RecoveryLoginForm.tsx
@@ -40,6 +40,18 @@ import { TurnstileWidget, turnstileEnabled } from "./TurnstileWidget";
  * with a passkey they now hold. That costs one ceremony and buys something:
  * the new credential is proven to work while the user is still in a position
  * to recover again if it does not.
+ *
+ * Keeping the held session alive
+ * ------------------------------
+ * Holding the session also means holding it outside `authFetch`, so nothing
+ * refreshes it silently. The access token would die at the ordinary
+ * `accessTokenTtl` while the row behind it stayed usable for the rest of its
+ * fifteen minutes, and the user would be sent back to the start with two
+ * thirds of the window unspent. This screen therefore redeems the refresh
+ * cookie itself, through `refreshHeldSession` — a grant that returns a fresh
+ * token set without adopting it. Rotation carries the row's absolute deadline
+ * forward rather than extending it, so refreshing can renew the token but can
+ * never buy more time than the session was granted.
  */
 
 export interface RecoveryLoginFormProps {
@@ -81,8 +93,27 @@ interface HeldRecovery {
   profile: RecoveryProfile;
 }
 
+/**
+ * How long before the held token expires the screen goes and gets another one.
+ *
+ * Precondition: the issuer's `accessTokenTtl` must exceed this, or the very
+ * first token already sits inside the lead and no refresh is ever scheduled.
+ * The default is 300 s against 30 s here. Enrolment survives a violation
+ * anyway — `enrolPasskey` refreshes on demand — but the background loop would
+ * not run.
+ */
+const REFRESH_LEAD_MS = 30_000;
+
+/**
+ * Floor on the halving retry after a refused grant. `@osn/client` reports a
+ * dead cookie and a cold isolate as the same failure, so a refusal inside the
+ * lead is worth retrying; below this gap there is no time left to spend and the
+ * honest answer is the expiry screen.
+ */
+const MIN_RETRY_GAP_MS = 2_000;
+
 export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
-  const { adoptSession } = useAuth();
+  const { adoptSession, refreshHeldSession } = useAuth();
 
   // Feature-detected on mount, matching `SignIn`, so a test can toggle the
   // underlying mock between renders.
@@ -101,7 +132,48 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
   let resetTurnstile: (() => void) | undefined;
 
   let expiryTimer: ReturnType<typeof setTimeout> | undefined;
-  onCleanup(() => clearTimeout(expiryTimer));
+
+  /**
+   * Identifies the recovery attempt a pending grant belongs to.
+   *
+   * Clearing the timer is not enough to stop the refresh loop. A grant already
+   * on the wire keeps running, and its continuation arms the next timer — so an
+   * unmount, a "Start again" or a finished enrolment would each leave a loop
+   * rotating the session on a screen that no longer exists. Once the user has
+   * signed in with the new passkey that is an ordinary session, which the
+   * issuer never refuses, so the loop would have no stop condition at all.
+   *
+   * Every continuation compares this before it writes any state or arms
+   * anything. Bumped on all five transitions out of a held session.
+   */
+  let epoch = 0;
+
+  /**
+   * Serialises the requests that touch the session, and nothing else.
+   *
+   * A grant rotates the session server-side: it deletes the old row and inserts
+   * a new one. An enrolment request in flight across that swap resolves to
+   * neither row and is refused — 409 on `/complete`, or the step-up bypass
+   * silently dropped on `/begin`. So grants and enrolment legs take turns.
+   *
+   * The WebAuthn ceremony deliberately sits OUTSIDE this. A prompt lasts as
+   * long as the user does, and holding the lock across it would guarantee the
+   * expired token is the one `/complete` sends — the exact failure this file
+   * exists to remove. A rotation landing mid-prompt is harmless: the server
+   * resolves the caller from the cookie first, and the cookie moves with the
+   * rotation.
+   */
+  let inFlight: Promise<unknown> = Promise.resolve();
+  function serialise<T>(op: () => Promise<T>): Promise<T> {
+    const next = inFlight.then(op, op);
+    inFlight = next.catch(() => {});
+    return next;
+  }
+
+  onCleanup(() => {
+    epoch += 1;
+    clearTimeout(expiryTimer);
+  });
 
   /**
    * A restricted session can do exactly one thing, and that one thing is a
@@ -118,39 +190,92 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
     props.registrationClient !== undefined &&
     props.runPasskeyRegistration !== undefined;
 
+  /** The screen the session is finished on. Also a state transition, so it bumps. */
+  function expire() {
+    epoch += 1;
+    clearTimeout(expiryTimer);
+    setHeld(null);
+    setError(null);
+    setView("expired");
+  }
+
   /**
-   * Arms the one deterministic expiry signal.
+   * Arms the end of the session.
    *
-   * The session row lives fifteen minutes, but the access token this screen
-   * holds is signed with the ordinary `accessTokenTtl` — five minutes by
-   * default — and this flow has no way to refresh it. The shorter deadline is
-   * therefore always the real one, so the timer fires before the row expires
-   * and no error-message matching is needed to tell the two apart.
-   *
-   * Widening this back out to the full fifteen minutes is `xchromo/osn#976`.
+   * The issuer caps a restricted session's access token at the life its own row
+   * has left, so once a token arrives with less than the lead on it, that token
+   * IS the deadline and no further grant can move it. Waiting it out is
+   * therefore the honest end of the window, and it needs no copy of the
+   * server's fifteen minutes on this side.
    */
   function armExpiry(session: Session) {
     clearTimeout(expiryTimer);
-    const remaining = session.expiresAt - Date.now();
-    expiryTimer = setTimeout(
-      () => {
-        setHeld(null);
-        setError(null);
-        setView("expired");
-      },
-      Math.max(0, remaining),
-    );
+    expiryTimer = setTimeout(expire, Math.max(0, session.expiresAt - Date.now()));
+  }
+
+  /**
+   * Arms the next grant, or the expiry screen when another grant cannot help.
+   *
+   * A held session is outside `authFetch`, so nothing refreshes it silently and
+   * the token would otherwise die at `accessTokenTtl` — five minutes — while
+   * the row behind it stays usable for fifteen.
+   */
+  function scheduleRefresh(session: Session) {
+    clearTimeout(expiryTimer);
+    const untilExpiry = session.expiresAt - Date.now();
+    if (untilExpiry <= REFRESH_LEAD_MS) {
+      armExpiry(session);
+      return;
+    }
+    const mine = epoch;
+    expiryTimer = setTimeout(() => void refreshHeld(mine), untilExpiry - REFRESH_LEAD_MS);
+  }
+
+  /**
+   * A refused grant usually means the row reached its absolute deadline, but
+   * `@osn/client` reports a transient 5xx the same way — and it gives up after
+   * about 0.6 s of retries. Ending the session on one cold isolate would cost
+   * the user the ten minutes this change exists to give back, so spend what is
+   * left of the lead on halving retries first. Each halving consumes real time,
+   * so the floor terminates it.
+   */
+  function scheduleRetry(session: Session) {
+    clearTimeout(expiryTimer);
+    const gap = (session.expiresAt - Date.now()) / 2;
+    if (gap < MIN_RETRY_GAP_MS) {
+      armExpiry(session);
+      return;
+    }
+    const mine = epoch;
+    expiryTimer = setTimeout(() => void refreshHeld(mine), gap);
+  }
+
+  /** Redeems the refresh cookie for a fresh token, keeping the session held. */
+  async function refreshHeld(mine: number) {
+    const current = held();
+    if (mine !== epoch || !current) return;
+    try {
+      const session = await serialise(refreshHeldSession);
+      if (mine !== epoch) return;
+      setHeld({ ...current, session });
+      scheduleRefresh(session);
+    } catch {
+      if (mine !== epoch) return;
+      scheduleRetry(current.session);
+    }
   }
 
   function beginRestricted(result: HeldRecovery) {
+    epoch += 1;
     setHeld(result);
-    armExpiry(result.session);
+    scheduleRefresh(result.session);
     setCode("");
     setError(null);
     setView("enrol");
   }
 
   function restart() {
+    epoch += 1;
     clearTimeout(expiryTimer);
     setHeld(null);
     setCode("");
@@ -242,6 +367,36 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
     }
   }
 
+  /**
+   * The token to send on the next leg, refreshed first when it is close enough
+   * to expiry to die mid-request.
+   *
+   * The WebAuthn challenge outlives the refresh lead several times over, so a
+   * ceremony begun just before a scheduled grant can easily end after the token
+   * it started with is dead. Asking for a fresh one at each leg is what makes a
+   * slow prompt safe, and it is why the ceremony itself needs no lock.
+   *
+   * Returns null when the grant is refused: the row has reached its absolute
+   * deadline, and the caller shows the timed-out screen rather than an error.
+   */
+  async function freshToken(): Promise<string | null> {
+    const current = held();
+    if (!current) return null;
+    if (current.session.expiresAt - Date.now() > REFRESH_LEAD_MS) {
+      return current.session.accessToken;
+    }
+    const mine = epoch;
+    try {
+      const session = await serialise(refreshHeldSession);
+      if (mine !== epoch) return null;
+      setHeld({ ...current, session });
+      scheduleRefresh(session);
+      return session.accessToken;
+    } catch {
+      return null;
+    }
+  }
+
   async function enrolPasskey() {
     const recovery = held();
     const client = props.registrationClient;
@@ -250,20 +405,37 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
     setBusy(true);
     setError(null);
     try {
+      const beginToken = await freshToken();
+      if (beginToken === null) {
+        expire();
+        return;
+      }
       // No step-up token: a recovery-audience caller is admitted past that
       // gate on the factor its session recorded. Losing the device does not
       // delete its passkey row, so the gate would otherwise block the common
       // recovery case outright.
-      const options = await client.passkeyRegisterBegin({
-        profileId: recovery.profile.id,
-        accessToken: recovery.session.accessToken,
-      });
+      const options = await serialise(() =>
+        client.passkeyRegisterBegin({
+          profileId: recovery.profile.id,
+          accessToken: beginToken,
+        }),
+      );
       const attestation = await run(options);
-      await client.passkeyRegisterComplete({
-        profileId: recovery.profile.id,
-        accessToken: recovery.session.accessToken,
-        attestation,
-      });
+      // Re-read rather than reuse `beginToken`: the ceremony may have outlived
+      // it, and a grant may have replaced the held session while it ran.
+      const completeToken = await freshToken();
+      if (completeToken === null) {
+        expire();
+        return;
+      }
+      await serialise(() =>
+        client.passkeyRegisterComplete({
+          profileId: recovery.profile.id,
+          accessToken: completeToken,
+          attestation,
+        }),
+      );
+      epoch += 1;
       clearTimeout(expiryTimer);
       setHeld(null);
       setView("enrolled");

--- a/osn/ui/src/auth/RecoveryLoginForm.tsx
+++ b/osn/ui/src/auth/RecoveryLoginForm.tsx
@@ -255,7 +255,7 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
     const current = held();
     if (mine !== epoch || !current) return;
     try {
-      const session = await serialise(refreshHeldSession);
+      const { session } = await serialise(refreshHeldSession);
       if (mine !== epoch) return;
       setHeld({ ...current, session });
       scheduleRefresh(session);
@@ -387,7 +387,7 @@ export function RecoveryLoginForm(props: RecoveryLoginFormProps) {
     }
     const mine = epoch;
     try {
-      const session = await serialise(refreshHeldSession);
+      const { session } = await serialise(refreshHeldSession);
       if (mine !== epoch) return null;
       setHeld({ ...current, session });
       scheduleRefresh(session);

--- a/osn/ui/tests/auth/RecoveryLoginForm.test.tsx
+++ b/osn/ui/tests/auth/RecoveryLoginForm.test.tsx
@@ -17,12 +17,14 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   adoptSession: vi.fn(),
+  refreshHeldSession: vi.fn(),
   webauthnSupported: true,
 }));
 
 vi.mock("@osn/client/solid", () => ({
   useAuth: () => ({
     adoptSession: hoisted.adoptSession,
+    refreshHeldSession: hoisted.refreshHeldSession,
   }),
 }));
 
@@ -133,6 +135,7 @@ beforeEach(() => {
   stub = makeClientStub();
   registration = makeRegistrationStub();
   hoisted.adoptSession.mockReset();
+  hoisted.refreshHeldSession.mockReset();
   hoisted.webauthnSupported = true;
 });
 
@@ -443,5 +446,208 @@ describe("RecoveryLoginForm — the restricted session", () => {
     expect(alert.textContent).toMatch(/NotAllowedError/);
     expect(screen.getByRole("button", { name: /Try again/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Start again/i })).toBeTruthy();
+  });
+});
+
+/**
+ * Keeping the held session alive.
+ *
+ * The session row lives fifteen minutes; the access token in the same response
+ * is signed with the ordinary five-minute TTL, and holding the session puts
+ * this flow outside `authFetch`, where the silent refresh lives. So the screen
+ * redeems the refresh cookie itself.
+ *
+ * Every case here drives `setTimeout`, so they all run on fake timers and use
+ * `vi.waitFor` rather than the testing-library one — RTL's polls on the faked
+ * `setTimeout` and never advances.
+ */
+describe("RecoveryLoginForm — keeping the restricted session alive", () => {
+  const TTL_MS = 300_000;
+  const LEAD_MS = 30_000;
+
+  /** A session `ms` from expiry, measured from the current (faked) clock. */
+  function sessionExpiringIn(ms: number, token = ACCESS_TOKEN) {
+    return { accessToken: token, idToken: null, expiresAt: Date.now() + ms, scopes: [] };
+  }
+
+  /**
+   * A grant that mints its token when it is called, not when it is set up.
+   * `mockResolvedValue` would freeze `expiresAt` at test-setup time, so after
+   * the clock advanced the "fresh" token would arrive already stale — the
+   * opposite of what the issuer does.
+   */
+  function grantsTokenExpiringIn(ms: number, token: string) {
+    return () => Promise.resolve(sessionExpiringIn(ms, token));
+  }
+
+  /** A promise the test resolves by hand, for asserting on an in-flight grant. */
+  function deferred<T>() {
+    let settle!: (value: T) => void;
+    let fail!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      settle = res;
+      fail = rej;
+    });
+    return { promise, settle, fail };
+  }
+
+  /** Drives the TOTP factor through to the enrolment screen holding `session`. */
+  async function reachEnrolmentHolding(session: ReturnType<typeof sessionExpiringIn>) {
+    stub.totpRecoveryComplete.mockResolvedValue({ session, profile: sampleProfile });
+    mountFull();
+    fireEvent.click(screen.getByRole("button", { name: /Use my authenticator app/i }));
+    fill(/Handle or email/i, "alice");
+    typeCode("654321");
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    await vi.waitFor(() => screen.getByRole("button", { name: /Add a passkey/i }));
+  }
+
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("refreshes before the token expires and enrols with the token it got back", async () => {
+    // The whole point of the change: at ten minutes the old build had been dead
+    // for five, and the button sent a bearer the issuer had stopped honouring.
+    hoisted.refreshHeldSession.mockImplementation(grantsTokenExpiringIn(TTL_MS, "acc_refreshed"));
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    await vi.advanceTimersByTimeAsync(TTL_MS - LEAD_MS);
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+
+    // Well past the original five minutes, and still usable.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(screen.getByRole("button", { name: /Add a passkey/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Add a passkey/i }));
+    await vi.waitFor(() => expect(registration.passkeyRegisterBegin).toHaveBeenCalled());
+    expect(registration.passkeyRegisterBegin.mock.calls[0]![0].accessToken).toBe("acc_refreshed");
+  });
+
+  it("stops granting once the issuer caps a token inside the refresh lead", async () => {
+    // The issuer caps a restricted session's token at the life its row has
+    // left, so a token arriving with less than the lead on it IS the deadline.
+    // Asking again would return the same instant; waiting it out is the end of
+    // the window, and it needs no copy of the server's fifteen minutes here.
+    await reachEnrolmentHolding(sessionExpiringIn(20_000));
+
+    await vi.advanceTimersByTimeAsync(19_000);
+    expect(screen.getByRole("button", { name: /Add a passkey/i })).toBeTruthy();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(hoisted.refreshHeldSession).not.toHaveBeenCalled();
+    expect(screen.getByText(/timed out/i)).toBeTruthy();
+  });
+
+  it("survives a transient refusal instead of ending the session ten minutes early", async () => {
+    // `@osn/client` gives up after ~0.6s of retries and reports a cold isolate
+    // exactly like a dead cookie. Treating the first refusal as final would
+    // hand back the window this change exists to give.
+    hoisted.refreshHeldSession
+      .mockRejectedValueOnce(new Error("503"))
+      .mockImplementation(grantsTokenExpiringIn(TTL_MS, "acc_second_try"));
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    await vi.advanceTimersByTimeAsync(TTL_MS - LEAD_MS);
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(LEAD_MS);
+    expect(hoisted.refreshHeldSession.mock.calls.length).toBeGreaterThan(1);
+    expect(screen.getByRole("button", { name: /Add a passkey/i })).toBeTruthy();
+  });
+
+  it("shows the timed-out screen once the grant is refused for good", async () => {
+    hoisted.refreshHeldSession.mockRejectedValue(new Error("invalid_grant"));
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    await vi.advanceTimersByTimeAsync(TTL_MS + 60_000);
+    expect(screen.getByText(/timed out/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Add a passkey/i })).toBeNull();
+  });
+
+  it("refreshes before completing a ceremony that outlived its token", async () => {
+    // A WebAuthn challenge lives two minutes; the refresh lead is thirty
+    // seconds. So a prompt begun just before a scheduled grant routinely
+    // outlives the token it started with, and `/complete` would send a dead
+    // bearer — the failure in this issue's title, reached by a different road.
+    const ceremony = deferred<never>();
+    hoisted.refreshHeldSession.mockImplementation(
+      grantsTokenExpiringIn(TTL_MS, "acc_mid_ceremony"),
+    );
+    stub.totpRecoveryComplete.mockResolvedValue({
+      session: sessionExpiringIn(TTL_MS),
+      profile: sampleProfile,
+    });
+    render(() => (
+      <RecoveryLoginForm
+        client={asClient(stub)}
+        registrationClient={asRegistration(registration)}
+        runPasskeyRegistration={() => ceremony.promise}
+      />
+    ));
+    fireEvent.click(screen.getByRole("button", { name: /Use my authenticator app/i }));
+    fill(/Handle or email/i, "alice");
+    typeCode("654321");
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    await vi.waitFor(() => screen.getByRole("button", { name: /Add a passkey/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add a passkey/i }));
+    await vi.waitFor(() => expect(registration.passkeyRegisterBegin).toHaveBeenCalled());
+    expect(registration.passkeyRegisterBegin.mock.calls[0]![0].accessToken).toBe(ACCESS_TOKEN);
+
+    // The user is still at their authenticator while the token dies.
+    await vi.advanceTimersByTimeAsync(TTL_MS);
+    ceremony.settle(attestation as never);
+
+    await vi.waitFor(() => expect(registration.passkeyRegisterComplete).toHaveBeenCalled());
+    expect(registration.passkeyRegisterComplete.mock.calls[0]![0].accessToken).toBe(
+      "acc_mid_ceremony",
+    );
+  });
+
+  it("abandons a grant that resolves after Start again", async () => {
+    // Clearing the timer does not stop a grant already on the wire, and its
+    // continuation arms the next one. Without a generation guard this re-holds
+    // a token from a family the new factor has already deleted, and rotates the
+    // session for as long as the page is open.
+    const grant = deferred<ReturnType<typeof sessionExpiringIn>>();
+    hoisted.refreshHeldSession.mockReturnValue(grant.promise);
+    // A failed ceremony is what puts "Start again" on the enrolment screen.
+    registration.passkeyRegisterBegin.mockRejectedValue(new Error("NotAllowedError"));
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    // Fails on the token it already holds, so no grant is spent getting here.
+    fireEvent.click(screen.getByRole("button", { name: /Add a passkey/i }));
+    await vi.waitFor(() => screen.getByRole("button", { name: /Start again/i }));
+    expect(hoisted.refreshHeldSession).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(TTL_MS - LEAD_MS);
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /Start again/i }));
+    grant.settle(sessionExpiringIn(TTL_MS, "acc_stale"));
+    await vi.advanceTimersByTimeAsync(TTL_MS * 3);
+
+    expect(screen.getByRole("button", { name: /Use a recovery code/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Add a passkey/i })).toBeNull();
+    // Still the one grant: nothing re-armed.
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons a grant that resolves after the screen unmounts", async () => {
+    // The worst version: after enrolment the user signs in, so the cookie names
+    // an ORDINARY session, which the issuer never refuses. A loop re-armed here
+    // has no stop condition at all.
+    const grant = deferred<ReturnType<typeof sessionExpiringIn>>();
+    hoisted.refreshHeldSession.mockReturnValue(grant.promise);
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    await vi.advanceTimersByTimeAsync(TTL_MS - LEAD_MS);
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    grant.settle(sessionExpiringIn(TTL_MS, "acc_orphan"));
+    await vi.advanceTimersByTimeAsync(TTL_MS * 3);
+
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/osn/ui/tests/auth/RecoveryLoginForm.test.tsx
+++ b/osn/ui/tests/auth/RecoveryLoginForm.test.tsx
@@ -471,13 +471,23 @@ describe("RecoveryLoginForm — keeping the restricted session alive", () => {
   }
 
   /**
+   * What `refreshHeldSession` actually resolves to — the session wrapped in
+   * `HeldSession`, never bare. Mirrors the real `@osn/client` contract, so a
+   * test that drives this mock exercises the same `{ session } = await …`
+   * destructuring shape the component reads.
+   */
+  function heldSessionExpiringIn(ms: number, token = ACCESS_TOKEN) {
+    return { held: true as const, session: sessionExpiringIn(ms, token) };
+  }
+
+  /**
    * A grant that mints its token when it is called, not when it is set up.
    * `mockResolvedValue` would freeze `expiresAt` at test-setup time, so after
    * the clock advanced the "fresh" token would arrive already stale — the
    * opposite of what the issuer does.
    */
   function grantsTokenExpiringIn(ms: number, token: string) {
-    return () => Promise.resolve(sessionExpiringIn(ms, token));
+    return () => Promise.resolve(heldSessionExpiringIn(ms, token));
   }
 
   /** A promise the test resolves by hand, for asserting on an in-flight grant. */
@@ -609,7 +619,7 @@ describe("RecoveryLoginForm — keeping the restricted session alive", () => {
     // continuation arms the next one. Without a generation guard this re-holds
     // a token from a family the new factor has already deleted, and rotates the
     // session for as long as the page is open.
-    const grant = deferred<ReturnType<typeof sessionExpiringIn>>();
+    const grant = deferred<ReturnType<typeof heldSessionExpiringIn>>();
     hoisted.refreshHeldSession.mockReturnValue(grant.promise);
     // A failed ceremony is what puts "Start again" on the enrolment screen.
     registration.passkeyRegisterBegin.mockRejectedValue(new Error("NotAllowedError"));
@@ -624,7 +634,7 @@ describe("RecoveryLoginForm — keeping the restricted session alive", () => {
     expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: /Start again/i }));
-    grant.settle(sessionExpiringIn(TTL_MS, "acc_stale"));
+    grant.settle(heldSessionExpiringIn(TTL_MS, "acc_stale"));
     await vi.advanceTimersByTimeAsync(TTL_MS * 3);
 
     expect(screen.getByRole("button", { name: /Use a recovery code/i })).toBeTruthy();
@@ -633,11 +643,53 @@ describe("RecoveryLoginForm — keeping the restricted session alive", () => {
     expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
   });
 
+  it("abandons a grant that resolves after enrolment succeeds", async () => {
+    // The highest-consequence transition: after a successful recovery the
+    // user holds an ORDINARY session, which the issuer never refuses — so a
+    // background grant that resolves after this epoch bump and is applied
+    // rather than discarded would re-arm a refresh loop with no stop
+    // condition at all.
+    //
+    // `passkeyRegisterComplete` is held open so a background refresh can
+    // queue up (and be genuinely dispatched) behind it: both of
+    // `enrolPasskey`'s own token reads are comfortably inside the lead here,
+    // so it never spends a grant of its own — the one call below is the
+    // background timer's, and it lands only once `/complete` has already
+    // resolved and epoch has already moved on.
+    const grant = deferred<ReturnType<typeof heldSessionExpiringIn>>();
+    hoisted.refreshHeldSession.mockReturnValue(grant.promise);
+    const complete = deferred<{ passkeyId: string }>();
+    registration.passkeyRegisterComplete.mockReturnValue(complete.promise);
+    await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add a passkey/i }));
+    await vi.waitFor(() => expect(registration.passkeyRegisterComplete).toHaveBeenCalled());
+
+    // The background timer fires while `/complete` is still on the wire. Its
+    // grant takes a place in the queue but isn't dispatched yet.
+    await vi.advanceTimersByTimeAsync(TTL_MS - LEAD_MS);
+    expect(hoisted.refreshHeldSession).not.toHaveBeenCalled();
+
+    // `/complete` resolves: enrolPasskey bumps epoch and clears `held`.
+    // Only then does the queued grant get dispatched — genuinely in flight
+    // against a session that, by the time it lands, no longer exists.
+    complete.settle({ passkeyId: "pk_new" });
+    await vi.waitFor(() => expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1));
+    expect(screen.getByText(/You're back in/i)).toBeTruthy();
+
+    // Settling it now must be a no-op.
+    grant.settle(heldSessionExpiringIn(TTL_MS, "acc_late"));
+    await vi.advanceTimersByTimeAsync(TTL_MS * 3);
+
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/You're back in/i)).toBeTruthy();
+  });
+
   it("abandons a grant that resolves after the screen unmounts", async () => {
     // The worst version: after enrolment the user signs in, so the cookie names
     // an ORDINARY session, which the issuer never refuses. A loop re-armed here
     // has no stop condition at all.
-    const grant = deferred<ReturnType<typeof sessionExpiringIn>>();
+    const grant = deferred<ReturnType<typeof heldSessionExpiringIn>>();
     hoisted.refreshHeldSession.mockReturnValue(grant.promise);
     await reachEnrolmentHolding(sessionExpiringIn(TTL_MS));
 
@@ -645,9 +697,36 @@ describe("RecoveryLoginForm — keeping the restricted session alive", () => {
     expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
 
     cleanup();
-    grant.settle(sessionExpiringIn(TTL_MS, "acc_orphan"));
+    grant.settle(heldSessionExpiringIn(TTL_MS, "acc_orphan"));
     await vi.advanceTimersByTimeAsync(TTL_MS * 3);
 
+    expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons a grant that resolves after unmount mid-ceremony", async () => {
+    // `freshToken()` has its own `if (mine !== epoch) return null;`, separate
+    // from `refreshHeld`'s — triggered on demand from the ceremony rather
+    // than the background timer, so it needs its own proof. Minting already
+    // inside the lead means `beginRestricted` arms an expiry timer, not a
+    // refresh one, so the one grant possible here is the one `freshToken()`
+    // requests when `enrolPasskey` clicks — isolating it from the background
+    // path the other two tests in this block cover.
+    const grant = deferred<ReturnType<typeof heldSessionExpiringIn>>();
+    hoisted.refreshHeldSession.mockReturnValue(grant.promise);
+    await reachEnrolmentHolding(sessionExpiringIn(LEAD_MS - 5_000));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add a passkey/i }));
+    await vi.waitFor(() => expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1));
+    // Still waiting on the grant — the ceremony itself never started.
+    expect(registration.passkeyRegisterBegin).not.toHaveBeenCalled();
+
+    cleanup();
+    grant.settle(heldSessionExpiringIn(TTL_MS, "acc_orphan_ceremony"));
+    await vi.advanceTimersByTimeAsync(TTL_MS * 3);
+
+    // Discarded: `freshToken()` returns null, `enrolPasskey` never asks for
+    // a ceremony, and nothing re-requests a grant.
+    expect(registration.passkeyRegisterBegin).not.toHaveBeenCalled();
     expect(hoisted.refreshHeldSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/wiki/architecture/account-recovery-factors.md
+++ b/wiki/architecture/account-recovery-factors.md
@@ -81,6 +81,23 @@ The restriction is a **distinct token audience**, not a flag:
   outlive the window in which that purpose is plausible, and a 30-day sliding
   session that can do nothing is a dead end that also consumes a slot against
   `MAX_SESSIONS_PER_ACCOUNT`.
+- **The access token is capped to what the row has left**, at both issuance
+  sites (`sessionBoundTtl` in `osn/api/src/services/auth/tokens.ts`). The row's
+  deadline is absolute and rotation copies it forward, so an uncapped grant late
+  in the window would mint a full-length token outliving the session behind it.
+  Nothing is granted by such a token — `recoverySessionAdmitsEnrolment` tests
+  the row, not the token — but the browser is told a deadline the server will
+  not honour, and the enrolment screen is built on that promise. Capping makes
+  the token's expiry the honest end of the window, which is what lets the client
+  hold no copy of the fifteen minutes. It bounds the token rather than the
+  session: `verifyJwt` allows 30 s of clock skew, so a capped token still
+  verifies briefly after its row is gone, granting nothing.
+- **The enrolment screen refreshes rather than expiring at five minutes.** The
+  flow holds the session instead of adopting it, which puts it outside
+  `authFetch` and its silent refresh, so `@osn/client` exposes
+  `refreshHeldSession` — a `/token` grant returning a fresh token set without
+  adopting it. Rotation cannot extend the deadline, so this renews the token and
+  never the window. See [[passkey-primary]].
 - `/login/recovery/email/complete` sets the session cookie exactly as
   `/login/recovery/complete` does, or `completePasskeyRegistration`'s
   other-session sweep cannot resolve the caller and returns `session_stale`.

--- a/wiki/systems/passkey-primary.md
+++ b/wiki/systems/passkey-primary.md
@@ -317,15 +317,23 @@ paths behave differently in four ways, each forced by the restriction:
 - **Expiry is its own screen**, not a 401 toast. Somebody who has just proved
   who they are and then meets a generic error concludes the product is broken.
 
-> [!warning] The screen gets five minutes, not fifteen
-> Two deadlines are in play and the shorter one is the one the browser sees.
-> The session row lives `RECOVERY_SESSION_TTL_SEC` (900 s), but the access
-> token in the same response is signed with `accessTokenTtl` — 300 s by default
-> — and this flow holds the token outside `AuthProvider`, so `authFetch`'s
-> silent refresh is unavailable and `@osn/client` exposes no standalone
-> `/token` grant to call instead. The screen therefore arms its timeout on the
-> session's own `expiresAt` and never claims fifteen minutes. Widening it back
-> out is `xchromo/osn#976`.
+> [!note] The screen gets the whole fifteen minutes, and refreshes to hold them
+> Two deadlines are in play. The session row lives `RECOVERY_SESSION_TTL_SEC`
+> (900 s); the access token in the same response is signed with
+> `accessTokenTtl` — 300 s by default. Holding the token outside
+> `AuthProvider` means `authFetch`'s silent refresh never runs, so the screen
+> redeems the refresh cookie itself through `refreshHeldSession`
+> (`osn/client/src/service.ts`), a `/token` grant that returns a fresh token
+> set **without adopting it**. It refreshes 30 s before each token expires.
+>
+> Two things bound it, and neither is a copy of the 900 on the client. The
+> server caps a restricted session's token at the life its own row has left
+> (`sessionBoundTtl`, `osn/api/src/services/auth/tokens.ts`), so the last token
+> of the window expires exactly when the row does. And rotation carries
+> `restricted_until` forward rather than extending it, so refreshing renews the
+> token but can never buy the session more time than it was granted. Once a
+> token arrives with less than the refresh lead on it, the screen stops
+> granting and waits it out — the timed-out screen and the row's death coincide.
 
 > [!important] An emailed code that yields a session is not the OTP login this page removed
 > The resemblance is real and worth stating plainly, because "we deleted OTP

--- a/wiki/systems/sessions.md
+++ b/wiki/systems/sessions.md
@@ -188,8 +188,11 @@ That `UPDATE` is the one write that turns a restricted session into a full one, 
 | `restricted_until IS NOT NULL` | An everyday passkey add quietly resetting the caller's session clock |
 | `expires_at > now` | Reviving a session past its 15-minute deadline. `liveSessionIds` has no expiry term, so an expired restricted row still classifies as the caller's own, and expiry is otherwise enforced only in `verifyRefreshToken` — which this path never calls. Without it the real bound was the deadline plus one access-token TTL |
 
-> [!note] No route mints one yet
-> The primitive ships ahead of the endpoints that use it. `POST /login/recovery/email/complete` and `POST /login/recovery/totp/complete` are separate work — see `wiki/architecture/account-recovery-factors.md` §B.
+**The access token is capped to the row, not just to `accessTokenTtl`.** `sessionBoundTtl` gives a restricted session `min(accessTokenTtl, restricted_until − now)`, at both issuance sites. Without it a grant late in the window mints a full-length token that outlives the row authorising it: harmless server-side, because the enrolment bypass reads the row, but it tells the browser a deadline the server will not honour — and the post-recovery enrolment screen counts on that value to know when the window ends. An ordinary session (`restricted_until` null) is untouched. This bounds the token, not the session: `verifyJwt` allows 30 s of clock skew, so a capped token still verifies for a moment after its row is gone, granting nothing.
+
+**Refreshing one from the browser.** `@osn/client` exposes `refreshHeldSession` alongside `refreshSession`, and the difference is the whole reason it exists: it redeems the refresh cookie and returns the token set **without adopting it** — no storage write, no cached account, no session resource refetched. It is for a flow that deliberately holds a session rather than publishing one, which is every flow whose token the rest of the app would reject. Post-recovery passkey enrolment is the caller; holding the session is what puts it outside `authFetch`, so this is its only refresh path. Both share one single-flight `/token` grant, so a component refreshing while the provider bootstraps produces one request — two would replay a rotated cookie, which is what reuse detection revokes a family for.
+
+**Two routes mint one:** `POST /login/recovery/email/complete` and `POST /login/recovery/totp/complete` — see `wiki/architecture/account-recovery-factors.md` §B.
 
 ## Rotation grace window (concurrency tolerance)
 


### PR DESCRIPTION
## Summary

A restricted recovery session lasts **15 minutes**; the screen that uses it stopped working after **5**. Two different deadlines are in play and only the shorter one reached the browser: the session row's `expiresAt` is `now + RECOVERY_SESSION_TTL_SEC` (900s), while the access token in the same response is signed with `accessTokenTtl` (300s by default, shared with every ordinary token).

A user who read the recovery screen for more than five minutes and then pressed "Add a passkey" sent a dead bearer and got a 401 — while the session row was still alive for another ten minutes, and one `/token` grant would have re-minted a valid recovery-audience token.

## Workspaces affected

`@osn/api`, `@osn/client`, `@osn/ui` — named in the changeset.

## Issues

**Closes**

| Issue | What |
|---|---|
| #976 | Post-recovery enrolment screen expires after 5 minutes, not the 15 the session grants |

Closes #976

**Opened**

| Issue | What |
|---|---|
| #986 | `<Register>` holds a session the same way and would gain the same protection |
| #987 | A reload mid-recovery bootstraps the recovery token as the app session and strands the user (pre-existing) |

## Decisions

### The screen refreshes in place rather than adopting — `approach`

`<RecoveryLoginForm>` holds the session **without** adopting it, and must: `@musubi/social`'s `AuthDialogs` unmounts the flow the moment `session()` turns truthy, and adopting publishes an `aud: "osn-recovery"` token that `listProfiles`' plain `fetch` rejects with no silent refresh to repair it. So `@osn/client` gained `refreshHeldSession`, which redeems the refresh cookie and **returns** a token set without writing storage, cache or any context signal.

Rotation already carries `restrictedUntil` forward, re-issues on the recovery audience, and does not extend the absolute deadline — so refreshing cannot buy more than the fifteen minutes the session was granted.

### The server now caps a restricted token to its row — `approach`

- **Issue** — this went beyond a client-only fix.
- **Why** — without it, a refresh near the row's real deadline still mints a **full-length** token, because the server has no reason to shorten it. The client would then hold a token claiming validity up to ~300s **past** the row's real 900s deadline: the enrol button looks live, the press 401s, and the issue's exact symptom reappears — just moved from T+300 to past T+900. Review confirmed the client-only fix would not have satisfied the issue's own "Done when".
- **Solution** — `sessionBoundTtl` caps a restricted token at the row's remaining life, floored at one second.
- **Rationale** — the cap is what makes the token's own expiry tell the truth, which is the only way the client avoids holding a copy of the server's 900. The floor exists for the sub-second gap between `verifyRefreshToken`'s clock read and `refreshTokens`' own later one; without it a session caught in that race would call `signJwt` with a non-positive TTL. Cap and floor only work together — capping without flooring makes each shortened token schedule its next grant at half its remaining life, an accelerating burst converging on the deadline.

### The held type is branded so adopting it will not compile — `S-M1`

- **Issue** — `refreshHeldSession` returned a plain `Session`, structurally identical to what `adoptSession` accepts. Nothing but discipline stopped `adoptSession(await refreshHeldSession())` — precisely the mistake the method exists to prevent, and #986 names this method as the reference implementation for the next flow that needs the same distinction.
- **Solution** — a nested `HeldSession { held: true; session: Session }`.
- **Rationale** — and this is the part worth reading: the reviewer's own suggested shape, `interface HeldSession extends Session { readonly held: true }`, **does not work**. A value carrying extra properties is still structurally assignable to the narrower interface, so `adoptSession` would have accepted it and the brand would have bought nothing. That was caught by running `tsc` against the suggestion rather than reasoning about it. The nested wrapper has no `accessToken` at its own top level, which is what actually produces the error.

Demonstrated rather than asserted — a test cannot show a compile error:

```
error TS2345: Argument of type 'HeldSession' is not assignable to parameter of type 'Session'.
  Type 'HeldSession' is missing the following properties from type 'Session': accessToken, idToken, expiresAt, scopes
```

I reproduced that independently on the committed tree, then removed the probe.

### `<Register>` deliberately left alone — `approach`

It holds a session the same way and would benefit, but its passkey-less session is **already an open finding** whose proposed partial fix *shortens* that session's life. A keep-alive pulls the opposite way, so landing it here would pre-empt a decision that is not this PR's to make. It also fails differently — a toast and a retry button that can never succeed, with no expiry state to hang a timer on — and holds its token in two signals plus `profileId()`. Filed as #986; the client half needs no further work when it is picked up.

**Out of scope** — #986, #987.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Client | `bun run --cwd osn/client test:run` | 22 files, 244 pass |
| UI | `bun run --cwd osn/ui test:run` | 20 files, 201 pass |
| App | `bun run --cwd musubi/social test:run` | 20 files, 151 pass |
| API | `bun run --cwd osn/api test:run` | 79 files, 1347 pass |
| Type check | `bun run check` | 39 successful, 39 total |
| Lint | `bun run lint` | 0 errors; standing warning count unchanged at 1037 |
| Format | `bun run fmt:check` | clean |

Lint exits 0 regardless of its ~1037 standing warnings, so the exit code is not evidence — the unchanged count is.

**Mutation proof.**

| Guard | Result |
|---|---|
| `adoptSession(await refreshHeldSession())` | compile error TS2345 (quoted above) — verified by me independently |
| `refreshHeld`'s post-await epoch check | red: called 2 times, expected 1 |
| `sessionBoundTtl`'s `Math.max(1, …)` floor | red: expected +0 to be 1 |
| `freshToken`'s own epoch check | red: `passkeyRegisterBegin` called when it must not be |
| The epoch guard (earlier round) | red: both "abandons a grant" tests |
| `credentials: "include"` on the grant | red: its own test |

The last two were verified by the reviewer in a copy-on-write clone rather than in the worktree, which is why a session interruption mid-review cost nothing.

**One test needed a different construction than the review suggested, and the reason is worth recording:** the literal recipe for the enrolment-success epoch case can never produce "called exactly once", because `refreshHeld`'s background trigger and `freshToken`'s staleness threshold are the same expression against the same value and both route through one `serialise` FIFO — so a genuinely in-flight background call is either consumed (2 calls) or short-circuited (0). The working construction holds `passkeyRegisterComplete` open instead, so the background refresh queues behind it and is dispatched only after `epoch` has already moved.

**Not verified by hand:** nothing here has been exercised against a live API with a real authenticator.
