### PR TITLE
fix(pr-metrics): read the complexity rating off the linked issue, not the PR

### DIFF
--- a/.changeset/metrics-complexity-source.md
+++ b/.changeset/metrics-complexity-source.md
@@ -1,0 +1,9 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Read `backfill`'s declared-complexity rating off the pull request's linked
+issue, not the pull request itself — this repository never puts a
+`complexity:` label on a pull request. Scoped to issues linked from
+xchromo/osn; a tracker-linked issue is left exactly as before pending
+xchromo/osn#1012.

--- a/tools/pr-metrics/backfill.ts
+++ b/tools/pr-metrics/backfill.ts
@@ -36,14 +36,32 @@ import {
   repoProjectPaths,
 } from "./index.ts";
 
+/** A pull request's linked issue, as `gh pr list --json closingIssuesReferences`
+ * already returns it — unconditionally, not a field this tool asked for by
+ * name (`--json` takes no nested selection; see `issueLabelsById`'s doc
+ * comment). The issue is usually not in this repository: see below. */
+interface IssueRef {
+  id: string;
+  number: number;
+  repository: { name: string; owner: { login: string } };
+}
+
 interface PullRequest {
   number: number;
   headRefName: string;
   mergedAt: string;
   baseRefOid: string;
   headRefOid: string;
-  labels: { name: string }[];
-  closingIssuesReferences: { number: number }[];
+  closingIssuesReferences: IssueRef[];
+}
+
+/** A card's complexity fields, decided per pull request below. Structurally
+ * compatible with `DeclaredComplexity` (`index.ts`) but not that type itself:
+ * `method` here also carries `"not-fetched"` and `"lookup-failed"`, neither
+ * of which `declaredFromLabels` can produce. */
+interface RatingOutcome {
+  declared: number | null;
+  method: string;
 }
 
 export interface ChangedFile {
@@ -168,6 +186,79 @@ async function commitCounts(repo: string, numbers: number[]): Promise<Map<number
   return counts;
 }
 
