### PR TITLE
fix(tools): keep every block of a split API response

### DIFF
--- a/.changeset/khaki-pianos-listen.md
+++ b/.changeset/khaki-pianos-listen.md
@@ -1,0 +1,12 @@
+---
+"@tools/pr-metrics": patch
+---
+
+Keep every block of a split API response. One response reaches the transcript as
+several records — a thinking block, a text block, one per `tool_use` — sharing a
+`requestId`, and the record dedupe keyed on that, so it kept the first block and
+dropped the rest. On one branch here it lost all four `Agent` dispatches and 321
+of 450 `Bash` calls, and the card then reported no subagents at all. Records now
+dedupe on `uuid`, which is what a cross-file duplicate actually repeats, and the
+two readers of `message.usage` count each `requestId` once so the cost a card
+reports does not move.

--- a/.claude/metrics/chore-astro-bundle-guards.json
+++ b/.claude/metrics/chore-astro-bundle-guards.json
@@ -5,7 +5,7 @@
     "branch": "chore/astro-bundle-guards",
     "base_sha": "0fbe9a2b7098c414b16bbbb8acd5e3302f1016d1",
     "head_sha": "40126c22a89a4383441130552bf38c70fc900a56",
-    "generated_at": "2026-09-11T06:24:24.042Z",
+    "generated_at": "2026-09-11T07:19:12.036Z",
     "merged_at": "2026-09-06T15:01:52Z",
     "phase": "at-merge"
   },
@@ -140,15 +140,16 @@
     "tokens_before_first_edit": 2623796,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Edit": 38,
-      "Read": 25,
-      "Bash": 14,
-      "Write": 3,
-      "Grep": 1
+      "Bash": 112,
+      "Edit": 53,
+      "Read": 48,
+      "Write": 11,
+      "Grep": 5,
+      "StructuredOutput": 4
     },
     "edit_churn": {
-      "files_edited_3plus": 4,
-      "max_edits_one_file": 8
+      "files_edited_3plus": 8,
+      "max_edits_one_file": 10
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-backfill-metrics-cards.json
+++ b/.claude/metrics/chore-backfill-metrics-cards.json
@@ -5,7 +5,7 @@
     "branch": "chore/backfill-metrics-cards",
     "base_sha": "495ac60d479588f0aca2c38612c7880d45ae3f2f",
     "head_sha": "f89331e80741ec70642d9f05a86bdfb07bb0e64a",
-    "generated_at": "2026-09-10T04:14:09.027Z",
+    "generated_at": "2026-09-11T07:19:12.018Z",
     "merged_at": "2026-09-09T06:37:16Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 3,
+      "Read": 9,
+      "StructuredOutput": 5,
+      "Grep": 2,
+      "Glob": 1,
       "Bash": 1
     },
     "edit_churn": {

--- a/.claude/metrics/chore-cire-migration-baseline.json
+++ b/.claude/metrics/chore-cire-migration-baseline.json
@@ -5,7 +5,7 @@
     "branch": "chore/cire-migration-baseline",
     "base_sha": "0e16137099a315501b2b9b902ba1aafb89640729",
     "head_sha": "d34d26bba2167e5fe69e03b77dd60efe32fdf932",
-    "generated_at": "2026-09-11T06:24:24.021Z",
+    "generated_at": "2026-09-11T07:19:12.007Z",
     "merged_at": "2026-09-10T04:12:16Z",
     "phase": "at-merge"
   },
@@ -127,8 +127,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Read": 4,
       "Bash": 2,
-      "Read": 2
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-dep-review-2026-09-10.json
+++ b/.claude/metrics/chore-dep-review-2026-09-10.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": 1,
+  "pr": {
+    "number": null,
+    "branch": "chore/dep-review-2026-09-10",
+    "base_sha": "3f3a6120c1142489f5544bef830db560d2db02f3",
+    "head_sha": "3f3a6120c1142489f5544bef830db560d2db02f3",
+    "generated_at": "2026-09-11T07:16:48.093Z",
+    "merged_at": null,
+    "phase": "at-open"
+  },
+  "issue": {
+    "number": null,
+    "type": null,
+    "labels": []
+  },
+  "complexity": {
+    "declared": null,
+    "method": "none"
+  },
+  "window": {
+    "sessions": 9,
+    "first_ts": "2026-09-10T13:59:01.813Z",
+    "last_ts": "2026-09-11T07:15:04.136Z",
+    "span_seconds": 62162,
+    "active_seconds": 8748,
+    "compactions": 16
+  },
+  "spend": {
+    "usd_equivalent": 63.42455799999996,
+    "tokens": {
+      "input": 1315,
+      "output": 169688,
+      "thinking": 41298,
+      "cache_write_5m": 826596,
+      "cache_write_1h": 1838107,
+      "cache_read": 66944169
+    },
+    "by_model": {
+      "claude-opus-4-7": {
+        "tokens": {
+          "input": 67,
+          "output": 7830,
+          "thinking": 0,
+          "cache_write_5m": 112829,
+          "cache_write_1h": 0,
+          "cache_read": 615216
+        },
+        "usd_equivalent": 1.2088742499999998,
+        "messages": 27
+      },
+      "claude-opus-5": {
+        "tokens": {
+          "input": 926,
+          "output": 161739,
+          "thinking": 41298,
+          "cache_write_5m": 431597,
+          "cache_write_1h": 1838107,
+          "cache_read": 65552441
+        },
+        "usd_equivalent": 57.90287674999996,
+        "messages": 463
+      },
+      "<synthetic>": {
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "thinking": 0,
+          "cache_write_5m": 0,
+          "cache_write_1h": 0,
+          "cache_read": 0
+        },
+        "usd_equivalent": 0,
+        "messages": 7
+      },
+      "claude-fable-5-1": {
+        "tokens": {
+          "input": 322,
+          "output": 119,
+          "thinking": 0,
+          "cache_write_5m": 282170,
+          "cache_write_1h": 0,
+          "cache_read": 776512
+        },
+        "usd_equivalent": 4.312807,
+        "messages": 11
+      }
+    },
+    "by_actor": {
+      "main": {
+        "tokens": {
+          "input": 561,
+          "output": 138778,
+          "thinking": 41298,
+          "cache_write_5m": 112829,
+          "cache_write_1h": 1838107,
+          "cache_read": 39881728
+        },
+        "usd_equivalent": 42.49937024999999,
+        "messages": 280
+      },
+      "subagent": {
+        "tokens": {
+          "input": 754,
+          "output": 30910,
+          "thinking": 0,
+          "cache_write_5m": 713767,
+          "cache_write_1h": 0,
+          "cache_read": 27062441
+        },
+        "usd_equivalent": 20.92518775,
+        "messages": 228
+      }
+    },
+    "effort": {
+      "high": 474
+    },
+    "unpriced_models": []
+  },
+  "diff": {
+    "files": {
+      "generated": 0,
+      "test": 0,
+      "docs": 0,
+      "config": 0,
+      "source": 0
+    },
+    "loc": {
+      "generated": {
+        "added": 0,
+        "deleted": 0
+      },
+      "test": {
+        "added": 0,
+        "deleted": 0
+      },
+      "docs": {
+        "added": 0,
+        "deleted": 0
+      },
+      "config": {
+        "added": 0,
+        "deleted": 0
+      },
+      "source": {
+        "added": 0,
+        "deleted": 0
+      }
+    },
+    "packages": [],
+    "touches_migration": false,
+    "commits": 0
+  },
+  "interaction": {
+    "user_turns": 31,
+    "corrective_turns": 23,
+    "tokens_before_first_edit": 95160,
+    "sessions_with_observed_edit": 1,
+    "tool_calls": {
+      "Bash": 450,
+      "Edit": 36,
+      "Write": 22,
+      "Read": 18,
+      "StructuredOutput": 8,
+      "Skill": 6,
+      "Agent": 4,
+      "AskUserQuestion": 2
+    },
+    "edit_churn": {
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 12
+    },
+    "skills": {
+      "obsidian:obsidian-markdown": 1,
+      "prep-pr": 1,
+      "review-security": 1,
+      "new-feat": 1,
+      "rate-complexity": 1,
+      "stress-plan": 1
+    },
+    "subagents": {
+      "general-purpose": 3,
+      "attacker": 1
+    }
+  }
+}

--- a/.claude/metrics/chore-deps-advisory-refresh.json
+++ b/.claude/metrics/chore-deps-advisory-refresh.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-advisory-refresh",
     "base_sha": "eee06ccf60ec4583b78fb994d13d299572e1b68f",
     "head_sha": "e9eec1c47da2f4ac48e986baece70fa99e8011e0",
-    "generated_at": "2026-09-09T06:24:29.025Z",
+    "generated_at": "2026-09-11T07:19:12.039Z",
     "merged_at": "2026-09-06T05:02:17Z",
     "phase": "at-merge"
   },
@@ -152,12 +152,14 @@
   "interaction": {
     "user_turns": 6,
     "corrective_turns": 1,
-    "tokens_before_first_edit": 9516686,
+    "tokens_before_first_edit": 408775,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 67,
-      "Write": 9,
-      "Read": 5
+      "Bash": 123,
+      "Write": 20,
+      "Read": 12,
+      "StructuredOutput": 6,
+      "Grep": 4
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-better-sqlite3-13.json
+++ b/.claude/metrics/chore-deps-better-sqlite3-13.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-better-sqlite3-13",
     "base_sha": "fca74814cbbdf0fe9646250dcfbef3fcb003bf5c",
     "head_sha": "71b25c1ddf796a4bb42f43bc5cfc1ec6e1f4b655",
-    "generated_at": "2026-09-09T06:24:29.029Z",
+    "generated_at": "2026-09-11T07:19:12.043Z",
     "merged_at": "2026-09-06T05:02:13Z",
     "phase": "at-merge"
   },
@@ -137,9 +137,11 @@
     "tokens_before_first_edit": 3417998,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 8,
+      "Bash": 15,
+      "Read": 5,
+      "Grep": 3,
       "Write": 2,
-      "Read": 1
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-changesets-cli-3.json
+++ b/.claude/metrics/chore-deps-changesets-cli-3.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-changesets-cli-3",
     "base_sha": "8058ef3d260f6c1e850e07f423f2d43557879743",
     "head_sha": "19090b4b4e04220bb5a041ff513c6f8e2ff2ad8b",
-    "generated_at": "2026-09-11T06:24:24.046Z",
+    "generated_at": "2026-09-11T07:19:12.042Z",
     "merged_at": "2026-09-06T05:02:15Z",
     "phase": "at-merge"
   },
@@ -133,17 +133,18 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1430183,
+    "tokens_before_first_edit": 714180,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 14,
+      "Bash": 22,
       "Write": 4,
-      "Edit": 2,
-      "Read": 1
+      "Read": 4,
+      "Edit": 3,
+      "StructuredOutput": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 2
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 3
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-deps-in-range-sweep.json
+++ b/.claude/metrics/chore-deps-in-range-sweep.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-in-range-sweep",
     "base_sha": "b485f54e96e6d30fde9c442e1ffc0ec666a0fa07",
     "head_sha": "5de432275d22a9731ab36a6b2d6aa644125464ac",
-    "generated_at": "2026-09-09T06:24:29.030Z",
+    "generated_at": "2026-09-11T07:19:12.044Z",
     "merged_at": "2026-09-06T05:02:10Z",
     "phase": "at-merge"
   },
@@ -23,7 +23,7 @@
     "first_ts": "2026-09-02T06:36:49.185Z",
     "last_ts": "2026-09-06T03:37:21.888Z",
     "span_seconds": 334833,
-    "active_seconds": 894,
+    "active_seconds": 896,
     "compactions": 0
   },
   "spend": {
@@ -169,8 +169,9 @@
     "tokens_before_first_edit": 218270,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 13,
-      "Write": 3
+      "Bash": 19,
+      "Write": 4,
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-ioredis-6.json
+++ b/.claude/metrics/chore-deps-ioredis-6.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-ioredis-6",
     "base_sha": "19090b4b4e04220bb5a041ff513c6f8e2ff2ad8b",
     "head_sha": "eee06ccf60ec4583b78fb994d13d299572e1b68f",
-    "generated_at": "2026-09-11T06:24:24.045Z",
+    "generated_at": "2026-09-11T07:19:12.040Z",
     "merged_at": "2026-09-06T05:02:16Z",
     "phase": "at-merge"
   },
