### PR TITLE
chore(tools): card the eight merged PRs that had none

### DIFF
--- a/.claude/metrics/chore-metrics-cards-sep-10.json
+++ b/.claude/metrics/chore-metrics-cards-sep-10.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 985,
+    "branch": "chore/metrics-cards-sep-10",
+    "base_sha": "4fac652a86749a64e17ed80d44e96942e0393256",
+    "head_sha": "a6fe5e86e7cb81f1bd68cf4954d209f1e6993ed2",
+    "generated_at": "2026-09-11T02:01:21.098Z",
+    "merged_at": "2026-09-10T05:11:44Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-10T04:16:14.157Z",
+    "last_ts": "2026-09-10T04:16:45.171Z",
+    "span_seconds": 31,
+    "active_seconds": 31,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.27977199999999997,
+    "tokens": {
+      "input": 12,
+      "output": 1550,
+      "thinking": 0,
+      "cache_write_5m": 19570,
+      "cache_write_1h": 0,
+      "cache_read": 237299
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 12,
+          "output": 1550,
+          "thinking": 0,
+          "cache_write_5m": 19570,
+          "cache_write_1h": 0,
+          "cache_read": 237299
+        },
+        "usd_equivalent": 0.27977199999999997,
+        "messages": 7
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 12,
+          "output": 1550,
+          "thinking": 0,
+          "cache_write_5m": 19570,
+          "cache_write_1h": 0,
+          "cache_read": 237299
+        },
+        "usd_equivalent": 0.27977199999999997,
+        "messages": 7
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 0,
+      "config": 8,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 1149,
+        "deleted": 29
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Grep": 1,
+      "Bash": 1,
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-d1-migration-cost-guard.json
+++ b/.claude/metrics/feat-d1-migration-cost-guard.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 995,
+    "branch": "feat/d1-migration-cost-guard",
+    "base_sha": "09ce0e2daf10c89df6bef57fe63bc31ebb16534f",
+    "head_sha": "f83f722101ecdf0b84458f5af44405d11ea77288",
+    "generated_at": "2026-09-11T02:01:21.097Z",
+    "merged_at": "2026-09-10T08:44:44Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 991,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-09-10T08:23:50.318Z",
+    "last_ts": "2026-09-10T08:32:11.957Z",
+    "span_seconds": 502,
+    "active_seconds": 272,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.3677557500000002,
+    "tokens": {
+      "input": 46,
+      "output": 15836,
+      "thinking": 0,
+      "cache_write_5m": 81373,
+      "cache_write_1h": 0,
+      "cache_read": 926089
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 46,
+          "output": 15836,
+          "thinking": 0,
+          "cache_write_5m": 81373,
+          "cache_write_1h": 0,
+          "cache_read": 926089
+        },
+        "usd_equivalent": 1.3677557500000002,
+        "messages": 26
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 46,
+          "output": 15836,
+          "thinking": 0,
+          "cache_write_5m": 81373,
+          "cache_write_1h": 0,
+          "cache_read": 926089
+        },
+        "usd_equivalent": 1.3677557500000002,
+        "messages": 26
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 2,
+      "docs": 2,
+      "config": 1,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 464,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 155,
+        "deleted": 5
+      },
+      "config": {
+        "added": 22,
+        "deleted": 0
+      },
+      "source": {
+        "added": 585,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 3
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 7,
+      "Bash": 4
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-free-tier-ceiling-alerts.json
+++ b/.claude/metrics/feat-free-tier-ceiling-alerts.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 993,
+    "branch": "feat/free-tier-ceiling-alerts",
+    "base_sha": "a1840dd0773d6902fcb12efaf8f68e6d4a299c9f",
+    "head_sha": "c20d4959e8d74162426f8f645668f45da3ade65d",
+    "generated_at": "2026-09-11T02:01:21.097Z",
+    "merged_at": "2026-09-10T08:44:57Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 989,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-09-10T08:17:43.086Z",
+    "last_ts": "2026-09-10T08:24:28.929Z",
+    "span_seconds": 406,
+    "active_seconds": 346,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.5584500000000001,
+    "tokens": {
+      "input": 43,
+      "output": 20838,
+      "thinking": 0,
+      "cache_write_5m": 99530,
+      "cache_write_1h": 0,
+      "cache_read": 830445
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 43,
+          "output": 20838,
+          "thinking": 0,
+          "cache_write_5m": 99530,
+          "cache_write_1h": 0,
+          "cache_read": 830445
+        },
+        "usd_equivalent": 1.5584500000000001,
+        "messages": 23
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 43,
+          "output": 20838,
+          "thinking": 0,
+          "cache_write_5m": 99530,
+          "cache_write_1h": 0,
+          "cache_read": 830445
+        },
+        "usd_equivalent": 1.5584500000000001,
+        "messages": 23
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 1,
+      "docs": 1,
+      "config": 2,
+      "source": 1
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 327,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 21,
+        "deleted": 0
+      },
+      "config": {
+        "added": 99,
+        "deleted": 1
+      },
+      "source": {
+        "added": 667,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Read": 6,
+      "Bash": 4
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/feat-totp-key-rotation.json
+++ b/.claude/metrics/feat-totp-key-rotation.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 1000,
+    "branch": "feat/totp-key-rotation",
+    "base_sha": "89b10ce9e3cb3e3d12c4bd6dd2cf723c0569ba3a",
+    "head_sha": "9180d8c61e6e52a165758f5947d3f2bfdebe518e",
+    "generated_at": "2026-09-11T02:01:21.083Z",
+    "merged_at": "2026-09-11T00:25:59Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 968,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-09-10T13:09:31.640Z",
+    "last_ts": "2026-09-10T14:48:41.099Z",
+    "span_seconds": 5949,
+    "active_seconds": 5987,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 48.442343750000006,
+    "tokens": {
+      "input": 1649,
+      "output": 53949,
+      "thinking": 0,
+      "cache_write_5m": 1398399,
+      "cache_write_1h": 0,
+      "cache_read": 89243859
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 17,
+          "output": 1653,
+          "thinking": 0,
+          "cache_write_5m": 16120,
+          "cache_write_1h": 0,
+          "cache_read": 169540
+        },
+        "usd_equivalent": 0.22692999999999997,
+        "messages": 7
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 900,
+          "output": 8773,
+          "thinking": 0,
+          "cache_write_5m": 314351,
+          "cache_write_1h": 0,
+          "cache_read": 3110381
+        },
+        "usd_equivalent": 7.487418500000001,
+        "messages": 30
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 314,
+          "output": 6868,
+          "thinking": 0,
+          "cache_write_5m": 460601,
+          "cache_write_1h": 0,
+          "cache_read": 27296810
+        },
+        "usd_equivalent": 6.6801725,
+        "messages": 157
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 418,
+          "output": 36655,
+          "thinking": 0,
+          "cache_write_5m": 607327,
+          "cache_write_1h": 0,
+          "cache_read": 58667128
+        },
+        "usd_equivalent": 34.04782275000001,
+        "messages": 209
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 17,
+          "output": 1653,
+          "thinking": 0,
+          "cache_write_5m": 16120,
+          "cache_write_1h": 0,
+          "cache_read": 169540
+        },
+        "usd_equivalent": 0.22692999999999997,
+        "messages": 7
+      },
+      "subagent": {
+        "tokens": {
+          "input": 1632,
+          "output": 52296,
+          "thinking": 0,
+          "cache_write_5m": 1382279,
+          "cache_write_1h": 0,
+          "cache_read": 89074319
+        },
+        "usd_equivalent": 48.21541375000002,
+        "messages": 396
+      }
+    },
+    "effort": {
+      "high": 30,
+      "xhigh": 366
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 5,
+      "docs": 5,
+      "config": 2,
+      "source": 9
+    },
+    "loc": {
+      "generated": {
+        "added": 36,
+        "deleted": 0
+      },
+      "test": {
+        "added": 893,
+        "deleted": 82
+      },
+      "docs": {
+        "added": 232,
+        "deleted": 36
+      },
+      "config": {
+        "added": 101,
+        "deleted": 16
+      },
+      "source": {
+        "added": 425,
+        "deleted": 91
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/db",
+      "shared/observability"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 63,
+      "Edit": 39,
+      "Read": 18,
+      "Write": 3,
+      "ToolSearch": 1,
+      "Glob": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 9
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-bare-root-agent-harness.json
+++ b/.claude/metrics/fix-bare-root-agent-harness.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 994,
+    "branch": "fix/bare-root-agent-harness",
+    "base_sha": "09ce0e2daf10c89df6bef57fe63bc31ebb16534f",
+    "head_sha": "9ebc63777192470e18443eecec7815269a320cc5",
+    "generated_at": "2026-09-11T02:01:21.097Z",
+    "merged_at": "2026-09-10T08:45:10Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 988,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 4,
+    "first_ts": "2026-09-10T08:25:45.057Z",
+    "last_ts": "2026-09-10T08:30:47.895Z",
+    "span_seconds": 303,
+    "active_seconds": 270,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 1.09959325,
+    "tokens": {
+      "input": 42,
+      "output": 14519,
+      "thinking": 0,
+      "cache_write_5m": 60801,
+      "cache_write_1h": 0,
+      "cache_read": 712804
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 42,
+          "output": 14519,
+          "thinking": 0,
+          "cache_write_5m": 60801,
+          "cache_write_1h": 0,
+          "cache_read": 712804
+        },
+        "usd_equivalent": 1.09959325,
+        "messages": 22
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 42,
+          "output": 14519,
+          "thinking": 0,
+          "cache_write_5m": 60801,
+          "cache_write_1h": 0,
+          "cache_read": 712804
+        },
+        "usd_equivalent": 1.09959325,
+        "messages": 22
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 2,
+      "docs": 2,
+      "config": 0,
+      "source": 2
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 452,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 10,
+        "deleted": 2
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 436,
+        "deleted": 5
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 4,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 4,
+      "Read": 3,
+      "Glob": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-cf-token-scope-visibility.json
+++ b/.claude/metrics/fix-cf-token-scope-visibility.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 997,
+    "branch": "fix/cf-token-scope-visibility",
+    "base_sha": "b5e6d72ea20c27fb71e825d93deec6e6300d8d49",
+    "head_sha": "fa91561dcb54dc057d62889b2af707311b5494f0",
+    "generated_at": "2026-09-11T02:01:21.097Z",
+    "merged_at": "2026-09-10T12:56:57Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 1,
+    "first_ts": "2026-09-10T12:55:14.821Z",
+    "last_ts": "2026-09-10T12:56:28.282Z",
+    "span_seconds": 73,
+    "active_seconds": 73,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 0.48608625000000005,
+    "tokens": {
+      "input": 10,
+      "output": 4307,
+      "thinking": 0,
+      "cache_write_5m": 51117,
+      "cache_write_1h": 0,
+      "cache_read": 117760
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 10,
+          "output": 4307,
+          "thinking": 0,
+          "cache_write_5m": 51117,
+          "cache_write_1h": 0,
+          "cache_read": 117760
+        },
+        "usd_equivalent": 0.48608625000000005,
+        "messages": 5
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 10,
+          "output": 4307,
+          "thinking": 0,
+          "cache_write_5m": 51117,
+          "cache_write_1h": 0,
+          "cache_read": 117760
+        },
+        "usd_equivalent": 0.48608625000000005,
+        "messages": 5
+      },
+      "subagent": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 0
+      }
+    },
+    "effort": {},
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 1,
+      "config": 1,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 40,
+        "deleted": 10
+      },
+      "config": {
+        "added": 33,
+        "deleted": 1
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 1
+  },
+  "interaction": {
+    "user_turns": 1,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 1,
+      "Read": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 0,
+      "max_edits_one_file": 0
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-recovery-passkey-cap.json
+++ b/.claude/metrics/fix-recovery-passkey-cap.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 998,
+    "branch": "fix/recovery-passkey-cap",
+    "base_sha": "b5e6d72ea20c27fb71e825d93deec6e6300d8d49",
+    "head_sha": "de55412c8ba35fbb7221b125bf4f59bac1a84ed4",
+    "generated_at": "2026-09-11T02:01:21.095Z",
+    "merged_at": "2026-09-10T12:59:21Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 970,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-09-10T03:29:47.543Z",
+    "last_ts": "2026-09-10T08:18:11.712Z",
+    "span_seconds": 17304,
+    "active_seconds": 5223,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 40.49537325000002,
+    "tokens": {
+      "input": 975,
+      "output": 65415,
+      "thinking": 0,
+      "cache_write_5m": 1242779,
+      "cache_write_1h": 0,
+      "cache_read": 65680145
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 37,
+          "output": 22702,
+          "thinking": 0,
+          "cache_write_5m": 181702,
+          "cache_write_1h": 0,
+          "cache_read": 1647283
+        },
+        "usd_equivalent": 2.5270140000000008,
+        "messages": 27
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 290,
+          "output": 107,
+          "thinking": 0,
+          "cache_write_5m": 173463,
+          "cache_write_1h": 0,
+          "cache_read": 1019373
+        },
+        "usd_equivalent": 3.1959105,
+        "messages": 10
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 110,
+          "output": 1928,
+          "thinking": 0,
+          "cache_write_5m": 214969,
+          "cache_write_1h": 0,
+          "cache_read": 8382965
+        },
+        "usd_equivalent": 2.233515500000001,
+        "messages": 55
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 538,
+          "output": 40678,
+          "thinking": 0,
+          "cache_write_5m": 672645,
+          "cache_write_1h": 0,
+          "cache_read": 54630524
+        },
+        "usd_equivalent": 32.538933250000014,
+        "messages": 269
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 1
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 37,
+          "output": 22702,
+          "thinking": 0,
+          "cache_write_5m": 181702,
+          "cache_write_1h": 0,
+          "cache_read": 1647283
+        },
+        "usd_equivalent": 2.5270140000000008,
+        "messages": 27
+      },
+      "subagent": {
+        "tokens": {
+          "input": 938,
+          "output": 42713,
+          "thinking": 0,
+          "cache_write_5m": 1061077,
+          "cache_write_1h": 0,
+          "cache_read": 64032862
+        },
+        "usd_equivalent": 37.96835925,
+        "messages": 335
+      }
+    },
+    "effort": {
+      "high": 10,
+      "xhigh": 324
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 4,
+      "docs": 4,
+      "config": 0,
+      "source": 6
+    },
+    "loc": {
+      "generated": {
+        "added": 33,
+        "deleted": 0
+      },
+      "test": {
+        "added": 726,
+        "deleted": 34
+      },
+      "docs": {
+        "added": 150,
+        "deleted": 7
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 266,
+        "deleted": 13
+      }
+    },
+    "packages": [
+      "osn/api",
+      "shared/observability"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 63,
+      "Edit": 46,
+      "Read": 28,
+      "Write": 4,
+      "Grep": 3
+    },
+    "edit_churn": {
+      "files_edited_3plus": 6,
+      "max_edits_one_file": 11
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}

