### PR TITLE
feat(scripts): ratchet the monorepo's lint-warning count in both directions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,29 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      # xchromo/osn#1008: the step above exits 0 whatever the warning count
+      # is — oxlintrc.json puts every non-correctness category at `warn`, so
+      # it only proves no error-level rule fired. This is its own step,
+      # after Lint rather than folded into it, so "a rule errored" and "the
+      # warning count moved" read as two different failures rather than one
+      # step failing for either reason. scripts/lint-warning-ceiling.txt is
+      # the single source of truth for the number; see that file and
+      # scripts/guard-lint-warnings.sh's own comment for the ratchet this
+      # enforces in both directions.
+      - name: Guard the lint-warning ceiling
+        run: bash scripts/guard-lint-warnings.sh
+
+      # The guard's own test, run against a small fixture project with a
+      # fixture ceiling file (LINT_WARNING_ROOT / LINT_WARNING_CEILING_FILE)
+      # rather than this repo's real tree, so it neither depends on nor
+      # perturbs the real warning count. It still runs the REAL oxlint
+      # binary from this checkout's own node_modules (LINT_WARNING_OXLINT_BIN),
+      # which is why it lives here — after Install dependencies — rather
+      # than in the script-tests job, which does no `bun install` on
+      # purpose.
+      - name: Test the lint-warning ceiling guard
+        run: bash scripts/tests/guard-lint-warnings.test.sh
+
       - name: Format check
         run: bun run fmt:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      # xchromo/osn#1008: the step above exits 0 whatever the warning count
-      # is — oxlintrc.json puts every non-correctness category at `warn`, so
-      # it only proves no error-level rule fired. This is its own step,
-      # after Lint rather than folded into it, so "a rule errored" and "the
-      # warning count moved" read as two different failures rather than one
-      # step failing for either reason. scripts/lint-warning-ceiling.txt is
-      # the single source of truth for the number; see that file and
+      # The step above exits 0 whatever the warning count is — oxlintrc.json
+      # puts every non-correctness category at `warn`, so it only proves no
+      # error-level rule fired. This is its own step, after Lint rather than
+      # folded into it, so "a rule errored" and "the warning count moved"
+      # read as two different failures rather than one step failing for
+      # either reason. scripts/lint-warning-ceiling.txt is the single source
+      # of truth for the number; see that file and
       # scripts/guard-lint-warnings.sh's own comment for the ratchet this
       # enforces in both directions.
       - name: Guard the lint-warning ceiling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ bun run test                          # run all tests (turbo, skips packages wit
 bun run test:d1                       # the Miniflare/workerd D1 tier (excluded from `test`)
 bun run test:browser                  # the real-Chromium tier
 bun run test:scripts                  # bun tests under scripts/ — TypeScript only. `bun test`
-                                      # never collects a *.test.sh, so the three shell tests
+                                      # never collects a *.test.sh, so the four shell tests
                                       # get their own CI steps (changeset-check.yml, ci.yml);
                                       # a new one needs a step or it runs nowhere
 bun run --cwd <pkg> test:run          # one package, once   (vitest packages)

--- a/scripts/guard-lint-warnings.sh
+++ b/scripts/guard-lint-warnings.sh
@@ -1,30 +1,13 @@
 #!/usr/bin/env bash
 # Guard the count of `bun run lint` warning-severity diagnostics across the
-# whole monorepo.
+# whole monorepo, so a branch that adds one can't stay green.
 #
-# xchromo/osn#1008: oxlintrc.json puts every non-`correctness` category at
-# `warn`, so `bun run lint` exits 0 whatever the warning count is — the CI
-# step at ci.yml's `lint` job proves only that no error-level rule fired.
-# Some of those warn-level rules are repo-specific and exist because the
-# mistake they catch actually happened (`house/no-tracker-ref-in-comment`,
-# `house/no-non-subscribing-store-read`), and with nothing enforcing the
-# total they are advisory notes nobody reads. Over one recent epic the count
-# drifted 1020 -> 1035 -> 1037 -> 1059 with no CI step noticing — the only
-# way to know was to read the number by hand on every branch.
-#
-# Mirrors scripts/guard-bundle-size.sh's two rules for a guard that gates on
-# a number (wiki/conventions/bundle-size-guards.md):
-#
-#   - the ceiling lives in ONE committed file this script reads
-#     (scripts/lint-warning-ceiling.txt), never a call-site argument and
-#     never typed into ci.yml. Missing or unparseable, this script refuses
-#     to run rather than passing with nothing to check against.
-#   - the headroom is smaller than the smallest mistake the guard exists to
-#     catch. The smallest mistake here is one new warning, so the headroom
-#     is ZERO: the ceiling is the exact current count. That makes this a
-#     ratchet in BOTH directions — a count BELOW the ceiling fails too, with
-#     a message to lower the file, because otherwise a cleanup's slack lets
-#     the count drift back to where it started with nothing noticing.
+# @see wiki/conventions/bundle-size-guards.md — the two rules this guard
+# follows (one committed file for the number; headroom smaller than the
+# smallest mistake it exists to catch) and why the headroom here is zero in
+# both directions, making this a ratchet rather than a one-way cap: a count
+# BELOW the ceiling fails too, with a message to lower the file, so a
+# cleanup's slack can't let the count drift back up unnoticed.
 #
 # Usage:
 #   guard-lint-warnings.sh          # what ci.yml's `lint` job calls, as its
@@ -33,26 +16,28 @@
 #                                     "the count moved" read as two different
 #                                     failures)
 #
-# Counting method: oxlint's human-readable output has no summary line to
-# grep for in the pinned version (verified: a clean run ends on the last
-# diagnostic, nothing printed after it), and grepping the word "warning"
-# over that output would also match it appearing inside a rule's own
-# message or a file path. `--format=json` instead gives one object per
-# diagnostic with an explicit `"severity": "warning" | "error"` field,
-# stamped by oxlint itself — filtering on that field is exact regardless of
-# message wording or output layout. scripts/lint-warning-count.ts does the
-# counting (unit-tested against a fixture report in
-# scripts/tests/lint-warning-count.test.ts); this script owns running the
-# real oxlint, reading the ceiling file, and the pass/fail decision.
+# Counting method: oxlint's human-readable output (what `bun run lint`
+# prints) has no summary line in the pinned version — confirmed by running
+# `bun run lint | tail` and `bun run lint | grep -c "Found \|Finished in "`
+# (zero matches) rather than inferred from the JSON output, which says
+# nothing about a separate code path. Grepping the word "warning" over that
+# output would also match it appearing inside a rule's own message or a file
+# path. `--format=json` instead gives one object per diagnostic with an
+# explicit `"severity": "warning" | "error"` field, stamped by oxlint itself
+# — filtering on that field is exact regardless of message wording or output
+# layout. scripts/lint-warning-count.ts does the counting (unit-tested
+# against a fixture report in scripts/tests/lint-warning-count.test.ts);
+# this script owns running the real oxlint, reading the ceiling file, and
+# the pass/fail decision.
 #
 # LINT_WARNING_CEILING_FILE overrides the ceiling file path, LINT_WARNING_ROOT
 # overrides the directory oxlint runs in (real usage: the repo root, matching
 # `bun run lint`'s own "."), and LINT_WARNING_OXLINT_BIN overrides the oxlint
 # binary path (default: LINT_WARNING_ROOT's own node_modules/.bin/oxlint —