@@ -147,20 +147,27 @@
   "interaction": {
     "user_turns": 5,
     "corrective_turns": 3,
-    "tokens_before_first_edit": 3826471,
+    "tokens_before_first_edit": 2671459,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 106,
-      "Write": 8,
-      "Read": 5,
-      "Edit": 1,
-      "Glob": 1
+      "Bash": 299,
+      "Write": 22,
+      "Read": 15,
+      "Edit": 9,
+      "StructuredOutput": 4,
+      "Agent": 3,
+      "Glob": 3,
+      "Skill": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 1
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 5
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "review-deps": 1
+    },
+    "subagents": {
+      "general-purpose": 3
+    }
   }
 }

--- a/.claude/metrics/chore-deps-jest-dom-7.json
+++ b/.claude/metrics/chore-deps-jest-dom-7.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-jest-dom-7",
     "base_sha": "5e6fdf4de54d344106bb09b0af379b0bda6621a2",
     "head_sha": "044f902c0402e536b7401d246ddfe2b35b2d7afe",
-    "generated_at": "2026-09-09T06:24:29.030Z",
+    "generated_at": "2026-09-11T07:19:12.044Z",
     "merged_at": "2026-09-06T05:02:11Z",
     "phase": "at-merge"
   },
@@ -23,7 +23,7 @@
     "first_ts": "2026-09-02T06:42:48.248Z",
     "last_ts": "2026-09-02T06:59:45.136Z",
     "span_seconds": 1017,
-    "active_seconds": 402,
+    "active_seconds": 404,
     "compactions": 0
   },
   "spend": {
@@ -134,11 +134,12 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1482268,
+    "tokens_before_first_edit": 1233758,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 6,
-      "Write": 2
+      "Bash": 8,
+      "Write": 3,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-jsdom-30.json
+++ b/.claude/metrics/chore-deps-jsdom-30.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-jsdom-30",
     "base_sha": "71b25c1ddf796a4bb42f43bc5cfc1ec6e1f4b655",
     "head_sha": "72aaf7458bd38fcd1de04d51639936aa6d5779e9",
-    "generated_at": "2026-09-09T06:24:29.028Z",
+    "generated_at": "2026-09-11T07:19:12.043Z",
     "merged_at": "2026-09-06T05:02:14Z",
     "phase": "at-merge"
   },
@@ -21,9 +21,9 @@
   "window": {
     "sessions": 2,
     "first_ts": "2026-09-02T06:52:26.288Z",
-    "last_ts": "2026-09-02T06:53:55.565Z",
-    "span_seconds": 89,
-    "active_seconds": 101,
+    "last_ts": "2026-09-02T06:53:56.770Z",
+    "span_seconds": 90,
+    "active_seconds": 103,
     "compactions": 0
   },
   "spend": {
@@ -138,8 +138,9 @@
     "tokens_before_first_edit": 881873,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 3,
-      "Write": 3
+      "Bash": 5,
+      "Write": 3,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-motion-13.json
+++ b/.claude/metrics/chore-deps-motion-13.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-motion-13",
     "base_sha": "044f902c0402e536b7401d246ddfe2b35b2d7afe",
     "head_sha": "650bb8b8dc6015c443f513a16c43981126a3ecfb",
-    "generated_at": "2026-09-09T06:24:29.029Z",
+    "generated_at": "2026-09-11T07:19:12.044Z",
     "merged_at": "2026-09-06T05:02:12Z",
     "phase": "at-merge"
   },
@@ -23,7 +23,7 @@
     "first_ts": "2026-09-02T06:44:28.972Z",
     "last_ts": "2026-09-02T06:46:50.457Z",
     "span_seconds": 141,
-    "active_seconds": 172,
+    "active_seconds": 173,
     "compactions": 0
   },
   "spend": {
@@ -135,11 +135,12 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 2043787,
+    "tokens_before_first_edit": 1786273,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 6,
-      "Write": 2
+      "Bash": 10,
+      "Read": 4,
+      "Write": 3
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-oxlint-oxfmt.json
+++ b/.claude/metrics/chore-deps-oxlint-oxfmt.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-oxlint-oxfmt",
     "base_sha": "72aaf7458bd38fcd1de04d51639936aa6d5779e9",
     "head_sha": "8058ef3d260f6c1e850e07f423f2d43557879743",
-    "generated_at": "2026-09-09T06:24:29.028Z",
+    "generated_at": "2026-09-11T07:19:12.042Z",
     "merged_at": "2026-09-06T05:02:14Z",
     "phase": "at-merge"
   },
@@ -138,14 +138,15 @@
     "tokens_before_first_edit": 1201068,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 34,
-      "Write": 7,
-      "Edit": 4,
-      "Read": 1
+      "Bash": 54,
+      "Write": 9,
+      "Edit": 6,
+      "StructuredOutput": 2,
+      "Read": 2
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 2
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 3
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-deps-solid-router-1.json
+++ b/.claude/metrics/chore-deps-solid-router-1.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-solid-router-1",
     "base_sha": "5de432275d22a9731ab36a6b2d6aa644125464ac",
     "head_sha": "5e6fdf4de54d344106bb09b0af379b0bda6621a2",
-    "generated_at": "2026-09-09T06:24:29.030Z",
+    "generated_at": "2026-09-11T07:19:12.044Z",
     "merged_at": "2026-09-06T05:02:10Z",
     "phase": "at-merge"
   },
@@ -136,10 +136,11 @@
     "tokens_before_first_edit": 1424132,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 7,
+      "Bash": 11,
+      "Read": 4,
       "Write": 2,
-      "Glob": 1,
-      "Read": 1
+      "Glob": 2,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-deps-workers-types-5.json
+++ b/.claude/metrics/chore-deps-workers-types-5.json
@@ -5,7 +5,7 @@
     "branch": "chore/deps-workers-types-5",
     "base_sha": "650bb8b8dc6015c443f513a16c43981126a3ecfb",
     "head_sha": "fca74814cbbdf0fe9646250dcfbef3fcb003bf5c",
-    "generated_at": "2026-09-09T06:24:29.029Z",
+    "generated_at": "2026-09-11T07:19:12.043Z",
     "merged_at": "2026-09-06T05:02:12Z",
     "phase": "at-merge"
   },
@@ -21,9 +21,9 @@
   "window": {
     "sessions": 3,
     "first_ts": "2026-09-02T06:46:48.386Z",
-    "last_ts": "2026-09-02T06:49:43.395Z",
-    "span_seconds": 175,
-    "active_seconds": 231,
+    "last_ts": "2026-09-02T06:49:45.244Z",
+    "span_seconds": 177,
+    "active_seconds": 233,
     "compactions": 0
   },
   "spend": {
@@ -139,17 +139,18 @@
   "interaction": {
     "user_turns": 1,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1590099,
+    "tokens_before_first_edit": 1322836,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 12,
-      "Read": 2,
-      "Write": 2,
-      "Edit": 1
+      "Bash": 16,
+      "Read": 6,
+      "Edit": 3,
+      "Write": 3,
+      "StructuredOutput": 2
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 1
+      "files_edited_3plus": 1,
+      "max_edits_one_file": 3
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/chore-house-rule-non-subscribing-read.json
+++ b/.claude/metrics/chore-house-rule-non-subscribing-read.json
@@ -5,7 +5,7 @@
     "branch": "chore/house-rule-non-subscribing-read",
     "base_sha": "bb5b11a229842de7193e5656dd0ec9349eb457e0",
     "head_sha": "14a3d50a122d0b82bd2246ef87fac70002cd5e58",
-    "generated_at": "2026-09-11T06:24:24.044Z",
+    "generated_at": "2026-09-11T07:19:12.038Z",
     "merged_at": "2026-09-06T09:12:08Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 6,
-      "Bash": 1,
+      "Read": 11,
+      "Bash": 3,
       "Grep": 1
     },
     "edit_churn": {

--- a/.claude/metrics/chore-metrics-cards-sep-10.json
+++ b/.claude/metrics/chore-metrics-cards-sep-10.json
@@ -5,7 +5,7 @@
     "branch": "chore/metrics-cards-sep-10",
     "base_sha": "4fac652a86749a64e17ed80d44e96942e0393256",
     "head_sha": "a6fe5e86e7cb81f1bd68cf4954d209f1e6993ed2",
-    "generated_at": "2026-09-11T02:01:21.098Z",
+    "generated_at": "2026-09-11T07:19:12.006Z",
     "merged_at": "2026-09-10T05:11:44Z",
     "phase": "at-merge"
   },
@@ -119,9 +119,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Grep": 1,
+      "Grep": 2,
+      "Read": 2,
       "Bash": 1,
-      "Read": 1
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-metrics-recovery-epic.json
+++ b/.claude/metrics/chore-metrics-recovery-epic.json
@@ -5,7 +5,7 @@
     "branch": "chore/metrics-recovery-epic",
     "base_sha": "4df6b5ffb84f9ee64a71ccb792b7906b9c7bfc49",
     "head_sha": "a336e6c4fa4e00f63b74afbb44293afd927517a3",
-    "generated_at": "2026-09-11T06:24:24.013Z",
+    "generated_at": "2026-09-11T07:19:11.994Z",
     "merged_at": "2026-09-11T02:05:47Z",
     "phase": "at-merge"
   },
@@ -119,8 +119,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Grep": 1,
       "Read": 1,
-      "Bash": 1
+      "Bash": 1,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-needs-decision-label.json
+++ b/.claude/metrics/chore-needs-decision-label.json
@@ -5,7 +5,7 @@
     "branch": "chore/needs-decision-label",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "cd521e65d3355f56a558b835c8fa2a55e02a6d81",
-    "generated_at": "2026-09-09T06:24:29.037Z",
+    "generated_at": "2026-09-11T07:19:12.051Z",
     "merged_at": "2026-08-31T04:33:47Z",
     "phase": "at-merge"
   },