--- a/.claude/metrics/fix-recovery-token-refresh.json
+++ b/.claude/metrics/fix-recovery-token-refresh.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": 999,
+    "branch": "fix/recovery-token-refresh",
+    "base_sha": "b366dfe5cc96a99ea00ed1e86fb6f2bbd914cc1b",
+    "head_sha": "ff1426b92fb114d305668cc452cafb3728deabb0",
+    "generated_at": "2026-09-11T02:01:21.092Z",
+    "merged_at": "2026-09-10T14:08:43Z",
+    "phase": "at-merge"
+  },
+  "issue": {
+    "number": 976,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 3,
+    "first_ts": "2026-09-10T03:30:20.231Z",
+    "last_ts": "2026-09-10T13:06:45.235Z",
+    "span_seconds": 34585,
+    "active_seconds": 7330,
+    "compactions": 0
+  },
+  "spend": {
+    "usd_equivalent": 51.22246085000001,
+    "tokens": {
+      "input": 1486,
+      "output": 48504,
+      "thinking": 0,
+      "cache_write_5m": 2612166,
+      "cache_write_1h": 0,
+      "cache_read": 101299715
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 32,
+          "output": 13522,
+          "thinking": 0,
+          "cache_write_5m": 165284,
+          "cache_write_1h": 0,
+          "cache_read": 1276350
+        },
+        "usd_equivalent": 2.00941,
+        "messages": 22
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 676,
+          "output": 749,
+          "thinking": 0,
+          "cache_write_5m": 321699,
+          "cache_write_1h": 0,
+          "cache_read": 2862131
+        },
+        "usd_equivalent": 6.9275785,
+        "messages": 23
+      },
+      "claude-sonnet-5": {
+        "tokens": {
+          "input": 384,
+          "output": 19849,
+          "thinking": 0,
+          "cache_write_5m": 1544336,
+          "cache_write_1h": 0,
+          "cache_read": 47823688
+        },
+        "usd_equivalent": 13.624835599999995,
+        "messages": 192
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 2
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 394,
+          "output": 14384,
+          "thinking": 0,
+          "cache_write_5m": 580847,
+          "cache_write_1h": 0,
+          "cache_read": 49337546
+        },
+        "usd_equivalent": 28.66063675,
+        "messages": 197
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 32,
+          "output": 13522,
+          "thinking": 0,
+          "cache_write_5m": 165284,
+          "cache_write_1h": 0,
+          "cache_read": 1276350
+        },
+        "usd_equivalent": 2.00941,
+        "messages": 22
+      },
+      "subagent": {
+        "tokens": {
+          "input": 1454,
+          "output": 34982,
+          "thinking": 0,
+          "cache_write_5m": 2446882,
+          "cache_write_1h": 0,
+          "cache_read": 100023365
+        },
+        "usd_equivalent": 49.21305085000001,
+        "messages": 414
+      }
+    },
+    "effort": {
+      "high": 23,
+      "xhigh": 389
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 1,
+      "test": 3,
+      "docs": 3,
+      "config": 0,
+      "source": 5
+    },
+    "loc": {
+      "generated": {
+        "added": 51,
+        "deleted": 0
+      },
+      "test": {
+        "added": 595,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 39,
+        "deleted": 11
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 348,
+        "deleted": 46
+      }
+    },
+    "packages": [
+      "osn/api",
+      "osn/client",
+      "osn/ui"
+    ],
+    "touches_migration": false,
+    "commits": 2
+  },
+  "interaction": {
+    "user_turns": 2,
+    "corrective_turns": 0,
+    "tokens_before_first_edit": null,
+    "sessions_with_observed_edit": 0,
+    "tool_calls": {
+      "Bash": 86,
+      "Edit": 42,
+      "Read": 24,
+      "ToolSearch": 1,
+      "Grep": 1
+    },
+    "edit_churn": {
+      "files_edited_3plus": 6,
+      "max_edits_one_file": 10
+    },
+    "skills": {},
+    "subagents": {}
+  }
+}