-# the same binary `bun run lint` resolves to). scripts/tests/guard-lint-warnings.test.sh
-# uses all three to point this script at a small fixture project instead of
-# the real monorepo, while still running the REAL oxlint binary from this
-# checkout's own node_modules.
+# the same binary `bun run lint` resolves to on this checkout's PATH).
+# scripts/tests/guard-lint-warnings.test.sh uses all three to point this
+# script at a small fixture project instead of the real monorepo, while
+# still running the REAL oxlint binary from this checkout's own node_modules.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -108,6 +93,13 @@ fi
 result_file="$WORK_DIR/result.txt"
 bun "$SCRIPT_DIR/lint-warning-count.ts" "$WORK_DIR/oxlint.json" >"$result_file"
 
+# lint-warning-count.ts exits non-zero on every failure it can hit (unreadable
+# file, invalid JSON), and `set -e` above would already have stopped this
+# script before this line ran in that case — so this branch is unreachable
+# through either of this script's own call sites today. Left in as defence
+# in depth against a future change to that script that prints something
+# non-numeric on its first line while still exiting 0, the same shape as
+# guard-bundle-size.sh's own unreachable-mode arm.
 count="$(head -n1 "$result_file")"
 if ! [[ "$count" =~ ^[0-9]+$ ]]; then
   echo "::error::guard-lint-warnings.sh: could not determine a warning count from oxlint's output." >&2

--- a/scripts/guard-lint-warnings.sh
+++ b/scripts/guard-lint-warnings.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Guard the count of `bun run lint` warning-severity diagnostics across the
+# whole monorepo.
+#
+# xchromo/osn#1008: oxlintrc.json puts every non-`correctness` category at
+# `warn`, so `bun run lint` exits 0 whatever the warning count is — the CI
+# step at ci.yml's `lint` job proves only that no error-level rule fired.
+# Some of those warn-level rules are repo-specific and exist because the
+# mistake they catch actually happened (`house/no-tracker-ref-in-comment`,
+# `house/no-non-subscribing-store-read`), and with nothing enforcing the
+# total they are advisory notes nobody reads. Over one recent epic the count
+# drifted 1020 -> 1035 -> 1037 -> 1059 with no CI step noticing — the only
+# way to know was to read the number by hand on every branch.
+#
+# Mirrors scripts/guard-bundle-size.sh's two rules for a guard that gates on
+# a number (wiki/conventions/bundle-size-guards.md):
+#
+#   - the ceiling lives in ONE committed file this script reads
+#     (scripts/lint-warning-ceiling.txt), never a call-site argument and
+#     never typed into ci.yml. Missing or unparseable, this script refuses
+#     to run rather than passing with nothing to check against.
+#   - the headroom is smaller than the smallest mistake the guard exists to
+#     catch. The smallest mistake here is one new warning, so the headroom
+#     is ZERO: the ceiling is the exact current count. That makes this a
+#     ratchet in BOTH directions — a count BELOW the ceiling fails too, with
+#     a message to lower the file, because otherwise a cleanup's slack lets
+#     the count drift back to where it started with nothing noticing.
+#
+# Usage:
+#   guard-lint-warnings.sh          # what ci.yml's `lint` job calls, as its
+#                                     own step after the existing `bun run
+#                                     lint` step (so "a rule errored" and
+#                                     "the count moved" read as two different
+#                                     failures)
+#
+# Counting method: oxlint's human-readable output has no summary line to
+# grep for in the pinned version (verified: a clean run ends on the last
+# diagnostic, nothing printed after it), and grepping the word "warning"
+# over that output would also match it appearing inside a rule's own
+# message or a file path. `--format=json` instead gives one object per
+# diagnostic with an explicit `"severity": "warning" | "error"` field,
+# stamped by oxlint itself — filtering on that field is exact regardless of
+# message wording or output layout. scripts/lint-warning-count.ts does the
+# counting (unit-tested against a fixture report in
+# scripts/tests/lint-warning-count.test.ts); this script owns running the
+# real oxlint, reading the ceiling file, and the pass/fail decision.
+#
+# LINT_WARNING_CEILING_FILE overrides the ceiling file path, LINT_WARNING_ROOT
+# overrides the directory oxlint runs in (real usage: the repo root, matching
+# `bun run lint`'s own "."), and LINT_WARNING_OXLINT_BIN overrides the oxlint
+# binary path (default: LINT_WARNING_ROOT's own node_modules/.bin/oxlint —
+# the same binary `bun run lint` resolves to). scripts/tests/guard-lint-warnings.test.sh
+# uses all three to point this script at a small fixture project instead of
+# the real monorepo, while still running the REAL oxlint binary from this
+# checkout's own node_modules.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CEILING_FILE="${LINT_WARNING_CEILING_FILE:-$SCRIPT_DIR/lint-warning-ceiling.txt}"
+LINT_ROOT="${LINT_WARNING_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+OXLINT_BIN="${LINT_WARNING_OXLINT_BIN:-$LINT_ROOT/node_modules/.bin/oxlint}"
+
+if [ ! -f "$CEILING_FILE" ]; then
+  echo "::error::guard-lint-warnings.sh: ceiling file not found: ${CEILING_FILE} — refusing to run rather than pass with nothing to check the count against." >&2
+  exit 1
+fi
+
+# One non-negative integer, alone on the first non-blank, non-comment line
+# (the same `#`-comment convention as bundle-size-budgets.txt). Fails closed
+# on anything else — a malformed file stops the guard rather than silently
+# parsing to 0 or to the wrong token.
+ceiling=""
+while IFS= read -r line || [ -n "$line" ]; do
+  stripped="${line%%#*}"
+  stripped="$(printf '%s' "$stripped" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [ -z "$stripped" ] && continue
+  ceiling="$stripped"
+  break
+done <"$CEILING_FILE"
+
+if [ -z "$ceiling" ] || ! [[ "$ceiling" =~ ^[0-9]+$ ]]; then
+  echo "::error::guard-lint-warnings.sh: ${CEILING_FILE} does not hold a single non-negative integer ceiling on its first non-comment line — refusing to run." >&2
+  exit 1
+fi
+
+if [ ! -x "$OXLINT_BIN" ]; then
+  echo "::error::guard-lint-warnings.sh: oxlint binary not found or not executable at ${OXLINT_BIN} — run \`bun install\` first." >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Same invocation `bun run lint` makes (oxlint -c oxlintrc.json .), plus
+# --format=json, run from LINT_ROOT so relative paths in the config and the
+# "." target resolve exactly the way they do for that script.
+set +e
+(cd "$LINT_ROOT" && "$OXLINT_BIN" -c oxlintrc.json . --format=json) >"$WORK_DIR/oxlint.json" 2>"$WORK_DIR/oxlint.stderr"
+oxlint_exit=$?
+set -e
+
+if [ "$oxlint_exit" -ne 0 ]; then
+  echo "::error::guard-lint-warnings.sh: oxlint exited with status ${oxlint_exit} — an error-level rule fired, not just warnings. Run \`bun run lint\` to see it; this guard only checks the warning count and cannot make a meaningful comparison while lint itself is failing." >&2
+  cat "$WORK_DIR/oxlint.stderr" >&2
+  exit 1
+fi
+
+result_file="$WORK_DIR/result.txt"
+bun "$SCRIPT_DIR/lint-warning-count.ts" "$WORK_DIR/oxlint.json" >"$result_file"
+
+count="$(head -n1 "$result_file")"
+if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+  echo "::error::guard-lint-warnings.sh: could not determine a warning count from oxlint's output." >&2
+  exit 1
+fi
+
+if [ "$count" -eq "$ceiling" ]; then
+  echo "guard-lint-warnings.sh: ${count} lint warnings, matches the ceiling in ${CEILING_FILE}."
+  exit 0
+fi
+
+if [ "$count" -gt "$ceiling" ]; then
+  delta=$((count - ceiling))
+  echo "::error::guard-lint-warnings.sh: ${count} lint warnings exceeds the ceiling of ${ceiling} in ${CEILING_FILE} by ${delta}. This branch added at least one new warning. Warnings by rule (highest first):" >&2
+  tail -n +2 "$result_file" | sed 's/^/  /' >&2
+  echo "Run \`bun run lint\` locally to see file:line locations for the rule(s) above. If the new warning(s) are intentional, edit ONLY ${CEILING_FILE} and set it to ${count}." >&2
+  exit 1
+fi
+
+delta=$((ceiling - count))
+echo "::error::guard-lint-warnings.sh: ${count} lint warnings is below the ceiling of ${ceiling} in ${CEILING_FILE} by ${delta}. Warnings were fixed — good — but the ceiling has to ratchet down with them, or the count can silently drift back up before anything notices. Edit ONLY ${CEILING_FILE} and set it to ${count}." >&2
+exit 1