@@ -119,7 +119,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 1
+      "Read": 2,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-repopulate-complexity.json
+++ b/.claude/metrics/chore-repopulate-complexity.json
@@ -1,72 +1,72 @@
 {
   "schema_version": 1,
   "pr": {
-    "number": 982,
-    "branch": "fix/cire-dev-d1-cost",
-    "base_sha": "0e16137099a315501b2b9b902ba1aafb89640729",
-    "head_sha": "c1e1493d9a6af0f660e0dd054e3fbc48549f1acd",
-    "generated_at": "2026-09-11T07:19:12.007Z",
-    "merged_at": "2026-09-10T04:10:24Z",
+    "number": 1018,
+    "branch": "chore/repopulate-complexity",
+    "base_sha": "1d1d9a039a6247303a45da92f371f0548e419da2",
+    "head_sha": "059e689822ae73939a47e8ccbe3826a29b095d48",
+    "generated_at": "2026-09-11T07:19:11.984Z",
+    "merged_at": "2026-09-11T06:31:57Z",
     "phase": "at-merge"
   },
   "issue": {
-    "number": 979,
+    "number": 1004,
     "type": null,
     "labels": [
-      "product:cire",
+      "product:shared",
       "area:ops",
-      "complexity:3",
+      "complexity:2",
       "complexity:unconfirmed"
     ]
   },
   "complexity": {
-    "declared": 3,
+    "declared": 2,
     "method": "unconfirmed"
   },
   "window": {
     "sessions": 2,
-    "first_ts": "2026-09-10T03:36:39.237Z",
-    "last_ts": "2026-09-10T03:39:01.129Z",
-    "span_seconds": 142,
-    "active_seconds": 188,
+    "first_ts": "2026-09-11T06:28:04.237Z",
+    "last_ts": "2026-09-11T06:29:21.537Z",
+    "span_seconds": 77,
+    "active_seconds": 142,
     "compactions": 0
   },
   "spend": {
-    "usd_equivalent": 1.23577025,
+    "usd_equivalent": 1.0485742499999997,
     "tokens": {
-      "input": 24,
-      "output": 12399,
+      "input": 27,
+      "output": 7987,
       "thinking": 0,
-      "cache_write_5m": 105279,
+      "cache_write_5m": 75729,
       "cache_write_1h": 0,
-      "cache_read": 535363
+      "cache_read": 750916
     },
     "by_model": {
       "claude-opus-4-7": {
         "tokens": {
-          "input": 24,
-          "output": 12399,
+          "input": 27,
+          "output": 7987,
           "thinking": 0,
-          "cache_write_5m": 105279,
+          "cache_write_5m": 75729,
           "cache_write_1h": 0,
-          "cache_read": 535363
+          "cache_read": 750916
         },
-        "usd_equivalent": 1.23577025,
-        "messages": 14
+        "usd_equivalent": 1.0485742499999997,
+        "messages": 17
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 24,
-          "output": 12399,
+          "input": 27,
+          "output": 7987,
           "thinking": 0,
-          "cache_write_5m": 105279,
+          "cache_write_5m": 75729,
           "cache_write_1h": 0,
-          "cache_read": 535363
+          "cache_read": 750916
         },
-        "usd_equivalent": 1.23577025,
-        "messages": 14
+        "usd_equivalent": 1.0485742499999997,
+        "messages": 17
       },
       "subagent": {
         "tokens": {
@@ -87,38 +87,38 @@
   "diff": {
     "files": {
       "generated": 1,
-      "test": 0,
-      "docs": 3,
-      "config": 2,
-      "source": 2
+      "test": 3,
+      "docs": 2,
+      "config": 52,
+      "source": 3
     },
     "loc": {
       "generated": {
-        "added": 20,
+        "added": 10,
         "deleted": 0
       },
       "test": {
-        "added": 0,
-        "deleted": 0
+        "added": 118,
+        "deleted": 37
       },
       "docs": {
-        "added": 89,
-        "deleted": 18
+        "added": 11,
+        "deleted": 2
       },
       "config": {
-        "added": 123,
-        "deleted": 27
+        "added": 854,
+        "deleted": 134
       },
       "source": {
-        "added": 10,
-        "deleted": 5
+        "added": 63,
+        "deleted": 12
       }
     },
     "packages": [
-      "cire/db"
+      "tools/pr-metrics"
     ],
     "touches_migration": false,
-    "commits": 1
+    "commits": 2
   },
   "interaction": {
     "user_turns": 2,
@@ -126,9 +126,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 13,
-      "Bash": 2,
-      "StructuredOutput": 2
+      "Read": 9,
+      "Bash": 3,
+      "StructuredOutput": 2,
+      "Grep": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-session-discipline.json
+++ b/.claude/metrics/chore-session-discipline.json
@@ -5,7 +5,7 @@
     "branch": "chore/session-discipline",
     "base_sha": "dc7bcaff1340a8d551100cdda8952b2488b9e62c",
     "head_sha": "186da7f067f9772488ba827112314d65cc7c4b25",
-    "generated_at": "2026-09-09T06:24:29.016Z",
+    "generated_at": "2026-09-11T07:19:12.031Z",
     "merged_at": "2026-09-07T03:52:44Z",
     "phase": "at-merge"
   },
@@ -119,7 +119,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 1
+      "Read": 3,
+      "Glob": 1,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/chore-svgo-advisory.json
+++ b/.claude/metrics/chore-svgo-advisory.json
@@ -5,7 +5,7 @@
     "branch": "chore/svgo-advisory",
     "base_sha": "2eb9393ca64639068c42d5a614e3df8ab68c6e61",
     "head_sha": "9d19c6885a48edb24aff2e429496fc5d53f97bb2",
-    "generated_at": "2026-09-11T06:24:24.037Z",
+    "generated_at": "2026-09-11T07:19:12.029Z",
     "merged_at": "2026-09-09T01:40:51Z",
     "phase": "at-merge"
   },
@@ -26,7 +26,7 @@
   "window": {
     "sessions": 1,
     "first_ts": "2026-09-09T01:37:24.548Z",
-    "last_ts": "2026-09-09T01:40:45.369Z",
+    "last_ts": "2026-09-09T01:40:45.931Z",
     "span_seconds": 201,
     "active_seconds": 201,
     "compactions": 0
@@ -123,7 +123,12 @@
     "corrective_turns": 0,
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
-    "tool_calls": {},
+    "tool_calls": {
+      "Bash": 8,
+      "Monitor": 2,
+      "Read": 2,
+      "ToolSearch": 1
+    },
     "edit_churn": {
       "files_edited_3plus": 0,
       "max_edits_one_file": 0

--- a/.claude/metrics/chore-vendored-tree-modes.json
+++ b/.claude/metrics/chore-vendored-tree-modes.json
@@ -5,7 +5,7 @@
     "branch": "chore/vendored-tree-modes",
     "base_sha": "273e4ba82e35358c1ef08ab4ae2e38f7692ac855",
     "head_sha": "268c616841441db40ca129c7affba09371e290f6",
-    "generated_at": "2026-09-11T06:24:24.055Z",
+    "generated_at": "2026-09-11T07:19:12.053Z",
     "merged_at": "2026-08-30T14:13:29Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 3
+      "Read": 4,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/docs-claude-md-refresh.json
+++ b/.claude/metrics/docs-claude-md-refresh.json
@@ -5,7 +5,7 @@
     "branch": "docs/claude-md-refresh",
     "base_sha": "7a77cbdc373417e2a7e36def286d3266aa81c9b7",
     "head_sha": "dabb55686d12fae7d5a41057ee037c52bcfd1f61",
-    "generated_at": "2026-09-09T06:24:29.021Z",
+    "generated_at": "2026-09-11T07:19:12.036Z",
     "merged_at": "2026-09-07T02:45:17Z",
     "phase": "at-merge"
   },
@@ -119,8 +119,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Read": 4,
       "Glob": 2,
-      "Read": 2
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/docs-test-layout-drift.json
+++ b/.claude/metrics/docs-test-layout-drift.json
@@ -5,7 +5,7 @@
     "branch": "docs/test-layout-drift",
     "base_sha": "804e8d42a9ee3c3571c905cafc61b2fd075523f3",
     "head_sha": "64a02029b5cc54967053669e22a0fadf5fbb4699",
-    "generated_at": "2026-09-09T06:24:29.024Z",
+    "generated_at": "2026-09-11T07:19:12.039Z",
     "merged_at": "2026-09-06T16:11:34Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 1
+      "Read": 2,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/docs-visual-verification-notes.json
+++ b/.claude/metrics/docs-visual-verification-notes.json
@@ -5,7 +5,7 @@
     "branch": "docs/visual-verification-notes",
     "base_sha": "3abce2e30862a1156039092bd08e6cf5f18af237",
     "head_sha": "2a7dcc777fe44c2c0c93061cf1cefc5cadbb306c",
-    "generated_at": "2026-09-09T06:24:29.020Z",
+    "generated_at": "2026-09-11T07:19:12.035Z",
     "merged_at": "2026-09-07T03:04:47Z",
     "phase": "at-merge"
   },
@@ -118,20 +118,23 @@
   "interaction": {
     "user_turns": 0,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 1932001,
+    "tokens_before_first_edit": 1339932,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 31,
-      "Edit": 7,
-      "Skill": 1,
-      "Agent": 1
+      "Bash": 66,
+      "Edit": 12,
+      "Skill": 2,
+      "Agent": 1,
+      "Read": 1,
+      "Write": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 3
+      "files_edited_3plus": 3,
+      "max_edits_one_file": 5
     },
     "skills": {
-      "obsidian:obsidian-markdown": 1
+      "obsidian:obsidian-markdown": 1,
+      "prep-pr": 1
     },
     "subagents": {
       "general-purpose": 1

--- a/.claude/metrics/feat-d1-migration-cost-guard.json
+++ b/.claude/metrics/feat-d1-migration-cost-guard.json
@@ -5,7 +5,7 @@
     "branch": "feat/d1-migration-cost-guard",
     "base_sha": "09ce0e2daf10c89df6bef57fe63bc31ebb16534f",
     "head_sha": "f83f722101ecdf0b84458f5af44405d11ea77288",
-    "generated_at": "2026-09-11T06:24:24.020Z",
+    "generated_at": "2026-09-11T07:19:12.005Z",
     "merged_at": "2026-09-10T08:44:44Z",
     "phase": "at-merge"
   },
@@ -124,8 +124,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 7,
-      "Bash": 4
+      "Read": 13,
+      "Bash": 4,
+      "StructuredOutput": 4,
+      "Grep": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/feat-free-tier-ceiling-alerts.json
+++ b/.claude/metrics/feat-free-tier-ceiling-alerts.json
@@ -5,7 +5,7 @@
     "branch": "feat/free-tier-ceiling-alerts",
     "base_sha": "a1840dd0773d6902fcb12efaf8f68e6d4a299c9f",
     "head_sha": "c20d4959e8d74162426f8f645668f45da3ade65d",
-    "generated_at": "2026-09-11T06:24:24.021Z",
+    "generated_at": "2026-09-11T07:19:12.006Z",
     "merged_at": "2026-09-10T08:44:57Z",
     "phase": "at-merge"
   },
@@ -124,8 +124,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 6,
-      "Bash": 4
+      "Read": 14,
+      "Bash": 4,
+      "StructuredOutput": 4
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/feat-lint-warning-ceiling.json
+++ b/.claude/metrics/feat-lint-warning-ceiling.json
@@ -5,7 +5,7 @@
     "branch": "feat/lint-warning-ceiling",
     "base_sha": "d3cf2f97a1b51c801b60f601017b41967c0309df",
     "head_sha": "686c33e6cde289833012854a3d75ccd92c13f886",
-    "generated_at": "2026-09-11T06:24:24.001Z",
+    "generated_at": "2026-09-11T07:19:11.987Z",
     "merged_at": "2026-09-11T06:15:30Z",
     "phase": "at-merge"
   },
@@ -151,15 +151,26 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 25,
-      "Edit": 14,
-      "Read": 8
+      "Bash": 154,
+      "Read": 33,
+      "Edit": 26,
+      "Write": 9,
+      "Skill": 3,
+      "StructuredOutput": 2,
+      "Grep": 1,
+      "Agent": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 7,
+      "max_edits_one_file": 8
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "obsidian:obsidian-markdown": 1,
+      "stress-plan": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-osn-recovery-audience.json
+++ b/.claude/metrics/feat-osn-recovery-audience.json
@@ -5,7 +5,7 @@
     "branch": "feat/osn-recovery-audience",
     "base_sha": "495ac60d479588f0aca2c38612c7880d45ae3f2f",
     "head_sha": "74cbaeafb02877661099270548b6bcee53631254",
-    "generated_at": "2026-09-11T06:24:24.028Z",
+    "generated_at": "2026-09-11T07:19:12.018Z",
     "merged_at": "2026-09-09T06:34:17Z",
     "phase": "at-merge"
   },
@@ -26,9 +26,9 @@
   "window": {
     "sessions": 1,
     "first_ts": "2026-09-09T05:08:39.534Z",
-    "last_ts": "2026-09-09T06:28:56.914Z",
-    "span_seconds": 4817,
-    "active_seconds": 4794,
+    "last_ts": "2026-09-09T06:29:36.257Z",
+    "span_seconds": 4857,
+    "active_seconds": 4833,
     "compactions": 0
   },
   "spend": {
@@ -142,16 +142,24 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 66,
-      "Edit": 50,
-      "Read": 3,
-      "Write": 3
+      "Bash": 252,
+      "Edit": 93,
+      "Read": 25,
+      "Write": 11,
+      "Skill": 4,
+      "Agent": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 8,
-      "max_edits_one_file": 14
+      "files_edited_3plus": 9,
+      "max_edits_one_file": 26
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 2
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-osn-recovery-cooldown.json
+++ b/.claude/metrics/feat-osn-recovery-cooldown.json
@@ -5,7 +5,7 @@
     "branch": "feat/osn-recovery-cooldown",
     "base_sha": "57fd79685c25dea10bfad65cdb5b0f99354fa0ec",
     "head_sha": "414ca7a96521ab9d148ee6c2e2b5d30e2d711355",
-    "generated_at": "2026-09-11T06:24:24.022Z",
+    "generated_at": "2026-09-11T07:19:12.007Z",
     "merged_at": "2026-09-09T17:03:07Z",
     "phase": "at-merge"
   },
@@ -171,15 +171,28 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 121,
-      "Edit": 30,
-      "Read": 9
+      "Bash": 416,
+      "Edit": 49,
+      "Read": 46,
+      "Skill": 5,
+      "Write": 5,
+      "Agent": 1,
+      "ToolSearch": 1,
+      "Monitor": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 4,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 9
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "review-security": 1,
+      "review-tests": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-osn-recovery-routes.json
+++ b/.claude/metrics/feat-osn-recovery-routes.json
@@ -5,7 +5,7 @@
     "branch": "feat/osn-recovery-routes",
     "base_sha": "0d468b94d48e80e66b707a0318b02a41e01faad5",
     "head_sha": "f33518077f260307123eaa5397d6c1241b756039",
