### PR TITLE
docs(conventions): catalogue the three ways a test here cannot fail

### DIFF
--- a/wiki/conventions/testing-patterns.md
+++ b/wiki/conventions/testing-patterns.md
@@ -6,7 +6,8 @@ related:
   - "[[backend-patterns]]"
   - "[[schema-layers]]"
   - "[[commands]]"
-last-reviewed: 2026-09-06
+  - "[[bundle-size-guards]]"
+last-reviewed: 2026-09-11
 ---
 
 # Testing Patterns
@@ -159,11 +160,89 @@ describe("events routes", () => {
 
 - **Never hand-write a DDL mirror.** Test databases are built from the live Drizzle schema via `applySchema()` (`@osn/db/testing`, `@pulse/db/testing`, `@zap/db/testing`) — never a `CREATE TABLE` string in a helper or a test file. A hand-written mirror makes constraint tests tautological: they assert the `UNIQUE` the author typed a few lines above, not the one the schema declares, so dropping `.unique()` from `src/schema` leaves them green. See [[#Schema-derived test databases]].
 
-- **A test must fail for the reason it is named.** Before landing a test that asserts a side effect (a row written, a notice sent), break the code path and confirm the test goes red. `expect(true).toBe(true)` after an action asserts nothing.
+- **A test must fail for the reason it is named.** Before landing a test that asserts a side effect (a row written, a notice sent), break the code path and confirm the test goes red. `expect(true).toBe(true)` after an action asserts nothing. Three ways that check is passed by a test which still cannot fail — a timestamp tie, a `waitFor`ed absence, and a red-proof that ate its own fix — are in [[#Assertions that cannot fail]].
 
 - **Every Solid Vitest config names `shared/test-config/no-jest-dom.ts` in `setupFiles`.** `vite-plugin-solid` prepends `@testing-library/jest-dom/vitest` to `setupFiles` for every run, and only two things stop it — one of your own `setupFiles` paths matching the regex `/jest-dom/` (`getJestDomExport` in the plugin's `dist/esm/index.mjs`), or a browser-mode project, which it skips because Vitest's browser assertions carry the matchers already. That file is a marker whose whole job is to match the regex. It exports nothing and must stay that way; a package that wants real shared setup adds a second entry of its own. Since 2026-08 all 13 configs that import the plugin carry it, and `bun run check:jest-dom-markers` (the `Scripts` CI job) fails the build if one loses it. The guard is per **file**, not per project: `cire/host`'s browser project has no `setupFiles` and still takes the injection, which is harmless there because that package imports the matchers in eighteen files anyway.
 
 - **Import the matchers where you assert with them, and declare the dependency only there.** A test that uses `toHaveAttribute` or `toBeInTheDocument` writes `import "@testing-library/jest-dom/vitest";` at the top of the file, and its package lists `@testing-library/jest-dom` in `devDependencies`. Three packages do — `cire/host`, `cire/vendor` and `pulse/web`. Ten others declared it while importing no matcher and were pruned. Bun's install layout is not hoisted, so an undeclared dependency is unresolvable rather than quietly satisfied: the failure is a red `Cannot find module`, not a green suite. `tsconfig.json` already has the test files in `include`, so the matcher types resolve across a package from any one import. `tools/lab` is the deliberate exception — it leaves the plugin out entirely, so nothing injects and it needs no marker; the guard matches the import statement rather than the plugin's name so its comment about the plugin does not trip it.
+
+## Assertions that cannot fail
+
+[[#Rules]] says a test must fail for the reason it is named. This is the
+catalogue of how that goes wrong here. Every entry below was found by
+deliberately breaking the code and watching the test stay green — never by
+reading it. One epic produced four such tests and four destroyed fixes from
+these three causes alone.
+
+### `created_at` is unix seconds, so rows written together tie
+
+Four separate false greens in one epic, all the same shape.
+
+A helper picked "the newest row" by sorting `created_at`. Two credentials
+enrolled in the same second tied, so the test read the *parent's* value and
+asserted it against the child — and an implementation that did the wrong thing
+passed the one test written to catch it. Elsewhere every fixture was backdated,
+so `<` and `<=` agreed on every row and a boundary went untested until a
+same-second case was added.
+
+Two rules follow:
+
+- **Order by something exact.** Where a decision comes down to which row is
+  newer, break the tie on an id the code already returns, not on the timestamp.
+  A test that seeds two rows and expects a particular one to win must make the
+  ordering explicit rather than hope the clock separates them.
+- **Pass one `Date`, not two `new Date()` calls.** A tie test that calls
+  `new Date()` twice is hoping both land in the same second. Build the value
+  once and hand it to both seeds.
+
+And where a comparison could flip — `<` against `<=` — seed the exact-equal
+case. That is the only row on which the two operators disagree.
+
+### `waitFor` calls its callback synchronously on the first attempt
+
+`@testing-library/dom` runs the callback once, immediately, before yielding. So
+this passes before anything has rendered:
+
+```ts
+// Green whether or not the guard exists.
+await waitFor(() => expect(screen.queryByRole("button", { name: X })).toBeNull());
+```
+
+`toBeNull()` is already true on an empty document, `waitFor` resolves on the
+spot, and a resource that would have rendered the button never gets a tick to
+settle. Wrapping a racy absence check in `waitFor` is the same bug with more
+ceremony — two such assertions were confirmed green 5/5 and 3/3 runs against a
+deliberately reintroduced bug.
+
+**Mount the case under test beside one that does render the thing**, wait for
+that sibling to paint, then assert the absence. The wait then turns on a
+condition that starts out false, so it has to observe a real render:
+
+```ts
+// The admitting twin is what makes the wait mean something.
+renderAdmitting();
+renderRefusing();
+await vi.waitFor(() => expect(screen.getByRole("button", { name: X })).toBeVisible());
+expect(screen.queryAllByRole("button", { name: X })).toHaveLength(1);
+```
+
+Under faked timers use `vi.waitFor`, not testing-library's — the latter schedules
+against the `setTimeout` the fake clock has replaced.
+
+### Commit before you red-proof
+
+Breaking a guard to watch a test go red is the only way to know the test works.
+Restoring with `git checkout -- <path>` while the work is **uncommitted**
+restores `origin/main`, not the work — silently deleting the fix being proved.
+
+Four people hit this in one epic. One noticed only because a test count changed;
+another only because an unrelated test failed. Nothing announces it.
+
+Commit first, then break, then `git checkout --` restores the commit. If the
+change genuinely cannot be committed yet, copy the file aside and restore from
+the copy. A read-only reviewer should mutate a copy of the whole worktree
+instead — `cp -Rc` is a cheap clone on APFS — which also means an interrupted
+review costs nothing.
 
 ## Schema-derived test databases
 


### PR DESCRIPTION
## Summary

`wiki/conventions/testing-patterns.md` already carries the rule — *"A test must fail for the reason it is named."* It did not say how that goes wrong in this repository. One epic produced **four** false-green tests and **four** destroyed fixes from three causes, none of which appeared anywhere in the conventions: `grep -ic` on that page returned 0 for `waitFor`, `same second`, `unix second`, `red-proof` and `mutation`.

This adds a §"Assertions that cannot fail" cataloguing the three, each with the pattern that works rather than only the hazard, and cross-links it from the existing rule.

## Workspaces affected

None — `wiki/` only, which `scripts/changeset-required.sh` reports as `skip`.

## Issues

**Closes**

| Issue | What |
|---|---|
| #1006 | testing-patterns has nothing on assertions that cannot fail |

Closes #1006

**Opened**

None.

## Decisions

### Every entry is something that happened, not something that could — `approach`

- **Issue** — a conventions page can fill with plausible hazards nobody has met.
- **Why** — the three here were each found by deliberately breaking code and watching a test stay green. None was found by reading.
- **Solution** — each entry names the observed failure and its count.
- **Rationale** — the `created_at` one caused four separate false greens in the same area of one epic, which is the argument for writing it down rather than fixing it a fifth time.

### `waitFor` gets the most space because the obvious fix is wrong — `approach`

Wrapping a racy absence check in `waitFor` looks like the fix and is the same bug with more ceremony: `@testing-library/dom` runs the callback once, immediately, so `toBeNull()` is already true on an empty document and it resolves before anything renders. That exact "fix" was proposed in a review, committed, red-proofed, found still green, and replaced. Two assertions were confirmed green 5/5 and 3/3 runs against a deliberately reintroduced bug.

The section gives the working pattern — mount the case under test beside one that *does* render the thing, wait for the sibling to paint, then assert — because a wait on a condition that starts out false has to observe a real render. It also notes that faked timers need `vi.waitFor` rather than testing-library's, which schedules against the `setTimeout` the fake clock replaced.

### The red-proof entry is about tooling, not testing, and belongs here anyway — `approach`

`git checkout -- <path>` restores `origin/main` when the work is uncommitted, so breaking a guard to prove a test goes red and then restoring **deletes the fix being proved**. Four people hit it in one epic; one noticed only because a test count changed, another only because an unrelated test failed. Nothing announces it.

It sits in this page because it only bites while red-proofing, which is the practice the page's own rule asks for. The advice for a read-only reviewer — mutate a `cp -Rc` clone of the worktree instead — is there because a review interrupted mid-mutation then costs nothing, which is exactly what happened.

### What was cross-linked rather than restated — `approach`

`wiki/conventions/bundle-size-guards.md` owns the corollary *"you have not verified a guard until you have seen it fail."* It is referenced from the frontmatter's `related` rather than repeated, so the two pages cannot drift.

**Out of scope** — None.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Format | `bun run fmt:check` | All matched files use the correct format |
| Changeset | `git diff --name-only \| bash scripts/changeset-required.sh` | `skip` — `wiki/` is on the allowlist |
| Link target | `ls wiki/conventions/bundle-size-guards.md` | exists |
| Heading anchor | the cross-link's `[[#Assertions that cannot fail]]` | matches the heading added at line 169 |

Documentation only; no code changed and no suite is affected. `last-reviewed` bumped.