--- a/scripts/lint-warning-ceiling.txt
+++ b/scripts/lint-warning-ceiling.txt
@@ -1,0 +1,22 @@
+# Lint-warning ceiling for scripts/guard-lint-warnings.sh.
+#
+# The single source of truth for how many warning-severity diagnostics
+# `bun run lint` (oxlintrc.json's categories) may report across the whole
+# monorepo. Nothing else names this number — not `.github/workflows/ci.yml`,
+# not a script argument.
+#
+# xchromo/osn#1008: `bun run lint` exits 0 whatever the warning count is, so
+# the count drifted upward across a recent epic (1020 -> 1035 -> 1037 ->
+# 1059) with no CI step noticing. The headroom here is zero in both
+# directions — an INCREASE fails (a new warning was added), and a DECREASE
+# also fails, with a message to lower this file to match. A decrease means
+# warnings were fixed, which is good, but leaving the old, higher number in
+# place is slack that would let the count silently drift back up before
+# anything noticed.
+#
+# Re-baselining, in either direction: run `bun run lint` (or
+# scripts/guard-lint-warnings.sh, which prints the new count on a failing
+# run), and replace the number below with it. One value, alone on the first
+# non-comment, non-blank line — nothing else in this file is read.
+
+1064   # measured via scripts/guard-lint-warnings.sh (oxlint --format=json), feat/lint-warning-ceiling @ 2026-09-11

--- a/scripts/lint-warning-ceiling.txt
+++ b/scripts/lint-warning-ceiling.txt
@@ -19,4 +19,4 @@
 # conflict rather than silently agreeing on the same leading number while
 # disagreeing on what it was measured from.
 
-1059   # measured via scripts/guard-lint-warnings.sh (oxlint --format=json), feat/lint-warning-ceiling @ 2026-09-11
+1061   # measured via scripts/guard-lint-warnings.sh (oxlint --format=json), feat/lint-warning-ceiling @ 2026-09-11

--- a/scripts/lint-warning-ceiling.txt
+++ b/scripts/lint-warning-ceiling.txt
@@ -5,18 +5,18 @@
 # monorepo. Nothing else names this number — not `.github/workflows/ci.yml`,
 # not a script argument.
 #
-# xchromo/osn#1008: `bun run lint` exits 0 whatever the warning count is, so
-# the count drifted upward across a recent epic (1020 -> 1035 -> 1037 ->
-# 1059) with no CI step noticing. The headroom here is zero in both
-# directions — an INCREASE fails (a new warning was added), and a DECREASE
-# also fails, with a message to lower this file to match. A decrease means
-# warnings were fixed, which is good, but leaving the old, higher number in
-# place is slack that would let the count silently drift back up before
-# anything noticed.
+# @see wiki/conventions/bundle-size-guards.md — why the headroom here is
+# zero in both directions: an INCREASE fails (a new warning was added), and
+# a DECREASE also fails, with a message to lower this file to match, so a
+# cleanup's slack can't let the count drift back up before anything notices.
 #
 # Re-baselining, in either direction: run `bun run lint` (or
 # scripts/guard-lint-warnings.sh, which prints the new count on a failing
 # run), and replace the number below with it. One value, alone on the first
-# non-comment, non-blank line — nothing else in this file is read.
+# non-comment, non-blank line — nothing else in this file is read. Keep the
+# trailing comment's branch and date current on every re-baseline: two
+# branches editing this line at once should collide as a real merge
+# conflict rather than silently agreeing on the same leading number while
+# disagreeing on what it was measured from.
 
-1064   # measured via scripts/guard-lint-warnings.sh (oxlint --format=json), feat/lint-warning-ceiling @ 2026-09-11
+1059   # measured via scripts/guard-lint-warnings.sh (oxlint --format=json), feat/lint-warning-ceiling @ 2026-09-11