-    "generated_at": "2026-09-11T06:24:24.026Z",
+    "generated_at": "2026-09-11T07:19:12.014Z",
     "merged_at": "2026-09-09T11:25:29Z",
     "phase": "at-merge"
   },
@@ -158,15 +158,26 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 58,
-      "Edit": 36,
-      "Read": 8
+      "Bash": 294,
+      "Edit": 85,
+      "Read": 53,
+      "Write": 7,
+      "Skill": 6,
+      "Agent": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 9
+      "files_edited_3plus": 10,
+      "max_edits_one_file": 16
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 2,
+      "review-security": 1,
+      "review-tests": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-osn-recovery-ui.json
+++ b/.claude/metrics/feat-osn-recovery-ui.json
@@ -5,7 +5,7 @@
     "branch": "feat/osn-recovery-ui",
     "base_sha": "91f5b5dd1b5e6c4bfe87857eaf2507087cb06ecc",
     "head_sha": "32ca41046a71a5770b2886e82d13d1b571bc78ac",
-    "generated_at": "2026-09-11T06:24:24.024Z",
+    "generated_at": "2026-09-11T07:19:12.011Z",
     "merged_at": "2026-09-09T16:53:34Z",
     "phase": "at-merge"
   },
@@ -164,19 +164,27 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 76,
-      "Edit": 24,
-      "Write": 5,
-      "Read": 3,
-      "Skill": 1
+      "Bash": 358,
+      "Edit": 47,
+      "Read": 29,
+      "Write": 12,
+      "Skill": 5,
+      "Agent": 1,
+      "ToolSearch": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 4,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 6,
+      "max_edits_one_file": 12
     },
     "skills": {
-      "review-security": 1
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "review-security": 1,
+      "review-tests": 1
     },
-    "subagents": {}
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-osn-totp-api.json
+++ b/.claude/metrics/feat-osn-totp-api.json
@@ -5,7 +5,7 @@
     "branch": "feat/osn-totp-api",
     "base_sha": "a621c6c6059ae34bff3a8b92c1086d34249b6153",
     "head_sha": "c536459c6ec92b740740b16a30d496fc50024dfc",
-    "generated_at": "2026-09-11T06:24:24.030Z",
+    "generated_at": "2026-09-11T07:19:12.020Z",
     "merged_at": "2026-09-09T05:15:20Z",
     "phase": "at-merge"
   },
@@ -147,16 +147,26 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 73,
-      "Edit": 25,
-      "Read": 4,
-      "Write": 3
+      "Bash": 331,
+      "Read": 55,
+      "Edit": 54,
+      "Write": 14,
+      "Skill": 5,
+      "Agent": 1,
+      "ToolSearch": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 15
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 2,
+      "review-security": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-pr-metrics-complexity.json
+++ b/.claude/metrics/feat-pr-metrics-complexity.json
@@ -5,7 +5,7 @@
     "branch": "feat/pr-metrics-complexity",
     "base_sha": "f73db88583845b1ada743c0283079fd0ba15079c",
     "head_sha": "3e722e57dd0d8b3ad660d9fd5dc9b3719fe90440",
-    "generated_at": "2026-09-09T06:24:29.018Z",
+    "generated_at": "2026-09-11T07:19:12.034Z",
     "merged_at": "2026-09-07T07:51:47Z",
     "phase": "at-merge"
   },
@@ -132,19 +132,21 @@
   "interaction": {
     "user_turns": 5,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 3807031,
+    "tokens_before_first_edit": 1240795,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 25,
-      "Read": 7,
+      "Bash": 36,
+      "Read": 20,
+      "Edit": 7,
+      "Grep": 5,
+      "StructuredOutput": 4,
       "EnterWorktree": 3,
-      "Edit": 3,
-      "Grep": 3,
+      "Write": 2,
       "Glob": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,
-      "max_edits_one_file": 1
+      "max_edits_one_file": 2
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/feat-pr-metrics-pipeline.json
+++ b/.claude/metrics/feat-pr-metrics-pipeline.json
@@ -5,7 +5,7 @@
     "branch": "feat/pr-metrics-pipeline",
     "base_sha": "3e722e57dd0d8b3ad660d9fd5dc9b3719fe90440",
     "head_sha": "d0f6c37428d32ebb46450b78fa74ac1c93b2c651",
-    "generated_at": "2026-09-09T06:24:29.016Z",
+    "generated_at": "2026-09-11T07:19:12.032Z",
     "merged_at": "2026-09-07T07:51:48Z",
     "phase": "at-merge"
   },
@@ -23,7 +23,7 @@
     "first_ts": "2026-09-07T03:10:01.388Z",
     "last_ts": "2026-09-07T11:32:45.585Z",
     "span_seconds": 30164,
-    "active_seconds": 6786,
+    "active_seconds": 6809,
     "compactions": 0
   },
   "spend": {
@@ -144,21 +144,28 @@
   "interaction": {
     "user_turns": 18,
     "corrective_turns": 12,
-    "tokens_before_first_edit": 2009541,
+    "tokens_before_first_edit": 1429576,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 64,
-      "Edit": 11,
-      "Read": 11,
-      "Write": 4,
+      "Bash": 168,
+      "Read": 27,
+      "Write": 17,
+      "Edit": 16,
+      "StructuredOutput": 4,
+      "Grep": 4,
       "EnterWorktree": 3,
-      "ToolSearch": 1
+      "Agent": 2,
+      "AskUserQuestion": 1,
+      "ToolSearch": 1,
+      "ExitPlanMode": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 7
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 8
     },
     "skills": {},
-    "subagents": {}
+    "subagents": {
+      "Explore": 2
+    }
   }
 }

--- a/.claude/metrics/feat-pr-session-metrics.json
+++ b/.claude/metrics/feat-pr-session-metrics.json
@@ -5,7 +5,7 @@
     "branch": "feat/pr-session-metrics",
     "base_sha": "8aa5cdc8463d7c156628902cfe414176dbd9a7a0",
     "head_sha": "f73db88583845b1ada743c0283079fd0ba15079c",
-    "generated_at": "2026-09-09T06:24:29.019Z",
+    "generated_at": "2026-09-11T07:19:12.034Z",
     "merged_at": "2026-09-07T07:51:46Z",
     "phase": "at-merge"
   },
@@ -132,21 +132,23 @@
   "interaction": {
     "user_turns": 8,
     "corrective_turns": 2,
-    "tokens_before_first_edit": 1974421,
+    "tokens_before_first_edit": 764066,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 28,
-      "Edit": 7,
-      "Read": 7,
-      "Grep": 3,
-      "EnterWorktree": 2,
-      "Write": 2,
+      "Bash": 57,
+      "Read": 13,
+      "Edit": 12,
+      "Write": 8,
+      "Grep": 6,
+      "EnterWorktree": 3,
+      "StructuredOutput": 3,
+      "ToolSearch": 1,
       "ExitWorktree": 1,
       "Glob": 1
     },
     "edit_churn": {
       "files_edited_3plus": 2,
-      "max_edits_one_file": 4
+      "max_edits_one_file": 6
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/feat-shared-crypto-totp.json
+++ b/.claude/metrics/feat-shared-crypto-totp.json
@@ -5,7 +5,7 @@
     "branch": "feat/shared-crypto-totp",
     "base_sha": "be06e53fb322237baf274b4091a777d7a1cad08f",
     "head_sha": "da51b21a83f31123722841649f4ef193118a0a4c",
-    "generated_at": "2026-09-11T06:24:24.036Z",
+    "generated_at": "2026-09-11T07:19:12.028Z",
     "merged_at": "2026-09-09T01:46:00Z",
     "phase": "at-merge"
   },
@@ -25,9 +25,9 @@
   "window": {
     "sessions": 1,
     "first_ts": "2026-09-08T14:21:42.291Z",
-    "last_ts": "2026-09-09T01:45:50.305Z",
-    "span_seconds": 41048,
-    "active_seconds": 4403,
+    "last_ts": "2026-09-09T01:45:52.827Z",
+    "span_seconds": 41051,
+    "active_seconds": 4406,
     "compactions": 0
   },
   "spend": {
@@ -152,15 +152,27 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 43,
-      "Edit": 34,
-      "Read": 2
+      "Bash": 156,
+      "Edit": 51,
+      "Read": 20,
+      "Write": 12,
+      "Skill": 5,
+      "Agent": 1,
+      "ToolSearch": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 6,
-      "max_edits_one_file": 7
+      "files_edited_3plus": 7,
+      "max_edits_one_file": 13
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "review-security": 1,
+      "review-tests": 1,
+      "obsidian:obsidian-markdown": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/feat-subagent-branch-attribution.json
+++ b/.claude/metrics/feat-subagent-branch-attribution.json
@@ -5,7 +5,7 @@
     "branch": "feat/subagent-branch-attribution",
     "base_sha": "a020dc6fe429b21c26399470519d79ef8e3793c1",
     "head_sha": "e93bea3b62fbd34ab573cf2867efbd2dfa7ff25d",
-    "generated_at": "2026-09-11T06:24:24.038Z",
+    "generated_at": "2026-09-11T07:19:12.031Z",
     "merged_at": "2026-09-08T13:33:50Z",
     "phase": "at-merge"
   },
@@ -24,9 +24,9 @@
   "window": {
     "sessions": 1,
     "first_ts": "2026-09-08T11:41:46.779Z",
-    "last_ts": "2026-09-08T12:44:09.509Z",
-    "span_seconds": 3743,
-    "active_seconds": 1583,
+    "last_ts": "2026-09-08T12:44:13.704Z",
+    "span_seconds": 3747,
+    "active_seconds": 1587,
     "compactions": 0
   },
   "spend": {
@@ -138,15 +138,19 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Edit": 19,
-      "Bash": 18,
-      "Read": 1
+      "Bash": 101,
+      "Edit": 26,
+      "Read": 10,
+      "Write": 4,
+      "Skill": 1
     },
     "edit_churn": {
       "files_edited_3plus": 3,
-      "max_edits_one_file": 11
+      "max_edits_one_file": 16
     },
-    "skills": {},
+    "skills": {
+      "review-security": 1
+    },
     "subagents": {}
   }
 }

--- a/.claude/metrics/feat-totp-key-rotation.json
+++ b/.claude/metrics/feat-totp-key-rotation.json
@@ -5,7 +5,7 @@
     "branch": "feat/totp-key-rotation",
     "base_sha": "89b10ce9e3cb3e3d12c4bd6dd2cf723c0569ba3a",
     "head_sha": "9180d8c61e6e52a165758f5947d3f2bfdebe518e",
-    "generated_at": "2026-09-11T06:24:24.014Z",
+    "generated_at": "2026-09-11T07:19:11.995Z",
     "merged_at": "2026-09-11T00:25:59Z",
     "phase": "at-merge"
   },
@@ -167,18 +167,29 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 63,
-      "Edit": 39,
-      "Read": 18,
-      "Write": 3,
-      "ToolSearch": 1,
+      "Bash": 296,
+      "Edit": 70,
+      "Read": 36,
+      "Write": 6,
+      "Skill": 5,
+      "Agent": 2,
+      "ToolSearch": 2,
+      "StructuredOutput": 2,
       "Glob": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 5,
-      "max_edits_one_file": 9
+      "files_edited_3plus": 9,
+      "max_edits_one_file": 16
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "review-security": 1,
+      "review-tests": 1
+    },
+    "subagents": {
+      "attacker": 2
+    }
   }
 }

--- a/.claude/metrics/fix-bare-root-agent-harness.json
+++ b/.claude/metrics/fix-bare-root-agent-harness.json
@@ -5,7 +5,7 @@
     "branch": "fix/bare-root-agent-harness",
     "base_sha": "09ce0e2daf10c89df6bef57fe63bc31ebb16534f",
     "head_sha": "9ebc63777192470e18443eecec7815269a320cc5",
-    "generated_at": "2026-09-11T06:24:24.020Z",
+    "generated_at": "2026-09-11T07:19:12.005Z",
     "merged_at": "2026-09-10T08:45:10Z",
     "phase": "at-merge"
   },
@@ -124,9 +124,11 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Read": 8,
       "Bash": 4,
-      "Read": 3,
-      "Glob": 1
+      "StructuredOutput": 4,
+      "Glob": 1,
+      "Grep": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-browserslist-advisories.json
+++ b/.claude/metrics/fix-browserslist-advisories.json
@@ -5,7 +5,7 @@
     "branch": "fix/browserslist-advisories",
     "base_sha": "a6c9eb6de6ea076c07b228dc21089ce79171cded",
     "head_sha": "5d14ee9f62b8c15a5a33931c8b680af25a27fb59",