### PR DESCRIPTION
## Summary

Cards for the eight merged pull requests that had none — the three follow-ups from the account-recovery epic (#998, #999, #1000) and five other recent merges.

Nothing else changed. The backfill also rewrote fifteen existing cards, but every one of those diffs was a new `generated_at` and nothing else, so they were discarded rather than committed.

## Workspaces affected

None — `.claude/metrics/` only, which `scripts/changeset-required.sh` reports as `skip`.

## Issues

**Closes**

This branch closes no issue.

**Opened**

| Issue | What |
|---|---|
| #1004 | `pr-metrics` reads complexity from the PR's labels, where it never lives |

## Decisions

### Only the new cards, not the rewrites — `approach`

- **Issue** — `backfill --limit 25` wrote 23 cards: 8 new, 15 rewrites.
- **Why** — every one of the fifteen rewrites differed only in `generated_at`. Committing them would put fifteen meaningless diffs in the history and make a future reviewer check fifteen files to find the zero changes in them.
- **Solution** — `git checkout -- .claude/metrics/` after the run, then add only the untracked files.
- **Rationale** — verified rather than assumed: each modified file's diff was filtered for non-`generated_at` lines and all fifteen came back empty.

**Out of scope** — the complexity bug below. It is a change to `tools/pr-metrics` with its own tests and README rules, and it deserves its own PR rather than riding along with a data update.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Changeset | `git diff --cached --name-only \| bash scripts/changeset-required.sh` | `skip` — `.claude/` is on the allowlist |
| Card contents | read back the three epic cards | issue numbers 970/976/968 linked, sessions and spend present |
| Churn check | per-file diff filtered for non-`generated_at` lines | all fifteen rewrites empty, discarded |

This branch changes no code, so the suites are unaffected.

## What the backfill revealed

Worth reading before trusting any spend-per-complexity analysis: **`complexity.declared` is `null` in all 91 cards in `.claude/metrics/`, and always has been.**

`backfill.ts:267` reads `pull.labels` — the pull request's own labels. This repository puts `complexity:` on the **issue**, per `CLAUDE.md`'s "Every issue also carries a `complexity:` rating". Pull requests here carry no labels at all: `gh pr view 998 --json labels` returns `[]` while `gh issue view 970 --json labels` returns `["product:osn-core","complexity:3","complexity:unconfirmed"]`.

So `declaredFromLabels` is fed an empty list every time and returns null every time. `CLAUDE.md` describes complexity as "the denominator every session-metrics query divides spend by" — that denominator has never existed in the data.

The fix looks small: `backfill.ts` already queries `closingIssuesReferences`, so the issue is in hand; it needs the issue's labels rather than the PR's. Filed separately.