### PR TITLE
docs(skills): say what actually attributes an orchestrated run

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -37,20 +37,30 @@ create worktrees — run it from `/Users/ac/.work/osn.git/main`, or use
 `new-feat` and `prep-pr` in place instead." There is no static equivalent of
 this run; the deliverable is merged pull requests.
 
-> [!warning] An orchestrated task is not measured by a session card.
+> [!warning] An orchestrated task is carded only if every dispatch carries the branch.
 > `gitBranch` is captured once when a session starts and inherited by every
-> subagent it dispatches — it is a property of the session, not of the work. So
-> a subagent building in a task worktree records the *orchestrator's* branch,
-> and the task's own card reads zero. This is not fixable by arranging branches
-> differently: `isolation: "worktree"` pins a subagent's `cwd` correctly but
-> still reports the parent's `gitBranch`, and the Agent tool has no way to pin
-> an agent to a worktree you chose.
+> subagent it dispatches — it is a property of the session, not of the work, and
+> `isolation: "worktree"` does not change it: that pins a subagent's `cwd`
+> correctly and still reports the parent's `gitBranch`. So a subagent building in
+> a task worktree would record the *orchestrator's* branch, and the task's own
+> card would read zero.
 >
-> The consequence to hold on to: **cards describe work done by a session in its
-> own worktree, and orchestrated work is absent from them.** A coverage number
-> is not a statement about this workflow. Where a task's cost genuinely matters,
-> run it through `new-feat` in its own session instead — that attributes
-> correctly. See `wiki/observability/session-metrics.md`.
+> What closes that is the `TASK-BRANCH:` marker in Step 3 — the collector reads
+> it back out of the dispatch prompt. **It is the whole of the attribution, and
+> it fails silently**: a dispatch that omits the line does not warn, it just
+> banks that subagent's spend against the orchestrator's own branch, where
+> nothing will look for it.
+>
+> So put it in every prompt this skill sends — hand-offs, fix subagents,
+> reviewers, shepherds, re-dispatches — and check the run afterwards rather than
+> assuming. Every task branch should appear in:
+>
+> ```bash
+> bun run --cwd tools/pr-metrics backfill -- --dry-run
+> ```
+>
+> A branch missing from that list was not attributed. See
+> `wiki/observability/session-metrics.md`.
 
 ## The blackboard
 
@@ -265,4 +275,4 @@ The full table, with the reason behind each, is `references/gotchas.md`. The one
 
 ## When not to use this
 
-A one-line or single-file change — edit it and open the PR directly. Outside the local bare repo — `new-feat` then `prep-pr` in place. A task whose cost you want measured — `new-feat` in its own session, since orchestrated work is not carded.
+A one-line or single-file change — edit it and open the PR directly. Outside the local bare repo — `new-feat` then `prep-pr` in place.


### PR DESCRIPTION
## Summary

`.claude/skills/orchestrate/SKILL.md` contradicted itself about whether orchestrated work is measured, and the stale half was the discouraging one.

Lines 40–53 warned that an orchestrated task "is not measured by a session card", that "the task's own card reads zero", and that "this is not fixable by arranging branches differently". Lines 139–147 of the same file specify the `TASK-BRANCH:` marker that the collector reads back out of the dispatch prompt — which is exactly the fix. The marker landed in #946; the warning predates it and was never removed.

## Workspaces affected

None — `.claude/skills/` only, which `scripts/changeset-required.sh` reports as `skip`.

## Issues

**Closes**

| Issue | What |
|---|---|
| #1005 | orchestrate's carding warning is stale and contradicts its own `TASK-BRANCH` mechanism |

Closes #1005

**Opened**

None.

## Decisions

### Why this was worth fixing rather than leaving as a harmless stale note — `approach`

- **Issue** — a reader following the skill is told, in a `[!warning]`, that their measurements are worthless and that nothing can be done about it.
- **Why** — that is an argument for not bothering with the marker, and omitting the marker is precisely what makes the claim true. A stale warning that induces the behaviour it warns about is worse than no warning at all.
- **Solution** — state the marker as the **condition** for attribution, name the failure mode as **silent**, and give the check that answers it after the fact.
- **Rationale** — the evidence is direct. An orchestrated run of eleven pull requests (#961, #962, #969, #972, #974, #975, #977, #978, #998, #999, #1000) emitted `TASK-BRANCH:` in every dispatch — hand-offs, fix subagents, reviewers, shepherds, re-dispatches — and every one of the eleven carded with real spend, $0.14 to $75.34. None read zero.

### What was kept — `approach`

The underlying mechanic is still true and still the reason the marker exists: `gitBranch` is captured once at session start and inherited, and `isolation: "worktree"` pins a subagent's `cwd` without changing it. That is now stated as the reason the marker is needed rather than as a reason attribution is impossible.

### A second copy of the same claim — `approach`

The skill's closing "When not to use this" section also read *"A task whose cost you want measured — `new-feat` in its own session, since orchestrated work is not carded."* Removed, for the same reason. The other two clauses in that sentence stand.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Format | `bun run fmt:check` | All matched files use the correct format |
| Changeset | `git diff --name-only \| bash scripts/changeset-required.sh` | `skip` — `.claude/` is on the allowlist |
| Stale claim gone | `grep -n "not carded\|orchestrated work is absent"` | no matches |

Documentation only; no code changed and no suite is affected.

**Verified rather than asserted:** the eleven-PR claim above is from `bun run --cwd tools/pr-metrics backfill -- --dry-run`, which lists every one of those branches with a non-zero figure. That same command is now the check the skill tells a reader to run.