-    "generated_at": "2026-09-11T06:24:24.048Z",
+    "generated_at": "2026-09-11T07:19:12.045Z",
     "merged_at": "2026-09-02T02:08:09Z",
     "phase": "at-merge"
   },
@@ -149,19 +149,27 @@
   "interaction": {
     "user_turns": 4,
     "corrective_turns": 2,
-    "tokens_before_first_edit": 2197258,
+    "tokens_before_first_edit": 589184,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 40,
-      "Read": 1
+      "Bash": 125,
+      "Read": 4,
+      "StructuredOutput": 2,
+      "Agent": 2,
+      "Write": 2,
+      "Skill": 1,
+      "Workflow": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,
-      "max_edits_one_file": 0
+      "max_edits_one_file": 1
     },
     "skills": {
+      "prep-pr": 1,
       "workflow-authoring": 1
     },
-    "subagents": {}
+    "subagents": {
+      "general-purpose": 2
+    }
   }
 }

--- a/.claude/metrics/fix-cf-token-scope-visibility.json
+++ b/.claude/metrics/fix-cf-token-scope-visibility.json
@@ -5,7 +5,7 @@
     "branch": "fix/cf-token-scope-visibility",
     "base_sha": "b5e6d72ea20c27fb71e825d93deec6e6300d8d49",
     "head_sha": "fa91561dcb54dc057d62889b2af707311b5494f0",
-    "generated_at": "2026-09-11T02:01:21.097Z",
+    "generated_at": "2026-09-11T07:19:12.005Z",
     "merged_at": "2026-09-10T12:56:57Z",
     "phase": "at-merge"
   },
@@ -119,8 +119,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Read": 2,
       "Bash": 1,
-      "Read": 1
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-changeset-stdin-guard.json
+++ b/.claude/metrics/fix-changeset-stdin-guard.json
@@ -5,7 +5,7 @@
     "branch": "fix/changeset-stdin-guard",
     "base_sha": "0adac539d2fae93b58d639c7e68514aeef95eb7a",
     "head_sha": "fedbc34710f6f6a9bf064b76ebce0f4b49bfd020",
-    "generated_at": "2026-09-11T06:24:24.011Z",
+    "generated_at": "2026-09-11T07:19:11.991Z",
     "merged_at": "2026-09-11T04:40:43Z",
     "phase": "at-merge"
   },
@@ -151,15 +151,27 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Edit": 4,
-      "Read": 3,
-      "Monitor": 1
+      "Bash": 65,
+      "Read": 18,
+      "Edit": 10,
+      "Skill": 2,
+      "Write": 2,
+      "Agent": 1,
+      "ToolSearch": 1,
+      "Monitor": 1,
+      "Grep": 1,
+      "StructuredOutput": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 2
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 4
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/fix-cire-consent-cookie-prefix.json
+++ b/.claude/metrics/fix-cire-consent-cookie-prefix.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-consent-cookie-prefix",
     "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
     "head_sha": "2ea7944b2511c5c3d2018d6dcc9f0cbf4580f3db",
-    "generated_at": "2026-09-11T06:24:24.053Z",
+    "generated_at": "2026-09-11T07:19:12.051Z",
     "merged_at": "2026-08-31T06:43:13Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 9,
-      "Grep": 1
+      "Read": 23,
+      "Grep": 5,
+      "StructuredOutput": 3
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-desired-state-seed-reland.json
+++ b/.claude/metrics/fix-cire-desired-state-seed-reland.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-desired-state-seed-reland",
     "base_sha": "bb5b11a229842de7193e5656dd0ec9349eb457e0",
     "head_sha": "367c7be91f24c9f540042c159c60f1df080ecf2a",
-    "generated_at": "2026-09-11T06:24:24.043Z",
+    "generated_at": "2026-09-11T07:19:12.038Z",
     "merged_at": "2026-09-06T09:10:39Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2,
-      "Glob": 1
+      "Read": 5,
+      "Glob": 2,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-desired-state-seed.json
+++ b/.claude/metrics/fix-cire-desired-state-seed.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-desired-state-seed",
     "base_sha": "ce3e26dd8704b7a23d774f1db4603a2399cc14cd",
     "head_sha": "c7c52be571002b14ca4c4bb66b2e6770d9e147e6",
-    "generated_at": "2026-09-09T06:24:29.024Z",
+    "generated_at": "2026-09-11T07:19:12.039Z",
     "merged_at": "2026-09-06T07:51:46Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 3,
-      "Read": 3,
+      "Read": 10,
+      "Bash": 4,
+      "StructuredOutput": 4,
       "Glob": 3
     },
     "edit_churn": {

--- a/.claude/metrics/fix-cire-dev-db-guard-toml.json
+++ b/.claude/metrics/fix-cire-dev-db-guard-toml.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-dev-db-guard-toml",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "f872171fc9896acba792ae38c44fbc8dc91987b8",
-    "generated_at": "2026-09-11T06:24:24.050Z",
+    "generated_at": "2026-09-11T07:19:12.046Z",
     "merged_at": "2026-09-06T07:51:26Z",
     "phase": "at-merge"
   },
@@ -119,7 +119,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 4
+      "Read": 8,
+      "StructuredOutput": 4
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-cire-store-notifying-invalidate.json
+++ b/.claude/metrics/fix-cire-store-notifying-invalidate.json
@@ -5,7 +5,7 @@
     "branch": "fix/cire-store-notifying-invalidate",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "66c9950197ee25bfc25f86664de7ac607504d843",
-    "generated_at": "2026-09-11T06:24:24.050Z",
+    "generated_at": "2026-09-11T07:19:12.047Z",
     "merged_at": "2026-09-06T07:50:35Z",
     "phase": "at-merge"
   },
@@ -120,7 +120,9 @@
     "corrective_turns": 0,
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
-    "tool_calls": {},
+    "tool_calls": {
+      "StructuredOutput": 2
+    },
     "edit_churn": {
       "files_edited_3plus": 0,
       "max_edits_one_file": 0

--- a/.claude/metrics/fix-metrics-complexity-source.json
+++ b/.claude/metrics/fix-metrics-complexity-source.json
@@ -5,7 +5,7 @@
     "branch": "fix/metrics-complexity-source",
     "base_sha": "0adac539d2fae93b58d639c7e68514aeef95eb7a",
     "head_sha": "d3fdc566691f3cf29c09f3d342d76c5c7a68cf5b",
-    "generated_at": "2026-09-11T06:24:24.012Z",
+    "generated_at": "2026-09-11T07:19:11.992Z",
     "merged_at": "2026-09-11T04:40:29Z",
     "phase": "at-merge"
   },
@@ -148,16 +148,26 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 13,
-      "Read": 4,
-      "Edit": 3,
-      "Write": 2
+      "Bash": 157,
+      "Read": 27,
+      "Edit": 14,
+      "Write": 5,
+      "Skill": 4,
+      "Agent": 2,
+      "StructuredOutput": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 0,
-      "max_edits_one_file": 2
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 6
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "rate-complexity": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1
+    },
+    "subagents": {
+      "attacker": 2
+    }
   }
 }

--- a/.claude/metrics/fix-metrics-node-fs-import.json
+++ b/.claude/metrics/fix-metrics-node-fs-import.json
@@ -5,7 +5,7 @@
     "branch": "fix/metrics-node-fs-import",
     "base_sha": "10e490c9aa8581cf5b4cf2f739e1f689370a0083",
     "head_sha": "c05ea4e4123ab69028dd1efb3347c506b5027105",
-    "generated_at": "2026-09-11T06:24:24.033Z",
+    "generated_at": "2026-09-11T07:19:12.026Z",
     "merged_at": "2026-09-09T02:54:03Z",
     "phase": "at-merge"
   },
@@ -188,28 +188,37 @@
     "tokens_before_first_edit": 231096,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 100,
-      "Edit": 28,
-      "Read": 8,
-      "Write": 6,
-      "mcp__claude-in-chrome__read_console_messages": 6,
-      "mcp__claude-in-chrome__navigate": 4,
-      "mcp__claude-in-chrome__read_network_requests": 2,
-      "Agent": 2,
+      "Bash": 272,
+      "Edit": 51,
+      "Read": 36,
+      "Write": 16,
+      "mcp__claude-in-chrome__read_console_messages": 8,
+      "Agent": 7,
+      "mcp__claude-in-chrome__navigate": 7,
+      "Skill": 5,
+      "StructuredOutput": 4,
+      "mcp__claude-in-chrome__read_network_requests": 3,
+      "mcp__claude-in-chrome__read_page": 3,
+      "ToolSearch": 2,
       "EnterWorktree": 1,
-      "Skill": 1,
       "TaskStop": 1,
-      "mcp__claude-in-chrome__read_page": 1
+      "mcp__claude-in-chrome__tabs_create_mcp": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 4,
-      "max_edits_one_file": 9
+      "files_edited_3plus": 9,
+      "max_edits_one_file": 13
     },
     "skills": {
-      "stress-plan": 1
+      "stress-plan": 1,
+      "prep-pr": 1,
+      "review-tests": 1,
+      "review-security": 1,
+      "review-performance": 1
     },
     "subagents": {
-      "general-purpose": 2
+      "attacker": 3,
+      "general-purpose": 3,
+      "shepherd": 1
     }
   }
 }

--- a/.claude/metrics/fix-osn-email-change-hardening.json
+++ b/.claude/metrics/fix-osn-email-change-hardening.json
@@ -5,7 +5,7 @@
     "branch": "fix/osn-email-change-hardening",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "eef98274e29c36bf658c2316542f56c5238e2788",
-    "generated_at": "2026-09-11T06:24:24.055Z",
+    "generated_at": "2026-09-11T07:19:12.052Z",
     "merged_at": "2026-08-31T04:33:06Z",
     "phase": "at-merge"
   },
@@ -122,8 +122,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 3,
-      "Grep": 2
+      "Read": 5,
+      "Grep": 4,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-osn-fof-bind-cap.json
+++ b/.claude/metrics/fix-osn-fof-bind-cap.json
@@ -5,7 +5,7 @@
     "branch": "fix/osn-fof-bind-cap",
     "base_sha": "e7c6f0f170f01a937c8e3fa06ff9db2bf4b0cdb9",
     "head_sha": "e189c0eb5e18726ff593766ce4aecfee816d3c43",
-    "generated_at": "2026-09-11T06:24:24.053Z",
+    "generated_at": "2026-09-11T07:19:12.050Z",
     "merged_at": "2026-08-31T15:41:16Z",
     "phase": "at-merge"
   },
@@ -121,10 +121,11 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 8,
+      "Read": 16,
+      "Grep": 6,
+      "StructuredOutput": 4,
       "Glob": 3,
-      "Bash": 2,
-      "Grep": 1
+      "Bash": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-osn-waituntil-sink.json
+++ b/.claude/metrics/fix-osn-waituntil-sink.json
@@ -5,7 +5,7 @@
     "branch": "fix/osn-waituntil-sink",
     "base_sha": "ca2887eedd58e3537da77121fa07993718584433",
     "head_sha": "8d84638db7b106a05158d73b0f670b08cbf46eb5",
-    "generated_at": "2026-09-11T06:24:24.027Z",
+    "generated_at": "2026-09-11T07:19:12.017Z",
     "merged_at": "2026-09-09T10:38:51Z",
     "phase": "at-merge"
   },