--- a/scripts/lint-warning-count.ts
+++ b/scripts/lint-warning-count.ts
@@ -2,20 +2,14 @@
 /**
  * Counts warning-severity diagnostics from an oxlint `--format=json` report.
  *
- * xchromo/osn#1008: `bun run lint`'s human-readable output has no summary
- * line in the oxlint version this repo pins (verified: a clean run ends on
- * the last diagnostic, nothing after it), so `grep -c " warning "` over that
- * output is the only text-based option — and it is fragile three ways: a
- * file path could itself contain the string, a rule's own message text can
- * say "warning" without being one line-per-diagnostic, and the format can
- * change under an oxlint upgrade with nothing here noticing. `--format=json`
- * instead gives one object per diagnostic with an explicit
+ * `--format=json` gives one object per diagnostic with an explicit
  * `"severity": "warning" | "error"` field, stamped by oxlint itself rather
  * than inferred from text — filtering on that field is exact regardless of
- * message wording or output layout. Verified against this repo's real
- * output before this script was written: a clean `oxlint -c oxlintrc.json .
- * --format=json` reports 1059 warning-severity diagnostics, matching the
- * line count of the human-readable form on the same run.
+ * message wording or output layout, unlike grepping the word "warning" over
+ * the human-readable output (which that format can itself contain inside a
+ * rule's own message or a file path). See scripts/guard-lint-warnings.sh's
+ * own comment for why the human-readable form has no summary line to count
+ * instead.
  *
  * scripts/guard-lint-warnings.sh runs oxlint itself (real invocation, real
  * config) and hands this script the resulting JSON file path — this module
@@ -64,7 +58,7 @@ export function countWarnings(report: OxlintReport): WarningCount {
 if (import.meta.main) {
   const jsonPath = process.argv[2];
   if (!jsonPath) {
-    console.error("usage: lint-warning-count.ts <oxlint-json-report-path>");
+    process.stderr.write("usage: lint-warning-count.ts <oxlint-json-report-path>\n");
     process.exit(1);
   }
 
@@ -72,7 +66,9 @@ if (import.meta.main) {
   try {
     raw = await Bun.file(jsonPath).text();
   } catch (err) {
-    console.error(`lint-warning-count.ts: could not read ${jsonPath}: ${(err as Error).message}`);
+    process.stderr.write(
+      `lint-warning-count.ts: could not read ${jsonPath}: ${(err as Error).message}\n`,
+    );
     process.exit(1);
   }
 
@@ -80,15 +76,15 @@ if (import.meta.main) {
   try {
     parsed = JSON.parse(raw) as OxlintReport;
   } catch (err) {
-    console.error(
-      `lint-warning-count.ts: ${jsonPath} was not valid JSON: ${(err as Error).message}`,
+    process.stderr.write(
+      `lint-warning-count.ts: ${jsonPath} was not valid JSON: ${(err as Error).message}\n`,
     );
     process.exit(1);
   }
 
   const { total, byRule } = countWarnings(parsed);
-  console.log(String(total));
+  process.stdout.write(`${total}\n`);
   for (const [code, n] of byRule) {
-    console.log(`${code} ${n}`);
+    process.stdout.write(`${code} ${n}\n`);
   }
 }

--- a/scripts/lint-warning-count.ts
+++ b/scripts/lint-warning-count.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+/**
+ * Counts warning-severity diagnostics from an oxlint `--format=json` report.
+ *
+ * xchromo/osn#1008: `bun run lint`'s human-readable output has no summary
+ * line in the oxlint version this repo pins (verified: a clean run ends on
+ * the last diagnostic, nothing after it), so `grep -c " warning "` over that
+ * output is the only text-based option — and it is fragile three ways: a
+ * file path could itself contain the string, a rule's own message text can
+ * say "warning" without being one line-per-diagnostic, and the format can
+ * change under an oxlint upgrade with nothing here noticing. `--format=json`
+ * instead gives one object per diagnostic with an explicit
+ * `"severity": "warning" | "error"` field, stamped by oxlint itself rather
+ * than inferred from text — filtering on that field is exact regardless of
+ * message wording or output layout. Verified against this repo's real
+ * output before this script was written: a clean `oxlint -c oxlintrc.json .
+ * --format=json` reports 1059 warning-severity diagnostics, matching the
+ * line count of the human-readable form on the same run.
+ *
+ * scripts/guard-lint-warnings.sh runs oxlint itself (real invocation, real
+ * config) and hands this script the resulting JSON file path — this module
+ * owns only the counting, so it can be unit-tested against a fixture report
+ * with no oxlint invocation at all. See scripts/tests/lint-warning-count.test.ts
+ * (the pure functions below) and .cli.test.ts (this file's CLI entry point).
+ */
+
+export interface OxlintDiagnostic {
+  readonly severity?: unknown;
+  readonly code?: unknown;
+}
+
+export interface OxlintReport {
+  readonly diagnostics?: readonly OxlintDiagnostic[];
+}
+
+export interface WarningCount {
+  readonly total: number;
+  // Highest count first, so the guard's over-ceiling message can print the
+  // rules most likely to be the new addition without the caller sorting.
+  readonly byRule: ReadonlyArray<readonly [string, number]>;
+}
+
+/**
+ * Filters an oxlint report's diagnostics down to `severity === "warning"`
+ * and groups the survivors by rule `code`. A diagnostic with no string
+ * `code` (defensive only — oxlint always sets one) groups under
+ * `"(unknown rule)"` rather than being dropped, so the total stays exact
+ * even if that ever happens.
+ */
+export function countWarnings(report: OxlintReport): WarningCount {
+  const diagnostics = Array.isArray(report.diagnostics) ? report.diagnostics : [];
+  const warnings = diagnostics.filter((d) => d != null && d.severity === "warning");
+
+  const byRuleMap = new Map<string, number>();
+  for (const w of warnings) {
+    const code = typeof w.code === "string" && w.code.length > 0 ? w.code : "(unknown rule)";
+    byRuleMap.set(code, (byRuleMap.get(code) ?? 0) + 1);
+  }
+  const byRule = [...byRuleMap.entries()].toSorted((a, b) => b[1] - a[1]);
+
+  return { total: warnings.length, byRule };
+}
+
+if (import.meta.main) {
+  const jsonPath = process.argv[2];
+  if (!jsonPath) {
+    console.error("usage: lint-warning-count.ts <oxlint-json-report-path>");
+    process.exit(1);
+  }
+
+  let raw: string;
+  try {
+    raw = await Bun.file(jsonPath).text();
+  } catch (err) {
+    console.error(`lint-warning-count.ts: could not read ${jsonPath}: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  let parsed: OxlintReport;
+  try {
+    parsed = JSON.parse(raw) as OxlintReport;
+  } catch (err) {
+    console.error(
+      `lint-warning-count.ts: ${jsonPath} was not valid JSON: ${(err as Error).message}`,
+    );
+    process.exit(1);
+  }
+
+  const { total, byRule } = countWarnings(parsed);
+  console.log(String(total));
+  for (const [code, n] of byRule) {
+    console.log(`${code} ${n}`);
+  }
+}

--- a/scripts/tests/guard-lint-warnings.test.sh
+++ b/scripts/tests/guard-lint-warnings.test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Tests for guard-lint-warnings.sh. Plain-bash assertions (no bats
+# dependency), matching the sibling shell tests under scripts/ (see
+# verify-vendored-anti-slop.test.sh).
+#
+# Runs the REAL oxlint binary from this checkout's own node_modules
+# (LINT_WARNING_OXLINT_BIN), against small throwaway fixture projects
+# (LINT_WARNING_ROOT) with their own oxlintrc.json — never this repo's real
+# tree, so these tests neither depend on nor perturb the real warning count.
+# That is why this file needs a `bun install` to have already happened and
+# therefore runs as its own step in ci.yml's `lint` job, after "Install
+# dependencies" — not in the script-tests job, which does no install on
+# purpose (see that job's own comment in ci.yml).
+#
+# Covers, one case per independent decision point — including the three
+# directions wiki/conventions/bundle-size-guards.md's corollary requires
+# ("you have not verified a guard until you have seen it fail"):
+#
+#   1. count == ceiling -> exit 0
+#   2. count >  ceiling -> exit 1, reports the delta and a rule breakdown
+#   3. count <  ceiling -> exit 1, says to lower the file, names the new count
+#   4. ceiling file missing -> exit 1, refuses to run
+#   5. ceiling file unparseable -> exit 1, refuses to run
+#   6. blank lines and a comment before the number are ignored
+#   7. the oxlint binary itself missing -> exit 1, refuses to run
+#   8. an error-level rule firing -> exit 1, a DIFFERENT message than the
+#      count-mismatch cases (this guard cannot compare a failed lint run)
+#
+# Run: bash scripts/tests/guard-lint-warnings.test.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")/.." && pwd)"
+guard="$here/guard-lint-warnings.sh"
+repo_root="$(cd "$here/.." && pwd)"
+oxlint_bin="$repo_root/node_modules/.bin/oxlint"
+pass=0
+fail=0
+
+if [ ! -x "$oxlint_bin" ]; then
+  echo "FAIL - setup: no oxlint binary at $oxlint_bin — run \`bun install\` before this test." >&2
+  exit 1
+fi
+
+# A fixture project with its own oxlintrc.json and exactly $2 warning-level
+# `no-console` diagnostics (one console.log per line), so the total is known
+# without depending on this repo's own rule set or file tree.
+make_fixture_project() {
+  local root="$1" n="$2" i
+  mkdir -p "$root"
+  cat >"$root/oxlintrc.json" <<'EOF'
+{
+  "categories": { "correctness": "error" },
+  "rules": { "no-console": "warn" }
+}
+EOF
+  mkdir -p "$root/src"
+  : >"$root/src/a.ts"
+  for ((i = 0; i < n; i++)); do
+    echo "console.log(${i});" >>"$root/src/a.ts"
+  done
+}
+
+# A fixture whose no-console warnings are STILL there (so a count-based
+# assertion on it would look identical to the plain fixture) but which also
+# trips an error-level rule — the case that must fail differently.
+make_fixture_project_with_error() {
+  local root="$1" n="$2"
+  make_fixture_project "$root" "$n"
+  cat >"$root/oxlintrc.json" <<'EOF'
+{
+  "categories": { "correctness": "error" },
+  "rules": { "no-console": "warn", "no-debugger": "error" }
+}
+EOF
+  echo "debugger;" >>"$root/src/a.ts"
+}
+
+run_guard() {
+  local ceiling_file="$1" fixture_root="$2"
+  LINT_WARNING_CEILING_FILE="$ceiling_file" \
+    LINT_WARNING_ROOT="$fixture_root" \
+    LINT_WARNING_OXLINT_BIN="$oxlint_bin" \
+    bash "$guard"
+}
+
+assert() {
+  local name="$1" got_exit="$2" want_exit="$3" output="$4" want_substr="$5"
+  if [ "$got_exit" -ne "$want_exit" ]; then
+    echo "FAIL - $name (exit $got_exit, want $want_exit)"
+    echo "  output: $output"
+    fail=$((fail + 1))
+    return
+  fi
+  if [ -n "$want_substr" ] && ! printf '%s' "$output" | grep -qF "$want_substr"; then
+    echo "FAIL - $name (missing '$want_substr' in output)"
+    echo "  output: $output"
+    fail=$((fail + 1))
+    return
+  fi
+  echo "ok   - $name"
+  pass=$((pass + 1))
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# 1. Equal -> pass.
+fx1="$tmp/eq"
+make_fixture_project "$fx1" 3
+ceiling1="$tmp/ceiling-eq.txt"
+printf '3\n' >"$ceiling1"
+out="$(run_guard "$ceiling1" "$fx1" 2>&1)"
+assert "count equal to the ceiling exits 0" "$?" 0 "$out" "matches the ceiling"
+
+# 2. Over -> fail, reports delta and rule breakdown.
+fx2="$tmp/over"
+make_fixture_project "$fx2" 3
+ceiling2="$tmp/ceiling-over.txt"
+printf '1\n' >"$ceiling2"
+out="$(run_guard "$ceiling2" "$fx2" 2>&1)"
+got=$?
+assert "count over the ceiling exits non-zero, reports the delta" "$got" 1 "$out" "exceeds the ceiling of 1"
+if ! printf '%s' "$out" | grep -qF "by 2"; then
+  echo "FAIL - over-ceiling message names the delta (2)"
+  echo "  output: $out"
+  fail=$((fail + 1))
+else
+  echo "ok   - over-ceiling message names the delta (2)"
+  pass=$((pass + 1))
+fi
+if ! printf '%s' "$out" | grep -qF "eslint(no-console) 3"; then
+  echo "FAIL - over-ceiling message breaks warnings down by rule"
+  echo "  output: $out"
+  fail=$((fail + 1))
+else
+  echo "ok   - over-ceiling message breaks warnings down by rule"
+  pass=$((pass + 1))
+fi
+
+# 3. Under -> fail, says to lower the file, names the new count.
+fx3="$tmp/under"
+make_fixture_project "$fx3" 3
+ceiling3="$tmp/ceiling-under.txt"
+printf '10\n' >"$ceiling3"
+out="$(run_guard "$ceiling3" "$fx3" 2>&1)"
+got=$?
+assert "count under the ceiling exits non-zero, says to lower the file" "$got" 1 "$out" "is below the ceiling of 10"
+if ! printf '%s' "$out" | grep -qF "set it to 3"; then
+  echo "FAIL - under-ceiling message names the new count (3)"
+  echo "  output: $out"
+  fail=$((fail + 1))
+else
+  echo "ok   - under-ceiling message names the new count (3)"
+  pass=$((pass + 1))
+fi
+
+# 4. Ceiling file missing -> refuses to run.
+fx4="$tmp/missing-ceiling-fixture"
+make_fixture_project "$fx4" 3
+out="$(run_guard "$tmp/does-not-exist.txt" "$fx4" 2>&1)"
+assert "a missing ceiling file refuses to run" "$?" 1 "$out" "ceiling file not found"
+
+# 5. Ceiling file unparseable -> refuses to run.
+fx5="$tmp/bad-ceiling-fixture"
+make_fixture_project "$fx5" 3
+ceiling5="$tmp/ceiling-bad.txt"
+printf 'not-a-number\n' >"$ceiling5"
+out="$(run_guard "$ceiling5" "$fx5" 2>&1)"
+assert "an unparseable ceiling file refuses to run" "$?" 1 "$out" "does not hold a single non-negative integer"
+
+# 6. Blank lines and a comment before the number are ignored.
+fx6="$tmp/comment-ceiling-fixture"
+make_fixture_project "$fx6" 3
+ceiling6="$tmp/ceiling-comment.txt"
+printf '\n# a full-line comment\n3   # measured on 2026-09-11\n' >"$ceiling6"
+out="$(run_guard "$ceiling6" "$fx6" 2>&1)"
+assert "blank lines and a leading comment line are ignored" "$?" 0 "$out" "matches the ceiling"
+
+# 7. The oxlint binary itself missing -> refuses to run.
+fx7="$tmp/no-oxlint-fixture"
+make_fixture_project "$fx7" 3
+ceiling7="$tmp/ceiling-no-oxlint.txt"
+printf '3\n' >"$ceiling7"
+out="$(LINT_WARNING_CEILING_FILE="$ceiling7" LINT_WARNING_ROOT="$fx7" LINT_WARNING_OXLINT_BIN="$tmp/no-such-oxlint" bash "$guard" 2>&1)"
+assert "a missing oxlint binary refuses to run" "$?" 1 "$out" "oxlint binary not found"
+
+# 8. An error-level rule firing fails differently from a count mismatch —
+# this guard cannot make a meaningful comparison while lint itself is
+# failing, so it must not report a delta at all.
+fx8="$tmp/error-fixture"
+make_fixture_project_with_error "$fx8" 3
+ceiling8="$tmp/ceiling-error.txt"
+printf '3\n' >"$ceiling8"
+out="$(run_guard "$ceiling8" "$fx8" 2>&1)"
+got=$?
+assert "an error-level rule firing exits non-zero with a distinct message" "$got" 1 "$out" "an error-level rule fired"
+if printf '%s' "$out" | grep -qF "exceeds the ceiling"; then
+  echo "FAIL - the oxlint-error case must not also claim a count mismatch"
+  echo "  output: $out"
+  fail=$((fail + 1))
+else
+  echo "ok   - the oxlint-error case does not also claim a count mismatch"
+  pass=$((pass + 1))
+fi
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/lint-warning-count.cli.test.ts
+++ b/scripts/tests/lint-warning-count.cli.test.ts
@@ -1,0 +1,86 @@
+// The pure-function tests in lint-warning-count.test.ts import
+// countWarnings() directly, so none of them exercise the import.meta.main
+// block that scripts/guard-lint-warnings.sh actually calls:
+// `bun scripts/lint-warning-count.ts <path>`. These tests run the real
+// script as a subprocess, the same way scripts/tests/cire-dev-db-guard.cli.test.ts
+// does, against a hand-written fixture JSON file shaped like a real oxlint
+// `--format=json` report — no oxlint invocation, so this needs no
+// `bun install` (matches every other file under scripts/).
+
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = new URL("../lint-warning-count.ts", import.meta.url).pathname;
+
+async function runCli(
+  ...args: readonly string[]
+): Promise<{ readonly exitCode: number; readonly stdout: string; readonly stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", SCRIPT, ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+async function withFixtureJson(
+  contents: string,
+  run: (path: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "lint-warning-count-cli-"));
+  try {
+    const path = join(dir, "report.json");
+    await writeFile(path, contents);
+    await run(path);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("prints the total on the first line, then one rule/count line per rule", async () => {
+  await withFixtureJson(
+    JSON.stringify({
+      diagnostics: [
+        { severity: "warning", code: "eslint(no-console)" },
+        { severity: "warning", code: "eslint(no-console)" },
+        { severity: "error", code: "eslint(no-debugger)" },
+      ],
+    }),
+    async (path) => {
+      const { exitCode, stdout } = await runCli(path);
+      expect(stdout).toBe("2\neslint(no-console) 2\n");
+      expect(exitCode).toBe(0);
+    },
+  );
+});
+
+test("a report with zero warnings prints just the total", async () => {
+  await withFixtureJson(JSON.stringify({ diagnostics: [] }), async (path) => {
+    const { exitCode, stdout } = await runCli(path);
+    expect(stdout).toBe("0\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+test("exits non-zero when the file does not exist", async () => {
+  const { exitCode, stderr } = await runCli("/no/such/file.json");
+  expect(stderr).toContain("could not read");
+  expect(exitCode).not.toBe(0);
+});
+
+test("exits non-zero when the file is not valid JSON", async () => {
+  await withFixtureJson("not json", async (path) => {
+    const { exitCode, stderr } = await runCli(path);
+    expect(stderr).toContain("not valid JSON");
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+test("exits non-zero with a usage message when no path argument is given", async () => {
+  const { exitCode, stderr } = await runCli();
+  expect(stderr).toContain("usage:");
+  expect(exitCode).not.toBe(0);
+});

--- a/scripts/tests/lint-warning-count.test.ts
+++ b/scripts/tests/lint-warning-count.test.ts
@@ -1,0 +1,92 @@
+// Pure-function tests for countWarnings() — no oxlint invocation, no
+// subprocess, no bun install required (matches every other file under
+// scripts/: bun:test, Bun/Node built-ins, and lint-warning-count.ts itself).
+// See .cli.test.ts for the import.meta.main CLI entry point this file's
+// functions feed.
+
+import { describe, expect, test } from "bun:test";
+
+import { countWarnings, type OxlintReport } from "../lint-warning-count";
+
+function diagnostic(severity: string, code: string) {
+  return { severity, code };
+}
+
+describe("countWarnings", () => {
+  test("counts only severity: warning, ignoring error and other values", () => {
+    const report: OxlintReport = {
+      diagnostics: [
+        diagnostic("warning", "eslint(no-console)"),
+        diagnostic("error", "eslint(no-debugger)"),
+        diagnostic("warning", "eslint(no-console)"),
+        diagnostic("off", "eslint(no-var)"),
+      ],
+    };
+
+    expect(countWarnings(report).total).toBe(2);
+  });
+
+  // The whole reason to filter on the `severity` field rather than grepping
+  // the word "warning": a diagnostic's own rule code (or message, which this
+  // type does not model) can contain that word without being
+  // warning-severity, and vice versa. This asserts the field, not the text,
+  // decides.
+  test("does not match on the word 'warning' appearing in a rule code", () => {
+    const report: OxlintReport = {
+      diagnostics: [
+        {
+          severity: "error",
+          code: "house(no-warning-suppression)",
+        },
+      ],
+    };
+
+    expect(countWarnings(report).total).toBe(0);
+  });
+
+  test("groups by rule code, highest count first", () => {
+    const report: OxlintReport = {
+      diagnostics: [
+        diagnostic("warning", "eslint(no-console)"),
+        diagnostic("warning", "house(no-tracker-ref-in-comment)"),
+        diagnostic("warning", "eslint(no-console)"),
+        diagnostic("warning", "eslint(no-console)"),
+        diagnostic("warning", "house(no-tracker-ref-in-comment)"),
+      ],
+    };
+
+    expect(countWarnings(report).byRule).toEqual([
+      ["eslint(no-console)", 3],
+      ["house(no-tracker-ref-in-comment)", 2],
+    ]);
+  });
+
+  test("an empty diagnostics array counts zero", () => {
+    expect(countWarnings({ diagnostics: [] }).total).toBe(0);
+  });
+
+  // A report shaped unexpectedly (missing/non-array `diagnostics`) is not
+  // this function's job to reject — the CLI entry point already validated
+  // the JSON parsed at all. Treating it as zero diagnostics rather than
+  // throwing keeps this function total, which the CLI test covers by giving
+  // it exactly this shape.
+  test("a missing diagnostics field counts zero rather than throwing", () => {
+    expect(countWarnings({}).total).toBe(0);
+  });
+
+  test("a diagnostic with a non-string code groups under '(unknown rule)'", () => {
+    const report = {
+      diagnostics: [{ severity: "warning", code: 42 }],
+    } as unknown as OxlintReport;
+
+    expect(countWarnings(report).byRule).toEqual([["(unknown rule)", 1]]);
+  });
+
+  test("a null entry in diagnostics is skipped rather than throwing", () => {
+    const report = {
+      diagnostics: [null, diagnostic("warning", "eslint(no-console)")],
+    } as unknown as OxlintReport;
+
+    expect(countWarnings(report).total).toBe(1);
+  });
+});

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -1,7 +1,7 @@
 ---
 title: Guards that gate on a number
-description: The two rules any committed threshold obeys, and the guards that hold them — scripts/guard-bundle-size.sh over each Astro app's deployed bundle, the src/pages test-route check beside it, and scripts/guard-d1-migration-cost.ts over what a from-zero D1 rebuild spends against the free-tier ceiling
-tags: [convention, build, astro, performance, ops, d1]
+description: The two rules any committed threshold obeys, and the guards that hold them — scripts/guard-bundle-size.sh over each Astro app's deployed bundle, the src/pages test-route check beside it, scripts/guard-d1-migration-cost.ts over what a from-zero D1 rebuild spends against the free-tier ceiling, and scripts/guard-lint-warnings.sh over how many warning-severity oxlint diagnostics the whole monorepo may carry
+tags: [convention, build, astro, performance, ops, d1, lint]
 related:
   - "[[cire-development]]"
   - "[[frontend-patterns]]"
@@ -9,7 +9,7 @@ related:
   - "[[review-findings]]"
   - "[[free-tier-limits]]"
   - "[[dev-environment]]"
-last-reviewed: 2026-09-10
+last-reviewed: 2026-09-11
 ---
 
 # Guards that gate on a number
@@ -27,6 +27,10 @@ A third guard on this page measures nothing to do with bundles. `scripts/guard-d
 gates what a from-zero D1 rebuild spends against a free-tier quota, and it is
 here because it obeys the same two rules and was built from this page. The page
 name still says bundles because the file has not moved.
+
+A fourth guard, `scripts/guard-lint-warnings.sh` (xchromo/osn#1008), gates how
+many warning-severity `oxlint` diagnostics the whole monorepo may carry —
+again nothing to do with bundles, again built from this page's two rules.
 
 ## Two rules for any guard that gates on a number
 
@@ -324,6 +328,88 @@ else, so it belongs there rather than in `build-test`. Its own tests
 `bun run test:scripts`, and one of them re-asserts the committed budget against
 the committed chain — so a migration that busts it fails the tests as well as
 the guard step.
+
+## `scripts/guard-lint-warnings.sh` — the lint-warning-count guard
+
+Same shape again, a fourth time: `oxlintrc.json`'s categories put every
+non-`correctness` finding at `warn`, so `bun run lint` exits 0 whatever the
+warning count is — the CI step at `ci.yml`'s `lint` job proved only that no
+error-level rule fired. Over one recent epic the count drifted 1020 → 1035 →
+1037 → 1059 with no CI step noticing, and the only way to know was to read
+the number by hand on every branch (xchromo/osn#1008). Some of the rules
+sitting at `warn` are repo-specific and exist because the mistake they catch
+actually happened — `house/no-tracker-ref-in-comment`,
+`house/no-non-subscribing-store-read` — and with nothing enforcing the total
+they are advisory notes nobody reads.
+
+```
+scripts/guard-lint-warnings.sh          # what ci.yml's `lint` job calls,
+                                         # as its own step after `bun run lint`
+```
+
+**The ceiling** lives in `scripts/lint-warning-ceiling.txt` — one integer,
+alone on the first non-comment line, nothing else names it. **The headroom is
+zero in both directions.** The smallest mistake this guard exists to catch is
+one new warning, so anything above the ceiling fails. That makes it a
+ratchet, not a one-way cap: a count *below* the ceiling fails too, with a
+message naming the new, lower number to write into the file. Skipping that
+half would leave slack — a cleanup that fixes ten warnings but leaves the old
+ceiling in place lets the count silently climb back to where it started,
+which is the exact failure this page's second rule warns against.
+
+### Counting method
+
+oxlint's human-readable output (what `bun run lint` prints) has no summary
+line in the version this repo pins — a clean run ends on the last diagnostic,
+nothing after it. `bun run lint`'s own line count is not even safe to use as
+a proxy: `bun run <script>` prepends its own `$ oxlint -c oxlintrc.json .`
+echo line to the output, so a plain `wc -l` over it overcounts by exactly
+one — this was caught by cross-checking the two counting methods against
+each other while building this guard, not by inspection.
+
+The guard instead runs oxlint directly (bypassing the package.json script
+and its echo line) with `--format=json`, which gives one object per
+diagnostic with an explicit `"severity": "warning" | "error"` field stamped
+by oxlint itself. Filtering on that field is exact regardless of message
+wording, file paths, or how the human-readable format is laid out — unlike
+`grep -c " warning "`, which the field also protects against a rule's own
+message text or a file path containing that word. `scripts/lint-warning-count.ts`
+does the counting and the per-rule breakdown; `scripts/guard-lint-warnings.sh`
+owns running the real oxlint, reading the ceiling file, and the pass/fail
+decision.
+
+*Measured 2026-09-11 — `oxlint -c oxlintrc.json . --format=json` on this
+branch, filtered to `severity: "warning"`: 1064. Verified against `bun run
+lint`'s own line count (1065) minus the one echo line `bun run` prepends.*
+
+### Where it runs
+
+Its own step in `ci.yml`'s `lint` job, after the existing `bun run lint`
+step and before `Format check` — deliberately separate from that step so "a
+rule errored" (Lint fails) and "the warning count moved" (this guard fails)
+read as two different failures rather than one step failing for either
+reason.
+
+Two test files, for the two things that can go wrong independently:
+
+- `scripts/tests/lint-warning-count.test.ts` (+ `.cli.test.ts`) — pure
+  counting logic, run in `script-tests` like everything else under
+  `scripts/tests/` (no `bun install`, since counting from a fixture JSON
+  report needs no oxlint invocation at all).
+- `scripts/tests/guard-lint-warnings.test.sh` — the shell script end to end,
+  against small fixture projects with their own `oxlintrc.json`, but run
+  with the REAL oxlint binary from this checkout's `node_modules`
+  (`LINT_WARNING_OXLINT_BIN`). That real binary is why this one runs as its
+  own step in the `lint` job instead, after `bun install` — `script-tests`
+  does none, on purpose (see that job's own comment in `ci.yml`).
+
+### Re-baselining, in either direction
+
+Run `bun run lint` or `scripts/guard-lint-warnings.sh` (the second prints the
+new count on a failing run), then edit **only**
+`scripts/lint-warning-ceiling.txt` to that number. Nothing else names the
+ceiling — not `ci.yml`, not a script argument — so there is nowhere else to
+update.
 
 ## Related
 

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -335,7 +335,7 @@ Same shape again, a fourth time: `oxlintrc.json`'s categories put every
 non-`correctness` finding at `warn`, so `bun run lint` exits 0 whatever the
 warning count is — the CI step at `ci.yml`'s `lint` job proved only that no
 error-level rule fired. Over one recent epic the count drifted 1020 → 1035 →
-1037 → 1059 with no CI step noticing, and the only way to know was to read
+1037 → 1061 with no CI step noticing, and the only way to know was to read
 the number by hand on every branch (xchromo/osn#1008). Some of the rules
 sitting at `warn` are repo-specific and exist because the mistake they catch
 actually happened — `house/no-tracker-ref-in-comment`,
@@ -361,10 +361,12 @@ which is the exact failure this page's second rule warns against.
 
 oxlint's human-readable output (what `bun run lint` prints) has no summary
 line in the version this repo pins — a clean run ends on the last diagnostic,
-nothing after it. `bun run lint`'s own line count is not even safe to use as
-a proxy: `bun run <script>` prepends its own `$ oxlint -c oxlintrc.json .`
-echo line to the output, so a plain `wc -l` over it overcounts by exactly
-one.
+nothing after it. `bun run lint`'s own line count is not safe to use as a
+proxy either: `bun run <script>` prints its own `$ oxlint -c oxlintrc.json .`
+echo line, on **stderr**, so `wc -l` over it counts the diagnostics when the
+streams are separate and one more than that whenever anything merges them
+(`2>&1`, a CI log, a terminal). A line count that changes with redirection is
+not a measurement.
 
 The guard instead runs oxlint directly (bypassing the package.json script
 and its echo line) with `--format=json`, which gives one object per
@@ -382,9 +384,10 @@ with nothing after it, and `bun run lint | grep -c "Found \|Finished in "`
 returns 0: this pinned oxlint prints no summary line to grep for at all. The
 JSON count and the human-readable line count were cross-checked against each
 other, not just asserted: `oxlint -c oxlintrc.json . --format=json` filtered
-to `severity: "warning"` reports 1059, and `bun run lint | wc -l` reports
-1060 — the diagnostic count plus exactly the one `$ oxlint ...` echo line
-`bun run` prepends.*
+to `severity: "warning"` reports 1061, `bun run lint 2>/dev/null | wc -l`
+reports the same 1061, and `bun run lint 2>&1 | wc -l` reports 1062 — the
+diagnostic count plus the one `$ oxlint ...` echo line `bun run` writes to
+stderr.*
 
 ### Where it runs
 

--- a/wiki/conventions/bundle-size-guards.md
+++ b/wiki/conventions/bundle-size-guards.md
@@ -364,8 +364,7 @@ line in the version this repo pins — a clean run ends on the last diagnostic,
 nothing after it. `bun run lint`'s own line count is not even safe to use as
 a proxy: `bun run <script>` prepends its own `$ oxlint -c oxlintrc.json .`
 echo line to the output, so a plain `wc -l` over it overcounts by exactly
-one — this was caught by cross-checking the two counting methods against
-each other while building this guard, not by inspection.
+one.
 
 The guard instead runs oxlint directly (bypassing the package.json script
 and its echo line) with `--format=json`, which gives one object per
@@ -378,9 +377,14 @@ does the counting and the per-rule breakdown; `scripts/guard-lint-warnings.sh`
 owns running the real oxlint, reading the ceiling file, and the pass/fail
 decision.
 
-*Measured 2026-09-11 — `oxlint -c oxlintrc.json . --format=json` on this
-branch, filtered to `severity: "warning"`: 1064. Verified against `bun run
-lint`'s own line count (1065) minus the one echo line `bun run` prepends.*
+*Measured 2026-09-11 — `bun run lint | tail` ends on the last diagnostic line
+with nothing after it, and `bun run lint | grep -c "Found \|Finished in "`
+returns 0: this pinned oxlint prints no summary line to grep for at all. The
+JSON count and the human-readable line count were cross-checked against each
+other, not just asserted: `oxlint -c oxlintrc.json . --format=json` filtered
+to `severity: "warning"` reports 1059, and `bun run lint | wc -l` reports
+1060 — the diagnostic count plus exactly the one `$ oxlint ...` echo line
+`bun run` prepends.*
 
 ### Where it runs
 
@@ -407,9 +411,29 @@ Two test files, for the two things that can go wrong independently:
 
 Run `bun run lint` or `scripts/guard-lint-warnings.sh` (the second prints the
 new count on a failing run), then edit **only**
-`scripts/lint-warning-ceiling.txt` to that number. Nothing else names the
-ceiling — not `ci.yml`, not a script argument — so there is nowhere else to
-update.
+`scripts/lint-warning-ceiling.txt` to that number, including a fresh trailing
+comment naming the branch and date it was measured from. **If the file and
+this page ever disagree, the file is right** — the same rule the bundle table
+above states for itself. An `oxlint` version bump is expected to move the
+count (a rule can be added, removed or have its default severity change) and
+trip this guard until the file is re-baselined; that is not a defect, it is
+the same zero-headroom trade this page's second rule always makes.
+
+> [!warning] Zero headroom means two concurrent PRs can still leave `main` red
+> `main`'s branch protection does not require a PR to be up to date with
+> `main` before merging. Two PRs that each add one warning, cut from the same
+> base, each write their own correct edit to
+> `scripts/lint-warning-ceiling.txt` and each pass in isolation. If both land,
+> the ceiling on `main` reflects only whichever merged last, not the sum of
+> both — unless the merge itself conflicts. The one thing standing between
+> that and a silently wrong ceiling is the trailing comment convention above:
+> two PRs' ceiling lines differ in branch name and date even when they
+> coincidentally agree on the leading number, so git treats concurrent edits
+> to this file as a real merge conflict a human has to resolve, rather than
+> auto-merging two edits to the same line. This is the same shape of gap
+> zero-headroom accepts everywhere on this page — the fix, if `main` does go
+> red this way, is the same as any other regression: re-measure and
+> re-baseline.
 
 ## Related
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -109,7 +109,7 @@ Map of Content for the OSN monorepo knowledge graph. Open this vault in Obsidian
 - [[contributing]] — PR workflow, changesets, branching
 - [[stacked-prs]] — basing one PR on another with the gh CLI, and merging the stack
 - [[component-lab]] — the in-repo Storybook replacement: prototyping components, three.js and canvas
-- [[bundle-size-guards]] — per-app Astro bundle-size guard + the src/pages test-route check, across all six apps
+- [[bundle-size-guards]] — the two rules any guard that gates on a number obeys, and the guards that hold them: per-app Astro bundle size, the src/pages test-route check, D1 migration-cost, and the monorepo-wide lint-warning ceiling
 - [[wiki-search]] — the three ways to search this vault, which exist where, and the guard that stops a branch reading stale
 
 ## Compliance


### PR DESCRIPTION
## Summary

`oxlintrc.json` puts every non-`correctness` finding at `warn`, so `bun run lint` exits 0 whatever the warning count is. The CI `lint` step proved only that no error-level rule fired. Over one epic the count drifted 1020 → 1035 → 1037 → 1061 and no step noticed; the only way to know was to read the number by hand on each branch.

This adds `scripts/guard-lint-warnings.sh` and a committed ceiling in `scripts/lint-warning-ceiling.txt`, as its own CI step after `bun run lint` — so "a rule errored" and "the warning count moved" read as two different failures.

**The headroom is zero in both directions.** Above the ceiling fails: a branch added a warning. *Below* the ceiling fails too, naming the new lower number to write into the file. Skipping that half would leave slack — a cleanup that fixes ten warnings and leaves the ceiling alone lets the count silently climb back to where it started, which is the failure `wiki/conventions/bundle-size-guards.md` §rule 2 exists to stop.

The guard has already fired on a real change rather than a fixture. #1013 merged two new warnings into `tools/pr-metrics/backfill.ts` while this branch was open; rebasing produced:

```
guard-lint-warnings.sh: 1061 lint warnings exceeds the ceiling of 1059 ... by 2.
This branch added at least one new warning. Warnings by rule (highest first):
  house(no-tracker-ref-in-comment) 755
  eslint(no-console) 151
  ...
```

The ceiling is re-baselined to **1061** in the last commit.

## Workspaces affected

None — `scripts/`, `.github/`, `wiki/`, `CLAUDE.md`. `scripts/changeset-required.sh` reports `skip`.

## Issues

**Closes**

| Issue | What |
|---|---|
| #1008 | nothing gates the monorepo's lint-warning count, so it drifts up unnoticed |

Closes #1008

**Opened**

None.

## Decisions

### Count `severity` in `--format=json`, never grep the human output — `approach`

- **Issue** — the obvious count is `bun run lint | grep -c warning` or a line count.
- **Why** — `grep -c warning` also matches the word inside a rule's own message text or a file path. A line count is worse: the `$ oxlint -c oxlintrc.json .` line `bun run` prints goes to **stderr**, so the number changes depending on whether anything merged the streams.
- **Solution** — run oxlint directly with `--format=json` and count diagnostics whose `"severity"` is `"warning"`, a field oxlint itself stamps.
- **Rationale** — exact regardless of message wording or output layout. `scripts/lint-warning-count.ts` owns the counting and is unit-tested against a fixture report; the shell script owns running oxlint, reading the ceiling and the pass/fail call.

This PR also corrects the wiki's earlier claim that a plain `wc -l` overcounts by one. It does not — the echo line is on stderr. Both figures are now written with the redirection that produces them: `2>/dev/null | wc -l` gives 1061, `2>&1 | wc -l` gives 1062.

### A ratchet, not a cap — `approach`

Failing below the ceiling is unusual and deliberate. The failure message says the count went *down*, which is good, and names the number to commit. Without it the guard has however much slack the last cleanup created.

### The ceiling file carries a branch and a date on the number's own line — `approach`

Two branches re-baselining at once would otherwise agree on a leading integer while disagreeing about what it was measured from, and merge cleanly. With the trailing comment they collide as a real conflict.

### oxlint exiting non-zero is its own error, not a count mismatch — `approach`

If an error-level rule fires, the guard says so and stops rather than comparing counts — a number taken from a failing lint run is not a measurement. A test covers that the two messages do not run together.

**Out of scope** — lowering the count itself. 755 of the 1061 are `house/no-tracker-ref-in-comment`; fixing them is a separate piece of work, and this guard is what stops the number growing while it waits.

## Test plan

| Gate | Command | Result |
|---|---|---|
| Guard | `bash scripts/guard-lint-warnings.sh` | 1061, matches the ceiling |
| Guard's own tests | `bash scripts/tests/guard-lint-warnings.test.sh` | passed: 12, failed: 0 |
| Scripts suite | `bun run test:scripts` | 265 pass, 0 fail |
| Type check | `bun run check` | 39/39 |
| Lint | `bun run lint` | exit 0 |
| Format | `bun run fmt:check` | clean |
| Changeset | `git diff --name-only \| bash scripts/changeset-required.sh` | `skip` |

The shell test points the guard at a small fixture project through `LINT_WARNING_CEILING_FILE` / `LINT_WARNING_ROOT` / `LINT_WARNING_OXLINT_BIN` while still running the **real** oxlint binary from this checkout, so the parsing is proved against genuine oxlint output rather than a recorded fixture. All four failure directions are covered: over the ceiling, under it, a malformed ceiling file, and a missing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018szASa48VKhpsRdC3R4kQb