+/** How many GraphQL nodes one `nodes(ids:)` document asks about. Verified
+ * against the real ceiling — `nodes(ids:)` rejects a request over 100 ids
+ * outright ("ARGUMENT_LIMIT") — and against cost: a 50-id document with a
+ * `labels(first: 20)` sub-selection each measured `cost: 1`, `nodeCount:
+ * 1050` against GitHub's 500,000-node per-query budget. 50 leaves headroom
+ * under the hard limit rather than assuming a cost this small never grows. */
+const NODE_QUERY_CHUNK = 50;
+
+/**
+ * The labels of every given issue, addressed by its GraphQL node id — never
+ * by `(repository, number)`.
+ *
+ * `closingIssuesReferences[].number` is not safe to look up with a
+ * repository-scoped `issue(number:)` alias (the shape `commitCounts` uses
+ * above for pull-request numbers): the linked issue is usually not in this
+ * repository at all — most of this repository's pull requests close a
+ * finding in the private `xchromo/osn-tracker` repo instead — so the same
+ * bare number can resolve to an unrelated issue in the wrong repository, or
+ * to nothing (`NOT_FOUND`) when it happens to be a pull-request number
+ * instead. Either way one bad alias makes the whole batched `gh api graphql`
+ * call exit non-zero, and `commitCounts`'s `if (!result.ok) continue` would
+ * then drop every OTHER issue in that chunk too.
+ *
+ * `nodes(ids:)` needs no repository scoping — `gh pr list --json
+ * closingIssuesReferences` already returns each linked issue's node id
+ * alongside its number — and resolves every id independently: a id GraphQL
+ * cannot resolve becomes `null` at that position without touching its
+ * siblings. The document's exit code still goes non-zero when any id in it
+ * is unresolved (verified live), so `result.out` is parsed regardless of
+ * `result.ok`; only output that isn't JSON at all — a total transport
+ * failure — gives up on the chunk.
+ *
+ * Returns a map keyed by id. `has(id)` distinguishes "resolved, whatever
+ * labels came back" from "never resolved" — callers need that distinction to
+ * avoid recording a failed lookup as if it were a successfully-checked,
+ * genuinely unrated issue (see the `"lookup-failed"` branch below).
+ */
+async function issueLabelsById(ids: string[]): Promise<Map<string, string[]>> {
+  const labels = new Map<string, string[]>();
+
+  for (let i = 0; i < ids.length; i += NODE_QUERY_CHUNK) {
+    const chunk = ids.slice(i, i + NODE_QUERY_CHUNK);
+    const idList = chunk.map((id) => JSON.stringify(id)).join(", ");
+
+    const result = await ghAsync([
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=query { nodes(ids: [${idList}]) { ... on Issue { labels(first: 20) { nodes { name } } } } }`,
+    ]);
+
+    let parsed: { data?: { nodes?: ({ labels?: { nodes?: { name: string }[] } } | null)[] } };
+    try {
+      parsed = JSON.parse(result.out) as typeof parsed;
+    } catch {
+      continue;
+    }
+
+    const nodes = parsed.data?.nodes ?? [];
+    chunk.forEach((id, idx) => {
+      const node = nodes[idx];
+      if (node)
+        labels.set(
+          id,
+          (node.labels?.nodes ?? []).map((l) => l.name),
+        );
+    });
+  }
+
+  return labels;
+}
+
 /** The changed-file list of every given pull request, a bounded number of
  * requests at a time. The list has to stay on the paginated REST endpoint:
  * `gh pr list --json files` silently truncates at 100 files, and this
@@ -226,7 +317,7 @@ if (import.meta.main) {
     "--limit",
     limit,
     "--json",
-    "number,headRefName,mergedAt,baseRefOid,headRefOid,labels,closingIssuesReferences",
+    "number,headRefName,mergedAt,baseRefOid,headRefOid,closingIssuesReferences",
   ]);
 
   if (!listed.ok) {
@@ -256,17 +347,64 @@ if (import.meta.main) {
   // Both fetches happen up front rather than twice per iteration. Neither
   // depends on the other's result, and the loop's own work is local.
   const numbers = carded.map((pull) => pull.number);
-  const [counts, files] = await Promise.all([
+
+  // A linked issue's labels are read only when the issue itself lives in
+  // this same repository — see `issueLabelsById`'s doc comment for why a
+  // repository-scoped alias can't be used for one elsewhere, and
+  // xchromo/osn#1012 for why one elsewhere (chiefly the private
+  // xchromo/osn-tracker) is never fetched at all: its labels can carry a
+  // severity/area pair that must not reach a card committed in this public
+  // repository. Keyed by pull-request number so the per-pull loop below can
+  // look its ref back up.
+  const [repoOwner, repoName] = repo.split("/");
+  const localIssueRefs = new Map<number, IssueRef>();
+  for (const pull of carded) {
+    const ref = pull.closingIssuesReferences[0];
+    if (ref && ref.repository.owner.login === repoOwner && ref.repository.name === repoName) {
+      localIssueRefs.set(pull.number, ref);
+    }
+  }
+  const uniqueIssueIds = [...new Set([...localIssueRefs.values()].map((ref) => ref.id))];
+
+  const [counts, files, labelsById] = await Promise.all([
     commitCounts(repo, numbers),
     fileLists(repo, numbers),
+    issueLabelsById(uniqueIssueIds),
   ]);
 
   for (const pull of carded) {
     const records = byBranch.get(pull.headRefName) ?? [];
-
-    const labels = pull.labels.map((label) => label.name);
-    const complexity = declaredFromLabels(labels);
     const changed = files.get(pull.number) ?? [];
+
+    const linkedRef = pull.closingIssuesReferences[0] ?? null;
+    const issueNumber = linkedRef?.number ?? null;
+    const localRef = localIssueRefs.get(pull.number) ?? null;
+
+    let labels: string[] = [];
+    let complexity: RatingOutcome;
+    if (linkedRef === null) {
+      // No linked issue at all — nothing to check. Matches what `card`
+      // itself writes when given no `--issue-labels` (index.ts).
+      complexity = { declared: null, method: "none" };
+    } else if (localRef === null) {
+      // A linked issue exists but lives outside this repository —
+      // deliberately never read (see the comment above `localIssueRefs`).
+      // Distinct from "none": a rating may well exist there; nobody checked.
+      complexity = { declared: null, method: "not-fetched" };
+    } else if (!labelsById.has(localRef.id)) {
+      // Queried and unresolved — a transport error, or the issue vanished
+      // between merge and backfill. Distinct from "none" for the same
+      // reason a zero-transcript pull request is skipped rather than carded
+      // at zero: a card must never claim to have checked something it did
+      // not.
+      complexity = { declared: null, method: "lookup-failed" };
+      console.warn(
+        `  ⚠️  could not fetch labels for issue #${localRef.number} (linked from PR #${pull.number}) — leaving complexity unrated rather than guessing.`,
+      );
+    } else {
+      labels = labelsById.get(localRef.id) ?? [];
+      complexity = declaredFromLabels(labels);
+    }
 
     const card = buildCard(
       records,
@@ -274,7 +412,7 @@ if (import.meta.main) {
       {
         branch: pull.headRefName,
         prNumber: pull.number,
-        issueNumber: pull.closingIssuesReferences[0]?.number ?? null,
+        issueNumber,
         issueType: null,
         issueLabels: labels,
         declaredComplexity: complexity.declared,

--- a/tools/pr-metrics/tests/backfill.test.ts
+++ b/tools/pr-metrics/tests/backfill.test.ts
@@ -319,6 +319,8 @@ test("backfill cards a marked subagent, and agrees with `card` on both figure an
     // dash is where the two used to differ.
     const backfilled = JSON.parse(await readFile(join(f.dir, "cards", `${SLUG}.json`), "utf8")) as {
       spend: { usd_equivalent: number; by_actor: Record<string, { tokens: { output: number } }> };
+      issue: { number: number | null; labels: string[] };
+      complexity: { declared: number | null; method: string };
     };
 
     // Assert the marker path FIRST. Equality alone can pass vacuously: if
@@ -328,6 +330,13 @@ test("backfill cards a marked subagent, and agrees with `card` on both figure an
     // same branch and must be rejected on ownership alone.
     expect(backfilled.spend.by_actor.subagent?.tokens.output).toBe(1000);
     expect(backfilled.spend.by_actor.main?.tokens.output).toBe(0);
+
+    // This fixture's PR has no linked issue (`closingIssuesReferences: []`) —
+    // a rating must never be guessed for it.
+    expect(backfilled.issue.number).toBeNull();
+    expect(backfilled.issue.labels).toEqual([]);
+    expect(backfilled.complexity.declared).toBeNull();
+    expect(backfilled.complexity.method).toBe("none");
 
     // Now the agreement the doc comment has only ever asserted in prose. Read
     // the JSON: both tools print `toFixed(2)`, so comparing stdout compares
@@ -507,6 +516,222 @@ test("one gh call per carded PR for files, plus one batched query, and no per-PR
     expect(calls.filter((c) => c.includes("api graphql"))).toHaveLength(1);
     expect(calls.filter((c) => c.includes("/files"))).toHaveLength(1);
     expect(calls.filter((c) => c.includes("--jq .commits"))).toHaveLength(0);
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// The bug this file exists to catch: `backfill` must read a rating off the
+// pull request's LINKED ISSUE, never the pull request's own labels (which
+// this repository never sets) — and the fetch has to work across two pull
+// requests sharing one batched `nodes(ids:)` document, not just one.
+test("backfill reads complexity off the linked issue's labels, in one batched nodes(ids:) call", async () => {
+  const f = await fixture({ withTranscript: false });
+  try {
+    const branchA = "feat/complexity-a";
+    const branchB = "feat/complexity-b";
+    const slugA = "feat-complexity-a";
+    const slugB = "feat-complexity-b";
+
+    await writeFile(
+      join(f.binDir, "gh"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
+case "$*" in
+  *"pr list"*)
+    printf '%s' '[{"number":5001,"headRefName":"${branchA}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","closingIssuesReferences":[{"id":"I_test_970","number":970,"repository":{"name":"osn","owner":{"login":"xchromo"}}}]},{"number":5002,"headRefName":"${branchB}","mergedAt":"2026-09-09T13:00:00Z","baseRefOid":"ccc","headRefOid":"ddd","closingIssuesReferences":[{"id":"I_test_200","number":200,"repository":{"name":"osn","owner":{"login":"xchromo"}}}]}]' ;;
+  *"nodes(ids:"*)
+    printf '%s' '{"data":{"nodes":[{"labels":{"nodes":[{"name":"product:osn-core"},{"name":"complexity:3"},{"name":"complexity:unconfirmed"}]}},{"labels":{"nodes":[{"name":"product:cire"}]}}]}}' ;;
+  *"api graphql"*)
+    printf '%s' '{"data":{"repository":{"p5001":{"commits":{"totalCount":3}},"p5002":{"commits":{"totalCount":1}}}}}' ;;
+  *"/files"*)
+    printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
+  *)
+    printf '%s' '3' ;;
+esac
+`,
+    );
+    await chmod(join(f.binDir, "gh"), 0o755);
+
+    const project = join(f.sessions, await projectDirFor(f.dir));
+    await mkdir(project, { recursive: true });
+    await writeFile(
+      join(project, "sess-a.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-a",
+        gitBranch: branchA,
+        requestId: "req-a",
+        timestamp: "2026-09-09T11:00:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 50 } },
+      })}\n`,
+    );
+    await writeFile(
+      join(project, "sess-b.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-b",
+        gitBranch: branchB,
+        requestId: "req-b",
+        timestamp: "2026-09-09T11:00:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 50 } },
+      })}\n`,
+    );
+
+    const run = await runBackfill(f);
+    expect(run.exitCode).toBe(0);
+
+    // One batched call for both issues' labels, not one per pull request.
+    const calls = (await readFile(f.log, "utf8")).split("\n").filter(Boolean);
+    expect(calls.filter((c) => c.includes("nodes(ids:"))).toHaveLength(1);
+
+    const cardA = JSON.parse(await readFile(join(f.dir, "cards", `${slugA}.json`), "utf8")) as {
+      issue: { number: number | null; labels: string[] };
+      complexity: { declared: number | null; method: string };
+    };
+    expect(cardA.issue.number).toBe(970);
+    expect(cardA.issue.labels).toEqual([
+      "product:osn-core",
+      "complexity:3",
+      "complexity:unconfirmed",
+    ]);
+    expect(cardA.complexity.declared).toBe(3);
+    expect(cardA.complexity.method).toBe("unconfirmed");
+
+    // The linked issue has no `complexity:` label — a real, checked "none",
+    // not a skipped fetch: `issue.labels` still carries what was found.
+    const cardB = JSON.parse(await readFile(join(f.dir, "cards", `${slugB}.json`), "utf8")) as {
+      issue: { number: number | null; labels: string[] };
+      complexity: { declared: number | null; method: string };
+    };
+    expect(cardB.issue.number).toBe(200);
+    expect(cardB.issue.labels).toEqual(["product:cire"]);
+    expect(cardB.complexity.declared).toBeNull();
+    expect(cardB.complexity.method).toBe("none");
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// `wiki/observability/session-metrics.md` §Backfilling: a linked issue outside
+// this repository — chiefly the private `xchromo/osn-tracker`, which closes
+// most of this repository's pull requests — is never fetched at all, because
+// its labels can carry a severity/area pair that must not reach a card
+// committed here. `method: "not-fetched"` says so, distinct from `"none"`.
+test("a linked issue outside this repository is never fetched", async () => {
+  const f = await fixture({ withTranscript: false });
+  try {
+    const branch = "feat/tracker-linked";
+    const slug = "feat-tracker-linked";
+
+    await writeFile(
+      join(f.binDir, "gh"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
+case "$*" in
+  *"pr list"*)
+    printf '%s' '[{"number":6001,"headRefName":"${branch}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","closingIssuesReferences":[{"id":"I_test_tracker_619","number":619,"repository":{"name":"osn-tracker","owner":{"login":"xchromo"}}}]}]' ;;
+  *"nodes(ids:"*)
+    printf '%s' 'SHOULD NOT BE CALLED' ;;
+  *"api graphql"*)
+    printf '%s' '{"data":{"repository":{"p6001":{"commits":{"totalCount":1}}}}}' ;;
+  *"/files"*)
+    printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
+  *)
+    printf '%s' '3' ;;
+esac
+`,
+    );
+    await chmod(join(f.binDir, "gh"), 0o755);
+
+    const project = join(f.sessions, await projectDirFor(f.dir));
+    await mkdir(project, { recursive: true });
+    await writeFile(
+      join(project, "sess-tracker.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-tracker",
+        gitBranch: branch,
+        requestId: "req-tracker",
+        timestamp: "2026-09-09T11:00:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 50 } },
+      })}\n`,
+    );
+
+    const run = await runBackfill(f);
+    expect(run.exitCode).toBe(0);
+
+    // The filter excludes it before any fetch — not merely fails softly.
+    const calls = await readFile(f.log, "utf8");
+    expect(calls).not.toContain("nodes(ids:");
+
+    const card = JSON.parse(await readFile(join(f.dir, "cards", `${slug}.json`), "utf8")) as {
+      issue: { number: number | null; labels: string[] };
+      complexity: { declared: number | null; method: string };
+    };
+    expect(card.issue.number).toBe(619);
+    expect(card.issue.labels).toEqual([]);
+    expect(card.complexity.declared).toBeNull();
+    expect(card.complexity.method).toBe("not-fetched");
+  } finally {
+    await rm(f.dir, { recursive: true, force: true });
+  }
+});
+
+// `backfill.ts`'s own rule ("a card must never claim to have checked
+// something it did not") applies to a rating exactly as it does to spend: a
+// lookup that never resolved must not read the same as one that resolved and
+// found nothing.
+test("a failed label lookup is reported and left unrated, not written as a checked none", async () => {
+  const f = await fixture({ withTranscript: false });
+  try {
+    const branch = "feat/lookup-fails";
+    const slug = "feat-lookup-fails";
+
+    await writeFile(
+      join(f.binDir, "gh"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
+case "$*" in
+  *"pr list"*)
+    printf '%s' '[{"number":7001,"headRefName":"${branch}","mergedAt":"2026-09-09T12:00:00Z","baseRefOid":"aaa","headRefOid":"bbb","closingIssuesReferences":[{"id":"I_test_vanished","number":444,"repository":{"name":"osn","owner":{"login":"xchromo"}}}]}]' ;;
+  *"nodes(ids:"*)
+    printf '%s' '{"data":{"nodes":[null]},"errors":[{"type":"NOT_FOUND"}]}'
+    exit 1 ;;
+  *"api graphql"*)
+    printf '%s' '{"data":{"repository":{"p7001":{"commits":{"totalCount":1}}}}}' ;;
+  *"/files"*)
+    printf '%s\\n' '{"filename":"osn/api/src/svc.ts","additions":1,"deletions":0}' ;;
+  *)
+    printf '%s' '3' ;;
+esac
+`,
+    );
+    await chmod(join(f.binDir, "gh"), 0o755);
+
+    const project = join(f.sessions, await projectDirFor(f.dir));
+    await mkdir(project, { recursive: true });
+    await writeFile(
+      join(project, "sess-vanished.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        sessionId: "sess-vanished",
+        gitBranch: branch,
+        requestId: "req-vanished",
+        timestamp: "2026-09-09T11:00:00.000Z",
+        message: { model: "claude-opus-5", usage: { output_tokens: 50 } },
+      })}\n`,
+    );
+
+    const run = await runBackfill(f);
+    expect(run.exitCode).toBe(0);
+    expect(run.stderr).toContain("#444");
+
+    const card = JSON.parse(await readFile(join(f.dir, "cards", `${slug}.json`), "utf8")) as {
+      complexity: { declared: number | null; method: string };
+    };
+    expect(card.complexity.declared).toBeNull();
+    expect(card.complexity.method).toBe("lookup-failed");
   } finally {
     await rm(f.dir, { recursive: true, force: true });
   }

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -14,7 +14,7 @@ related:
   - "[[observability/metrics]]"
   - "[[conventions/review-findings]]"
   - "[[conventions/stacked-prs]]"
-last-reviewed: 2026-09-10
+last-reviewed: 2026-09-11
 ---
 
 # Session Metrics
@@ -306,6 +306,29 @@ the datalake, and it would drag every average it touches toward nothing.
 Ratings are transcribed, never invented: a backfilled card carries whatever the
 issue's `complexity:` label says, and `rate-complexity`'s backfill mode marks
 anything it adds `complexity:unconfirmed`.
+
+The issue is the pull request's **first-listed** linked issue —
+`closingIssuesReferences[0]`, an ordering GitHub controls, not this tool. A
+pull request closing several issues is attributed to whichever one GitHub
+lists first.
+
+**Only when that issue lives in this same repository.** Most of this
+repository's pull requests close a finding in the private
+`xchromo/osn-tracker` repo instead, and that issue's labels are never fetched
+at all — its `severity:`/`area:` pair must not reach a card committed here
+(see `CLAUDE.md` §Comments on not linking a finding from a public file).
+Such a card writes `complexity.method: "not-fetched"`, not `"none"`: a rating
+may well exist on that issue, nobody checked. `xchromo/osn#1012` tracks
+whether and how to surface it safely later.
+
+`complexity.method` can therefore read five ways: `"confirmed"` /
+`"unconfirmed"` (a rating was found, on an issue in this repository),
+`"none"` (no linked issue, or a linked issue here with no `complexity:`
+label), `"not-fetched"` (the linked issue is in another repository), or
+`"lookup-failed"` (a fetch was attempted and did not resolve — a transport
+error, or the issue vanished between merge and backfill). Only `"confirmed"`
+is a rating to act on; the rest are all a null `complexity.declared`, for
+different reasons.
 
 ## The two fields that name a cause
 


### PR DESCRIPTION
## Summary

`tools/pr-metrics/backfill.ts:267` built its complexity label list from `pull.labels` — the pull request's own labels. This repository puts `complexity:` on the **issue**; pull requests here carry no labels at all. So `declaredFromLabels` was handed an empty array every time and returned `null` on all 91 cards ever written, with `complexity.method` reading `"none"`. The denominator the session-metrics spend comparison divides by has never existed.

The fix reads the linked issue's labels instead. `backfill.ts` already asks `gh pr list` for `closingIssuesReferences`; that selection now carries the issue's node id and repository, and a GraphQL `nodes(ids:)` batch fetches the labels for every linked issue in one request. `issue.labels` on the card is populated from the same source, having been `[]` for the same reason. The pull request's own labels are out of the complexity decision entirely, so a stray `complexity:` label on a PR cannot override the issue's.

Labels are read **only** when the linked issue lives in `xchromo/osn`. A linked issue in the private `xchromo/osn-tracker` has its labels left unread — `severity:` and finding labels must not be transcribed into a card committed to a public repository.

`complexity.method` gains two values so a `null` says which kind of null it is: `"not-fetched"` (no linked issue, or the issue is not in `xchromo/osn`) and `"lookup-failed"` (the fetch errored).

## Workspaces affected

| Package | Bump | Why |
|---|---|---|
| `@tools/pr-metrics` | patch | the backfill reads its complexity rating from a different place |

## Issues

**Closes**

None yet — #1004's last "done when" is a re-run of the backfill over the real `.claude/metrics/` tree, which is a data change to 91 committed cards and belongs in its own pull request. This one is the code change and its tests.

**Opened**

| Issue | What |
|---|---|
| #1011 | the `SessionEnd` hook cards a session with no issue number, so a dead remote session keeps a null complexity forever |
| #1012 | `needs:decision` — what pr-metrics may transcribe from a tracker-linked issue's labels |

## Decisions

### Read the labels, never compute a score — `approach`

- **Issue** — a tool that wants a complexity number has an obvious wrong fix available: derive one from diff size.
- **Why** — `tools/pr-metrics/README.md` forbids it, and is right: "a score blended from diff size cannot separate a wasteful PR from a hard debug that ended in a one-line fix".
- **Solution** — the only source is the human's declared `complexity:` label on the issue. Where there is none, the card still writes `null`.
- **Rationale** — the rating exists to be declared before the cost is known. A computed one would defeat the rule it is there to enforce.

### One GraphQL batch rather than one `gh issue view` per pull request — `approach`

`nodes(ids:)` takes every linked issue's node id in a single request, so a backfill over 91 pull requests costs one label fetch, not 91. The node ids come from the `closingIssuesReferences` selection that was already being requested.

### `osn`-repo-only label reading is a hard gate, not a filter — `security`

- **Issue** — a pull request may close an issue in the private `xchromo/osn-tracker`.
- **Why** — cards are committed to `xchromo/osn`, which is public. A tracker issue's labels name a severity and, by the label set, the kind of finding.
- **Solution** — the repository is checked before the labels are read at all; a non-`osn` issue's labels are never fetched into the process.
- **Rationale** — filtering after the fetch would leave the values one refactor away from a card. #1012 asks the owner whether anything at all should be transcribed from a tracker issue.

### Two null reasons instead of one — `approach`

`"none"` said only "no rating". `"not-fetched"` and `"lookup-failed"` separate "there was nothing to read" from "the read failed", so a future null is diagnosable without re-running the tool.

**Out of scope** — the `generated_at` churn noted at the end of #1004 (every run rewrites every card it touches with a one-line timestamp diff). Left for the re-run pull request, where it actually bites.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Unit | `bun run --cwd tools/pr-metrics test` | 120 pass, 0 fail |
| Type check | `bun run check` | 39/39 |
| Lint | `bun run lint` | exit 0 |
| Format | `bun run fmt:check` | clean |
| Live | backfill PR #1000 → `osn#968` | `complexity: {"declared": 3, "method": "unconfirmed"}`, previously `null` / `"none"` |

The new tests cover the label source directly — a change that moved it back to the pull request's labels fails them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018szASa48VKhpsRdC3R4kQb