@@ -166,14 +166,23 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 8,
-      "Read": 1
+      "Bash": 84,
+      "Read": 8,
+      "Skill": 2,
+      "Agent": 2,
+      "Write": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,
-      "max_edits_one_file": 0
+      "max_edits_one_file": 1
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1
+    },
+    "subagents": {
+      "explorer": 1,
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/fix-pr-metrics-split-response-dedupe.json
+++ b/.claude/metrics/fix-pr-metrics-split-response-dedupe.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
   "pr": {
-    "number": 888,
-    "branch": "fix/ci-playwright-workspace-version",
-    "base_sha": "42178e92200ef4a2e3dd2ec2d134641ca2282ab6",
-    "head_sha": "b485f54e96e6d30fde9c442e1ffc0ec666a0fa07",
-    "generated_at": "2026-09-11T07:19:12.039Z",
-    "merged_at": "2026-09-06T05:02:09Z",
-    "phase": "at-merge"
+    "number": null,
+    "branch": "fix/pr-metrics-split-response-dedupe",
+    "base_sha": "3f3a6120c1142489f5544bef830db560d2db02f3",
+    "head_sha": "3f3a6120c1142489f5544bef830db560d2db02f3",
+    "generated_at": "2026-09-11T07:16:51.963Z",
+    "merged_at": null,
+    "phase": "at-open"
   },
   "issue": {
     "number": null,
@@ -20,48 +20,48 @@
   },
   "window": {
     "sessions": 1,
-    "first_ts": "2026-09-06T04:09:27.226Z",
-    "last_ts": "2026-09-06T04:09:34.738Z",
-    "span_seconds": 8,
-    "active_seconds": 8,
-    "compactions": 0
+    "first_ts": "2026-09-11T06:32:59.984Z",
+    "last_ts": "2026-09-11T07:16:48.190Z",
+    "span_seconds": 2628,
+    "active_seconds": 658,
+    "compactions": 1
   },
   "spend": {
-    "usd_equivalent": 0.338594,
+    "usd_equivalent": 2.3463354999999995,
     "tokens": {
-      "input": 4,
-      "output": 555,
-      "thinking": 296,
+      "input": 58,
+      "output": 11478,
+      "thinking": 3292,
       "cache_write_5m": 0,
-      "cache_write_1h": 660,
-      "cache_read": 636198
+      "cache_write_1h": 68856,
+      "cache_read": 2741071
     },
     "by_model": {
       "claude-opus-5": {
         "tokens": {
-          "input": 4,
-          "output": 555,
-          "thinking": 296,
+          "input": 58,
+          "output": 11478,
+          "thinking": 3292,
           "cache_write_5m": 0,
-          "cache_write_1h": 660,
-          "cache_read": 636198
+          "cache_write_1h": 68856,
+          "cache_read": 2741071
         },
-        "usd_equivalent": 0.338594,
-        "messages": 2
+        "usd_equivalent": 2.3463354999999995,
+        "messages": 29
       }
     },
     "by_actor": {
       "main": {
         "tokens": {
-          "input": 4,
-          "output": 555,
-          "thinking": 296,
+          "input": 58,
+          "output": 11478,
+          "thinking": 3292,
           "cache_write_5m": 0,
-          "cache_write_1h": 660,
-          "cache_read": 636198
+          "cache_write_1h": 68856,
+          "cache_read": 2741071
         },
-        "usd_equivalent": 0.338594,
-        "messages": 2
+        "usd_equivalent": 2.3463354999999995,
+        "messages": 29
       },
       "subagent": {
         "tokens": {
@@ -77,7 +77,7 @@
       }
     },
     "effort": {
-      "high": 2
+      "high": 29
     },
     "unpriced_models": []
   },
@@ -86,7 +86,7 @@
       "generated": 0,
       "test": 0,
       "docs": 0,
-      "config": 1,
+      "config": 0,
       "source": 0
     },
     "loc": {
@@ -103,7 +103,7 @@
         "deleted": 0
       },
       "config": {
-        "added": 23,
+        "added": 0,
         "deleted": 0
       },
       "source": {
@@ -113,15 +113,16 @@
     },
     "packages": [],
     "touches_migration": false,
-    "commits": 1
+    "commits": 0
   },
   "interaction": {
-    "user_turns": 0,
-    "corrective_turns": 0,
-    "tokens_before_first_edit": null,
-    "sessions_with_observed_edit": 0,
+    "user_turns": 1,
+    "corrective_turns": 1,
+    "tokens_before_first_edit": 1957960,
+    "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 2
+      "Bash": 28,
+      "EnterWorktree": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-pulse-d1-bind-cap.json
+++ b/.claude/metrics/fix-pulse-d1-bind-cap.json
@@ -5,7 +5,7 @@
     "branch": "fix/pulse-d1-bind-cap",
     "base_sha": "15e404061d22adc354aeebda036351cf728ce450",
     "head_sha": "caf24cd736bf28fdf1d7ca62a2d7c1c4bf88af9b",
-    "generated_at": "2026-09-11T06:24:24.052Z",
+    "generated_at": "2026-09-11T07:19:12.049Z",
     "merged_at": "2026-09-06T09:25:51Z",
     "phase": "at-merge"
   },
@@ -122,7 +122,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2
+      "Read": 16,
+      "Grep": 5,
+      "StructuredOutput": 3
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-recovery-passkey-cap.json
+++ b/.claude/metrics/fix-recovery-passkey-cap.json
@@ -5,7 +5,7 @@
     "branch": "fix/recovery-passkey-cap",
     "base_sha": "b5e6d72ea20c27fb71e825d93deec6e6300d8d49",
     "head_sha": "de55412c8ba35fbb7221b125bf4f59bac1a84ed4",
-    "generated_at": "2026-09-11T06:24:24.018Z",
+    "generated_at": "2026-09-11T07:19:12.002Z",
     "merged_at": "2026-09-10T12:59:21Z",
     "phase": "at-merge"
   },
@@ -177,17 +177,29 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 63,
-      "Edit": 46,
-      "Read": 28,
-      "Write": 4,
-      "Grep": 3
+      "Bash": 261,
+      "Edit": 65,
+      "Read": 63,
+      "Grep": 12,
+      "Write": 9,
+      "Skill": 5,
+      "Agent": 1,
+      "ToolSearch": 1,
+      "Monitor": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 6,
-      "max_edits_one_file": 11
+      "files_edited_3plus": 10,
+      "max_edits_one_file": 16
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "review-security": 1,
+      "review-tests": 1
+    },
+    "subagents": {
+      "attacker": 1
+    }
   }
 }

--- a/.claude/metrics/fix-recovery-token-refresh.json
+++ b/.claude/metrics/fix-recovery-token-refresh.json
@@ -5,7 +5,7 @@
     "branch": "fix/recovery-token-refresh",
     "base_sha": "b366dfe5cc96a99ea00ed1e86fb6f2bbd914cc1b",
     "head_sha": "ff1426b92fb114d305668cc452cafb3728deabb0",
-    "generated_at": "2026-09-11T06:24:24.016Z",
+    "generated_at": "2026-09-11T07:19:11.998Z",
     "merged_at": "2026-09-10T14:08:43Z",
     "phase": "at-merge"
   },
@@ -178,17 +178,29 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 86,
-      "Edit": 42,
-      "Read": 24,
+      "Bash": 355,
+      "Edit": 75,
+      "Read": 55,
+      "Grep": 7,
+      "Write": 6,
+      "Skill": 5,
+      "Agent": 2,
       "ToolSearch": 1,
-      "Grep": 1
+      "StructuredOutput": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 6,
-      "max_edits_one_file": 10
+      "files_edited_3plus": 9,
+      "max_edits_one_file": 17
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "new-feat": 1,
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "review-security": 1,
+      "review-tests": 1
+    },
+    "subagents": {
+      "attacker": 2
+    }
   }
 }

--- a/.claude/metrics/fix-redis-reply-boundary.json
+++ b/.claude/metrics/fix-redis-reply-boundary.json
@@ -5,7 +5,7 @@
     "branch": "fix/redis-reply-boundary",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "972d2be097a8148570897352b6744db208dfb14c",
-    "generated_at": "2026-09-11T06:24:24.054Z",
+    "generated_at": "2026-09-11T07:19:12.052Z",
     "merged_at": "2026-08-31T04:34:02Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 8,
-      "Grep": 1,
+      "Read": 19,
+      "Grep": 10,
+      "StructuredOutput": 4,
       "Bash": 1
     },
     "edit_churn": {

--- a/.claude/metrics/fix-sqlite-foreign-keys.json
+++ b/.claude/metrics/fix-sqlite-foreign-keys.json
@@ -5,7 +5,7 @@
     "branch": "fix/sqlite-foreign-keys",
     "base_sha": "1789a19df627206d8bcbff0ff2d02a54f667370b",
     "head_sha": "7dd2a0d7c529ed55edcf40f587313f29cca541bf",
-    "generated_at": "2026-09-11T06:24:24.055Z",
+    "generated_at": "2026-09-11T07:19:12.052Z",
     "merged_at": "2026-08-30T14:20:51Z",
     "phase": "at-merge"
   },
@@ -125,8 +125,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 5,
-      "Grep": 4
+      "Grep": 9,
+      "Read": 8,
+      "Bash": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/fix-zap-class-guard.json
+++ b/.claude/metrics/fix-zap-class-guard.json
@@ -5,7 +5,7 @@
     "branch": "fix/zap-class-guard",
     "base_sha": "273e4ba82e35358c1ef08ab4ae2e38f7692ac855",
     "head_sha": "50b30905dc82292d0e3478b6b394e9eabc0bafea",
-    "generated_at": "2026-09-11T06:24:24.055Z",
+    "generated_at": "2026-09-11T07:19:12.053Z",
     "merged_at": "2026-08-30T14:14:43Z",
     "phase": "at-merge"
   },
@@ -122,8 +122,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 11,
-      "StructuredOutput": 1,
+      "Read": 22,
+      "Grep": 5,
+      "StructuredOutput": 4,
       "Bash": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-cire-d1-sessions.json
+++ b/.claude/metrics/perf-cire-d1-sessions.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-d1-sessions",
     "base_sha": "f3bef1bf425835270c41cc7387c5289086e66018",
     "head_sha": "4deb5734ac742957ceee569a64cd09b0cb5ff86f",
-    "generated_at": "2026-09-09T06:24:29.034Z",
+    "generated_at": "2026-09-11T07:19:12.047Z",
     "merged_at": "2026-09-06T09:35:37Z",
     "phase": "at-merge"
   },
@@ -132,23 +132,31 @@
   "interaction": {
     "user_turns": 15,
     "corrective_turns": 12,
-    "tokens_before_first_edit": 2137073,
+    "tokens_before_first_edit": 2026657,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 98,
-      "Edit": 10,
-      "Read": 6,
-      "Write": 5,
+      "Bash": 258,
+      "Edit": 24,
+      "Read": 17,
+      "Write": 12,
+      "Agent": 3,
+      "StructuredOutput": 3,
+      "Grep": 2,
       "EnterWorktree": 1,
-      "Grep": 1,
+      "Skill": 1,
+      "ToolSearch": 1,
       "WebFetch": 1,
       "Glob": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 5
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 6
     },
-    "skills": {},
-    "subagents": {}
+    "skills": {
+      "obsidian:obsidian-markdown": 1
+    },
+    "subagents": {
+      "general-purpose": 3
+    }
   }
 }

--- a/.claude/metrics/perf-cire-entitlement-reads.json
+++ b/.claude/metrics/perf-cire-entitlement-reads.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-entitlement-reads",
     "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
     "head_sha": "16d786d2fc27a381037f8b64b391856bb1d819fc",
-    "generated_at": "2026-09-11T06:24:24.053Z",
+    "generated_at": "2026-09-11T07:19:12.050Z",
     "merged_at": "2026-08-31T06:44:15Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 1
+      "Read": 7,
+      "Grep": 3,
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-cire-events-editor-scope.json
+++ b/.claude/metrics/perf-cire-events-editor-scope.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-events-editor-scope",
     "base_sha": "cb345fbec36cce19e5a5cc97d45927cafd69984e",
     "head_sha": "a9dfce45a733bd60ae28ccfdf758584fe029f8b3",
-    "generated_at": "2026-09-11T06:24:24.050Z",
+    "generated_at": "2026-09-11T07:19:12.047Z",
     "merged_at": "2026-09-06T07:49:41Z",
     "phase": "at-merge"
   },
@@ -122,8 +122,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 11,
-      "Bash": 4,
+      "Read": 21,
+      "Bash": 6,
+      "StructuredOutput": 5,
+      "Grep": 2,
       "Glob": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-cire-font-build-guard.json
+++ b/.claude/metrics/perf-cire-font-build-guard.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-font-build-guard",
     "base_sha": "fcf34fccdf0b4a94f3c8efd2f73dec7fdba0b3b6",
     "head_sha": "f214eab18a664d314561822e78b0bdcb009733c4",
-    "generated_at": "2026-09-11T06:24:24.054Z",
+    "generated_at": "2026-09-11T07:19:12.051Z",
     "merged_at": "2026-08-31T06:42:12Z",
     "phase": "at-merge"
   },
@@ -123,7 +123,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 1
+      "Read": 3,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-cire-invites-ssr-bundle.json
+++ b/.claude/metrics/perf-cire-invites-ssr-bundle.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-invites-ssr-bundle",
     "base_sha": "851df71756b28cbe60cc72bac4f82de072179237",
     "head_sha": "0fbe9a2b7098c414b16bbbb8acd5e3302f1016d1",
-    "generated_at": "2026-09-11T06:24:24.043Z",
+    "generated_at": "2026-09-11T07:19:12.037Z",
     "merged_at": "2026-09-06T15:01:51Z",
     "phase": "at-merge"
   },
@@ -132,18 +132,20 @@
   "interaction": {
     "user_turns": 4,
     "corrective_turns": 0,
-    "tokens_before_first_edit": 884171,
+    "tokens_before_first_edit": 781854,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 12,
-      "Read": 8,
-      "Edit": 6,
-      "Write": 2,
-      "Glob": 1
+      "Bash": 53,
+      "Read": 20,
+      "Edit": 12,
+      "Grep": 6,
+      "StructuredOutput": 3,
+      "Glob": 3,
+      "Write": 2
     },
     "edit_churn": {
-      "files_edited_3plus": 1,
-      "max_edits_one_file": 3
+      "files_edited_3plus": 2,
+      "max_edits_one_file": 6
     },
     "skills": {},
     "subagents": {}

--- a/.claude/metrics/perf-cire-invites-worker-size.json
+++ b/.claude/metrics/perf-cire-invites-worker-size.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-invites-worker-size",
     "base_sha": "7094065879b85fc107c0778a176d3d8002a9cf85",
     "head_sha": "6379aad47887720961d148bc96d0d90a5d2f1b0f",
-    "generated_at": "2026-09-11T06:24:24.050Z",
+    "generated_at": "2026-09-11T07:19:12.046Z",
     "merged_at": "2026-09-02T01:17:53Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,10 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 7,
-      "Glob": 2
+      "Read": 18,
+      "Glob": 3,
+      "StructuredOutput": 3,
+      "Bash": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-cire-store-reactive-readers.json
+++ b/.claude/metrics/perf-cire-store-reactive-readers.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-store-reactive-readers",
     "base_sha": "07e6b0d68307fb03d356f327b276ebea627e3136",
     "head_sha": "ce3e26dd8704b7a23d774f1db4603a2399cc14cd",
-    "generated_at": "2026-09-11T06:24:24.049Z",
+    "generated_at": "2026-09-11T07:19:12.046Z",
     "merged_at": "2026-09-06T07:50:37Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2,
-      "Bash": 1,
+      "StructuredOutput": 3,
+      "Read": 3,
+      "Bash": 2,
       "Grep": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-cire-store-stale-while-revalidate.json
+++ b/.claude/metrics/perf-cire-store-stale-while-revalidate.json
@@ -5,7 +5,7 @@
     "branch": "perf/cire-store-stale-while-revalidate",
     "base_sha": "66c9950197ee25bfc25f86664de7ac607504d843",
     "head_sha": "07e6b0d68307fb03d356f327b276ebea627e3136",
-    "generated_at": "2026-09-11T06:24:24.049Z",
+    "generated_at": "2026-09-11T07:19:12.046Z",
     "merged_at": "2026-09-06T07:50:36Z",
     "phase": "at-merge"
   },
@@ -121,6 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
+      "Read": 9,
+      "StructuredOutput": 2,
+      "Grep": 2,
       "Glob": 1
     },
     "edit_churn": {

--- a/.claude/metrics/perf-osn-recommender-fanout.json
+++ b/.claude/metrics/perf-osn-recommender-fanout.json
@@ -5,7 +5,7 @@
     "branch": "perf/osn-recommender-fanout",
     "base_sha": "8b55084abdc82867cb1aeaacb4102ecb1213b146",
     "head_sha": "e7c6f0f170f01a937c8e3fa06ff9db2bf4b0cdb9",
-    "generated_at": "2026-09-11T06:24:24.053Z",
+    "generated_at": "2026-09-11T07:19:12.050Z",
     "merged_at": "2026-08-31T15:41:14Z",
     "phase": "at-merge"
   },
@@ -123,7 +123,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2
+      "Read": 3,
+      "Grep": 1,
+      "StructuredOutput": 1
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-turbo-test-inputs.json
+++ b/.claude/metrics/perf-turbo-test-inputs.json
@@ -5,7 +5,7 @@
     "branch": "perf/turbo-test-inputs",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "b5751a716de151d0e134f638a3354e979a5aa65c",
-    "generated_at": "2026-09-11T06:24:24.054Z",
+    "generated_at": "2026-09-11T07:19:12.051Z",
     "merged_at": "2026-08-31T04:33:35Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,8 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 2
+      "Read": 8,
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/perf-zap-write-hops.json
+++ b/.claude/metrics/perf-zap-write-hops.json
@@ -5,7 +5,7 @@
     "branch": "perf/zap-write-hops",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "b5f9c7f45fef921b4e354576e72b91aea72ebe69",
-    "generated_at": "2026-09-11T06:24:24.054Z",
+    "generated_at": "2026-09-11T07:19:12.052Z",
     "merged_at": "2026-08-31T04:33:24Z",
     "phase": "at-merge"
   },
@@ -121,8 +121,9 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Read": 4,
-      "Bash": 2
+      "Read": 8,
+      "Bash": 3,
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/.claude/metrics/refactor-separate-osn-from-musubi.json
+++ b/.claude/metrics/refactor-separate-osn-from-musubi.json
@@ -5,7 +5,7 @@
     "branch": "refactor/separate-osn-from-musubi",
     "base_sha": "10e490c9aa8581cf5b4cf2f739e1f689370a0083",
     "head_sha": "9b33d22a6e4b7520cf96a450e65a09f4434e9b59",
-    "generated_at": "2026-09-11T06:24:24.031Z",
+    "generated_at": "2026-09-11T07:19:12.023Z",
     "merged_at": "2026-09-09T02:56:45Z",
     "phase": "at-merge"
   },
@@ -26,7 +26,7 @@
     "first_ts": "2026-09-08T14:34:45.201Z",
     "last_ts": "2026-09-09T02:08:33.027Z",
     "span_seconds": 41628,
-    "active_seconds": 5079,
+    "active_seconds": 5092,
     "compactions": 0
   },
   "spend": {
@@ -186,20 +186,35 @@
     "tokens_before_first_edit": 259301,
     "sessions_with_observed_edit": 1,
     "tool_calls": {
-      "Bash": 71,
-      "Edit": 13,
-      "Write": 3,
-      "Agent": 2,
-      "Read": 2,
+      "Bash": 290,
+      "Edit": 24,
+      "Read": 19,
+      "Write": 10,
+      "Skill": 6,
+      "Agent": 5,
+      "Grep": 4,
+      "StructuredOutput": 4,
+      "EnterWorktree": 1,
+      "AskUserQuestion": 1,
+      "Glob": 1,
+      "ToolSearch": 1,
       "Monitor": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 3,
-      "max_edits_one_file": 4
+      "files_edited_3plus": 5,
+      "max_edits_one_file": 8
     },
-    "skills": {},
+    "skills": {
+      "stress-plan": 1,
+      "obsidian:obsidian-markdown": 1,
+      "prep-pr": 1,
+      "review-tests": 1,
+      "review-security": 1,
+      "review-performance": 1
+    },
     "subagents": {
-      "general-purpose": 2
+      "attacker": 2,
+      "general-purpose": 3
     }
   }
 }

--- a/.claude/metrics/test-pr-metrics-backfill.json
+++ b/.claude/metrics/test-pr-metrics-backfill.json
@@ -5,7 +5,7 @@
     "branch": "test/pr-metrics-backfill",
     "base_sha": "5667074a2ffd3b62aae424c5c3fd33fc162f32d4",
     "head_sha": "39d45644798c7bdd2df95301e66689e234cc92ea",
-    "generated_at": "2026-09-11T06:24:24.037Z",
+    "generated_at": "2026-09-11T07:19:12.030Z",
     "merged_at": "2026-09-08T14:48:06Z",
     "phase": "at-merge"
   },
@@ -139,15 +139,19 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "Bash": 19,
-      "Edit": 17,
-      "Read": 1
+      "Bash": 139,
+      "Edit": 29,
+      "Read": 6,
+      "Write": 1,
+      "Skill": 1
     },
     "edit_churn": {
-      "files_edited_3plus": 2,
-      "max_edits_one_file": 12
+      "files_edited_3plus": 3,
+      "max_edits_one_file": 20
     },
-    "skills": {},
+    "skills": {
+      "review-performance": 1
+    },
     "subagents": {}
   }
 }

--- a/.claude/metrics/test-pulse-account-cookie.json
+++ b/.claude/metrics/test-pulse-account-cookie.json
@@ -5,7 +5,7 @@
     "branch": "test/pulse-account-cookie",
     "base_sha": "a381059a5908272c3c5b024743bccc1fc7fba168",
     "head_sha": "d31fe56e410df2c5033c4602daaa17b73d7093e2",
-    "generated_at": "2026-09-11T06:24:24.055Z",
+    "generated_at": "2026-09-11T07:19:12.052Z",
     "merged_at": "2026-08-31T04:32:47Z",
     "phase": "at-merge"
   },
@@ -121,7 +121,7 @@
     "tokens_before_first_edit": null,
     "sessions_with_observed_edit": 0,
     "tool_calls": {
-      "StructuredOutput": 1
+      "StructuredOutput": 2
     },
     "edit_churn": {
       "files_edited_3plus": 0,

--- a/tools/pr-metrics/index.ts
+++ b/tools/pr-metrics/index.ts
@@ -442,6 +442,30 @@ export function skillCommandsIn(record: SessionRecord): string[] {
   return found;
 }
 
+/**
+ * Whether this record is the first of its API response to be seen, recording
+ * it as seen if so.
+ *
+ * `message.usage` on a split response is the whole response's usage, repeated
+ * verbatim on every record that carries a block of it. Summing it per record
+ * would multiply a response's cost by the number of blocks it was split
+ * across. Every reader of `message.usage` needs this guard; the tool counts
+ * next to it do not, because those are per record and each block holds its own.
+ *
+ * A record with no `requestId` is always counted. Two of them from one
+ * response would double-count, which is the lesser of the two errors and the
+ * one this tool has always preferred.
+ */
+function firstOfResponse(record: SessionRecord, seen: Set<string>): boolean {
+  const id = record.requestId;
+  if (typeof id !== "string") return true;
+  if (seen.has(id)) return false;
+
+  seen.add(id);
+
+  return true;
+}
+
 export interface SpendSummary {
   usd_equivalent: number;
   tokens: TokenTotals;
@@ -457,10 +481,15 @@ export function aggregateSpend(records: SessionRecord[]): SpendSummary {
   const byActor = { main: emptyBucket(), subagent: emptyBucket() };
   const effort: Record<string, number> = {};
   const unpriced = new Set<string>();
+  const countedResponses = new Set<string>();
   let usd = 0;
 
   for (const record of records) {
     if (record.type !== "assistant") continue;
+    // A later block of a response the loop has already priced. It repeats that
+    // response's usage, so counting it again would inflate both the cost and
+    // the message count — `messages` counts responses, not records.
+    if (!firstOfResponse(record, countedResponses)) continue;
 
     const model = record.message?.model ?? "unknown";
     const tokens = readUsage(record.message?.usage);
@@ -606,6 +635,7 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
   // "we did not observe the boundary" and "every token was exploration" are
   // very different claims, and only one of them is true.
   const pendingBySession = new Map<string, number>();
+  const countedResponses = new Set<string>();
   let tokensBeforeFirstEdit = 0;
   let sessionsWithObservedEdit = 0;
 
@@ -658,7 +688,14 @@ export function aggregateInteraction(records: SessionRecord[]): InteractionSumma
     const uses = toolUses(record);
     if (uses.length > 0) sessionsWithWork.add(session);
 
-    if (!record.isSidechain && !sessionsPastFirstEdit.has(session)) {
+    // The same guard `aggregateSpend` uses, and for the same reason: this sum
+    // reads `message.usage`, which a split response repeats on every block.
+    // The tool counting below is per record and needs no guard.
+    if (
+      firstOfResponse(record, countedResponses) &&
+      !sessionsPastFirstEdit.has(session) &&
+      !record.isSidechain
+    ) {
       const tokens = readUsage(record.message?.usage);
       const spent =
         tokens.input +
@@ -1376,10 +1413,26 @@ function ownedByRepo(sessionsDir: string, file: string, prefixes: string[] | und
   return prefixes.some((prefix) => project === prefix || project.startsWith(`${prefix}-`));
 }
 
-/** `requestId` where there is one, else the record's own uuid. A record with
- * neither is always kept: dropping it would be worse than counting it twice. */
+/**
+ * The record's own uuid, which is what a cross-file duplicate repeats.
+ *
+ * This keys the *record* dedupe, and it deliberately does not fall back to
+ * `requestId`. One API response reaches the transcript as several records — a
+ * thinking block, a text block, one per `tool_use` — all sharing a
+ * `requestId`, so keying on that kept the first block of every response and
+ * threw the rest away. On one branch here that dropped 167 of 973 records,
+ * including all three `Agent` dispatches and 101 of 161 `Bash` calls, and the
+ * card then stated the session used no subagents.
+ *
+ * The two phenomena separate cleanly: duplicate records repeat a `uuid`,
+ * duplicate *usage* repeats a `requestId`. So records dedupe here and usage
+ * deduped where it is read — `firstOfResponse`, in the two aggregators.
+ *
+ * A record with no uuid is always kept: dropping it would be worse than
+ * counting it twice, and the usage guard stops the one cost that would follow.
+ */
 function dedupeKey(record: SessionRecord): string | null {
-  return record.requestId ?? record.uuid ?? null;
+  return record.uuid ?? null;
 }
 
 /**

--- a/tools/pr-metrics/tests/dispatch-branch.test.ts
+++ b/tools/pr-metrics/tests/dispatch-branch.test.ts
@@ -206,6 +206,7 @@ test("readRecordsForBranch counts a record present in two session files once", a
       gitBranch: "feat/x",
       isSidechain: false,
       requestId: "req-dup",
+      uuid: "u-dup",
       timestamp: "2026-09-08T10:02:00.000Z",
       message: { model: "claude-opus-5", usage: { output_tokens: 500 } },
     })}\n`;
@@ -418,16 +419,18 @@ test("resolveDispatchBranch terminates when two siblings dispatch each other", a
   }
 });
 
-// T-U1. `requestId` is the assistant side; `uuid` is the fallback for the
-// records `user_turns` and `corrective_turns` are counted from. If it never
-// fires those numbers double on a duplicated conversation.
-test("the uuid fallback dedupes records that carry no requestId", async () => {
+// T-U1. `uuid` is what a cross-file duplicate repeats, on the assistant side
+// and on the `user` records `user_turns` and `corrective_turns` are counted
+// from alike. If the dedupe never fires those numbers double on a duplicated
+// conversation.
+test("a record present in two files is dropped on its uuid, assistant or user", async () => {
   const dir = await tree();
   try {
     const assistant = JSON.stringify({
       type: "assistant",
       gitBranch: "feat/x",
       requestId: "req-dup",
+      uuid: "u-assistant",
       message: { model: "claude-opus-5", usage: { output_tokens: 5 } },
     });
     const user = JSON.stringify({ type: "user", gitBranch: "feat/x", uuid: "u-dup" });
@@ -444,6 +447,37 @@ test("the uuid fallback dedupes records that carry no requestId", async () => {
   }
 });
 
+// One API response reaches the transcript as several records — a thinking
+// block, a text block, one per `tool_use` — sharing a `requestId` and each
+// carrying its own `uuid`. Keying the dedupe on `requestId` kept the first and
+// threw the rest away, which is every tool call the response made bar one.
+test("the blocks of one split response all survive the dedupe", async () => {
+  const dir = await tree();
+  try {
+    const block = (uuid: string, name: string) =>
+      JSON.stringify({
+        type: "assistant",
+        gitBranch: "feat/x",
+        requestId: "req-split",
+        uuid,
+        message: {
+          model: "claude-opus-5",
+          content: [{ type: "tool_use", name, input: {} }],
+          usage: { output_tokens: 9 },
+        },
+      });
+
+    await writeFile(
+      join(dir, "proj/sess-1.jsonl"),
+      [block("u-1", "Bash"), block("u-2", "Bash"), block("u-3", "Agent")].join("\n"),
+    );
+
+    expect(readRecordsForBranch(dir, "feat/x")).toHaveLength(3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 // T-S1. `backfill` reads through `recordsByBranch`, so an un-deduped pass here
 // is the live-card/backfilled-card disagreement the shared reader exists to end.
 test("recordsByBranch dedupes a record present in two session files", async () => {
@@ -453,6 +487,7 @@ test("recordsByBranch dedupes a record present in two session files", async () =
       type: "assistant",
       gitBranch: "feat/x",
       requestId: "req-dup",
+      uuid: "u-dup",
       message: { model: "claude-opus-5", usage: { output_tokens: 7 } },
     });
     await writeFile(join(dir, "proj/sess-1.jsonl"), `${line}\n`);

--- a/tools/pr-metrics/tests/pr-metrics.test.ts
+++ b/tools/pr-metrics/tests/pr-metrics.test.ts
@@ -6,6 +6,7 @@ import {
   aggregateWindow,
   branchSlug,
   classifyPath,
+  type ContentBlock,
   costOf,
   declaredFromLabels,
   emptyTokens,
@@ -644,4 +645,59 @@ test("aggregateInteraction does not count a slash command as a turn", () => {
 
   expect(interaction.user_turns).toBe(0);
   expect(interaction.skills).toEqual({ "review-deps": 1 });
+});
+
+// --- split responses --------------------------------------------------------
+
+// Claude Code writes one API response as several records — a thinking block, a
+// text block, one per `tool_use` — all carrying the same `requestId` and the
+// same `usage`. The usage belongs to the response, so summing it per record
+// multiplies a response's cost by the number of blocks it was split across.
+test("aggregateSpend prices a split response once, not once per block", () => {
+  const split = (content: ContentBlock[]) =>
+    assistant({
+      requestId: "req-split",
+      message: {
+        model: "claude-opus-5",
+        content,
+        usage: usage({ input_tokens: 1000, output_tokens: 200 }),
+      },
+    });
+
+  const spend = aggregateSpend([split([toolUse("Bash")]), split([toolUse("Agent")])]);
+
+  expect(spend.tokens.output).toBe(200);
+  expect(spend.tokens.input).toBe(1000);
+  expect(spend.by_actor.main.messages).toBe(1);
+});
+
+// The blocks the old record dedupe threw away: every `tool_use` after the
+// first one of a response. On one branch here that lost all three `Agent`
+// dispatches, and the card then said the session used no subagents at all.
+test("aggregateInteraction counts every block of a split response", () => {
+  const split = (content: ContentBlock[]) =>
+    assistant({
+      requestId: "req-split",
+      message: { model: "claude-opus-5", content, usage: usage({ output_tokens: 300 }) },
+    });
+
+  const interaction = aggregateInteraction([
+    split([toolUse("Bash")]),
+    split([toolUse("Bash")]),
+    split([toolUse("Agent", { subagent_type: "implementer" })]),
+    assistant({
+      requestId: "req-split",
+      message: {
+        model: "claude-opus-5",
+        content: [toolUse("Edit", { file_path: "a.ts" })],
+        usage: usage({ output_tokens: 300 }),
+      },
+    }),
+  ]);
+
+  expect(interaction.tool_calls.Bash).toBe(2);
+  expect(interaction.subagents.implementer).toBe(1);
+  // One response, so the exploration that led to the edit is 300 tokens — not
+  // 1200, which is what reading `usage` off each of the four blocks would give.
+  expect(interaction.tokens_before_first_edit).toBe(300);
 });

--- a/wiki/observability/session-metrics.md
+++ b/wiki/observability/session-metrics.md
@@ -87,15 +87,24 @@ join: this repository runs one worktree and one branch per task, so a branch
 name maps to exactly one pull request. For delegated work it is not enough —
 see [[#Attributing subagent spend]].
 
-Three traps the collector handles and any reimplementation must:
+Five traps the collector handles and any reimplementation must:
 
 - **Subagent spend is in a sibling directory**, `<session-id>/subagents/*.jsonl`,
   not in the main transcript. Missing it under-reports every delegated task, and
   on orchestrated work that is most of the cost.
 - **One conversation is sometimes written into two session files.** 615 assistant
   records on this machine — 5.2% of session spend — appear in both, and reading
-  them twice doubles the branch's cost. `readRecordsForBranch` keys on
-  `requestId` and returns each once.
+  them twice doubles the branch's cost. A duplicate repeats the record's `uuid`,
+  so that is what `readRecordsForBranch` keys on, returning each once.
+- **One API response is several records.** A thinking block, a text block and one
+  per `tool_use` all reach the transcript separately, sharing a `requestId` and
+  repeating that response's `message.usage` verbatim. The two phenomena pull
+  opposite ways and must not share a key: keying the record dedupe on `requestId`
+  keeps the first block of every response and throws the rest away, which is
+  every tool call the response made bar one. So records dedupe on `uuid`, and
+  every reader of `message.usage` — `aggregateSpend`, and the exploration sum in
+  `aggregateInteraction` — counts a `requestId` once instead, or a response's
+  cost is multiplied by the number of blocks it was split across.
 - **Most `role: "user"` records are machinery** — tool results, hook output,
   system reminders, slash-command envelopes. Counting them destroys `user_turns`
   as a measure of steering.


### PR DESCRIPTION
## Summary

`pr-metrics` deduped transcript records on `requestId`. That is not a record
identifier — it identifies an **API response**, and one response reaches the
transcript as several records: a thinking block, a text block, one per
`tool_use`. So the reader kept the first block of every response and threw the
rest away, which is every tool call the response made bar one.

On `chore/dep-review-2026-09-10` that dropped 431 of 2,571 records — with them
all four `Agent` dispatches and 321 of 450 `Bash` calls. The card said the
session used no subagents at all.

The two phenomena separate cleanly and must not share a key:

- a **cross-file duplicate** repeats the record's `uuid`, so records dedupe on
  `uuid`;
- duplicate **usage** repeats a `requestId` — `message.usage` on a split
  response is the whole response's usage, copied onto every block — so the two
  places that read it, `aggregateSpend` and the exploration sum in
  `aggregateInteraction`, count each `requestId` once.

That second half is what keeps the cost honest. Measured over the same
transcript, old code against new: `spend.usd_equivalent` stays **63.424558** and
`spend.by_actor.subagent` stays **228 messages / $20.925188**, to the cent, while
`Bash` goes 129 → 450 and `subagents` goes `{}` → `{general-purpose: 3,
attacker: 1}`.

Issue #1016 quotes different absolute figures (40.3187, 217 messages, ~161
`Bash`, three dispatches). Those were measured when it was written; that branch's
transcripts have grown since. Both halves of its "done when" hold on the data as
it stands today — the counts recover, the spend does not move.

All 75 cards with a local transcript are regenerated: every one of them had tool
counts and a subagent map to recover.

## Workspaces affected

- `@tools/pr-metrics` — the fix, and four new tests
- `wiki/` — `wiki/observability/session-metrics.md`, whose trap list said the
  reader keys on `requestId`
- `.claude/metrics/` — 75 regenerated cards

## Issues

Closes #1016.

## Decisions

**Records dedupe on `uuid`, not on a tuned `requestId` key.** Keying on
`(requestId, index)` or similar would work by accident; the two phenomena are
genuinely different, and separating them is what makes the fix explainable and
the usage guard correct wherever it is needed next.

**A record with no `uuid` is kept, and one with no `requestId` is counted.**
Dropping an unidentified record is the worse error, and the usage guard stops the
only cost that follows from counting it twice. This matches what the tool already
preferred elsewhere.

**`aggregateSpend` `continue`s on a repeated response rather than skipping only
the token add.** `messages` counts responses, not records — that is what keeps
`by_actor.subagent` at 228 rather than inflating with the recovered blocks.

## Test plan

- `bun run --cwd tools/pr-metrics test` — **128 pass / 0 fail**. Four new tests,
  all of which fail against the old key and pass against the new one (verified by
  reverting `index.ts` and re-running):
  - the blocks of one split response all survive the reader's dedupe;
  - `aggregateSpend` prices a split response once, not once per block;
  - `aggregateInteraction` counts the `tool_use` in every block, and banks the
    response's exploration tokens once (300, not 1,200);
  - the existing cross-file duplicate fixtures now carry a `uuid`, which is how a
    real duplicate looks.
- `bun run check` — 39/39.
- `bun run fmt` clean; `bash scripts/guard-lint-warnings.sh` — 1062, matches the
  ceiling.
- `bash scripts/validate-changesets.sh` — valid.
- Real-transcript check on `chore/dep-review-2026-09-10`, old code against new,
  numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018szASa48VKhpsRdC3R4kQb
